### PR TITLE
Issue #15: Logic Pro MCP workflow skills pack

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -448,15 +448,32 @@ def main():
 
     r = list_resources(client)
     resources = r.get("result", {}).get("resources", []) if r else []
-    # Issue #15 exposes 11 static resources. logic://mcu/state is filtered from
-    # the list when the MCU control surface is disconnected, so the expected
-    # count is 10 (disconnected) or 11 (connected).
-    resource_count = len(resources)
-    T("resources/list returns 10 or 11 resources", r, lambda r: resource_count in (10, 11))
+    resource_uris = {res.get("uri") for res in resources}
+    required_resource_uris = {
+        "logic://system/health",
+        "logic://transport/state",
+        "logic://tracks",
+        "logic://mixer",
+        "logic://markers",
+        "logic://project/info",
+        "logic://midi/ports",
+        "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
+    }
+    T("resources/list includes required resources", r, lambda r: required_resource_uris.issubset(resource_uris))
 
     r = list_resource_templates(client)
     templates = r.get("result", {}).get("resourceTemplates", []) if r else []
-    T("resources/templates/list returns 5 templates", r, lambda r: len(templates) == 5)
+    template_uris = {tpl.get("uriTemplate") for tpl in templates}
+    required_template_uris = {
+        "logic://tracks/{index}",
+        "logic://tracks/{index}/regions",
+        "logic://mixer/{strip}",
+        "logic://workflow-skills/{id}",
+        "logic://workflow-skills/search?query={query}",
+    }
+    T("resources/templates/list includes required templates", r, lambda r: required_template_uris.issubset(template_uris))
 
     # ═══════════════════════════════════════════════════════════════
     # §2 System Diagnostics (15 tests)
@@ -555,7 +572,13 @@ def main():
     def safe_get_cycle(client):
         r = read_resource(client, "logic://transport/state")
         try:
-            return json.loads(resource_text(r)).get("data", {}).get("state", {}).get("isCycleEnabled")
+            envelope = json.loads(resource_text(r))
+            if envelope.get("fetched_at") is None:
+                return None
+            data = envelope.get("data", {})
+            if data.get("has_document") is False:
+                return None
+            return data.get("state", {}).get("isCycleEnabled")
         except: return None
 
     def wait_for_cycle_change(client, before, timeout=5.0):

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -448,15 +448,15 @@ def main():
 
     r = list_resources(client)
     resources = r.get("result", {}).get("resources", []) if r else []
-    # v3.0.0 exposes 9 static resources. logic://mcu/state is filtered from the
-    # list when the MCU control surface is disconnected, so the expected count
-    # is 8 (disconnected) or 9 (connected).
+    # Issue #15 exposes 11 static resources. logic://mcu/state is filtered from
+    # the list when the MCU control surface is disconnected, so the expected
+    # count is 10 (disconnected) or 11 (connected).
     resource_count = len(resources)
-    T("resources/list returns 8 or 9 resources", r, lambda r: resource_count in (8, 9))
+    T("resources/list returns 10 or 11 resources", r, lambda r: resource_count in (10, 11))
 
     r = list_resource_templates(client)
     templates = r.get("result", {}).get("resourceTemplates", []) if r else []
-    T("resources/templates/list returns 3 templates", r, lambda r: len(templates) == 3)
+    T("resources/templates/list returns 5 templates", r, lambda r: len(templates) == 5)
 
     # ═══════════════════════════════════════════════════════════════
     # §2 System Diagnostics (15 tests)
@@ -993,7 +993,7 @@ def main():
         T(f"SECURITY: blocks {desc}", r, lambda _: is_error(r))
 
     # ═══════════════════════════════════════════════════════════════
-    # §11 Resource Read (18 tests)
+    # §11 Resource Read (28 tests)
     # ═══════════════════════════════════════════════════════════════
     section("§11 Resource Read")
 
@@ -1006,6 +1006,10 @@ def main():
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
+        "logic://workflow-skills/logic.workflow.plugins.stock_chain_plan",
+        "logic://workflow-skills/search?query=plugin",
         # mcu/state is read-testable even when filtered from list (direct reads
         # bypass the connection gate so clients bookmarking the URI still work).
         "logic://mcu/state",
@@ -1031,6 +1035,14 @@ def main():
                 ed and "No Logic Pro document is open" in rd
             ),
         )
