### PR TITLE
Issue #14: Verified stock plugin intelligence

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -448,15 +448,15 @@ def main():
 
     r = list_resources(client)
     resources = r.get("result", {}).get("resources", []) if r else []
-    # v3.0.0 exposes 9 static resources. logic://mcu/state is filtered from the
-    # list when the MCU control surface is disconnected, so the expected count
-    # is 8 (disconnected) or 9 (connected).
+    # Issue #14 exposes 12 static resources. logic://mcu/state is filtered from
+    # the list when the MCU control surface is disconnected, so the expected
+    # count is 11 (disconnected) or 12 (connected).
     resource_count = len(resources)
-    T("resources/list returns 8 or 9 resources", r, lambda r: resource_count in (8, 9))
+    T("resources/list returns 11 or 12 resources", r, lambda r: resource_count in (11, 12))
 
     r = list_resource_templates(client)
     templates = r.get("result", {}).get("resourceTemplates", []) if r else []
-    T("resources/templates/list returns 3 templates", r, lambda r: len(templates) == 3)
+    T("resources/templates/list returns 5 templates", r, lambda r: len(templates) == 5)
 
     # ═══════════════════════════════════════════════════════════════
     # §2 System Diagnostics (15 tests)
@@ -993,7 +993,7 @@ def main():
         T(f"SECURITY: blocks {desc}", r, lambda _: is_error(r))
 
     # ═══════════════════════════════════════════════════════════════
-    # §11 Resource Read (18 tests)
+    # §11 Resource Read (28 tests)
     # ═══════════════════════════════════════════════════════════════
     section("§11 Resource Read")
 
@@ -1006,6 +1006,11 @@ def main():
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
+        "logic://stock-plugins/logic.stock.effect.gain",
+        "logic://stock-plugins/search?query=gain",
         # mcu/state is read-testable even when filtered from list (direct reads
         # bypass the connection gate so clients bookmarking the URI still work).
         "logic://mcu/state",
@@ -1031,6 +1036,13 @@ def main():
                 ed and "No Logic Pro document is open" in rd
             ),
         )
+
+    r = read_resource(client, "logic://stock-plugins")
+    stock_catalog = safe_json(resource_text(r))
+    T("stock plugin catalog validates", r,
+      lambda _: bool(stock_catalog and stock_catalog.get("validation", {}).get("is_valid") is True))
+    T("stock plugin catalog exposes truth labels", r,
+      lambda _: any("availability_state" in e for e in stock_catalog.get("entries", [])) if stock_catalog else False)
 
     # Transport resource should have tempo
     r = read_resource(client, "logic://transport/state")

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -555,7 +555,13 @@ def main():
     def safe_get_cycle(client):
         r = read_resource(client, "logic://transport/state")
         try:
-            return json.loads(resource_text(r)).get("data", {}).get("state", {}).get("isCycleEnabled")
+            envelope = json.loads(resource_text(r))
+            if envelope.get("fetched_at") is None:
+                return None
+            data = envelope.get("data", {})
+            if data.get("has_document") is False:
+                return None
+            return data.get("state", {}).get("isCycleEnabled")
         except: return None
 
     def wait_for_cycle_change(client, before, timeout=5.0):

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -448,15 +448,33 @@ def main():
 
     r = list_resources(client)
     resources = r.get("result", {}).get("resources", []) if r else []
-    # Issue #14 exposes 12 static resources. logic://mcu/state is filtered from
-    # the list when the MCU control surface is disconnected, so the expected
-    # count is 11 (disconnected) or 12 (connected).
-    resource_count = len(resources)
-    T("resources/list returns 11 or 12 resources", r, lambda r: resource_count in (11, 12))
+    resource_uris = {res.get("uri") for res in resources}
+    required_resource_uris = {
+        "logic://system/health",
+        "logic://transport/state",
+        "logic://tracks",
+        "logic://mixer",
+        "logic://markers",
+        "logic://project/info",
+        "logic://midi/ports",
+        "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
+    }
+    T("resources/list includes required resources", r, lambda r: required_resource_uris.issubset(resource_uris))
 
     r = list_resource_templates(client)
     templates = r.get("result", {}).get("resourceTemplates", []) if r else []
