### PR TITLE
docs: improve contributor onboarding

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,10 +28,6 @@
 - name: wontfix
   color: ffffff
   description: Intentionally not planned.
-- name: help wanted
-  color: 008672
-  description: Maintainer-approved work where external help is useful.
-
 - name: epic
   color: 5319e7
   description: Cross-cutting parent issue that groups multiple deliverables.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -31,9 +31,6 @@
 - name: help wanted
   color: 008672
   description: Maintainer-approved work where external help is useful.
-- name: good first issue
-  color: 7057ff
-  description: Small, well-scoped issue suitable for new contributors.
 
 - name: epic
   color: 5319e7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ You do not need a full Logic Pro setup for many contributions. Docs, examples, i
 
 Start here:
 
-- Use [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) for maintainer-approved work where outside help is useful.
+- Review the [open issues](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen) and choose a narrow, already-scoped change.
 - Comment on the issue before starting if the issue has ambiguity about scope or acceptance criteria.
 - Keep each PR narrow. One issue, one behavioral change, one verification story.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,50 @@
-# Contributing
+# Contributing to Logic Pro MCP
 
 Thanks for your interest. Logic Pro MCP is a Swift 6 actor-based macOS binary that bridges Logic Pro to the Model Context Protocol.
+
+You do not need a full Logic Pro setup for most first contributions. Docs, examples, issue reproduction notes, parser tests, validation tests, and CLI message improvements can usually be completed with Swift and the normal unit test suite.
+
+Start here:
+
+- Browse [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) for small, scoped work.
+- Use [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) for maintainer-approved work where outside help is useful.
+- Comment on the issue before starting if the issue has ambiguity about scope or acceptance criteria.
+- Keep the first PR narrow. One issue, one behavioral change, one verification story.
 
 ## Prerequisites
 
 - macOS 14+
 - Swift 6.0+ (Xcode 16 or Command Line Tools)
 - Logic Pro 12.0.1+ (only for live E2E testing — unit tests run without it)
+
+## Good First PRs
+
+Good first PRs are intentionally low-risk and reviewable:
+
+- Documentation examples in `README.md`, `docs/SETUP.md`, `docs/API.md`, or `docs/TROUBLESHOOTING.md`
+- New unit tests around validation, JSON envelopes, parser edge cases, permission summaries, or resource schemas
+- Clearer CLI or error output that does not change the public contract
+- Reproduction notes for an existing issue, especially with exact Logic Pro/macOS versions
+- Small refactors that remove duplication without changing routing, safety, or fallback behavior
+
+Avoid these for a first PR unless the issue explicitly asks for them:
+
+- New automation fallbacks
+- Logic-facing write behavior
+- Release, signing, Homebrew, or installer trust changes
+- Broad rewrites across multiple channel/router surfaces
+- Claims that something is "verified" without independent readback evidence
+
+## Do I Need Logic Pro?
+
+| Work type | Logic Pro required? | Expected verification |
+|-----------|---------------------|-----------------------|
+| Docs-only changes | No | `git diff --check` |
+| Unit tests, parser tests, schema tests | No | `swift test --filter <testName>` and relevant full-suite evidence when practical |
+| CLI text or non-Logic validation | No | Focused tests plus `swift build` |
+| MCP resource contract changes | Usually no | Focused resource tests and JSON envelope assertions |
+| Channel routing or write/readback changes | Yes for final evidence | Unit tests plus live Logic Pro evidence |
+| Release, installer, signing, Homebrew | No Logic needed, but maintainer review required | Release workflow or documented dry-run evidence |
 
 ## Development Loop
 
@@ -15,7 +53,7 @@ git clone https://github.com/MongLong0214/logic-pro-mcp.git
 cd logic-pro-mcp
 
 swift build              # debug
-swift test               # 1388 unit + integration tests on current v3.6.0 source
+swift test               # 1396 unit + integration tests on current v3.6.0 source
 swift build -c release   # release binary at .build/release/LogicProMCP
 ```
 
@@ -25,6 +63,8 @@ For a faster local iteration:
 # After making changes to source + tests:
 swift test --filter <testName>
 ```
+
+Use `swift test --no-parallel` before asking for review when the change touches shared routing, state, resource envelopes, or safety-sensitive behavior.
 
 ## Live E2E Testing
 
@@ -41,6 +81,8 @@ This exercises every tool against a real Logic Pro instance. Requires:
 - MCU Control Surface registered (see [docs/SETUP.md](docs/SETUP.md))
 - Accessibility + Automation permissions granted
 