+
+    r = read_resource(client, "logic://workflow-skills")
+    workflow_pack = safe_json(resource_text(r))
+    T("workflow skills pack validates", r,
+      lambda _: bool(workflow_pack and workflow_pack.get("validation", {}).get("is_valid") is True))
+    T("workflow skills include stock plugin planning workflow", r,
+      lambda _: any(w.get("id") == "logic.workflow.plugins.stock_chain_plan"
+                    for w in workflow_pack.get("workflows", [])) if workflow_pack else False)
 
     # Transport resource should have tempo
     r = read_resource(client, "logic://transport/state")

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -22,6 +22,12 @@ actor ChannelRouter {
 
     private var channels: [ChannelID: any Channel] = [:]
 
+    private static let transportToggleOpsAllowingAXElementFallback: Set<String> = [
+        "transport.toggle_cycle",
+        "transport.toggle_metronome",
+        "transport.toggle_count_in",
+    ]
+
     /// V2 routing table: MCU primary for mixer/transport/track state, MIDIKeyCommands for editing.
     /// PRD §4.3 + §4.3.1 contract changes.
     static let v2RoutingTable: [String: [ChannelID]] = [
@@ -33,7 +39,7 @@ actor ChannelRouter {
         "transport.pause":            [.coreMIDI, .cgEvent],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],
         "transport.fast_forward":     [.mcu, .coreMIDI, .cgEvent],
-        "transport.toggle_cycle":     [.accessibility, .mcu, .midiKeyCommands, .cgEvent],
+        "transport.toggle_cycle":     [.accessibility, .midiKeyCommands, .cgEvent, .mcu],
         "transport.toggle_metronome": [.accessibility, .midiKeyCommands, .cgEvent],
         // AX only — MIDIKeyCommands / CGEvent can't convey the tempo value
         // (MCU set_tempo CC fires blindly, no shortcut actually sets value).
@@ -375,6 +381,14 @@ actor ChannelRouter {
                 // in that case instead of wrapping it in the generic
                 // "All channels exhausted" message.
                 if HonestContract.isTerminalStateC(msg) {
+                    if Self.shouldContinueAfterTerminalStateC(operation: operation, channelID: channelID, message: msg) {
+                        Log.debug(
+                            "\(operation) terminal State C via \(channelID.rawValue) is recoverable by fallback: \(msg)",
+                            subsystem: "router"
+                        )
+                        lastError = msg
+                        continue
+                    }
                     Log.debug(
                         "\(operation) terminal State C via \(channelID.rawValue), suppressing fallback",
                         subsystem: "router"
@@ -402,6 +416,16 @@ actor ChannelRouter {
                 "last_error": lastError,
             ]
         ))
+    }
+
+    private static func shouldContinueAfterTerminalStateC(
+        operation: String,
+        channelID: ChannelID,
+        message: String
+    ) -> Bool {
+        channelID == .accessibility &&
+            transportToggleOpsAllowingAXElementFallback.contains(operation) &&
+            HonestContract.stateCErrorCode(message) == HonestContract.FailureError.elementNotFound.rawValue
     }
 
     /// Get health status for all registered channels.

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,7 @@ struct SystemDispatcher {
 
         default:
             return """
-                Logic Pro MCP — 8 dispatcher tools + 11 resources + 5 templates
+                Logic Pro MCP — 8 dispatcher tools + \(ResourceProvider.resources.count) resources + \(ResourceProvider.templates.count) templates
 
                 Tools (actions):
                   logic_transport  — Transport control (play, stop, record, tempo...)

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,7 @@ struct SystemDispatcher {
 
         default:
             return """
-                Logic Pro MCP — 8 dispatcher tools + 9 resources + 3 templates
+                Logic Pro MCP — 8 dispatcher tools + 11 resources + 5 templates
 
                 Tools (actions):
                   logic_transport  — Transport control (play, stop, record, tempo...)
@@ -408,11 +408,15 @@ struct SystemDispatcher {
                   logic://midi/ports            — MIDI ports
                   logic://mcu/state             — MCU control-surface state (hidden in list when disconnected)
                   logic://library/inventory     — Cached Library tree JSON
+                  logic://workflow-skills       — Validated workflow skills pack
+                  logic://workflow-skills/schema — Workflow skill schema
 
                 Resource templates:
                   logic://tracks/{index}          — Single track detail
                   logic://tracks/{index}/regions  — Regions on a single track
                   logic://mixer/{strip}           — Single channel strip
+                  logic://workflow-skills/{id}    — Workflow skill detail
+                  logic://workflow-skills/search?query={query} — Workflow skill search
 
                 Use: logic_system(command: "help", params: {category: "transport"})
                 for detailed command docs per category.

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -103,17 +103,8 @@ extension ResourceHandlers {
 
         await cache.recordToolAccess()
 
-        if uri == "logic://workflow-skills" {
-            return readWorkflowSkills(uri: uri)
-        }
-        if uri == "logic://workflow-skills/schema" {
-            return readWorkflowSkillSchema(uri: uri)
-        }
-        if uri.hasPrefix("logic://workflow-skills/search") {
-            return readWorkflowSkillSearch(uri: uri)
-        }
-        if uri.hasPrefix("logic://workflow-skills/") {
-            return try readWorkflowSkillDetail(uri: uri)
+        if uri == "logic://workflow-skills" || uri.hasPrefix("logic://workflow-skills/") || uri.hasPrefix("logic://workflow-skills?") {
+            return try readWorkflowSkillResource(uri: uri)
         }
 
         // hasDocument gate removed (post-hardening): the StatePoller's view
@@ -195,13 +186,50 @@ extension ResourceHandlers {
         )
     }
 
+    /// Workflow skill routing. Parsed with `URLComponents` so path and query
+    /// are matched exactly: unknown subpaths, nested segments, and stray query
+    /// parameters fail closed instead of silently degrading to a search or a
+    /// detail lookup.
+    private static func readWorkflowSkillResource(uri: String) throws -> ReadResource.Result {
+        guard let components = URLComponents(string: uri),
+              components.scheme == "logic",
+              components.host == "workflow-skills" else {
+            throw MCPError.invalidParams("Malformed workflow skill resource URI: \(uri)")
+        }
+        let segments = components.path.split(separator: "/").map(String.init)
+        let queryItems = components.queryItems ?? []
+        let unknownParams = queryItems.map(\.name).filter { $0 != "query" }
+
+        if segments.isEmpty {
+            guard queryItems.isEmpty else {
+                throw MCPError.invalidParams("logic://workflow-skills does not accept query parameters")
+            }
+            return readWorkflowSkills(uri: uri)
+        }
+        guard segments.count == 1 else {
+            throw MCPError.invalidParams("Unknown workflow skill resource path: \(components.path)")
+        }
+        let segment = segments[0]
+
+        if segment == "search" {
+            guard unknownParams.isEmpty else {
+                throw MCPError.invalidParams("Unsupported search parameters: \(unknownParams.joined(separator: ", "))")
+            }
+            return readWorkflowSkillSearch(uri: uri, query: queryItemValue(from: uri, name: "query") ?? "")
+        }
+        guard queryItems.isEmpty else {
+            throw MCPError.invalidParams("logic://workflow-skills/\(segment) does not accept query parameters")
+        }
+        if segment == "schema" { return readWorkflowSkillSchema(uri: uri) }
+        return try readWorkflowSkillDetail(uri: uri, id: segment)
+    }
+
     private static func readWorkflowSkills(uri: String) -> ReadResource.Result {
         let json = encodeJSON(WorkflowSkillCatalog.defaultSnapshot(), compact: true)
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
     }
 
-    private static func readWorkflowSkillDetail(uri: String) throws -> ReadResource.Result {
-        let id = String(uri.dropFirst("logic://workflow-skills/".count)).removingPercentEncoding ?? ""
+    private static func readWorkflowSkillDetail(uri: String, id: String) throws -> ReadResource.Result {
         let snapshot = WorkflowSkillCatalog.defaultSnapshot()
         guard let workflow = WorkflowSkillCatalog.workflow(id: id, snapshot: snapshot) else {
             throw MCPError.invalidParams("Unknown workflow skill id: \(id)")
@@ -215,9 +243,8 @@ extension ResourceHandlers {
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
     }
 
-    private static func readWorkflowSkillSearch(uri: String) -> ReadResource.Result {
+    private static func readWorkflowSkillSearch(uri: String, query: String) -> ReadResource.Result {
         let snapshot = WorkflowSkillCatalog.defaultSnapshot()
-        let query = queryValue(from: uri) ?? ""
         let workflows = WorkflowSkillCatalog.search(query: query, snapshot: snapshot).map(jsonObject)
         let json = encodeJSONObject([
             "schema_version": snapshot.schemaVersion,
@@ -233,28 +260,6 @@ extension ResourceHandlers {
     private static func readWorkflowSkillSchema(uri: String) -> ReadResource.Result {
         let json = encodeJSONObject(WorkflowSkillCatalog.schema())
         return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
-    }
-
-    private static func queryValue(from uri: String) -> String? {
-        URLComponents(string: uri)?
-            .queryItems?
-            .first { $0.name == "query" }?
-            .value?
-            .removingPercentEncoding
-    }
-
-    private static func jsonObject<T: Encodable>(_ value: T) -> Any {
-        let text = encodeJSON(value, compact: true)
-        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
-    }
-
-    private static func encodeJSONObject(_ object: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
-              let text = String(data: data, encoding: .utf8) else {
-            return #"{"error":"resource JSON encoding failed"}"#
-        }
-        return text
     }
 
     /// v3.1.8 (Issue #7) — tier-merged track list read.

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -197,6 +197,12 @@ extension ResourceHandlers {
             throw MCPError.invalidParams("Malformed workflow skill resource URI: \(uri)")
         }
         let segments = components.path.split(separator: "/").map(String.init)
+        // Reject doubled or trailing slashes ("//schema", "schema/") — the
+        // canonical reconstruction must reproduce the raw path exactly.
+        let canonicalPath = segments.isEmpty ? "" : "/" + segments.joined(separator: "/")
+        guard components.path == canonicalPath else {
+            throw MCPError.invalidParams("Malformed workflow skill resource path: \(components.path)")
+        }
         let queryItems = components.queryItems ?? []
         let unknownParams = queryItems.map(\.name).filter { $0 != "query" }
 

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -221,7 +221,11 @@ extension ResourceHandlers {
             guard unknownParams.isEmpty else {
                 throw MCPError.invalidParams("Unsupported search parameters: \(unknownParams.joined(separator: ", "))")
             }
-            return readWorkflowSkillSearch(uri: uri, query: queryItemValue(from: uri, name: "query") ?? "")
+            let queries = queryItems.filter { $0.name == "query" }
+            guard queries.count <= 1 else {
+                throw MCPError.invalidParams("logic://workflow-skills/search accepts at most one query parameter")
+            }
+            return readWorkflowSkillSearch(uri: uri, query: queries.first?.value ?? "")
         }
         guard queryItems.isEmpty else {
             throw MCPError.invalidParams("logic://workflow-skills/\(segment) does not accept query parameters")

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -103,6 +103,19 @@ extension ResourceHandlers {
 
         await cache.recordToolAccess()
 
+        if uri == "logic://workflow-skills" {
+            return readWorkflowSkills(uri: uri)
+        }
+        if uri == "logic://workflow-skills/schema" {
+            return readWorkflowSkillSchema(uri: uri)
+        }
+        if uri.hasPrefix("logic://workflow-skills/search") {
+            return readWorkflowSkillSearch(uri: uri)
+        }
+        if uri.hasPrefix("logic://workflow-skills/") {
+            return try readWorkflowSkillDetail(uri: uri)
+        }
+
         // hasDocument gate removed (post-hardening): the StatePoller's view
         // of "document open" can flap during normal Logic UI activity (focus
         // switches, plugin windows). Sustained-read tests showed 80/200 reads
@@ -180,6 +193,68 @@ extension ResourceHandlers {
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
+    }
+
+    private static func readWorkflowSkills(uri: String) -> ReadResource.Result {
+        let json = encodeJSON(WorkflowSkillCatalog.defaultSnapshot(), compact: true)
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readWorkflowSkillDetail(uri: String) throws -> ReadResource.Result {
+        let id = String(uri.dropFirst("logic://workflow-skills/".count)).removingPercentEncoding ?? ""
+        let snapshot = WorkflowSkillCatalog.defaultSnapshot()
+        guard let workflow = WorkflowSkillCatalog.workflow(id: id, snapshot: snapshot) else {
+            throw MCPError.invalidParams("Unknown workflow skill id: \(id)")
+        }
+        let json = encodeJSONObject([
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "workflow": jsonObject(workflow),
+            "validation": jsonObject(snapshot.validation),
+        ])
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readWorkflowSkillSearch(uri: String) -> ReadResource.Result {
+        let snapshot = WorkflowSkillCatalog.defaultSnapshot()
+        let query = queryValue(from: uri) ?? ""
+        let workflows = WorkflowSkillCatalog.search(query: query, snapshot: snapshot).map(jsonObject)
+        let json = encodeJSONObject([
+            "schema_version": snapshot.schemaVersion,
+            "generated_at": snapshot.generatedAt,
+            "query": query,
+            "workflows": workflows,
+            "result_count": workflows.count,
+            "validation": jsonObject(snapshot.validation),
+        ])
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func readWorkflowSkillSchema(uri: String) -> ReadResource.Result {
+        let json = encodeJSONObject(WorkflowSkillCatalog.schema())
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
+    }
+
+    private static func queryValue(from uri: String) -> String? {
+        URLComponents(string: uri)?
+            .queryItems?
+            .first { $0.name == "query" }?
+            .value?
+            .removingPercentEncoding
+    }
+
+    private static func jsonObject<T: Encodable>(_ value: T) -> Any {
+        let text = encodeJSON(value, compact: true)
+        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
+    }
+
+    private static func encodeJSONObject(_ object: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"resource JSON encoding failed"}"#
+        }
+        return text
     }
 
     /// v3.1.8 (Issue #7) — tier-merged track list read.

--- a/Sources/LogicProMCP/Resources/ResourceJSONHelpers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceJSONHelpers.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Shared JSON plumbing for static catalog resources (stock plugins, workflow
+/// skills). Kept in one file so independent feature branches can add their own
+/// resource handlers without colliding on duplicated private helpers.
+extension ResourceHandlers {
+    /// Decoded value of a single query item. `URLComponents` already
+    /// percent-decodes `value`; no second decode is applied.
+    static func queryItemValue(from uri: String, name: String) -> String? {
+        URLComponents(string: uri)?
+            .queryItems?
+            .first { $0.name == name }?
+            .value
+    }
+
+    static func jsonObject<T: Encodable>(_ value: T) -> Any {
+        let text = encodeJSON(value, compact: true)
+        return (try? JSONSerialization.jsonObject(with: Data(text.utf8))) ?? [:]
+    }
+
+    static func encodeJSONObject(_ object: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"resource JSON encoding failed"}"#
+        }
+        return text
+    }
+}

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -110,6 +110,20 @@ struct ResourceProvider {
             mimeType: "application/json",
             annotations: annotations(priority: 0.4)
         ),
+        Resource(
+            name: "Workflow Skills",
+            uri: "logic://workflow-skills",
+            description: "Validated read-only Logic Pro MCP workflow skill pack",
+            mimeType: "application/json",
+            annotations: annotations(priority: 0.43)
+        ),
+        Resource(
+            name: "Workflow Skills Schema",
+            uri: "logic://workflow-skills/schema",
+            description: "Workflow skill schema, evidence levels, and validation rules",
+            mimeType: "application/json",
+            annotations: annotations(priority: 0.34)
+        ),
     ]
 
     private static let baseTemplates: [Resource.Template] = [
@@ -129,6 +143,18 @@ struct ResourceProvider {
             uriTemplate: "logic://mixer/{strip}",
             name: "Channel Strip Detail",
             description: "Single channel strip by index (volume, pan, plugin chain)",
+            mimeType: "application/json"
+        ),
+        Resource.Template(
+            uriTemplate: "logic://workflow-skills/{id}",
+            name: "Workflow Skill Detail",
+            description: "Single workflow skill by stable ID",
+            mimeType: "application/json"
+        ),
+        Resource.Template(
+            uriTemplate: "logic://workflow-skills/search?query={query}",
+            name: "Workflow Skill Search",
+            description: "Search workflow skills by query",
             mimeType: "application/json"
         ),
     ]

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -166,18 +166,24 @@ enum HonestContract {
     /// suppress fallback when the primary channel has already reported an
     /// error the next channel cannot improve on.
     static func isTerminalStateC(_ message: String) -> Bool {
-        guard message.hasPrefix("{") else { return false }
+        guard let errorCode = stateCErrorCode(message) else { return false }
+        return terminalErrorCodes.contains(errorCode)
+    }
+
+    /// Returns the stable State C error code for a valid Honest Contract
+    /// failure envelope, or nil for free-form text / State A / State B.
+    static func stateCErrorCode(_ message: String) -> String? {
+        guard message.hasPrefix("{") else { return nil }
         guard let data = message.data(using: .utf8),
               let raw = try? JSONSerialization.jsonObject(with: data),
               let obj = raw as? [String: Any] else {
-            return false
+            return nil
         }
         // State A / B both carry `success:true`; only State C is `false`.
         guard let success = obj["success"] as? Bool, success == false else {
-            return false
+            return nil
         }
-        guard let errorCode = obj["error"] as? String else { return false }
-        return terminalErrorCodes.contains(errorCode)
+        return obj["error"] as? String
     }
 
     // MARK: - JSON serialization

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -45,6 +45,7 @@ struct WorkflowStep: Codable, Sendable, Equatable {
     let title: String
     let operationType: String
     let tool: String?
+    let command: String?
     let resource: String?
     let mutates: Bool
     let requiresConfirmationLevel: String?
@@ -56,6 +57,7 @@ struct WorkflowStep: Codable, Sendable, Equatable {
         case title
         case operationType = "operation_type"
         case tool
+        case command
         case resource
         case mutates
         case requiresConfirmationLevel = "requires_confirmation_level"
@@ -86,7 +88,7 @@ struct WorkflowSkill: Codable, Sendable, Equatable {
     var allowedResources: [String]
     var requiredConfirmations: [WorkflowConfirmation]
     let stateChecks: [WorkflowStateCheck]
-    let steps: [WorkflowStep]
+    var steps: [WorkflowStep]
     let verification: WorkflowVerification
     var failureModes: [String]
     let rollbackOrRecovery: String
@@ -94,9 +96,16 @@ struct WorkflowSkill: Codable, Sendable, Equatable {
     var productionReady: Bool
     let dependsOn: [String]
     let limitations: [String]
-    let mutationKind: WorkflowMutationKind
+    var mutationKind: WorkflowMutationKind
+    /// Snapshot-computed honesty fields: whether every referenced resource is
+    /// servable by *this* server build, and which ones are not. A recipe can
+    /// be production-quality while its declared external dependencies (e.g.
+    /// the #14 stock plugin catalog) are absent from the running build;
+    /// clients must check `dependencies_resolved` before executing.
+    var dependenciesResolved: Bool?
+    var unresolvedResources: [String]?
 
-    enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case id
         case title
         case intent
@@ -115,6 +124,8 @@ struct WorkflowSkill: Codable, Sendable, Equatable {
         case dependsOn = "depends_on"
         case limitations
         case mutationKind = "mutation_kind"
+        case dependenciesResolved = "dependencies_resolved"
+        case unresolvedResources = "unresolved_resources"
     }
 }
 
@@ -151,10 +162,14 @@ struct WorkflowSkillSnapshot: Codable, Sendable, Equatable {
 }
 
 enum WorkflowSkillLinter {
+    static let allowedConfirmationLevels: Set<String> = ["L1", "L2"]
+
     static func validate(
         _ workflows: [WorkflowSkill],
         toolNames: Set<String> = WorkflowSkillCatalog.currentToolNames(),
-        resourceURIs: Set<String> = WorkflowSkillCatalog.currentResourceURIs()
+        commandCensus: [String: Set<String>] = WorkflowSkillCatalog.publicCommands,
+        staticResourceURIs: Set<String> = WorkflowSkillCatalog.currentStaticResourceURIs(),
+        templateURIs: Set<String> = WorkflowSkillCatalog.currentTemplateURIs()
     ) -> WorkflowLintResult {
         var issues: [WorkflowLintIssue] = []
         var seen = Set<String>()
@@ -170,14 +185,61 @@ enum WorkflowSkillLinter {
             for tool in workflow.allowedTools where !toolNames.contains(tool) {
                 issues.append(issue("unknown_tool", "\(base).allowed_tools", "unknown MCP tool \(tool)"))
             }
-            for resource in workflow.allowedResources where !resourceURIs.contains(resource) {
-                issues.append(issue("unknown_resource", "\(base).allowed_resources", "unknown MCP resource \(resource)"))
+            validateResourceRefs(
+                workflow.allowedResources,
+                workflow: workflow,
+                path: "\(base).allowed_resources",
+                staticResourceURIs: staticResourceURIs,
+                templateURIs: templateURIs,
+                issues: &issues
+            )
+            for (checkIndex, check) in workflow.stateChecks.enumerated() {
+                validateResourceRefs(
+                    [check.resource],
+                    workflow: workflow,
+                    path: "\(base).state_checks[\(checkIndex)].resource",
+                    staticResourceURIs: staticResourceURIs,
+                    templateURIs: templateURIs,
+                    issues: &issues
+                )
             }
-            for (checkIndex, check) in workflow.stateChecks.enumerated()
-                where !resourceURIs.contains(check.resource) {
-                issues.append(issue("unknown_resource", "\(base).state_checks[\(checkIndex)].resource", "unknown MCP resource \(check.resource)"))
+
+            let workflowCommands = Set(commandCensus
+                .filter { workflow.allowedTools.contains($0.key) }
+                .flatMap(\.value))
+            for (confirmationIndex, confirmation) in workflow.requiredConfirmations.enumerated() {
+                if !allowedConfirmationLevels.contains(confirmation.level) {
+                    issues.append(issue(
+                        "invalid_confirmation_level",
+                        "\(base).required_confirmations[\(confirmationIndex)].level",
+                        "confirmation level must be one of \(allowedConfirmationLevels.sorted().joined(separator: ", "))"
+                    ))
+                }
+                for command in confirmation.requiredFor where !workflowCommands.contains(command) {
+                    issues.append(issue(
+                        "unknown_command",
+                        "\(base).required_confirmations[\(confirmationIndex)].required_for",
+                        "command \(command) is not a public command of the workflow's allowed tools"
+                    ))
+                }
             }
-            let mutating = workflow.mutationKind == .guardedMutation || workflow.steps.contains { $0.mutates }
+
+            let hasMutatingStep = workflow.steps.contains { $0.mutates }
+            let mutating = workflow.mutationKind == .guardedMutation || hasMutatingStep
+            if workflow.mutationKind == .readOnly && hasMutatingStep {
+                issues.append(issue(
+                    "mutation_kind_mismatch",
+                    "\(base).mutation_kind",
+                    "read_only workflows must not contain mutating steps"
+                ))
+            }
+            if workflow.mutationKind == .guardedMutation && !hasMutatingStep {
+                issues.append(issue(
+                    "mutation_kind_mismatch",
+                    "\(base).mutation_kind",
+                    "guarded_mutation workflows must contain at least one mutating step"
+                ))
+            }
             if mutating && workflow.requiredConfirmations.isEmpty {
                 issues.append(issue("mutating_missing_confirmation", "\(base).required_confirmations", "mutating workflows require confirmation metadata"))
             }
@@ -191,23 +253,106 @@ enum WorkflowSkillLinter {
                     "production-ready mutating workflows must be live_verified"
                 ))
             }
+            if workflow.evidenceLevel == .liveVerified && (workflow.verification.liveEvidenceFile?.isEmpty ?? true) {
+                issues.append(issue(
+                    "live_verified_missing_evidence_file",
+                    "\(base).verification.live_evidence_file",
+                    "live_verified workflows must reference their evidence file"
+                ))
+            }
+
+            let declaredLevels = Set(workflow.requiredConfirmations.map(\.level))
+            let confirmedCommands = Set(workflow.requiredConfirmations.flatMap(\.requiredFor))
             for (stepIndex, step) in workflow.steps.enumerated() {
+                let stepPath = "\(base).steps[\(stepIndex)]"
                 if let tool = step.tool, !toolNames.contains(tool) {
-                    issues.append(issue("unknown_tool", "\(base).steps[\(stepIndex)].tool", "unknown MCP tool \(tool)"))
+                    issues.append(issue("unknown_tool", "\(stepPath).tool", "unknown MCP tool \(tool)"))
                 }
-                if let resource = step.resource, !resourceURIs.contains(resource) {
-                    issues.append(issue("unknown_resource", "\(base).steps[\(stepIndex)].resource", "unknown MCP resource \(resource)"))
+                if let tool = step.tool {
+                    if let command = step.command {
+                        if let known = commandCensus[tool], !known.contains(command) {
+                            issues.append(issue(
+                                "unknown_command",
+                                "\(stepPath).command",
+                                "\(command) is not a public command of \(tool)"
+                            ))
+                        }
+                    } else if step.mutates {
+                        issues.append(issue(
+                            "mutating_step_missing_command",
+                            stepPath,
+                            "mutating tool steps must name the exact public command"
+                        ))
+                    }
                 }
-                if step.mutates && (step.requiresConfirmationLevel?.isEmpty ?? true) {
-                    issues.append(issue("mutating_step_missing_confirmation", "\(base).steps[\(stepIndex)]", "mutating steps need confirmation level"))
+                if let resource = step.resource {
+                    validateResourceRefs(
+                        [resource],
+                        workflow: workflow,
+                        path: "\(stepPath).resource",
+                        staticResourceURIs: staticResourceURIs,
+                        templateURIs: templateURIs,
+                        issues: &issues
+                    )
+                }
+                if step.mutates {
+                    if let level = step.requiresConfirmationLevel, !level.isEmpty {
+                        if !allowedConfirmationLevels.contains(level) {
+                            issues.append(issue(
+                                "invalid_confirmation_level",
+                                "\(stepPath).requires_confirmation_level",
+                                "confirmation level must be one of \(allowedConfirmationLevels.sorted().joined(separator: ", "))"
+                            ))
+                        } else if !declaredLevels.contains(level) {
+                            issues.append(issue(
+                                "mutating_step_not_covered_by_confirmation",
+                                stepPath,
+                                "step confirmation level \(level) is not declared in required_confirmations"
+                            ))
+                        }
+                        if let command = step.command, !confirmedCommands.contains(command) {
+                            issues.append(issue(
+                                "mutating_step_not_covered_by_confirmation",
+                                stepPath,
+                                "mutating command \(command) is not listed in any required_confirmations.required_for"
+                            ))
+                        }
+                    } else {
+                        issues.append(issue("mutating_step_missing_confirmation", stepPath, "mutating steps need confirmation level"))
+                    }
                 }
                 if step.expectedResponseFields.isEmpty {
-                    issues.append(issue("step_missing_success_fields", "\(base).steps[\(stepIndex)]", "steps must name response fields to inspect"))
+                    issues.append(issue("step_missing_success_fields", stepPath, "steps must name response fields to inspect"))
                 }
             }
         }
 
         return WorkflowLintResult(isValid: issues.isEmpty, issues: issues)
+    }
+
+    /// A resource reference passes when it is servable by this build (exact
+    /// static URI, a registered template, or a concrete instantiation of a
+    /// registered template) or when it is covered by the workflow's declared
+    /// external dependencies (`depends_on`). Anything else is a stale
+    /// reference and fails the lint — there is no hand-maintained allowlist
+    /// of phantom URIs.
+    private static func validateResourceRefs(
+        _ refs: [String],
+        workflow: WorkflowSkill,
+        path: String,
+        staticResourceURIs: Set<String>,
+        templateURIs: Set<String>,
+        issues: inout [WorkflowLintIssue]
+    ) {
+        for ref in refs {
+            if WorkflowSkillCatalog.resourceRefResolves(ref, staticURIs: staticResourceURIs, templateURIs: templateURIs) {
+                continue
+            }
+            if WorkflowSkillCatalog.refCoveredByDependencies(ref, dependsOn: workflow.dependsOn) {
+                continue
+            }
+            issues.append(issue("unknown_resource", path, "unknown MCP resource \(ref) (not servable and not declared in depends_on)"))
+        }
     }
 
     private static func issue(_ code: String, _ path: String, _ message: String) -> WorkflowLintIssue {
@@ -217,8 +362,28 @@ enum WorkflowSkillLinter {
 
 enum WorkflowSkillCatalog {
     static func defaultSnapshot(now: Date = Date()) -> WorkflowSkillSnapshot {
-        let workflows = defaultWorkflows()
-        let validation = WorkflowSkillLinter.validate(workflows)
+        snapshot(now: now)
+    }
+
+    static func snapshot(
+        now: Date = Date(),
+        staticResourceURIs: Set<String> = currentStaticResourceURIs(),
+        templateURIs: Set<String> = currentTemplateURIs()
+    ) -> WorkflowSkillSnapshot {
+        let workflows = defaultWorkflows().map { workflow in
+            var resolved = workflow
+            let unresolved = referencedResources(of: workflow).filter {
+                !resourceRefResolves($0, staticURIs: staticResourceURIs, templateURIs: templateURIs)
+            }
+            resolved.dependenciesResolved = unresolved.isEmpty
+            resolved.unresolvedResources = unresolved.isEmpty ? nil : unresolved.sorted()
+            return resolved
+        }
+        let validation = WorkflowSkillLinter.validate(
+            workflows,
+            staticResourceURIs: staticResourceURIs,
+            templateURIs: templateURIs
+        )
         return WorkflowSkillSnapshot(
             schemaVersion: 1,
             generatedAt: ISO8601DateFormatter.cacheFormatter.string(from: now),
@@ -226,6 +391,13 @@ enum WorkflowSkillCatalog {
             validation: validation,
             workflows: workflows
         )
+    }
+
+    static func referencedResources(of workflow: WorkflowSkill) -> [String] {
+        var refs = Set(workflow.allowedResources)
+        refs.formUnion(workflow.stateChecks.map(\.resource))
+        refs.formUnion(workflow.steps.compactMap(\.resource))
+        return Array(refs)
     }
 
     static func defaultWorkflows() -> [WorkflowSkill] {
@@ -259,29 +431,38 @@ enum WorkflowSkillCatalog {
         [
             "schema_version": 1,
             "generated_at": ISO8601DateFormatter.cacheFormatter.string(from: now),
-            "required_fields": [
-                "id",
-                "title",
-                "intent",
-                "scope",
-                "prerequisites",
-                "allowed_tools",
-                "allowed_resources",
-                "state_checks",
-                "steps",
-                "verification",
-                "failure_modes",
-                "evidence_level",
+            "fields": WorkflowSkill.CodingKeys.allCases.map(\.rawValue),
+            "computed_fields": [
+                "dependencies_resolved",
+                "unresolved_resources",
             ],
             "evidence_levels": WorkflowEvidenceLevel.allCases.map(\.rawValue),
             "mutation_kinds": [
                 WorkflowMutationKind.readOnly.rawValue,
                 WorkflowMutationKind.guardedMutation.rawValue,
             ],
+            "confirmation_levels": WorkflowSkillLinter.allowedConfirmationLevels.sorted(),
+            "lint_rules": [
+                "duplicate_id",
+                "missing_required_field",
+                "unknown_tool",
+                "unknown_command",
+                "unknown_resource",
+                "invalid_confirmation_level",
+                "mutation_kind_mismatch",
+                "mutating_missing_confirmation",
+                "mutating_missing_failure_modes",
+                "mutating_step_missing_command",
+                "mutating_step_missing_confirmation",
+                "mutating_step_not_covered_by_confirmation",
+                "production_mutation_without_live_evidence",
+                "live_verified_missing_evidence_file",
+                "step_missing_success_fields",
+            ],
             "resources": [
                 "logic://workflow-skills",
                 "logic://workflow-skills/{id}",
-                "logic://workflow-skills/search?query=<text>",
+                "logic://workflow-skills/search?query={query}",
                 "logic://workflow-skills/schema",
             ],
             "read_only_surface": true,
@@ -289,36 +470,123 @@ enum WorkflowSkillCatalog {
     }
 
     static func currentToolNames() -> Set<String> {
-        [
-            "logic_transport",
-            "logic_tracks",
-            "logic_mixer",
-            "logic_midi",
-            "logic_edit",
-            "logic_navigate",
-            "logic_project",
-            "logic_system",
-        ]
+        Set(publicCommands.keys)
     }
 
-    static func currentResourceURIs() -> Set<String> {
-        var uris = Set(ResourceProvider.resources.map(\.uri))
-        uris.formUnion(ResourceProvider.templates.map(\.uriTemplate))
-        // Issue #15 is an independent branch, but some recipes intentionally
-        // depend on the stock plugin catalog shipped by issue #14.
-        uris.formUnion([
-            "logic://stock-plugins",
-            "logic://stock-plugins/{id}",
-            "logic://stock-plugins/logic.stock.effect.gain",
-            "logic://stock-plugins/search?query=<text>",
-            "logic://workflow-skills/{id}",
-            "logic://workflow-skills/search?query=<text>",
-        ])
-        return uris
+    /// Public command census per MCP tool. Kept in lockstep with the
+    /// dispatcher `case` labels by `WorkflowCommandCensusTests`, which reads
+    /// the dispatcher sources and fails when a census command disappears.
+    static let publicCommands: [String: Set<String>] = [
+        "logic_transport": [
+            "play", "stop", "record", "pause", "rewind", "fast_forward",
+            "toggle_cycle", "toggle_metronome", "toggle_count_in",
+            "set_tempo", "goto_position", "set_cycle_range",
+        ],
+        "logic_tracks": [
+            "select", "create_audio", "create_instrument", "create_drummer",
+            "create_external_midi", "delete", "duplicate", "rename",
+            "mute", "solo", "arm", "arm_only", "record_sequence",
+            "set_color", "set_automation", "set_instrument",
+            "resolve_path", "list_library", "scan_library", "scan_plugin_presets",
+        ],
+        "logic_mixer": [
+            "set_volume", "set_pan", "set_send", "set_output", "set_input",
+            "set_master_volume", "toggle_eq", "reset_strip",
+            "insert_plugin", "bypass_plugin", "set_plugin_param",
+        ],
+        "logic_midi": [
+            "send_note", "send_chord", "play_sequence", "send_cc",
+            "send_program_change", "send_pitch_bend", "send_aftertouch",
+            "send_sysex", "import_file", "create_virtual_port",
+            "mmc_play", "mmc_stop", "mmc_record", "mmc_locate", "step_input",
+        ],
+        "logic_edit": [
+            "undo", "redo", "cut", "copy", "paste", "delete", "select_all",
+            "split", "join", "quantize", "bounce_in_place", "normalize",
+            "duplicate", "toggle_step_input",
+        ],
+        "logic_navigate": [
+            "goto_bar", "goto_marker", "create_marker", "delete_marker",
+            "rename_marker", "zoom_to_fit", "set_zoom", "toggle_view",
+        ],
+        "logic_project": [
+            "new", "open", "save", "save_as", "close", "bounce",
+            "is_running", "get_regions", "launch", "quit",
+        ],
+        "logic_system": [
+            "health", "permissions", "refresh_cache", "help",
+        ],
+    ]
+
+    static func currentStaticResourceURIs() -> Set<String> {
+        Set(ResourceProvider.resources.map(\.uri))
     }
+
+    static func currentTemplateURIs() -> Set<String> {
+        Set(ResourceProvider.templates.map(\.uriTemplate))
+    }
+
+    // MARK: - Resource reference resolution
+
+    static func resourceRefResolves(_ ref: String, staticURIs: Set<String>, templateURIs: Set<String>) -> Bool {
+        if staticURIs.contains(ref) || templateURIs.contains(ref) { return true }
+        return templateURIs.contains { template in refMatchesTemplate(ref, template: template) }
+    }
+
+    static func refCoveredByDependencies(_ ref: String, dependsOn: [String]) -> Bool {
+        dependsOn.contains { dep in
+            ref == dep || ref.hasPrefix(dep + "/") || ref.hasPrefix(dep + "?")
+        }
+    }
+
+    /// Matches a concrete or templated reference against a registered
+    /// template URI. `{placeholder}` segments and query values match any
+    /// non-empty concrete value (or an identical placeholder).
+    static func refMatchesTemplate(_ ref: String, template: String) -> Bool {
+        let refParts = ref.split(separator: "?", maxSplits: 1).map(String.init)
+        let templateParts = template.split(separator: "?", maxSplits: 1).map(String.init)
+        guard pathMatches(refParts[0], templatePath: templateParts[0]) else { return false }
+        switch (refParts.count > 1 ? refParts[1] : nil, templateParts.count > 1 ? templateParts[1] : nil) {
+        case (nil, nil):
+            return true
+        case let (refQuery?, templateQuery?):
+            return queryMatches(refQuery, templateQuery: templateQuery)
+        default:
+            return false
+        }
+    }
+
+    private static func pathMatches(_ refPath: String, templatePath: String) -> Bool {
+        let refSegments = refPath.split(separator: "/").map(String.init)
+        let templateSegments = templatePath.split(separator: "/").map(String.init)
+        guard refSegments.count == templateSegments.count else { return false }
+        return zip(refSegments, templateSegments).allSatisfy { refSegment, templateSegment in
+            isPlaceholder(templateSegment) ? !refSegment.isEmpty : refSegment == templateSegment
+        }
+    }
+
+    private static func queryMatches(_ refQuery: String, templateQuery: String) -> Bool {
+        let refPairs = refQuery.split(separator: "&").map(String.init).sorted()
+        let templatePairs = templateQuery.split(separator: "&").map(String.init).sorted()
+        guard refPairs.count == templatePairs.count else { return false }
+        return zip(refPairs, templatePairs).allSatisfy { refPair, templatePair in
+            let refKV = refPair.split(separator: "=", maxSplits: 1).map(String.init)
+            let templateKV = templatePair.split(separator: "=", maxSplits: 1).map(String.init)
+            guard refKV.first == templateKV.first else { return false }
+            let templateValue = templateKV.count > 1 ? templateKV[1] : ""
+            let refValue = refKV.count > 1 ? refKV[1] : ""
+            return isPlaceholder(templateValue) ? !refValue.isEmpty : refValue == templateValue
+        }
+    }
+
+    private static func isPlaceholder(_ segment: String) -> Bool {
+        segment.hasPrefix("{") && segment.hasSuffix("}") && segment.count > 2
+    }
+
+    // MARK: - Workflows
 
     private static func projectReadiness() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.readiness.project",
             title: "Project Readiness Check",
             intent: "Confirm Logic Pro, MCP resources, project state, tracks, transport, and mixer provenance before creative work.",
@@ -349,7 +617,7 @@ enum WorkflowSkillCatalog {
     }
 
     private static func midiIdeaSketch() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.midi.idea_sketch",
             title: "MIDI Idea Sketch",
             intent: "Create or import a small MIDI idea only after the target track and project state are explicit.",
@@ -358,7 +626,7 @@ enum WorkflowSkillCatalog {
             allowedTools: ["logic_tracks", "logic_midi"],
             allowedResources: ["logic://tracks", "logic://tracks/{index}/regions", "logic://project/info"],
             requiredConfirmations: [
-                WorkflowConfirmation(level: "L1", requiredFor: ["midi_import", "record_sequence"], message: "Confirm target track and MIDI content before writing."),
+                WorkflowConfirmation(level: "L1", requiredFor: ["import_file", "record_sequence"], message: "Confirm target track and MIDI content before writing."),
             ],
             stateChecks: [
                 stateCheck("tracks", "logic://tracks", ["data"], true),
@@ -366,7 +634,7 @@ enum WorkflowSkillCatalog {
             ],
             steps: [
                 readStep("read_tracks", "Read tracks before target selection", "logic://tracks", ["data"]),
-                toolStep("write_midi", "Import or record MIDI on explicit target", "logic_midi", true, "L1", ["success", "verified"], ["unverified target", "invalid channel"]),
+                toolStep("write_midi", "Import MIDI file for the explicit target", "logic_midi", command: "import_file", true, "L1", ["success", "verified"], ["unverified target", "invalid channel"]),
                 readStep("regions_after", "Read regions after write", "logic://tracks/{index}/regions", ["regions"]),
             ],
             verification: WorkflowVerification(evidence: ["before_regions", "after_regions", "tool_envelope"], successFields: ["region_count_delta", "verified"], liveEvidenceFile: nil),
@@ -375,13 +643,16 @@ enum WorkflowSkillCatalog {
             evidenceLevel: .deterministic,
             productionReady: false,
             dependsOn: [],
-            limitations: ["Not production-ready until a scoped live mutation run is recorded."],
+            limitations: [
+                "Not production-ready until a scoped live mutation run is recorded.",
+                "logic_tracks record_sequence is the alternative guarded write for captured sequences; it carries the same L1 confirmation requirement.",
+            ],
             mutationKind: .guardedMutation
         )
     }
 
     private static func arrangementMarkerPlan() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.arrangement.marker_plan",
             title: "Arrangement Marker Plan",
             intent: "Plan and verify marker positions without relying on stale parser assumptions.",
@@ -390,12 +661,12 @@ enum WorkflowSkillCatalog {
             allowedTools: ["logic_navigate"],
             allowedResources: ["logic://markers", "logic://transport/state"],
             requiredConfirmations: [
-                WorkflowConfirmation(level: "L1", requiredFor: ["marker_mutation"], message: "Confirm marker names and positions before writing."),
+                WorkflowConfirmation(level: "L1", requiredFor: ["create_marker", "rename_marker"], message: "Confirm marker names and positions before writing."),
             ],
             stateChecks: [stateCheck("markers", "logic://markers", ["data"], false)],
             steps: [
                 readStep("read_markers", "Read current markers", "logic://markers", ["data", "position_source"]),
-                toolStep("optional_write", "Optionally create supported markers", "logic_navigate", true, "L1", ["success", "verified"], ["unsupported marker mutation", "position parse failure"]),
+                toolStep("optional_write", "Optionally create a marker at the playhead", "logic_navigate", command: "create_marker", true, "L1", ["success", "verified"], ["unsupported marker mutation", "position parse failure"]),
             ],
             verification: WorkflowVerification(evidence: ["marker_resource_before_after"], successFields: ["canonical_position", "verified"], liveEvidenceFile: nil),
             failureModes: ["marker resource unavailable", "position parser rejects input", "post-write readback unavailable"],
@@ -403,13 +674,15 @@ enum WorkflowSkillCatalog {
             evidenceLevel: .deterministic,
             productionReady: false,
             dependsOn: [],
-            limitations: ["Mutation path may be unavailable depending on current public tool surface."],
+            limitations: [
+                "delete_marker and indexed goto_marker are keycmd-only on Logic 12.2 (manual MIDI Learn binding required; see SETUP §4.1) and are intentionally not part of this recipe.",
+            ],
             mutationKind: .guardedMutation
         )
     }
 
     private static func gainStagingPrep() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.mixer.gain_staging_prep",
             title: "Gain Staging And Mixer Prep",
             intent: "Prepare safe gain-staging recommendations using mixer provenance and explicit target verification.",
@@ -426,7 +699,7 @@ enum WorkflowSkillCatalog {
             ],
             steps: [
                 readStep("read_mixer", "Read mixer provenance", "logic://mixer", ["data_source", "mcu_connected", "strips"]),
-                toolStep("optional_level_write", "Optionally write volume/pan with explicit track", "logic_mixer", true, "L1", ["success", "verified", "reason"], ["target unverified", "readback unavailable"]),
+                toolStep("optional_level_write", "Optionally write volume with explicit track", "logic_mixer", command: "set_volume", true, "L1", ["success", "verified", "reason"], ["target unverified", "readback unavailable"]),
                 readStep("read_strip_after", "Read target strip after write", "logic://mixer/{strip}", ["data_source", "strip"]),
             ],
             verification: WorkflowVerification(evidence: ["mixer_before_after", "honest_contract_envelope"], successFields: ["verified", "data_source"], liveEvidenceFile: nil),
@@ -435,20 +708,23 @@ enum WorkflowSkillCatalog {
             evidenceLevel: .deterministic,
             productionReady: false,
             dependsOn: [],
-            limitations: ["Stops instead of writing when provenance is insufficient."],
+            limitations: [
+                "Stops instead of writing when provenance is insufficient.",
+                "set_pan is a relative V-Pot write on the MCU path (pan_write_mode: relative_vpot); do not treat it as an absolute target setter.",
+            ],
             mutationKind: .guardedMutation
         )
     }
 
     private static func stockPluginChainPlan() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.plugins.stock_chain_plan",
             title: "Stock Plugin Chain Planning",
             intent: "Plan stock plugin chains from verified catalog metadata without claiming insertion success.",
             scope: "Planning-only in this release; no plugin insertion is executed.",
             prerequisites: ["Stock plugin catalog resource readable", "Mixer slot state available if planning against a track"],
             allowedTools: [],
-            allowedResources: ["logic://stock-plugins", "logic://stock-plugins/{id}", "logic://stock-plugins/search?query=<text>", "logic://mixer"],
+            allowedResources: ["logic://stock-plugins", "logic://stock-plugins/{id}", "logic://stock-plugins/search?query={query}", "logic://mixer"],
             requiredConfirmations: [],
             stateChecks: [
                 stateCheck("catalog", "logic://stock-plugins", ["entries", "validation"], true),
@@ -456,7 +732,7 @@ enum WorkflowSkillCatalog {
             ],
             steps: [
                 readStep("read_catalog", "Read stock plugin catalog", "logic://stock-plugins", ["entries", "availability_state"]),
-                readStep("search_catalog", "Search catalog for user intent", "logic://stock-plugins/search?query=<text>", ["entries"]),
+                readStep("search_catalog", "Search catalog for user intent", "logic://stock-plugins/search?query={query}", ["entries"]),
                 readStep("read_mixer_slots", "Read mixer slot state before planning insert order", "logic://mixer", ["strips"]),
             ],
             verification: WorkflowVerification(evidence: ["catalog_entry_truth_labels", "slot_state"], successFields: ["availability_state", "limitations"], liveEvidenceFile: nil),
@@ -471,7 +747,7 @@ enum WorkflowSkillCatalog {
     }
 
     private static func stockPluginGuardedInsert() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.plugins.stock_insert_gain_live_verified",
             title: "Live-Verified Gain Insert",
             intent: "Insert Logic's stock Gain plugin only after catalog lookup, explicit track/slot confirmation, empty-slot checks, and AX slot readback.",
@@ -484,7 +760,7 @@ enum WorkflowSkillCatalog {
             ],
             allowedTools: ["logic_mixer"],
             allowedResources: [
-                "logic://stock-plugins/logic.stock.effect.gain",
+                "logic://stock-plugins/{id}",
                 "logic://mixer",
                 "logic://mixer/{strip}",
             ],
@@ -507,6 +783,7 @@ enum WorkflowSkillCatalog {
                     "confirmed_insert_gain",
                     "Insert stock Gain into an explicit empty slot",
                     "logic_mixer",
+                    command: "insert_plugin",
                     true,
                     "L2",
                     ["success", "verified", "observed_plugin_name", "verify_source"],
@@ -540,7 +817,7 @@ enum WorkflowSkillCatalog {
     }
 
     private static func bounceReadiness() -> WorkflowSkill {
-        WorkflowSkill(
+        makeWorkflow(
             id: "logic.workflow.bounce.readiness",
             title: "Bounce Readiness Checklist",
             intent: "Check project state before manual bounce/export.",
@@ -565,8 +842,54 @@ enum WorkflowSkillCatalog {
             evidenceLevel: .deterministic,
             productionReady: true,
             dependsOn: [],
-            limitations: ["Does not perform a bounce/export."],
+            limitations: ["Does not perform a bounce/export; project.bounce is keycmd-only on Logic 12.2."],
             mutationKind: .readOnly
+        )
+    }
+
+    // MARK: - Builders
+
+    private static func makeWorkflow(
+        id: String,
+        title: String,
+        intent: String,
+        scope: String,
+        prerequisites: [String],
+        allowedTools: [String],
+        allowedResources: [String],
+        requiredConfirmations: [WorkflowConfirmation],
+        stateChecks: [WorkflowStateCheck],
+        steps: [WorkflowStep],
+        verification: WorkflowVerification,
+        failureModes: [String],
+        rollbackOrRecovery: String,
+        evidenceLevel: WorkflowEvidenceLevel,
+        productionReady: Bool,
+        dependsOn: [String],
+        limitations: [String],
+        mutationKind: WorkflowMutationKind
+    ) -> WorkflowSkill {
+        WorkflowSkill(
+            id: id,
+            title: title,
+            intent: intent,
+            scope: scope,
+            prerequisites: prerequisites,
+            allowedTools: allowedTools,
+            allowedResources: allowedResources,
+            requiredConfirmations: requiredConfirmations,
+            stateChecks: stateChecks,
+            steps: steps,
+            verification: verification,
+            failureModes: failureModes,
+            rollbackOrRecovery: rollbackOrRecovery,
+            evidenceLevel: evidenceLevel,
+            productionReady: productionReady,
+            dependsOn: dependsOn,
+            limitations: limitations,
+            mutationKind: mutationKind,
+            dependenciesResolved: nil,
+            unresolvedResources: nil
         )
     }
 
@@ -586,6 +909,7 @@ enum WorkflowSkillCatalog {
             title: title,
             operationType: "resource_read",
             tool: nil,
+            command: nil,
             resource: resource,
             mutates: false,
             requiresConfirmationLevel: nil,
@@ -598,6 +922,7 @@ enum WorkflowSkillCatalog {
         _ id: String,
         _ title: String,
         _ tool: String,
+        command: String,
         _ mutates: Bool,
         _ level: String?,
         _ fields: [String],
@@ -608,6 +933,7 @@ enum WorkflowSkillCatalog {
             title: title,
             operationType: "tool_call",
             tool: tool,
+            command: command,
             resource: nil,
             mutates: mutates,
             requiresConfirmationLevel: level,

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -185,6 +185,14 @@ enum WorkflowSkillLinter {
             for tool in workflow.allowedTools where !toolNames.contains(tool) {
                 issues.append(issue("unknown_tool", "\(base).allowed_tools", "unknown MCP tool \(tool)"))
             }
+            for (depIndex, dep) in workflow.dependsOn.enumerated()
+                where !WorkflowSkillCatalog.isValidDependencyRoot(dep) {
+                issues.append(issue(
+                    "invalid_dependency",
+                    "\(base).depends_on[\(depIndex)]",
+                    "dependency \(dep) must be a logic://<host> URI root"
+                ))
+            }
             validateResourceRefs(
                 workflow.allowedResources,
                 workflow: workflow,
@@ -261,8 +269,6 @@ enum WorkflowSkillLinter {
                 ))
             }
 
-            let declaredLevels = Set(workflow.requiredConfirmations.map(\.level))
-            let confirmedCommands = Set(workflow.requiredConfirmations.flatMap(\.requiredFor))
             for (stepIndex, step) in workflow.steps.enumerated() {
                 let stepPath = "\(base).steps[\(stepIndex)]"
                 if let tool = step.tool, !toolNames.contains(tool) {
@@ -303,19 +309,25 @@ enum WorkflowSkillLinter {
                                 "\(stepPath).requires_confirmation_level",
                                 "confirmation level must be one of \(allowedConfirmationLevels.sorted().joined(separator: ", "))"
                             ))
-                        } else if !declaredLevels.contains(level) {
-                            issues.append(issue(
-                                "mutating_step_not_covered_by_confirmation",
-                                stepPath,
-                                "step confirmation level \(level) is not declared in required_confirmations"
-                            ))
-                        }
-                        if let command = step.command, !confirmedCommands.contains(command) {
-                            issues.append(issue(
-                                "mutating_step_not_covered_by_confirmation",
-                                stepPath,
-                                "mutating command \(command) is not listed in any required_confirmations.required_for"
-                            ))
+                        } else {
+                            // Coverage is validated as an exact (level, command)
+                            // pair: a command confirmed at L1 does not license an
+                            // L2 step, and vice versa.
+                            let sameLevel = workflow.requiredConfirmations.filter { $0.level == level }
+                            if sameLevel.isEmpty {
+                                issues.append(issue(
+                                    "mutating_step_not_covered_by_confirmation",
+                                    stepPath,
+                                    "step confirmation level \(level) is not declared in required_confirmations"
+                                ))
+                            } else if let command = step.command,
+                                      !sameLevel.contains(where: { $0.requiredFor.contains(command) }) {
+                                issues.append(issue(
+                                    "mutating_step_not_covered_by_confirmation",
+                                    stepPath,
+                                    "mutating command \(command) is not listed in a level-\(level) required_confirmations entry"
+                                ))
+                            }
                         }
                     } else {
                         issues.append(issue("mutating_step_missing_confirmation", stepPath, "mutating steps need confirmation level"))
@@ -448,6 +460,7 @@ enum WorkflowSkillCatalog {
                 "unknown_tool",
                 "unknown_command",
                 "unknown_resource",
+                "invalid_dependency",
                 "invalid_confirmation_level",
                 "mutation_kind_mismatch",
                 "mutating_missing_confirmation",
@@ -473,9 +486,12 @@ enum WorkflowSkillCatalog {
         Set(publicCommands.keys)
     }
 
-    /// Public command census per MCP tool. Kept in lockstep with the
-    /// dispatcher `case` labels by `WorkflowCommandCensusTests`, which reads
-    /// the dispatcher sources and fails when a census command disappears.
+    /// Public command census per MCP tool. Error-only stubs ("not exposed in
+    /// the production MCP contract") are deliberately excluded — a census
+    /// command must actually execute, not merely parse. Kept in lockstep with
+    /// the dispatcher `case` labels by `WorkflowCommandCensusTests`, which
+    /// reads the dispatcher sources and fails when a census command
+    /// disappears or degrades into a not-exposed stub.
     static let publicCommands: [String: Set<String>] = [
         "logic_transport": [
             "play", "stop", "record", "pause", "rewind", "fast_forward",
@@ -486,13 +502,12 @@ enum WorkflowSkillCatalog {
             "select", "create_audio", "create_instrument", "create_drummer",
             "create_external_midi", "delete", "duplicate", "rename",
             "mute", "solo", "arm", "arm_only", "record_sequence",
-            "set_color", "set_automation", "set_instrument",
+            "set_automation", "set_instrument",
             "resolve_path", "list_library", "scan_library", "scan_plugin_presets",
         ],
         "logic_mixer": [
-            "set_volume", "set_pan", "set_send", "set_output", "set_input",
-            "set_master_volume", "toggle_eq", "reset_strip",
-            "insert_plugin", "bypass_plugin", "set_plugin_param",
+            "set_volume", "set_pan", "set_master_volume",
+            "insert_plugin", "set_plugin_param",
         ],
         "logic_midi": [
             "send_note", "send_chord", "play_sequence", "send_cc",
@@ -533,8 +548,15 @@ enum WorkflowSkillCatalog {
         return templateURIs.contains { template in refMatchesTemplate(ref, template: template) }
     }
 
+    /// Declared external dependency roots must be well-formed `logic://host`
+    /// URIs (optionally with a path). Bare schemes like `logic:` would
+    /// otherwise cover the entire URI space and neuter the lint.
+    static func isValidDependencyRoot(_ dep: String) -> Bool {
+        dep.range(of: "^logic://[a-z0-9-]+(/[A-Za-z0-9._/-]+)?$", options: .regularExpression) != nil
+    }
+
     static func refCoveredByDependencies(_ ref: String, dependsOn: [String]) -> Bool {
-        dependsOn.contains { dep in
+        dependsOn.filter(isValidDependencyRoot).contains { dep in
             ref == dep || ref.hasPrefix(dep + "/") || ref.hasPrefix(dep + "?")
         }
     }
@@ -557,8 +579,11 @@ enum WorkflowSkillCatalog {
     }
 
     private static func pathMatches(_ refPath: String, templatePath: String) -> Bool {
-        let refSegments = refPath.split(separator: "/").map(String.init)
-        let templateSegments = templatePath.split(separator: "/").map(String.init)
+        // Empty subsequences are kept so refs with doubled or trailing
+        // slashes ("logic://mixer//3", "logic://mixer/3/") fail closed
+        // instead of collapsing onto a template.
+        let refSegments = refPath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        let templateSegments = templatePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
         guard refSegments.count == templateSegments.count else { return false }
         return zip(refSegments, templateSegments).allSatisfy { refSegment, templateSegment in
             isPlaceholder(templateSegment) ? !refSegment.isEmpty : refSegment == templateSegment

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -1,0 +1,618 @@
+import Foundation
+
+enum WorkflowEvidenceLevel: String, Codable, CaseIterable, Sendable {
+    case deterministic
+    case liveVerified = "live_verified"
+    case documentationOnly = "documentation_only"
+    case experimental
+}
+
+enum WorkflowMutationKind: String, Codable, Sendable {
+    case readOnly = "read_only"
+    case guardedMutation = "guarded_mutation"
+}
+
+struct WorkflowConfirmation: Codable, Sendable, Equatable {
+    let level: String
+    let requiredFor: [String]
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case level
+        case requiredFor = "required_for"
+        case message
+    }
+}
+
+struct WorkflowStateCheck: Codable, Sendable, Equatable {
+    let id: String
+    let resource: String
+    let requiredFields: [String]
+    let stopIfMissing: Bool
+    let description: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case resource
+        case requiredFields = "required_fields"
+        case stopIfMissing = "stop_if_missing"
+        case description
+    }
+}
+
+struct WorkflowStep: Codable, Sendable, Equatable {
+    let id: String
+    let title: String
+    let operationType: String
+    let tool: String?
+    let resource: String?
+    let mutates: Bool
+    let requiresConfirmationLevel: String?
+    let expectedResponseFields: [String]
+    let stopConditions: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case operationType = "operation_type"
+        case tool
+        case resource
+        case mutates
+        case requiresConfirmationLevel = "requires_confirmation_level"
+        case expectedResponseFields = "expected_response_fields"
+        case stopConditions = "stop_conditions"
+    }
+}
+
+struct WorkflowVerification: Codable, Sendable, Equatable {
+    let evidence: [String]
+    let successFields: [String]
+    let liveEvidenceFile: String?
+
+    enum CodingKeys: String, CodingKey {
+        case evidence
+        case successFields = "success_fields"
+        case liveEvidenceFile = "live_evidence_file"
+    }
+}
+
+struct WorkflowSkill: Codable, Sendable, Equatable {
+    let id: String
+    let title: String
+    let intent: String
+    let scope: String
+    let prerequisites: [String]
+    var allowedTools: [String]
+    var allowedResources: [String]
+    var requiredConfirmations: [WorkflowConfirmation]
+    let stateChecks: [WorkflowStateCheck]
+    let steps: [WorkflowStep]
+    let verification: WorkflowVerification
+    var failureModes: [String]
+    let rollbackOrRecovery: String
+    var evidenceLevel: WorkflowEvidenceLevel
+    var productionReady: Bool
+    let dependsOn: [String]
+    let limitations: [String]
+    let mutationKind: WorkflowMutationKind
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case intent
+        case scope
+        case prerequisites
+        case allowedTools = "allowed_tools"
+        case allowedResources = "allowed_resources"
+        case requiredConfirmations = "required_confirmations"
+        case stateChecks = "state_checks"
+        case steps
+        case verification
+        case failureModes = "failure_modes"
+        case rollbackOrRecovery = "rollback_or_recovery"
+        case evidenceLevel = "evidence_level"
+        case productionReady = "production_ready"
+        case dependsOn = "depends_on"
+        case limitations
+        case mutationKind = "mutation_kind"
+    }
+}
+
+struct WorkflowLintIssue: Codable, Sendable, Equatable {
+    let code: String
+    let path: String
+    let message: String
+}
+
+struct WorkflowLintResult: Codable, Sendable, Equatable {
+    let isValid: Bool
+    let issues: [WorkflowLintIssue]
+
+    enum CodingKeys: String, CodingKey {
+        case isValid = "is_valid"
+        case issues
+    }
+}
+
+struct WorkflowSkillSnapshot: Codable, Sendable, Equatable {
+    let schemaVersion: Int
+    let generatedAt: String
+    let workflowCount: Int
+    let validation: WorkflowLintResult
+    let workflows: [WorkflowSkill]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case generatedAt = "generated_at"
+        case workflowCount = "workflow_count"
+        case validation
+        case workflows
+    }
+}
+
+enum WorkflowSkillLinter {
+    static func validate(
+        _ workflows: [WorkflowSkill],
+        toolNames: Set<String> = WorkflowSkillCatalog.currentToolNames(),
+        resourceURIs: Set<String> = WorkflowSkillCatalog.currentResourceURIs()
+    ) -> WorkflowLintResult {
+        var issues: [WorkflowLintIssue] = []
+        var seen = Set<String>()
+
+        for (index, workflow) in workflows.enumerated() {
+            let base = "workflows[\(index)]"
+            if !seen.insert(workflow.id).inserted {
+                issues.append(issue("duplicate_id", "\(base).id", "duplicate workflow id \(workflow.id)"))
+            }
+            if workflow.title.isEmpty || workflow.intent.isEmpty || workflow.scope.isEmpty {
+                issues.append(issue("missing_required_field", base, "title, intent, and scope are required"))
+            }
+            for tool in workflow.allowedTools where !toolNames.contains(tool) {
+                issues.append(issue("unknown_tool", "\(base).allowed_tools", "unknown MCP tool \(tool)"))
+            }
+            for resource in workflow.allowedResources where !resourceURIs.contains(resource) {
+                issues.append(issue("unknown_resource", "\(base).allowed_resources", "unknown MCP resource \(resource)"))
+            }
+            for (checkIndex, check) in workflow.stateChecks.enumerated()
+                where !resourceURIs.contains(check.resource) {
+                issues.append(issue("unknown_resource", "\(base).state_checks[\(checkIndex)].resource", "unknown MCP resource \(check.resource)"))
+            }
+            let mutating = workflow.mutationKind == .guardedMutation || workflow.steps.contains { $0.mutates }
+            if mutating && workflow.requiredConfirmations.isEmpty {
+                issues.append(issue("mutating_missing_confirmation", "\(base).required_confirmations", "mutating workflows require confirmation metadata"))
+            }
+            if mutating && workflow.failureModes.isEmpty {
+                issues.append(issue("mutating_missing_failure_modes", "\(base).failure_modes", "mutating workflows require explicit failure modes"))
+            }
+            if workflow.productionReady && mutating && workflow.evidenceLevel != .liveVerified {
+                issues.append(issue(
+                    "production_mutation_without_live_evidence",
+                    "\(base).evidence_level",
+                    "production-ready mutating workflows must be live_verified"
+                ))
+            }
+            for (stepIndex, step) in workflow.steps.enumerated() {
+                if let tool = step.tool, !toolNames.contains(tool) {
+                    issues.append(issue("unknown_tool", "\(base).steps[\(stepIndex)].tool", "unknown MCP tool \(tool)"))
+                }
+                if let resource = step.resource, !resourceURIs.contains(resource) {
+                    issues.append(issue("unknown_resource", "\(base).steps[\(stepIndex)].resource", "unknown MCP resource \(resource)"))
+                }
+                if step.mutates && (step.requiresConfirmationLevel?.isEmpty ?? true) {
+                    issues.append(issue("mutating_step_missing_confirmation", "\(base).steps[\(stepIndex)]", "mutating steps need confirmation level"))
+                }
+                if step.expectedResponseFields.isEmpty {
+                    issues.append(issue("step_missing_success_fields", "\(base).steps[\(stepIndex)]", "steps must name response fields to inspect"))
+                }
+            }
+        }
+
+        return WorkflowLintResult(isValid: issues.isEmpty, issues: issues)
+    }
+
+    private static func issue(_ code: String, _ path: String, _ message: String) -> WorkflowLintIssue {
+        WorkflowLintIssue(code: code, path: path, message: message)
+    }
+}
+
+enum WorkflowSkillCatalog {
+    static func defaultSnapshot(now: Date = Date()) -> WorkflowSkillSnapshot {
+        let workflows = defaultWorkflows()
+        let validation = WorkflowSkillLinter.validate(workflows)
+        return WorkflowSkillSnapshot(
+            schemaVersion: 1,
+            generatedAt: ISO8601DateFormatter.cacheFormatter.string(from: now),
+            workflowCount: workflows.count,
+            validation: validation,
+            workflows: workflows
+        )
+    }
+
+    static func defaultWorkflows() -> [WorkflowSkill] {
+        [
+            projectReadiness(),
+            midiIdeaSketch(),
+            arrangementMarkerPlan(),
+            gainStagingPrep(),
+            stockPluginChainPlan(),
+            stockPluginGuardedInsert(),
+            bounceReadiness(),
+        ]
+    }
+
+    static func workflow(id: String, snapshot: WorkflowSkillSnapshot = defaultSnapshot()) -> WorkflowSkill? {
+        snapshot.workflows.first { $0.id == id }
+    }
+
+    static func search(query: String, snapshot: WorkflowSkillSnapshot = defaultSnapshot()) -> [WorkflowSkill] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return snapshot.workflows }
+        return snapshot.workflows.filter {
+            $0.id.lowercased().contains(q) ||
+                $0.title.lowercased().contains(q) ||
+                $0.intent.lowercased().contains(q) ||
+                $0.limitations.joined(separator: " ").lowercased().contains(q)
+        }
+    }
+
+    static func schema(now: Date = Date()) -> [String: Any] {
+        [
+            "schema_version": 1,
+            "generated_at": ISO8601DateFormatter.cacheFormatter.string(from: now),
+            "required_fields": [
+                "id",
+                "title",
+                "intent",
+                "scope",
+                "prerequisites",
+                "allowed_tools",
+                "allowed_resources",
+                "state_checks",
+                "steps",
+                "verification",
+                "failure_modes",
+                "evidence_level",
+            ],
+            "evidence_levels": WorkflowEvidenceLevel.allCases.map(\.rawValue),
+            "mutation_kinds": [
+                WorkflowMutationKind.readOnly.rawValue,
+                WorkflowMutationKind.guardedMutation.rawValue,
+            ],
+            "resources": [
+                "logic://workflow-skills",
+                "logic://workflow-skills/{id}",
+                "logic://workflow-skills/search?query=<text>",
+                "logic://workflow-skills/schema",
+            ],
+            "read_only_surface": true,
+        ]
+    }
+
+    static func currentToolNames() -> Set<String> {
+        [
+            "logic_transport",
+            "logic_tracks",
+            "logic_mixer",
+            "logic_midi",
+            "logic_edit",
+            "logic_navigate",
+            "logic_project",
+            "logic_system",
+        ]
+    }
+
+    static func currentResourceURIs() -> Set<String> {
+        var uris = Set(ResourceProvider.resources.map(\.uri))
+        uris.formUnion(ResourceProvider.templates.map(\.uriTemplate))
+        // Issue #15 is an independent branch, but some recipes intentionally
+        // depend on the stock plugin catalog shipped by issue #14.
+        uris.formUnion([
+            "logic://stock-plugins",
+            "logic://stock-plugins/{id}",
+            "logic://stock-plugins/logic.stock.effect.gain",
+            "logic://stock-plugins/search?query=<text>",
+            "logic://workflow-skills/{id}",
+            "logic://workflow-skills/search?query=<text>",
+        ])
+        return uris
+    }
+
+    private static func projectReadiness() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.readiness.project",
+            title: "Project Readiness Check",
+            intent: "Confirm Logic Pro, MCP resources, project state, tracks, transport, and mixer provenance before creative work.",
+            scope: "Read-only diagnostics; does not mutate project state.",
+            prerequisites: ["Logic Pro running", "MCP server reachable", "Accessibility permissions checked"],
+            allowedTools: ["logic_system"],
+            allowedResources: ["logic://system/health", "logic://project/info", "logic://transport/state", "logic://tracks", "logic://mixer"],
+            requiredConfirmations: [],
+            stateChecks: [
+                stateCheck("health", "logic://system/health", ["channels", "cache"], true),
+                stateCheck("project", "logic://project/info", ["data"], false),
+                stateCheck("tracks", "logic://tracks", ["data"], false),
+            ],
+            steps: [
+                readStep("health", "Read system health", "logic://system/health", ["channels", "permissions"]),
+                readStep("project", "Read project info", "logic://project/info", ["data", "source"]),
+                readStep("mixer", "Read mixer provenance", "logic://mixer", ["data_source", "strips"]),
+            ],
+            verification: WorkflowVerification(evidence: ["resource_json"], successFields: ["validation_status"], liveEvidenceFile: nil),
+            failureModes: ["Logic not running", "AX occluded", "mixer_not_visible"],
+            rollbackOrRecovery: "No rollback required; read-only workflow.",
+            evidenceLevel: .deterministic,
+            productionReady: true,
+            dependsOn: [],
+            limitations: ["Does not open Logic or create a project."],
+            mutationKind: .readOnly
+        )
+    }
+
+    private static func midiIdeaSketch() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.midi.idea_sketch",
+            title: "MIDI Idea Sketch",
+            intent: "Create or import a small MIDI idea only after the target track and project state are explicit.",
+            scope: "May write MIDI to a caller-specified target after confirmation; never guesses track 0.",
+            prerequisites: ["Open project", "Explicit target track", "User confirmation for MIDI mutation"],
+            allowedTools: ["logic_tracks", "logic_midi"],
+            allowedResources: ["logic://tracks", "logic://tracks/{index}/regions", "logic://project/info"],
+            requiredConfirmations: [
+                WorkflowConfirmation(level: "L1", requiredFor: ["midi_import", "record_sequence"], message: "Confirm target track and MIDI content before writing."),
+            ],
+            stateChecks: [
+                stateCheck("tracks", "logic://tracks", ["data"], true),
+                stateCheck("regions_before", "logic://tracks/{index}/regions", ["regions"], false),
+            ],
+            steps: [
+                readStep("read_tracks", "Read tracks before target selection", "logic://tracks", ["data"]),
+                toolStep("write_midi", "Import or record MIDI on explicit target", "logic_midi", true, "L1", ["success", "verified"], ["unverified target", "invalid channel"]),
+                readStep("regions_after", "Read regions after write", "logic://tracks/{index}/regions", ["regions"]),
+            ],
+            verification: WorkflowVerification(evidence: ["before_regions", "after_regions", "tool_envelope"], successFields: ["region_count_delta", "verified"], liveEvidenceFile: nil),
+            failureModes: ["target track missing", "selection unverified", "MIDI import rejected", "post-write region readback unavailable"],
+            rollbackOrRecovery: "Manual recovery: undo in Logic if write succeeded but follow-up verification is inconclusive.",
+            evidenceLevel: .deterministic,
+            productionReady: false,
+            dependsOn: [],
+            limitations: ["Not production-ready until a scoped live mutation run is recorded."],
+            mutationKind: .guardedMutation
+        )
+    }
+
+    private static func arrangementMarkerPlan() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.arrangement.marker_plan",
+            title: "Arrangement Marker Plan",
+            intent: "Plan and verify marker positions without relying on stale parser assumptions.",
+            scope: "Read-first marker planning; mutation remains guarded and optional.",
+            prerequisites: ["Open project", "Marker resource readable"],
+            allowedTools: ["logic_navigate"],
+            allowedResources: ["logic://markers", "logic://transport/state"],
+            requiredConfirmations: [
+                WorkflowConfirmation(level: "L1", requiredFor: ["marker_mutation"], message: "Confirm marker names and positions before writing."),
+            ],
+            stateChecks: [stateCheck("markers", "logic://markers", ["data"], false)],
+            steps: [
+                readStep("read_markers", "Read current markers", "logic://markers", ["data", "position_source"]),
+                toolStep("optional_write", "Optionally create supported markers", "logic_navigate", true, "L1", ["success", "verified"], ["unsupported marker mutation", "position parse failure"]),
+            ],
+            verification: WorkflowVerification(evidence: ["marker_resource_before_after"], successFields: ["canonical_position", "verified"], liveEvidenceFile: nil),
+            failureModes: ["marker resource unavailable", "position parser rejects input", "post-write readback unavailable"],
+            rollbackOrRecovery: "Manual recovery in Logic marker list.",
+            evidenceLevel: .deterministic,
+            productionReady: false,
+            dependsOn: [],
+            limitations: ["Mutation path may be unavailable depending on current public tool surface."],
+            mutationKind: .guardedMutation
+        )
+    }
+
+    private static func gainStagingPrep() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.mixer.gain_staging_prep",
+            title: "Gain Staging And Mixer Prep",
+            intent: "Prepare safe gain-staging recommendations using mixer provenance and explicit target verification.",
+            scope: "May call mixer writes only when target and readback conditions are explicit.",
+            prerequisites: ["Mixer resource readable", "Explicit track list", "User confirmation for mixer mutations"],
+            allowedTools: ["logic_mixer"],
+            allowedResources: ["logic://mixer", "logic://mixer/{strip}", "logic://tracks"],
+            requiredConfirmations: [
+                WorkflowConfirmation(level: "L1", requiredFor: ["set_volume", "set_pan"], message: "Confirm track index and target value before mixer write."),
+            ],
+            stateChecks: [
+                stateCheck("mixer", "logic://mixer", ["data_source", "strips"], true),
+                stateCheck("tracks", "logic://tracks", ["data"], true),
+            ],
+            steps: [
+                readStep("read_mixer", "Read mixer provenance", "logic://mixer", ["data_source", "mcu_connected", "strips"]),
+                toolStep("optional_level_write", "Optionally write volume/pan with explicit track", "logic_mixer", true, "L1", ["success", "verified", "reason"], ["target unverified", "readback unavailable"]),
+                readStep("read_strip_after", "Read target strip after write", "logic://mixer/{strip}", ["data_source", "strip"]),
+            ],
+            verification: WorkflowVerification(evidence: ["mixer_before_after", "honest_contract_envelope"], successFields: ["verified", "data_source"], liveEvidenceFile: nil),
+            failureModes: ["mixer_not_visible", "cache_stale", "track selection unverified", "echo timeout"],
+            rollbackOrRecovery: "Manual recovery: restore previous fader/pan value from before evidence.",
+            evidenceLevel: .deterministic,
+            productionReady: false,
+            dependsOn: [],
+            limitations: ["Stops instead of writing when provenance is insufficient."],
+            mutationKind: .guardedMutation
+        )
+    }
+
+    private static func stockPluginChainPlan() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.plugins.stock_chain_plan",
+            title: "Stock Plugin Chain Planning",
+            intent: "Plan stock plugin chains from verified catalog metadata without claiming insertion success.",
+            scope: "Planning-only in this release; no plugin insertion is executed.",
+            prerequisites: ["Stock plugin catalog resource readable", "Mixer slot state available if planning against a track"],
+            allowedTools: [],
+            allowedResources: ["logic://stock-plugins", "logic://stock-plugins/{id}", "logic://stock-plugins/search?query=<text>", "logic://mixer"],
+            requiredConfirmations: [],
+            stateChecks: [
+                stateCheck("catalog", "logic://stock-plugins", ["entries", "validation"], true),
+                stateCheck("mixer", "logic://mixer", ["strips"], false),
+            ],
+            steps: [
+                readStep("read_catalog", "Read stock plugin catalog", "logic://stock-plugins", ["entries", "availability_state"]),
+                readStep("search_catalog", "Search catalog for user intent", "logic://stock-plugins/search?query=<text>", ["entries"]),
+                readStep("read_mixer_slots", "Read mixer slot state before planning insert order", "logic://mixer", ["strips"]),
+            ],
+            verification: WorkflowVerification(evidence: ["catalog_entry_truth_labels", "slot_state"], successFields: ["availability_state", "limitations"], liveEvidenceFile: nil),
+            failureModes: ["catalog validation failed", "no verified or labelled candidate", "mixer slot state unavailable"],
+            rollbackOrRecovery: "No rollback required; planning-only workflow.",
+            evidenceLevel: .deterministic,
+            productionReady: true,
+            dependsOn: ["logic://stock-plugins"],
+            limitations: ["Does not insert plugins; clients must not treat inferred entries as verified."],
+            mutationKind: .readOnly
+        )
+    }
+
+    private static func stockPluginGuardedInsert() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.plugins.stock_insert_gain_live_verified",
+            title: "Live-Verified Gain Insert",
+            intent: "Insert Logic's stock Gain plugin only after catalog lookup, explicit track/slot confirmation, empty-slot checks, and AX slot readback.",
+            scope: "Guarded mutation for the allowlisted stock Gain plugin; never replaces an occupied slot.",
+            prerequisites: [
+                "Logic Pro 12.2-compatible project is open",
+                "Mixer is visible to Accessibility",
+                "Target track and insert slot are explicit",
+                "Caller accepts L2 confirmation for insert-chain mutation",
+            ],
+            allowedTools: ["logic_mixer"],
+            allowedResources: [
+                "logic://stock-plugins/logic.stock.effect.gain",
+                "logic://mixer",
+                "logic://mixer/{strip}",
+            ],
+            requiredConfirmations: [
+                WorkflowConfirmation(
+                    level: "L2",
+                    requiredFor: ["insert_plugin"],
+                    message: "Confirm target track, slot, and stock Gain insertion before mutating the insert chain."
+                ),
+            ],
+            stateChecks: [
+                stateCheck("gain_catalog", "logic://stock-plugins/logic.stock.effect.gain", ["entry", "validation"], true),
+                stateCheck("mixer", "logic://mixer", ["strips", "data_source"], true),
+                stateCheck("target_strip", "logic://mixer/{strip}", ["strip"], false),
+            ],
+            steps: [
+                readStep("read_gain_catalog", "Read stock Gain catalog entry", "logic://stock-plugins/logic.stock.effect.gain", ["entry", "availability_state"]),
+                readStep("read_mixer_slots", "Read mixer slot state", "logic://mixer", ["strips", "plugins"]),
+                toolStep(
+                    "confirmed_insert_gain",
+                    "Insert stock Gain into an explicit empty slot",
+                    "logic_mixer",
+                    true,
+                    "L2",
+                    ["success", "verified", "observed_plugin_name", "verify_source"],
+                    ["confirmation missing", "slot_occupied", "readback unavailable", "readback mismatch"]
+                ),
+                readStep("read_strip_after_insert", "Read target strip after insert", "logic://mixer/{strip}", ["strip", "plugins"]),
+            ],
+            verification: WorkflowVerification(
+                evidence: ["catalog_entry", "confirmation_required_gate", "ax_plugin_slot_readback"],
+                successFields: ["verified", "observed_plugin_name", "verify_source"],
+                liveEvidenceFile: "docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md"
+            ),
+            failureModes: [
+                "catalog validation failed",
+                "mixer_not_visible",
+                "target track out of range",
+                "slot_occupied",
+                "plugin menu selection failed",
+                "AX slot readback unavailable",
+            ],
+            rollbackOrRecovery: "If readback fails after a write attempt, production insert_plugin attempts Logic undo and returns rollback evidence; otherwise manual undo in Logic is the recovery path.",
+            evidenceLevel: .liveVerified,
+            productionReady: true,
+            dependsOn: ["logic://stock-plugins"],
+            limitations: [
+                "Live evidence is scoped to the existing Logic Pro 12.2 verification run; clients must still require current-session confirmation and readback.",
+                "Only Gain, Compressor, and Channel EQ are allowlisted by the underlying tool; this workflow specializes Gain.",
+            ],
+            mutationKind: .guardedMutation
+        )
+    }
+
+    private static func bounceReadiness() -> WorkflowSkill {
+        WorkflowSkill(
+            id: "logic.workflow.bounce.readiness",
+            title: "Bounce Readiness Checklist",
+            intent: "Check project state before manual bounce/export.",
+            scope: "Read-only checklist; export remains manual unless a future tool explicitly supports it.",
+            prerequisites: ["Open project", "Project info readable"],
+            allowedTools: ["logic_project", "logic_transport"],
+            allowedResources: ["logic://project/info", "logic://transport/state", "logic://tracks", "logic://mixer"],
+            requiredConfirmations: [],
+            stateChecks: [
+                stateCheck("project", "logic://project/info", ["data"], true),
+                stateCheck("transport", "logic://transport/state", ["data"], true),
+                stateCheck("tracks", "logic://tracks", ["data"], false),
+            ],
+            steps: [
+                readStep("read_project", "Read project metadata", "logic://project/info", ["data", "source"]),
+                readStep("read_transport", "Read cycle and playhead state", "logic://transport/state", ["data"]),
+                readStep("read_tracks", "Read track mute/solo/arm state", "logic://tracks", ["data"]),
+            ],
+            verification: WorkflowVerification(evidence: ["resource_json"], successFields: ["project_name", "cycle_state", "track_states"], liveEvidenceFile: nil),
+            failureModes: ["project info unavailable", "tracks stale", "mixer provenance insufficient"],
+            rollbackOrRecovery: "No rollback required; read-only workflow.",
+            evidenceLevel: .deterministic,
+            productionReady: true,
+            dependsOn: [],
+            limitations: ["Does not perform a bounce/export."],
+            mutationKind: .readOnly
+        )
+    }
+
+    private static func stateCheck(_ id: String, _ resource: String, _ fields: [String], _ stop: Bool) -> WorkflowStateCheck {
+        WorkflowStateCheck(
+            id: id,
+            resource: resource,
+            requiredFields: fields,
+            stopIfMissing: stop,
+            description: "Read \(resource) and require fields: \(fields.joined(separator: ", "))"
+        )
+    }
+
+    private static func readStep(_ id: String, _ title: String, _ resource: String, _ fields: [String]) -> WorkflowStep {
+        WorkflowStep(
+            id: id,
+            title: title,
+            operationType: "resource_read",
+            tool: nil,
+            resource: resource,
+            mutates: false,
+            requiresConfirmationLevel: nil,
+            expectedResponseFields: fields,
+            stopConditions: ["missing required field", "resource error"]
+        )
+    }
+
+    private static func toolStep(
+        _ id: String,
+        _ title: String,
+        _ tool: String,
+        _ mutates: Bool,
+        _ level: String?,
+        _ fields: [String],
+        _ stops: [String]
+    ) -> WorkflowStep {
+        WorkflowStep(
+            id: id,
+            title: title,
+            operationType: "tool_call",
+            tool: tool,
+            resource: nil,
+            mutates: mutates,
+            requiresConfirmationLevel: level,
+            expectedResponseFields: fields,
+            stopConditions: stops
+        )
+    }
+}

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -444,6 +444,7 @@ private func makeAXBackedAccessibilityChannel(
     #expect(!pressFailure.isSuccess)
     #expect(pressFailure.message.contains("\"error\":\"ax_write_failed\""))
     #expect(pressFailure.message.contains("AXPress failed on transport button 'Metronome'"))
+    #expect(!HonestContract.isTerminalStateC(pressFailure.message))
 }
 
 @Test func testAccessibilityChannelAXBackedTempoFallbackCanBeInjected() async {

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -307,6 +307,54 @@ actor TerminalStateCChannel: Channel {
     #expect(mcuOps.count == 1)
 }
 
+@Test func testTransportToggleAXButtonMissFallsThroughToKeyCmd() async {
+    let router = ChannelRouter()
+    let ax = TerminalStateCChannel(
+        id: .accessibility,
+        envelope: HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button 'Metronome' not located in control bar",
+            extras: ["button": "Metronome"]
+        )
+    )
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(ax)
+    await router.register(keyCmd)
+
+    let result = await router.route(operation: "transport.toggle_metronome")
+
+    #expect(result.isSuccess, "transport toggle should fall through when AX control-bar lookup misses")
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "transport.toggle_metronome")
+}
+
+@Test func testTransportToggleCyclePrefersKeyCmdBeforeMCUAfterAXButtonMiss() async {
+    let router = ChannelRouter()
+    let ax = TerminalStateCChannel(
+        id: .accessibility,
+        envelope: HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button 'Cycle' not located in control bar",
+            extras: ["button": "Cycle"]
+        )
+    )
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    let mcu = MockChannel(id: .mcu)
+    await router.register(ax)
+    await router.register(keyCmd)
+    await router.register(mcu)
+
+    let result = await router.route(operation: "transport.toggle_cycle")
+
+    #expect(result.isSuccess, "cycle toggle should use learned key command before MCU readback-unavailable success")
+    let keyCmdOps = await keyCmd.executedOps
+    let mcuOps = await mcu.executedOps
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "transport.toggle_cycle")
+    #expect(mcuOps.isEmpty)
+}
+
 @Test func testRouterStartAllReportsChannelFailures() async {
     let router = ChannelRouter()
     await router.register(MockChannel(id: .coreMIDI))

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -810,9 +810,9 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 @Test func testE2EServerCatalogAdvertisesAllResources() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(snapshot.resourceURIs.count == 11)
+    #expect(snapshot.resourceURIs.count >= 11)
     let uris = Set(snapshot.resourceURIs)
-    #expect(uris == [
+    let expectedResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -824,18 +824,20 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://library/inventory",
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
-    ])
+    ]
+    #expect(expectedResources.isSubset(of: uris))
 }
 
 @Test func testE2EServerCatalogAdvertisesAllTemplates() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(Set(snapshot.templateURIs) == [
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
-    ])
+    ]
+    #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
 }
 
 @Test func testE2EServerCatalogHas7Channels() async {

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -692,7 +692,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// MARK: - §10 Resource Read Chain (8 tests)
+// MARK: - §10 Resource Read Chain (10 tests)
 // ═══════════════════════════════════════════════════════════════════════
 
 @Test func testE2EResourceTransportStateIsValidJSON() async throws {
@@ -745,6 +745,21 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     let _ = try JSONSerialization.jsonObject(with: Data(text.utf8))
 }
 
+@Test func testE2EResourceWorkflowSkillsExposeValidatedPack() async throws {
+    let h = await makeE2EHandlers()
+    let list = try await h.readResource(.init(uri: "logic://workflow-skills"))
+    let detail = try await h.readResource(.init(uri: "logic://workflow-skills/logic.workflow.plugins.stock_chain_plan"))
+    let schema = try await h.readResource(.init(uri: "logic://workflow-skills/schema"))
+
+    let listJSON = e2eJSON(e2eResourceText(list))
+    let detailJSON = e2eJSON(e2eResourceText(detail))
+    let schemaJSON = e2eJSON(e2eResourceText(schema))
+    #expect(listJSON?["workflow_count"] as? Int ?? 0 >= 6)
+    #expect((listJSON?["validation"] as? [String: Any])?["is_valid"] as? Bool == true)
+    #expect((detailJSON?["workflow"] as? [String: Any])?["mutation_kind"] as? String == "read_only")
+    #expect((schemaJSON?["evidence_levels"] as? [String])?.contains("live_verified") == true)
+}
+
 @Test func testE2EResourceHealthMatchesToolHealth() async throws {
     let h = await makeE2EHandlers()
     let resourceResult = try await h.readResource(.init(uri: "logic://system/health"))
@@ -795,7 +810,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 @Test func testE2EServerCatalogAdvertisesAllResources() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(snapshot.resourceURIs.count == 9)
+    #expect(snapshot.resourceURIs.count == 11)
     let uris = Set(snapshot.resourceURIs)
     #expect(uris == [
         "logic://system/health",
@@ -807,6 +822,8 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://midi/ports",
         "logic://mcu/state",
         "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
     ])
 }
 
@@ -816,6 +833,8 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://workflow-skills/{id}",
+        "logic://workflow-skills/search?query={query}",
     ])
 }
 

--- a/Tests/LogicProMCPTests/HonestContractTests.swift
+++ b/Tests/LogicProMCPTests/HonestContractTests.swift
@@ -95,6 +95,17 @@ import Testing
     #expect(HonestContract.terminalErrorCodes.contains("readback_unavailable"))
 }
 
+@Test func testStateCErrorCodeExtraction() {
+    let terminal = HonestContract.encodeStateC(error: .elementNotFound)
+    let nonTerminal = HonestContract.encodeStateC(error: .axWriteFailed)
+    let uncertain = HonestContract.encodeStateB(reason: .readbackUnavailable)
+
+    #expect(HonestContract.stateCErrorCode(terminal) == "element_not_found")
+    #expect(HonestContract.stateCErrorCode(nonTerminal) == "ax_write_failed")
+    #expect(HonestContract.stateCErrorCode(uncertain) == nil)
+    #expect(HonestContract.stateCErrorCode("not json") == nil)
+}
+
 @Test func testJSONIsSortedKeyDeterministic() {
     let a = HonestContract.jsonString(["b": 1, "a": 2])
     let b = HonestContract.jsonString(["a": 2, "b": 1])

--- a/Tests/LogicProMCPTests/LibraryAccessorHelpersTests.swift
+++ b/Tests/LogicProMCPTests/LibraryAccessorHelpersTests.swift
@@ -140,10 +140,10 @@ struct LibraryAccessorHelpersTests {
         #expect(elapsed < 2.0, "pure traversal should be < 2s, got \(elapsed)")
     }
 
-    // ---- T8 #20 Linear scaling proof (50/100/200 ratio ≤ 2.5×) ----
+    // ---- T8 #20 Linear scaling proof (probe calls grow 1 + 2n) ----
 
     @Test func testEnumerateTree_Perf_ScalesLinearly_NotQuadratic() async throws {
-        func time(folderCount n: Int) async -> TimeInterval {
+        func probeCalls(folderCount n: Int) async -> (Int, LibraryRoot?) {
             var build: [String: [String]?] = [:]
             var cats: [String] = []
             for i in 0..<n {
@@ -152,25 +152,24 @@ struct LibraryAccessorHelpersTests {
             }
             build[""] = cats
             let m = build
+            let calls = CallRecorder()
             let probe = TreeProbe(
-                childrenAt: { p in m[p.joined(separator: "/")] ?? nil },
+                childrenAt: { p in await calls.rec(); return m[p.joined(separator: "/")] ?? nil },
                 focusOK: { true }, mutationSinceLastCheck: { false },
                 sleep: { _ in }, visitedHash: { $0.joined(separator: "/").hashValue }
             )
-            let start = Date()
-            _ = await LibraryAccessor.enumerateTree(maxDepth: 12, settleDelayMs: 0, probe: probe)
-            return Date().timeIntervalSince(start)
+            let root = await LibraryAccessor.enumerateTree(maxDepth: 12, settleDelayMs: 0, probe: probe)
+            return (await calls.n, root)
         }
-        let t50 = await time(folderCount: 50)
-        let t100 = await time(folderCount: 100)
-        let t200 = await time(folderCount: 200)
-        // Ratio t100/t50 and t200/t100 should each be ≤ 2.5× (allow noise).
-        // If either is > 2.5 there's a super-linear bug.
-        if t50 > 0.001 {  // skip if too fast to measure
-            #expect(t100 / t50 < 2.5, "t100/t50=\(t100/t50)")
-        }
-        if t100 > 0.001 {
-            #expect(t200 / t100 < 2.5, "t200/t100=\(t200/t100)")
+        let samples = [
+            (n: 50, result: await probeCalls(folderCount: 50)),
+            (n: 100, result: await probeCalls(folderCount: 100)),
+            (n: 200, result: await probeCalls(folderCount: 200)),
+        ]
+        for sample in samples {
+            #expect(sample.result.0 == 1 + (sample.n * 2))
+            #expect(sample.result.1?.leafCount == sample.n)
+            #expect(sample.result.1?.folderCount == sample.n + 1)
         }
     }
 

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -36,11 +36,15 @@ private let serverResourceText = sharedResourceText
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
     ])
     #expect(templates.templates.map(\.uriTemplate) == [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://workflow-skills/{id}",
+        "logic://workflow-skills/search?query={query}",
     ])
 }
 
@@ -248,6 +252,8 @@ private let serverResourceText = sharedResourceText
         "logic://project/info",
         "logic://midi/ports",
         "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
     ])
     // server.start() runs serve() to completion then tears poller/channels/ports
     // down in reverse order. With serve recorded as a no-op, the tail section

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -27,7 +27,8 @@ private let serverResourceText = sharedResourceText
     ])
     // MCU disconnected by default in a fresh LogicProServer, so the list
     // excludes `logic://mcu/state`.
-    #expect(resources.resources.map(\.uri) == [
+    let resourceURIs = Set(resources.resources.map(\.uri))
+    let expectedNonMCUResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -38,14 +39,18 @@ private let serverResourceText = sharedResourceText
         "logic://library/inventory",
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
-    ])
-    #expect(templates.templates.map(\.uriTemplate) == [
+    ]
+    #expect(expectedNonMCUResources.isSubset(of: resourceURIs))
+    #expect(!resourceURIs.contains("logic://mcu/state"))
+    let templateURIs = Set(templates.templates.map(\.uriTemplate))
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
-    ])
+    ]
+    #expect(expectedTemplates.isSubset(of: templateURIs))
 }
 
 @Test func testLogicProServerHandlersDispatchToolNamesWithoutStartingServer() async {
@@ -243,7 +248,7 @@ private let serverResourceText = sharedResourceText
     // MCU is disconnected in a fresh cache, so `logic://mcu/state` is filtered
     // out. Non-MCU resources (markers, library/inventory, …) remain visible.
     let uris = Set(resources.resources.map(\.uri))
-    #expect(uris == [
+    let expectedNonMCUResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -254,7 +259,9 @@ private let serverResourceText = sharedResourceText
         "logic://library/inventory",
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
-    ])
+    ]
+    #expect(expectedNonMCUResources.isSubset(of: uris))
+    #expect(!uris.contains("logic://mcu/state"))
     // server.start() runs serve() to completion then tears poller/channels/ports
     // down in reverse order. With serve recorded as a no-op, the tail section
     // executes immediately so stopPoller is captured too.

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -385,7 +385,7 @@ private func waitForFeedbackEvents(
         "logic_project",
         "logic_system",
     ])
