### PR TITLE
fix: surface track arm verification state

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -1076,7 +1076,8 @@ actor AccessibilityChannel: Channel {
         let baseExtras: [String: Any] = [
             "track": index,
             "button": buttonName,
-            "requested": desired
+            "requested": desired,
+            "verification_source": "ax_value"
         ]
 
         if let cur = current, cur == desired {

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -473,7 +473,9 @@ actor MCUChannel: Channel {
                 extras: [
                     "function": "\(function)",
                     "track": track,
-                    "enabled": enabled
+                    "enabled": enabled,
+                    "write_source": "mcu",
+                    "verification_source": "mcu_led_echo"
                 ]
             ))
         }

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -207,6 +207,9 @@ struct TrackDispatcher {
                 operation: "track.set_arm",
                 params: ["index": String(index), "enabled": String(enabled)]
             )
+            if result.isSuccess, !trackArmResultIsVerified(result) {
+                return toolTextResult(result.message, isError: true)
+            }
             return toolTextResult(result)
 
         case "record_sequence":
@@ -218,13 +221,20 @@ struct TrackDispatcher {
             }
             let tracks = await cache.getTracks()
             var disarmed: [Int] = []
+            var unverifiedDisarm: [Int] = []
             var failedDisarm: [Int] = []
             for t in tracks where t.id != index && t.isArmed {
                 let r = await router.route(
                     operation: "track.set_arm",
                     params: ["index": String(t.id), "enabled": "false"]
                 )
-                if r.isSuccess { disarmed.append(t.id) } else { failedDisarm.append(t.id) }
+                if !r.isSuccess {
+                    failedDisarm.append(t.id)
+                } else if trackArmResultIsVerified(r) {
+                    disarmed.append(t.id)
+                } else {
+                    unverifiedDisarm.append(t.id)
+                }
             }
             let armResult = await router.route(
                 operation: "track.set_arm",
@@ -233,23 +243,52 @@ struct TrackDispatcher {
             // If the primary arm action failed, return an explicit error instead
             // of a structured success payload. Partial-disarm visibility still
             // available in the error detail.
-            let detail = armResult.message.replacingOccurrences(of: "\"", with: "\\\"")
             guard armResult.isSuccess else {
                 return toolTextResult(
                     "arm_only failed: target arm rejected — \(armResult.message); disarmed=\(disarmed) failedDisarm=\(failedDisarm)",
                     isError: true
                 )
             }
+            if !trackArmResultIsVerified(armResult) {
+                return toolTextResult(
+                    armOnlyResponse(
+                        targetIndex: index,
+                        armResult: armResult,
+                        armedSuccess: false,
+                        verified: false,
+                        disarmed: disarmed,
+                        unverifiedDisarm: unverifiedDisarm,
+                        failedDisarm: failedDisarm
+                    ),
+                    isError: true
+                )
+            }
             // Report partial disarm failures explicitly — the target arm
             // succeeded, but some other tracks may still be armed.
-            if !failedDisarm.isEmpty {
+            if !failedDisarm.isEmpty || !unverifiedDisarm.isEmpty {
                 return toolTextResult(
-                    "arm_only partial: target \(index) armed, but these tracks failed to disarm: \(failedDisarm) (disarmed: \(disarmed))",
+                    armOnlyResponse(
+                        targetIndex: index,
+                        armResult: armResult,
+                        armedSuccess: false,
+                        verified: false,
+                        disarmed: disarmed,
+                        unverifiedDisarm: unverifiedDisarm,
+                        failedDisarm: failedDisarm
+                    ),
                     isError: true
                 )
             }
             return toolTextResult(.success(
-                "{\"armed\":\(index),\"armedSuccess\":true,\"disarmed\":\(disarmed),\"failedDisarm\":[],\"detail\":\"\(detail)\"}"
+                armOnlyResponse(
+                    targetIndex: index,
+                    armResult: armResult,
+                    armedSuccess: true,
+                    verified: true,
+                    disarmed: disarmed,
+                    unverifiedDisarm: [],
+                    failedDisarm: []
+                )
             ))
 
         case "set_color":
@@ -356,6 +395,73 @@ struct TrackDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func trackArmResultIsVerified(_ result: ChannelResult) -> Bool {
+        guard result.isSuccess else { return false }
+        guard let json = trackArmEnvelope(result),
+              json["success"] != nil else {
+            // Legacy/plain-string mock successes are treated as verified so
+            // existing non-HC test doubles keep working. Real product channels
+            // now return HC envelopes, so the verified gate still applies in
+            // production.
+            return true
+        }
+        return (json["verified"] as? Bool) == true
+    }
+
+    private static func trackArmEnvelope(_ result: ChannelResult) -> [String: Any]? {
+        guard let data = result.message.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+
+    private static func armOnlyResponse(
+        targetIndex: Int,
+        armResult: ChannelResult,
+        armedSuccess: Bool,
+        verified: Bool,
+        disarmed: [Int],
+        unverifiedDisarm: [Int],
+        failedDisarm: [Int]
+    ) -> String {
+        var response: [String: Any] = [
+            "armed": targetIndex,
+            "target_track": targetIndex,
+            "armedSuccess": armedSuccess,
+            "verified": verified,
+            "requested_enabled": true,
+            "observed_enabled": NSNull(),
+            "verification_source": NSNull(),
+            "disarmed": disarmed,
+            "unverifiedDisarm": unverifiedDisarm,
+            "failedDisarm": failedDisarm,
+            "detail": armResult.message,
+        ]
+        if let envelope = trackArmEnvelope(armResult) {
+            response["requested_enabled"] = envelope["requested"] ?? envelope["enabled"] ?? true
+            response["observed_enabled"] = envelope["observed"] ?? NSNull()
+            response["verification_source"] =
+                envelope["verification_source"] ?? envelope["method"] ?? NSNull()
+            if let reason = envelope["reason"] {
+                response["reason"] = reason
+            }
+            if let function = envelope["function"] {
+                response["function"] = function
+            }
+            if let button = envelope["button"] {
+                response["button"] = button
+            }
+            if let action = envelope["action"] {
+                response["action"] = action
+            }
+            if let writeSource = envelope["write_source"] {
+                response["write_source"] = writeSource
+            }
+        }
+        return HonestContract.jsonString(response)
     }
 
     // MARK: - record_sequence SMF-import implementation

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -89,6 +89,58 @@ private actor FailingExecuteChannel: Channel {
     }
 }
 
+private actor TrackArmEnvelopeChannel: Channel {
+    nonisolated let id: ChannelID
+    let unverifiedIndices: Set<Int>
+    let failedIndices: Set<Int>
+
+    init(
+        id: ChannelID = .accessibility,
+        unverifiedIndices: Set<Int> = [],
+        failedIndices: Set<Int> = []
+    ) {
+        self.id = id
+        self.unverifiedIndices = unverifiedIndices
+        self.failedIndices = failedIndices
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        guard operation == "track.set_arm" else {
+            return .success("Mock: \(operation)")
+        }
+        let index = Int(params["index"] ?? "") ?? -1
+        let enabled = (params["enabled"] ?? "true") == "true"
+        let extras: [String: Any] = [
+            "track": index,
+            "enabled": enabled,
+            "function": "recArm",
+            "verification_source": "mock_ax_readback",
+        ]
+        if failedIndices.contains(index) {
+            return .error("Mock failure: track.set_arm \(index)")
+        }
+        if unverifiedIndices.contains(index) {
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: extras
+            ))
+        }
+        return .success(HonestContract.encodeStateA(
+            extras: extras.merging([
+                "observed": enabled,
+                "verification_source": "mock_ax_readback",
+            ]) { _, new in new }
+        ))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "track arm envelope channel")
+    }
+}
+
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
@@ -1396,6 +1448,83 @@ private actor SelectiveFailChannel: Channel {
     let text = dispatcherText(result)
     #expect(text.contains("\"armedSuccess\":true"))
     #expect(text.contains("\"armed\":1"))
+    #expect(text.contains("\"verified\":true"))
+    #expect(text.contains("\"requested_enabled\":true"))
+    #expect(text.contains("\"observed_enabled\":true"))
+    #expect(text.contains("\"verification_source\":\"mock_ax_readback\""))
+}
+
+@Test func testArmReturnsErrorForUnverifiedEnvelope() async {
+    let router = ChannelRouter()
+    let ax = TrackArmEnvelopeChannel(unverifiedIndices: [5])
+    await router.register(ax)
+    let cache = StateCache()
+
+    let result = await TrackDispatcher.handle(
+        command: "arm",
+        params: ["index": .int(5), "enabled": .bool(true)],
+        router: router,
+        cache: cache
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError!)
+    #expect(text.contains("\"verified\":false"))
+    #expect(text.contains("\"reason\":\"readback_unavailable\""))
+    #expect(text.contains("\"verification_source\":\"mock_ax_readback\""))
+}
+
+@Test func testArmOnlyTreatsUnverifiedTargetArmAsError() async {
+    let router = ChannelRouter()
+    let ax = TrackArmEnvelopeChannel(unverifiedIndices: [1])
+    await router.register(ax)
+    let cache = StateCache()
+    await cache.updateTracks([
+        TrackState(id: 1, name: "Target", type: .softwareInstrument),
+    ])
+
+    let result = await TrackDispatcher.handle(
+        command: "arm_only",
+        params: ["index": .int(1)],
+        router: router,
+        cache: cache
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError!)
+    #expect(text.contains("\"armedSuccess\":false"))
+    #expect(text.contains("\"verified\":false"))
+    #expect(text.contains("\"unverifiedDisarm\":[]"))
+    #expect(text.contains("\"requested_enabled\":true"))
+    #expect(text.contains("\"observed_enabled\":null"))
+    #expect(text.contains("\"verification_source\":\"mock_ax_readback\""))
+}
+
+@Test func testArmOnlyTreatsUnverifiedDisarmAsError() async {
+    let router = ChannelRouter()
+    let ax = TrackArmEnvelopeChannel(unverifiedIndices: [0])
+    await router.register(ax)
+    let cache = StateCache()
+    await cache.updateTracks([
+        TrackState(id: 0, name: "Track 1", type: .audio, isArmed: true),
+        TrackState(id: 1, name: "Target", type: .softwareInstrument),
+    ])
+
+    let result = await TrackDispatcher.handle(
+        command: "arm_only",
+        params: ["index": .int(1)],
+        router: router,
+        cache: cache
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError!)
+    #expect(text.contains("\"armed\":1"))
+    #expect(text.contains("\"unverifiedDisarm\":[0]"))
+    #expect(text.contains("\"verified\":false"))
+    #expect(text.contains("\"requested_enabled\":true"))
+    #expect(text.contains("\"observed_enabled\":true"))
+    #expect(text.contains("\"verification_source\":\"mock_ax_readback\""))
 }
 
 // MARK: - EditDispatcher

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -1430,7 +1430,7 @@ private actor SelectiveFailChannel: Channel {
 
 @Test func testArmOnlySuccessPathReportsArmedSuccess() async {
     let router = ChannelRouter()
-    let ax = MockChannel(id: .accessibility)
+    let ax = TrackArmEnvelopeChannel()
     await router.register(ax)
     let cache = StateCache()
     await cache.updateTracks([

--- a/docs/tickets/demo-qa/issue-55-arm-verification-2026-06-19.md
+++ b/docs/tickets/demo-qa/issue-55-arm-verification-2026-06-19.md
@@ -1,0 +1,129 @@
+# Issue 55 Verification - 2026-06-19
+
+## Root cause
+
+- `TrackDispatcher.handle(command: "arm")` and `TrackDispatcher.handle(command: "arm_only")` only checked `ChannelResult.isSuccess`.
+- Fallback channels can return Honest Contract State B envelopes for `track.set_arm`, for example `{"success":true,"verified":false,"reason":"readback_unavailable",...}` from the MCU strip-button path.
+- The dispatcher flattened that nested `verified:false` envelope into an outer tool success, so demo QA and transcript classification overstated certainty.
+- `arm_only` also hid the target/readback metadata inside a nested string instead of surfacing it at the outer response level.
+
+## Fix
+
+- `logic_tracks.arm` now returns an outer tool error when `track.set_arm` succeeds but the nested Honest Contract envelope is unverified.
+- `logic_tracks.arm_only` now:
+  - treats unverified target-arm and unverified disarm operations as outer errors
+  - returns structured outer fields for `target_track`, `requested_enabled`, `observed_enabled`, `verification_source`, `disarmed`, `unverifiedDisarm`, `failedDisarm`, and `verified`
+  - preserves the raw nested arm envelope in `detail`
+- AX record-arm verification now tags successful readback with `verification_source: "ax_value"`.
+- MCU strip-button fallbacks now tag unverified record-arm writes with `write_source: "mcu"` and `verification_source: "mcu_led_echo"`.
+
+## Deterministic test coverage
+
+Executed in `/private/tmp/logic-pro-mcp-issue55` on 2026-06-19:
+
+```bash
+swift test --skip-build --filter testArmReturnsErrorForUnverifiedEnvelope
+swift test --skip-build --filter testArmOnlyTreatsUnverifiedTargetArmAsError
+swift test --skip-build --filter testArmOnlyTreatsUnverifiedDisarmAsError
+swift test --skip-build --filter testArmOnlySuccessPathReportsArmedSuccess
+swift test --skip-build --filter DispatcherTests
+```
+
+Observed results:
+
+- All 4 targeted arm verification tests passed.
+- `swift test --skip-build --filter DispatcherTests` passed all 90 dispatcher tests.
+
+Added/updated regression tests:
+
+- `testArmReturnsErrorForUnverifiedEnvelope`
+- `testArmOnlyTreatsUnverifiedTargetArmAsError`
+- `testArmOnlyTreatsUnverifiedDisarmAsError`
+- `testArmOnlySuccessPathReportsArmedSuccess`
+
+## Live E2E verification
+
+Environment:
+
+- Logic Pro 12.2
+- Release binary: `/private/tmp/logic-pro-mcp-issue55/.build/release/LogicProMCP`
+- Open project during probe: `Untitled 3 - Tracks`
+
+Probe note:
+
+- Track-arm state is resource-backed, so the verification run called `logic_system.refresh_cache` between steps to eliminate poller lag from the probe itself.
+
+Health snapshot before the run:
+
+```json
+{
+  "logic_pro_running": true,
+  "logic_pro_has_document": true,
+  "logic_pro_version": "12.2",
+  "project": "Untitled 3 - Tracks",
+  "track_count": 3
+}
+```
+
+Reset both tracks, then arm track 0:
+
+```json
+{
+  "arm0": {
+    "action": "mouse-click",
+    "button": "Record",
+    "observed": true,
+    "requested": true,
+    "success": true,
+    "track": 0,
+    "verification_source": "ax_value",
+    "verified": true
+  }
+}
+```
+
+Track resource after `arm(0, true)` plus `refresh_cache`:
+
+```json
+[
+  {"id": 0, "name": "Deluxe Classic", "isArmed": true},
+  {"id": 1, "name": "Studio Grand", "isArmed": false},
+  {"id": 2, "name": "Studio Grand", "isArmed": false}
+]
+```
+
+Call `logic_tracks.arm_only {index: 1}`:
+
+```json
+{
+  "action": "mouse-click",
+  "armed": 1,
+  "armedSuccess": true,
+  "button": "Record",
+  "detail": "{\"action\":\"mouse-click\",\"button\":\"Record\",\"observed\":true,\"requested\":true,\"success\":true,\"track\":1,\"verification_source\":\"ax_value\",\"verified\":true}",
+  "disarmed": [0],
+  "failedDisarm": [],
+  "observed_enabled": true,
+  "requested_enabled": true,
+  "target_track": 1,
+  "unverifiedDisarm": [],
+  "verification_source": "ax_value",
+  "verified": true
+}
+```
+
+Track resource after `arm_only(1)` plus `refresh_cache`:
+
+```json
+[
+  {"id": 0, "name": "Deluxe Classic", "isArmed": false},
+  {"id": 1, "name": "Studio Grand", "isArmed": true},
+  {"id": 2, "name": "Studio Grand", "isArmed": false}
+]
+```
+
+Conclusion:
+
+- The outer `arm_only` response now carries verification metadata instead of hiding it in a nested string.
+- Verified AX success stays outer-success only when the target arm matches the observed state.
+- The live run confirmed `arm_only` reported `disarmed: [0]` and the resource state showed track 0 disarmed while track 1 remained armed.


### PR DESCRIPTION
Closes #55

## Root cause

- `TrackDispatcher` treated any successful `ChannelResult` from `track.set_arm` as an outer success.
- Fallback channels can return Honest Contract State B for record-arm, for example `success:true` plus `verified:false`.
- `arm_only` also buried requested/observed/source metadata inside a nested detail string instead of surfacing it at the outer response layer.

## What changed

- `logic_tracks.arm` now returns an outer tool error when the nested arm envelope is unverified.
- `logic_tracks.arm_only` now reports structured outer fields for `target_track`, `requested_enabled`, `observed_enabled`, `verification_source`, `disarmed`, `unverifiedDisarm`, `failedDisarm`, and `verified`.
- AX record-arm verification now tags successful readback with `verification_source:"ax_value"`.
- MCU strip-button fallbacks now tag unverified arm writes with `write_source:"mcu"` and `verification_source:"mcu_led_echo"`.
- Added regression coverage and a ticket verification note at `docs/tickets/demo-qa/issue-55-arm-verification-2026-06-19.md`.

## Verification

- `swift test --skip-build --filter testArmReturnsErrorForUnverifiedEnvelope`
- `swift test --skip-build --filter testArmOnlyTreatsUnverifiedTargetArmAsError`
- `swift test --skip-build --filter testArmOnlyTreatsUnverifiedDisarmAsError`
- `swift test --skip-build --filter testArmOnlySuccessPathReportsArmedSuccess`
- `swift test --skip-build --filter DispatcherTests` (90 passed)
- Live E2E with `/private/tmp/logic-pro-mcp-issue55/.build/release/LogicProMCP` on Logic Pro 12.2:
  - `arm(0,true)` returned `verified:true`, `observed:true`, `verification_source:"ax_value"`
  - `arm_only(1)` returned `armedSuccess:true`, `verified:true`, `requested_enabled:true`, `observed_enabled:true`, `verification_source:"ax_value"`, `disarmed:[0]`
  - `logic://tracks` after `logic_system.refresh_cache` showed track 0 `isArmed:false` and track 1 `isArmed:true`
