### PR TITLE
Fix Homebrew formula pkgshare paths and gate them against the release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,40 @@ jobs:
           shasum -a 256 LogicProMCP-macOS-arm64.tar.gz >> SHA256SUMS.txt
           shasum -a 256 LogicProMCP >> SHA256SUMS.txt
 
+      - name: Verify Formula install paths against tarball
+        # Issue #22: v3.4.6/v3.5.0 shipped a Formula whose pkgshare.install
+        # paths did not exist in the published tarball (formula flat vs
+        # tarball nested), so `brew install` failed at the install step.
+        # PR #2 fixed the same failure class in the opposite direction
+        # (formula nested vs tarball flat). This gate asserts — against the
+        # actual artifact about to be published — that every path the
+        # Formula installs is present in the tarball listing, so BOTH drift
+        # directions fail the release before anything ships. The PR-time
+        # half of the guard is VersionConsistencyTests
+        # .testFormulaInstallPathsMatchRepoAndReleaseStaging.
+        run: |
+          tar -tzf LogicProMCP-macOS-universal.tar.gz > tarball-listing.txt
+          echo "Tarball listing:"
+          cat tarball-listing.txt
+          PATHS=$(sed -nE 's/^[[:space:]]*(pkgshare|bin)\.install "([^"]+)".*/\2/p' Formula/logic-pro-mcp.rb)
+          if [ -z "$PATHS" ]; then
+            echo "::error::Parsed no install paths from Formula/logic-pro-mcp.rb — parser or Formula layout drifted"
+            exit 1
+          fi
+          FAIL=0
+          while IFS= read -r p; do
+            if grep -Fxq "$p" tarball-listing.txt; then
+              echo "OK: $p"
+            else
+              echo "::error::Formula installs '$p' but it is missing from LogicProMCP-macOS-universal.tar.gz"
+              FAIL=1
+            fi
+          done <<< "$PATHS"
+          if [ "$FAIL" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Formula install paths verified against the built tarball."
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - **`brew install` regression (Issue #22, thomas-doesburg)** — the Formula installed its five helper assets from the tarball root, while the published v3.4.6/v3.5.0 tarballs stage them under `docs/` and `Scripts/` (the inverse of the v3.1.x mismatch fixed in PR #2), so the Homebrew install step failed. `pkgshare.install` paths now match the staged layout. Two guards now block both drift directions: a PR-time test (`VersionConsistencyTests.testFormulaInstallPathsMatchRepoAndReleaseStaging`) asserts every Formula install path exists in the repo and is staged by `release.yml`, and a tag-time release-workflow gate asserts every install path against the actual built tarball (`tar -tzf`) before anything is published. Because the Homebrew tap serves the Formula from `main`, the fix applies to the already-published v3.4.6/v3.5.0 artifacts on `brew update` — the tarballs themselves were always correct; only the install paths were wrong.
+- **Install docs cover the Homebrew 6.0 tap trust model** — README/SETUP now include the `brew trust monglong0214/logic-pro-mcp` step required before `brew install` on Homebrew 6.0+, and TROUBLESHOOTING gained an Install section for the untrusted-tap refusal and the issue #22 `Errno::ENOENT` symptom. MAINTAINERS documents the two-layer Formula/tarball gate.
 
 ## [3.5.0] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Fixed
+
+- **`brew install` regression (Issue #22, thomas-doesburg)** — the Formula installed its five helper assets from the tarball root, while the published v3.4.6/v3.5.0 tarballs stage them under `docs/` and `Scripts/` (the inverse of the v3.1.x mismatch fixed in PR #2), so the Homebrew install step failed. `pkgshare.install` paths now match the staged layout. Two guards now block both drift directions: a PR-time test (`VersionConsistencyTests.testFormulaInstallPathsMatchRepoAndReleaseStaging`) asserts every Formula install path exists in the repo and is staged by `release.yml`, and a tag-time release-workflow gate asserts every install path against the actual built tarball (`tar -tzf`) before anything is published. Because the Homebrew tap serves the Formula from `main`, the fix applies to the already-published v3.4.6/v3.5.0 artifacts on `brew update` — the tarballs themselves were always correct; only the install paths were wrong.
 
 ## [3.5.0] — 2026-06-12
 

--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -29,11 +29,18 @@ class LogicProMcp < Formula
     bin.install "LogicProMCP"
     # Helper assets shipped with the binary so users can complete Logic Pro
     # integration without re-cloning the repo.
-    pkgshare.install "SETUP.md"
-    pkgshare.install "install-keycmds.sh"
-    pkgshare.install "uninstall-keycmds.sh"
-    pkgshare.install "keycmd-preset.plist"
-    pkgshare.install "LogicProMCP-Scripter.js"
+    #
+    # Issue #22: these paths must match the tarball layout staged by
+    # .github/workflows/release.yml, which packages repo-relative nested
+    # paths (docs/, Scripts/). Homebrew flattens them into pkgshare by
+    # basename, which install-keycmds.sh relies on (sibling preset lookup).
+    # Guarded both ways: VersionConsistencyTests at PR time, and the
+    # release workflow's tarball-listing gate at tag time.
+    pkgshare.install "docs/SETUP.md"
+    pkgshare.install "Scripts/install-keycmds.sh"
+    pkgshare.install "Scripts/uninstall-keycmds.sh"
+    pkgshare.install "Scripts/keycmd-preset.plist"
+    pkgshare.install "Scripts/LogicProMCP-Scripter.js"
   end
 
   def caveats

--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ The current published stable release is `v3.5.0` (2026-06-12 KST). It ships ADHO
 
 ```bash
 brew tap MongLong0214/logic-pro-mcp https://github.com/MongLong0214/logic-pro-mcp
+brew trust monglong0214/logic-pro-mcp   # Homebrew 6.0+ requires trusting third-party taps
 brew install logic-pro-mcp
 ```
 
-The Homebrew formula pins both the release tarball URL and its SHA256; Homebrew itself is a trusted delivery channel with its own signature chain. This is the hardened path for production installs.
+The Homebrew formula pins both the release tarball URL and its SHA256; Homebrew itself is a trusted delivery channel with its own signature chain. This is the hardened path for production installs. (On Homebrew older than 6.0 the `brew trust` step does not exist — skip it.)
 
 For source-tree development, build locally:
 

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -98,3 +98,54 @@ private func readRepoFile(_ relativePath: String) throws -> String {
     #expect(api.contains("| `toggle_cycle` | — | text | Accessibility → MIDIKeyCommands → CGEvent → MCU |"))
     #expect(api.contains("| `set_tempo` | `{ tempo: number }` (5–999, matches Logic's actual accepted range) | text | Accessibility |"))
 }
+
+/// Issue #22 (thomas-doesburg): `brew install` broke at v3.4.6/v3.5.0 because
+/// the Formula installed helper assets from the tarball root while the release
+/// workflow stages them with repo-relative nested paths (`docs/SETUP.md`,
+/// `Scripts/…`). PR #2 fixed the same failure class in the opposite direction
+/// (formula nested / tarball flat), so this guards BOTH drift directions at
+/// PR time: every `pkgshare.install` path must exist in the repo at exactly
+/// the staged relative path, and every installed path (including
+/// `bin.install`) must appear in the release workflow's tarball staging list.
+/// The tag-time half of the guard lives in release.yml ("Verify Formula
+/// install paths against tarball"), which re-asserts the same paths against
+/// the actual built artifact before anything is published.
+@Test func testFormulaInstallPathsMatchRepoAndReleaseStaging() throws {
+    let formula = try readRepoFile("Formula/logic-pro-mcp.rb")
+    let releaseWorkflow = try readRepoFile(".github/workflows/release.yml")
+
+    func installPaths(_ directive: String) -> [String] {
+        formula.components(separatedBy: "\n").compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("\(directive).install \"") else { return nil }
+            let parts = trimmed.components(separatedBy: "\"")
+            return parts.count >= 2 ? parts[1] : nil
+        }
+    }
+
+    let pkgsharePaths = installPaths("pkgshare")
+    let binPaths = installPaths("bin")
+    #expect(
+        pkgsharePaths.count == 5,
+        "expected the 5 helper assets in Formula pkgshare.install; parser or Formula drifted: \(pkgsharePaths)"
+    )
+    #expect(binPaths == ["LogicProMCP"], "Formula bin.install drifted: \(binPaths)")
+
+    let root = repositoryRootURL()
+    for path in pkgsharePaths {
+        #expect(
+            !path.hasPrefix("/") && !path.contains(".."),
+            "Formula install path '\(path)' must be a clean repo-relative path"
+        )
+        #expect(
+            FileManager.default.fileExists(atPath: root.appendingPathComponent(path).path),
+            "Formula installs '\(path)' but no such file exists in the repo — the tarball stages repo-relative paths, so brew install would fail (issue #22)"
+        )
+    }
+    for path in pkgsharePaths + binPaths {
+        #expect(
+            releaseWorkflow.contains(path),
+            "Formula installs '\(path)' but release.yml does not stage it into the tarball (issue #22)"
+        )
+    }
+}

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -88,6 +88,8 @@ curl -fsSL "https://github.com/MongLong0214/logic-pro-mcp/releases/download/$VER
 
 Commit the formula update as a separate follow-up when needed. Users installing via `brew install` against the tap will then resolve to the newly-published artifact.
 
