### PR TITLE
fix: honest key-command readback handling

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MCP
 
 func intParam(_ params: [String: Value], _ keys: String..., default defaultValue: Int = 0) -> Int {
@@ -172,4 +173,48 @@ func routedTextResult(
     params: [String: String] = [:]
 ) async -> CallTool.Result {
     toolTextResult(await router.route(operation: operation, params: params))
+}
+
+private let dispatcherJSONDecoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+}()
+
+func decodedJSONObject(_ raw: String) -> [String: Any]? {
+    guard let data = raw.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    return object
+}
+
+func decodeJSONValue<T: Decodable>(_ type: T.Type, from raw: String) -> T? {
+    guard let data = raw.data(using: .utf8) else { return nil }
+    return try? dispatcherJSONDecoder.decode(type, from: data)
+}
+
+func honestContractExtras(from raw: String) -> [String: Any] {
+    guard var object = decodedJSONObject(raw) else { return [:] }
+    for key in ["success", "verified", "reason", "error", "state", "hc_schema"] {
+        object.removeValue(forKey: key)
+    }
+    return object
+}
+
+func channelResultIsVerified(_ result: ChannelResult) -> Bool {
+    guard result.isSuccess else { return false }
+    return decodedJSONObject(result.message)?["verified"] as? Bool == true
+}
+
+func channelResultIsUnverified(_ result: ChannelResult) -> Bool {
+    guard result.isSuccess else { return false }
+    return decodedJSONObject(result.message)?["verified"] as? Bool == false
+}
+
+func toolTextResultTreatingUnverifiedAsError(_ result: ChannelResult) -> CallTool.Result {
+    if channelResultIsUnverified(result) {
+        return toolTextResult(result.message, isError: true)
+    }
+    return toolTextResult(result)
 }

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -61,7 +61,7 @@ struct EditDispatcher {
 
         case "select_all":
             let result = await router.route(operation: "edit.select_all")
-            return toolTextResult(result)
+            return toolTextResultTreatingUnverifiedAsError(result)
 
         case "split":
             let result = await router.route(operation: "edit.split")
@@ -89,7 +89,7 @@ struct EditDispatcher {
                 operation: "edit.quantize",
                 params: ["value": value]
             )
-            return toolTextResult(result)
+            return toolTextResultTreatingUnverifiedAsError(result)
 
         case "bounce_in_place":
             let result = await router.route(operation: "edit.bounce_in_place")

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -35,7 +35,12 @@ struct NavigateDispatcher {
                 operation: "transport.goto_position",
                 params: ["position": "\(bar).1.1.1"]
             )
-            return toolTextResult(result)
+            return await TransportDispatcher.finalizeGotoPositionResult(
+                result,
+                requestedPosition: "\(bar).1.1.1",
+                router: router,
+                cache: cache
+            )
 
         case "goto_marker":
             // v3.1.10 (boomer P1-1) — resolve the target marker from cache and
@@ -48,19 +53,24 @@ struct NavigateDispatcher {
             //
             let markers = await cache.getMarkers()
             func routeMarkerTarget(_ target: MarkerState) async -> CallTool.Result {
-                let result = await router.route(
+                var result = await router.route(
                     operation: "transport.goto_position",
                     params: ["position": target.position]
                 )
                 // canonical 마커는 응답 그대로. fallback/unknown 만 uncertainty
                 // 머신 가독으로 surface (HC State A/B 한정; State C 보존).
-                guard !target.positionSource.isCanonical else {
-                    return toolTextResult(result)
+                if !target.positionSource.isCanonical {
+                    let merged = mergeMarkerUncertainty(
+                        into: result.message, source: target.positionSource
+                    )
+                    result = result.isSuccess ? .success(merged) : .error(merged)
                 }
-                let merged = mergeMarkerUncertainty(
-                    into: result.message, source: target.positionSource
+                return await TransportDispatcher.finalizeGotoPositionResult(
+                    result,
+                    requestedPosition: target.position,
+                    router: router,
+                    cache: cache
                 )
-                return toolTextResult(merged, isError: !result.isSuccess)
             }
             // H-2 (2026-05-08 enterprise review): pre-fix the cache-cold
             // index-based path fell back to `nav.goto_marker` (CC 38), which
@@ -117,12 +127,12 @@ struct NavigateDispatcher {
             )
 
         case "create_marker":
-            let name = stringParam(params, "name", default: "Marker")
-            let result = await router.route(
-                operation: "nav.create_marker",
-                params: ["name": name]
+            let providedName = stringParam(params, "name")
+            return await finalizeCreateMarkerResult(
+                requestedName: providedName.isEmpty ? nil : providedName,
+                router: router,
+                cache: cache
             )
-            return toolTextResult(result)
 
         case "delete_marker":
             // RB-1.b (2026-05-08 enterprise review): pre-fix `intParam(default: 0)`
@@ -165,7 +175,7 @@ struct NavigateDispatcher {
 
         case "zoom_to_fit":
             let result = await router.route(operation: "nav.zoom_to_fit")
-            return toolTextResult(result)
+            return toolTextResultTreatingUnverifiedAsError(result)
 
         case "set_zoom":
             // Accept both `level` (docs) and `direction` (common caller term) —
@@ -184,16 +194,16 @@ struct NavigateDispatcher {
                     operation: "nav.set_zoom_level",
                     params: ["level": "8"]
                 )
-                return toolTextResult(result)
+                return toolTextResultTreatingUnverifiedAsError(result)
             case "out":
                 let result = await router.route(
                     operation: "nav.set_zoom_level",
                     params: ["level": "2"]
                 )
-                return toolTextResult(result)
+                return toolTextResultTreatingUnverifiedAsError(result)
             case "fit":
                 let result = await router.route(operation: "nav.zoom_to_fit")
-                return toolTextResult(result)
+                return toolTextResultTreatingUnverifiedAsError(result)
             default:
                 guard let numericLevel = Int(level),
                       (1...10).contains(numericLevel) else {
@@ -205,7 +215,7 @@ struct NavigateDispatcher {
                     operation: "nav.set_zoom_level",
                     params: ["level": String(numericLevel)]
                 )
-                return toolTextResult(result)
+                return toolTextResultTreatingUnverifiedAsError(result)
             }
 
         case "toggle_view":
@@ -239,6 +249,97 @@ struct NavigateDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func finalizeCreateMarkerResult(
+        requestedName: String?,
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        let routedName = requestedName ?? "Marker"
+        let routeResult = await router.route(
+            operation: "nav.create_marker",
+            params: ["name": routedName]
+        )
+        guard routeResult.isSuccess else {
+            return toolTextResult(routeResult)
+        }
+        guard channelResultIsUnverified(routeResult) else {
+            return toolTextResult(routeResult)
+        }
+        let beforeMarkers = await liveMarkers(router: router, cache: cache)
+        guard let beforeMarkers else {
+            return toolTextResult(
+                HonestContract.addExtras(
+                    ["verification_source": "logic://markers"],
+                    into: routeResult.message
+                ),
+                isError: true
+            )
+        }
+        guard let afterMarkers = await liveMarkers(router: router, cache: cache) else {
+            return toolTextResult(
+                HonestContract.addExtras(
+                    ["verification_source": "logic://markers"],
+                    into: routeResult.message
+                ),
+                isError: true
+            )
+        }
+
+        var extras = honestContractExtras(from: routeResult.message)
+        extras["verification_source"] = "logic://markers"
+        extras["marker_count_before"] = beforeMarkers.count
+        extras["marker_count_after"] = afterMarkers.count
+        if let requestedName {
+            extras["requested_name"] = requestedName
+        }
+
+        let createdMarker = createdMarker(after: afterMarkers, before: beforeMarkers)
+        if let createdMarker {
+            extras["observed_marker_id"] = createdMarker.id
+            extras["observed_marker_name"] = createdMarker.name
+            extras["observed_marker_position"] = createdMarker.position
+            extras["observed_marker_position_source"] = createdMarker.positionSource.rawValue
+        }
+
+        guard afterMarkers.count > beforeMarkers.count, let createdMarker else {
+            return toolTextResult(
+                HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras),
+                isError: true
+            )
+        }
+
+        if let requestedName, createdMarker.name != requestedName {
+            return toolTextResult(
+                HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras),
+                isError: true
+            )
+        }
+
+        return toolTextResult(HonestContract.encodeStateA(extras: extras))
+    }
+
+    private static func liveMarkers(
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> [MarkerState]? {
+        let readback = await router.route(operation: "nav.get_markers")
+        guard readback.isSuccess,
+              let markers = decodeJSONValue([MarkerState].self, from: readback.message) else {
+            return nil
+        }
+        await cache.updateMarkers(markers)
+        return markers
+    }
+
+    private static func createdMarker(
+        after afterMarkers: [MarkerState],
+        before beforeMarkers: [MarkerState]
+    ) -> MarkerState? {
+        return afterMarkers.last(where: { candidate in
+            !beforeMarkers.contains(candidate)
+        })
     }
 
     /// goto_marker 응답에 marker provenance uncertainty 를 surface — State A/B

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -44,8 +44,14 @@ struct TransportDispatcher {
             return toolTextResult(result)
 
         case "toggle_metronome":
+            let beforeTransport = await liveTransportState(router: router, cache: cache)
             let result = await router.route(operation: "transport.toggle_metronome")
-            return toolTextResult(result)
+            return await finalizeToggleMetronomeResult(
+                result,
+                beforeTransport: beforeTransport,
+                router: router,
+                cache: cache
+            )
 
         case "toggle_count_in":
             let result = await router.route(operation: "transport.toggle_count_in")
@@ -111,7 +117,12 @@ struct TransportDispatcher {
                     operation: "transport.goto_position",
                     params: ["position": "\(bar).1.1.1"]
                 )
-                return toolTextResult(result)
+                return await finalizeGotoPositionResult(
+                    result,
+                    requestedPosition: "\(bar).1.1.1",
+                    router: router,
+                    cache: cache
+                )
             }
             let time = stringParam(params, "position", default: "1.1.1.1")
             // Validate position format before routing. Accept:
@@ -126,7 +137,12 @@ struct TransportDispatcher {
                 operation: "transport.goto_position",
                 params: ["position": time]
             )
-            return toolTextResult(result)
+            return await finalizeGotoPositionResult(
+                result,
+                requestedPosition: time,
+                router: router,
+                cache: cache
+            )
 
         case "set_cycle_range":
             guard params["start"] != nil, params["end"] != nil else {
@@ -198,5 +214,97 @@ struct TransportDispatcher {
         }
 
         return false
+    }
+
+    static func finalizeGotoPositionResult(
+        _ result: ChannelResult,
+        requestedPosition: String,
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        guard result.isSuccess else {
+            return toolTextResult(result)
+        }
+        guard channelResultIsUnverified(result) else {
+            return toolTextResult(result)
+        }
+        guard let observedTransport = await liveTransportState(router: router, cache: cache) else {
+            return toolTextResult(
+                HonestContract.addExtras(
+                    ["verification_source": "transport_state"],
+                    into: result.message
+                ),
+                isError: true
+            )
+        }
+
+        var extras = honestContractExtras(from: result.message)
+        extras["verification_source"] = "transport_state"
+        extras["requested"] = requestedPosition
+        extras["observed"] = observedTransport.position
+        extras["observed_time_position"] = observedTransport.timePosition
+
+        if !requestedPosition.contains(":"), observedTransport.position == requestedPosition {
+            return toolTextResult(HonestContract.encodeStateA(extras: extras))
+        }
+
+        let reason: HonestContract.UncertainReason =
+            requestedPosition.contains(":") ? .readbackUnavailable : .readbackMismatch
+        return toolTextResult(
+            HonestContract.encodeStateB(reason: reason, extras: extras),
+            isError: true
+        )
+    }
+
+    private static func finalizeToggleMetronomeResult(
+        _ result: ChannelResult,
+        beforeTransport: TransportState?,
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        guard result.isSuccess else {
+            return toolTextResult(result)
+        }
+        guard channelResultIsUnverified(result) else {
+            return toolTextResult(result)
+        }
+        guard let beforeTransport,
+              let afterTransport = await liveTransportState(router: router, cache: cache) else {
+            return toolTextResult(
+                HonestContract.addExtras(
+                    ["verification_source": "transport_state"],
+                    into: result.message
+                ),
+                isError: true
+            )
+        }
+
+        var extras = honestContractExtras(from: result.message)
+        extras["verification_source"] = "transport_state"
+        extras["previous_enabled"] = beforeTransport.isMetronomeEnabled
+        extras["requested_enabled"] = !beforeTransport.isMetronomeEnabled
+        extras["observed_enabled"] = afterTransport.isMetronomeEnabled
+
+        if beforeTransport.isMetronomeEnabled != afterTransport.isMetronomeEnabled {
+            return toolTextResult(HonestContract.encodeStateA(extras: extras))
+        }
+
+        return toolTextResult(
+            HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras),
+            isError: true
+        )
+    }
+
+    private static func liveTransportState(
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> TransportState? {
+        let readback = await router.route(operation: "transport.get_state")
+        guard readback.isSuccess,
+              let transport = decodeJSONValue(TransportState.self, from: readback.message) else {
+            return nil
+        }
+        await cache.updateTransport(transport)
+        return transport
     }
 }

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -39,6 +39,21 @@ private func makeLogicProjectPath(name: String = UUID().uuidString, create: Bool
     return path.path
 }
 
+private func encodeDispatcherJSON<T: Encodable>(_ value: T) -> String {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try! encoder.encode(value)
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func parseDispatcherObject(_ raw: String) -> [String: Any]? {
+    guard let data = raw.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    return object
+}
+
 private final class ProjectLifecycleHarness {
     var scripts: [String] = []
     var runningStates: [Bool]
@@ -86,6 +101,110 @@ private actor FailingExecuteChannel: Channel {
 
     func healthCheck() async -> ChannelHealth {
         .healthy(detail: "failing execute channel")
+    }
+}
+
+private actor StaticResultChannel: Channel {
+    nonisolated let id: ChannelID
+    let results: [String: ChannelResult]
+    let defaultResult: ChannelResult
+    var executedOps: [(String, [String: String])] = []
+
+    init(
+        id: ChannelID,
+        results: [String: ChannelResult],
+        defaultResult: ChannelResult = .error("unexpected operation")
+    ) {
+        self.id = id
+        self.results = results
+        self.defaultResult = defaultResult
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        return results[operation] ?? defaultResult
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "static result channel")
+    }
+}
+
+private actor SequencedTransportReadbackChannel: Channel {
+    nonisolated let id: ChannelID
+    let toggleResult: ChannelResult
+    let gotoPositionResult: ChannelResult
+    var transportStates: [TransportState]
+    var executedOps: [(String, [String: String])] = []
+
+    init(
+        id: ChannelID = .accessibility,
+        toggleResult: ChannelResult = .error("unexpected toggle"),
+        gotoPositionResult: ChannelResult = .error("unexpected goto"),
+        transportStates: [TransportState]
+    ) {
+        self.id = id
+        self.toggleResult = toggleResult
+        self.gotoPositionResult = gotoPositionResult
+        self.transportStates = transportStates
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        switch operation {
+        case "transport.toggle_metronome":
+            return toggleResult
+        case "transport.goto_position":
+            return gotoPositionResult
+        case "transport.get_state":
+            guard !transportStates.isEmpty else {
+                return .error("missing transport state")
+            }
+            let next = transportStates.removeFirst()
+            return .success(encodeDispatcherJSON(next))
+        default:
+            return .error("unexpected operation: \(operation)")
+        }
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "sequenced transport readback")
+    }
+}
+
+private actor SequencedMarkersChannel: Channel {
+    nonisolated let id: ChannelID
+    var markerSnapshots: [[MarkerState]]
+    var executedOps: [(String, [String: String])] = []
+
+    init(id: ChannelID = .accessibility, markerSnapshots: [[MarkerState]]) {
+        self.id = id
+        self.markerSnapshots = markerSnapshots
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        guard operation == "nav.get_markers" else {
+            return .error("unexpected operation: \(operation)")
+        }
+        guard !markerSnapshots.isEmpty else {
+            return .error("missing marker snapshot")
+        }
+        let next = markerSnapshots.removeFirst()
+        return .success(encodeDispatcherJSON(next))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "sequenced marker readback")
     }
 }
 
@@ -189,6 +308,89 @@ private actor FailingExecuteChannel: Channel {
         ("transport.goto_position", ["position": "00:00:10:12"]),
         ("transport.set_cycle_range", ["start": "4.1.1.1", "end": "12.1.1.1"]),
     ])
+}
+
+@Test func testTransportDispatcherToggleMetronomeVerifiesViaTransportStateReadback() async throws {
+    let router = ChannelRouter()
+    let ax = SequencedTransportReadbackChannel(
+        toggleResult: .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button not visible"
+        )),
+        transportStates: [
+            TransportState(
+                isMetronomeEnabled: false,
+                position: "1.1.1.1",
+                timePosition: "00:00:00.000",
+                lastUpdated: Date()
+            ),
+            TransportState(
+                isMetronomeEnabled: true,
+                position: "1.1.1.1",
+                timePosition: "00:00:00.000",
+                lastUpdated: Date()
+            ),
+        ]
+    )
+    let keyCmd = StaticResultChannel(
+        id: .midiKeyCommands,
+        results: [
+            "transport.toggle_metronome": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            ))
+        ]
+    )
+    await router.register(ax)
+    await router.register(keyCmd)
+
+    let result = await TransportDispatcher.handle(
+        command: "toggle_metronome",
+        params: [:],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["verification_source"] as? String == "transport_state")
+    #expect(object["previous_enabled"] as? Bool == false)
+    #expect(object["requested_enabled"] as? Bool == true)
+    #expect(object["observed_enabled"] as? Bool == true)
+}
+
+@Test func testTransportDispatcherGotoPositionReturnsErrorWhenTransportReadbackDoesNotMatch() async throws {
+    let router = ChannelRouter()
+    let ax = SequencedTransportReadbackChannel(
+        gotoPositionResult: .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["via": "dialog"]
+        )),
+        transportStates: [
+            TransportState(
+                position: "8.1.1.1",
+                timePosition: "00:00:08.000",
+                lastUpdated: Date()
+            )
+        ]
+    )
+    await router.register(ax)
+
+    let result = await TransportDispatcher.handle(
+        command: "goto_position",
+        params: ["bar": .int(9)],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(result.isError == true)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["verified"] as? Bool == false)
+    #expect(object["reason"] as? String == "readback_mismatch")
+    #expect(object["verification_source"] as? String == "transport_state")
+    #expect(object["requested"] as? String == "9.1.1.1")
+    #expect(object["observed"] as? String == "8.1.1.1")
 }
 
 @Test func testTransportDispatcherRejectsMissingSemanticPayloads() async {
@@ -1482,6 +1684,43 @@ private actor SelectiveFailChannel: Channel {
     #expect(await missingKeyCmd.executedOps.isEmpty)
 }
 
+@Test func testEditDispatcherTreatsUnverifiedStateBAsError() async {
+    let router = ChannelRouter()
+    let keyCmd = StaticResultChannel(
+        id: .midiKeyCommands,
+        results: [
+            "edit.select_all": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            )),
+            "edit.quantize": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            )),
+        ]
+    )
+    await router.register(keyCmd)
+    let cache = StateCache()
+
+    let selectAllResult = await EditDispatcher.handle(
+        command: "select_all",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+    let quantizeResult = await EditDispatcher.handle(
+        command: "quantize",
+        params: ["value": .string("1/16")],
+        router: router,
+        cache: cache
+    )
+
+    #expect(selectAllResult.isError == true)
+    #expect(quantizeResult.isError == true)
+    #expect(dispatcherText(selectAllResult).contains("\"verified\":false"))
+    #expect(dispatcherText(quantizeResult).contains("\"verified\":false"))
+}
+
 @Test func testEditDispatcherUnknownFails() async {
     let router = ChannelRouter()
     let cache = StateCache()
@@ -2189,6 +2428,149 @@ private actor SelectiveFailChannel: Channel {
         ("nav.set_zoom_level", ["level": "2"]),
         ("nav.set_zoom_level", ["level": "5"]),
     ])
