### PR TITLE
fix: accept /private/tmp MIDI import alias

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -64,6 +64,29 @@ actor AccessibilityChannel: Channel {
         return ScanMode(rawValue: raw) ?? .ax
     }
 
+    static func managedMIDIImportDirectoryPrefixes() -> [String] {
+        let rawRoots = [
+            "/tmp/LogicProMCP",
+            "/private/tmp/LogicProMCP",
+        ]
+
+        return Array(
+            Set(
+                rawRoots.flatMap { root in
+                    [
+                        root,
+                        URL(fileURLWithPath: root, isDirectory: true)
+                            .resolvingSymlinksInPath()
+                            .standardizedFileURL
+                            .path,
+                    ]
+                }
+            )
+        )
+        .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
+        .sorted()
+    }
+
     static func validatedMIDIImportPath(_ path: String) -> String? {
         guard path.rangeOfCharacter(from: .controlCharacters) == nil else { return nil }
 
@@ -72,13 +95,7 @@ actor AccessibilityChannel: Channel {
             .standardizedFileURL
         guard requestedURL.pathExtension.lowercased() == "mid" else { return nil }
 
-        let allowedDirectoryURL = URL(fileURLWithPath: "/tmp/LogicProMCP", isDirectory: true)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        let allowedDirectoryPath = allowedDirectoryURL.path.hasSuffix("/")
-            ? allowedDirectoryURL.path
-            : allowedDirectoryURL.path + "/"
-        guard requestedURL.path.hasPrefix(allowedDirectoryPath) else { return nil }
+        guard managedMIDIImportDirectoryPrefixes().contains(where: requestedURL.path.hasPrefix) else { return nil }
 
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: requestedURL.path, isDirectory: &isDirectory),

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -581,8 +581,13 @@ struct MIDIDispatcher {
             return .failure(ValidationFailure("import_file 'path' must not contain control characters"))
         }
 
-        let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
-        guard normalized.hasPrefix("/tmp/LogicProMCP/"),
+        let normalized = URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+        let allowedPrefixes = AccessibilityChannel.managedMIDIImportDirectoryPrefixes()
+
+        guard allowedPrefixes.contains(where: normalized.hasPrefix),
               normalized.lowercased().hasSuffix(".mid") else {
             return .failure(ValidationFailure("import_file 'path' must be /tmp/LogicProMCP/*.mid"))
         }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -738,6 +738,23 @@ private func makeAXBackedAccessibilityChannel(
     #expect(validated?.hasSuffix("/LogicProMCP/\(file.lastPathComponent)") == true)
 }
 
+@Test func testAccessibilityChannelValidatedMIDIImportPathAcceptsPrivateTmpRepresentation() throws {
+    let managedDirectory = URL(fileURLWithPath: "/private/tmp/LogicProMCP", isDirectory: true)
+    try FileManager.default.createDirectory(at: managedDirectory, withIntermediateDirectories: true)
+    let file = managedDirectory.appendingPathComponent("private-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: file)
+    defer { try? FileManager.default.removeItem(at: file) }
+
+    let validated = AccessibilityChannel.validatedMIDIImportPath(file.path)
+
+    #expect(validated?.hasSuffix("/LogicProMCP/\(file.lastPathComponent)") == true)
+    #expect(
+        AccessibilityChannel.managedMIDIImportDirectoryPrefixes().contains { prefix in
+            validated?.hasPrefix(prefix) == true
+        }
+    )
+}
+
 @Test func testAccessibilityChannelValidatedMIDIImportPathRejectsSymlinkEscape() throws {
     let managedDirectory = URL(fileURLWithPath: "/tmp/LogicProMCP", isDirectory: true)
     try FileManager.default.createDirectory(at: managedDirectory, withIntermediateDirectories: true)

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -2064,6 +2064,24 @@ private actor SelectiveFailChannel: Channel {
     ])
 }
 
