### PR TITLE
Formula: match flat release tarball layout (fixes brew install)

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -28,11 +28,11 @@ class LogicProMcp < Formula
     bin.install "LogicProMCP"
     # Helper assets shipped with the binary so users can complete Logic Pro
     # integration without re-cloning the repo.
-    pkgshare.install "docs/SETUP.md"
-    pkgshare.install "Scripts/install-keycmds.sh"
-    pkgshare.install "Scripts/uninstall-keycmds.sh"
-    pkgshare.install "Scripts/keycmd-preset.plist"
-    pkgshare.install "Scripts/LogicProMCP-Scripter.js"
+    pkgshare.install "SETUP.md"
+    pkgshare.install "install-keycmds.sh"
+    pkgshare.install "uninstall-keycmds.sh"
+    pkgshare.install "keycmd-preset.plist"
+    pkgshare.install "LogicProMCP-Scripter.js"
   end
 
   def caveats


### PR DESCRIPTION
## Problem

`brew install logic-pro-mcp` fails on every release since v3.1.1 (current: v3.1.4) with:

```
Errno::ENOENT: No such file or directory - docs/SETUP.md
```

## Root cause

The release tarball ships every helper file at the archive root, with no `docs/` or `Scripts/` subdirectories:

```
$ tar tzf LogicProMCP-macOS-universal.tar.gz   # v3.1.4
LogicProMCP
SETUP.md
install-keycmds.sh
uninstall-keycmds.sh
keycmd-preset.plist
LogicProMCP-Scripter.js
```

But the formula's `install` block expects `docs/SETUP.md` and `Scripts/*`, so the first `pkgshare.install` raises `Errno::ENOENT` and the install never completes. SHA256 in the formula matches the tarball, so the binary itself is fine — it's purely a path mismatch.

Confirmed against v3.1.1, v3.1.2, v3.1.3, and v3.1.4. No release pipeline change appears to have shipped a `docs/`+`Scripts/` layout — looks like the formula was authored against an earlier intended layout that never made it into the published artifact.

## Fix

Drop the `docs/` and `Scripts/` prefixes from the five `pkgshare.install` calls. The `caveats` reference to `#{pkgshare}/SETUP.md` is unchanged — `pkgshare.install` already lands files in `pkgshare/`, regardless of source-side path.

## Verification

```
$ brew install --formula logic-pro-mcp
==> Pouring logic-pro-mcp-3.1.4...
==> Caveats
Logic Pro MCP Server is installed at /opt/homebrew/opt/logic-pro-mcp/bin/LogicProMCP.
🍺  /opt/homebrew/Cellar/logic-pro-mcp/3.1.4: 9 files, ...

$ ls /opt/homebrew/opt/logic-pro-mcp/share/logic-pro-mcp/
LogicProMCP-Scripter.js  install-keycmds.sh    keycmd-preset.plist
SETUP.md                 uninstall-keycmds.sh

$ LogicProMCP --check-permissions
Accessibility: ...
Automation (Logic Pro): ...
```

Tested on macOS Sonoma 14.x, arm64, Xcode 16.4.

## Alternative considered

Updating the release pipeline to emit `docs/` and `Scripts/` subdirectories instead would also work and would let the formula stay as-is. Going with the formula change because the flat tarball layout has shipped across four releases and any consumers who curl the tarball directly will already depend on the flat paths.