+}
+
+@Test func testNavigateDispatcherGotoBarUsesTransportStateReadbackVerification() async throws {
+    let router = ChannelRouter()
+    let ax = SequencedTransportReadbackChannel(
+        gotoPositionResult: .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["via": "dialog"]
+        )),
+        transportStates: [
+            TransportState(
+                position: "17.1.1.1",
+                timePosition: "00:00:17.000",
+                lastUpdated: Date()
+            )
+        ]
+    )
+    await router.register(ax)
+
+    let result = await NavigateDispatcher.handle(
+        command: "goto_bar",
+        params: ["bar": .int(17)],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["verification_source"] as? String == "transport_state")
+    #expect(object["observed"] as? String == "17.1.1.1")
+}
+
+@Test func testNavigateDispatcherCreateMarkerVerifiesViaMarkerReadback() async throws {
+    let router = ChannelRouter()
+    let markersAX = SequencedMarkersChannel(markerSnapshots: [
+        [MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser)],
+        [
+            MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser),
+            MarkerState(id: 1, name: "Marker 1", position: "9.1.1.1", positionSource: .parser),
+        ],
+    ])
+    let keyCmd = StaticResultChannel(
+        id: .midiKeyCommands,
+        results: [
+            "nav.create_marker": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            ))
+        ]
+    )
+    await router.register(markersAX)
+    await router.register(keyCmd)
+    let cache = StateCache()
+
+    let result = await NavigateDispatcher.handle(
+        command: "create_marker",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["verification_source"] as? String == "logic://markers")
+    #expect(object["marker_count_before"] as? Int == 1)
+    #expect(object["marker_count_after"] as? Int == 2)
+    #expect(object["observed_marker_name"] as? String == "Marker 1")
+    #expect(await cache.getMarkers().count == 2)
+}
+
+@Test func testNavigateDispatcherCreateMarkerReturnsErrorWhenObservedNameDoesNotMatch() async throws {
+    let router = ChannelRouter()
+    let markersAX = SequencedMarkersChannel(markerSnapshots: [
+        [MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser)],
+        [
+            MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser),
+            MarkerState(id: 1, name: "Marker 2", position: "9.1.1.1", positionSource: .parser),
+        ],
+    ])
+    let keyCmd = StaticResultChannel(
+        id: .midiKeyCommands,
+        results: [
+            "nav.create_marker": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            ))
+        ]
+    )
+    await router.register(markersAX)
+    await router.register(keyCmd)
+
+    let result = await NavigateDispatcher.handle(
+        command: "create_marker",
+        params: ["name": .string("Bridge")],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(result.isError == true)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["verified"] as? Bool == false)
+    #expect(object["reason"] as? String == "readback_mismatch")
+    #expect(object["requested_name"] as? String == "Bridge")
+    #expect(object["observed_marker_name"] as? String == "Marker 2")
+}
+
+@Test func testNavigateDispatcherZoomCommandsTreatUnverifiedStateBAsError() async {
+    let router = ChannelRouter()
+    let keyCmd = StaticResultChannel(
+        id: .midiKeyCommands,
+        results: [
+            "nav.zoom_to_fit": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            )),
+            "nav.set_zoom_level": .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: ["method": "midi_key_command"]
+            )),
+        ]
+    )
+    await router.register(keyCmd)
+    let cache = StateCache()
+
+    let fitResult = await NavigateDispatcher.handle(
+        command: "zoom_to_fit",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+    let zoomInResult = await NavigateDispatcher.handle(
+        command: "set_zoom",
+        params: ["level": .string("in")],
+        router: router,
+        cache: cache
+    )
+
+    #expect(fitResult.isError == true)
+    #expect(zoomInResult.isError == true)
+    #expect(dispatcherText(fitResult).contains("\"verified\":false"))
+    #expect(dispatcherText(zoomInResult).contains("\"verified\":false"))
 }
 
 // RB-1.b (2026-05-08 enterprise review): pre-fix `delete_marker` and