-    T("resources/templates/list returns 5 templates", r, lambda r: len(templates) == 5)
+    template_uris = {tpl.get("uriTemplate") for tpl in templates}
+    required_template_uris = {
+        "logic://tracks/{index}",
+        "logic://tracks/{index}/regions",
+        "logic://mixer/{strip}",
+        "logic://stock-plugins/{id}",
+        "logic://stock-plugins/search?query={query}",
+    }
+    T("resources/templates/list includes required templates", r, lambda r: required_template_uris.issubset(template_uris))
 
     # ═══════════════════════════════════════════════════════════════
     # §2 System Diagnostics (15 tests)

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -22,6 +22,12 @@ actor ChannelRouter {
 
     private var channels: [ChannelID: any Channel] = [:]
 
+    private static let transportToggleOpsAllowingAXElementFallback: Set<String> = [
+        "transport.toggle_cycle",
+        "transport.toggle_metronome",
+        "transport.toggle_count_in",
+    ]
+
     /// V2 routing table: MCU primary for mixer/transport/track state, MIDIKeyCommands for editing.
     /// PRD §4.3 + §4.3.1 contract changes.
     static let v2RoutingTable: [String: [ChannelID]] = [
@@ -33,7 +39,7 @@ actor ChannelRouter {
         "transport.pause":            [.coreMIDI, .cgEvent],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],
         "transport.fast_forward":     [.mcu, .coreMIDI, .cgEvent],
-        "transport.toggle_cycle":     [.accessibility, .mcu, .midiKeyCommands, .cgEvent],
+        "transport.toggle_cycle":     [.accessibility, .midiKeyCommands, .cgEvent, .mcu],
         "transport.toggle_metronome": [.accessibility, .midiKeyCommands, .cgEvent],
         // AX only — MIDIKeyCommands / CGEvent can't convey the tempo value
         // (MCU set_tempo CC fires blindly, no shortcut actually sets value).
@@ -375,6 +381,14 @@ actor ChannelRouter {
                 // in that case instead of wrapping it in the generic
                 // "All channels exhausted" message.
                 if HonestContract.isTerminalStateC(msg) {
+                    if Self.shouldContinueAfterTerminalStateC(operation: operation, channelID: channelID, message: msg) {
+                        Log.debug(
+                            "\(operation) terminal State C via \(channelID.rawValue) is recoverable by fallback: \(msg)",
+                            subsystem: "router"
+                        )
+                        lastError = msg
+                        continue
+                    }
                     Log.debug(
                         "\(operation) terminal State C via \(channelID.rawValue), suppressing fallback",
                         subsystem: "router"
@@ -402,6 +416,16 @@ actor ChannelRouter {
                 "last_error": lastError,
             ]
         ))
+    }
+
+    private static func shouldContinueAfterTerminalStateC(
+        operation: String,
+        channelID: ChannelID,
+        message: String
+    ) -> Bool {
+        channelID == .accessibility &&
+            transportToggleOpsAllowingAXElementFallback.contains(operation) &&
+            HonestContract.stateCErrorCode(message) == HonestContract.FailureError.elementNotFound.rawValue
     }
 
     /// Get health status for all registered channels.

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,7 @@ struct SystemDispatcher {
 
         default:
             return """
-                Logic Pro MCP — 8 dispatcher tools + 12 resources + 5 templates
+                Logic Pro MCP — 8 dispatcher tools + \(ResourceProvider.resources.count) resources + \(ResourceProvider.templates.count) templates
 
                 Tools (actions):
                   logic_transport  — Transport control (play, stop, record, tempo...)

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,7 @@ struct SystemDispatcher {
 
         default:
             return """
-                Logic Pro MCP — 8 dispatcher tools + 9 resources + 3 templates
+                Logic Pro MCP — 8 dispatcher tools + 12 resources + 5 templates
 
                 Tools (actions):
                   logic_transport  — Transport control (play, stop, record, tempo...)
@@ -408,11 +408,16 @@ struct SystemDispatcher {
                   logic://midi/ports            — MIDI ports
                   logic://mcu/state             — MCU control-surface state (hidden in list when disconnected)
                   logic://library/inventory     — Cached Library tree JSON
+                  logic://stock-plugins         — Stock plugin intelligence catalog
+                  logic://stock-plugins/census  — Stock plugin census metadata
+                  logic://stock-plugins/capabilities — Stock plugin catalog capabilities
 
                 Resource templates:
                   logic://tracks/{index}          — Single track detail
                   logic://tracks/{index}/regions  — Regions on a single track
                   logic://mixer/{strip}           — Single channel strip
+                  logic://stock-plugins/{id}      — Stock plugin detail
+                  logic://stock-plugins/search?query={query} — Stock plugin search
 
                 Use: logic_system(command: "help", params: {category: "transport"})
                 for detailed command docs per category.

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -502,6 +502,20 @@ enum StockPluginCatalogValidator {
                     "\(state.rawValue) state requires source, method, and observed_at"
                 ))
             }
+            if state == .manifested, provenance.sourcePath?.isEmpty ?? true {
+                issues.append(issue(
+                    "manifested_missing_source_path",
+                    path,
+                    "manifested state requires the probed source_path"
+                ))
+            }
+            if state == .unavailable, provenance.evidence.isEmpty {
+                issues.append(issue(
+                    "unavailable_missing_evidence",
+                    path,
+                    "unavailable state requires absence evidence"
+                ))
+            }
         case .inferred:
             if provenance.inferenceReason?.isEmpty ?? true {
                 issues.append(issue(
@@ -533,7 +547,12 @@ enum StockPluginCatalog {
         let entries = seeds
             .map { buildEntry(seed: $0, census: census) }
             .sorted { $0.id < $1.id }
-        let validation = StockPluginCatalogValidator.validate(entries)
+        let conflicts = censusConflicts(census)
+        let entryValidation = StockPluginCatalogValidator.validate(entries)
+        let validation = StockPluginValidationResult(
+            isValid: entryValidation.isValid && conflicts.isEmpty,
+            issues: conflicts + entryValidation.issues
+        )
         return StockPluginCatalogSnapshot(
             schemaVersion: 1,
             generatedAt: census.observedAt,
@@ -544,6 +563,29 @@ enum StockPluginCatalog {
             validation: validation,
             entries: entries
         )
+    }
+
+    /// Contradictory live evidence for the same plugin must fail loudly, not
+    /// be resolved by precedence alone: a plugin cannot be both verified and
+    /// readback-mismatched, nor absent yet seen live.
+    static func censusConflicts(_ census: StockPluginCensus) -> [StockPluginValidationIssue] {
+        let contradictions: [(String, Set<String>, String, Set<String>)] = [
+            ("verified", census.verifiedPluginIDs, "readback_mismatch", census.readbackMismatchPluginIDs),
+            ("verified", census.verifiedPluginIDs, "unavailable", census.unavailablePluginIDs),
+            ("observed", census.observedPluginIDs, "unavailable", census.unavailablePluginIDs),
+            ("readback_mismatch", census.readbackMismatchPluginIDs, "unavailable", census.unavailablePluginIDs),
+        ]
+        var issues: [StockPluginValidationIssue] = []
+        for (leftName, left, rightName, right) in contradictions {
+            for id in left.intersection(right).sorted() {
+                issues.append(StockPluginValidationIssue(
+                    code: "census_conflict",
+                    path: "census.\(id)",
+                    message: "census claims both \(leftName) and \(rightName) for \(id)"
+                ))
+            }
+        }
+        return issues
     }
 
     static func entry(id: String, snapshot: StockPluginCatalogSnapshot = productionSnapshot) -> StockPluginCatalogEntry? {
@@ -645,6 +687,10 @@ enum StockPluginCatalog {
         let roots = factorySettingsRoots(appPath: appPath)
         var result: [String: StockPluginLocalManifest] = [:]
         for seed in seeds {
+            // POSIX paths cannot contain "/" in a single component, so names
+            // like "I/O" have no probeable folder; skip rather than letting
+            // the separator silently change the probed directory.
+            guard !seed.name.contains("/") else { continue }
             for root in roots {
                 let folder = root + "/" + seed.name
                 var isDirectory: ObjCBool = false
@@ -925,25 +971,14 @@ enum StockPluginCatalog {
         let presetNames: [String]
     }
 
-    /// Truth-state precedence: live evidence beats local metadata beats static
-    /// knowledge. Only census-injected sets can produce `verified`,
-    /// `observed`, `readback_mismatch`, or `unavailable`; the production probe
-    /// alone never claims more than `manifested`.
+    /// Truth-state precedence: contradiction beats confirmation, live evidence
+    /// beats local metadata, local metadata beats static knowledge. A
+    /// `readback_mismatch` therefore wins over `verified` — contradictory live
+    /// evidence must never be silently upgraded (the conflict is also surfaced
+    /// via `censusConflicts`). Only census-injected sets can produce
+    /// `verified`, `observed`, `readback_mismatch`, or `unavailable`; the
+    /// production probe alone never claims more than `manifested`.
     private static func resolve(seedID: String, census: StockPluginCensus) -> StateResolution {
-        if census.verifiedPluginIDs.contains(seedID) {
-            return StateResolution(
-                state: .verified,
-                provenance: .verified(
-                    source: "live_logic",
-                    method: "ax_insert_readback",
-                    observedAt: census.observedAt,
-                    logicVersion: census.logicVersion,
-                    locale: census.locale,
-                    evidence: ["plugin_identity_readback"]
-                ),
-                presetNames: census.localManifests[seedID]?.presetNames ?? []
-            )
-        }
         if census.readbackMismatchPluginIDs.contains(seedID) {
             return StateResolution(
                 state: .readbackMismatch,
@@ -956,7 +991,27 @@ enum StockPluginCatalog {
                 presetNames: []
             )
         }
+        if census.verifiedPluginIDs.contains(seedID) {
+            let presets = census.localManifests[seedID]?.presetNames ?? []
+            var evidence = ["plugin_identity_readback"]
+            if !presets.isEmpty { evidence.append("factory_preset_filenames") }
+            return StateResolution(
+                state: .verified,
+                provenance: .verified(
+                    source: "live_logic",
+                    method: "ax_insert_readback",
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: evidence
+                ),
+                presetNames: presets
+            )
+        }
         if census.observedPluginIDs.contains(seedID) {
+            let presets = census.localManifests[seedID]?.presetNames ?? []
+            var evidence = ["menu_item_observed"]
+            if !presets.isEmpty { evidence.append("factory_preset_filenames") }
             return StateResolution(
                 state: .observed,
                 provenance: .observed(
@@ -964,9 +1019,9 @@ enum StockPluginCatalog {
                     observedAt: census.observedAt,
                     logicVersion: census.logicVersion,
                     locale: census.locale,
-                    evidence: ["menu_item_observed"]
+                    evidence: evidence
                 ),
-                presetNames: census.localManifests[seedID]?.presetNames ?? []
+                presetNames: presets
             )
         }
         if census.unavailablePluginIDs.contains(seedID) {

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -1,0 +1,643 @@
+import Foundation
+
+enum StockPluginTruthState: String, Codable, CaseIterable, Sendable {
+    case verified
+    case observed
+    case manifested
+    case inferred
+    case unavailable
+    case readbackMismatch = "readback_mismatch"
+}
+
+enum StockPluginType: String, Codable, Sendable {
+    case effect
+    case instrument
+    case midiEffect = "midi_effect"
+    case utility
+    case metering
+}
+
+enum StockPluginSafeWriteCapability: String, Codable, Sendable {
+    case none
+    case insertOnly = "insert_only"
+    case parameterWriteUnverified = "parameter_write_unverified"
+    case parameterWriteReadback = "parameter_write_readback"
+}
+
+struct StockPluginProvenance: Codable, Sendable, Equatable {
+    let source: String
+    let method: String
+    let observedAt: String?
+    let logicVersion: String?
+    let locale: String?
+    let sourcePath: String?
+    let inferenceReason: String?
+    let evidence: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case source
+        case method
+        case observedAt = "observed_at"
+        case logicVersion = "logic_version"
+        case locale
+        case sourcePath = "source_path"
+        case inferenceReason = "inference_reason"
+        case evidence
+    }
+
+    static func inferred(reason: String) -> Self {
+        Self(
+            source: "static_catalog",
+            method: "logic_stock_plugin_schema",
+            observedAt: nil,
+            logicVersion: nil,
+            locale: nil,
+            sourcePath: nil,
+            inferenceReason: reason,
+            evidence: []
+        )
+    }
+
+    static func unavailable(method: String, observedAt: String, logicVersion: String?, locale: String?) -> Self {
+        Self(
+            source: "local_census",
+            method: method,
+            observedAt: observedAt,
+            logicVersion: logicVersion,
+            locale: locale,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: ["absence_checked"]
+        )
+    }
+
+    static func manifested(
+        sourcePath: String,
+        method: String,
+        observedAt: String,
+        logicVersion: String?,
+        locale: String,
+        evidence: [String]
+    ) -> Self {
+        Self(
+            source: "local_logic_app",
+            method: method,
+            observedAt: observedAt,
+            logicVersion: logicVersion,
+            locale: locale,
+            sourcePath: sourcePath,
+            inferenceReason: nil,
+            evidence: evidence
+        )
+    }
+
+    static func verified(
+        source: String,
+        method: String,
+        observedAt: String,
+        logicVersion: String?,
+        locale: String?,
+        evidence: [String]
+    ) -> Self {
+        Self(
+            source: source,
+            method: method,
+            observedAt: observedAt,
+            logicVersion: logicVersion,
+            locale: locale,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: evidence
+        )
+    }
+}
+
+struct StockPluginValueRange: Codable, Sendable, Equatable {
+    let min: Double
+    let max: Double
+    let defaultValue: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case min
+        case max
+        case defaultValue = "default_value"
+    }
+}
+
+struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
+    let id: String
+    let displayName: String
+    let unit: String?
+    let valueRange: StockPluginValueRange?
+    let writeMethod: String?
+    let readbackMethod: String?
+    let availabilityState: StockPluginTruthState
+    let provenance: StockPluginProvenance
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case unit
+        case valueRange = "value_range"
+        case writeMethod = "write_method"
+        case readbackMethod = "readback_method"
+        case availabilityState = "availability_state"
+        case provenance
+    }
+}
+
+struct StockPluginInsertPath: Codable, Sendable, Equatable {
+    let path: [String]
+    let availabilityState: StockPluginTruthState
+    let provenance: StockPluginProvenance
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case availabilityState = "availability_state"
+        case provenance
+    }
+}
+
+struct StockPluginSlotSupport: Codable, Sendable, Equatable {
+    let audio: Bool
+    let instrument: Bool
+    let midiFX: Bool
+    let aux: Bool
+    let stereo: Bool?
+    let mono: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case audio
+        case instrument
+        case midiFX = "midi_fx"
+        case aux
+        case stereo
+        case mono
+    }
+
+    init(audio: Bool, instrument: Bool, midiFX: Bool, aux: Bool, stereo: Bool? = nil, mono: Bool? = nil) {
+        self.audio = audio
+        self.instrument = instrument
+        self.midiFX = midiFX
+        self.aux = aux
+        self.stereo = stereo
+        self.mono = mono
+    }
+}
+
+struct StockPluginCatalogEntry: Codable, Sendable, Equatable {
+    let id: String
+    let displayName: String
+    let type: StockPluginType
+    let category: String
+    let availabilityState: StockPluginTruthState
+    let provenance: StockPluginProvenance
+    let insertPaths: [StockPluginInsertPath]
+    let slotSupport: StockPluginSlotSupport
+    let knownPresets: [String]
+    let parameters: [StockPluginParameterMetadata]
+    let safeWriteCapabilities: StockPluginSafeWriteCapability
+    let limitations: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case type
+        case category
+        case availabilityState = "availability_state"
+        case provenance
+        case insertPaths = "insert_paths"
+        case slotSupport = "slot_support"
+        case knownPresets = "known_presets"
+        case parameters
+        case safeWriteCapabilities = "safe_write_capabilities"
+        case limitations
+    }
+}
+
+struct StockPluginValidationIssue: Codable, Sendable, Equatable {
+    let code: String
+    let path: String
+    let message: String
+}
+
+struct StockPluginValidationResult: Codable, Sendable, Equatable {
+    let isValid: Bool
+    let issues: [StockPluginValidationIssue]
+
+    enum CodingKeys: String, CodingKey {
+        case isValid = "is_valid"
+        case issues
+    }
+}
+
+struct StockPluginCatalogSnapshot: Codable, Sendable, Equatable {
+    let schemaVersion: Int
+    let generatedAt: String
+    let logicVersion: String?
+    let locale: String
+    let catalogSource: String
+    let pluginCount: Int
+    let validation: StockPluginValidationResult
+    let entries: [StockPluginCatalogEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case generatedAt = "generated_at"
+        case logicVersion = "logic_version"
+        case locale
+        case catalogSource = "catalog_source"
+        case pluginCount = "plugin_count"
+        case validation
+        case entries
+    }
+}
+
+struct StockPluginCensus: Sendable, Equatable {
+    let observedAt: String
+    let logicVersion: String?
+    let locale: String
+    let logicAppPath: String?
+    let verifiedPluginIDs: Set<String>
+    let observedPluginIDs: Set<String>
+
+    static func production(now: Date = Date()) -> Self {
+        let observedAt = ISO8601DateFormatter.cacheFormatter.string(from: now)
+        let appPath = "/Applications/Logic Pro.app"
+        let bundle = Bundle(path: appPath)
+        let version = bundle?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let existingPath = FileManager.default.fileExists(atPath: appPath) ? appPath : nil
+        return Self(
+            observedAt: observedAt,
+            logicVersion: version,
+            locale: Locale.current.identifier,
+            logicAppPath: existingPath,
+            verifiedPluginIDs: [],
+            observedPluginIDs: []
+        )
+    }
+
+    static func deterministic() -> Self {
+        Self(
+            observedAt: "2026-06-09T00:00:00.000Z",
+            logicVersion: nil,
+            locale: "en_US",
+            logicAppPath: nil,
+            verifiedPluginIDs: [],
+            observedPluginIDs: []
+        )
+    }
+}
+
+enum StockPluginCatalogValidator {
+    static func validate(_ entries: [StockPluginCatalogEntry]) -> StockPluginValidationResult {
+        var issues: [StockPluginValidationIssue] = []
+        var seen = Set<String>()
+
+        for (index, entry) in entries.enumerated() {
+            let base = "entries[\(index)]"
+            if entry.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                issues.append(issue("missing_id", base, "plugin entry id is required"))
+            }
+            if !seen.insert(entry.id).inserted {
+                issues.append(issue("duplicate_id", "\(base).id", "duplicate plugin id \(entry.id)"))
+            }
+            validateProvenance(
+                entry.provenance,
+                state: entry.availabilityState,
+                path: "\(base).provenance",
+                issues: &issues
+            )
+            if entry.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                issues.append(issue("missing_display_name", "\(base).display_name", "display name is required"))
+            }
+            if entry.insertPaths.isEmpty && entry.availabilityState != .unavailable {
+                issues.append(issue("missing_insert_path", "\(base).insert_paths", "available entries need insert path hints"))
+            }
+            for (pathIndex, insertPath) in entry.insertPaths.enumerated() {
+                validateProvenance(
+                    insertPath.provenance,
+                    state: insertPath.availabilityState,
+                    path: "\(base).insert_paths[\(pathIndex)].provenance",
+                    issues: &issues
+                )
+            }
+            for (paramIndex, parameter) in entry.parameters.enumerated() {
+                validateProvenance(
+                    parameter.provenance,
+                    state: parameter.availabilityState,
+                    path: "\(base).parameters[\(paramIndex)].provenance",
+                    issues: &issues
+                )
+                if parameter.availabilityState == .verified,
+                   (parameter.readbackMethod?.isEmpty ?? true) || !parameter.provenance.evidence.contains("parameter_readback") {
+                    issues.append(issue(
+                        "verified_parameter_missing_readback",
+                        "\(base).parameters[\(paramIndex)]",
+                        "verified parameters require readback method and parameter_readback evidence"
+                    ))
+                }
+            }
+        }
+        return StockPluginValidationResult(isValid: issues.isEmpty, issues: issues)
+    }
+
+    private static func validateProvenance(
+        _ provenance: StockPluginProvenance,
+        state: StockPluginTruthState,
+        path: String,
+        issues: inout [StockPluginValidationIssue]
+    ) {
+        switch state {
+        case .verified:
+            if provenance.source.isEmpty ||
+                provenance.method.isEmpty ||
+                (provenance.observedAt?.isEmpty ?? true) ||
+                provenance.evidence.isEmpty {
+                issues.append(issue(
+                    "verified_missing_provenance",
+                    path,
+                    "verified state requires source, method, observed_at, and evidence"
+                ))
+            }
+        case .observed, .manifested, .unavailable, .readbackMismatch:
+            if provenance.source.isEmpty ||
+                provenance.method.isEmpty ||
+                (provenance.observedAt?.isEmpty ?? true) {
+                issues.append(issue(
+                    "observed_missing_provenance",
+                    path,
+                    "\(state.rawValue) state requires source, method, and observed_at"
+                ))
+            }
+        case .inferred:
+            if provenance.inferenceReason?.isEmpty ?? true {
+                issues.append(issue(
+                    "inferred_missing_reason",
+                    path,
+                    "inferred state requires inference_reason"
+                ))
+            }
+        }
+    }
+
+    private static func issue(_ code: String, _ path: String, _ message: String) -> StockPluginValidationIssue {
+        StockPluginValidationIssue(code: code, path: path, message: message)
+    }
+}
+
+enum StockPluginCatalog {
+    static func defaultSnapshot(census: StockPluginCensus = .production()) -> StockPluginCatalogSnapshot {
+        let entries = defaultEntries(census: census).sorted { $0.id < $1.id }
+        let validation = StockPluginCatalogValidator.validate(entries)
+        return StockPluginCatalogSnapshot(
+            schemaVersion: 1,
+            generatedAt: census.observedAt,
+            logicVersion: census.logicVersion,
+            locale: census.locale,
+            catalogSource: census.logicAppPath == nil ? "static_catalog" : "static_catalog+local_logic_app",
+            pluginCount: entries.count,
+            validation: validation,
+            entries: entries
+        )
+    }
+
+    static func entry(id: String, snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> StockPluginCatalogEntry? {
+        snapshot.entries.first { $0.id == id }
+    }
+
+    static func search(query: String, snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> [StockPluginCatalogEntry] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return snapshot.entries }
+        return snapshot.entries.filter { entry in
+            entry.id.lowercased().contains(q) ||
+                entry.displayName.lowercased().contains(q) ||
+                entry.category.lowercased().contains(q) ||
+                entry.limitations.joined(separator: " ").lowercased().contains(q)
+        }
+    }
+
+    static func capabilities(snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> [String: Any] {
+        [
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "logic_version": snapshot.logicVersion ?? NSNull(),
+            "catalog_source": snapshot.catalogSource,
+            "truth_labels": StockPluginTruthState.allCases.map(\.rawValue),
+            "safe_write_capabilities": [
+                StockPluginSafeWriteCapability.none.rawValue,
+                StockPluginSafeWriteCapability.insertOnly.rawValue,
+                StockPluginSafeWriteCapability.parameterWriteUnverified.rawValue,
+                StockPluginSafeWriteCapability.parameterWriteReadback.rawValue,
+            ],
+            "resources": [
+                "logic://stock-plugins",
+                "logic://stock-plugins/{id}",
+                "logic://stock-plugins/search?query=<text>",
+                "logic://stock-plugins/census",
+                "logic://stock-plugins/capabilities",
+            ],
+            "catalog_entry_fields": [
+                "id",
+                "display_name",
+                "type",
+                "category",
+                "availability_state",
+                "provenance",
+                "insert_paths",
+                "slot_support",
+                "known_presets",
+                "parameters",
+                "safe_write_capabilities",
+                "limitations",
+            ],
+            "write_side_behavior": "unchanged; discovery resources are read-only",
+            "validation": [
+                "is_valid": snapshot.validation.isValid,
+                "issue_count": snapshot.validation.issues.count,
+            ],
+        ]
+    }
+
+    private static func defaultEntries(census: StockPluginCensus) -> [StockPluginCatalogEntry] {
+        let base = StockPluginProvenance.inferred(reason: "Logic stock plugin identity documented by project catalog; not live verified in this response")
+        let manifested: StockPluginProvenance? = census.logicAppPath.map {
+            StockPluginProvenance.manifested(
+                sourcePath: $0,
+                method: "logic_app_bundle_metadata",
+                observedAt: census.observedAt,
+                logicVersion: census.logicVersion,
+                locale: census.locale,
+                evidence: ["logic_app_bundle_present"]
+            )
+        }
+
+        return [
+            entry(
+                id: "logic.stock.effect.channel_eq",
+                displayName: "Channel EQ",
+                type: .effect,
+                category: "EQ",
+                path: ["Audio FX", "EQ", "Channel EQ"],
+                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
+                provenance: overlayProvenance(id: "logic.stock.effect.channel_eq", census: census, fallback: manifested ?? base),
+                fallbackState: manifested == nil ? .inferred : .manifested,
+                limitations: ["parameter names and readback are not verified by this catalog"]
+            ),
+            entry(
+                id: "logic.stock.effect.compressor",
+                displayName: "Compressor",
+                type: .effect,
+                category: "Dynamics",
+                path: ["Audio FX", "Dynamics", "Compressor"],
+                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
+                provenance: overlayProvenance(id: "logic.stock.effect.compressor", census: census, fallback: manifested ?? base),
+                fallbackState: manifested == nil ? .inferred : .manifested,
+                limitations: ["model and parameter mapping are not verified by this catalog"]
+            ),
+            entry(
+                id: "logic.stock.effect.gain",
+                displayName: "Gain",
+                type: .utility,
+                category: "Utility",
+                path: ["Audio FX", "Utility", "Gain"],
+                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
+                provenance: overlayProvenance(id: "logic.stock.effect.gain", census: census, fallback: manifested ?? base),
+                fallbackState: manifested == nil ? .inferred : .manifested,
+                parameters: [
+                    StockPluginParameterMetadata(
+                        id: "gain",
+                        displayName: "Gain",
+                        unit: "dB",
+                        valueRange: StockPluginValueRange(min: -96, max: 24, defaultValue: 0),
+                        writeMethod: nil,
+                        readbackMethod: nil,
+                        availabilityState: .inferred,
+                        provenance: base
+                    ),
+                ],
+                safeWriteCapabilities: .insertOnly,
+                limitations: ["insert path is a hint unless live Logic evidence upgrades this entry"]
+            ),
+            entry(
+                id: "logic.stock.effect.limiter",
+                displayName: "Limiter",
+                type: .effect,
+                category: "Dynamics",
+                path: ["Audio FX", "Dynamics", "Limiter"],
+                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
+                provenance: overlayProvenance(id: "logic.stock.effect.limiter", census: census, fallback: manifested ?? base),
+                fallbackState: manifested == nil ? .inferred : .manifested,
+                limitations: ["parameter control is not claimed"]
+            ),
+            unavailableEntry(
+                id: "logic.stock.effect.legacy.silververb",
+                displayName: "SilverVerb",
+                category: "Reverb",
+                census: census
+            ),
+        ]
+    }
+
+    private static func overlayProvenance(
+        id: String,
+        census: StockPluginCensus,
+        fallback: StockPluginProvenance
+    ) -> StockPluginProvenance {
+        if census.verifiedPluginIDs.contains(id) {
+            return .verified(
+                source: "live_logic",
+                method: "ax_insert_readback",
+                observedAt: census.observedAt,
+                logicVersion: census.logicVersion,
+                locale: census.locale,
+                evidence: ["plugin_identity_readback"]
+            )
+        }
+        if census.observedPluginIDs.contains(id) {
+            return StockPluginProvenance(
+                source: "live_logic",
+                method: "ax_menu_observation",
+                observedAt: census.observedAt,
+                logicVersion: census.logicVersion,
+                locale: census.locale,
+                sourcePath: nil,
+                inferenceReason: nil,
+                evidence: ["menu_item_observed"]
+            )
+        }
+        return fallback
+    }
+
+    private static func state(for provenance: StockPluginProvenance, fallback: StockPluginTruthState) -> StockPluginTruthState {
+        if provenance.source == "live_logic", provenance.method == "ax_insert_readback" { return .verified }
+        if provenance.source == "live_logic" { return .observed }
+        if provenance.source == "local_logic_app" { return .manifested }
+        return fallback
+    }
+
+    private static func entry(
+        id: String,
+        displayName: String,
+        type: StockPluginType,
+        category: String,
+        path: [String],
+        slotSupport: StockPluginSlotSupport,
+        provenance: StockPluginProvenance,
+        fallbackState: StockPluginTruthState,
+        parameters: [StockPluginParameterMetadata] = [],
+        safeWriteCapabilities: StockPluginSafeWriteCapability = .none,
+        knownPresets: [String] = [],
+        limitations: [String]
+    ) -> StockPluginCatalogEntry {
+        let availabilityState = state(for: provenance, fallback: fallbackState)
+        return StockPluginCatalogEntry(
+            id: id,
+            displayName: displayName,
+            type: type,
+            category: category,
+            availabilityState: availabilityState,
+            provenance: provenance,
+            insertPaths: [
+                StockPluginInsertPath(
+                    path: path,
+                    availabilityState: availabilityState,
+                    provenance: provenance
+                ),
+            ],
+            slotSupport: slotSupport,
+            knownPresets: knownPresets,
+            parameters: parameters,
+            safeWriteCapabilities: safeWriteCapabilities,
+            limitations: limitations
+        )
+    }
+
+    private static func unavailableEntry(
+        id: String,
+        displayName: String,
+        category: String,
+        census: StockPluginCensus
+    ) -> StockPluginCatalogEntry {
+        let provenance = StockPluginProvenance.unavailable(
+            method: "default_catalog_absence_marker",
+            observedAt: census.observedAt,
+            logicVersion: census.logicVersion,
+            locale: census.locale
+        )
+        return StockPluginCatalogEntry(
+            id: id,
+            displayName: displayName,
+            type: .effect,
+            category: category,
+            availabilityState: .unavailable,
+            provenance: provenance,
+            insertPaths: [],
+            slotSupport: StockPluginSlotSupport(audio: false, instrument: false, midiFX: false, aux: false),
+            knownPresets: [],
+            parameters: [],
+            safeWriteCapabilities: .none,
+            limitations: ["not available in the current supported stock-plugin catalog"]
+        )
+    }
+}

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -58,16 +58,22 @@ struct StockPluginProvenance: Codable, Sendable, Equatable {
         )
     }
 
-    static func unavailable(method: String, observedAt: String, logicVersion: String?, locale: String?) -> Self {
+    static func unavailable(
+        method: String,
+        observedAt: String,
+        logicVersion: String?,
+        locale: String?,
+        evidence: [String]
+    ) -> Self {
         Self(
-            source: "local_census",
+            source: "live_logic",
             method: method,
             observedAt: observedAt,
             logicVersion: logicVersion,
             locale: locale,
             sourcePath: nil,
             inferenceReason: nil,
-            evidence: ["absence_checked"]
+            evidence: evidence
         )
     }
 
@@ -91,6 +97,25 @@ struct StockPluginProvenance: Codable, Sendable, Equatable {
         )
     }
 
+    static func observed(
+        method: String,
+        observedAt: String,
+        logicVersion: String?,
+        locale: String?,
+        evidence: [String]
+    ) -> Self {
+        Self(
+            source: "live_logic",
+            method: method,
+            observedAt: observedAt,
+            logicVersion: logicVersion,
+            locale: locale,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: evidence
+        )
+    }
+
     static func verified(
         source: String,
         method: String,
@@ -102,6 +127,24 @@ struct StockPluginProvenance: Codable, Sendable, Equatable {
         Self(
             source: source,
             method: method,
+            observedAt: observedAt,
+            logicVersion: logicVersion,
+            locale: locale,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: evidence
+        )
+    }
+
+    static func readbackMismatch(
+        observedAt: String,
+        logicVersion: String?,
+        locale: String?,
+        evidence: [String]
+    ) -> Self {
+        Self(
+            source: "live_logic",
+            method: "ax_insert_readback",
             observedAt: observedAt,
             logicVersion: logicVersion,
             locale: locale,
@@ -253,6 +296,16 @@ struct StockPluginCatalogSnapshot: Codable, Sendable, Equatable {
     }
 }
 
+/// Per-plugin evidence harvested from the local Logic Pro installation.
+/// Presence of a factory "Plug-In Settings/<Display Name>" folder is positive,
+/// plugin-specific evidence (`manifested`). Absence of a folder is NOT
+/// evidence of absence — several real plugins ship presets elsewhere — so the
+/// probe only ever upgrades entries and never produces `unavailable`.
+struct StockPluginLocalManifest: Sendable, Equatable {
+    let sourcePath: String
+    let presetNames: [String]
+}
+
 struct StockPluginCensus: Sendable, Equatable {
     let observedAt: String
     let logicVersion: String?
@@ -260,20 +313,44 @@ struct StockPluginCensus: Sendable, Equatable {
     let logicAppPath: String?
     let verifiedPluginIDs: Set<String>
     let observedPluginIDs: Set<String>
+    let readbackMismatchPluginIDs: Set<String>
+    let unavailablePluginIDs: Set<String>
+    let localManifests: [String: StockPluginLocalManifest]
+
+    init(
+        observedAt: String,
+        logicVersion: String?,
+        locale: String,
+        logicAppPath: String?,
+        verifiedPluginIDs: Set<String> = [],
+        observedPluginIDs: Set<String> = [],
+        readbackMismatchPluginIDs: Set<String> = [],
+        unavailablePluginIDs: Set<String> = [],
+        localManifests: [String: StockPluginLocalManifest] = [:]
+    ) {
+        self.observedAt = observedAt
+        self.logicVersion = logicVersion
+        self.locale = locale
+        self.logicAppPath = logicAppPath
+        self.verifiedPluginIDs = verifiedPluginIDs
+        self.observedPluginIDs = observedPluginIDs
+        self.readbackMismatchPluginIDs = readbackMismatchPluginIDs
+        self.unavailablePluginIDs = unavailablePluginIDs
+        self.localManifests = localManifests
+    }
 
     static func production(now: Date = Date()) -> Self {
         let observedAt = ISO8601DateFormatter.cacheFormatter.string(from: now)
         let appPath = "/Applications/Logic Pro.app"
-        let bundle = Bundle(path: appPath)
+        let appPresent = FileManager.default.fileExists(atPath: appPath)
+        let bundle = appPresent ? Bundle(path: appPath) : nil
         let version = bundle?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        let existingPath = FileManager.default.fileExists(atPath: appPath) ? appPath : nil
         return Self(
             observedAt: observedAt,
             logicVersion: version,
             locale: Locale.current.identifier,
-            logicAppPath: existingPath,
-            verifiedPluginIDs: [],
-            observedPluginIDs: []
+            logicAppPath: appPresent ? appPath : nil,
+            localManifests: appPresent ? StockPluginCatalog.probeLocalManifests(appPath: appPath) : [:]
         )
     }
 
@@ -282,9 +359,7 @@ struct StockPluginCensus: Sendable, Equatable {
             observedAt: "2026-06-09T00:00:00.000Z",
             logicVersion: nil,
             locale: "en_US",
-            logicAppPath: nil,
-            verifiedPluginIDs: [],
-            observedPluginIDs: []
+            logicAppPath: nil
         )
     }
 }
@@ -298,6 +373,8 @@ enum StockPluginCatalogValidator {
             let base = "entries[\(index)]"
             if entry.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 issues.append(issue("missing_id", base, "plugin entry id is required"))
+            } else if entry.id.range(of: Self.idPattern, options: .regularExpression) == nil {
+                issues.append(issue("invalid_id_format", "\(base).id", "plugin id \(entry.id) must match \(Self.idPattern)"))
             }
             if !seen.insert(entry.id).inserted {
                 issues.append(issue("duplicate_id", "\(base).id", "duplicate plugin id \(entry.id)"))
@@ -314,7 +391,21 @@ enum StockPluginCatalogValidator {
             if entry.insertPaths.isEmpty && entry.availabilityState != .unavailable {
                 issues.append(issue("missing_insert_path", "\(base).insert_paths", "available entries need insert path hints"))
             }
+            if !entry.knownPresets.isEmpty && !hasPresetProvenance(entry.provenance) {
+                issues.append(issue(
+                    "presets_missing_provenance",
+                    "\(base).known_presets",
+                    "known presets require preset-name evidence in provenance"
+                ))
+            }
             for (pathIndex, insertPath) in entry.insertPaths.enumerated() {
+                if insertPath.path.isEmpty || insertPath.path.contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                    issues.append(issue(
+                        "invalid_insert_path",
+                        "\(base).insert_paths[\(pathIndex)].path",
+                        "insert path segments must be non-empty"
+                    ))
+                }
                 validateProvenance(
                     insertPath.provenance,
                     state: insertPath.availabilityState,
@@ -322,7 +413,30 @@ enum StockPluginCatalogValidator {
                     issues: &issues
                 )
             }
+            var seenParameterIDs = Set<String>()
             for (paramIndex, parameter) in entry.parameters.enumerated() {
+                if !seenParameterIDs.insert(parameter.id).inserted {
+                    issues.append(issue(
+                        "duplicate_parameter_id",
+                        "\(base).parameters[\(paramIndex)].id",
+                        "duplicate parameter id \(parameter.id)"
+                    ))
+                }
+                if let range = parameter.valueRange {
+                    if range.min > range.max {
+                        issues.append(issue(
+                            "invalid_value_range",
+                            "\(base).parameters[\(paramIndex)].value_range",
+                            "min must be <= max"
+                        ))
+                    } else if let def = range.defaultValue, def < range.min || def > range.max {
+                        issues.append(issue(
+                            "invalid_value_range",
+                            "\(base).parameters[\(paramIndex)].value_range",
+                            "default_value must sit within [min, max]"
+                        ))
+                    }
+                }
                 validateProvenance(
                     parameter.provenance,
                     state: parameter.availabilityState,
@@ -340,6 +454,13 @@ enum StockPluginCatalogValidator {
             }
         }
         return StockPluginValidationResult(isValid: issues.isEmpty, issues: issues)
+    }
+
+    static let idPattern = "^logic\\.stock\\.(effect|instrument|midi_fx)\\.[a-z0-9_]+$"
+
+    private static func hasPresetProvenance(_ provenance: StockPluginProvenance) -> Bool {
+        provenance.evidence.contains("factory_preset_filenames") ||
+            provenance.evidence.contains("preset_names_observed")
     }
 
     private static func validateProvenance(
@@ -360,7 +481,18 @@ enum StockPluginCatalogValidator {
                     "verified state requires source, method, observed_at, and evidence"
                 ))
             }
-        case .observed, .manifested, .unavailable, .readbackMismatch:
+        case .readbackMismatch:
+            if provenance.source.isEmpty ||
+                provenance.method.isEmpty ||
+                (provenance.observedAt?.isEmpty ?? true) ||
+                provenance.evidence.isEmpty {
+                issues.append(issue(
+                    "mismatch_missing_provenance",
+                    path,
+                    "readback_mismatch state requires source, method, observed_at, and evidence"
+                ))
+            }
+        case .observed, .manifested, .unavailable:
             if provenance.source.isEmpty ||
                 provenance.method.isEmpty ||
                 (provenance.observedAt?.isEmpty ?? true) {
@@ -387,8 +519,20 @@ enum StockPluginCatalogValidator {
 }
 
 enum StockPluginCatalog {
-    static func defaultSnapshot(census: StockPluginCensus = .production()) -> StockPluginCatalogSnapshot {
-        let entries = defaultEntries(census: census).sorted { $0.id < $1.id }
+    /// Process-wide production snapshot. The census probe (app bundle check +
+    /// per-plugin factory settings folders) runs once; resources then serve a
+    /// stable, cache-friendly payload with a constant `generated_at`.
+    static let productionSnapshot: StockPluginCatalogSnapshot = defaultSnapshot(census: .production())
+
+    /// Cap on factory preset names surfaced per entry, keeping the list
+    /// resource payload bounded. The full set remains on disk at the entry's
+    /// provenance `source_path`.
+    static let maxFactoryPresetNames = 12
+
+    static func defaultSnapshot(census: StockPluginCensus) -> StockPluginCatalogSnapshot {
+        let entries = seeds
+            .map { buildEntry(seed: $0, census: census) }
+            .sorted { $0.id < $1.id }
         let validation = StockPluginCatalogValidator.validate(entries)
         return StockPluginCatalogSnapshot(
             schemaVersion: 1,
@@ -402,28 +546,53 @@ enum StockPluginCatalog {
         )
     }
 
-    static func entry(id: String, snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> StockPluginCatalogEntry? {
+    static func entry(id: String, snapshot: StockPluginCatalogSnapshot = productionSnapshot) -> StockPluginCatalogEntry? {
         snapshot.entries.first { $0.id == id }
     }
 
-    static func search(query: String, snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> [StockPluginCatalogEntry] {
+    static func search(query: String, snapshot: StockPluginCatalogSnapshot = productionSnapshot) -> [StockPluginCatalogEntry] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return snapshot.entries }
         return snapshot.entries.filter { entry in
             entry.id.lowercased().contains(q) ||
                 entry.displayName.lowercased().contains(q) ||
                 entry.category.lowercased().contains(q) ||
+                entry.type.rawValue.contains(q) ||
                 entry.limitations.joined(separator: " ").lowercased().contains(q)
         }
     }
 
-    static func capabilities(snapshot: StockPluginCatalogSnapshot = defaultSnapshot()) -> [String: Any] {
+    static func capabilities(snapshot: StockPluginCatalogSnapshot = productionSnapshot) -> [String: Any] {
         [
             "schema_version": snapshot.schemaVersion,
             "generated_at": snapshot.generatedAt,
             "logic_version": snapshot.logicVersion ?? NSNull(),
             "catalog_source": snapshot.catalogSource,
             "truth_labels": StockPluginTruthState.allCases.map(\.rawValue),
+            "production_reachable_states": [
+                StockPluginTruthState.inferred.rawValue,
+                StockPluginTruthState.manifested.rawValue,
+            ],
+            "census_injectable_states": [
+                StockPluginTruthState.verified.rawValue,
+                StockPluginTruthState.observed.rawValue,
+                StockPluginTruthState.readbackMismatch.rawValue,
+                StockPluginTruthState.unavailable.rawValue,
+            ],
+            "state_semantics": [
+                "verified": "live insert/readback evidence on this machine",
+                "observed": "seen in a live Logic session without full readback",
+                "manifested": "per-plugin factory metadata found in the local Logic installation",
+                "inferred": "documented stock identity only; verify against the live menu",
+                "unavailable": "a live census recorded this plugin as absent",
+                "readback_mismatch": "live readback returned a different identity than expected",
+            ],
+            "id_namespaces": [
+                "logic.stock.effect.*",
+                "logic.stock.instrument.*",
+                "logic.stock.midi_fx.*",
+            ],
+            "preset_name_cap": maxFactoryPresetNames,
             "safe_write_capabilities": [
                 StockPluginSafeWriteCapability.none.rawValue,
                 StockPluginSafeWriteCapability.insertOnly.rawValue,
@@ -433,7 +602,7 @@ enum StockPluginCatalog {
             "resources": [
                 "logic://stock-plugins",
                 "logic://stock-plugins/{id}",
-                "logic://stock-plugins/search?query=<text>",
+                "logic://stock-plugins/search?query={query}",
                 "logic://stock-plugins/census",
                 "logic://stock-plugins/capabilities",
             ],
@@ -459,185 +628,382 @@ enum StockPluginCatalog {
         ]
     }
 
-    private static func defaultEntries(census: StockPluginCensus) -> [StockPluginCatalogEntry] {
-        let base = StockPluginProvenance.inferred(reason: "Logic stock plugin identity documented by project catalog; not live verified in this response")
-        let manifested: StockPluginProvenance? = census.logicAppPath.map {
-            StockPluginProvenance.manifested(
-                sourcePath: $0,
-                method: "logic_app_bundle_metadata",
-                observedAt: census.observedAt,
-                logicVersion: census.logicVersion,
-                locale: census.locale,
-                evidence: ["logic_app_bundle_present"]
-            )
-        }
+    // MARK: - Local installation probe
 
-        return [
-            entry(
-                id: "logic.stock.effect.channel_eq",
-                displayName: "Channel EQ",
-                type: .effect,
-                category: "EQ",
-                path: ["Audio FX", "EQ", "Channel EQ"],
-                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
-                provenance: overlayProvenance(id: "logic.stock.effect.channel_eq", census: census, fallback: manifested ?? base),
-                fallbackState: manifested == nil ? .inferred : .manifested,
-                limitations: ["parameter names and readback are not verified by this catalog"]
-            ),
-            entry(
-                id: "logic.stock.effect.compressor",
-                displayName: "Compressor",
-                type: .effect,
-                category: "Dynamics",
-                path: ["Audio FX", "Dynamics", "Compressor"],
-                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
-                provenance: overlayProvenance(id: "logic.stock.effect.compressor", census: census, fallback: manifested ?? base),
-                fallbackState: manifested == nil ? .inferred : .manifested,
-                limitations: ["model and parameter mapping are not verified by this catalog"]
-            ),
-            entry(
-                id: "logic.stock.effect.gain",
-                displayName: "Gain",
-                type: .utility,
-                category: "Utility",
-                path: ["Audio FX", "Utility", "Gain"],
-                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
-                provenance: overlayProvenance(id: "logic.stock.effect.gain", census: census, fallback: manifested ?? base),
-                fallbackState: manifested == nil ? .inferred : .manifested,
-                parameters: [
-                    StockPluginParameterMetadata(
-                        id: "gain",
-                        displayName: "Gain",
-                        unit: "dB",
-                        valueRange: StockPluginValueRange(min: -96, max: 24, defaultValue: 0),
-                        writeMethod: nil,
-                        readbackMethod: nil,
-                        availabilityState: .inferred,
-                        provenance: base
-                    ),
-                ],
-                safeWriteCapabilities: .insertOnly,
-                limitations: ["insert path is a hint unless live Logic evidence upgrades this entry"]
-            ),
-            entry(
-                id: "logic.stock.effect.limiter",
-                displayName: "Limiter",
-                type: .effect,
-                category: "Dynamics",
-                path: ["Audio FX", "Dynamics", "Limiter"],
-                slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true),
-                provenance: overlayProvenance(id: "logic.stock.effect.limiter", census: census, fallback: manifested ?? base),
-                fallbackState: manifested == nil ? .inferred : .manifested,
-                limitations: ["parameter control is not claimed"]
-            ),
-            unavailableEntry(
-                id: "logic.stock.effect.legacy.silververb",
-                displayName: "SilverVerb",
-                category: "Reverb",
-                census: census
-            ),
+    /// Factory plug-in settings roots. The app bundle root is authoritative
+    /// for the installed Logic version; the shared Application Support root
+    /// covers content installed via additional-content downloads.
+    static func factorySettingsRoots(appPath: String) -> [String] {
+        [
+            appPath + "/Contents/Resources/Plug-In Settings",
+            "/Library/Application Support/Logic/Plug-In Settings",
         ]
     }
 
-    private static func overlayProvenance(
-        id: String,
-        census: StockPluginCensus,
-        fallback: StockPluginProvenance
-    ) -> StockPluginProvenance {
-        if census.verifiedPluginIDs.contains(id) {
-            return .verified(
-                source: "live_logic",
-                method: "ax_insert_readback",
-                observedAt: census.observedAt,
-                logicVersion: census.logicVersion,
-                locale: census.locale,
-                evidence: ["plugin_identity_readback"]
-            )
+    static func probeLocalManifests(appPath: String) -> [String: StockPluginLocalManifest] {
+        let fm = FileManager.default
+        let roots = factorySettingsRoots(appPath: appPath)
+        var result: [String: StockPluginLocalManifest] = [:]
+        for seed in seeds {
+            for root in roots {
+                let folder = root + "/" + seed.name
+                var isDirectory: ObjCBool = false
+                guard fm.fileExists(atPath: folder, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
+                let presets = ((try? fm.contentsOfDirectory(atPath: folder)) ?? [])
+                    .filter { $0.hasSuffix(".pst") }
+                    .map { String($0.dropLast(4)) }
+                    .sorted()
+                result[seed.id] = StockPluginLocalManifest(
+                    sourcePath: folder,
+                    presetNames: Array(presets.prefix(maxFactoryPresetNames))
+                )
+                break
+            }
         }
-        if census.observedPluginIDs.contains(id) {
-            return StockPluginProvenance(
-                source: "live_logic",
-                method: "ax_menu_observation",
-                observedAt: census.observedAt,
-                logicVersion: census.logicVersion,
-                locale: census.locale,
-                sourcePath: nil,
-                inferenceReason: nil,
-                evidence: ["menu_item_observed"]
-            )
-        }
-        return fallback
+        return result
     }
 
-    private static func state(for provenance: StockPluginProvenance, fallback: StockPluginTruthState) -> StockPluginTruthState {
-        if provenance.source == "live_logic", provenance.method == "ax_insert_readback" { return .verified }
-        if provenance.source == "live_logic" { return .observed }
-        if provenance.source == "local_logic_app" { return .manifested }
-        return fallback
+    // MARK: - Seed catalog
+
+    private struct Seed {
+        let id: String
+        let name: String
+        let type: StockPluginType
+        let category: String
+        let menu: [String]
+        let write: StockPluginSafeWriteCapability
+        let parameters: [StockPluginParameterMetadata]
+        let notes: [String]
     }
 
-    private static func entry(
-        id: String,
-        displayName: String,
-        type: StockPluginType,
-        category: String,
-        path: [String],
-        slotSupport: StockPluginSlotSupport,
-        provenance: StockPluginProvenance,
-        fallbackState: StockPluginTruthState,
+    private static func fx(
+        _ idSuffix: String,
+        _ name: String,
+        _ category: String,
+        type: StockPluginType = .effect,
+        write: StockPluginSafeWriteCapability = .none,
         parameters: [StockPluginParameterMetadata] = [],
-        safeWriteCapabilities: StockPluginSafeWriteCapability = .none,
-        knownPresets: [String] = [],
-        limitations: [String]
-    ) -> StockPluginCatalogEntry {
-        let availabilityState = state(for: provenance, fallback: fallbackState)
-        return StockPluginCatalogEntry(
-            id: id,
-            displayName: displayName,
+        notes: [String] = []
+    ) -> Seed {
+        Seed(
+            id: "logic.stock.effect.\(idSuffix)",
+            name: name,
             type: type,
             category: category,
-            availabilityState: availabilityState,
-            provenance: provenance,
-            insertPaths: [
-                StockPluginInsertPath(
-                    path: path,
-                    availabilityState: availabilityState,
-                    provenance: provenance
-                ),
-            ],
-            slotSupport: slotSupport,
-            knownPresets: knownPresets,
+            menu: ["Audio FX", category, name],
+            write: write,
             parameters: parameters,
-            safeWriteCapabilities: safeWriteCapabilities,
-            limitations: limitations
+            notes: notes
         )
     }
 
-    private static func unavailableEntry(
-        id: String,
-        displayName: String,
-        category: String,
-        census: StockPluginCensus
-    ) -> StockPluginCatalogEntry {
-        let provenance = StockPluginProvenance.unavailable(
-            method: "default_catalog_absence_marker",
-            observedAt: census.observedAt,
-            logicVersion: census.logicVersion,
-            locale: census.locale
-        )
-        return StockPluginCatalogEntry(
-            id: id,
-            displayName: displayName,
-            type: .effect,
+    private static func inst(_ idSuffix: String, _ name: String, _ category: String, notes: [String] = []) -> Seed {
+        Seed(
+            id: "logic.stock.instrument.\(idSuffix)",
+            name: name,
+            type: .instrument,
             category: category,
-            availabilityState: .unavailable,
-            provenance: provenance,
-            insertPaths: [],
-            slotSupport: StockPluginSlotSupport(audio: false, instrument: false, midiFX: false, aux: false),
-            knownPresets: [],
+            menu: ["Instrument", name],
+            write: .none,
             parameters: [],
-            safeWriteCapabilities: .none,
-            limitations: ["not available in the current supported stock-plugin catalog"]
+            notes: notes
+        )
+    }
+
+    private static func midiFX(_ idSuffix: String, _ name: String, notes: [String] = []) -> Seed {
+        Seed(
+            id: "logic.stock.midi_fx.\(idSuffix)",
+            name: name,
+            type: .midiEffect,
+            category: "MIDI FX",
+            menu: ["MIDI FX", name],
+            write: .none,
+            parameters: [],
+            notes: notes
+        )
+    }
+
+    private static let gainParameters = [
+        StockPluginParameterMetadata(
+            id: "gain",
+            displayName: "Gain",
+            unit: "dB",
+            valueRange: StockPluginValueRange(min: -96, max: 24, defaultValue: 0),
+            writeMethod: nil,
+            readbackMethod: nil,
+            availabilityState: .inferred,
+            provenance: .inferred(reason: "documented Gain parameter range; no write/readback path is claimed")
+        ),
+    ]
+
+    /// Curated stock catalog seeds. Display names double as probe keys for the
+    /// factory settings folders, so they must match Logic's folder spelling
+    /// (e.g. "Ringshifter", "DeEsser 2", "Vintage B3").
+    private static let seeds: [Seed] = [
+        // EQ
+        fx("channel_eq", "Channel EQ", "EQ", write: .insertOnly),
+        fx("linear_phase_eq", "Linear Phase EQ", "EQ"),
+        fx("match_eq", "Match EQ", "EQ"),
+        fx("single_band_eq", "Single Band EQ", "EQ"),
+        fx("vintage_console_eq", "Vintage Console EQ", "EQ"),
+        fx("vintage_graphic_eq", "Vintage Graphic EQ", "EQ"),
+        fx("vintage_tube_eq", "Vintage Tube EQ", "EQ"),
+        // Dynamics
+        fx("adaptive_limiter", "Adaptive Limiter", "Dynamics"),
+        fx("compressor", "Compressor", "Dynamics", write: .insertOnly),
+        fx("deesser_2", "DeEsser 2", "Dynamics"),
+        fx("enveloper", "Enveloper", "Dynamics"),
+        fx("expander", "Expander", "Dynamics"),
+        fx("limiter", "Limiter", "Dynamics"),
+        fx("multipressor", "Multipressor", "Dynamics"),
+        fx("noise_gate", "Noise Gate", "Dynamics"),
+        // Reverb
+        fx("chromaverb", "ChromaVerb", "Reverb"),
+        fx("quantec_room_simulator", "Quantec Room Simulator", "Reverb", notes: ["introduced in Logic Pro 11.1; absent on older installs"]),
+        fx("silververb", "SilverVerb", "Reverb", notes: ["legacy plugin; may sit in a Legacy submenu depending on Logic version"]),
+        fx("space_designer", "Space Designer", "Reverb"),
+        // Delay
+        fx("delay_designer", "Delay Designer", "Delay"),
+        fx("echo", "Echo", "Delay"),
+        fx("sample_delay", "Sample Delay", "Delay"),
+        fx("stereo_delay", "Stereo Delay", "Delay"),
+        fx("tape_delay", "Tape Delay", "Delay"),
+        // Modulation
+        fx("chorus", "Chorus", "Modulation"),
+        fx("ensemble", "Ensemble", "Modulation"),
+        fx("flanger", "Flanger", "Modulation"),
+        fx("microphaser", "Microphaser", "Modulation"),
+        fx("modulation_delay", "Modulation Delay", "Modulation"),
+        fx("phaser", "Phaser", "Modulation"),
+        fx("ringshifter", "Ringshifter", "Modulation"),
+        fx("rotor_cabinet", "Rotor Cabinet", "Modulation"),
+        fx("scanner_vibrato", "Scanner Vibrato", "Modulation"),
+        fx("spreader", "Spreader", "Modulation"),
+        fx("tremolo", "Tremolo", "Modulation"),
+        // Distortion
+        fx("bitcrusher", "Bitcrusher", "Distortion"),
+        fx("chromaglow", "ChromaGlow", "Distortion", notes: ["requires Apple silicon; introduced in Logic Pro 11"]),
+        fx("clip_distortion", "Clip Distortion", "Distortion"),
+        fx("distortion", "Distortion", "Distortion"),
+        fx("distortion_ii", "Distortion II", "Distortion"),
+        fx("overdrive", "Overdrive", "Distortion"),
+        fx("phase_distortion", "Phase Distortion", "Distortion"),
+        // Filter
+        fx("autofilter", "AutoFilter", "Filter"),
+        fx("evoc_20_filterbank", "EVOC 20 Filterbank", "Filter"),
+        fx("fuzz_wah", "Fuzz-Wah", "Filter"),
+        fx("spectral_gate", "Spectral Gate", "Filter"),
+        // Imaging
+        fx("direction_mixer", "Direction Mixer", "Imaging"),
+        fx("stereo_spread", "Stereo Spread", "Imaging"),
+        // Pitch
+        fx("pitch_correction", "Pitch Correction", "Pitch"),
+        fx("pitch_shifter", "Pitch Shifter", "Pitch"),
+        fx("vocal_transformer", "Vocal Transformer", "Pitch"),
+        // Utility
+        fx("gain", "Gain", "Utility", type: .utility, write: .insertOnly, parameters: gainParameters,
+           notes: ["insert path is a hint unless live Logic evidence upgrades this entry"]),
+        fx("io", "I/O", "Utility", type: .utility, notes: ["external hardware insert utility"]),
+        fx("test_oscillator", "Test Oscillator", "Utility", type: .utility),
+        // Metering
+        fx("correlation_meter", "Correlation Meter", "Metering", type: .metering),
+        fx("level_meter", "Level Meter", "Metering", type: .metering),
+        fx("loudness_meter", "Loudness Meter", "Metering", type: .metering),
+        fx("multimeter", "MultiMeter", "Metering", type: .metering),
+        fx("tuner", "Tuner", "Metering", type: .metering),
+        // Specialized
+        fx("exciter", "Exciter", "Specialized"),
+        fx("subbass", "SubBass", "Specialized"),
+        // Multi Effects
+        fx("beat_breaker", "Beat Breaker", "Multi Effects", notes: ["introduced in Logic Pro 11"]),
+        fx("phat_fx", "Phat FX", "Multi Effects"),
+        fx("remix_fx", "Remix FX", "Multi Effects"),
+        fx("step_fx", "Step FX", "Multi Effects"),
+        // Amps and Pedals
+        fx("amp_designer", "Amp Designer", "Amps and Pedals"),
+        fx("bass_amp_designer", "Bass Amp Designer", "Amps and Pedals"),
+        fx("pedalboard", "Pedalboard", "Amps and Pedals"),
+        // Instruments
+        inst("alchemy", "Alchemy", "Synthesizer"),
+        inst("drum_kit_designer", "Drum Kit Designer", "Drums"),
+        inst("drum_machine_designer", "Drum Machine Designer", "Drums", notes: ["hosted via Drum Machine Designer track stacks"]),
+        inst("drum_synth", "Drum Synth", "Drums"),
+        inst("efm1", "EFM1", "Synthesizer"),
+        inst("es_e", "ES E", "Synthesizer", notes: ["legacy ensemble synth"]),
+        inst("es_m", "ES M", "Synthesizer", notes: ["legacy mono synth"]),
+        inst("es_p", "ES P", "Synthesizer", notes: ["legacy poly synth"]),
+        inst("es1", "ES1", "Synthesizer"),
+        inst("es2", "ES2", "Synthesizer"),
+        inst("evoc_20_polysynth", "EVOC 20 PolySynth", "Synthesizer"),
+        inst("external_instrument", "External Instrument", "Utility"),
+        inst("playback", "Playback", "Utility", notes: ["availability varies by Logic version"]),
+        inst("quick_sampler", "Quick Sampler", "Sampler"),
+        inst("retro_synth", "Retro Synth", "Synthesizer"),
+        inst("sample_alchemy", "Sample Alchemy", "Sampler"),
+        inst("sampler", "Sampler", "Sampler"),
+        inst("sculpture", "Sculpture", "Synthesizer"),
+        inst("studio_bass", "Studio Bass", "Bass", notes: ["introduced in Logic Pro 11"]),
+        inst("studio_horns", "Studio Horns", "Orchestral"),
+        inst("studio_strings", "Studio Strings", "Orchestral"),
+        inst("ultrabeat", "Ultrabeat", "Drums", notes: ["legacy drum synth"]),
+        inst("vintage_b3", "Vintage B3", "Keyboards"),
+        inst("vintage_clav", "Vintage Clav", "Keyboards"),
+        inst("vintage_electric_piano", "Vintage Electric Piano", "Keyboards"),
+        inst("vintage_mellotron", "Vintage Mellotron", "Keyboards"),
+        // MIDI FX
+        midiFX("arpeggiator", "Arpeggiator"),
+        midiFX("chord_trigger", "Chord Trigger"),
+        midiFX("modifier", "Modifier"),
+        midiFX("modulator", "Modulator"),
+        midiFX("note_repeater", "Note Repeater"),
+        midiFX("randomizer", "Randomizer"),
+        midiFX("scripter", "Scripter", notes: ["the MCP Scripter channel drives this plugin for parameter writes"]),
+        midiFX("transposer", "Transposer"),
+        midiFX("velocity_processor", "Velocity Processor"),
+    ]
+
+    static var seedCount: Int { seeds.count }
+
+    // MARK: - Census overlay
+
+    private static func buildEntry(seed: Seed, census: StockPluginCensus) -> StockPluginCatalogEntry {
+        let resolution = resolve(seedID: seed.id, census: census)
+
+        if resolution.state == .unavailable {
+            return StockPluginCatalogEntry(
+                id: seed.id,
+                displayName: seed.name,
+                type: seed.type,
+                category: seed.category,
+                availabilityState: .unavailable,
+                provenance: resolution.provenance,
+                insertPaths: [],
+                slotSupport: StockPluginSlotSupport(audio: false, instrument: false, midiFX: false, aux: false),
+                knownPresets: [],
+                parameters: [],
+                safeWriteCapabilities: .none,
+                limitations: seed.notes + ["recorded as absent by the current census"]
+            )
+        }
+
+        return StockPluginCatalogEntry(
+            id: seed.id,
+            displayName: seed.name,
+            type: seed.type,
+            category: seed.category,
+            availabilityState: resolution.state,
+            provenance: resolution.provenance,
+            insertPaths: [
+                StockPluginInsertPath(
+                    path: seed.menu,
+                    availabilityState: resolution.state,
+                    provenance: resolution.provenance
+                ),
+            ],
+            slotSupport: slotSupport(for: seed.type),
+            knownPresets: resolution.presetNames,
+            parameters: seed.parameters,
+            safeWriteCapabilities: seed.write,
+            limitations: seed.notes
+        )
+    }
+
+    private static func slotSupport(for type: StockPluginType) -> StockPluginSlotSupport {
+        switch type {
+        case .effect, .utility, .metering:
+            return StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true, stereo: true, mono: true)
+        case .instrument:
+            return StockPluginSlotSupport(audio: false, instrument: true, midiFX: false, aux: false)
+        case .midiEffect:
+            return StockPluginSlotSupport(audio: false, instrument: false, midiFX: true, aux: false)
+        }
+    }
+
+    private struct StateResolution {
+        let state: StockPluginTruthState
+        let provenance: StockPluginProvenance
+        let presetNames: [String]
+    }
+
+    /// Truth-state precedence: live evidence beats local metadata beats static
+    /// knowledge. Only census-injected sets can produce `verified`,
+    /// `observed`, `readback_mismatch`, or `unavailable`; the production probe
+    /// alone never claims more than `manifested`.
+    private static func resolve(seedID: String, census: StockPluginCensus) -> StateResolution {
+        if census.verifiedPluginIDs.contains(seedID) {
+            return StateResolution(
+                state: .verified,
+                provenance: .verified(
+                    source: "live_logic",
+                    method: "ax_insert_readback",
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: ["plugin_identity_readback"]
+                ),
+                presetNames: census.localManifests[seedID]?.presetNames ?? []
+            )
+        }
+        if census.readbackMismatchPluginIDs.contains(seedID) {
+            return StateResolution(
+                state: .readbackMismatch,
+                provenance: .readbackMismatch(
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: ["plugin_identity_readback_mismatch"]
+                ),
+                presetNames: []
+            )
+        }
+        if census.observedPluginIDs.contains(seedID) {
+            return StateResolution(
+                state: .observed,
+                provenance: .observed(
+                    method: "ax_menu_observation",
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: ["menu_item_observed"]
+                ),
+                presetNames: census.localManifests[seedID]?.presetNames ?? []
+            )
+        }
+        if census.unavailablePluginIDs.contains(seedID) {
+            return StateResolution(
+                state: .unavailable,
+                provenance: .unavailable(
+                    method: "live_census_absence",
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: ["absence_checked"]
+                ),
+                presetNames: []
+            )
+        }
+        if let manifest = census.localManifests[seedID] {
+            var evidence = ["factory_plugin_settings_folder"]
+            if !manifest.presetNames.isEmpty {
+                evidence.append("factory_preset_filenames")
+            }
+            return StateResolution(
+                state: .manifested,
+                provenance: .manifested(
+                    sourcePath: manifest.sourcePath,
+                    method: "factory_plugin_settings_probe",
+                    observedAt: census.observedAt,
+                    logicVersion: census.logicVersion,
+                    locale: census.locale,
+                    evidence: evidence
+                ),
+                presetNames: manifest.presetNames
+            )
+        }
+        return StateResolution(
+            state: .inferred,
+            provenance: .inferred(reason: "documented Logic stock plugin identity; not verified on this machine in this response"),
+            presetNames: []
         )
     }
 }

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -103,20 +103,8 @@ extension ResourceHandlers {
 
         await cache.recordToolAccess()
 
-        if uri == "logic://stock-plugins" {
-            return readStockPlugins(uri: uri)
-        }
-        if uri == "logic://stock-plugins/census" {
-            return readStockPluginCensus(uri: uri)
-        }
-        if uri == "logic://stock-plugins/capabilities" {
-            return readStockPluginCapabilities(uri: uri)
-        }
-        if uri.hasPrefix("logic://stock-plugins/search") {
-            return readStockPluginSearch(uri: uri)
-        }
-        if uri.hasPrefix("logic://stock-plugins/") {
-            return try readStockPluginDetail(uri: uri)
+        if uri == "logic://stock-plugins" || uri.hasPrefix("logic://stock-plugins/") || uri.hasPrefix("logic://stock-plugins?") {
+            return try readStockPluginResource(uri: uri)
         }
 
         // hasDocument gate removed (post-hardening): the StatePoller's view
@@ -198,14 +186,52 @@ extension ResourceHandlers {
         )
     }
 
+    /// Stock plugin discovery routing. Parsed with `URLComponents` so path and
+    /// query are matched exactly: unknown subpaths, nested segments, and stray
+    /// query parameters fail closed instead of silently degrading to a search
+    /// or a detail lookup.
+    private static func readStockPluginResource(uri: String) throws -> ReadResource.Result {
+        guard let components = URLComponents(string: uri),
+              components.scheme == "logic",
+              components.host == "stock-plugins" else {
+            throw MCPError.invalidParams("Malformed stock plugin resource URI: \(uri)")
+        }
+        let segments = components.path.split(separator: "/").map(String.init)
+        let queryItems = components.queryItems ?? []
+        let unknownParams = queryItems.map(\.name).filter { $0 != "query" }
+
+        if segments.isEmpty {
+            guard queryItems.isEmpty else {
+                throw MCPError.invalidParams("logic://stock-plugins does not accept query parameters")
+            }
+            return readStockPlugins(uri: uri)
+        }
+        guard segments.count == 1 else {
+            throw MCPError.invalidParams("Unknown stock plugin resource path: \(components.path)")
+        }
+        let segment = segments[0]
+
+        if segment == "search" {
+            guard unknownParams.isEmpty else {
+                throw MCPError.invalidParams("Unsupported search parameters: \(unknownParams.joined(separator: ", "))")
+            }
+            return readStockPluginSearch(uri: uri, query: queryItemValue(from: uri, name: "query") ?? "")
+        }
+        guard queryItems.isEmpty else {
+            throw MCPError.invalidParams("logic://stock-plugins/\(segment) does not accept query parameters")
+        }
+        if segment == "census" { return readStockPluginCensus(uri: uri) }
+        if segment == "capabilities" { return readStockPluginCapabilities(uri: uri) }
+        return try readStockPluginDetail(uri: uri, id: segment)
+    }
+
     private static func readStockPlugins(uri: String) -> ReadResource.Result {
-        let json = encodeJSON(StockPluginCatalog.defaultSnapshot(), compact: true)
+        let json = encodeJSON(StockPluginCatalog.productionSnapshot, compact: true)
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
     }
 
-    private static func readStockPluginDetail(uri: String) throws -> ReadResource.Result {
-        let id = String(uri.dropFirst("logic://stock-plugins/".count)).removingPercentEncoding ?? ""
-        let snapshot = StockPluginCatalog.defaultSnapshot()
+    private static func readStockPluginDetail(uri: String, id: String) throws -> ReadResource.Result {
+        let snapshot = StockPluginCatalog.productionSnapshot
         guard let entry = StockPluginCatalog.entry(id: id, snapshot: snapshot) else {
             throw MCPError.invalidParams("Unknown stock plugin id: \(id)")
         }
@@ -220,9 +246,8 @@ extension ResourceHandlers {
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
     }
 
-    private static func readStockPluginSearch(uri: String) -> ReadResource.Result {
-        let snapshot = StockPluginCatalog.defaultSnapshot()
-        let query = queryValue(from: uri) ?? ""
+    private static func readStockPluginSearch(uri: String, query: String) -> ReadResource.Result {
+        let snapshot = StockPluginCatalog.productionSnapshot
         let entries = StockPluginCatalog.search(query: query, snapshot: snapshot).map(jsonObject)
         let json = encodeJSONObject([
             "schema_version": snapshot.schemaVersion,
@@ -238,7 +263,7 @@ extension ResourceHandlers {
     }
 
     private static func readStockPluginCensus(uri: String) -> ReadResource.Result {
-        let snapshot = StockPluginCatalog.defaultSnapshot()
+        let snapshot = StockPluginCatalog.productionSnapshot
         let counts = Dictionary(grouping: snapshot.entries, by: { $0.availabilityState.rawValue })
             .mapValues(\.count)
         let json = encodeJSONObject([
@@ -257,28 +282,6 @@ extension ResourceHandlers {
     private static func readStockPluginCapabilities(uri: String) -> ReadResource.Result {
         let json = encodeJSONObject(StockPluginCatalog.capabilities())
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
-    }
-
-    private static func queryValue(from uri: String) -> String? {
-        URLComponents(string: uri)?
-            .queryItems?
-            .first { $0.name == "query" }?
-            .value?
-            .removingPercentEncoding
-    }
-
-    private static func jsonObject<T: Encodable>(_ value: T) -> Any {
-        let text = encodeJSON(value, compact: true)
-        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
-    }
-
-    private static func encodeJSONObject(_ object: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
-              let text = String(data: data, encoding: .utf8) else {
-            return #"{"error":"resource JSON encoding failed"}"#
-        }
-        return text
     }
 
     /// v3.1.8 (Issue #7) — tier-merged track list read.

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -221,7 +221,11 @@ extension ResourceHandlers {
             guard unknownParams.isEmpty else {
                 throw MCPError.invalidParams("Unsupported search parameters: \(unknownParams.joined(separator: ", "))")
             }
-            return readStockPluginSearch(uri: uri, query: queryItemValue(from: uri, name: "query") ?? "")
+            let queries = queryItems.filter { $0.name == "query" }
+            guard queries.count <= 1 else {
+                throw MCPError.invalidParams("logic://stock-plugins/search accepts at most one query parameter")
+            }
+            return readStockPluginSearch(uri: uri, query: queries.first?.value ?? "")
         }
         guard queryItems.isEmpty else {
             throw MCPError.invalidParams("logic://stock-plugins/\(segment) does not accept query parameters")

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -103,6 +103,22 @@ extension ResourceHandlers {
 
         await cache.recordToolAccess()
 
+        if uri == "logic://stock-plugins" {
+            return readStockPlugins(uri: uri)
+        }
+        if uri == "logic://stock-plugins/census" {
+            return readStockPluginCensus(uri: uri)
+        }
+        if uri == "logic://stock-plugins/capabilities" {
+            return readStockPluginCapabilities(uri: uri)
+        }
+        if uri.hasPrefix("logic://stock-plugins/search") {
+            return readStockPluginSearch(uri: uri)
+        }
+        if uri.hasPrefix("logic://stock-plugins/") {
+            return try readStockPluginDetail(uri: uri)
+        }
+
         // hasDocument gate removed (post-hardening): the StatePoller's view
         // of "document open" can flap during normal Logic UI activity (focus
         // switches, plugin windows). Sustained-read tests showed 80/200 reads
@@ -180,6 +196,89 @@ extension ResourceHandlers {
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
+    }
+
+    private static func readStockPlugins(uri: String) -> ReadResource.Result {
+        let json = encodeJSON(StockPluginCatalog.defaultSnapshot(), compact: true)
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readStockPluginDetail(uri: String) throws -> ReadResource.Result {
+        let id = String(uri.dropFirst("logic://stock-plugins/".count)).removingPercentEncoding ?? ""
+        let snapshot = StockPluginCatalog.defaultSnapshot()
+        guard let entry = StockPluginCatalog.entry(id: id, snapshot: snapshot) else {
+            throw MCPError.invalidParams("Unknown stock plugin id: \(id)")
+        }
+        let json = encodeJSONObject([
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "logic_version": snapshot.logicVersion ?? NSNull(),
+            "catalog_source": snapshot.catalogSource,
+            "entry": jsonObject(entry),
+            "validation": jsonObject(snapshot.validation),
+        ])
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readStockPluginSearch(uri: String) -> ReadResource.Result {
+        let snapshot = StockPluginCatalog.defaultSnapshot()
+        let query = queryValue(from: uri) ?? ""
+        let entries = StockPluginCatalog.search(query: query, snapshot: snapshot).map(jsonObject)
+        let json = encodeJSONObject([
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "logic_version": snapshot.logicVersion ?? NSNull(),
+            "catalog_source": snapshot.catalogSource,
+            "query": query,
+            "entries": entries,
+            "result_count": entries.count,
+            "validation": jsonObject(snapshot.validation),
+        ])
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readStockPluginCensus(uri: String) -> ReadResource.Result {
+        let snapshot = StockPluginCatalog.defaultSnapshot()
+        let counts = Dictionary(grouping: snapshot.entries, by: { $0.availabilityState.rawValue })
+            .mapValues(\.count)
+        let json = encodeJSONObject([
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "logic_version": snapshot.logicVersion ?? NSNull(),
+            "locale": snapshot.locale,
+            "catalog_source": snapshot.catalogSource,
+            "plugin_count": snapshot.pluginCount,
+            "entries_by_state": counts,
+            "validation": jsonObject(snapshot.validation),
+        ])
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readStockPluginCapabilities(uri: String) -> ReadResource.Result {
+        let json = encodeJSONObject(StockPluginCatalog.capabilities())
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func queryValue(from uri: String) -> String? {
+        URLComponents(string: uri)?
+            .queryItems?
+            .first { $0.name == "query" }?
+            .value?
+            .removingPercentEncoding
+    }
+
+    private static func jsonObject<T: Encodable>(_ value: T) -> Any {
+        let text = encodeJSON(value, compact: true)
+        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
+    }
+
+    private static func encodeJSONObject(_ object: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"resource JSON encoding failed"}"#
+        }
+        return text
     }
 
     /// v3.1.8 (Issue #7) — tier-merged track list read.

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -197,6 +197,12 @@ extension ResourceHandlers {
             throw MCPError.invalidParams("Malformed stock plugin resource URI: \(uri)")
         }
         let segments = components.path.split(separator: "/").map(String.init)
+        // Reject doubled or trailing slashes ("//census", "census/") — the
+        // canonical reconstruction must reproduce the raw path exactly.
+        let canonicalPath = segments.isEmpty ? "" : "/" + segments.joined(separator: "/")
+        guard components.path == canonicalPath else {
+            throw MCPError.invalidParams("Malformed stock plugin resource path: \(components.path)")
+        }
         let queryItems = components.queryItems ?? []
         let unknownParams = queryItems.map(\.name).filter { $0 != "query" }
 

--- a/Sources/LogicProMCP/Resources/ResourceJSONHelpers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceJSONHelpers.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Shared JSON plumbing for static catalog resources (stock plugins, workflow
+/// skills). Kept in one file so independent feature branches can add their own
+/// resource handlers without colliding on duplicated private helpers.
+extension ResourceHandlers {
+    /// Decoded value of a single query item. `URLComponents` already
+    /// percent-decodes `value`; no second decode is applied.
+    static func queryItemValue(from uri: String, name: String) -> String? {
+        URLComponents(string: uri)?
+            .queryItems?
+            .first { $0.name == name }?
+            .value
+    }
+
+    static func jsonObject<T: Encodable>(_ value: T) -> Any {
+        let text = encodeJSON(value, compact: true)
+        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
+    }
+
+    static func encodeJSONObject(_ object: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"resource JSON encoding failed"}"#
+        }
+        return text
+    }
+}

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -110,6 +110,27 @@ struct ResourceProvider {
             mimeType: "application/json",
             annotations: annotations(priority: 0.4)
         ),
+        Resource(
+            name: "Stock Plugin Intelligence",
+            uri: "logic://stock-plugins",
+            description: "Read-only Logic stock plugin catalog with truth labels, provenance, and limitations",
+            mimeType: "application/json",
+            annotations: annotations(priority: 0.45)
+        ),
+        Resource(
+            name: "Stock Plugin Census",
+            uri: "logic://stock-plugins/census",
+            description: "Current-machine stock plugin catalog census metadata and validation state",
+            mimeType: "application/json",
+            annotations: annotations(priority: 0.35)
+        ),
+        Resource(
+            name: "Stock Plugin Capabilities",
+            uri: "logic://stock-plugins/capabilities",
+            description: "Stock plugin catalog schema capabilities, truth labels, and read-only contract",
+            mimeType: "application/json",
+            annotations: annotations(priority: 0.35)
+        ),
     ]
 
     private static let baseTemplates: [Resource.Template] = [
@@ -129,6 +150,18 @@ struct ResourceProvider {
             uriTemplate: "logic://mixer/{strip}",
             name: "Channel Strip Detail",
             description: "Single channel strip by index (volume, pan, plugin chain)",
+            mimeType: "application/json"
+        ),
+        Resource.Template(
+            uriTemplate: "logic://stock-plugins/{id}",
+            name: "Stock Plugin Detail",
+            description: "Single stock plugin catalog entry by stable ID",
+            mimeType: "application/json"
+        ),
+        Resource.Template(
+            uriTemplate: "logic://stock-plugins/search?query={query}",
+            name: "Stock Plugin Search",
+            description: "Search stock plugin catalog entries by query",
             mimeType: "application/json"
         ),
     ]

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -166,18 +166,24 @@ enum HonestContract {
     /// suppress fallback when the primary channel has already reported an
     /// error the next channel cannot improve on.
     static func isTerminalStateC(_ message: String) -> Bool {
-        guard message.hasPrefix("{") else { return false }
+        guard let errorCode = stateCErrorCode(message) else { return false }
+        return terminalErrorCodes.contains(errorCode)
+    }
+
+    /// Returns the stable State C error code for a valid Honest Contract
+    /// failure envelope, or nil for free-form text / State A / State B.
+    static func stateCErrorCode(_ message: String) -> String? {
+        guard message.hasPrefix("{") else { return nil }
         guard let data = message.data(using: .utf8),
               let raw = try? JSONSerialization.jsonObject(with: data),
               let obj = raw as? [String: Any] else {
-            return false
+            return nil
         }
         // State A / B both carry `success:true`; only State C is `false`.
         guard let success = obj["success"] as? Bool, success == false else {
-            return false
+            return nil
         }
-        guard let errorCode = obj["error"] as? String else { return false }
-        return terminalErrorCodes.contains(errorCode)
+        return obj["error"] as? String
     }
 
     // MARK: - JSON serialization

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -444,6 +444,7 @@ private func makeAXBackedAccessibilityChannel(
     #expect(!pressFailure.isSuccess)
     #expect(pressFailure.message.contains("\"error\":\"ax_write_failed\""))
     #expect(pressFailure.message.contains("AXPress failed on transport button 'Metronome'"))
+    #expect(!HonestContract.isTerminalStateC(pressFailure.message))
 }
 
 @Test func testAccessibilityChannelAXBackedTempoFallbackCanBeInjected() async {

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -307,6 +307,54 @@ actor TerminalStateCChannel: Channel {
     #expect(mcuOps.count == 1)
 }
 
+@Test func testTransportToggleAXButtonMissFallsThroughToKeyCmd() async {
+    let router = ChannelRouter()
+    let ax = TerminalStateCChannel(
+        id: .accessibility,
+        envelope: HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button 'Metronome' not located in control bar",
+            extras: ["button": "Metronome"]
+        )
+    )
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(ax)
+    await router.register(keyCmd)
+
+    let result = await router.route(operation: "transport.toggle_metronome")
+
+    #expect(result.isSuccess, "transport toggle should fall through when AX control-bar lookup misses")
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "transport.toggle_metronome")
+}
+
+@Test func testTransportToggleCyclePrefersKeyCmdBeforeMCUAfterAXButtonMiss() async {
+    let router = ChannelRouter()
+    let ax = TerminalStateCChannel(
+        id: .accessibility,
+        envelope: HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button 'Cycle' not located in control bar",
+            extras: ["button": "Cycle"]
+        )
+    )
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    let mcu = MockChannel(id: .mcu)
+    await router.register(ax)
+    await router.register(keyCmd)
+    await router.register(mcu)
+
+    let result = await router.route(operation: "transport.toggle_cycle")
+
+    #expect(result.isSuccess, "cycle toggle should use learned key command before MCU readback-unavailable success")
+    let keyCmdOps = await keyCmd.executedOps
+    let mcuOps = await mcu.executedOps
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "transport.toggle_cycle")
+    #expect(mcuOps.isEmpty)
+}
+
 @Test func testRouterStartAllReportsChannelFailures() async {
     let router = ChannelRouter()
     await router.register(MockChannel(id: .coreMIDI))

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -810,9 +810,9 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 @Test func testE2EServerCatalogAdvertisesAllResources() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(snapshot.resourceURIs.count == 12)
+    #expect(snapshot.resourceURIs.count >= 12)
     let uris = Set(snapshot.resourceURIs)
-    #expect(uris == [
+    let expectedResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -825,18 +825,20 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://stock-plugins",
         "logic://stock-plugins/census",
         "logic://stock-plugins/capabilities",
-    ])
+    ]
+    #expect(expectedResources.isSubset(of: uris))
 }
 
 @Test func testE2EServerCatalogAdvertisesAllTemplates() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(Set(snapshot.templateURIs) == [
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
-    ])
+    ]
+    #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
 }
 
 @Test func testE2EServerCatalogHas7Channels() async {

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -692,7 +692,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// MARK: - §10 Resource Read Chain (8 tests)
+// MARK: - §10 Resource Read Chain (10 tests)
 // ═══════════════════════════════════════════════════════════════════════
 
 @Test func testE2EResourceTransportStateIsValidJSON() async throws {
@@ -745,6 +745,21 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     let _ = try JSONSerialization.jsonObject(with: Data(text.utf8))
 }
 
+@Test func testE2EResourceStockPluginsExposeTruthLabels() async throws {
+    let h = await makeE2EHandlers()
+    let list = try await h.readResource(.init(uri: "logic://stock-plugins"))
+    let detail = try await h.readResource(.init(uri: "logic://stock-plugins/logic.stock.effect.gain"))
+    let search = try await h.readResource(.init(uri: "logic://stock-plugins/search?query=gain"))
+
+    let listJSON = e2eJSON(e2eResourceText(list))
+    let detailJSON = e2eJSON(e2eResourceText(detail))
+    let searchJSON = e2eJSON(e2eResourceText(search))
+    #expect(listJSON?["schema_version"] as? Int == 1)
+    #expect((listJSON?["validation"] as? [String: Any])?["is_valid"] as? Bool == true)
+    #expect((detailJSON?["entry"] as? [String: Any])?["availability_state"] != nil)
+    #expect((searchJSON?["entries"] as? [[String: Any]])?.isEmpty == false)
+}
+
 @Test func testE2EResourceHealthMatchesToolHealth() async throws {
     let h = await makeE2EHandlers()
     let resourceResult = try await h.readResource(.init(uri: "logic://system/health"))
@@ -795,7 +810,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 @Test func testE2EServerCatalogAdvertisesAllResources() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(snapshot.resourceURIs.count == 9)
+    #expect(snapshot.resourceURIs.count == 12)
     let uris = Set(snapshot.resourceURIs)
     #expect(uris == [
         "logic://system/health",
@@ -807,6 +822,9 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://midi/ports",
         "logic://mcu/state",
         "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
     ])
 }
 
@@ -816,6 +834,8 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://stock-plugins/{id}",
+        "logic://stock-plugins/search?query={query}",
     ])
 }
 

--- a/Tests/LogicProMCPTests/HonestContractTests.swift
+++ b/Tests/LogicProMCPTests/HonestContractTests.swift
@@ -95,6 +95,17 @@ import Testing
     #expect(HonestContract.terminalErrorCodes.contains("readback_unavailable"))
 }
 
+@Test func testStateCErrorCodeExtraction() {
+    let terminal = HonestContract.encodeStateC(error: .elementNotFound)
+    let nonTerminal = HonestContract.encodeStateC(error: .axWriteFailed)
+    let uncertain = HonestContract.encodeStateB(reason: .readbackUnavailable)
+
+    #expect(HonestContract.stateCErrorCode(terminal) == "element_not_found")
+    #expect(HonestContract.stateCErrorCode(nonTerminal) == "ax_write_failed")
+    #expect(HonestContract.stateCErrorCode(uncertain) == nil)
+    #expect(HonestContract.stateCErrorCode("not json") == nil)
+}
+
 @Test func testJSONIsSortedKeyDeterministic() {
     let a = HonestContract.jsonString(["b": 1, "a": 2])
     let b = HonestContract.jsonString(["a": 2, "b": 1])

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -36,11 +36,16 @@ private let serverResourceText = sharedResourceText
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
     ])
     #expect(templates.templates.map(\.uriTemplate) == [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://stock-plugins/{id}",
+        "logic://stock-plugins/search?query={query}",
     ])
 }
 
@@ -248,6 +253,9 @@ private let serverResourceText = sharedResourceText
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
     ])
     // server.start() runs serve() to completion then tears poller/channels/ports
     // down in reverse order. With serve recorded as a no-op, the tail section

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -27,7 +27,8 @@ private let serverResourceText = sharedResourceText
     ])
     // MCU disconnected by default in a fresh LogicProServer, so the list
     // excludes `logic://mcu/state`.
-    #expect(resources.resources.map(\.uri) == [
+    let resourceURIs = Set(resources.resources.map(\.uri))
+    let expectedNonMCUResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -39,14 +40,18 @@ private let serverResourceText = sharedResourceText
         "logic://stock-plugins",
         "logic://stock-plugins/census",
         "logic://stock-plugins/capabilities",
-    ])
-    #expect(templates.templates.map(\.uriTemplate) == [
+    ]
+    #expect(expectedNonMCUResources.isSubset(of: resourceURIs))
+    #expect(!resourceURIs.contains("logic://mcu/state"))
+    let templateURIs = Set(templates.templates.map(\.uriTemplate))
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
-    ])
+    ]
+    #expect(expectedTemplates.isSubset(of: templateURIs))
 }
 
 @Test func testLogicProServerHandlersDispatchToolNamesWithoutStartingServer() async {
@@ -244,7 +249,7 @@ private let serverResourceText = sharedResourceText
     // MCU is disconnected in a fresh cache, so `logic://mcu/state` is filtered
     // out. Non-MCU resources (markers, library/inventory, …) remain visible.
     let uris = Set(resources.resources.map(\.uri))
-    #expect(uris == [
+    let expectedNonMCUResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -256,7 +261,9 @@ private let serverResourceText = sharedResourceText
         "logic://stock-plugins",
         "logic://stock-plugins/census",
         "logic://stock-plugins/capabilities",
-    ])
+    ]
+    #expect(expectedNonMCUResources.isSubset(of: uris))
+    #expect(!uris.contains("logic://mcu/state"))
     // server.start() runs serve() to completion then tears poller/channels/ports
     // down in reverse order. With serve recorded as a no-op, the tail section
     // executes immediately so stopPoller is captured too.

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -395,18 +395,23 @@ private func waitForFeedbackEvents(
         "logic://midi/ports",
         "logic://mcu/state",
         "logic://library/inventory",
+        "logic://stock-plugins",
+        "logic://stock-plugins/census",
+        "logic://stock-plugins/capabilities",
     ])
     #expect(snapshot.templateURIs == [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://stock-plugins/{id}",
+        "logic://stock-plugins/search?query={query}",
     ])
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 4 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {
     let banner = ServerCatalog.startupBanner(channelCount: 7)
-    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 7 channels")
+    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 7 channels")
 }
 
 @Test func testLogicProServerCompositionSnapshotMatchesExpectedOrder() async {
@@ -425,5 +430,5 @@ private func waitForFeedbackEvents(
     ])
     #expect(snapshot.toolNames.count == 8)
     #expect(snapshot.resourceURIs.contains("logic://system/health"))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 7 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 7 channels")
 }

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -385,7 +385,7 @@ private func waitForFeedbackEvents(
         "logic_project",
         "logic_system",
     ])
-    #expect(snapshot.resourceURIs == [
+    let expectedResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -398,20 +398,22 @@ private func waitForFeedbackEvents(
         "logic://stock-plugins",
         "logic://stock-plugins/census",
         "logic://stock-plugins/capabilities",
-    ])
-    #expect(snapshot.templateURIs == [
+    ]
+    #expect(expectedResources.isSubset(of: Set(snapshot.resourceURIs)))
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
-    ])
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 4 channels")
+    ]
+    #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {
     let banner = ServerCatalog.startupBanner(channelCount: 7)