+The Formula's install paths are guarded in both directions after issue #22 (formula flat vs tarball nested — the inverse of PR #2): `VersionConsistencyTests.testFormulaInstallPathsMatchRepoAndReleaseStaging` fails any PR whose Formula paths don't exist in the repo or aren't staged by `release.yml`, and the release workflow's "Verify Formula install paths against tarball" step fails the tag run if any `pkgshare`/`bin` install path is missing from the actual built tarball. If you change the tarball layout or the Formula's install block, change both together.
+
 If you also maintain a private Homebrew tap, publish the formula update there.
 
 ### Environment variables (runtime)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -19,10 +19,11 @@ Complete installation, Logic Pro integration, and verification. Should take ~10 
 
 ```bash
 brew tap MongLong0214/logic-pro-mcp https://github.com/MongLong0214/logic-pro-mcp
+brew trust monglong0214/logic-pro-mcp   # Homebrew 6.0+ requires trusting third-party taps
 brew install logic-pro-mcp
 ```
 
-Homebrew pins both the release tarball URL and its SHA256 in the formula, and Homebrew itself is a trusted delivery channel with its own signature chain. Use this path whenever possible.
+Homebrew pins both the release tarball URL and its SHA256 in the formula, and Homebrew itself is a trusted delivery channel with its own signature chain. Use this path whenever possible. (On Homebrew older than 6.0 the `brew trust` step does not exist — skip it.)
 
 ### Option B — Download-inspect-run one-line installer
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,6 +6,29 @@ For MCU-specific problems, see [SETUP.md §3](SETUP.md#3-register-mcu-control-su
 
 ---
 
+## Install (Homebrew)
+
+### `Error: Refusing to load formula … from untrusted tap monglong0214/logic-pro-mcp`
+
+Homebrew 6.0 introduced a tap trust model: formulae from third-party taps refuse to load until the tap is trusted once.
+
+```bash
+brew trust monglong0214/logic-pro-mcp
+```
+
+Then retry `brew install logic-pro-mcp`. On Homebrew older than 6.0 this error (and the `brew trust` command) does not exist.
+
+### `Errno::ENOENT: No such file or directory - SETUP.md` during `brew install` / `brew upgrade`
+
+The v3.4.6/v3.5.0 Formula installed helper assets from the tarball root while the published tarballs nest them under `docs/` and `Scripts/` (issue #22). Fixed on `main` — the tap serves the Formula from `main`, so:
+
+```bash
+brew update
+brew upgrade logic-pro-mcp   # or: brew install logic-pro-mcp
+```
+
+The published tarballs themselves were always correct; no pinned-hash change is involved. Both drift directions are now CI-gated (PR-time `VersionConsistencyTests` + a tag-time tarball-listing gate in the release workflow).
+
 ## Server Won't Start
 
 ### `claude mcp add` succeeds but server never responds


### PR DESCRIPTION
## Summary
- Fixes #22 (@thomas-doesburg): `brew install`/`brew upgrade` failed at v3.4.6 and v3.5.0 because the Formula installed its five helper assets from the tarball root while `release.yml` stages them under `docs/` and `Scripts/` — the inverse of the v3.1.x mismatch fixed in PR #2.
- `pkgshare.install` paths now match the staged tarball layout (Homebrew flattens into pkgshare by basename; `install-keycmds.sh`'s sibling `dirname "$0"` preset lookup keeps working — verified on the installed keg).
- Adopts the reporter's CI suggestion in **two layers** so both drift directions of this flip-flop class fail before users see them:
  - **PR time** — `VersionConsistencyTests.testFormulaInstallPathsMatchRepoAndReleaseStaging`: every Formula install path must exist in the repo at the staged relative path and appear in `release.yml`'s tarball staging list. TDD RED on the broken Formula (5 exact failures) → GREEN after the fix.
  - **Tag time** — new `release.yml` step "Verify Formula install paths against tarball": `tar -tzf` on the just-built universal tarball must contain every `pkgshare`/`bin` install path, or the release fails before publishing.
- No re-tag needed: the tap serves the Formula from `main`, and the published v3.4.6/v3.5.0 tarballs were always correct — `brew update && brew upgrade` is fixed by this merge alone.

## Reproduction → fix evidence (this host, brew 6.0.1, tap-based — the real user path)
- **Repro (tap @ current main)**: `brew reinstall monglong0214/logic-pro-mcp/logic-pro-mcp` → `Errno::ENOENT: No such file or directory - SETUP.md` (exact issue symptom).
- **With this Formula**: keg `3.5.0` installs from the published artifact (sha `d8c3e955…6489`); `share/logic-pro-mcp/` carries all 5 assets; `LogicProMCP --check-permissions` exit 0; `brew test` PASS; MCP `initialize` answers `{"name":"logic-pro-mcp","version":"3.5.0"}` (the reporter's own verification, now on 3.5.0).
- **Gate simulation vs the published v3.5.0 tarball listing**: fixed Formula → 6/6 OK; broken Formula → correctly blocked (5 missing).

## Verification
- `ruby -c Formula/logic-pro-mcp.rb` → Syntax OK; `release.yml` YAML parses.
- `git diff --check` OK; `python3 -m py_compile Scripts/live-e2e-test.py` OK.
- `swift test` (parallel) and `swift test --no-parallel` → **1277 passed** (1276 + new guard test).
- `swift build -c release` → PASS.
- Strict live E2E against Logic Pro 12.2 (`LOGIC_PRO_MCP_STRICT_LIVE=1`) → **313 passed / 0 skipped / 0 failed** (no server-side regression; server code untouched).

## Notes
- The signing observation in #22 is addressed in the issue thread: ADHOC on stable is the documented 2026-06-09 owner decision while Developer ID credentials are absent; `RELEASE-METADATA.json` records the actual mode and the workflow auto-switches to notarized when secrets exist.