--- a/docs/tickets/demo-recording-failures-2026-06-18/issue-40-key-command-readback-verification-2026-06-19.md
+++ b/docs/tickets/demo-recording-failures-2026-06-18/issue-40-key-command-readback-verification-2026-06-19.md
@@ -1,0 +1,73 @@
+# Issue #40 Verification - 2026-06-19
+
+## Root cause
+
+- The affected dispatchers forwarded routed channel results with `toolTextResult(result)` and never reinterpreted Honest Contract State B.
+- That meant key-command / fallback paths such as `logic_edit.select_all`, `logic_edit.quantize`, `logic_navigate.zoom_to_fit`, `logic_navigate.create_marker`, `logic_transport.toggle_metronome`, and `logic_transport.goto_position` surfaced outer MCP success even when the nested payload already said `verified:false`.
+- The repo already had observable readback surfaces for transport state (`transport.get_state`, `logic://transport/state`) and markers (`nav.get_markers`, `logic://markers`), but the dispatchers never used them to upgrade or reject fallback writes.
+- `create_marker` also accepted an optional `name`, while the live key-command path only fires the shortcut. Pre-fix, a marker-name mismatch still looked like a clean success.
+
+## Fix
+
+- Added shared dispatcher helpers for decoding Honest Contract envelopes and promoting nested State B to outer `isError:true`.
+- `logic_edit.select_all`, `logic_edit.quantize`, `logic_navigate.zoom_to_fit`, and `logic_navigate.set_zoom` now surface unverified State B as outer error instead of false-green success.
+- `logic_transport.goto_position` plus `logic_navigate.goto_bar` / `goto_marker` now post-verify unverified writes against live transport state and only return State A when the observed position matches.
+- `logic_transport.toggle_metronome` now post-verifies fallback writes against live transport state.
+- `logic_navigate.create_marker` now compares live marker snapshots before/after, updates the marker cache, returns State A only on proven marker creation, and returns outer-error State B on no delta or requested-name mismatch.
+- Added dispatcher regression coverage for the new transport-state, marker-readback, and outer-error behaviors.
+
+## Automated verification
+
+- `swift test --filter DispatcherTests`
+  - Passed: 94 tests
+
+## Live verification
+
+Environment:
+- Logic Pro 12.2 running from `/Applications/Logic Pro.app`
+- Release binary: `/private/tmp/logic-pro-mcp-issue40/.build/release/LogicProMCP`
+- Marker probe pre-step: manually opened `Navigate > Open Marker List` so `logic://markers` had the Logic 12.2 marker surface available
+
+Observed results:
+
+- `logic_transport.goto_position { "bar": 1 }`
+  - Returned State A:
+    - `success:true`
+    - `verified:true`
+    - `requested:"1.1.1.1"`
+    - `observed:"1.1.1.1"`
+    - `via:"slider"`
+  - `logic://transport/state` immediately reported `position:"1.1.1.1"`.
+
+- `logic_edit.select_all`
+  - Returned outer `isError:true` with nested State B `reason:"readback_unavailable"`.
+
+- `logic_edit.quantize { "value": "1/16" }`
+  - Returned outer `isError:true` with nested State B `reason:"readback_unavailable"`.
+
+- `logic_navigate.zoom_to_fit`
+  - Returned outer `isError:true` with nested State B `reason:"readback_unavailable"`.
+
+- `logic_transport.toggle_metronome`
+  - Returned outer `isError:true` with nested State B:
+    - `reason:"readback_mismatch"`
+    - `verification_source:"transport_state"`
+    - `previous_enabled:false`
+    - `requested_enabled:true`
+    - `observed_enabled:false`
+  - `logic://transport/state` confirmed the metronome flag never changed in this UI state.
+
+- `logic_navigate.create_marker {}`
+  - Returned outer `isError:true` with nested State B:
+    - `reason:"readback_mismatch"`
+    - `verification_source:"logic://markers"`
+    - `marker_count_before:0`
+    - `marker_count_after:0`
+  - `logic://markers` remained empty before and after the shortcut.
+
+## Conclusion
+
+- Issue #40's contract bug is fixed: unverified key-command-backed commands no longer present as clean MCP success.
+- Live verification also surfaced two remaining environment/setup truths that are now reported honestly instead of masked:
+  - the current metronome toggle path did not change transport state in this Logic session
+  - the current marker-create shortcut produced no observable marker delta in `logic://markers`


