### PR TITLE
chore: add GitHub templates and label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,25 +6,22 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for behavior that is broken, unsafe, unverifiable, or different from the documented contract. Security issues should be reported privately through SECURITY.md, not as public issues.
+        Use this for behavior that is broken, unsafe, unverifiable, or different from the documented contract. Report security issues privately through SECURITY.md.
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight
       options:
-        - label: I searched existing open and closed issues for duplicates.
+        - label: I searched existing issues for duplicates.
           required: true
         - label: This is not a private security report.
           required: true
-        - label: I separated observed evidence from assumptions.
-          required: true
 
   - type: dropdown
-    id: impact
+    id: priority
     attributes:
-      label: Impact
-      description: Pick the highest user-visible impact.
+      label: Priority
       options:
         - P0 - data loss, destructive wrong target, or unsafe write
         - P1 - core workflow blocked or incorrect verified state
@@ -36,21 +33,19 @@ body:
   - type: dropdown
     id: surface
     attributes:
-      label: Affected surface
+      label: Primary area
       options:
+        - logic-ui
         - transport
         - tracks
         - midi
         - mixer
         - plugins
-        - edit
-        - navigation
-        - project
+        - project-export
         - resources
-        - accessibility
-        - setup
-        - release/install
-        - demo/live harness
+        - setup-release
+        - workflow
+        - demo
         - docs
         - unknown
     validations:
@@ -60,7 +55,6 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Include all relevant versions and setup state.
       placeholder: |
         - Logic Pro version:
         - macOS version:
@@ -75,7 +69,6 @@ body:
     id: steps
     attributes:
       label: Reproduction steps
-      description: Provide the smallest exact sequence that reproduces the problem.
       placeholder: |
         1. Start from...
         2. Call...
@@ -87,8 +80,7 @@ body:
     id: actual
     attributes:
       label: Actual behavior
-      description: What happened? Include the exact response envelope when possible.
-      render: json
+      description: What happened? Include the exact response envelope, log, or screenshot when useful.
     validations:
       required: true
 
@@ -96,10 +88,9 @@ body:
     id: expected
     attributes:
       label: Expected behavior
-      description: State the expected user-visible result and expected Honest Contract state.
       placeholder: |
-        Expected State A / State B / State C:
-        Expected readback or failure reason:
+        Expected user-visible result:
+        Expected State A / State B / State C outcome:
     validations:
       required: true
 
@@ -107,7 +98,6 @@ body:
     id: evidence
     attributes:
       label: Evidence
-      description: Paste command output, logs, screenshots, transcript paths, issue links, or live E2E snippets. Redact secrets.
       placeholder: |
         - Command:
         - Output:
@@ -119,12 +109,10 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
-      description: Define what must be true before this can close.
+      label: Done when
       placeholder: |