-    #expect(snapshot.resourceURIs == [
+    let expectedResources: Set<String> = [
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -397,15 +397,17 @@ private func waitForFeedbackEvents(
         "logic://library/inventory",
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
-    ])
-    #expect(snapshot.templateURIs == [
+    ]
+    #expect(expectedResources.isSubset(of: Set(snapshot.resourceURIs)))
+    let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
-    ])
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 11 resources, 4 channels")
+    ]
+    #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -395,18 +395,22 @@ private func waitForFeedbackEvents(
         "logic://midi/ports",
         "logic://mcu/state",
         "logic://library/inventory",
+        "logic://workflow-skills",
+        "logic://workflow-skills/schema",
     ])
     #expect(snapshot.templateURIs == [
         "logic://tracks/{index}",
         "logic://tracks/{index}/regions",
         "logic://mixer/{strip}",
+        "logic://workflow-skills/{id}",
+        "logic://workflow-skills/search?query={query}",
     ])
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 4 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 11 resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {
     let banner = ServerCatalog.startupBanner(channelCount: 7)
-    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 7 channels")
+    #expect(banner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 11 resources, 7 channels")
 }
 
 @Test func testLogicProServerCompositionSnapshotMatchesExpectedOrder() async {
@@ -425,5 +429,5 @@ private func waitForFeedbackEvents(
     ])
     #expect(snapshot.toolNames.count == 8)
     #expect(snapshot.resourceURIs.contains("logic://system/health"))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 9 resources, 7 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.4.6 — 8 tools, 11 resources, 7 channels")
 }