-    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 7 channels")
+    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }
 
 @Test func testLogicProServerCompositionSnapshotMatchesExpectedOrder() async {
@@ -430,5 +432,5 @@ private func waitForFeedbackEvents(
     ])
     #expect(snapshot.toolNames.count == 8)
     #expect(snapshot.resourceURIs.contains("logic://system/health"))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 7 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }

--- a/Tests/LogicProMCPTests/ResourceProviderTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProviderTests.swift
@@ -20,19 +20,24 @@ struct ResourceProviderTests {
         #expect(uris.count == Set(uris).count, "Duplicate template URI: \(uris)")
     }
 
-    @Test("new resources are registered: markers, mcu/state, library/inventory")
+    @Test("new resources are registered: markers, mcu/state, library/inventory, stock plugins")
     func newResourcesRegistered() {
         let uris = Set(ResourceProvider.resources.map(\.uri))
         #expect(uris.contains("logic://markers"))
         #expect(uris.contains("logic://mcu/state"))
         #expect(uris.contains("logic://library/inventory"))
+        #expect(uris.contains("logic://stock-plugins"))
+        #expect(uris.contains("logic://stock-plugins/census"))
+        #expect(uris.contains("logic://stock-plugins/capabilities"))
     }
 
-    @Test("new templates are registered: regions per track, mixer per strip")
+    @Test("new templates are registered: regions per track, mixer per strip, catalog/search detail")
     func newTemplatesRegistered() {
         let uris = Set(ResourceProvider.templates.map(\.uriTemplate))
         #expect(uris.contains("logic://tracks/{index}/regions"))
         #expect(uris.contains("logic://mixer/{strip}"))
+        #expect(uris.contains("logic://stock-plugins/{id}"))
+        #expect(uris.contains("logic://stock-plugins/search?query={query}"))
     }
 
     @Test("every static resource URI maps to a handler")

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -8,10 +8,20 @@ private func stockPluginResourceObject(_ uri: String) async throws -> [String: A
     return try #require(sharedJSONObject(sharedResourceText(result)))
 }
 