+@Test func testMIDIDispatcherRoutesPrivateTmpImportFileCommand() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await MIDIDispatcher.handle(
+        command: "import_file",
+        params: ["path": .string("/private/tmp/LogicProMCP/acid.mid")],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(!result.isError!)
+    expectExecutedOps(await ax.executedOps, equals: [
+        ("midi.import_file", ["path": "/private/tmp/LogicProMCP/acid.mid"]),
+    ])
+}
+
 @Test func testMIDIDispatcherUnknownCommandFailsInDispatcherSuite() async {
     let result = await MIDIDispatcher.handle(
         command: "panic_all_channels",

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -282,10 +282,10 @@ Or use Scripter for deterministic plugin parameter control (no track routing nee
 
 ### `logic_midi import_file` rejects the path
 
-**Cause:** `import_file` intentionally accepts only Standard MIDI Files generated or staged under `/tmp/LogicProMCP/`. The server resolves symlinks and standardized paths before checking the boundary, so traversal tricks and symlink escapes are rejected.
+**Cause:** `import_file` intentionally accepts only Standard MIDI Files generated or staged under the managed temp directory. The accepted boundary is `/tmp/LogicProMCP/*.mid` plus its macOS alias `/private/tmp/LogicProMCP/*.mid`. The server resolves symlinks and standardized paths before checking the boundary, so traversal tricks and symlink escapes are still rejected.
 
 **Fix:**
-1. Copy or generate the `.mid` file under `/tmp/LogicProMCP/`.
+1. Copy or generate the `.mid` file under `/tmp/LogicProMCP/` or `/private/tmp/LogicProMCP/`.
 2. Ensure the path has a `.mid` extension and is a regular file, not a directory.
 3. Send imports sequentially and wait for `verified:true` before sending the next file.
 

--- a/docs/tickets/demo-qa/issue-49-import-path-verification-2026-06-19.md
+++ b/docs/tickets/demo-qa/issue-49-import-path-verification-2026-06-19.md
@@ -1,0 +1,59 @@
+# Issue #49 Verification — MIDI Import Path Normalization
+
+Date: 2026-06-19 KST
+Issue: `#49 Demo QA: MIDI import rejects valid /tmp LogicProMCP paths after macOS path normalization`
+Branch: `fix/demo-qa-49-import-path`
+
+## Root Cause
+
+`MIDIDispatcher.importFilePathParam` validated the caller path against a single managed prefix after path normalization. The check accepted only `/tmp/LogicProMCP/*.mid`, so callers using the macOS alias `/private/tmp/LogicProMCP/*.mid` were rejected before the AX import path ran.
+
+The AX channel had the same boundary assumption: it only treated the `/tmp/LogicProMCP/` spelling as managed, even though the same file can legitimately appear through the `/private/tmp` alias on macOS.
+
+## Fix
+
+1. Added a shared managed-temp prefix helper in `AccessibilityChannel` so both dispatcher and AX validation use the same allowlist.
+2. Accepted both `/tmp/LogicProMCP/` and `/private/tmp/LogicProMCP/` plus their normalized aliases.
+3. Kept the fail-closed checks for control characters, extension, regular-file status, and symlink/traversal escapes.
+
+## Deterministic Verification
+
+Targeted regression tests run on the branch:
+
+- `swift test --filter testMIDIDispatcherRoutesImportFileCommand`
+- `swift test --filter testMIDIDispatcherRoutesPrivateTmpImportFileCommand`
+- `swift test --filter testAccessibilityChannelValidatedMIDIImportPathAcceptsManagedTempMID`
+- `swift test --filter testAccessibilityChannelValidatedMIDIImportPathAcceptsPrivateTmpRepresentation`
+
+Observed result:
+
+- All 4 targeted tests passed.
+
+## Live E2E Verification
+
+Environment:
+
+- Logic Pro 12.2
+- Strict live MCP transport via `tmux`
+- Release binary: `.build/release/LogicProMCP`
+
+Notes:
+
+- An initial probe from the `Choose a Project` bootstrap state produced `readback_mismatch` for the first `/tmp` import because no real project window had been established yet. That is bootstrap-state noise tracked separately under `#45`, not a path-validation failure.
+- After Logic entered a normal arrange-window project (`Untitled 3 - Tracks`, `track_count: 1`), both path spellings succeeded.
+
+Targeted live probe result:
+
+```text
+health: {"project": "Untitled 3 - Tracks", "track_count": 1}
+tmp /tmp/LogicProMCP/issue49-live-tmp-2.mid
+{"observed_delta":1,"requested":"\/tmp\/LogicProMCP\/issue49-live-tmp-2.mid","success":true,"track_count_after":2,"track_count_before":1,"verified":true,"via":"ax_menu_import"}
+private /private/tmp/LogicProMCP/issue49-live-private-2.mid
+{"observed_delta":1,"requested":"\/tmp\/LogicProMCP\/issue49-live-private-2.mid","success":true,"track_count_after":3,"track_count_before":2,"verified":true,"via":"ax_menu_import"}
+```
+
+Conclusion:
+
+- `/tmp/LogicProMCP/*.mid` succeeds in a real Logic session.
+- `/private/tmp/LogicProMCP/*.mid` also succeeds and is normalized onto the same managed import path.
+- The path bug from `#49` is fixed; remaining import failures from bootstrap/modal/project state belong to other issues, not path normalization.


### PR DESCRIPTION
Closes #49.

## Root cause

`logic_midi.import_file` had a split boundary check:

- `MIDIDispatcher.importFilePathParam` validated only `/tmp/LogicProMCP/*.mid` after normalization.
- `AccessibilityChannel.validatedMIDIImportPath` made the same single-prefix assumption.

On macOS, the same managed temp file can legitimately appear via `/tmp/LogicProMCP/...` or `/private/tmp/LogicProMCP/...`. That meant a valid caller path could be rejected before the AX import flow ever ran.

## What changed

- Added a shared managed-temp prefix helper so dispatcher and AX validation use the same allowlist.
- Accepted both `/tmp/LogicProMCP/` and `/private/tmp/LogicProMCP/` plus normalized aliases.
- Kept fail-closed checks for control characters, extension, regular-file status, and symlink/traversal escapes.
- Added an issue-specific verification note at `docs/tickets/demo-qa/issue-49-import-path-verification-2026-06-19.md`.
- Updated `docs/TROUBLESHOOTING.md` to document both accepted path spellings.

## Deterministic verification

- `swift test --filter testMIDIDispatcherRoutesImportFileCommand`
- `swift test --filter testMIDIDispatcherRoutesPrivateTmpImportFileCommand`
- `swift test --filter testAccessibilityChannelValidatedMIDIImportPathAcceptsManagedTempMID`
- `swift test --filter testAccessibilityChannelValidatedMIDIImportPathAcceptsPrivateTmpRepresentation`

All 4 targeted tests passed.

## Live E2E

Environment:

- Logic Pro 12.2
- strict-live tmux transport
- release binary `.build/release/LogicProMCP`

Targeted live probe from a normal arrange-window project state:

```text
health: {"project": "Untitled 3 - Tracks", "track_count": 1}
tmp /tmp/LogicProMCP/issue49-live-tmp-2.mid
{"observed_delta":1,"requested":"\/tmp\/LogicProMCP\/issue49-live-tmp-2.mid","success":true,"track_count_after":2,"track_count_before":1,"verified":true,"via":"ax_menu_import"}
private /private/tmp/LogicProMCP/issue49-live-private-2.mid
{"observed_delta":1,"requested":"\/tmp\/LogicProMCP\/issue49-live-private-2.mid","success":true,"track_count_after":3,"track_count_before":2,"verified":true,"via":"ax_menu_import"}
```

Note:

- An earlier probe from the `Choose a Project` bootstrap surface produced `readback_mismatch` before a real project existed. That is bootstrap-state noise tracked separately under `#45`, not a remaining path-validation failure.