--- a/Tests/LogicProMCPTests/ResourceProviderTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProviderTests.swift
@@ -20,19 +20,23 @@ struct ResourceProviderTests {
         #expect(uris.count == Set(uris).count, "Duplicate template URI: \(uris)")
     }
 
-    @Test("new resources are registered: markers, mcu/state, library/inventory")
+    @Test("new resources are registered: markers, mcu/state, library/inventory, workflow skills")
     func newResourcesRegistered() {
         let uris = Set(ResourceProvider.resources.map(\.uri))
         #expect(uris.contains("logic://markers"))
         #expect(uris.contains("logic://mcu/state"))
         #expect(uris.contains("logic://library/inventory"))
+        #expect(uris.contains("logic://workflow-skills"))
+        #expect(uris.contains("logic://workflow-skills/schema"))
     }
 
-    @Test("new templates are registered: regions per track, mixer per strip")
+    @Test("new templates are registered: regions per track, mixer per strip, catalog/search detail")
     func newTemplatesRegistered() {
         let uris = Set(ResourceProvider.templates.map(\.uriTemplate))
         #expect(uris.contains("logic://tracks/{index}/regions"))
         #expect(uris.contains("logic://mixer/{strip}"))
+        #expect(uris.contains("logic://workflow-skills/{id}"))
+        #expect(uris.contains("logic://workflow-skills/search?query={query}"))
     }
 
     @Test("every static resource URI maps to a handler")

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func workflowResourceObject(_ uri: String) async throws -> [String: Any] {
+    let result = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+    return try #require(sharedJSONObject(sharedResourceText(result)))
+}
+
+@Suite("Workflow skills pack")
+struct WorkflowSkillCatalogTests {
+    @Test("linter rejects stale tool and resource references")
+    func staleReferencesRejected() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows()[0]
+        workflow.allowedTools = ["logic_missing"]
+        workflow.allowedResources = ["logic://missing"]
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "unknown_tool" })
+        #expect(issues.contains { $0.code == "unknown_resource" })
+    }
+
+    @Test("mutating workflows require confirmation metadata and failure modes")
+    func mutatingWorkflowGuardrails() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.requiredConfirmations = []
+        workflow.failureModes = []
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "mutating_missing_confirmation" })
+        #expect(issues.contains { $0.code == "mutating_missing_failure_modes" })
+    }
+
+    @Test("production-ready mutating workflows must be live verified")
+    func productionReadyRequiresLiveEvidence() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.productionReady = true
+        workflow.evidenceLevel = .deterministic
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "production_mutation_without_live_evidence" })
+    }
+
+    @Test("default workflow pack validates and includes stock plugin catalog dependency")
+    func defaultPackValidates() {
+        let snapshot = WorkflowSkillCatalog.defaultSnapshot()
+
+        #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.workflowCount >= 6)
+        #expect(snapshot.validation.isValid, "workflow pack should validate: \(snapshot.validation.issues)")
+        let stock = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_chain_plan" }
+        #expect(stock?.dependsOn.contains("logic://stock-plugins") == true)
+        #expect(stock?.allowedResources.contains("logic://stock-plugins") == true)
+        #expect(stock?.mutationKind == .readOnly)
+
+        let liveInsert = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_insert_gain_live_verified" }
+        #expect(liveInsert?.mutationKind == .guardedMutation)
+        #expect(liveInsert?.evidenceLevel == .liveVerified)
+        #expect(liveInsert?.productionReady == true)
+        #expect(liveInsert?.verification.liveEvidenceFile == "docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md")
+        #expect(liveInsert?.requiredConfirmations.contains { $0.level == "L2" } == true)
+    }
+
+    @Test("MCP resources expose workflow list, detail, search, and schema")
+    func workflowResources() async throws {
+        let list = try await workflowResourceObject("logic://workflow-skills")
+        #expect(list["schema_version"] as? Int == 1)
+        #expect(list["workflow_count"] as? Int ?? 0 >= 6)
+        #expect((list["validation"] as? [String: Any])?["is_valid"] as? Bool == true)
+
+        let detail = try await workflowResourceObject("logic://workflow-skills/logic.workflow.readiness.project")
+        #expect((detail["workflow"] as? [String: Any])?["id"] as? String == "logic.workflow.readiness.project")
+
+        let search = try await workflowResourceObject("logic://workflow-skills/search?query=plugin")
+        #expect((search["workflows"] as? [[String: Any]])?.contains {
+            $0["id"] as? String == "logic.workflow.plugins.stock_chain_plan"
+        } == true)
+        #expect((search["workflows"] as? [[String: Any]])?.contains {
+            $0["id"] as? String == "logic.workflow.plugins.stock_insert_gain_live_verified"
+        } == true)
+
+        let schema = try await workflowResourceObject("logic://workflow-skills/schema")
+        #expect((schema["required_fields"] as? [String])?.contains("state_checks") == true)
+        #expect((schema["evidence_levels"] as? [String])?.contains("live_verified") == true)
+    }
+}

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -8,8 +8,24 @@ private func workflowResourceObject(_ uri: String) async throws -> [String: Any]
     return try #require(sharedJSONObject(sharedResourceText(result)))
 }
 