+private func stockPluginResourceThrows(_ uri: String) async -> Bool {
+    do {
+        _ = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+        return false
+    } catch {
+        return true
+    }
+}
+
 private func makeStockPluginEntry(
     id: String,
     state: StockPluginTruthState,
     provenance: StockPluginProvenance,
+    knownPresets: [String] = [],
     parameters: [StockPluginParameterMetadata] = []
 ) -> StockPluginCatalogEntry {
     StockPluginCatalogEntry(
@@ -29,15 +39,35 @@ private func makeStockPluginEntry(
             ),
         ],
         slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true),
-        knownPresets: [],
+        knownPresets: knownPresets,
         parameters: parameters,
         safeWriteCapabilities: .insertOnly,
         limitations: ["fixture"]
     )
 }
 
-@Suite("Stock plugin intelligence")
-struct StockPluginCatalogTests {
+private func censusFixture(
+    verified: Set<String> = [],
+    observed: Set<String> = [],
+    mismatched: Set<String> = [],
+    unavailable: Set<String> = [],
+    manifests: [String: StockPluginLocalManifest] = [:]
+) -> StockPluginCensus {
+    StockPluginCensus(
+        observedAt: "2026-06-10T00:00:00.000Z",
+        logicVersion: "12.2",
+        locale: "en_US",
+        logicAppPath: "/Applications/Logic Pro.app",
+        verifiedPluginIDs: verified,
+        observedPluginIDs: observed,
+        readbackMismatchPluginIDs: mismatched,
+        unavailablePluginIDs: unavailable,
+        localManifests: manifests
+    )
+}
+
+@Suite("Stock plugin intelligence — validator")
+struct StockPluginValidatorTests {
     @Test("validator rejects duplicate stable IDs")
     func duplicateIDsRejected() {
         let provenance = StockPluginProvenance.inferred(reason: "fixture")
@@ -48,6 +78,18 @@ struct StockPluginCatalogTests {
 
         let issues = StockPluginCatalogValidator.validate(entries).issues
         #expect(issues.contains { $0.code == "duplicate_id" })
+    }
+
+    @Test("validator rejects malformed stable IDs")
+    func invalidIDFormatRejected() {
+        let provenance = StockPluginProvenance.inferred(reason: "fixture")
+        let badIDs = ["Gain", "logic.stock.thirdparty.gain", "logic.stock.effect.Gain", "logic.stock.effect."]
+        for badID in badIDs {
+            let issues = StockPluginCatalogValidator.validate(
+                [makeStockPluginEntry(id: badID, state: .inferred, provenance: provenance)]
+            ).issues
+            #expect(issues.contains { $0.code == "invalid_id_format" }, "expected invalid_id_format for \(badID)")
+        }
     }
 
     @Test("verified entries require source, method, timestamp, and evidence")
@@ -66,6 +108,47 @@ struct StockPluginCatalogTests {
 
         let issues = StockPluginCatalogValidator.validate(entries).issues
         #expect(issues.contains { $0.code == "verified_missing_provenance" })
+    }
+
+    @Test("readback_mismatch entries require evidence")
+    func readbackMismatchRequiresEvidence() {
+        let bad = StockPluginProvenance(
+            source: "live_logic",
+            method: "ax_insert_readback",
+            observedAt: "2026-06-10T00:00:00Z",
+            logicVersion: nil,
+            locale: nil,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: []
+        )
+        let entries = [makeStockPluginEntry(id: "logic.stock.effect.gain", state: .readbackMismatch, provenance: bad)]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "mismatch_missing_provenance" })
+    }
+
+    @Test("non-empty known presets require preset-name evidence")
+    func presetsRequireProvenance() {
+        let provenance = StockPluginProvenance.manifested(
+            sourcePath: "/x",
+            method: "factory_plugin_settings_probe",
+            observedAt: "2026-06-10T00:00:00Z",
+            logicVersion: "12.2",
+            locale: "en_US",
+            evidence: ["factory_plugin_settings_folder"]
+        )
+        let entries = [
+            makeStockPluginEntry(
+                id: "logic.stock.effect.gain",
+                state: .manifested,
+                provenance: provenance,
+                knownPresets: ["Fabricated Preset"]
+            ),
+        ]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "presets_missing_provenance" })
     }
 
     @Test("verified parameters require explicit readback evidence")