-        - [ ] Regression test covers the failure.
-        - [ ] The tool/resource returns the correct State A/B/C outcome.
-        - [ ] Live Logic evidence is attached when the behavior depends on Logic UI state.
-        - [ ] Docs are updated if the public contract changed.
+        - [ ] Failure is reproduced or narrowed to an unsupported state.
+        - [ ] Test or live probe covers the fix.
+        - [ ] Public contract/docs are updated if behavior changed.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,130 @@
+name: Bug report
+description: Report a reproducible product bug, regression, or contract violation.
+title: "Bug: "
+labels: ["bug", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for behavior that is broken, unsafe, unverifiable, or different from the documented contract. Security issues should be reported privately through SECURITY.md, not as public issues.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing open and closed issues for duplicates.
+          required: true
+        - label: This is not a private security report.
+          required: true
+        - label: I separated observed evidence from assumptions.
+          required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: Pick the highest user-visible impact.
+      options:
+        - P0 - data loss, destructive wrong target, or unsafe write
+        - P1 - core workflow blocked or incorrect verified state
+        - P2 - degraded workflow with a usable workaround
+        - P3 - low-risk polish or diagnostics issue
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - transport
+        - tracks
+        - midi
+        - mixer
+        - plugins
+        - edit
+        - navigation
+        - project
+        - resources
+        - accessibility
+        - setup
+        - release/install
+        - demo/live harness
+        - docs
+        - unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include all relevant versions and setup state.
+      placeholder: |
+        - Logic Pro version:
+        - macOS version:
+        - Logic Pro MCP version or commit:
+        - Install method: Homebrew / release asset / source build
+        - MCP client:
+        - Required Logic setup completed: MCU / Accessibility / Automation / Scripter
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest exact sequence that reproduces the problem.
+      placeholder: |
+        1. Start from...
+        2. Call...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened? Include the exact response envelope when possible.
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: State the expected user-visible result and expected Honest Contract state.
+      placeholder: |
+        Expected State A / State B / State C:
+        Expected readback or failure reason:
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Paste command output, logs, screenshots, transcript paths, issue links, or live E2E snippets. Redact secrets.
+      placeholder: |
+        - Command:
+        - Output:
+        - Transcript:
+        - Screenshot/video:
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define what must be true before this can close.
+      placeholder: |
+        - [ ] Regression test covers the failure.
+        - [ ] The tool/resource returns the correct State A/B/C outcome.
+        - [ ] Live Logic evidence is attached when the behavior depends on Logic UI state.
+        - [ ] Docs are updated if the public contract changed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Private security report
+    url: https://github.com/MongLong0214/logic-pro-mcp/security/policy
+    about: Report vulnerabilities privately through the security policy.
+  - name: Setup and troubleshooting docs
+    url: https://github.com/MongLong0214/logic-pro-mcp/blob/main/docs/TROUBLESHOOTING.md
+    about: Check known setup, Logic Pro permission, and readback issues before filing.

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,55 @@
+name: Documentation issue
+description: Report missing, stale, confusing, or risky documentation.
+title: "Docs: "
+labels: ["documentation", "area: docs", "status: needs triage"]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I checked the README, docs/API.md, docs/SETUP.md, docs/TROUBLESHOOTING.md, and SECURITY.md where relevant.
+          required: true
+
+  - type: dropdown
+    id: doc_type
+    attributes:
+      label: Documentation type
+      options:
+        - Setup or install
+        - API reference
+        - Troubleshooting
+        - Architecture or maintainer guide
+        - Security or trust model
+        - Release evidence
+        - README or marketing claim
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      placeholder: |
+        What is missing, stale, confusing, or potentially misleading?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change
+      placeholder: |
+        The docs should say...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or source of truth
+      placeholder: |
+        Link to release evidence, source file, issue, PR, or live verification note.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       label: Preflight
       options:
-        - label: I checked the README, docs/API.md, docs/SETUP.md, docs/TROUBLESHOOTING.md, and SECURITY.md where relevant.
+        - label: I checked the relevant README, docs, changelog, or security policy first.
           required: true
 
   - type: dropdown
@@ -37,19 +37,19 @@ body:
       required: true
 
   - type: textarea
-    id: proposed_change
+    id: source
     attributes:
-      label: Proposed change
+      label: Source of truth
       placeholder: |
-        The docs should say...
+        Link to release evidence, source file, issue, PR, or live verification note.
     validations:
       required: true
 
   - type: textarea
-    id: evidence
+    id: proposed_change
     attributes:
-      label: Evidence or source of truth
+      label: Proposed fix
       placeholder: |
-        Link to release evidence, source file, issue, PR, or live verification note.
+        The docs should say...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,110 @@
+name: Feature request
+description: Propose a new user workflow, MCP surface, or product capability.
+title: "Feature: "
+labels: ["enhancement", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new capabilities. If the current behavior is broken or unverifiable, file a bug instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing open and closed issues for related work.
+          required: true
+        - label: I described the user workflow before proposing implementation details.
+          required: true
+
+  - type: dropdown
+    id: value
+    attributes:
+      label: Product value
+      options:
+        - P0 - enables a critical adoption or safety path
+        - P1 - unlocks a high-value Logic Pro workflow
+        - P2 - improves an existing workflow
+        - P3 - nice-to-have polish or convenience
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - setup
+        - workflow
+        - transport
+        - tracks
+        - midi
+        - mixer
+        - plugins
+        - edit/navigation
+        - project/export
+        - resources
+        - library
+        - docs
+        - release/install
+        - demo/live harness
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user job is hard, impossible, risky, or slow today?
+      placeholder: |
+        As a Logic Pro MCP user, I need...
+        Today this fails because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the desired behavior, public API shape, or workflow outcome.
+      placeholder: |
+        The server should...
+        The client should be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: Contract and safety notes
+      description: Explain target validation, confirmation, readback, provenance, or fail-closed requirements.
+      placeholder: |
+        - Mutating operation?
+        - Required explicit target?
+        - Readback source:
+        - Failure/uncertain state:
+        - Destructive confirmation:
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Public behavior is documented.
+        - [ ] Unit/integration coverage exists for the new contract.
+        - [ ] Live Logic evidence is attached if the feature writes to Logic.
+        - [ ] Existing clients receive a compatible response shape or a documented breaking change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional but useful for avoiding hidden scope.
+      placeholder: |
+        - Alternative:
+        - Why not:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,22 +6,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for new capabilities. If the current behavior is broken or unverifiable, file a bug instead.
+        Use this for new capabilities. If current behavior is broken or unverifiable, file a bug.
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight
       options:
-        - label: I searched existing open and closed issues for related work.
-          required: true
-        - label: I described the user workflow before proposing implementation details.
+        - label: I searched existing issues for related work.
           required: true
 
   - type: dropdown
-    id: value
+    id: priority
     attributes:
-      label: Product value
+      label: Priority
       options:
         - P0 - enables a critical adoption or safety path
         - P1 - unlocks a high-value Logic Pro workflow
@@ -35,20 +33,18 @@ body:
     attributes:
       label: Primary area
       options:
-        - setup
-        - workflow
+        - logic-ui
         - transport
         - tracks
         - midi
         - mixer
         - plugins
-        - edit/navigation
-        - project/export
+        - project-export
         - resources
-        - library
+        - setup-release
+        - workflow
+        - demo
         - docs
-        - release/install
-        - demo/live harness
     validations:
       required: true
 
@@ -56,7 +52,6 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What user job is hard, impossible, risky, or slow today?
       placeholder: |
         As a Logic Pro MCP user, I need...
         Today this fails because...
@@ -66,8 +61,7 @@ body:
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed behavior
-      description: Describe the desired behavior, public API shape, or workflow outcome.
+      label: Proposed outcome
       placeholder: |
         The server should...
         The client should be able to...
@@ -77,8 +71,7 @@ body:
   - type: textarea
     id: contract
     attributes:
-      label: Contract and safety notes
-      description: Explain target validation, confirmation, readback, provenance, or fail-closed requirements.
+      label: Safety and contract notes
       placeholder: |
         - Mutating operation?
         - Required explicit target?
@@ -91,20 +84,10 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
+      label: Done when
       placeholder: |
         - [ ] Public behavior is documented.
-        - [ ] Unit/integration coverage exists for the new contract.
+        - [ ] Tests cover the new contract.
         - [ ] Live Logic evidence is attached if the feature writes to Logic.
-        - [ ] Existing clients receive a compatible response shape or a documented breaking change.
     validations:
       required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Optional but useful for avoiding hidden scope.
-      placeholder: |
-        - Alternative:
-        - Why not:

--- a/.github/ISSUE_TEMPLATE/live_qa_failure.yml
+++ b/.github/ISSUE_TEMPLATE/live_qa_failure.yml
@@ -1,24 +1,34 @@
 name: Live QA failure
 description: Capture a failure found during real Logic Pro testing, demo production, or live E2E.
 title: "Live QA: "
-labels: ["bug", "area: demo", "evidence: live required", "status: needs triage"]
+labels: ["bug", "area: demo", "status: needs triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this when a real Logic Pro session, demo transcript, or strict live E2E run exposes an uncertain or failed behavior. Keep public claims tied to verified evidence.
+        Use this when a real Logic Pro session, demo transcript, or live E2E run exposes uncertain or failed behavior.
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight
       options:
-        - label: I checked whether this is already covered by an existing canonical issue.
+        - label: I checked whether this is already covered by an existing issue.
           required: true
-        - label: I am not reporting a synthetic renderer artifact as a product bug unless it affected public evidence.
+        - label: I separated product behavior from demo/rendering artifacts.
           required: true
-        - label: I included enough evidence to distinguish State A, State B, and State C.
-          required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - unsafe write, data loss, or destructive wrong target
+        - P1 - public claim, core workflow, or verified-state blocker
+        - P2 - important live gap with workaround
+        - P3 - low-risk demo or diagnostic gap
+    validations:
+      required: true
 
   - type: textarea
     id: live_context
@@ -37,7 +47,7 @@ body:
   - type: dropdown
     id: state
     attributes:
-      label: Observed contract state
+      label: Observed outcome
       options:
         - State B - uncertain success
         - State C - hard failure
@@ -51,16 +61,14 @@ body:
     id: observed
     attributes:
       label: Observed evidence
-      description: Include exact response snippets, resource readback, or transcript entries.
-      render: json
+      description: Include exact response snippets, resource readback, transcript entries, or artifact paths.
     validations:
       required: true
 
   - type: textarea
     id: user_claim_risk
     attributes:
-      label: User claim risk
-      description: What claim would be unsafe or misleading until this is fixed?
+      label: Claim boundary
       placeholder: |
         Until this is fixed, do not claim...
     validations:
@@ -69,11 +77,10 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
+      label: Done when
       placeholder: |
-        - [ ] The live failure is reproduced or narrowed to a documented unsupported state.
-        - [ ] The server returns State A only with readback evidence.
-        - [ ] Demo/public docs avoid claiming unverified behavior.
-        - [ ] Strict live E2E or a targeted live probe covers the fix when feasible.
+        - [ ] Failure is reproduced or documented as unsupported.
+        - [ ] State A is returned only with readback evidence.
+        - [ ] Public demo/docs avoid unverified claims.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/live_qa_failure.yml
+++ b/.github/ISSUE_TEMPLATE/live_qa_failure.yml
@@ -1,0 +1,79 @@
+name: Live QA failure
+description: Capture a failure found during real Logic Pro testing, demo production, or live E2E.
+title: "Live QA: "
+labels: ["bug", "area: demo", "evidence: live required", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when a real Logic Pro session, demo transcript, or strict live E2E run exposes an uncertain or failed behavior. Keep public claims tied to verified evidence.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I checked whether this is already covered by an existing canonical issue.
+          required: true
+        - label: I am not reporting a synthetic renderer artifact as a product bug unless it affected public evidence.
+          required: true
+        - label: I included enough evidence to distinguish State A, State B, and State C.
+          required: true
+
+  - type: textarea
+    id: live_context
+    attributes:
+      label: Live context
+      placeholder: |
+        - Date/time:
+        - Logic Pro version:
+        - Project/session state:
+        - Capture or E2E script:
+        - Transcript/provenance path:
+        - Related media artifact:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: state
+    attributes:
+      label: Observed contract state
+      options:
+        - State B - uncertain success
+        - State C - hard failure
+        - Mismatch between response and live UI/resource
+        - Public evidence boundary problem
+        - Unknown, needs triage
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed evidence
+      description: Include exact response snippets, resource readback, or transcript entries.
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_claim_risk
+    attributes:
+      label: User claim risk
+      description: What claim would be unsafe or misleading until this is fixed?
+      placeholder: |
+        Until this is fixed, do not claim...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] The live failure is reproduced or narrowed to a documented unsupported state.
+        - [ ] The server returns State A only with readback evidence.
+        - [ ] Demo/public docs avoid claiming unverified behavior.
+        - [ ] Strict live E2E or a targeted live probe covers the fix when feasible.
+    validations:
+      required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,135 @@
+# Canonical GitHub label taxonomy for logic-pro-mcp.
+# Keep default GitHub labels for compatibility, then add structured priority,
+# status, area, and evidence labels for triage and release planning.
+
+- name: bug
+  color: d73a4a
+  description: Something is broken, unsafe, or contradicts the documented contract.
+- name: enhancement
+  color: a2eeef
+  description: New feature, workflow, or product improvement.
+- name: documentation
+  color: 0075ca
+  description: Documentation-only work.
+- name: question
+  color: d876e3
+  description: More information is required before triage can proceed.
+- name: duplicate
+  color: cfd3d7
+  description: Already tracked by another issue or pull request.
+- name: invalid
+  color: e4e669
+  description: Not actionable as filed.
+- name: wontfix
+  color: ffffff
+  description: Intentionally not planned.
+- name: help wanted
+  color: 008672
+  description: Maintainer-approved work where external help is useful.
+- name: good first issue
+  color: 7057ff
+  description: Small, well-scoped issue suitable for new contributors.
+
+- name: epic
+  color: 5319e7
+  description: Cross-cutting parent issue that groups multiple deliverables.
+
+- name: "priority: p0"
+  color: b60205
+  description: Critical safety, destructive wrong-target, data loss, or release-blocking issue.
+- name: "priority: p1"
+  color: d93f0b
+  description: Core workflow blocker or high-risk correctness gap.
+- name: "priority: p2"
+  color: fbca04
+  description: Important improvement with a workaround or limited blast radius.
+- name: "priority: p3"
+  color: c5def5
+  description: Low-risk polish, cleanup, or nice-to-have improvement.
+
+- name: "status: needs triage"
+  color: ededed
+  description: Newly filed and not yet accepted into a work bundle.
+- name: "status: ready"
+  color: 0e8a16
+  description: Scoped enough for implementation.
+- name: "status: in progress"
+  color: 0052cc
+  description: Actively being worked.
+- name: "status: blocked"
+  color: b60205
+  description: Cannot move until a named dependency or external condition changes.
+- name: "status: needs repro"
+  color: fbca04
+  description: Needs a smaller reproduction or live confirmation before implementation.
+- name: "status: needs review"
+  color: 1d76db
+  description: Implementation exists and needs focused maintainer review.
+
+- name: "area: accessibility"
+  color: bfd4f2
+  description: macOS Accessibility tree lookup, AX actions, UI element matching, or localization.
+- name: "area: audio"
+  color: c2e0c6
+  description: Audio output, bounce analysis, media artifacts, or sound verification.
+- name: "area: demo"
+  color: fef2c0
+  description: Public demos, live capture, transcripts, or evidence rendering.
+- name: "area: docs"
+  color: 0075ca
+  description: README, guides, API docs, troubleshooting, or maintainer docs.
+- name: "area: edit"
+  color: fbca04
+  description: Edit commands, selection, quantization, split, undo, or menu-backed actions.
+- name: "area: export"
+  color: 0366d6
+  description: Bounce, stem export, file artifacts, and export verification.
+- name: "area: library"
+  color: 5319e7
+  description: Logic library, stock instruments, patches, or cataloging.
+- name: "area: midi"
+  color: c5def5
+  description: CoreMIDI, MIDI files, note generation, import, sequencing, or ports.
+- name: "area: mixer"
+  color: d4c5f9
+  description: Mixer strips, volume, pan, sends, MCU feedback, or readback.
+- name: "area: navigation"
+  color: bfdadc
+  description: Marker, zoom, view, playhead, or arrangement navigation behavior.
+- name: "area: plugins"
+  color: 5319e7
+  description: Plugin inventory, insert slots, parameters, Scripter, or verified apply-back.
+- name: "area: project"
+  color: e4e669
+  description: Project lifecycle, session state, file identity, save/open/close, or cleanup.
+- name: "area: release"
+  color: 0e8a16
+  description: Release assets, Homebrew formula, install scripts, signing, or CI packaging.
+- name: "area: resources"
+  color: 006b75
+  description: MCP resources, templates, cache envelopes, freshness, or provenance.
+- name: "area: setup"
+  color: f9d0c4
+  description: User setup, permissions, Logic configuration, doctor checks, or adoption flow.
+- name: "area: tracks"
+  color: c2e0c6
+  description: Track creation, selection, naming, arming, types, or track header readback.
+- name: "area: transport"
+  color: fef2c0
+  description: Play, stop, record, tempo, cycle, locator, metronome, or transport resources.
+- name: "area: workflow"
+  color: bfdadc
+  description: Higher-level agent workflows, planning surfaces, or workflow skills.
+
+- name: "evidence: live required"
+  color: e99695
+  description: Closure requires real Logic Pro evidence, not only unit tests.
+- name: "evidence: needs readback"
+  color: fbca04
+  description: The main gap is missing, stale, or mismatched readback.
+- name: "evidence: state b"
+  color: d93f0b
+  description: Currently returns or depends on uncertain-success behavior.
+- name: "evidence: verified"
+  color: 0e8a16
+  description: The issue has attached verification evidence for the current claim.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,6 +1,10 @@
-# Canonical GitHub label taxonomy for logic-pro-mcp.
-# Keep default GitHub labels for compatibility, then add structured priority,
-# status, area, and evidence labels for triage and release planning.
+# GitHub label policy for logic-pro-mcp.
+#
+# Keep labels practical:
+# - Every accepted open issue should have exactly one type, priority, status,
+#   and primary area label.
+# - Use issue body, PR notes, and linked evidence for State A/B/C details.
+# - Avoid evidence/status micro-labels unless they change day-to-day execution.
 
 - name: bug
   color: d73a4a
@@ -59,58 +63,34 @@
 - name: "status: blocked"
   color: b60205
   description: Cannot move until a named dependency or external condition changes.
-- name: "status: needs repro"
-  color: fbca04
-  description: Needs a smaller reproduction or live confirmation before implementation.
-- name: "status: needs review"
-  color: 1d76db
-  description: Implementation exists and needs focused maintainer review.
 
-- name: "area: accessibility"
+- name: "area: logic-ui"
   color: bfd4f2
-  description: macOS Accessibility tree lookup, AX actions, UI element matching, or localization.
-- name: "area: audio"
-  color: c2e0c6
-  description: Audio output, bounce analysis, media artifacts, or sound verification.
-- name: "area: demo"
-  color: fef2c0
-  description: Public demos, live capture, transcripts, or evidence rendering.
+  description: Accessibility, UI element matching, localization, edit commands, navigation, or view state.
 - name: "area: docs"
   color: 0075ca
   description: README, guides, API docs, troubleshooting, or maintainer docs.
-- name: "area: edit"
-  color: fbca04
-  description: Edit commands, selection, quantization, split, undo, or menu-backed actions.
-- name: "area: export"
+- name: "area: demo"
+  color: fef2c0
+  description: Public demos, live capture, transcripts, media artifacts, or evidence rendering.
+- name: "area: project-export"
   color: 0366d6
-  description: Bounce, stem export, file artifacts, and export verification.
-- name: "area: library"
-  color: 5319e7
-  description: Logic library, stock instruments, patches, or cataloging.
+  description: Project lifecycle, save/open/close, bounce, stems, files, or cleanup.
 - name: "area: midi"
   color: c5def5
   description: CoreMIDI, MIDI files, note generation, import, sequencing, or ports.
 - name: "area: mixer"
   color: d4c5f9
   description: Mixer strips, volume, pan, sends, MCU feedback, or readback.
-- name: "area: navigation"
-  color: bfdadc
-  description: Marker, zoom, view, playhead, or arrangement navigation behavior.
 - name: "area: plugins"
   color: 5319e7
-  description: Plugin inventory, insert slots, parameters, Scripter, or verified apply-back.
-- name: "area: project"
-  color: e4e669
-  description: Project lifecycle, session state, file identity, save/open/close, or cleanup.
-- name: "area: release"
-  color: 0e8a16
-  description: Release assets, Homebrew formula, install scripts, signing, or CI packaging.
+  description: Plugin, instrument library, patch, insert slot, parameter, Scripter, or verified apply-back.
 - name: "area: resources"
   color: 006b75
   description: MCP resources, templates, cache envelopes, freshness, or provenance.
-- name: "area: setup"
+- name: "area: setup-release"
   color: f9d0c4
-  description: User setup, permissions, Logic configuration, doctor checks, or adoption flow.
+  description: Setup, permissions, Homebrew, install scripts, release assets, signing, or CI packaging.
 - name: "area: tracks"
   color: c2e0c6
   description: Track creation, selection, naming, arming, types, or track header readback.
@@ -120,16 +100,3 @@
 - name: "area: workflow"
   color: bfdadc
   description: Higher-level agent workflows, planning surfaces, or workflow skills.
-
-- name: "evidence: live required"
-  color: e99695
-  description: Closure requires real Logic Pro evidence, not only unit tests.
-- name: "evidence: needs readback"
-  color: fbca04
-  description: The main gap is missing, stale, or mismatched readback.
-- name: "evidence: state b"
-  color: d93f0b
-  description: Currently returns or depends on uncertain-success behavior.
-- name: "evidence: verified"
-  color: 0e8a16
-  description: The issue has attached verification evidence for the current claim.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -3,6 +3,7 @@
 # Keep labels practical:
 # - Every accepted open issue should have exactly one type, priority, status,
 #   and primary area label.
+# - Status labels describe triage/execution state, not release readiness.
 # - Use issue body, PR notes, and linked evidence for State A/B/C details.
 # - Avoid evidence/status micro-labels unless they change day-to-day execution.
 
@@ -56,7 +57,7 @@
   description: Newly filed and not yet accepted into a work bundle.
 - name: "status: ready"
   color: 0e8a16
-  description: Scoped enough for implementation.
+  description: Triaged and scoped for a focused implementation PR; not done or release-ready.
 - name: "status: in progress"
   color: 0052cc
   description: Actively being worked.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,52 +1,37 @@
-# Summary
+## Summary
 
-## What changed
 - 
 
 ## Linked issue
-Closes #
 
-## Why this is safe
-- Target validation:
-- Readback/provenance:
-- Destructive or irreversible behavior:
-- Compatibility impact:
+- Closes #
 
-# Verification
+## Risk
 
-## Deterministic checks
+- Priority: P0 / P1 / P2 / P3
+- Area:
+- User-visible impact:
+- Contract impact: none / docs only / State A-B-C changed
+
+## Verification
+
 - [ ] `swift build`
-- [ ] `swift test`
+- [ ] `swift test --no-parallel`
 - [ ] `swift build -c release`
-- [ ] Targeted test command:
+- [ ] Targeted test:
+- [ ] Live Logic evidence: not required / attached below
 
-## Logic Pro live evidence
-- [ ] Not required; change is docs/tests/tooling-only.
-- [ ] Required and attached below.
-
-Live evidence:
+Evidence:
 ```text
 
 ```
 
-## Honest Contract impact
-- [ ] No mutating operation contract changed.
-- [ ] State A/B/C behavior changed and tests/docs were updated.
-- [ ] New or changed failure reasons are documented.
+## Release readiness
 
-Details:
-```text
+- [ ] Public claims, API docs, troubleshooting, and changelog are updated if behavior changed.
+- [ ] Mutating or destructive behavior has explicit target validation, confirmation, and readback.
+- [ ] Known limitations are documented in the PR or docs.
 
-```
+## Reviewer focus
 
-# Release and docs
-- [ ] README updated if public claims changed.
-- [ ] `docs/API.md` updated if MCP surface changed.
-- [ ] `docs/TROUBLESHOOTING.md` updated for new user-facing failure modes.
-- [ ] `CHANGELOG.md` updated under `[Unreleased]` when behavior changed.
-- [ ] Release/install metadata unaffected, or all versioned release surfaces were updated together.
-
-# Reviewer focus
-- Risk level: P0 / P1 / P2 / P3
-- Areas to inspect first:
-- Known limitations:
+-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+# Summary
+
+## What changed
+- 
+
+## Linked issue
+Closes #
+
+## Why this is safe
+- Target validation:
+- Readback/provenance:
+- Destructive or irreversible behavior:
+- Compatibility impact:
+
+# Verification
+
+## Deterministic checks
+- [ ] `swift build`
+- [ ] `swift test`
+- [ ] `swift build -c release`
+- [ ] Targeted test command:
+
+## Logic Pro live evidence
+- [ ] Not required; change is docs/tests/tooling-only.
+- [ ] Required and attached below.
+
+Live evidence:
+```text
+
+```
+
+## Honest Contract impact
+- [ ] No mutating operation contract changed.
+- [ ] State A/B/C behavior changed and tests/docs were updated.
+- [ ] New or changed failure reasons are documented.
+
+Details:
+```text
+
+```
+
+# Release and docs
+- [ ] README updated if public claims changed.
+- [ ] `docs/API.md` updated if MCP surface changed.
+- [ ] `docs/TROUBLESHOOTING.md` updated for new user-facing failure modes.
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` when behavior changed.
+- [ ] Release/install metadata unaffected, or all versioned release surfaces were updated together.
+
+# Reviewer focus
+- Risk level: P0 / P1 / P2 / P3
+- Areas to inspect first:
+- Known limitations:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square" /></a>
   <img src="https://img.shields.io/badge/tests-1396_passing-brightgreen.svg?style=flat-square" />
   <img src="https://img.shields.io/badge/stable-v3.6.0-blue.svg?style=flat-square" />
+  <a href="https://github.com/MongLong0214/logic-pro-mcp/issues"><img src="https://img.shields.io/github/issues/MongLong0214/logic-pro-mcp?style=flat-square&label=issues" /></a>
+  <a href="https://github.com/MongLong0214/logic-pro-mcp/pulls"><img src="https://img.shields.io/github/issues-pr/MongLong0214/logic-pro-mcp?style=flat-square&label=PRs" /></a>
   <a href="https://github.com/MongLong0214/logic-pro-mcp/stargazers"><img src="https://img.shields.io/github/stars/MongLong0214/logic-pro-mcp?style=flat-square&label=stars" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@
   <a href="https://swift.org"><img src="https://img.shields.io/badge/Swift-6.0+-F05138.svg?style=flat-square" /></a>
   <a href="https://developer.apple.com/macos/"><img src="https://img.shields.io/badge/macOS-14+-000000.svg?style=flat-square&logo=apple" /></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-0.10-blue.svg?style=flat-square" /></a>
+  <a href="https://github.com/MongLong0214/logic-pro-mcp/actions/workflows/ci.yml"><img src="https://github.com/MongLong0214/logic-pro-mcp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square" /></a>
   <img src="https://img.shields.io/badge/tests-1396_passing-brightgreen.svg?style=flat-square" />
   <img src="https://img.shields.io/badge/stable-v3.6.0-blue.svg?style=flat-square" />
-  <a href="https://github.com/MongLong0214/logic-pro-mcp/issues"><img src="https://img.shields.io/github/issues/MongLong0214/logic-pro-mcp?style=flat-square&label=issues" /></a>
-  <a href="https://github.com/MongLong0214/logic-pro-mcp/pulls"><img src="https://img.shields.io/github/issues-pr/MongLong0214/logic-pro-mcp?style=flat-square&label=PRs" /></a>
-  <a href="https://github.com/MongLong0214/logic-pro-mcp/stargazers"><img src="https://img.shields.io/github/stars/MongLong0214/logic-pro-mcp?style=flat-square&label=stars" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Add practical GitHub issue forms for bug reports, feature requests, live QA failures, and documentation reports.
- Add a focused PR template for linked issues, risk, contract impact, verification, and release readiness.
- Add a versioned label taxonomy: type + priority + status + primary area only.
- Clarify that status labels describe triage/execution state; `status: ready` means scoped for implementation, not done or release-ready.
- Keep README badges production-oriented by adding CI and removing the dynamic star count.

## Verification
- ruby -ryaml parsed all issue form YAML files and `.github/labels.yml`.
- `git diff --check -- .github README.md` passed.
- Remote label taxonomy was synced with `gh label create/edit`.
- All 25 currently open issues have type, priority, status, and primary area labels.
- PR #61 is open, mergeable, and CI is passing.

## Safety
- No main/default branch push or merge performed.
- No source code behavior changed.