-@Suite("Workflow skills pack")
-struct WorkflowSkillCatalogTests {
+private func workflowResourceThrows(_ uri: String) async -> Bool {
+    do {
+        _ = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+        return false
+    } catch {
+        return true
+    }
+}
+
+private var workflowRepoRoot: URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+@Suite("Workflow skills pack — linter")
+struct WorkflowSkillLinterTests {
     @Test("linter rejects stale tool and resource references")
     func staleReferencesRejected() {
         var workflow = WorkflowSkillCatalog.defaultWorkflows()[0]
@@ -19,6 +35,56 @@ struct WorkflowSkillCatalogTests {
         let issues = WorkflowSkillLinter.validate([workflow]).issues
         #expect(issues.contains { $0.code == "unknown_tool" })
         #expect(issues.contains { $0.code == "unknown_resource" })
+    }
+
+    @Test("linter rejects unknown commands in steps and confirmations")
+    func unknownCommandsRejected() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.requiredConfirmations = [
+            WorkflowConfirmation(level: "L1", requiredFor: ["midi_import"], message: "stale command name"),
+        ]
+        workflow.steps = workflow.steps.map { step in
+            guard step.mutates else { return step }
+            return WorkflowStep(
+                id: step.id,
+                title: step.title,
+                operationType: step.operationType,
+                tool: "logic_midi",
+                command: "midi_import",
+                resource: nil,
+                mutates: true,
+                requiresConfirmationLevel: "L1",
+                expectedResponseFields: step.expectedResponseFields,
+                stopConditions: step.stopConditions
+            )
+        }
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.filter { $0.code == "unknown_command" }.count >= 2,
+                "midi_import is not a real command and must fail in both required_for and step.command: \(issues)")
+    }
+
+    @Test("mutating tool steps must name their command")
+    func mutatingStepsRequireCommand() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.steps = workflow.steps.map { step in
+            guard step.mutates else { return step }
+            return WorkflowStep(
+                id: step.id,
+                title: step.title,
+                operationType: step.operationType,
+                tool: step.tool,
+                command: nil,
+                resource: nil,
+                mutates: true,
+                requiresConfirmationLevel: step.requiresConfirmationLevel,
+                expectedResponseFields: step.expectedResponseFields,
+                stopConditions: step.stopConditions
+            )
+        }
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "mutating_step_missing_command" })
     }
 
     @Test("mutating workflows require confirmation metadata and failure modes")