### PR DESCRIPTION
## Summary
Fixes #40.

### Root cause
- `EditDispatcher`, `NavigateDispatcher`, and `TransportDispatcher` forwarded routed channel results with `toolTextResult(result)` and never reinterpreted Honest Contract State B.
- That let key-command / fallback paths return nested `verified:false` while the outer MCP tool still surfaced `isError:false`, which is exactly the false-green contract seen in the demo transcripts.
- The repo already had live readback surfaces for transport state (`transport.get_state`, `logic://transport/state`) and markers (`nav.get_markers`, `logic://markers`), but these dispatchers never consumed them to upgrade or reject fallback writes.
- `create_marker` also accepted an optional `name`, while the live shortcut path only fires the shortcut; pre-fix, any name mismatch was still reported as success.

### What changed
- added shared dispatcher helpers for decoding Honest Contract envelopes
- `logic_edit.select_all`, `logic_edit.quantize`, `logic_navigate.zoom_to_fit`, and `logic_navigate.set_zoom` now surface nested State B as outer `isError:true`
- `logic_transport.goto_position` plus `logic_navigate.goto_bar` / `goto_marker` now post-verify unverified writes against live transport state and only return State A when the observed position matches
- `logic_transport.toggle_metronome` now post-verifies fallback writes against live transport state
- `logic_navigate.create_marker` now compares live marker snapshots before/after, updates the marker cache, and returns outer-error State B on no delta or requested-name mismatch
- added dispatcher regression coverage and an issue verification note

### Verification
- `swift test --filter DispatcherTests`
  - 94 tests passed
- live release-binary probe on 2026-06-19 (`/private/tmp/logic-pro-mcp-issue40/.build/release/LogicProMCP`)
  - `logic_transport.goto_position {"bar":1}` returned State A with observed `1.1.1.1`, and `logic://transport/state` matched
  - `logic_edit.select_all`, `logic_edit.quantize`, and `logic_navigate.zoom_to_fit` now return outer `isError:true` with nested State B instead of false-green success
  - `logic_transport.toggle_metronome` now returns outer-error State B `readback_mismatch` when transport state does not actually change
  - `logic_navigate.create_marker {}` now returns outer-error State B `readback_mismatch` when `logic://markers` shows no marker delta
- detailed notes: `docs/tickets/demo-recording-failures-2026-06-18/issue-40-key-command-readback-verification-2026-06-19.md`