@@ -101,18 +184,165 @@ struct StockPluginCatalogTests {
         #expect(issues.contains { $0.code == "verified_parameter_missing_readback" })
     }
 
-    @Test("default catalog includes honest inferred and unavailable states")
-    func defaultCatalogHasConservativeTruthLabels() {
-        let snapshot = StockPluginCatalog.defaultSnapshot()
-        let states = Set(snapshot.entries.map(\.availabilityState))
+    @Test("parameter value ranges and duplicate parameter IDs are validated")
+    func parameterSanityValidated() {
+        let provenance = StockPluginProvenance.inferred(reason: "fixture")
+        let invertedRange = StockPluginParameterMetadata(
+            id: "gain",
+            displayName: "Gain",
+            unit: "dB",
+            valueRange: StockPluginValueRange(min: 10, max: -10, defaultValue: nil),
+            writeMethod: nil,
+            readbackMethod: nil,
+            availabilityState: .inferred,
+            provenance: provenance
+        )
+        let outOfRangeDefault = StockPluginParameterMetadata(
+            id: "mix",
+            displayName: "Mix",
+            unit: "%",
+            valueRange: StockPluginValueRange(min: 0, max: 100, defaultValue: 250),
+            writeMethod: nil,
+            readbackMethod: nil,
+            availabilityState: .inferred,
+            provenance: provenance
+        )
+        let duplicate = StockPluginParameterMetadata(
+            id: "mix",
+            displayName: "Mix Copy",
+            unit: nil,
+            valueRange: nil,
+            writeMethod: nil,
+            readbackMethod: nil,
+            availabilityState: .inferred,
+            provenance: provenance
+        )
+        let entries = [
+            makeStockPluginEntry(
+                id: "logic.stock.effect.gain",
+                state: .inferred,
+                provenance: provenance,
+                parameters: [invertedRange, outOfRangeDefault, duplicate]
+            ),
+        ]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.filter { $0.code == "invalid_value_range" }.count == 2)
+        #expect(issues.contains { $0.code == "duplicate_parameter_id" })
+    }
+}
+
+@Suite("Stock plugin intelligence — catalog and census")
+struct StockPluginCatalogTests {
+    @Test("deterministic census yields a fully inferred, valid catalog")
+    func deterministicCatalogIsFullyInferred() {
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: .deterministic())
 
         #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.catalogSource == "static_catalog")
+        #expect(snapshot.pluginCount == StockPluginCatalog.seedCount)
+        #expect(snapshot.entries.count == StockPluginCatalog.seedCount)
+        #expect(snapshot.entries.allSatisfy { $0.availabilityState == .inferred })
+        #expect(snapshot.entries.allSatisfy { $0.knownPresets.isEmpty })
+        #expect(snapshot.entries.map(\.id) == snapshot.entries.map(\.id).sorted())
+        #expect(snapshot.validation.isValid, "deterministic catalog should validate: \(snapshot.validation.issues)")
         #expect(snapshot.entries.contains { $0.id == "logic.stock.effect.gain" })
-        #expect(states.contains(.inferred) || states.contains(.manifested) || states.contains(.verified))
-        #expect(states.contains(.unavailable))
-        #expect(snapshot.validation.isValid, "default catalog should validate: \(snapshot.validation.issues)")
+        #expect(snapshot.entries.contains { $0.id == "logic.stock.instrument.alchemy" })
+        #expect(snapshot.entries.contains { $0.id == "logic.stock.midi_fx.scripter" })
     }
 
