### PR TITLE
fix: stabilize live track rename via Track menu fallback

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -1235,8 +1235,8 @@ enum AXLogicProElements {
     /// Find the track name text field on a header.
     static func findTrackNameField(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }
-        return AXHelpers.findDescendant(of: header, role: kAXStaticTextRole, maxDepth: 4, runtime: runtime.ax)
-            ?? AXHelpers.findDescendant(of: header, role: kAXTextFieldRole, maxDepth: 4, runtime: runtime.ax)
+        return AXHelpers.findDescendant(of: header, role: kAXTextFieldRole, maxDepth: 4, runtime: runtime.ax)
+            ?? AXHelpers.findDescendant(of: header, role: kAXStaticTextRole, maxDepth: 4, runtime: runtime.ax)
     }
 
     // MARK: - Markers

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -121,6 +121,12 @@ enum AXMouseHelper {
         postKey(0x24, runtime: runtime)   // kVK_Return = 0x24
     }
 
+    /// Post a Delete/Backspace key tap. Used by inline text-edit flows after
+    /// the target control selects its existing contents on double-click.
+    static func pressDelete(runtime: Runtime = .production) {
+        postKey(0x33, runtime: runtime)   // kVK_Delete = 0x33
+    }
+
     /// Post an Escape key tap (used to dismiss unwanted popups on error).
     static func pressEscape(runtime: Runtime = .production) {
         postKey(0x35, runtime: runtime)   // kVK_Escape = 0x35

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -289,15 +289,14 @@ enum AXValueExtractors {
     // MARK: - Private helpers
 
     private static func extractTrackName(from header: AXUIElement, runtime: AXHelpers.Runtime) -> String {
-        // Try static text first.
-        if let text = AXHelpers.findDescendant(of: header, role: kAXStaticTextRole, maxDepth: 3, runtime: runtime),
-           let name = extractTextValue(text, runtime: runtime)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !name.isEmpty {
-            return name
-        }
-
-        // Text fields in live Logic often expose the track name via AXDescription, while AXValue is a numeric placeholder.
-        if let field = AXHelpers.findDescendant(of: header, role: kAXTextFieldRole, maxDepth: 3, runtime: runtime) {
+        // Logic 12.2 commonly exposes the authoritative live name on an
+        // AXTextField's description while AXValue stays the numeric placeholder
+        // "0". Prefer text-field metadata when it contains a real name; fall
+        // back to static text only when the text-field path is empty/useless.
+        let textFields = AXHelpers.findAllDescendants(
+            of: header, role: kAXTextFieldRole, maxDepth: 3, runtime: runtime
+        )
+        for field in textFields {
             let candidates = [
                 AXHelpers.getDescription(field, runtime: runtime),
                 AXHelpers.getTitle(field, runtime: runtime),
@@ -308,6 +307,14 @@ enum AXValueExtractors {
                     return candidate
                 }
             }
+        }
+
+        if let text = AXHelpers.findDescendant(
+            of: header, role: kAXStaticTextRole, maxDepth: 3, runtime: runtime
+        ),
+           let name = extractTextValue(text, runtime: runtime)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return name
         }
 
         // AXLayoutItem headers commonly describe themselves as `4개의 ‘Holographic Squares’ 트랙`.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -163,6 +163,8 @@ actor AccessibilityChannel: Channel {
             hasVisibleWindow: @escaping @Sendable () -> Bool = { ProcessUtils.hasVisibleWindow() },
             logicRuntime: AXLogicProElements.Runtime = .production,
             controlBarMouseRuntime: AXMouseHelper.Runtime = .production,
+            trackRenameMouseRuntime: AXMouseHelper.Runtime = .production,
+            processRuntime: ProcessUtils.Runtime = .production,
             runTempoFallback: @escaping @Sendable (String) -> Bool = { tempo in
                 AccessibilityChannel.runTempoFallbackScript(tempo: tempo)
             }
@@ -186,7 +188,14 @@ actor AccessibilityChannel: Channel {
                 selectedTrack: { AccessibilityChannel.defaultGetSelectedTrack(runtime: logicRuntime) },
                 selectTrack: { await AccessibilityChannel.defaultSelectTrack(params: $0, runtime: logicRuntime) },
                 setTrackToggle: { AccessibilityChannel.defaultSetTrackToggle(params: $0, button: $1, runtime: logicRuntime) },
-                renameTrack: { AccessibilityChannel.defaultRenameTrack(params: $0, runtime: logicRuntime) },
+                renameTrack: {
+                    AccessibilityChannel.defaultRenameTrack(
+                        params: $0,
+                        runtime: logicRuntime,
+                        mouseRuntime: trackRenameMouseRuntime,
+                        processRuntime: processRuntime
+                    )
+                },
                 mixerState: { AccessibilityChannel.defaultGetMixerState(runtime: logicRuntime) },
                 channelStrip: { AccessibilityChannel.defaultGetChannelStrip(params: $0, runtime: logicRuntime) },
                 setMixerValue: { AccessibilityChannel.defaultSetMixerValue(params: $0, target: $1, runtime: logicRuntime) },
@@ -1157,7 +1166,9 @@ actor AccessibilityChannel: Channel {
 
     private static func defaultRenameTrack(
         params: [String: String],
-        runtime: AXLogicProElements.Runtime = .production
+        runtime: AXLogicProElements.Runtime = .production,
+        mouseRuntime: AXMouseHelper.Runtime = .production,
+        processRuntime: ProcessUtils.Runtime = .production
     ) -> ChannelResult {
         guard let indexStr = params["index"], let index = Int(indexStr),
               let name = params["name"] else {
@@ -1167,35 +1178,139 @@ actor AccessibilityChannel: Channel {
             ))
         }
         let truncatedName = String(name.prefix(255))
-        guard let field = AXLogicProElements.findTrackNameField(trackIndex: index, runtime: runtime) else {
+        let baseExtras: [String: Any] = ["track": index, "requested": truncatedName]
+
+        func observedTrackName() -> String? {
+            AXLogicProElements.trackName(at: index, runtime: runtime)
+        }
+
+        func verifiedResult(via: String) -> ChannelResult? {
+            guard let observed = observedTrackName(), observed == truncatedName else { return nil }
+            return .success(HonestContract.encodeStateA(
+                extras: baseExtras.merging([
+                    "observed": observed,
+                    "via": via
+                ]) { _, new in new }
+            ))
+        }
+
+        if let currentName = observedTrackName(), currentName == truncatedName {
+            return .success(HonestContract.encodeStateA(
+                extras: baseExtras.merging([
+                    "observed": currentName,
+                    "via": "no-op"
+                ]) { _, new in new }
+            ))
+        }
+
+        guard AXLogicProElements.findTrackHeader(at: index, runtime: runtime) != nil else {
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "name field for track \(index) not located",
-                extras: ["track": index, "requested": truncatedName]
+                hint: "Track at index \(index) not found",
+                extras: baseExtras
             ))
         }
-        AXHelpers.performAction(field, kAXPressAction, runtime: runtime.ax)
-        AXHelpers.setAttribute(field, kAXValueAttribute, truncatedName as CFTypeRef, runtime: runtime.ax)
-        AXHelpers.performAction(field, kAXConfirmAction, runtime: runtime.ax)
-        usleep(50_000)
 
-        let baseExtras: [String: Any] = ["track": index, "requested": truncatedName]
-        let observed = AXHelpers.getValue(field, runtime: runtime.ax) as? String
-        guard let observed else {
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackUnavailable,
-                extras: baseExtras.merging(["observed": NSNull()]) { _, new in new }
+        if let field = AXLogicProElements.findTrackNameField(trackIndex: index, runtime: runtime) {
+            AXHelpers.performAction(field, kAXPressAction, runtime: runtime.ax)
+            AXHelpers.setAttribute(field, kAXValueAttribute, truncatedName as CFTypeRef, runtime: runtime.ax)
+            AXHelpers.performAction(field, kAXConfirmAction, runtime: runtime.ax)
+            usleep(50_000)
+            if let verified = verifiedResult(via: "ax_set_value") {
+                return verified
+            }
+        }
+
+        _ = ProcessUtils.activateLogicPro(runtime: processRuntime)
+        guard selectTrackForRename(index: index, runtime: runtime) else {
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "Failed to select track \(index) before rename",
+                extras: baseExtras
             ))
         }
-        if observed == truncatedName {
-            return .success(HonestContract.encodeStateA(
-                extras: baseExtras.merging(["observed": observed]) { _, new in new }
+        raiseTrackWindowForRename(index: index, runtime: runtime)
+
+        let click = clickTrackMenu(
+            ["Rename Track", "트랙 이름 변경", "이름 변경"],
+            menuName: "트랙",
+            englishMenuName: "Track",
+            runtime: runtime
+        )
+        guard click.isSuccess else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Track > Rename Track menu item not found / not pressable",
+                extras: baseExtras
             ))
         }
+
+        usleep(150_000)
+        AXMouseHelper.typeText(truncatedName, runtime: mouseRuntime)
+        usleep(50_000)
+        AXMouseHelper.pressReturn(runtime: mouseRuntime)
+        usleep(150_000)
+
+        if let verified = verifiedResult(via: "track_menu") {
+            return verified
+        }
+
+        AXMouseHelper.pressEscape(runtime: mouseRuntime)
+        usleep(50_000)
+        let observed = observedTrackName()
         return .success(HonestContract.encodeStateB(
-            reason: .readbackMismatch,
-            extras: baseExtras.merging(["observed": observed]) { _, new in new }
+            reason: observed == nil ? .readbackUnavailable : .readbackMismatch,
+            extras: baseExtras.merging([
+                "observed": observed as Any? ?? NSNull(),
+                "via": "track_menu"
+            ]) { _, new in new }
         ))
+    }
+
+    private static func raiseTrackWindowForRename(
+        index: Int,
+        runtime: AXLogicProElements.Runtime = .production
+    ) {
+        guard let header = AXLogicProElements.findTrackHeader(at: index, runtime: runtime),
+              let window: AXUIElement = AXHelpers.getAttribute(header, kAXWindowAttribute, runtime: runtime.ax)
+        else {
+            return
+        }
+        _ = AXHelpers.performAction(window, kAXRaiseAction, runtime: runtime.ax)
+        usleep(50_000)
+    }
+
+    private static func selectTrackForRename(
+        index: Int,
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> Bool {
+        let initialHeaders = AXLogicProElements.allTrackHeaders(runtime: runtime)
+        guard index >= 0 && index < initialHeaders.count else { return false }
+        if AXValueExtractors.extractSelectedState(initialHeaders[index], runtime: runtime.ax) == true {
+            return true
+        }
+
+        guard AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime) else {
+            return false
+        }
+
+        var sawSelectionMetadata = false
+        for attempt in 0..<6 {
+            let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+            guard index < headers.count else { return false }
+
+            let selectionStates = headers.map { AXValueExtractors.extractSelectedState($0, runtime: runtime.ax) }
+            if selectionStates.contains(where: { $0 != nil }) {
+                sawSelectionMetadata = true
+            }
+            if selectionStates[index] == true {
+                return true
+            }
+            if attempt < 5 {
+                usleep(100_000)
+            }
+        }
+        return !sawSelectionMetadata
     }
 
     private enum TrackSelectionVerification {
@@ -1519,20 +1634,28 @@ actor AccessibilityChannel: Channel {
         englishMenuName: String = "Track",
         runtime: AXLogicProElements.Runtime = .production
     ) -> ChannelResult {
-        if let item = AXLogicProElements.menuItem(path: [menuName, menuItemTitle], runtime: runtime) {
-            guard AXHelpers.performAction(item, kAXPressAction, runtime: runtime.ax) else {
-                return .error("Failed to click menu item: \(menuItemTitle)")
+        clickTrackMenu([menuItemTitle], menuName: menuName, englishMenuName: englishMenuName, runtime: runtime)
+    }
+
+    private static func clickTrackMenu(
+        _ menuItemTitles: [String],
+        menuName: String = "트랙",
+        englishMenuName: String = "Track",
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ChannelResult {
+        for menuTitle in [menuName, englishMenuName] {
+            for itemTitle in menuItemTitles {
+                guard let item = AXLogicProElements.menuItem(path: [menuTitle, itemTitle], runtime: runtime) else {
+                    continue
+                }
+                guard AXHelpers.performAction(item, kAXPressAction, runtime: runtime.ax) else {
+                    return .error("Failed to click menu item: \(itemTitle)")
+                }
+                return .success("{\"menu_clicked\":\"\(itemTitle)\"}")
             }
-            return .success("{\"menu_clicked\":\"\(menuItemTitle)\"}")
         }
-        // Fallback: English menu names for non-Korean locales
-        if let item = AXLogicProElements.menuItem(path: [englishMenuName, menuItemTitle], runtime: runtime) {
-            guard AXHelpers.performAction(item, kAXPressAction, runtime: runtime.ax) else {
-                return .error("Failed to click menu item: \(menuItemTitle)")
-            }
-            return .success("{\"menu_clicked\":\"\(menuItemTitle)\"}")
-        }
-        return .error("Cannot find menu item: \(menuName) > \(menuItemTitle)")
+        let joinedTitles = menuItemTitles.joined(separator: " | ")
+        return .error("Cannot find menu item: \(menuName) > \(joinedTitles)")
     }
 
     // MARK: - Mixer

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -144,6 +144,15 @@ struct TrackDispatcher {
                 operation: "track.rename",
                 params: ["index": String(index), "name": name]
             )
+            guard result.isSuccess else {
+                return toolTextResult(result.message, isError: true)
+            }
+            if let data = result.message.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let verified = json["verified"] as? Bool,
+               verified == false {
+                return toolTextResult(result.message, isError: true)
+            }
             return toolTextResult(result)
 
         case "mute":

--- a/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
@@ -97,6 +97,32 @@ import Testing
     #expect(AXLogicProElements.findPanKnob(trackIndex: 0, runtime: runtime) == pan)
 }
 
+@Test func testAXLogicProElementsFindTrackNameFieldPrefersTextFieldOverStaticText() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(90)
+    let window = builder.element(91)
+    let trackList = builder.element(92)
+    let header = builder.element(93)
+    let staticName = builder.element(94)
+    let editableName = builder.element(95)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [header])
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setChildren(header, [staticName, editableName])
+    builder.setAttribute(staticName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(staticName, kAXValueAttribute as String, "Old Label")
+    builder.setAttribute(editableName, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    builder.setAttribute(editableName, kAXDescriptionAttribute as String, "Live Name")
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    #expect(AXLogicProElements.findTrackNameField(trackIndex: 0, runtime: runtime) == editableName)
+}
+
 @Test func testAXLogicProElementsResolveMenuItemsAcrossNestedMenus() {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(1)

--- a/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
+++ b/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
@@ -227,6 +227,25 @@ import Testing
     #expect(unknownTrack.color == nil)
 }
 
+@Test func testAXValueExtractorsPreferTrackTextFieldDescriptionOverStaticText() {
+    let builder = FakeAXRuntimeBuilder()
+    let header = builder.element(230)
+    let staticName = builder.element(231)
+    let editableName = builder.element(232)
+
+    builder.setChildren(header, [staticName, editableName])
+    builder.setAttribute(staticName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(staticName, kAXValueAttribute as String, "Old Label")
+    builder.setAttribute(editableName, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    builder.setAttribute(editableName, kAXDescriptionAttribute as String, "Live Label")
+    builder.setAttribute(editableName, kAXValueAttribute as String, 0)
+
+    let runtime = builder.makeAXRuntime()
+    let track = AXValueExtractors.extractTrackState(from: header, index: 0, runtime: runtime)
+
+    #expect(track.name == "Live Label")
+}
+
 @Test func testAXValueExtractorsInfersTrackTypeFromHeaderDescendants() {
     let builder = FakeAXRuntimeBuilder()
     let header = builder.element(240)

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -35,6 +35,8 @@ private final class ControlBarMouseRecorder: @unchecked Sendable {
     var unicodeEvents: [UniChar] = []
     var sleeps: [useconds_t] = []
     var onMouseEvent: ((CGEventType, CGPoint, Int64) -> Void)?
+    var onKeyEvent: ((CGKeyCode) -> Void)?
+    var onUnicodeScalar: ((UniChar) -> Void)?
 
     func runtime() -> AXMouseHelper.Runtime {
         AXMouseHelper.Runtime(
@@ -45,10 +47,12 @@ private final class ControlBarMouseRecorder: @unchecked Sendable {
             },
             postKeyEvent: { keyCode in
                 self.keyEvents.append(keyCode)
+                self.onKeyEvent?(keyCode)
                 return true
             },
             postUnicodeScalar: { scalar in
                 self.unicodeEvents.append(scalar)
+                self.onUnicodeScalar?(scalar)
                 return true
             },
             sleepMicros: { micros in
@@ -56,6 +60,23 @@ private final class ControlBarMouseRecorder: @unchecked Sendable {
             }
         )
     }
+}
+
+private final class TrackRenameSession: @unchecked Sendable {
+    var editing = false
+    var typed = ""
+    var renamePressed = false
+    var selectionCommitted = false
+}
+
+private func makeProcessRuntime(isRunning: Bool = true) -> ProcessUtils.Runtime {
+    ProcessUtils.Runtime(
+        logicProPID: { 4242 },
+        fallbackLogicProPID: { 4242 },
+        logicProRunning: { isRunning },
+        activateLogicPro: { true },
+        logicProBundleURL: { nil }
+    )
 }
 
 private func makeAccessibilityRuntime(
@@ -125,6 +146,13 @@ private func makeAXBackedAccessibilityChannel(
         postUnicodeScalar: { _ in false },
         sleepMicros: { _ in }
     ),
+    trackRenameMouseRuntime: AXMouseHelper.Runtime = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in false },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    ),
+    processRuntime: ProcessUtils.Runtime = makeProcessRuntime(),
     runTempoFallback: @escaping @Sendable (String) -> Bool = { _ in false }
 ) -> AccessibilityChannel {
     let runtime = AccessibilityChannel.Runtime.axBacked(
@@ -132,6 +160,8 @@ private func makeAXBackedAccessibilityChannel(
         isLogicProRunning: { isRunning },
         logicRuntime: logicRuntime ?? builder.makeLogicRuntime(appElement: app),
         controlBarMouseRuntime: controlBarMouseRuntime,
+        trackRenameMouseRuntime: trackRenameMouseRuntime,
+        processRuntime: processRuntime,
         runTempoFallback: runTempoFallback
     )
     return AccessibilityChannel(runtime: runtime)
@@ -991,6 +1021,159 @@ private func makeAXBackedAccessibilityChannel(
     #expect(selectedTrack.isSelected)
 }
 
+@Test func testAccessibilityChannelTrackRenameFallsBackToTrackMenuAndVerifiesTrackName() async {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(560)
+    let window = builder.element(561)
+    let menuBar = builder.element(562)
+    let trackMenu = builder.element(563)
+    let renameItem = builder.element(564)
+    let trackList = builder.element(565)
+    let header = builder.element(566)
+    let nameField = builder.element(567)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [header])
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header, kAXDescriptionAttribute as String, "Track 1 “Deluxe Classic”")
+    builder.setAttribute(header, kAXSelectedAttribute as String, false)
+    builder.setChildren(header, [nameField])
+    builder.setAttribute(nameField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    builder.setAttribute(nameField, kAXDescriptionAttribute as String, "Deluxe Classic")
+    builder.setAttribute(nameField, kAXValueAttribute as String, 0)
+
+    builder.setChildren(menuBar, [trackMenu])
+    builder.setAttribute(trackMenu, kAXTitleAttribute as String, "Track")
+    builder.setChildren(trackMenu, [renameItem])
+    builder.setAttribute(renameItem, kAXTitleAttribute as String, "Rename Track")
+
+    let mouseRecorder = ControlBarMouseRecorder()
+    let session = TrackRenameSession()
+    mouseRecorder.onUnicodeScalar = { scalar in
+        guard session.editing, let unicode = UnicodeScalar(scalar) else { return }
+        session.typed.append(Character(unicode))
+    }
+    mouseRecorder.onKeyEvent = { keyCode in
+        guard session.editing else { return }
+        switch keyCode {
+        case 0x24:
+            builder.setAttribute(nameField, kAXDescriptionAttribute as String, session.typed)
+            builder.setAttribute(header, kAXDescriptionAttribute as String, "Track 1 “\(session.typed)”")
+            session.editing = false
+        default:
+            break
+        }
+    }
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if builder.elementID(element) == builder.elementID(header), action == kAXPressAction as String {
+                builder.setAttribute(header, kAXSelectedAttribute as String, true)
+                session.selectionCommitted = true
+                return true
+            }
+            if builder.elementID(element) == builder.elementID(renameItem), action == kAXPressAction as String {
+                session.renamePressed = true
+                session.editing = true
+                session.typed = ""
+                return true
+            }
+            return true
+        }
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: app,
+        logicRuntime: logicRuntime,
+        trackRenameMouseRuntime: mouseRecorder.runtime()
+    )
+
+    let result = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Track Alpha"])
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["verified"] as? Bool == true)
+    #expect(obj["via"] as? String == "track_menu")
+    #expect(obj["observed"] as? String == "Track Alpha")
+    #expect(builder.attributeValue(nameField, kAXDescriptionAttribute as String) as? String == "Track Alpha")
+    #expect((builder.attributeValue(header, kAXDescriptionAttribute as String) as? String)?.contains("Track Alpha") == true)
+    #expect(session.selectionCommitted)
+    #expect(session.renamePressed)
+    #expect(mouseRecorder.keyEvents.contains(0x24))
+}
+
+@Test func testAccessibilityChannelTrackRenameReturnsReadbackMismatchWhenTrackMenuDoesNotChangeName() async {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(570)
+    let window = builder.element(571)
+    let menuBar = builder.element(572)
+    let trackMenu = builder.element(573)
+    let renameItem = builder.element(574)
+    let trackList = builder.element(575)
+    let header = builder.element(576)
+    let nameField = builder.element(577)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [header])
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header, kAXDescriptionAttribute as String, "Track 1 “Deluxe Classic”")
+    builder.setAttribute(header, kAXSelectedAttribute as String, false)
+    builder.setChildren(header, [nameField])
+    builder.setAttribute(nameField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    builder.setAttribute(nameField, kAXDescriptionAttribute as String, "Deluxe Classic")
+    builder.setAttribute(nameField, kAXValueAttribute as String, 0)
+
+    builder.setChildren(menuBar, [trackMenu])
+    builder.setAttribute(trackMenu, kAXTitleAttribute as String, "Track")
+    builder.setChildren(trackMenu, [renameItem])
+    builder.setAttribute(renameItem, kAXTitleAttribute as String, "Rename Track")
+
+    let mouseRecorder = ControlBarMouseRecorder()
+    let session = TrackRenameSession()
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if builder.elementID(element) == builder.elementID(header), action == kAXPressAction as String {
+                builder.setAttribute(header, kAXSelectedAttribute as String, true)
+                return true
+            }
+            if builder.elementID(element) == builder.elementID(renameItem), action == kAXPressAction as String {
+                session.editing = true
+                return true
+            }
+            return true
+        }
+    )
+    mouseRecorder.onKeyEvent = { keyCode in
+        guard session.editing, keyCode == 0x24 else { return }
+        session.editing = false
+    }
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: app,
+        logicRuntime: logicRuntime,
+        trackRenameMouseRuntime: mouseRecorder.runtime()
+    )
+
+    let result = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Track Beta"])
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["verified"] as? Bool == false)
+    #expect(obj["reason"] as? String == "readback_mismatch")
+    #expect(obj["via"] as? String == "track_menu")
+    #expect(obj["observed"] as? String == "Deluxe Classic")
+}
+
 @Test func testAccessibilityChannelAXBackedTrackSelectFailsWhenVerifiedSelectionSettlesElsewhere() async {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(610)
@@ -1078,10 +1261,10 @@ private func makeAXBackedAccessibilityChannel(
     #expect(!missingMute.isSuccess)
     #expect(missingMute.message.contains("Cannot find Mute button"))
 
-    let missingRenameField = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Lead"])
-    #expect(!missingRenameField.isSuccess)
-    #expect(missingRenameField.message.contains("\"error\":\"element_not_found\""))
-    #expect(missingRenameField.message.contains("name field for track 0 not located"))
+    let missingRenameMenu = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Lead"])
+    #expect(!missingRenameMenu.isSuccess)
+    #expect(missingRenameMenu.message.contains("\"error\":\"element_not_found\""))
+    #expect(missingRenameMenu.message.contains("Track > Rename Track menu item not found"))
 
     let missingRenameParams = await channel.execute(operation: "track.rename", params: ["index": "0"])
     #expect(!missingRenameParams.isSuccess)

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -89,6 +89,29 @@ private actor FailingExecuteChannel: Channel {
     }
 }
 
+private actor FixedResultChannel: Channel {
+    nonisolated let id: ChannelID
+    let result: ChannelResult
+    var executedOps: [(String, [String: String])] = []
+
+    init(id: ChannelID, result: ChannelResult) {
+        self.id = id
+        self.result = result
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        return result
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "fixed result")
+    }
+}
+
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
@@ -865,6 +888,29 @@ private actor FailingExecuteChannel: Channel {
         ("track.set_solo", ["index": "5", "enabled": "true"]),
         ("track.set_arm", ["index": "5", "enabled": "false"]),
     ])