+Live E2E is not required for docs-only PRs or unit-test-only PRs. If an issue requires live evidence, include the exact command, Logic Pro version, macOS version, and the observed State A/B/C result in the PR description.
+
 ## Project Layout
 
 ```
@@ -54,7 +96,7 @@ Sources/LogicProMCP/
 ├── Server/            LogicProServer + ServerConfig
 └── Utilities/         DestructivePolicy, AppleScriptSafety, Logger, PermissionChecker
 
-Tests/LogicProMCPTests/  1388 tests across the Swift test target on the v3.6.0 source
+Tests/LogicProMCPTests/  1396 tests across the Swift test target on the v3.6.0 source
 Scripts/                 install / uninstall / live E2E / Scripter JS
 docs/                    SETUP, API, ARCHITECTURE, TROUBLESHOOTING, MAINTAINERS, live verification notes
 artifacts/               generated local artifacts; only final v4 MIDI-only package is allowed in git
@@ -76,10 +118,42 @@ When adding a new operation, assign it to the channel with the best protocol sup
 
 Register the operation in `ChannelRouter.v2RoutingTable` as an ordered list; the router tries each channel in turn.
 
+When adding or changing routes, do not add quiet fallback chains. If a fallback is necessary, make the condition, reason, and verification boundary visible in the response or logs.
+
+## Branch and PR Workflow
+
+1. Create a branch from current `main`.
+2. Link exactly one issue unless the issue explicitly groups related work.
+3. Add or update tests before changing production behavior.
+4. Keep generated media, local Logic projects, and temporary artifacts out of the PR.
+5. Open a PR with the template filled in, including exact commands run.
+6. Do not push directly to `main`.
+
+Use this branch naming style:
+
+```bash
+git switch -c docs/setup-cursor-example
+git switch -c test/note-sequence-parser-invalid-channel
+git switch -c fix/permission-summary-automation-copy
+```
+
+## Verification Matrix
+
+| Change | Minimum local evidence |
+|--------|------------------------|
+| Markdown/docs only | `git diff --check` |
+| Python scripts | `python3 -m py_compile <script>` |
+| Swift parser/validation tests | `swift test --filter <testName>` |
+| Public MCP envelope/resource changes | Focused tests plus JSON assertions |
+| Shared routing/state changes | `swift test --no-parallel` |
+| Logic-facing write/readback changes | Focused tests, full suite, and live Logic Pro evidence |
+
+If you cannot run a required gate, say so in the PR and explain why. Do not mark unverified live behavior as verified.
+
 ## Pull Request Checklist
 
 - [ ] `swift build` clean
-- [ ] `swift test` green (all 1388 tests on current v3.6.0 source)
+- [ ] `swift test` green (all 1396 tests on current v3.6.0 source)
 - [ ] New behavior covered by at least one unit test
 - [ ] Changed production code keeps the global coverage floor green (`region >=70%`, `line >=78%`); high-risk Logic-facing changes target about 90% line coverage on the touched surface or document the live/manual evidence that substitutes for direct measurement
 - [ ] Public API change → `CHANGELOG.md` entry under `[Unreleased]`; new MCP tools also require README, `docs/API.md`, `docs/ARCHITECTURE.md`, and release-note updates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,13 @@
 
 Thanks for your interest. Logic Pro MCP is a Swift 6 actor-based macOS binary that bridges Logic Pro to the Model Context Protocol.
 
-You do not need a full Logic Pro setup for most first contributions. Docs, examples, issue reproduction notes, parser tests, validation tests, and CLI message improvements can usually be completed with Swift and the normal unit test suite.
+You do not need a full Logic Pro setup for many contributions. Docs, examples, issue reproduction notes, parser tests, validation tests, and CLI message improvements can usually be completed with Swift and the normal unit test suite.
 
 Start here:
 
-- Browse [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) for small, scoped work.
 - Use [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) for maintainer-approved work where outside help is useful.
 - Comment on the issue before starting if the issue has ambiguity about scope or acceptance criteria.
-- Keep the first PR narrow. One issue, one behavioral change, one verification story.
+- Keep each PR narrow. One issue, one behavioral change, one verification story.
 
 ## Prerequisites
 
@@ -17,9 +16,9 @@ Start here:
 - Swift 6.0+ (Xcode 16 or Command Line Tools)
 - Logic Pro 12.0.1+ (only for live E2E testing — unit tests run without it)
 
-## Good First PRs
+## Low-Risk PRs
 
-Good first PRs are intentionally low-risk and reviewable:
+Low-risk PRs are intentionally narrow and reviewable:
 
 - Documentation examples in `README.md`, `docs/SETUP.md`, `docs/API.md`, or `docs/TROUBLESHOOTING.md`
 - New unit tests around validation, JSON envelopes, parser edge cases, permission summaries, or resource schemas
@@ -27,7 +26,7 @@ Good first PRs are intentionally low-risk and reviewable:
 - Reproduction notes for an existing issue, especially with exact Logic Pro/macOS versions
 - Small refactors that remove duplication without changing routing, safety, or fallback behavior
 
-Avoid these for a first PR unless the issue explicitly asks for them:
+Avoid these unless the issue explicitly asks for them:
 
 - New automation fallbacks
 - Logic-facing write behavior

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 
 If this project helps you make music with Claude, Cursor, or any MCP client, star the repo. It helps the project reach more Logic Pro users and maintainers.
 
+Want to contribute? Start with [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22), and the [Contributing Guide](CONTRIBUTING.md). Most first PRs do not require Logic Pro; docs, examples, validation tests, and CLI-message improvements are welcome.
+
 ## Why It Exists
 
 Most Logic Pro automation attempts fall into one of three traps:
@@ -216,7 +218,7 @@ See [Architecture](docs/ARCHITECTURE.md) for channel priorities, state flow, cac
 | [Live Verify v3.5.0](docs/live-verify-v3.5.0.md) | Maintainers, QA | Previous stable deterministic, coverage, release-build, packaging, and fresh Logic Pro 12.2 strict live E2E evidence |
 | [Security Policy](SECURITY.md) | Security reviewers | Threat model, reporting, hardening |
 | [Changelog](CHANGELOG.md) | Everyone | Per-release changes |
-| [Contributing](CONTRIBUTING.md) | Contributors | Dev setup, PR workflow |
+| [Contributing](CONTRIBUTING.md) | Contributors | Dev setup, first issue workflow, PR verification |
 
 ## Status
 
@@ -290,6 +292,6 @@ MIT. See [LICENSE](LICENSE).
 
 ## Contributing
 
-Bug reports, PRs, and feature discussions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev workflow.
+Bug reports, PRs, and feature discussions are welcome. The best starting points are [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22), and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Security vulnerabilities: please do **not** open a public issue. See [SECURITY.md](SECURITY.md) for the private disclosure process.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 
 If this project helps you make music with Claude, Cursor, or any MCP client, star the repo. It helps the project reach more Logic Pro users and maintainers.
 
-Want to contribute? Start with [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22), and the [Contributing Guide](CONTRIBUTING.md). Most first PRs do not require Logic Pro; docs, examples, validation tests, and CLI-message improvements are welcome.
+Want to contribute? Start with [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) and the [Contributing Guide](CONTRIBUTING.md). Many docs, examples, validation tests, and CLI-message improvements do not require Logic Pro.
 
 ## Why It Exists
 
@@ -292,6 +292,6 @@ MIT. See [LICENSE](LICENSE).
 
 ## Contributing
 
-Bug reports, PRs, and feature discussions are welcome. The best starting points are [`good first issue`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22), and [CONTRIBUTING.md](CONTRIBUTING.md).
+Bug reports, PRs, and feature discussions are welcome. The best starting points are [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Security vulnerabilities: please do **not** open a public issue. See [SECURITY.md](SECURITY.md) for the private disclosure process.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 
 If this project helps you make music with Claude, Cursor, or any MCP client, star the repo. It helps the project reach more Logic Pro users and maintainers.
 
-Want to contribute? Start with [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) and the [Contributing Guide](CONTRIBUTING.md). Many docs, examples, validation tests, and CLI-message improvements do not require Logic Pro.
+Want to contribute? Start with the [Contributing Guide](CONTRIBUTING.md) and the [open issues](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen). Many docs, examples, validation tests, and CLI-message improvements do not require Logic Pro.
 
 ## Why It Exists
 
@@ -218,7 +218,7 @@ See [Architecture](docs/ARCHITECTURE.md) for channel priorities, state flow, cac
 | [Live Verify v3.5.0](docs/live-verify-v3.5.0.md) | Maintainers, QA | Previous stable deterministic, coverage, release-build, packaging, and fresh Logic Pro 12.2 strict live E2E evidence |
 | [Security Policy](SECURITY.md) | Security reviewers | Threat model, reporting, hardening |
 | [Changelog](CHANGELOG.md) | Everyone | Per-release changes |
-| [Contributing](CONTRIBUTING.md) | Contributors | Dev setup, first issue workflow, PR verification |
+| [Contributing](CONTRIBUTING.md) | Contributors | Dev setup, scoped PR workflow, PR verification |
 
 ## Status
 
@@ -292,6 +292,6 @@ MIT. See [LICENSE](LICENSE).
 
 ## Contributing
 
-Bug reports, PRs, and feature discussions are welcome. The best starting points are [`help wanted`](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) and [CONTRIBUTING.md](CONTRIBUTING.md).
+Bug reports, PRs, and feature discussions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [open issues](https://github.com/MongLong0214/logic-pro-mcp/issues?q=is%3Aissue%20is%3Aopen) for the dev workflow.
 
 Security vulnerabilities: please do **not** open a public issue. See [SECURITY.md](SECURITY.md) for the private disclosure process.


### PR DESCRIPTION
## Summary
- Make CONTRIBUTING.md easier for external contributors without a separate entry-level label path.
- Clarify which contribution types do not require Logic Pro.
- Use open issues plus CONTRIBUTING.md as the contributor entry point instead of special contributor labels.
- Surface contributor links in README near the top and in the documentation table.

## Verification
- git diff --check -- README.md CONTRIBUTING.md .github/labels.yml
- ruby YAML label parse and duplicate-name check: 28 labels
- contributor-label phrase grep over README.md, CONTRIBUTING.md, and .github/labels.yml: no matches
- GitHub issue labels checked for #63-#72 after cleanup

## Notes
- Docs/label-spec change only; no Swift build/test required.
- Does not merge to main; opened as a normal PR for review.