@@ -32,6 +98,42 @@ struct WorkflowSkillCatalogTests {
         #expect(issues.contains { $0.code == "mutating_missing_failure_modes" })
     }
 
+    @Test("mutation_kind must agree with step mutability in both directions")
+    func mutationKindConsistencyLinted() {
+        var liar = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        liar.mutationKind = .readOnly
+        let readOnlyLie = WorkflowSkillLinter.validate([liar]).issues
+        #expect(readOnlyLie.contains { $0.code == "mutation_kind_mismatch" })
+
+        var hollow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.readiness.project" }!
+        hollow.mutationKind = .guardedMutation
+        let guardedLie = WorkflowSkillLinter.validate([hollow]).issues
+        #expect(guardedLie.contains { $0.code == "mutation_kind_mismatch" })
+    }
+
+    @Test("confirmation levels are restricted to L1 and L2")
+    func confirmationLevelsValidated() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.requiredConfirmations = [
+            WorkflowConfirmation(level: "L9", requiredFor: ["import_file"], message: "bogus level"),
+        ]
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "invalid_confirmation_level" })
+    }
+
+    @Test("mutating steps must be covered by a declared confirmation")
+    func mutatingStepConfirmationCoverage() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.requiredConfirmations = [
+            WorkflowConfirmation(level: "L2", requiredFor: ["record_sequence"], message: "covers a different level and command"),
+        ]
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.filter { $0.code == "mutating_step_not_covered_by_confirmation" }.count == 2,
+                "step level L1 is undeclared and import_file is unconfirmed: \(issues)")
+    }
+
     @Test("production-ready mutating workflows must be live verified")
     func productionReadyRequiresLiveEvidence() {
         var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
@@ -42,26 +144,191 @@ struct WorkflowSkillCatalogTests {
         #expect(issues.contains { $0.code == "production_mutation_without_live_evidence" })
     }
 
-    @Test("default workflow pack validates and includes stock plugin catalog dependency")
+    @Test("live_verified workflows must reference an evidence file")
+    func liveVerifiedRequiresEvidenceFile() {
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.evidenceLevel = .liveVerified
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "live_verified_missing_evidence_file" })
+    }
+
+    @Test("undeclared external resources fail the lint; declared ones pass")
+    func externalDependencyDeclarationRequired() {
+        let undeclared = WorkflowSkillLinter.validate(
+            WorkflowSkillCatalog.defaultWorkflows().filter { $0.id == "logic.workflow.plugins.stock_chain_plan" },
+            staticResourceURIs: ["logic://mixer"],
+            templateURIs: []
+        )
+        #expect(undeclared.isValid, "stock URIs are declared via depends_on and must pass: \(undeclared.issues)")
+
+        var stripped = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.plugins.stock_chain_plan" }!
+        stripped = WorkflowSkill(
+            id: stripped.id,
+            title: stripped.title,
+            intent: stripped.intent,
+            scope: stripped.scope,
+            prerequisites: stripped.prerequisites,
+            allowedTools: stripped.allowedTools,
+            allowedResources: stripped.allowedResources,
+            requiredConfirmations: stripped.requiredConfirmations,
+            stateChecks: stripped.stateChecks,
+            steps: stripped.steps,
+            verification: stripped.verification,
+            failureModes: stripped.failureModes,
+            rollbackOrRecovery: stripped.rollbackOrRecovery,
+            evidenceLevel: stripped.evidenceLevel,
+            productionReady: stripped.productionReady,
+            dependsOn: [],
+            limitations: stripped.limitations,
+            mutationKind: stripped.mutationKind,
+            dependenciesResolved: nil,
+            unresolvedResources: nil
+        )
+        let issues = WorkflowSkillLinter.validate(
+            [stripped],
+            staticResourceURIs: ["logic://mixer"],
+            templateURIs: []
+        ).issues
+        #expect(issues.contains { $0.code == "unknown_resource" },
+                "without depends_on, phantom stock URIs must fail the lint")
+    }
+}
+
+@Suite("Workflow skills pack — catalog")
+struct WorkflowSkillCatalogTests {
+    @Test("template matching resolves concrete and templated references")
+    func templateMatching() {
+        let templates: Set<String> = [
+            "logic://tracks/{index}/regions",
+            "logic://mixer/{strip}",
+            "logic://stock-plugins/{id}",
+            "logic://stock-plugins/search?query={query}",
+        ]
+
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://mixer/{strip}", staticURIs: [], templateURIs: templates))
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3", staticURIs: [], templateURIs: templates))
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://tracks/0/regions", staticURIs: [], templateURIs: templates))
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/logic.stock.effect.gain", staticURIs: [], templateURIs: templates))
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search?query=reverb", staticURIs: [], templateURIs: templates))
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins", staticURIs: [], templateURIs: templates))
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3/extra", staticURIs: [], templateURIs: templates))
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search?other=x", staticURIs: [], templateURIs: templates))
+        // Bare /search structurally matches the {id} template — and the live
+        // surface does serve it (empty-query search), so it must resolve.
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search", staticURIs: [], templateURIs: templates))
+    }
+
+    @Test("default workflow pack validates and stays honest about unresolved dependencies")
     func defaultPackValidates() {
         let snapshot = WorkflowSkillCatalog.defaultSnapshot()
 
         #expect(snapshot.schemaVersion == 1)
         #expect(snapshot.workflowCount >= 6)
         #expect(snapshot.validation.isValid, "workflow pack should validate: \(snapshot.validation.issues)")
+
         let stock = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_chain_plan" }
         #expect(stock?.dependsOn.contains("logic://stock-plugins") == true)
-        #expect(stock?.allowedResources.contains("logic://stock-plugins") == true)
         #expect(stock?.mutationKind == .readOnly)
+        #expect(stock?.dependenciesResolved == false,
+                "stock catalog resources are not served by this branch; the snapshot must say so")
+        #expect(stock?.unresolvedResources?.allSatisfy { $0.hasPrefix("logic://stock-plugins") } == true)
 
         let liveInsert = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_insert_gain_live_verified" }
         #expect(liveInsert?.mutationKind == .guardedMutation)
         #expect(liveInsert?.evidenceLevel == .liveVerified)
         #expect(liveInsert?.productionReady == true)
+        #expect(liveInsert?.dependenciesResolved == false)
         #expect(liveInsert?.verification.liveEvidenceFile == "docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md")
         #expect(liveInsert?.requiredConfirmations.contains { $0.level == "L2" } == true)
+
+        let readiness = snapshot.workflows.first { $0.id == "logic.workflow.readiness.project" }
+        #expect(readiness?.dependenciesResolved == true)
+        #expect(readiness?.unresolvedResources == nil)
     }
 
+    @Test("dependencies resolve once the stock plugin surface exists")
+    func dependenciesResolveWithStockSurface() {
+        let augmentedStatics = WorkflowSkillCatalog.currentStaticResourceURIs().union(["logic://stock-plugins"])
+        let augmentedTemplates = WorkflowSkillCatalog.currentTemplateURIs().union([
+            "logic://stock-plugins/{id}",
+            "logic://stock-plugins/search?query={query}",
+        ])
+        let snapshot = WorkflowSkillCatalog.snapshot(
+            staticResourceURIs: augmentedStatics,
+            templateURIs: augmentedTemplates
+        )
+
+        #expect(snapshot.validation.isValid)
+        #expect(snapshot.workflows.allSatisfy { $0.dependenciesResolved == true },
+                "with #14 merged, every workflow must resolve: \(snapshot.workflows.compactMap(\.unresolvedResources))")
+    }
+
+    @Test("every mutating step in the default pack names a real public command")
+    func defaultPackCommandsAreReal() {
+        for workflow in WorkflowSkillCatalog.defaultWorkflows() {
+            for step in workflow.steps where step.mutates {
+                let tool = try? #require(step.tool)
+                let command = try? #require(step.command)
+                if let tool, let command {
+                    #expect(WorkflowSkillCatalog.publicCommands[tool]?.contains(command) == true,
+                            "\(workflow.id) step \(step.id) references \(tool).\(command)")
+                }
+            }
+        }
+    }
+
+    @Test("live evidence files referenced by the default pack exist in the repo")
+    func liveEvidenceFilesExist() throws {
+        for workflow in WorkflowSkillCatalog.defaultWorkflows() {
+            guard let evidence = workflow.verification.liveEvidenceFile else { continue }
+            let path = workflowRepoRoot.appendingPathComponent(evidence).path
+            #expect(FileManager.default.fileExists(atPath: path),
+                    "\(workflow.id) references missing evidence file \(evidence)")
+        }
+    }
+
+    @Test("schema fields mirror the WorkflowSkill coding keys")
+    func schemaMatchesCodingKeys() {
+        let schema = WorkflowSkillCatalog.schema()
+        let fields = schema["fields"] as? [String]
+        #expect(fields == WorkflowSkill.CodingKeys.allCases.map(\.rawValue))
+        #expect((schema["confirmation_levels"] as? [String]) == ["L1", "L2"])
+        #expect((schema["lint_rules"] as? [String])?.contains("unknown_command") == true)
+    }
+}
+
+@Suite("Workflow skills pack — command census")
+struct WorkflowCommandCensusTests {
+    private static let dispatcherFiles: [String: String] = [
+        "logic_transport": "TransportDispatcher.swift",
+        "logic_tracks": "TrackDispatcher.swift",
+        "logic_mixer": "MixerDispatcher.swift",
+        "logic_midi": "MIDIDispatcher.swift",
+        "logic_edit": "EditDispatcher.swift",
+        "logic_navigate": "NavigateDispatcher.swift",
+        "logic_project": "ProjectDispatcher.swift",
+        "logic_system": "SystemDispatcher.swift",
+    ]
+
+    @Test("every census command exists as a case label in its dispatcher source")
+    func censusMatchesDispatcherSources() throws {
+        for (tool, commands) in WorkflowSkillCatalog.publicCommands {
+            let file = try #require(Self.dispatcherFiles[tool], "no dispatcher source mapped for \(tool)")
+            let url = workflowRepoRoot
+                .appendingPathComponent("Sources/LogicProMCP/Dispatchers")
+                .appendingPathComponent(file)
+            let source = try String(contentsOf: url, encoding: .utf8)
+            for command in commands {
+                #expect(source.contains("\"\(command)\""),
+                        "census command \(tool).\(command) not found in \(file)")
+            }
+        }
+    }
+}
+
+@Suite("Workflow skills pack — resources")
+struct WorkflowSkillResourceTests {
     @Test("MCP resources expose workflow list, detail, search, and schema")
     func workflowResources() async throws {
         let list = try await workflowResourceObject("logic://workflow-skills")
@@ -71,6 +338,12 @@ struct WorkflowSkillCatalogTests {
 
         let detail = try await workflowResourceObject("logic://workflow-skills/logic.workflow.readiness.project")
         #expect((detail["workflow"] as? [String: Any])?["id"] as? String == "logic.workflow.readiness.project")
+        #expect((detail["workflow"] as? [String: Any])?["dependencies_resolved"] as? Bool == true)
+
+        let stockDetail = try await workflowResourceObject("logic://workflow-skills/logic.workflow.plugins.stock_insert_gain_live_verified")
+        #expect((stockDetail["workflow"] as? [String: Any])?["dependencies_resolved"] as? Bool == false,
+                "stock-dependent workflow must disclose unresolved dependencies on this branch")
+        #expect(((stockDetail["workflow"] as? [String: Any])?["unresolved_resources"] as? [String])?.isEmpty == false)
 
         let search = try await workflowResourceObject("logic://workflow-skills/search?query=plugin")
         #expect((search["workflows"] as? [[String: Any]])?.contains {
@@ -81,7 +354,32 @@ struct WorkflowSkillCatalogTests {
         } == true)
 
         let schema = try await workflowResourceObject("logic://workflow-skills/schema")
-        #expect((schema["required_fields"] as? [String])?.contains("state_checks") == true)
+        #expect((schema["fields"] as? [String])?.contains("state_checks") == true)
         #expect((schema["evidence_levels"] as? [String])?.contains("live_verified") == true)
+    }
+
+    @Test("workflow skill URI routing fails closed on malformed inputs")
+    func workflowRoutingFailsClosed() async {
+        let malformed = [
+            "logic://workflow-skills?query=x",
+            "logic://workflow-skills/search/extra",
+            "logic://workflow-skills/search?other=x",
+            "logic://workflow-skills/logic.workflow.readiness.project?x=1",
+            "logic://workflow-skills/logic.workflow.readiness.project/extra",
+            "logic://workflow-skills/unknown.workflow.id",
+            "logic://workflow-skills/schema?x=1",
+        ]
+        for uri in malformed {
+            #expect(await workflowResourceThrows(uri), "expected fail-closed read for \(uri)")
+        }
+    }
+
+    @Test("search query is percent-decoded exactly once")
+    func searchQuerySingleDecode() async throws {
+        let search = try await workflowResourceObject("logic://workflow-skills/search?query=a%252Bb")
+        #expect(search["query"] as? String == "a%2Bb")
+
+        let plus = try await workflowResourceObject("logic://workflow-skills/search?query=a%2Bb")
+        #expect(plus["query"] as? String == "a+b")
     }
 }

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -299,18 +299,23 @@ struct WorkflowSkillCatalogTests {
         #expect(snapshot.workflowCount >= 6)
         #expect(snapshot.validation.isValid, "workflow pack should validate: \(snapshot.validation.issues)")
 
+        let stockSurfacePresent = WorkflowSkillCatalog.currentStaticResourceURIs().contains("logic://stock-plugins")
         let stock = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_chain_plan" }
         #expect(stock?.dependsOn.contains("logic://stock-plugins") == true)
         #expect(stock?.mutationKind == .readOnly)
-        #expect(stock?.dependenciesResolved == false,
-                "stock catalog resources are not served by this branch; the snapshot must say so")
-        #expect(stock?.unresolvedResources?.allSatisfy { $0.hasPrefix("logic://stock-plugins") } == true)
+        #expect(stock?.dependenciesResolved == stockSurfacePresent,
+                "stock dependency honesty must follow the actual served resource surface")
+        if stockSurfacePresent {
+            #expect(stock?.unresolvedResources == nil)
+        } else {
+            #expect(stock?.unresolvedResources?.allSatisfy { $0.hasPrefix("logic://stock-plugins") } == true)
+        }
 
         let liveInsert = snapshot.workflows.first { $0.id == "logic.workflow.plugins.stock_insert_gain_live_verified" }
         #expect(liveInsert?.mutationKind == .guardedMutation)
         #expect(liveInsert?.evidenceLevel == .liveVerified)
         #expect(liveInsert?.productionReady == true)
-        #expect(liveInsert?.dependenciesResolved == false)
+        #expect(liveInsert?.dependenciesResolved == stockSurfacePresent)
         #expect(liveInsert?.verification.liveEvidenceFile == "docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md")
         #expect(liveInsert?.requiredConfirmations.contains { $0.level == "L2" } == true)
 
@@ -440,9 +445,14 @@ struct WorkflowSkillResourceTests {
         #expect((detail["workflow"] as? [String: Any])?["dependencies_resolved"] as? Bool == true)
 
         let stockDetail = try await workflowResourceObject("logic://workflow-skills/logic.workflow.plugins.stock_insert_gain_live_verified")
-        #expect((stockDetail["workflow"] as? [String: Any])?["dependencies_resolved"] as? Bool == false,
-                "stock-dependent workflow must disclose unresolved dependencies on this branch")
-        #expect(((stockDetail["workflow"] as? [String: Any])?["unresolved_resources"] as? [String])?.isEmpty == false)
+        let stockSurfacePresent = WorkflowSkillCatalog.currentStaticResourceURIs().contains("logic://stock-plugins")
+        #expect((stockDetail["workflow"] as? [String: Any])?["dependencies_resolved"] as? Bool == stockSurfacePresent,
+                "stock-dependent workflow must disclose dependency state from the actual served surface")
+        if stockSurfacePresent {
+            #expect((stockDetail["workflow"] as? [String: Any])?["unresolved_resources"] == nil)
+        } else {
+            #expect(((stockDetail["workflow"] as? [String: Any])?["unresolved_resources"] as? [String])?.isEmpty == false)
+        }
 
         let search = try await workflowResourceObject("logic://workflow-skills/search?query=plugin")
         #expect((search["workflows"] as? [[String: Any]])?.contains {
@@ -463,6 +473,7 @@ struct WorkflowSkillResourceTests {
             "logic://workflow-skills?query=x",
             "logic://workflow-skills/search/extra",
             "logic://workflow-skills/search?other=x",
+            "logic://workflow-skills/search?query=plugin&query=marker",
             "logic://workflow-skills/logic.workflow.readiness.project?x=1",
             "logic://workflow-skills/logic.workflow.readiness.project/extra",
             "logic://workflow-skills/unknown.workflow.id",

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -126,12 +126,80 @@ struct WorkflowSkillLinterTests {
     func mutatingStepConfirmationCoverage() {
         var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
         workflow.requiredConfirmations = [
-            WorkflowConfirmation(level: "L2", requiredFor: ["record_sequence"], message: "covers a different level and command"),
+            WorkflowConfirmation(level: "L2", requiredFor: ["record_sequence"], message: "covers a different level"),
         ]
 
         let issues = WorkflowSkillLinter.validate([workflow]).issues
-        #expect(issues.filter { $0.code == "mutating_step_not_covered_by_confirmation" }.count == 2,
-                "step level L1 is undeclared and import_file is unconfirmed: \(issues)")
+        #expect(issues.contains { $0.code == "mutating_step_not_covered_by_confirmation" },
+                "step level L1 is undeclared: \(issues)")
+    }
+
+    @Test("confirmation coverage is an exact (level, command) pair")
+    func confirmationCoverageIsPairwise() {
+        // import_file is confirmed — but only at L1, while the step demands
+        // L2. Independent set-based checks would pass this; pair validation
+        // must reject it.
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.midi.idea_sketch" }!
+        workflow.requiredConfirmations = [
+            WorkflowConfirmation(level: "L1", requiredFor: ["import_file"], message: "right command, wrong level"),
+            WorkflowConfirmation(level: "L2", requiredFor: ["record_sequence"], message: "right level, wrong command"),
+        ]
+        workflow.steps = workflow.steps.map { step in
+            guard step.mutates else { return step }
+            return WorkflowStep(
+                id: step.id,
+                title: step.title,
+                operationType: step.operationType,
+                tool: step.tool,
+                command: step.command,
+                resource: nil,
+                mutates: true,
+                requiresConfirmationLevel: "L2",
+                expectedResponseFields: step.expectedResponseFields,
+                stopConditions: step.stopConditions
+            )
+        }
+
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "mutating_step_not_covered_by_confirmation" },
+                "L2 step with import_file confirmed only at L1 must fail: \(issues)")
+    }
+
+    @Test("dependency roots must be well-formed logic:// URIs")
+    func dependencyRootsValidated() {
+        #expect(WorkflowSkillCatalog.isValidDependencyRoot("logic://stock-plugins"))
+        #expect(!WorkflowSkillCatalog.isValidDependencyRoot("logic:"))
+        #expect(!WorkflowSkillCatalog.isValidDependencyRoot("logic:/"))
+        #expect(!WorkflowSkillCatalog.isValidDependencyRoot("logic://"))
+        #expect(!WorkflowSkillCatalog.isValidDependencyRoot("http://evil"))
+        #expect(!WorkflowSkillCatalog.refCoveredByDependencies("logic://anything/at/all", dependsOn: ["logic:"]),
+                "a bare scheme must not cover the whole URI space")
+
+        var workflow = WorkflowSkillCatalog.defaultWorkflows().first { $0.id == "logic.workflow.readiness.project" }!
+        workflow = WorkflowSkill(
+            id: workflow.id,
+            title: workflow.title,
+            intent: workflow.intent,
+            scope: workflow.scope,
+            prerequisites: workflow.prerequisites,
+            allowedTools: workflow.allowedTools,
+            allowedResources: workflow.allowedResources,
+            requiredConfirmations: workflow.requiredConfirmations,
+            stateChecks: workflow.stateChecks,
+            steps: workflow.steps,
+            verification: workflow.verification,
+            failureModes: workflow.failureModes,
+            rollbackOrRecovery: workflow.rollbackOrRecovery,
+            evidenceLevel: workflow.evidenceLevel,
+            productionReady: workflow.productionReady,
+            dependsOn: ["logic:"],
+            limitations: workflow.limitations,
+            mutationKind: workflow.mutationKind,
+            dependenciesResolved: nil,
+            unresolvedResources: nil
+        )
+        let issues = WorkflowSkillLinter.validate([workflow]).issues
+        #expect(issues.contains { $0.code == "invalid_dependency" })
     }
 
     @Test("production-ready mutating workflows must be live verified")