+}
+
+@Test func testTrackDispatcherRenameTreatsStateBAsError() async {
+    let router = ChannelRouter()
+    let ax = FixedResultChannel(
+        id: .accessibility,
+        result: .success("""
+        {"success":true,"verified":false,"reason":"readback_mismatch","track":0,"requested":"Bass","observed":"Deluxe Classic"}
+        """)
+    )
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handle(
+        command: "rename",
+        params: ["index": .int(0), "name": .string("Bass")],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(result.isError == true)
+    #expect(dispatcherText(result).contains("\"verified\":false"))
+    let ops = await ax.executedOps
+    expectExecutedOps(ops, equals: [("track.rename", ["index": "0", "name": "Bass"])])
 }
 
 @Test func testTrackDispatcherDeleteAndDuplicateRespectSelectionFlow() async {


### PR DESCRIPTION
Fixes #34

## Summary
- prefer live track-name metadata from the Logic 12.2 `AXTextField` (`AXDescription` / `AXTitle`) instead of the fake numeric `AXValue`
- keep the direct `AXValue` write attempt, but verify against live track readback instead of trusting the field write
- replace the brittle coordinate double-click rename fallback with a controlled `Track > Rename Track` flow
- raise the owning Tracks window before invoking the menu fallback so the path works even when another Logic window is main
- treat nested `verified:false` rename payloads as outer tool errors in the dispatcher

## Root Cause
On Logic Pro 12.2, the visible track name lives in a non-settable `AXTextField` description, while `AXValue` reports a placeholder `0`. The old rename path assumed `AXValue` writes were authoritative, then fell back to a coordinate double-click inline edit path that was brittle across the live multi-display setup. That left `track.rename` able to report apparent success while the live UI did not actually commit the rename.

## Verification
- `swift test --filter TrackRename`
- `swift test --filter RenameTreatsStateBAsError`
- `swift test --filter FindTrackNameField`
- `swift test --filter PreferTrackTextField`
- `swift test --filter AXBackedTrack`
- `swift build -c release`

## Live Verification
Using `/private/tmp/logic-pro-mcp-issue34/.build/release/LogicProMCP` with full MCP initialize:
- before: track 0 read as `Deluxe Classic`
- rename call to `QA Rename a28c99` returned `verified:true` with `via:"track_menu"`
- immediate `logic://tracks` read showed track 0 renamed to `QA Rename a28c99`
- restore call back to `Deluxe Classic` returned `verified:true` with `via:"track_menu"`
- follow-up `logic://tracks` `ax_live` reads at `2026-06-19T13:49:41Z` and `2026-06-19T13:49:45Z` showed track 0 back to `Deluxe Classic`

## Note
The live Logic session had already been left with track 0 muted from an earlier failed probe before this fix branch was verified. This PR fixes rename behavior only; it does not change mute handling.