+    @Test("census overlay produces every injectable truth state with provenance")
+    func censusOverlayProducesAllStates() throws {
+        let census = censusFixture(
+            verified: ["logic.stock.effect.gain"],
+            observed: ["logic.stock.effect.compressor"],
+            mismatched: ["logic.stock.effect.channel_eq"],
+            unavailable: ["logic.stock.effect.silververb"],
+            manifests: [
+                "logic.stock.effect.limiter": StockPluginLocalManifest(
+                    sourcePath: "/Applications/Logic Pro.app/Contents/Resources/Plug-In Settings/Limiter",
+                    presetNames: ["Drum Limiter", "Vocal Limiter"]
+                ),
+            ]
+        )
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: census)
+        #expect(snapshot.validation.isValid, "overlaid catalog should validate: \(snapshot.validation.issues)")
+
+        let verified = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.gain" })
+        #expect(verified.availabilityState == .verified)
+        #expect(verified.provenance.evidence.contains("plugin_identity_readback"))
+
+        let observed = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.compressor" })
+        #expect(observed.availabilityState == .observed)
+        #expect(observed.provenance.method == "ax_menu_observation")
+
+        let mismatched = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.channel_eq" })
+        #expect(mismatched.availabilityState == .readbackMismatch)
+        #expect(mismatched.provenance.evidence.contains("plugin_identity_readback_mismatch"))
+
+        let unavailable = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.silververb" })
+        #expect(unavailable.availabilityState == .unavailable)
+        #expect(unavailable.insertPaths.isEmpty)
+        #expect(unavailable.safeWriteCapabilities == StockPluginSafeWriteCapability.none)
+        #expect(unavailable.provenance.evidence.contains("absence_checked"))
+
+        let manifested = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.limiter" })
+        #expect(manifested.availabilityState == .manifested)
+        #expect(manifested.knownPresets == ["Drum Limiter", "Vocal Limiter"])
+        #expect(manifested.provenance.sourcePath?.hasSuffix("Plug-In Settings/Limiter") == true)
+        #expect(manifested.provenance.evidence.contains("factory_plugin_settings_folder"))
+        #expect(manifested.provenance.evidence.contains("factory_preset_filenames"))
+    }
+
+    @Test("production snapshot never claims more than manifested")
+    func productionSnapshotIsConservative() {
+        let snapshot = StockPluginCatalog.productionSnapshot
+        let states = Set(snapshot.entries.map(\.availabilityState))
+
+        #expect(snapshot.validation.isValid, "production catalog should validate: \(snapshot.validation.issues)")
+        #expect(states.subtracting([.inferred, .manifested]).isEmpty,
+                "production census must not fabricate live evidence; saw \(states)")
+        #expect(snapshot.entries.contains { $0.id == "logic.stock.effect.gain" })
+    }
+
+    @Test("insert-only write capability matches the live insert allowlist")
+    func insertOnlyMatchesInsertAllowlist() {
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: .deterministic())
+        let insertable = snapshot.entries.filter { $0.safeWriteCapabilities == .insertOnly }
+
+        #expect(Set(insertable.map(\.id)) == [
+            "logic.stock.effect.channel_eq",
+            "logic.stock.effect.compressor",
+            "logic.stock.effect.gain",
+        ])
+        for entry in insertable {
+            #expect(
+                AccessibilityChannel.pluginInsertSpec(named: entry.displayName) != nil,
+                "\(entry.displayName) must be accepted by the insert_plugin allowlist"
+            )
+        }
+        let nonInsertable = snapshot.entries.first { $0.id == "logic.stock.effect.chromaverb" }
+        #expect(nonInsertable?.safeWriteCapabilities == StockPluginSafeWriteCapability.none)
+        #expect(AccessibilityChannel.pluginInsertSpec(named: "ChromaVerb") == nil)
+    }
+
+    @Test("search matches id, name, category, and type case-insensitively")
+    func searchSemantics() {
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: .deterministic())
+
+        #expect(StockPluginCatalog.search(query: "", snapshot: snapshot).count == snapshot.entries.count)
+        #expect(StockPluginCatalog.search(query: "REVERB", snapshot: snapshot)
+            .contains { $0.id == "logic.stock.effect.chromaverb" })
+        #expect(StockPluginCatalog.search(query: "midi_effect", snapshot: snapshot)
+            .allSatisfy { $0.type == .midiEffect })
+        #expect(StockPluginCatalog.search(query: "vintage b3", snapshot: snapshot)
+            .contains { $0.id == "logic.stock.instrument.vintage_b3" })
+        #expect(StockPluginCatalog.search(query: "no-such-plugin-xyz", snapshot: snapshot).isEmpty)
+    }
+}
+
+@Suite("Stock plugin intelligence — resources")
+struct StockPluginResourceTests {
     @Test("MCP resources expose stock plugin list, detail, search, census, and capabilities")
     func stockPluginResources() async throws {
         let list = try await stockPluginResourceObject("logic://stock-plugins")
@@ -130,10 +360,50 @@ struct StockPluginCatalogTests {
         let census = try await stockPluginResourceObject("logic://stock-plugins/census")
         #expect(census["catalog_source"] as? String != nil)
         #expect(census["logic_version"] != nil)
+        #expect((census["entries_by_state"] as? [String: Int]) != nil)
 
         let capabilities = try await stockPluginResourceObject("logic://stock-plugins/capabilities")
         #expect((capabilities["truth_labels"] as? [String])?.contains("verified") == true)
         #expect((capabilities["catalog_entry_fields"] as? [String])?.contains("known_presets") == true)
         #expect((capabilities["resources"] as? [String])?.contains("logic://stock-plugins") == true)
+        #expect((capabilities["production_reachable_states"] as? [String]) == ["inferred", "manifested"])
+        #expect((capabilities["census_injectable_states"] as? [String])?.contains("readback_mismatch") == true)
+    }
+
+    @Test("stock plugin URI routing fails closed on malformed inputs")
+    func stockPluginRoutingFailsClosed() async {
+        let malformed = [
+            "logic://stock-plugins?query=gain",
+            "logic://stock-plugins/search/extra",
+            "logic://stock-plugins/search?other=x",
+            "logic://stock-plugins/logic.stock.effect.gain?x=1",
+            "logic://stock-plugins/logic.stock.effect.gain/extra",
+            "logic://stock-plugins/unknown.plugin.id",
+            "logic://stock-plugins/census?x=1",
+        ]
+        for uri in malformed {
+            #expect(await stockPluginResourceThrows(uri), "expected fail-closed read for \(uri)")
+        }
+    }
+
+    @Test("search query is percent-decoded exactly once")
+    func searchQuerySingleDecode() async throws {
+        let search = try await stockPluginResourceObject("logic://stock-plugins/search?query=a%252Bb")
+        #expect(search["query"] as? String == "a%2Bb")
+
+        let plus = try await stockPluginResourceObject("logic://stock-plugins/search?query=a%2Bb")
+        #expect(plus["query"] as? String == "a+b")
+    }
+
+    @Test("search with empty or missing query returns the full catalog")
+    func searchEmptyQueryReturnsAll() async throws {
+        let missing = try await stockPluginResourceObject("logic://stock-plugins/search")
+        let empty = try await stockPluginResourceObject("logic://stock-plugins/search?query=")
+        let list = try await stockPluginResourceObject("logic://stock-plugins")
+
+        let total = (list["entries"] as? [[String: Any]])?.count
+        #expect(total != nil)
+        #expect((missing["entries"] as? [[String: Any]])?.count == total)
+        #expect((empty["entries"] as? [[String: Any]])?.count == total)
     }
 }

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -380,6 +380,8 @@ struct StockPluginResourceTests {
             "logic://stock-plugins/logic.stock.effect.gain/extra",
             "logic://stock-plugins/unknown.plugin.id",
             "logic://stock-plugins/census?x=1",
+            "logic://stock-plugins//census",
+            "logic://stock-plugins/census/",
         ]
         for uri in malformed {
             #expect(await stockPluginResourceThrows(uri), "expected fail-closed read for \(uri)")

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -151,6 +151,42 @@ struct StockPluginValidatorTests {
         #expect(issues.contains { $0.code == "presets_missing_provenance" })
     }
 
+    @Test("manifested entries require a probed source path")
+    func manifestedRequiresSourcePath() {
+        let bad = StockPluginProvenance(
+            source: "local_logic_app",
+            method: "factory_plugin_settings_probe",
+            observedAt: "2026-06-10T00:00:00Z",
+            logicVersion: "12.2",
+            locale: "en_US",
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: ["factory_plugin_settings_folder"]
+        )
+        let entries = [makeStockPluginEntry(id: "logic.stock.effect.gain", state: .manifested, provenance: bad)]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "manifested_missing_source_path" })
+    }
+
+    @Test("unavailable entries require absence evidence")
+    func unavailableRequiresEvidence() {
+        let bad = StockPluginProvenance(
+            source: "live_logic",
+            method: "live_census_absence",
+            observedAt: "2026-06-10T00:00:00Z",
+            logicVersion: "12.2",
+            locale: "en_US",
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: []
+        )
+        let entries = [makeStockPluginEntry(id: "logic.stock.effect.gain", state: .unavailable, provenance: bad)]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "unavailable_missing_evidence" })
+    }
+
     @Test("verified parameters require explicit readback evidence")
     func verifiedParametersRequireReadback() {
         let provenance = StockPluginProvenance.verified(
@@ -292,6 +328,43 @@ struct StockPluginCatalogTests {
         #expect(manifested.provenance.sourcePath?.hasSuffix("Plug-In Settings/Limiter") == true)
         #expect(manifested.provenance.evidence.contains("factory_plugin_settings_folder"))
         #expect(manifested.provenance.evidence.contains("factory_preset_filenames"))
+    }
+
+    @Test("verified overlay keeps factory presets with merged provenance")
+    func verifiedOverlayKeepsFactoryPresets() throws {
+        let census = censusFixture(
+            verified: ["logic.stock.effect.gain"],
+            manifests: [
+                "logic.stock.effect.gain": StockPluginLocalManifest(
+                    sourcePath: "/Applications/Logic Pro.app/Contents/Resources/Plug-In Settings/Gain",
+                    presetNames: ["#default", "Convert To Mono"]
+                ),
+            ]
+        )
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: census)
+
+        let gain = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.gain" })
+        #expect(gain.availabilityState == .verified)
+        #expect(gain.knownPresets == ["#default", "Convert To Mono"])
+        #expect(gain.provenance.evidence.contains("plugin_identity_readback"))
+        #expect(gain.provenance.evidence.contains("factory_preset_filenames"))
+        #expect(snapshot.validation.isValid,
+                "verified entries carrying factory presets must validate: \(snapshot.validation.issues)")
+    }
+
+    @Test("contradictory census evidence fails loudly and never yields verified")
+    func censusConflictSurfaced() throws {
+        let census = censusFixture(
+            verified: ["logic.stock.effect.gain"],
+            mismatched: ["logic.stock.effect.gain"]
+        )
+        let snapshot = StockPluginCatalog.defaultSnapshot(census: census)
+
+        let gain = try #require(snapshot.entries.first { $0.id == "logic.stock.effect.gain" })
+        #expect(gain.availabilityState == .readbackMismatch,
+                "contradiction must resolve to the non-claiming state")
+        #expect(!snapshot.validation.isValid)
+        #expect(snapshot.validation.issues.contains { $0.code == "census_conflict" })
     }
 
     @Test("production snapshot never claims more than manifested")

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func stockPluginResourceObject(_ uri: String) async throws -> [String: Any] {
+    let result = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+    return try #require(sharedJSONObject(sharedResourceText(result)))
+}
+
+private func makeStockPluginEntry(
+    id: String,
+    state: StockPluginTruthState,
+    provenance: StockPluginProvenance,
+    parameters: [StockPluginParameterMetadata] = []
+) -> StockPluginCatalogEntry {
+    StockPluginCatalogEntry(
+        id: id,
+        displayName: "Gain",
+        type: .effect,
+        category: "Utility",
+        availabilityState: state,
+        provenance: provenance,
+        insertPaths: [
+            StockPluginInsertPath(
+                path: ["Audio FX", "Utility", "Gain"],
+                availabilityState: state,
+                provenance: provenance
+            ),
+        ],
+        slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true),
+        knownPresets: [],
+        parameters: parameters,
+        safeWriteCapabilities: .insertOnly,
+        limitations: ["fixture"]
+    )
+}
+
+@Suite("Stock plugin intelligence")
+struct StockPluginCatalogTests {
+    @Test("validator rejects duplicate stable IDs")
+    func duplicateIDsRejected() {
+        let provenance = StockPluginProvenance.inferred(reason: "fixture")
+        let entries = [
+            makeStockPluginEntry(id: "logic.stock.effect.gain", state: .inferred, provenance: provenance),
+            makeStockPluginEntry(id: "logic.stock.effect.gain", state: .inferred, provenance: provenance),
+        ]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "duplicate_id" })
+    }
+
+    @Test("verified entries require source, method, timestamp, and evidence")
+    func verifiedProvenanceRequired() {
+        let bad = StockPluginProvenance(
+            source: "",
+            method: "",
+            observedAt: nil,
+            logicVersion: nil,
+            locale: nil,
+            sourcePath: nil,
+            inferenceReason: nil,
+            evidence: []
+        )
+        let entries = [makeStockPluginEntry(id: "logic.stock.effect.gain", state: .verified, provenance: bad)]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "verified_missing_provenance" })
+    }
+
+    @Test("verified parameters require explicit readback evidence")
+    func verifiedParametersRequireReadback() {
+        let provenance = StockPluginProvenance.verified(
+            source: "live_logic",
+            method: "ax_plugin_window",
+            observedAt: "2026-06-09T00:00:00Z",
+            logicVersion: "12.2",
+            locale: "en_US",
+            evidence: ["window_identity"]
+        )
+        let parameter = StockPluginParameterMetadata(
+            id: "gain",
+            displayName: "Gain",
+            unit: "dB",
+            valueRange: StockPluginValueRange(min: -24, max: 24, defaultValue: 0),
+            writeMethod: "unsupported",
+            readbackMethod: nil,
+            availabilityState: .verified,
+            provenance: provenance
+        )
+        let entries = [
+            makeStockPluginEntry(
+                id: "logic.stock.effect.gain",
+                state: .verified,
+                provenance: provenance,
+                parameters: [parameter]
+            ),
+        ]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        #expect(issues.contains { $0.code == "verified_parameter_missing_readback" })
+    }
+
+    @Test("default catalog includes honest inferred and unavailable states")
+    func defaultCatalogHasConservativeTruthLabels() {
+        let snapshot = StockPluginCatalog.defaultSnapshot()
+        let states = Set(snapshot.entries.map(\.availabilityState))
+
+        #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.entries.contains { $0.id == "logic.stock.effect.gain" })
+        #expect(states.contains(.inferred) || states.contains(.manifested) || states.contains(.verified))
+        #expect(states.contains(.unavailable))
+        #expect(snapshot.validation.isValid, "default catalog should validate: \(snapshot.validation.issues)")
+    }
+
+    @Test("MCP resources expose stock plugin list, detail, search, census, and capabilities")
+    func stockPluginResources() async throws {
+        let list = try await stockPluginResourceObject("logic://stock-plugins")
+        #expect(list["schema_version"] as? Int == 1)
+        #expect((list["entries"] as? [[String: Any]])?.isEmpty == false)
+        #expect((list["validation"] as? [String: Any])?["is_valid"] as? Bool == true)
+
+        let detail = try await stockPluginResourceObject("logic://stock-plugins/logic.stock.effect.gain")
+        #expect((detail["entry"] as? [String: Any])?["id"] as? String == "logic.stock.effect.gain")
+        #expect((detail["entry"] as? [String: Any])?["known_presets"] as? [String] != nil)
+
+        let search = try await stockPluginResourceObject("logic://stock-plugins/search?query=gain")
+        #expect((search["entries"] as? [[String: Any]])?.contains { $0["id"] as? String == "logic.stock.effect.gain" } == true)
+
+        let census = try await stockPluginResourceObject("logic://stock-plugins/census")
+        #expect(census["catalog_source"] as? String != nil)
+        #expect(census["logic_version"] != nil)
+
+        let capabilities = try await stockPluginResourceObject("logic://stock-plugins/capabilities")
+        #expect((capabilities["truth_labels"] as? [String])?.contains("verified") == true)
+        #expect((capabilities["catalog_entry_fields"] as? [String])?.contains("known_presets") == true)
+        #expect((capabilities["resources"] as? [String])?.contains("logic://stock-plugins") == true)
+    }
+}

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -449,6 +449,7 @@ struct StockPluginResourceTests {
             "logic://stock-plugins?query=gain",
             "logic://stock-plugins/search/extra",
             "logic://stock-plugins/search?other=x",
+            "logic://stock-plugins/search?query=gain&query=compressor",
             "logic://stock-plugins/logic.stock.effect.gain?x=1",
             "logic://stock-plugins/logic.stock.effect.gain/extra",
             "logic://stock-plugins/unknown.plugin.id",

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,20 +58,24 @@ Prefer resources over repeated tool calls — they are cheap and safe to poll at
 
 ### Stock Plugin Intelligence
 
-`logic://stock-plugins` is read-only. It does not insert plugins or broaden existing write gates. Entries include `known_presets`; this is intentionally an empty array unless preset names have provenance.
+`logic://stock-plugins` is read-only. It does not insert plugins or broaden existing write gates. The catalog covers the documented Logic stock set (effects, instruments, MIDI FX) under stable ID namespaces `logic.stock.effect.*`, `logic.stock.instrument.*`, and `logic.stock.midi_fx.*`.
 
 Each entry has an `availability_state`:
 
 | State | Trust contract |
 |-------|----------------|
-| `verified` | Current-machine evidence exists with source, method, timestamp, and evidence. |
-| `observed` | Seen locally/live, but not fully validated. |
-| `manifested` | Logic app metadata is present, but plugin identity was not live-read back. |
-| `inferred` | Static Logic stock knowledge only; clients must not claim local verification. |
-| `unavailable` | Checked/declared absent from this supported catalog path. |
-| `readback_mismatch` | Expected and observed plugin/parameter identity differed. |
+| `verified` | Live insert/readback evidence on this machine, with source, method, timestamp, and evidence. |
+| `observed` | Seen in a live Logic session (e.g. menu observation) without full readback. |
+| `manifested` | Per-plugin factory metadata was found in the local Logic installation (a `Plug-In Settings/<Display Name>` folder), with the probed `source_path` recorded in provenance. |
+| `inferred` | Documented stock identity only; clients must verify against the live menu before relying on it. |
+| `unavailable` | A live census recorded this plugin as absent. Never produced by static knowledge alone. |
+| `readback_mismatch` | Live readback returned a different identity than expected. |
 
-Clients should prefer stable `id` values and treat `display_name` as user-facing text, not identity. Parameter metadata remains conservative: no parameter is `verified` unless a readback path is evidenced.
+The production census can only produce `inferred` and `manifested` (see `production_reachable_states` in `logic://stock-plugins/capabilities`); `verified`, `observed`, `unavailable`, and `readback_mismatch` require injected live-census evidence and are never fabricated. Absence of a factory settings folder is deliberately **not** treated as evidence of absence.
+
+`known_presets` stays empty unless preset names have provenance. For `manifested` entries it lists factory preset filenames harvested from the probed settings folder (capped at `preset_name_cap`, currently 12; the full set remains on disk at the provenance `source_path`).
+
+Clients should prefer stable `id` values and treat `display_name` as user-facing text, not identity. Insert paths are menu hints unless their own state says otherwise. Parameter metadata remains conservative: no parameter is `verified` unless a readback path is evidenced. Entries with `safe_write_capabilities: "insert_only"` (Gain, Compressor, Channel EQ) match the `logic_mixer insert_plugin` allowlist; everything else is discovery-only.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete schema for Logic Pro MCP server. The server exposes **8 tools**, **9 resources**, and **3 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
+Complete schema for Logic Pro MCP server. The server exposes **8 tools**, **12 resources**, and **5 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
 
 **Design principle:** Tools perform write/action operations. **Reads are exposed exclusively through resources** — use `resources/read` for state queries, not tool calls.
 
@@ -30,7 +30,7 @@ All tool invocations use:
 
 ## Resource Catalog (Read-only)
 
-**9 static resources + 3 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
+**12 static resources + 5 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
 
 | URI | Content | Source |
 |-----|---------|--------|
@@ -43,13 +43,35 @@ All tool invocations use:
 | `logic://midi/ports` | `{ sources, destinations }` | CoreMIDI live query |
 | `logic://mcu/state` | `{ connection, display }` — MCU handshake + LCD state | Cache |
 | `logic://library/inventory` | Cached Library tree JSON (empty placeholder if not yet scanned) | File (resolved via `LOGIC_PRO_MCP_LIBRARY_INVENTORY` env, `Resources/library-inventory.json`, or `~/Library/Application Support/LogicProMCP/`). All candidates must sit under the path allowlist (`~/Library/Application Support/LogicProMCP/`, `<CWD>/Resources/`, `~/Music/Logic/`); extend via `LOGIC_PRO_MCP_INVENTORY_ALLOWLIST` (colon-separated, additive). |
+| `logic://stock-plugins` | `{ schema_version, generated_at, logic_version, catalog_source, validation, entries[] }` — conservative Logic stock plugin catalog with per-entry truth labels | Static catalog + local Logic app census |
+| `logic://stock-plugins/census` | Catalog census metadata, state counts, validation state | Static catalog + local Logic app census |
+| `logic://stock-plugins/capabilities` | Truth labels, safe write capability labels, and read-only catalog contract | Static |
 | `logic://tracks/{index}` | Single `TrackState` JSON | Cache — template |
 | `logic://tracks/{index}/regions` | `RegionState[]` JSON filtered by `trackIndex` | Cache — template |
 | `logic://mixer/{strip}` | `{ cache_age_sec, fetched_at, data_source, strip: ChannelStripState }` | Cache — template |
+| `logic://stock-plugins/{id}` | Single stock plugin catalog entry by stable ID | Static catalog + local Logic app census — template |
+| `logic://stock-plugins/search?query={query}` | Search stock plugin catalog entries | Static catalog + local Logic app census — template |
 
 All resources return `contents: [{ uri, text, mimeType: "application/json" }]`.
 
 Prefer resources over repeated tool calls — they are cheap and safe to poll at 1 Hz.
+
+### Stock Plugin Intelligence
+
+`logic://stock-plugins` is read-only. It does not insert plugins or broaden existing write gates. Entries include `known_presets`; this is intentionally an empty array unless preset names have provenance.
+
+Each entry has an `availability_state`:
+
+| State | Trust contract |
+|-------|----------------|
+| `verified` | Current-machine evidence exists with source, method, timestamp, and evidence. |
+| `observed` | Seen locally/live, but not fully validated. |
+| `manifested` | Logic app metadata is present, but plugin identity was not live-read back. |
+| `inferred` | Static Logic stock knowledge only; clients must not claim local verification. |
+| `unavailable` | Checked/declared absent from this supported catalog path. |
+| `readback_mismatch` | Expected and observed plugin/parameter identity differed. |
+
+Clients should prefer stable `id` values and treat `display_name` as user-facing text, not identity. Parameter metadata remains conservative: no parameter is `verified` unless a readback path is evidenced.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Logic Pro MCP Server is a Swift 6 actor-based system that multiplexes **7 native
        │                  │                   │                    │
 ┌──────▼────────┐  ┌──────▼────────┐  ┌───────▼────────┐  ┌────────▼──────┐
 │  Dispatchers  │  │ ResourceHandlers │ │   StateCache   │  │  StatePoller  │
-│ (8 tools)     │  │  (6 + template) │ │   (actor)      │  │ (3s AX poll)  │
+│ (8 tools)     │  │ (14 + 7 templ.) │ │   (actor)      │  │ (3s AX poll)  │
 └──────┬────────┘  └──────┬────────┘  └───────▲────────┘  └────────┬──────┘
        │                  │                   │                    │
        │                  │                   │                    │
@@ -63,7 +63,7 @@ Legend — `↕` bidirectional, `↑` read, `↓` write.
 | **Routing** | `ChannelRouter` — priority chain selection, fallback, health checks | `actor` | Actor |
 | **Channels** | 7 communication channels, each wrapping one macOS API | `actor` | Actor per channel |
 | **State** | `StateCache` (store) + `StatePoller` (3s AX refresh) | `actor` | Actor |
-| **Resources** | `ResourceHandlers` — URI routing, JSON serialization | `struct` | Pure |
+| **Resources** | `ResourceHandlers` — URI routing, read-only state/catalog JSON serialization | `struct` | Pure |
 | **Utilities** | `AppleScriptSafety`, `DestructivePolicy`, `PermissionChecker`, `Logger` | mixed | Pure / `enum` |
 
 ---

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -132,7 +132,7 @@ Read this column-by-column. **"requires keycmd binding?"** is the question that 
 | `project.save (60)`                                                              | `logic_project.save`                           | AppleScript / CGEvent `Cmd+S`               | NO                       |
 | `project.save_as (61)`                                                           | `logic_project.save_as`                        | AppleScript / Accessibility                 | NO                       |
 | **`project.bounce (62)`**                                                        | `logic_project.bounce`                         | _none — cgEvent fallback unmapped_          | **YES**                  |
-| `transport.toggle_cycle (72)`                                                    | `logic_transport.toggle_cycle`                 | Accessibility / MCU / CGEvent `C`           | NO                       |
+| `transport.toggle_cycle (72)`                                                    | `logic_transport.toggle_cycle`                 | Accessibility / KeyCmd / CGEvent `C` / MCU  | NO                       |
 | **`transport.capture_recording (73)`**                                           | `logic_transport.capture_recording` _(none today; orphan)_ | _none — cgEvent fallback unmapped_ | **YES**                  |
 | `transport.toggle_metronome (98)`                                                | `logic_transport.toggle_metronome`             | Accessibility / CGEvent `K`                 | NO                       |
 | `transport.toggle_count_in (99)`                                                 | `logic_transport.toggle_count_in`              | Accessibility                               | NO                       |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,9 +35,17 @@ head -40 /tmp/mcp-stderr.txt
 Look for lines like:
 - `MIDIPortManager started` — CoreMIDI initialized
 - `Accessibility channel started` — AX ready
-- `Starting logic-pro-mcp v3.0.0 — 8 tools, 9 resources, 7 channels` — composition complete
+- `Starting logic-pro-mcp v3.4.6 — 8 tools, 12 resources, 7 channels` — composition complete
 
 If you see `AccessibilityError.notTrusted`, grant Accessibility permission.
+
+### Stock plugin catalog looks conservative
+
+**Symptom:** `logic://stock-plugins` returns entries labelled `inferred` or `manifested` instead of `verified`.
+
+**Cause:** the catalog is intentionally fail-closed. Static Logic stock knowledge and local app metadata are useful discovery signals, but they are not live plugin readback.
+
+**Fix:** clients should branch on `availability_state`. Treat `verified` as the only current-machine proof label; treat `inferred`/`manifested` as planning hints that still need user confirmation and write-side verification.
 
 ---
 

--- a/docs/prd/PRD-verified-stock-plugin-intelligence.md
+++ b/docs/prd/PRD-verified-stock-plugin-intelligence.md
@@ -1,0 +1,118 @@
+# PRD: Verified Stock Plugin Intelligence (Issue #14)
+
+**Status**: Approved for implementation
+**Date**: 2026-06-09
+**Owner**: Logic Pro MCP
+**Related issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/14
+**Supersedes**: invalidated combined implementation `8ea264c`
+
+## 1. Problem
+
+MCP clients need a trustworthy way to discover Logic Pro stock plugins without prompt-memory guesses. Today they cannot reliably know which stock plugin IDs exist, which names are observed versus inferred, which insert paths are safe hints, or which parameters are actually controllable/readback-capable.
+
+The server must expose a provenance-backed, read-only stock plugin intelligence layer before any broader plugin insertion or parameter automation claims.
+
+## 2. Goals
+
+- Provide a stable stock plugin catalog schema with explicit truth labels.
+- Enforce provenance rules so `verified` is never returned without evidence.
+- Expose read-only MCP resources for catalog list, detail, search, census, and capabilities.
+- Preserve existing mixer/plugin write safety gates.
+- Document client trust boundaries and limitations.
+
+## 3. Non-Goals
+
+- No third-party Audio Unit discovery.
+- No silent plugin insertion or write-side broadening.
+- No universal parameter automation claim.
+- No verified parameter metadata unless exact readback evidence exists.
+- No release claim based on superseded commit `8ea264c`.
+
+## 4. Truth Model
+
+Truth labels are part of the public wire contract:
+
+- `verified`: confirmed by current-machine evidence with source, method, timestamp, and Logic version when available.
+- `observed`: seen in live/local observation but not fully validated.
+- `manifested`: present in local metadata without live readback.
+- `inferred`: known/static Logic behavior, not verified on this machine.
+- `unavailable`: expected plugin checked and absent.
+- `readback_mismatch`: expected and observed values differ.
+
+## 5. Schema
+
+Every catalog response includes:
+
+- `schema_version`
+- `generated_at`
+- `logic_version`
+- `locale`
+- `catalog_source`
+- `validation`
+- `entries`
+
+Every plugin entry includes:
+
+- `id`
+- `display_name`
+- `type`
+- `category`
+- `availability_state`
+- `provenance`
+- `insert_paths`
+- `slot_support`
+- `known_presets`
+- `parameters`
+- `safe_write_capabilities`
+- `limitations`
+
+Every parameter entry includes its own truth label and provenance. A parameter cannot be `verified` unless both write and readback method evidence are present. Presets are represented by `known_presets` and must remain empty unless preset names are backed by provenance.
+
+## 6. MCP Resources
+
+Read-only resources:
+
+- `logic://stock-plugins`
+- `logic://stock-plugins/{id}`
+- `logic://stock-plugins/search?query=<text>`
+- `logic://stock-plugins/census`
+- `logic://stock-plugins/capabilities`
+
+No resource in this PRD may mutate Logic state.
+
+## 7. Implementation Tickets
+
+Canonical ticket board: `docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md`
+
+- `I14-T1`: schema models and truth-label validator.
+- `I14-T2`: deterministic catalog seed with current-machine census overlay.
+- `I14-T3`: read-only MCP resource handlers and resource registration.
+- `I14-T4`: integration tests for list/detail/search/census/capabilities.
+- `I14-T5`: docs and verification evidence.
+
+## 8. Acceptance Criteria
+
+- PRD and ticket board exist before implementation.
+- Unit tests cover required fields, duplicate IDs, provenance, truth labels, and parameter evidence.
+- No `verified` plugin or parameter can be emitted without required provenance.
+- Discovery responses distinguish `verified`, `observed`, `manifested`, `inferred`, `unavailable`, and `readback_mismatch`.
+- Existing mixer/plugin safety gates remain fail-closed.
+- Read-only MCP resources expose list, detail, search, census, and capabilities.
+- Docs/API and troubleshooting docs describe examples and limitations.
+- Verification includes `swift test --no-parallel`, `swift build -c release`, `python3 -m py_compile Scripts/live-e2e-test.py`, and targeted live evidence when a live Logic session is available.
+
+## 9. Test Plan
+
+- Schema validator tests for duplicates, required provenance, and invalid parameter verification.
+- Catalog tests for stable IDs, search, detail lookup, and unavailable entries.
+- Resource tests for registered URIs/templates and read-only response shape.
+- E2E tests through server resource reads.
+- Live smoke test records Logic version, locale, catalog states, and at least one observed/verified stock plugin identity when possible.
+
+## 10. ADR
+
+**Decision**: ship #14 as read-only catalog intelligence with strict truth labels and a local-census overlay.
+**Drivers**: prevent hallucinated plugin claims, preserve safety gates, provide useful client discovery now.
+**Alternatives considered**: hard-coded static list only, live AX-only scanner, write-enabled insert planner.
+**Why chosen**: static-only cannot claim verification; live-only is brittle and unavailable in CI; write-enabled scope belongs behind a later explicit gate.
+**Consequences**: first release is conservative and may label many entries `inferred` or `unavailable`; clients get honest metadata instead of false confidence.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
@@ -35,6 +35,20 @@
 - `python3 -m py_compile Scripts/live-e2e-test.py` passes.
 - Live evidence is recorded when Logic is available; otherwise the limitation is explicit and no live-verified claim is made.
 
+## Hardening Round (2026-06-10)
+
+Adversarial review (Codex gpt-5.5 xhigh + full-repo review cross-check) returned 3 P1 / 4 P2 findings. All addressed:
+
+- [x] `R1` Fabricated provenance removed: blanket app-presence no longer claims `manifested`; the census now probes per-plugin factory `Plug-In Settings/<Display Name>` folders (app bundle + `/Library/Application Support/Logic`) and records the probed `source_path`. The hardcoded `unavailable` SilverVerb entry (claimed `absence_checked` without any check — the folder exists in Logic 12.2) is replaced by a real probed entry.
+- [x] `R2` Every truth state is now producible and tested: census carries `verified`/`observed`/`readback_mismatch`/`unavailable` ID sets plus local manifests; overlay precedence is tested per state. Production probe alone can never claim more than `manifested` (regression-tested).
+- [x] `R3` Deterministic tests pinned to `StockPluginCensus.deterministic()`; production snapshot asserted conservative on any host.
+- [x] `R4` URI routing fails closed via `URLComponents` (unknown subpaths, nested segments, stray query params rejected); search query double-decode bug fixed and regression-tested.
+- [x] `R5` Catalog expanded to 103 documented stock entries (effects/instruments/MIDI FX) under `logic.stock.{effect,instrument,midi_fx}.*` with honest `inferred` baselines; `known_presets` populated only from probed factory preset filenames (capped, provenance-marked). Validator extended: id format, value-range sanity, duplicate parameter IDs, preset provenance, mismatch evidence.
+- [x] `R6` `safe_write_capabilities: insert_only` pinned to the live `insert_plugin` allowlist (Gain, Compressor, Channel EQ) by test.
+- [x] `R7` Shared resource JSON helpers moved to `ResourceJSONHelpers.swift` so #14/#15 branches no longer collide on duplicated private helpers.
+
+Release identity note: `serverVersion` stays `3.4.6` on this branch by design — packaging surfaces (manifest/Formula/install.sh) pin the published v3.4.6 artifacts and must not drift mid-branch. Merging this PR requires the next release to ship as `v3.5.0` (new public resources = minor bump); do not rebuild/redistribute as `3.4.6`.
+
 ## Verification
 
-See `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md`.
+See `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md` and `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md` (hardening round).

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
@@ -55,6 +55,7 @@ See `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-0
 
 Final production-readiness pass (2026-06-10):
 
+- Resource/template catalog assertions were hardened to require the #14 surface as a subset rather than freezing exact counts, and `logic_system help` now derives catalog counts from `ResourceProvider` so later public resources cannot stale the banner.
 - `swift test --no-parallel` — 1232 tests passed.
 - `swift build -c release` — passed.
 - `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache-issue14 python3 -m py_compile Scripts/live-e2e-test.py` — passed.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
@@ -1,7 +1,7 @@
 # Issue #14 Ticket Board: Verified Stock Plugin Intelligence
 
-**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/14  
-**PRD**: `docs/prd/PRD-verified-stock-plugin-intelligence.md`  
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/14
+**PRD**: `docs/prd/PRD-verified-stock-plugin-intelligence.md`
 **Status**: Done
 
 ## Tickets
@@ -52,3 +52,11 @@ Release identity note: `serverVersion` stays `3.4.6` on this branch by design �
 ## Verification
 
 See `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md` and `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md` (hardening round).
+
+Final production-readiness pass (2026-06-10):
+
+- `swift test --no-parallel` — 1232 tests passed.
+- `swift build -c release` — passed.
+- `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache-issue14 python3 -m py_compile Scripts/live-e2e-test.py` — passed.
+- `git diff --check origin/main` — passed.
+- `LOGIC_PRO_MCP_STRICT_LIVE=1 Scripts/live-e2e-test.sh` — 283/283 passed.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/STATUS.md
@@ -1,0 +1,40 @@
+# Issue #14 Ticket Board: Verified Stock Plugin Intelligence
+
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/14  
+**PRD**: `docs/prd/PRD-verified-stock-plugin-intelligence.md`  
+**Status**: Done
+
+## Tickets
+
+- [x] `I14-T1` Schema and validator
+  - Define truth labels, provenance, plugin entries, insert paths, slot support, parameter metadata, and catalog snapshot.
+  - Validator rejects duplicate IDs, missing verified provenance, and verified parameters without readback evidence.
+
+- [x] `I14-T2` Deterministic catalog and census overlay
+  - Seed conservative Logic stock plugin entries.
+  - Overlay current-machine census data without promoting static guesses to verified.
+  - Include at least one unavailable expected entry for client branch coverage.
+
+- [x] `I14-T3` MCP resources
+  - Register `logic://stock-plugins`, `logic://stock-plugins/{id}`, `logic://stock-plugins/search?query=`, `logic://stock-plugins/census`, and `logic://stock-plugins/capabilities`.
+  - Keep resources read-only and side-effect free.
+
+- [x] `I14-T4` Tests
+  - Unit tests for validator/catalog/search.
+  - Resource and server E2E tests for all surfaces.
+  - Safety regression proving write-side gates are not broadened.
+
+- [x] `I14-T5` Docs and evidence
+  - Update API and troubleshooting docs.
+  - Add live/deterministic verification evidence.
+
+## Done Criteria
+
+- All tickets complete.
+- `swift build -c release` and `swift test --no-parallel` pass.
+- `python3 -m py_compile Scripts/live-e2e-test.py` passes.
+- Live evidence is recorded when Logic is available; otherwise the limitation is explicit and no live-verified claim is made.
+
+## Verification
+
+See `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md`.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md
@@ -19,7 +19,7 @@ The implemented #14 surface is read-only catalog intelligence. It does not broad
 | Full test suite | PASS | `swift test --no-parallel` -> 1214 tests passed. |
 | Release build | PASS | `swift build -c release` -> build complete. |
 | Python E2E syntax | PASS | `PYTHONPYCACHEPREFIX=/private/tmp/logic-pro-mcp-pycache python3 -m py_compile Scripts/live-e2e-test.py` exit 0. |
-| Coverage gate | PASS | `swift test --enable-code-coverage --no-parallel` -> 1220 tests passed; TOTAL region 73.52%, line 81.45% against CI hard gate region >=70%, line >=78%. |
+| Coverage gate | Not run on split branch | CI coverage runs on PR; local focused/full tests and release build passed before PR. |
 
 ## Release-Binary Read-Only Smoke
 

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-09.md
@@ -1,0 +1,54 @@
+# Verification Evidence - Issue #14 Verified Stock Plugin Intelligence
+
+Date: 2026-06-09 KST
+Branch: `feature/issue-14-stock-plugin-intelligence`
+Scope: current working tree, Logic Pro MCP release binary, Logic Pro 12.2 host.
+
+## Claim Boundary
+
+The implemented #14 surface is read-only catalog intelligence. It does not broaden plugin insertion or parameter-write behavior. Catalog entries can be `manifested` from local Logic app metadata, `inferred` from static catalog knowledge, `unavailable`, `observed`, `verified`, or `readback_mismatch`; `verified` requires provenance and evidence.
+
+`known_presets` is part of the schema, but remains empty unless preset names have provenance. Parameter metadata remains conservative and cannot be `verified` without readback evidence.
+
+## Deterministic Gates
+
+| Gate | Result | Evidence |
+|---|---:|---|
+| Format check | PASS | `git diff --check` exit 0. |
+| Focused catalog/resource E2E tests | PASS | `swift test --no-parallel --filter StockPluginCatalogTests --filter testE2EResourceStockPluginsExposeTruthLabels --filter testE2EServerCatalogAdvertisesAllResources --filter testE2EServerCatalogAdvertisesAllTemplates` -> 8 tests passed. |
+| Full test suite | PASS | `swift test --no-parallel` -> 1214 tests passed. |
+| Release build | PASS | `swift build -c release` -> build complete. |
+| Python E2E syntax | PASS | `PYTHONPYCACHEPREFIX=/private/tmp/logic-pro-mcp-pycache python3 -m py_compile Scripts/live-e2e-test.py` exit 0. |
+| Coverage gate | PASS | `swift test --enable-code-coverage --no-parallel` -> 1220 tests passed; TOTAL region 73.52%, line 81.45% against CI hard gate region >=70%, line >=78%. |
+
+## Release-Binary Read-Only Smoke
+
+Command: release-binary MCP stdio smoke against `.build/release/LogicProMCP`.
+
+Result:
+
+```json
+{"ok":true,"resource_count":11,"stock_catalog_valid":true,"stock_census_states":{"manifested":4,"unavailable":1},"stock_entry_count":5,"stock_gain_state":"manifested","template_count":5}
+```
+
+`resource_count` is 11 because `logic://mcu/state` is hidden when the resource list is filtered for the current MCU state; CI accepts 11 or 12.
+
+## Live Stock Plugin Insert Evidence
+
+Issue #14 asks for targeted live verification around at least one safe stock plugin insert/readback path. The current branch reuses the existing repository evidence for the already-supported guarded path:
+
+- Evidence file: `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md`
+- Logic Pro version: 12.2.
+- Operation: `logic_mixer insert_plugin { track: 0, slot: 6, plugin_name: "Gain", confirmed: true }`.
+- Result: State A with `success:true`, `verified:true`, `verify_source:"ax_plugin_slot"`, `observed_plugin_name:"Gain"`.
+- Guardrail: repeating the same insert failed closed with `slot_occupied`.
+
+Fresh reruns on 2026-06-09 reached a valid TCC/tmux live context but the Logic GUI was stuck behind the Project Chooser modal, so current-session insert attempts failed closed with `element_not_found` / `Cannot locate visible mixer for insert_plugin`. This failure is recorded as a live precondition block, not as a product success claim.
+
+## Acceptance Mapping
+
+- PRD/ticket docs: `docs/prd/PRD-verified-stock-plugin-intelligence.md`, this ticket board.
+- Schema: `Sources/LogicProMCP/Plugins/StockPluginCatalog.swift` includes stable IDs, display names, type/category, truth state, provenance, insert paths, slot support, `known_presets`, parameter metadata, and safe write capability labels.
+- Tests: `Tests/LogicProMCPTests/StockPluginCatalogTests.swift` covers duplicate IDs, provenance, verified-parameter readback, conservative states, and MCP resources.
+- Resources: `logic://stock-plugins`, `logic://stock-plugins/{id}`, `logic://stock-plugins/search?query=`, `logic://stock-plugins/census`, `logic://stock-plugins/capabilities`.
+- Safety: discovery resources are read-only; existing write gates are unchanged and insert verification evidence remains L2/confirmed.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
@@ -57,6 +57,10 @@ Additional hardening: catalog expanded to 103 documented stock entries; validato
 
 97/103 entries are `manifested` from real per-plugin folder probes on this machine; the 6 remaining stay honestly `inferred` (their factory content lives outside the probed roots). `verified`, `observed`, `unavailable`, and `readback_mismatch` are absent from production output by design — they require injected live-census evidence.
 
+## Convergence Round 2→3
+
+A cross-branch round-2 re-review (Codex gpt-5.5 xhigh on the sibling #15 branch) surfaced one routing edge shared by both branches: doubled/trailing-slash paths (`logic://stock-plugins//census`, `.../census/`) were silently normalized by segment splitting. Fixed with a canonical-path guard in `readStockPluginResource` plus fail-closed regression tests. `swift test --no-parallel` → 1225 tests passed after the fix.
+
 ## Claim Boundary (unchanged)
 
 Read-only discovery only. No write-side broadening. `verified` labels remain provenance-gated; parameter verification still requires explicit readback evidence. Live insert/readback evidence for the guarded Gain path remains `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md`.

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
@@ -57,9 +57,18 @@ Additional hardening: catalog expanded to 103 documented stock entries; validato
 
 97/103 entries are `manifested` from real per-plugin folder probes on this machine; the 6 remaining stay honestly `inferred` (their factory content lives outside the probed roots). `verified`, `observed`, `unavailable`, and `readback_mismatch` are absent from production output by design — they require injected live-census evidence.
 
-## Convergence Round 2→3
+## Convergence Rounds 2→4
 
-A cross-branch round-2 re-review (Codex gpt-5.5 xhigh on the sibling #15 branch) surfaced one routing edge shared by both branches: doubled/trailing-slash paths (`logic://stock-plugins//census`, `.../census/`) were silently normalized by segment splitting. Fixed with a canonical-path guard in `readStockPluginResource` plus fail-closed regression tests. `swift test --no-parallel` → 1225 tests passed after the fix.
+Round-2 re-review (Codex gpt-5.5 xhigh): all 7 round-1 findings **CLOSED**; verdict PASS-WITH-CONDITIONS with 4 new edges, all fixed in follow-up commits:
+
+| New finding | Fix |
+|---|---|
+| `verified`/`observed` overlays copied factory presets without preset evidence, so a real live census would fail validation (P2) | Preset evidence merged into overlay provenance (`factory_preset_filenames`); regression test `verifiedOverlayKeepsFactoryPresets` |
+| Contradictory census sets resolved silently by precedence — verified beat mismatch (P2) | `census_conflict` validation issues surface contradictions (verified∩mismatch, live∩unavailable); precedence reordered so contradiction never yields `verified`; regression test |
+| Validator accepted under-evidenced labels (P3) | `manifested` now requires probed `source_path`; `unavailable` requires absence evidence; new issue codes + tests |
+| Probe path concatenation not component-safe for names like "I/O" (P3) | Probe skips names containing `/` (no POSIX folder can match); shared routing edge (doubled/trailing slashes) fixed with canonical-path guard + tests |
+
+Round-4 gates: `swift test --no-parallel` → **1229 tests passed**; `swift build -c release` PASS; `git diff --check` PASS.
 
 ## Claim Boundary (unchanged)
 

--- a/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
+++ b/docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md
@@ -1,0 +1,62 @@
+# Verification Evidence - Issue #14 Hardening Round (2026-06-10)
+
+Date: 2026-06-10 KST
+Branch: `feature/issue-14-stock-plugin-intelligence`
+Scope: post-review hardening of the stock plugin intelligence surface, Logic Pro 12.2 host.
+
+## Review Inputs
+
+- Adversarial review: Codex gpt-5.5 (`model_reasoning_effort=xhigh`), verdict on the pre-hardening branch: FAIL (3 P1 / 4 P2).
+- Cross-check: 2026-06-08/09 full-repo enterprise review (release identity, Honest Contract globalization).
+- Machine evidence motivating R1: `/Applications/Logic Pro.app/Contents/Resources/Plug-In Settings/SilverVerb` exists on this Logic 12.2 install, while the pre-hardening catalog shipped SilverVerb as `unavailable` with fabricated `absence_checked` evidence.
+
+## Findings → Fixes
+
+| Finding (severity) | Fix |
+|---|---|
+| `manifested` overclaimed from app presence (P1) | Per-plugin factory `Plug-In Settings/<Display Name>` folder probe (app bundle root + `/Library/Application Support/Logic`); probed `source_path` recorded in provenance; no folder → stays `inferred`. |
+| `unavailable` claimed an absence check that never ran (P1) | Fabricated entry removed. `unavailable` is only producible via census `unavailablePluginIDs` (live census / fixtures). Folder absence is explicitly not treated as evidence of absence. |
+| Release identity unchanged under grown surface (P1) | Documented contract: merge ⇒ next release must be `v3.5.0`; no rebuild as `3.4.6`. Packaging surfaces intentionally untouched on branch (they pin published v3.4.6 artifacts). |
+| `verified`/`observed` dead and untested (P2) | Census ID-set overlay implemented end-to-end and unit-tested per state. |
+| `readback_mismatch` not producible (P2) | `readbackMismatchPluginIDs` census set + provenance factory + validator evidence rule + tests. |
+| Tests not deterministic (P2) | Unit assertions pinned to `StockPluginCensus.deterministic()`; production snapshot covered by a host-independent conservativeness invariant (`states ⊆ {inferred, manifested}`). |
+| URI routing accepted malformed URIs; query double-decoded (P2) | `URLComponents`-based exact routing; unknown subpaths/params fail closed; single-decode regression test (`a%252Bb` → `a%2Bb`). |
+
+Additional hardening: catalog expanded to 103 documented stock entries; validator extended (id format, value ranges, duplicate parameter IDs, preset provenance, mismatch evidence); `insert_only` capability pinned to the `insert_plugin` allowlist by test; shared JSON helpers extracted to `ResourceJSONHelpers.swift` to remove the #14/#15 duplicate-helper merge hazard.
+
+## Deterministic Gates
+
+| Gate | Result | Evidence |
+|---|---:|---|
+| Format check | PASS | `git diff --check` exit 0. |
+| Stock plugin suites | PASS | `swift test --no-parallel --filter StockPlugin` → 17 tests passed. |
+| Full test suite | PASS | `swift test --no-parallel` → 1225 tests passed. |
+| Release build | PASS | `swift build -c release` → build complete. |
+| Python E2E syntax | PASS | `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache python3 -m py_compile Scripts/live-e2e-test.py` exit 0. |
+
+## Release-Binary Read-Only Smoke (Logic Pro 12.2 host)
+
+```json
+{
+ "ok": true,
+ "resource_count": 11,
+ "template_count": 5,
+ "stock_catalog_valid": true,
+ "stock_entry_count": 103,
+ "stock_census_states": {"inferred": 6, "manifested": 97},
+ "logic_version": "12.2",
+ "stock_gain_state": "manifested",
+ "gain_presets": ["#default", "Convert To Mono", "Invert Phase - Left", "Invert Phase - Right"],
+ "gain_source_path": "/Applications/Logic Pro.app/Contents/Resources/Plug-In Settings/Gain",
+ "search_reverb_count": 4,
+ "malformed_uri_fails_closed": true
+}
+```
+
+`resource_count` is 11 because `logic://mcu/state` is hidden while the MCU surface is disconnected.
+
+97/103 entries are `manifested` from real per-plugin folder probes on this machine; the 6 remaining stay honestly `inferred` (their factory content lives outside the probed roots). `verified`, `observed`, `unavailable`, and `readback_mismatch` are absent from production output by design — they require injected live-census evidence.
+
+## Claim Boundary (unchanged)
+
+Read-only discovery only. No write-side broadening. `verified` labels remain provenance-gated; parameter verification still requires explicit readback evidence. Live insert/readback evidence for the guarded Gain path remains `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md`.


### PR DESCRIPTION
## Summary

Refs #14.

This PR implements issue #14 only, on an independent branch. It does not include the workflow skills pack from #15.

Delivered:
- New PRD and ticket board for verified stock plugin intelligence.
- `StockPluginCatalog` schema with stable IDs, truth states, provenance, insert paths, slot support, known presets, parameter metadata, safe write labels, and validation.
- **103 documented stock entries** (effects, instruments, MIDI FX) under stable namespaces `logic.stock.{effect,instrument,midi_fx}.*`.
- **Per-plugin local census**: the production census probes factory `Plug-In Settings/<Display Name>` folders (Logic app bundle + `/Library/Application Support/Logic`) — `manifested` is only claimed with a recorded per-plugin `source_path`, and `known_presets` is populated exclusively from probed factory preset filenames (provenance-marked, capped at 12).
- Read-only MCP resources and templates for stock plugin list, detail, search, census, and capabilities — with fail-closed `URLComponents` routing (unknown subpaths, nested segments, and stray query params are rejected).
- API/troubleshooting/architecture docs and branch-specific verification evidence.

## Hardening round (2026-06-10)

An adversarial review (independent adversarial review + enterprise full-repo cross-check) on the initial branch returned **3 P1 / 4 P2 — all fixed**:

| Finding | Fix |
|---|---|
| P1: `manifested` claimed from mere app presence | Real per-plugin factory-folder probe with `source_path` evidence; no folder → honestly `inferred` |
| P1: `unavailable` SilverVerb claimed `absence_checked` with no check (the folder **exists** on Logic 12.2) | Fabricated entry removed; `unavailable` now requires census absence evidence; folder absence is never treated as evidence of absence |
| P1: release identity (see Merge contract below) | Documented: next release after merge must be `v3.5.0` |
| P2: `verified`/`observed` upgrade paths dead + untested | Census ID-set overlay implemented and unit-tested per state |
| P2: `readback_mismatch` advertised but not producible | Census mismatch set + provenance factory + validator evidence rule + tests |
| P2: tests not deterministic | Unit tests pinned to `StockPluginCensus.deterministic()`; production snapshot covered by host-independent invariant `states ⊆ {inferred, manifested}` |
| P2: URI routing accepted malformed URIs; search query double-decoded | Exact-path routing, fail-closed; single-decode regression test |

Additional: validator extended (id format, value-range sanity, duplicate parameter IDs, preset provenance, mismatch evidence); `safe_write_capabilities: insert_only` pinned to the live `insert_plugin` allowlist (Gain, Compressor, Channel EQ) by test; shared JSON helpers extracted to `ResourceJSONHelpers.swift`.

## Verification

- `git diff --check` PASS
- `PYTHONPYCACHEPREFIX=... python3 -m py_compile Scripts/live-e2e-test.py` PASS
- Stock plugin suites PASS: 17 tests
- `swift test --no-parallel` PASS: **1225 tests**
- `swift build -c release` PASS
- Release-binary MCP smoke (Logic Pro 12.2 host): 11 runtime resources, 5 templates, catalog valid, **103 entries, 97 `manifested` via real probes**, Gain `manifested` with factory presets + `source_path`, malformed URIs fail closed
- Evidence: `docs/tickets/issue14-verified-stock-plugin-intelligence/VERIFICATION-2026-06-10.md`

## Boundary

This branch is read-only discovery intelligence. It does not broaden plugin insertion or parameter writes. The production census can only produce `inferred`/`manifested`; `verified`, `observed`, `unavailable`, and `readback_mismatch` require injected live-census evidence and are never fabricated.

## Merge contract (cross-PR)

- #17 and #18 are independent branches that both extend the resource surface; **whichever merges second must rebase** and reconcile combined counts (14 resources / 7 templates, startup banner, `docs/API.md`, live-e2e expectations). `ResourceJSONHelpers.swift` is byte-identical on both branches to avoid duplicate-helper conflicts.
- `serverVersion` intentionally stays `3.4.6` on this branch (packaging surfaces pin the published v3.4.6 artifacts). **The first release containing this PR must ship as `v3.5.0`** — new public resources are a minor-version contract change; do not rebuild as `3.4.6`.

Do not merge until review approval.