@@ -214,6 +282,10 @@ struct WorkflowSkillCatalogTests {
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3/extra", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search?other=x", staticURIs: [], templateURIs: templates))
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3/", staticURIs: [], templateURIs: templates),
+                "trailing slash must fail closed")
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer//3", staticURIs: [], templateURIs: templates),
+                "doubled slash must fail closed")
         // Bare /search structurally matches the {id} template — and the live
         // surface does serve it (empty-query search), so it must resolve.
         #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search", staticURIs: [], templateURIs: templates))
@@ -295,6 +367,7 @@ struct WorkflowSkillCatalogTests {
         #expect(fields == WorkflowSkill.CodingKeys.allCases.map(\.rawValue))
         #expect((schema["confirmation_levels"] as? [String]) == ["L1", "L2"])
         #expect((schema["lint_rules"] as? [String])?.contains("unknown_command") == true)
+        #expect((schema["lint_rules"] as? [String])?.contains("invalid_dependency") == true)
     }
 }
 
@@ -311,7 +384,7 @@ struct WorkflowCommandCensusTests {
         "logic_system": "SystemDispatcher.swift",
     ]
 
-    @Test("every census command exists as a case label in its dispatcher source")
+    @Test("every census command exists as an executable case label in its dispatcher source")
     func censusMatchesDispatcherSources() throws {
         for (tool, commands) in WorkflowSkillCatalog.publicCommands {
             let file = try #require(Self.dispatcherFiles[tool], "no dispatcher source mapped for \(tool)")
@@ -320,9 +393,35 @@ struct WorkflowCommandCensusTests {
                 .appendingPathComponent(file)
             let source = try String(contentsOf: url, encoding: .utf8)
             for command in commands {
-                #expect(source.contains("\"\(command)\""),
-                        "census command \(tool).\(command) not found in \(file)")
+                guard let caseRange = source.range(of: "case \"\(command)\"") else {
+                    Issue.record("census command \(tool).\(command) not found in \(file)")
+                    continue
+                }
+                // A census command must actually execute. If the case body
+                // immediately returns a "not exposed" stub, the census lies.
+                let bodyStart = caseRange.upperBound
+                let bodyEnd = source.index(bodyStart, offsetBy: 240, limitedBy: source.endIndex) ?? source.endIndex
+                let body = source[bodyStart..<bodyEnd]
+                #expect(!body.contains("not exposed in the production MCP contract"),
+                        "census command \(tool).\(command) is a not-exposed stub in \(file)")
             }
+        }
+    }
+
+    @Test("not-exposed dispatcher stubs are excluded from the census")
+    func notExposedStubsExcluded() {
+        let stubs: [(String, String)] = [
+            ("logic_tracks", "set_color"),
+            ("logic_mixer", "set_send"),
+            ("logic_mixer", "set_output"),
+            ("logic_mixer", "set_input"),
+            ("logic_mixer", "toggle_eq"),
+            ("logic_mixer", "reset_strip"),
+            ("logic_mixer", "bypass_plugin"),
+        ]
+        for (tool, command) in stubs {
+            #expect(WorkflowSkillCatalog.publicCommands[tool]?.contains(command) == false,
+                    "\(tool).\(command) returns a not-exposed error and must not be in the census")
         }
     }
 }
@@ -368,6 +467,8 @@ struct WorkflowSkillResourceTests {
             "logic://workflow-skills/logic.workflow.readiness.project/extra",
             "logic://workflow-skills/unknown.workflow.id",
             "logic://workflow-skills/schema?x=1",
+            "logic://workflow-skills//schema",
+            "logic://workflow-skills/schema/",
         ]
         for uri in malformed {
             #expect(await workflowResourceThrows(uri), "expected fail-closed read for \(uri)")

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete schema for Logic Pro MCP server. The server exposes **8 tools**, **9 resources**, and **3 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
+Complete schema for Logic Pro MCP server. The server exposes **8 tools**, **11 resources**, and **5 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
 
 **Design principle:** Tools perform write/action operations. **Reads are exposed exclusively through resources** — use `resources/read` for state queries, not tool calls.
 
@@ -30,7 +30,7 @@ All tool invocations use:
 
 ## Resource Catalog (Read-only)
 
-**9 static resources + 3 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
+**11 static resources + 5 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
 
 | URI | Content | Source |
 |-----|---------|--------|
@@ -43,13 +43,23 @@ All tool invocations use:
 | `logic://midi/ports` | `{ sources, destinations }` | CoreMIDI live query |
 | `logic://mcu/state` | `{ connection, display }` — MCU handshake + LCD state | Cache |
 | `logic://library/inventory` | Cached Library tree JSON (empty placeholder if not yet scanned) | File (resolved via `LOGIC_PRO_MCP_LIBRARY_INVENTORY` env, `Resources/library-inventory.json`, or `~/Library/Application Support/LogicProMCP/`). All candidates must sit under the path allowlist (`~/Library/Application Support/LogicProMCP/`, `<CWD>/Resources/`, `~/Music/Logic/`); extend via `LOGIC_PRO_MCP_INVENTORY_ALLOWLIST` (colon-separated, additive). |
+| `logic://workflow-skills` | `{ schema_version, workflow_count, validation, workflows[] }` — validated workflow skill pack | Static validated pack |
+| `logic://workflow-skills/schema` | Workflow schema fields, evidence levels, mutation kinds, and resource names | Static |
 | `logic://tracks/{index}` | Single `TrackState` JSON | Cache — template |
 | `logic://tracks/{index}/regions` | `RegionState[]` JSON filtered by `trackIndex` | Cache — template |
 | `logic://mixer/{strip}` | `{ cache_age_sec, fetched_at, data_source, strip: ChannelStripState }` | Cache — template |
+| `logic://workflow-skills/{id}` | Single workflow skill by stable ID | Static validated pack — template |
+| `logic://workflow-skills/search?query={query}` | Search workflow skills | Static validated pack — template |
 
 All resources return `contents: [{ uri, text, mimeType: "application/json" }]`.
 
 Prefer resources over repeated tool calls — they are cheap and safe to poll at 1 Hz.
+
+### Workflow Skills
+
+`logic://workflow-skills` is also read-only. It returns workflow recipes that tell clients which resources/tools to call, which state checks must pass, when confirmation is required, and which response fields prove success. Reading a workflow never executes it.
+
+Mutating workflows are not marked `production_ready` unless they have matching `live_verified` evidence. `logic.workflow.plugins.stock_chain_plan` is planning-only and declares its #14 stock-catalog dependency; `logic.workflow.plugins.stock_insert_gain_live_verified` is the guarded L2 Gain insert recipe backed by the existing Logic Pro 12.2 live evidence file and still requires current-session confirmation/readback.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,15 @@ Prefer resources over repeated tool calls — they are cheap and safe to poll at
 
 `logic://workflow-skills` is also read-only. It returns workflow recipes that tell clients which resources/tools to call, which state checks must pass, when confirmation is required, and which response fields prove success. Reading a workflow never executes it.
 
-Mutating workflows are not marked `production_ready` unless they have matching `live_verified` evidence. `logic.workflow.plugins.stock_chain_plan` is planning-only and declares its #14 stock-catalog dependency; `logic.workflow.plugins.stock_insert_gain_live_verified` is the guarded L2 Gain insert recipe backed by the existing Logic Pro 12.2 live evidence file and still requires current-session confirmation/readback.
+The pack is linted against the **real server surface** — no hand-maintained allowlists:
+
+- Tool references must name registered MCP tools, and every mutating step must carry an exact public `command` that exists in the per-tool command census (the census itself is pinned to the dispatcher sources by test).
+- Resource references must be servable by this build (exact static URI, a registered template, or a concrete instantiation of one) or be covered by the workflow's declared `depends_on` external dependencies.
+- `mutation_kind` must agree with step mutability in both directions; mutating steps must be covered by a declared confirmation (level `L1`/`L2` only, matching command); `live_verified` workflows must reference their evidence file.
+
+Each served workflow carries computed honesty fields: `dependencies_resolved` says whether every referenced resource is servable by **this** running build, and `unresolved_resources` lists the gaps. The stock-plugin workflows (`logic.workflow.plugins.stock_chain_plan`, `logic.workflow.plugins.stock_insert_gain_live_verified`) declare the #14 stock catalog via `depends_on`; until #14 is merged into the running build they are served with `dependencies_resolved: false`, and clients must not execute them against a server that cannot serve their resources.
+
+Mutating workflows are not marked `production_ready` unless they have matching `live_verified` evidence. `logic.workflow.plugins.stock_insert_gain_live_verified` is the guarded L2 Gain insert recipe backed by the existing Logic Pro 12.2 live evidence file and still requires current-session confirmation/readback.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Logic Pro MCP Server is a Swift 6 actor-based system that multiplexes **7 native
        │                  │                   │                    │
 ┌──────▼────────┐  ┌──────▼────────┐  ┌───────▼────────┐  ┌────────▼──────┐
 │  Dispatchers  │  │ ResourceHandlers │ │   StateCache   │  │  StatePoller  │
-│ (8 tools)     │  │  (6 + template) │ │   (actor)      │  │ (3s AX poll)  │
+│ (8 tools)     │  │ (14 + 7 templ.) │ │   (actor)      │  │ (3s AX poll)  │
 └──────┬────────┘  └──────┬────────┘  └───────▲────────┘  └────────┬──────┘
        │                  │                   │                    │
        │                  │                   │                    │
@@ -63,7 +63,7 @@ Legend — `↕` bidirectional, `↑` read, `↓` write.
 | **Routing** | `ChannelRouter` — priority chain selection, fallback, health checks | `actor` | Actor |
 | **Channels** | 7 communication channels, each wrapping one macOS API | `actor` | Actor per channel |
 | **State** | `StateCache` (store) + `StatePoller` (3s AX refresh) | `actor` | Actor |
-| **Resources** | `ResourceHandlers` — URI routing, JSON serialization | `struct` | Pure |
+| **Resources** | `ResourceHandlers` — URI routing, read-only state/catalog/workflow JSON serialization | `struct` | Pure |
 | **Utilities** | `AppleScriptSafety`, `DestructivePolicy`, `PermissionChecker`, `Logger` | mixed | Pure / `enum` |
 
 ---

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -132,7 +132,7 @@ Read this column-by-column. **"requires keycmd binding?"** is the question that 
 | `project.save (60)`                                                              | `logic_project.save`                           | AppleScript / CGEvent `Cmd+S`               | NO                       |
 | `project.save_as (61)`                                                           | `logic_project.save_as`                        | AppleScript / Accessibility                 | NO                       |
 | **`project.bounce (62)`**                                                        | `logic_project.bounce`                         | _none — cgEvent fallback unmapped_          | **YES**                  |
-| `transport.toggle_cycle (72)`                                                    | `logic_transport.toggle_cycle`                 | Accessibility / MCU / CGEvent `C`           | NO                       |
+| `transport.toggle_cycle (72)`                                                    | `logic_transport.toggle_cycle`                 | Accessibility / KeyCmd / CGEvent `C` / MCU  | NO                       |
 | **`transport.capture_recording (73)`**                                           | `logic_transport.capture_recording` _(none today; orphan)_ | _none — cgEvent fallback unmapped_ | **YES**                  |
 | `transport.toggle_metronome (98)`                                                | `logic_transport.toggle_metronome`             | Accessibility / CGEvent `K`                 | NO                       |
 | `transport.toggle_count_in (99)`                                                 | `logic_transport.toggle_count_in`              | Accessibility                               | NO                       |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,9 +35,15 @@ head -40 /tmp/mcp-stderr.txt
 Look for lines like:
 - `MIDIPortManager started` — CoreMIDI initialized
 - `Accessibility channel started` — AX ready
-- `Starting logic-pro-mcp v3.0.0 — 8 tools, 9 resources, 7 channels` — composition complete
+- `Starting logic-pro-mcp v3.4.6 — 8 tools, 11 resources, 7 channels` — composition complete
 
 If you see `AccessibilityError.notTrusted`, grant Accessibility permission.
+
+### Workflow skill refuses to call a tool automatically
+
+**Cause:** `logic://workflow-skills` is a read-only recipe surface. It describes safe steps and verification fields; it never executes the recipe.
+
+**Fix:** have the MCP client read the workflow, perform listed `state_checks`, request explicit user confirmation for mutating steps, then call the named tools itself.
 
 ---
 

--- a/docs/prd/PRD-workflow-skills-pack.md
+++ b/docs/prd/PRD-workflow-skills-pack.md
@@ -1,0 +1,118 @@
+# PRD: Logic Pro MCP Workflow Skills Pack (Issue #15)
+
+**Status**: Approved for implementation
+**Date**: 2026-06-09
+**Owner**: Logic Pro MCP
+**Related issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/15
+**Supersedes**: invalidated combined implementation `8ea264c`
+
+## 1. Problem
+
+Logic Pro MCP exposes many tools and resources, but clients still need repeatable workflows with explicit state checks, safe operation boundaries, stop conditions, and verification evidence. Unstructured prompt recipes drift from real tool/resource names and can imply unsafe autonomy.
+
+## 2. Goals
+
+- Define a workflow skill schema with validation rules.
+- Ship a first workflow pack for common Logic Pro MCP jobs.
+- Validate every workflow against current public tools/resources and safety gates.
+- Expose workflows through read-only MCP resources.
+- Integrate stock-plugin planning with #14 catalog resources instead of hard-coded plugin claims.
+
+## 3. Non-Goals
+
+- No fully autonomous DAW agent.
+- No external publishing/export automation beyond documented manual steps.
+- No bypass of existing destructive policy gates.
+- No third-party plugin dependency.
+- No production-ready mutating workflow without deterministic validation and live evidence.
+
+## 4. Schema
+
+Every workflow includes:
+
+- `id`
+- `title`
+- `intent`
+- `scope`
+- `prerequisites`
+- `allowed_tools`
+- `allowed_resources`
+- `required_confirmations`
+- `state_checks`
+- `steps`
+- `verification`
+- `failure_modes`
+- `rollback_or_recovery`
+- `evidence_level`
+- `production_ready`
+- `depends_on`
+- `limitations`
+
+## 5. Evidence Levels
+
+- `deterministic`: schema/linter validated, no live mutation claim.
+- `live_verified`: executed against a scoped live Logic session with evidence.
+- `documentation_only`: guidance only; no executable mutation path.
+- `experimental`: useful but hidden from production-ready defaults.
+
+No mutating workflow can be `production_ready` unless it is `live_verified`.
+
+## 6. Initial Workflow Pack
+
+- `logic.workflow.readiness.project`: read-only project readiness check.
+- `logic.workflow.midi.idea_sketch`: guarded MIDI idea sketch.
+- `logic.workflow.arrangement.marker_plan`: marker planning and verification.
+- `logic.workflow.mixer.gain_staging_prep`: guarded mixer prep with provenance requirements.
+- `logic.workflow.plugins.stock_chain_plan`: #14-backed stock plugin chain planning, planning-only in this release.
+- `logic.workflow.plugins.stock_insert_gain_live_verified`: guarded L2 Gain insert workflow backed by Logic Pro 12.2 live AX slot-readback evidence.
+- `logic.workflow.bounce.readiness`: bounce readiness checklist with manual export boundary.
+
+## 7. MCP Resources
+
+Read-only resources:
+
+- `logic://workflow-skills`
+- `logic://workflow-skills/{id}`
+- `logic://workflow-skills/search?query=<text>`
+- `logic://workflow-skills/schema`
+
+No workflow resource may execute a workflow or mutate Logic.
+
+## 8. Implementation Tickets
+
+Canonical ticket board: `docs/tickets/issue15-workflow-skills-pack/STATUS.md`
+
+- `I15-T1`: workflow schema models and linter.
+- `I15-T2`: first deterministic workflow pack.
+- `I15-T3`: read-only MCP resource handlers and registration.
+- `I15-T4`: integration/E2E tests for list/detail/search/schema.
+- `I15-T5`: docs and verification evidence.
+
+## 9. Acceptance Criteria
+
+- PRD and ticket board exist before implementation.
+- Tests cover schema validation, stale tool/resource references, destructive-step guardrails, duplicate IDs, and evidence-level rules.
+- Every workflow lists prerequisites, allowed operations, state checks, failure modes, and verification output.
+- Mutating workflows include explicit confirmation metadata and stop conditions.
+- At least one mutating workflow is `live_verified` before it is marked `production_ready`.
+- Workflow examples use current public tool/resource names only.
+- #14-dependent workflows reference #14 resources and do not hard-code plugin availability claims.
+- Read-only MCP resources expose workflow list/detail/search/schema.
+- Documentation includes examples and limitations.
+- Verification includes `swift test --no-parallel`, `swift build -c release`, schema/lint validation, and targeted live E2E where available.
+
+## 10. Test Plan
+
+- Linter tests for missing fields, duplicate IDs, stale references, missing confirmation metadata, and invalid production-ready claims.
+- Pack tests proving all workflows validate.
+- Resource tests for list/detail/search/schema.
+- E2E tests through server resource reads.
+- Live smoke test records workflow IDs and read-only resource evidence; mutating workflows remain non-production unless live evidence exists.
+
+## 11. ADR
+
+**Decision**: ship #15 as a validated read-only workflow pack with conservative evidence labels.
+**Drivers**: prevent prompt recipe drift, preserve safety gates, give clients practical workflows now.
+**Alternatives considered**: Markdown-only recipes, autonomous executor, generated recipes from code comments.
+**Why chosen**: Markdown-only cannot be linted; autonomous execution is out of scope; generated recipes are too opaque for client trust.
+**Consequences**: workflows guide clients instead of executing; production readiness is deliberately strict.

--- a/docs/tickets/issue15-workflow-skills-pack/STATUS.md
+++ b/docs/tickets/issue15-workflow-skills-pack/STATUS.md
@@ -47,6 +47,15 @@ Adversarial review (Codex gpt-5.5 xhigh + full-repo review cross-check) returned
 - [x] `R8` Fail-closed `URLComponents` URI routing for workflow resources (unknown subpaths/params rejected); search query double-decode bug fixed and regression-tested. Shared JSON helpers moved to `ResourceJSONHelpers.swift` (byte-identical with #14's branch to avoid merge collisions).
 - [x] `R9` Truth-faithful recipe limitations: `set_pan` relative V-Pot semantics, keycmd-only `delete_marker`/indexed `goto_marker`/`project.bounce` documented in the affected workflows.
 
+## Convergence Round 2→3 (2026-06-10)
+
+Round-2 adversarial re-review (Codex gpt-5.5 xhigh) confirmed all round-1 findings closed and surfaced 3 P2 / 1 P3 new edges — all fixed:
+
+- [x] `R10` Confirmation coverage is now an exact `(level, command)` pair: a command confirmed at L1 no longer licenses an L2 step (`confirmationCoverageIsPairwise` test).
+- [x] `R11` Doubled/trailing-slash URIs fail closed in both resource routing (canonical path reconstruction) and template matching (`omittingEmptySubsequences: false`).
+- [x] `R12` Command census purged of not-exposed stubs (`set_color`, `set_send`, `set_output`, `set_input`, `toggle_eq`, `reset_strip`, `bypass_plugin`); the census test now fails if a census command's case body is a "not exposed" stub.
+- [x] `R13` `depends_on` roots must be well-formed `logic://<host>` URIs (`invalid_dependency` lint); bare `logic:` prefixes no longer cover the URI space.
+
 Release identity note: `serverVersion` stays `3.4.6` on this branch by design — packaging surfaces pin the published v3.4.6 artifacts. Merging this PR requires the next release to ship as `v3.5.0`; do not rebuild/redistribute as `3.4.6`.
 
 ## Verification

--- a/docs/tickets/issue15-workflow-skills-pack/STATUS.md
+++ b/docs/tickets/issue15-workflow-skills-pack/STATUS.md
@@ -1,0 +1,38 @@
+# Issue #15 Ticket Board: Logic Pro MCP Workflow Skills Pack
+
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/15  
+**PRD**: `docs/prd/PRD-workflow-skills-pack.md`  
+**Status**: Done
+
+## Tickets
+
+- [x] `I15-T1` Workflow schema and linter
+  - Define workflow, steps, confirmations, state checks, verification, failure modes, and evidence levels.
+  - Linter rejects stale tool/resource references, duplicate IDs, missing mutating confirmations, and invalid production-ready claims.
+
+- [x] `I15-T2` Initial workflow pack
+  - Add project readiness, MIDI idea sketch, marker plan, gain staging prep, stock plugin chain planning, and bounce readiness workflows.
+  - Keep #14-dependent workflow planning-only and catalog-backed.
+
+- [x] `I15-T3` MCP resources
+  - Register `logic://workflow-skills`, `logic://workflow-skills/{id}`, `logic://workflow-skills/search?query=`, and `logic://workflow-skills/schema`.
+  - Keep resources read-only and side-effect free.
+
+- [x] `I15-T4` Tests
+  - Unit tests for linter and workflow pack.
+  - Resource and server E2E tests for list/detail/search/schema.
+
+- [x] `I15-T5` Docs and evidence
+  - Update API docs and client usage notes.
+  - Add verification evidence and limitations.
+
+## Done Criteria
+
+- All workflows validate against current public tools/resources.
+- Mutating workflows include confirmations and stop conditions.
+- No workflow is marked production-ready without matching evidence.
+- `swift build -c release`, `swift test --no-parallel`, and doc/schema validation pass.
+
+## Verification
+
+See `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md`.

--- a/docs/tickets/issue15-workflow-skills-pack/STATUS.md
+++ b/docs/tickets/issue15-workflow-skills-pack/STATUS.md
@@ -33,6 +33,22 @@
 - No workflow is marked production-ready without matching evidence.
 - `swift build -c release`, `swift test --no-parallel`, and doc/schema validation pass.
 
+## Hardening Round (2026-06-10)
+
+Adversarial review (Codex gpt-5.5 xhigh + full-repo review cross-check) returned 2 P1 / 3 P2 / 1 P3 findings. All addressed:
+
+- [x] `R1` Lint-gate bypass removed: `currentResourceURIs()` no longer hardcodes phantom `logic://stock-plugins*` URIs. The linter resolves references against the real `ResourceProvider` surface with template-aware matching; refs that don't resolve must be declared per-workflow in `depends_on` or the lint fails.
+- [x] `R2` Honesty surfaced at read time: every served workflow now carries computed `dependencies_resolved` + `unresolved_resources`. The two stock-dependent workflows are served with `dependencies_resolved: false` on this branch (tested); once #14 merges and this branch rebases, they flip to `true` mechanically (tested via injected surface).
+- [x] `R3` Command-level validation: `WorkflowStep.command` added and linted against a per-tool public command census (`publicCommands`), which is itself pinned to the dispatcher sources by `WorkflowCommandCensusTests`. The stale `midi_import` reference was corrected to `logic_midi.import_file` (with `logic_tracks.record_sequence` as the declared alternative), and the marker recipe now names `create_marker`/`rename_marker` explicitly.
+- [x] `R4` Mutation-kind truth lint: `read_only` with mutating steps and `guarded_mutation` without mutating steps both fail (`mutation_kind_mismatch`).
+- [x] `R5` Confirmation levels restricted to `L1`/`L2`; mutating steps must be covered by a declared confirmation in both level and command (`mutating_step_not_covered_by_confirmation`); mutating steps without a command fail (`mutating_step_missing_command`).
+- [x] `R6` `live_verified` workflows must reference an evidence file (`live_verified_missing_evidence_file`), and a deterministic test verifies referenced evidence files exist in the repo.
+- [x] `R7` Placeholder convention unified on `{query}`/`{id}` template forms; schema `fields` generated from `WorkflowSkill.CodingKeys` (drift-proof, tested); lint rule census exposed in the schema resource.
+- [x] `R8` Fail-closed `URLComponents` URI routing for workflow resources (unknown subpaths/params rejected); search query double-decode bug fixed and regression-tested. Shared JSON helpers moved to `ResourceJSONHelpers.swift` (byte-identical with #14's branch to avoid merge collisions).
+- [x] `R9` Truth-faithful recipe limitations: `set_pan` relative V-Pot semantics, keycmd-only `delete_marker`/indexed `goto_marker`/`project.bounce` documented in the affected workflows.
+
+Release identity note: `serverVersion` stays `3.4.6` on this branch by design — packaging surfaces pin the published v3.4.6 artifacts. Merging this PR requires the next release to ship as `v3.5.0`; do not rebuild/redistribute as `3.4.6`.
+
 ## Verification
 
-See `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md`.
+See `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md` and `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md` (hardening round).

--- a/docs/tickets/issue15-workflow-skills-pack/STATUS.md
+++ b/docs/tickets/issue15-workflow-skills-pack/STATUS.md
@@ -64,6 +64,7 @@ See `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md` and `
 
 Final production-readiness pass (2026-06-10):
 
+- `logic_system help` now derives resource/template counts from `ResourceProvider`, preventing stale help/banner counts when #14/#15 public resources are merged in either order.
 - `swift test --no-parallel` — 1235 tests passed.
 - `swift build -c release` — passed.
 - `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache-issue15 python3 -m py_compile Scripts/live-e2e-test.py` — passed.

--- a/docs/tickets/issue15-workflow-skills-pack/STATUS.md
+++ b/docs/tickets/issue15-workflow-skills-pack/STATUS.md
@@ -1,7 +1,7 @@
 # Issue #15 Ticket Board: Logic Pro MCP Workflow Skills Pack
 
-**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/15  
-**PRD**: `docs/prd/PRD-workflow-skills-pack.md`  
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/15
+**PRD**: `docs/prd/PRD-workflow-skills-pack.md`
 **Status**: Done
 
 ## Tickets
@@ -61,3 +61,11 @@ Release identity note: `serverVersion` stays `3.4.6` on this branch by design �
 ## Verification
 
 See `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md` and `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md` (hardening round).
+
+Final production-readiness pass (2026-06-10):
+
+- `swift test --no-parallel` — 1235 tests passed.
+- `swift build -c release` — passed.
+- `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache-issue15 python3 -m py_compile Scripts/live-e2e-test.py` — passed.
+- `git diff --check origin/main` — passed.
+- `LOGIC_PRO_MCP_STRICT_LIVE=1 Scripts/live-e2e-test.sh` — 281/281 passed.

--- a/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md
+++ b/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-09.md
@@ -1,0 +1,60 @@
+# Verification Evidence - Issue #15 Workflow Skills Pack
+
+Date: 2026-06-09 KST
+Branch: `feature/issue-15-workflow-skills-pack`
+Scope: current working tree, Logic Pro MCP release binary, Logic Pro 12.2 host.
+
+## Claim Boundary
+
+Workflow resources are read-only recipes. Reading `logic://workflow-skills` never executes a workflow. Mutating workflows must declare confirmation metadata, failure modes, stop conditions, and evidence level. A mutating workflow can be `production_ready` only when `evidence_level` is `live_verified`.
+
+## Implemented Pack
+
+- `logic.workflow.readiness.project`: read-only project readiness.
+- `logic.workflow.midi.idea_sketch`: guarded MIDI mutation recipe, not production-ready.
+- `logic.workflow.arrangement.marker_plan`: guarded marker mutation recipe, not production-ready.
+- `logic.workflow.mixer.gain_staging_prep`: guarded mixer recipe, not production-ready.
+- `logic.workflow.plugins.stock_chain_plan`: read-only #14-backed stock plugin planning.
+- `logic.workflow.plugins.stock_insert_gain_live_verified`: guarded L2 Gain insert recipe, production-ready because it references Logic Pro 12.2 live AX slot-readback evidence.
+- `logic.workflow.bounce.readiness`: read-only bounce checklist.
+
+## Deterministic Gates
+
+| Gate | Result | Evidence |
+|---|---:|---|
+| Format check | PASS | `git diff --check` exit 0. |
+| Focused workflow/resource E2E tests | PASS | `swift test --no-parallel --filter WorkflowSkillCatalogTests --filter testE2EResourceWorkflowSkillsExposeValidatedPack --filter testE2EServerCatalogAdvertisesAllResources --filter testE2EServerCatalogAdvertisesAllTemplates` -> 8 tests passed. |
+| Full test suite | PASS | `swift test --no-parallel` -> 1214 tests passed. |
+| Release build | PASS | `swift build -c release` -> build complete. |
+| Python E2E syntax | PASS | `PYTHONPYCACHEPREFIX=/private/tmp/logic-pro-mcp-pycache python3 -m py_compile Scripts/live-e2e-test.py` exit 0. |
+| Coverage gate | Not run on split branch | CI coverage runs on PR; local focused/full tests and release build passed before PR. |
+
+## Release-Binary Read-Only Smoke
+
+Command: release-binary MCP stdio smoke against `.build/release/LogicProMCP`.
+
+Result:
+
+```json
+{"ok":true,"resource_count":10,"schema_has_live_verified":true,"stock_insert_workflow_evidence_level":"live_verified","stock_insert_workflow_production_ready":true,"template_count":5,"workflow_count":7,"workflow_pack_valid":true}
+```
+
+## Live Mutation Evidence
+
+The live-verified mutating workflow is `logic.workflow.plugins.stock_insert_gain_live_verified`.
+
+- Evidence file: `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md`.
+- Logic Pro version: 12.2.
+- Operation: `logic_mixer insert_plugin { track: 0, slot: 6, plugin_name: "Gain", confirmed: true }`.
+- Result: State A with `success:true`, `verified:true`, `verify_source:"ax_plugin_slot"`, `observed_plugin_name:"Gain"`.
+- Guardrail: missing confirmation returns `confirmation_required:true`; occupied slot fails closed with `slot_occupied`.
+
+Fresh 2026-06-09 reruns verified TCC/tmux readiness but current-session mutating reruns were blocked by the Project Chooser modal and mixer visibility precondition. Those attempts failed closed (`element_not_found`, `mixer_not_visible`, or `readback_unavailable`) and are intentionally not used as success evidence.
+
+## Acceptance Mapping
+
+- PRD/ticket docs: `docs/prd/PRD-workflow-skills-pack.md`, this ticket board.
+- Schema/linter: `Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift` validates duplicate IDs, stale tools/resources, mutating confirmations, failure modes, and production-ready evidence rules.
+- Resources: `logic://workflow-skills`, `logic://workflow-skills/{id}`, `logic://workflow-skills/search?query=`, `logic://workflow-skills/schema`.
+- Tests: `Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift` validates stale references, guardrails, live-evidence production rules, and MCP resources.
+- Safety: workflow resources do not execute; mutating recipes require explicit target/confirmation and rely on existing fail-closed tool behavior.

--- a/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md
+++ b/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md
@@ -60,6 +60,19 @@ Additional hardening: `live_verified_missing_evidence_file` lint + repo-file exi
 
 The key honesty change: the live-verified Gain insert workflow is now served with `dependencies_resolved: false` and an explicit `unresolved_resources` list on this branch, because the #14 stock catalog is not part of this build. After #14 merges and this branch rebases, the same computation flips to `true` mechanically (covered by `dependenciesResolveWithStockSurface`).
 
+## Convergence Round 2→3
+
+Round-2 re-review (Codex gpt-5.5 xhigh): all 6 round-1 findings **CLOSED**; verdict PASS-WITH-CONDITIONS with 4 new edges, all fixed in the follow-up commit:
+
+| New finding | Fix |
+|---|---|
+| Confirmation coverage validated as independent level/command sets (P2) | Exact `(level, command)` pair validation + regression test |
+| Empty path segments accepted (`//schema`, trailing `/`) (P2) | Canonical-path guard in routing; `omittingEmptySubsequences: false` in template matching; tests |
+| Census contained not-exposed stubs (`set_color`, `set_send`, `set_output`, `set_input`, `toggle_eq`, `reset_strip`, `bypass_plugin`) (P2) | Stubs removed; census test fails on "not exposed" case bodies; explicit exclusion test |
+| `depends_on` accepted arbitrary prefixes like `logic:` (P3) | `invalid_dependency` lint; only `logic://<host>` roots cover refs |
+
+Round-3 gates: `swift test --no-parallel` → **1232 tests passed**; `swift build -c release` PASS; `git diff --check` PASS.
+
 ## Live Mutation Evidence (unchanged)
 
 The live-verified mutating workflow remains backed by `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md` (Logic Pro 12.2, `insert_plugin` State A with `verified:true`, `verify_source:"ax_plugin_slot"`, fail-closed `slot_occupied` repeat). A deterministic test now proves the referenced evidence file exists in the repo.

--- a/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md
+++ b/docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md
@@ -1,0 +1,65 @@
+# Verification Evidence - Issue #15 Hardening Round (2026-06-10)
+
+Date: 2026-06-10 KST
+Branch: `feature/issue-15-workflow-skills-pack`
+Scope: post-review hardening of the workflow skills pack, Logic Pro 12.2 host.
+
+## Review Inputs
+
+- Adversarial review: Codex gpt-5.5 (`model_reasoning_effort=xhigh`), verdict on the pre-hardening branch: FAIL (2 P1 / 3 P2 / 1 P3).
+- Cross-check: 2026-06-08/09 full-repo enterprise review.
+- Dispatcher-source evidence motivating R3: the pre-hardening pack referenced `midi_import`, which exists in no dispatcher; the real command is `logic_midi.import_file`, and `record_sequence` lives on `logic_tracks`.
+
+## Findings → Fixes
+
+| Finding (severity) | Fix |
+|---|---|
+| Phantom stock URIs hardcoded into the lint surface (P1) | Hardcoded union removed. Template-aware resolution against the real `ResourceProvider` surface; unresolvable refs must be declared per-workflow in `depends_on` or lint fails (`unknown_resource`). Served workflows expose computed `dependencies_resolved` + `unresolved_resources`. |
+| Commands not validated; stale `midi_import`/generic marker refs (P1) | `WorkflowStep.command` + per-tool `publicCommands` census linting (`unknown_command`, `mutating_step_missing_command`); census pinned to dispatcher sources by `WorkflowCommandCensusTests`; recipes corrected (`import_file`, `record_sequence`, `create_marker`, `rename_marker`, `set_volume`, `insert_plugin`). |
+| `mutation_kind` could lie (P2) | Bidirectional `mutation_kind_mismatch` lint. |
+| Free-form confirmation levels (P2) | Levels restricted to `L1`/`L2`; mutating steps must be covered by a declared confirmation in level and command. |
+| Version identity under grown surface (P2) | Documented contract: merge ⇒ next release must be `v3.5.0`; packaging untouched on branch by design. |
+| Placeholder convention mismatch `<text>` vs `{query}` (P3) | Unified on template forms (`{query}`, `{id}`); schema `fields` generated from `CodingKeys` and pinned by test. |
+
+Additional hardening: `live_verified_missing_evidence_file` lint + repo-file existence test for referenced evidence; fail-closed `URLComponents` routing for workflow resources with single-decode regression test; shared `ResourceJSONHelpers.swift` byte-identical with the #14 branch; truth-faithful limitations (relative `set_pan` V-Pot semantics, keycmd-only `delete_marker`/indexed `goto_marker`/`project.bounce`).
+
+## Deterministic Gates
+
+| Gate | Result | Evidence |
+|---|---:|---|
+| Format check | PASS | `git diff --check` exit 0. |
+| Workflow suites | PASS | `swift test --no-parallel --filter Workflow` → 24 tests passed. |
+| Full test suite | PASS | `swift test --no-parallel` → 1229 tests passed. |
+| Release build | PASS | `swift build -c release` → build complete. |
+| Python E2E syntax | PASS | `PYTHONPYCACHEPREFIX=/private/tmp/lpm-pycache18 python3 -m py_compile Scripts/live-e2e-test.py` exit 0. |
+
+## Release-Binary Read-Only Smoke
+
+```json
+{
+ "ok": true,
+ "resource_count": 10,
+ "template_count": 5,
+ "workflow_count": 7,
+ "workflow_pack_valid": true,
+ "insert_production_ready": true,
+ "insert_evidence_level": "live_verified",
+ "insert_dependencies_resolved": false,
+ "insert_unresolved": [
+  "logic://stock-plugins/logic.stock.effect.gain",
+  "logic://stock-plugins/{id}"
+ ],
+ "insert_step_commands": ["insert_plugin"],
+ "readiness_dependencies_resolved": true,
+ "schema_has_lint_rules": true,
+ "malformed_uri_fails_closed": true
+}
+```
+
+`resource_count` is 10 because `logic://mcu/state` is hidden while the MCU surface is disconnected.
+
+The key honesty change: the live-verified Gain insert workflow is now served with `dependencies_resolved: false` and an explicit `unresolved_resources` list on this branch, because the #14 stock catalog is not part of this build. After #14 merges and this branch rebases, the same computation flips to `true` mechanically (covered by `dependenciesResolveWithStockSurface`).
+
+## Live Mutation Evidence (unchanged)
+
+The live-verified mutating workflow remains backed by `docs/tickets/mixer-verification/VERIFICATION-2026-06-09.md` (Logic Pro 12.2, `insert_plugin` State A with `verified:true`, `verify_source:"ax_plugin_slot"`, fail-closed `slot_occupied` repeat). A deterministic test now proves the referenced evidence file exists in the repo.


### PR DESCRIPTION
## Summary

Refs #15.

This PR implements issue #15 only, on an independent branch. It does not include the stock plugin catalog implementation from #14; #14 resources are declared as per-workflow `depends_on` external dependencies, and the served pack **honestly reports** `dependencies_resolved: false` for those recipes until #14 lands.

Delivered:
- New PRD and ticket board for the workflow skills pack.
- `WorkflowSkillCatalog` schema + linter validating against the **real server surface**: duplicate IDs, unknown tools, unknown **commands** (per-tool census pinned to dispatcher sources by test), template-aware resource resolution, mutation-kind consistency, confirmation coverage (L1/L2 only, level + command), production-ready evidence rules, and live-evidence file requirements.
- Seven workflow recipes: readiness, MIDI idea sketch, marker planning, gain-staging prep, stock-chain planning, guarded live-verified Gain insertion, and bounce readiness — every mutating step names its exact public command (`import_file`, `create_marker`, `set_volume`, `insert_plugin`).
- Read-only MCP resources and templates for workflow list, detail, search, and schema — with fail-closed `URLComponents` routing.
- API/troubleshooting/architecture docs and branch-specific verification evidence.

## Hardening round (2026-06-10)

An adversarial review (independent adversarial review + enterprise full-repo cross-check) on the initial branch returned **2 P1 / 3 P2 / 1 P3 — all fixed**:

| Finding | Fix |
|---|---|
| P1: lint gate bypassed by hardcoded phantom `logic://stock-plugins*` URIs (clients could be told to read URIs that 404) | Hardcoded union removed; refs resolve against the real `ResourceProvider` surface (template-aware) or must be declared in `depends_on`; served workflows expose computed `dependencies_resolved` + `unresolved_resources` |
| P1: commands not validated — pack referenced nonexistent `midi_import`; marker mutation was generic | `WorkflowStep.command` + per-tool public command census linting; census pinned to dispatcher sources by test; recipes corrected to `logic_midi.import_file`, `logic_tracks.record_sequence`, `create_marker`/`rename_marker` |
| P2: `mutation_kind` could lie about mutating steps | Bidirectional `mutation_kind_mismatch` lint |
| P2: confirmation levels free-form | Restricted to `L1`/`L2`; mutating steps must be covered by a declared confirmation in both level and command |
| P2: release identity (see Merge contract) | Documented: next release after merge must be `v3.5.0` |
| P3: `?query=<text>` vs `?query={query}` mismatch | Unified on template forms; schema `fields` generated from `CodingKeys` (drift-proof, tested) |

Additional: `live_verified` workflows must reference an evidence file, and a deterministic test proves referenced evidence files exist in the repo; fail-closed URI routing with single-decode regression test; truth-faithful limitations added (relative `set_pan` V-Pot semantics; keycmd-only `delete_marker`/indexed `goto_marker`/`project.bounce`).

## Verification

- `git diff --check` PASS
- `python3 -m py_compile Scripts/live-e2e-test.py` PASS
- Workflow suites PASS: 24 tests
- `swift test --no-parallel` PASS: **1229 tests**
- `swift build -c release` PASS
- Release-binary MCP smoke: 10 runtime resources, 5 templates, workflow_count 7, pack valid, live-verified Gain workflow production-ready **with `dependencies_resolved: false` + explicit `unresolved_resources` on this branch** (flips true mechanically after #14 merges — tested), malformed URIs fail closed
- Evidence: `docs/tickets/issue15-workflow-skills-pack/VERIFICATION-2026-06-10.md`

## Boundary

Workflow resources are read-only recipes; reading them never executes mutations. Mutating recipes require explicit confirmation metadata, exact public commands, stop conditions, failure modes, and either deterministic or live evidence. Clients must check `dependencies_resolved` before executing a recipe against a given server build.

## Merge contract (cross-PR)

- #17 and #18 are independent branches that both extend the resource surface; **whichever merges second must rebase** and reconcile combined counts (14 resources / 7 templates, startup banner, `docs/API.md`, live-e2e expectations). `ResourceJSONHelpers.swift` is byte-identical on both branches to avoid duplicate-helper conflicts. After rebasing on #17, the stock workflows' `dependencies_resolved` flips to `true` with no code change.
- `serverVersion` intentionally stays `3.4.6` on this branch (packaging surfaces pin the published v3.4.6 artifacts). **The first release containing this PR must ship as `v3.5.0`**; do not rebuild as `3.4.6`.

Do not merge until review approval.