### PR TITLE
Fix Demo QA #37: restore live Logic region readback

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3050,6 +3050,72 @@ actor AccessibilityChannel: Channel {
         init(_ message: String) { self.message = message }
     }
 
+    private static func normalizeRegionGroupDescription(_ description: String) -> String {
+        description
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split { $0.isWhitespace }
+            .joined(separator: " ")
+    }
+
+    private static func isExplicitTrackContentDescription(_ description: String) -> Bool {
+        let normalized = normalizeRegionGroupDescription(description)
+        return normalized == "트랙 콘텐츠"
+            || normalized == "track content"
+            || normalized == "track contents"
+            || normalized == "tracks content"
+            || normalized == "tracks contents"
+    }
+
+    private static func isGenericContentDescription(_ description: String) -> Bool {
+        let normalized = normalizeRegionGroupDescription(description)
+        return normalized == "콘텐츠"
+            || normalized == "content"
+            || normalized == "contents"
+    }
+
+    private static func frame(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> CGRect? {
+        guard let position = AXHelpers.getPosition(element, runtime: runtime),
+              let size = AXHelpers.getSize(element, runtime: runtime) else {
+            return nil
+        }
+        return CGRect(origin: position, size: size)
+    }
+
+    private static func isVisibleArrangeRegion(
+        _ item: AXUIElement,
+        within window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        guard let windowFrame = frame(of: window, runtime: runtime),
+              let itemFrame = frame(of: item, runtime: runtime),
+              !windowFrame.isEmpty,
+              !itemFrame.isEmpty else {
+            return true
+        }
+        return itemFrame.intersects(windowFrame)
+    }
+
+    private static func classifyRegionKind(name: String, help: String) -> String {
+        let searchable = "\(name) \(help)".lowercased()
+        if searchable.contains("drummer")
+            || searchable.contains("session player")
+            || searchable.contains("드러머")
+            || searchable.contains("세션 플레이어") {
+            return "drummer"
+        }
+        if searchable.contains("midi") {
+            return "midi"
+        }
+        if searchable.contains("audio") || searchable.contains("오디오") {
+            return "audio"
+        }
+        return "unknown"
+    }
+
     /// Walk the arrange area's "Track Content" group, collect every
     /// AXLayoutItem region with parsed bar positions and its underlying AX
     /// element handle. Shared across `defaultGetRegions`,
@@ -3064,23 +3130,30 @@ actor AccessibilityChannel: Channel {
             of: window, role: kAXGroupRole, maxDepth: 14, runtime: runtime.ax
         )
         var contentGroup: AXUIElement? = nil
+        var genericContentGroup: AXUIElement? = nil
         var groupDescSamples: [String] = []
         for g in candidates {
             let desc = AXHelpers.getDescription(g, runtime: runtime.ax) ?? ""
             if !desc.isEmpty { groupDescSamples.append(desc) }
-            let lower = desc.lowercased()
-            if desc.contains("트랙 콘텐츠") || desc == "콘텐츠"
-                || lower == "track content" || lower == "content" {
+            if isExplicitTrackContentDescription(desc) {
                 contentGroup = g
                 break
             }
+            if genericContentGroup == nil, isGenericContentDescription(desc) {
+                genericContentGroup = g
+            }
+        }
+        if contentGroup == nil {
+            contentGroup = genericContentGroup
         }
         guard let content = contentGroup else {
             let detailed = groupDescSamples.prefix(20).map { s -> String in
                 let bytes = s.unicodeScalars.map { String(format: "U+%04X", $0.value) }.joined(separator: ",")
                 return "'\(s)'(\(s.unicodeScalars.count)=\(bytes))"
             }.joined(separator: " | ")
-            return .failure(RegionEnumerationError("Track Content group not found (scanned \(candidates.count) AXGroups; samples: \(detailed))"))
+            return .failure(RegionEnumerationError(
+                "Track Content group not found (scanned \(candidates.count) AXGroups; landmarks: \(detailed)). Recovery hint: ensure the Tracks arrange area is visible and not replaced by a modal, editor, or plugin window."
+            ))
         }
 
         let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
@@ -3099,19 +3172,13 @@ actor AccessibilityChannel: Channel {
             let help = AXHelpers.getHelp(item, runtime: runtime.ax) ?? ""
             let isRegion = help.contains("리전") || help.lowercased().contains("region")
             guard isRegion else { nonRegionCount += 1; continue }
+            guard isVisibleArrangeRegion(item, within: window, runtime: runtime.ax) else {
+                continue
+            }
 
             let name = AXHelpers.getDescription(item, runtime: runtime.ax) ?? ""
             let (startBar, endBar) = parseRegionBars(from: help)
-
-            let lower = help.lowercased()
-            let kind: String
-            if help.contains("MIDI") || lower.contains("midi") {
-                kind = "midi"
-            } else if help.contains("오디오") || lower.contains("audio") {
-                kind = "audio"
-            } else {
-                kind = "unknown"
-            }
+            let kind = classifyRegionKind(name: name, help: help)
 
             var trackIndex = -1
             if let pos = AXHelpers.getPosition(item, runtime: runtime.ax),
@@ -3195,10 +3262,10 @@ actor AccessibilityChannel: Channel {
     /// Returns (-1, -1) if neither pattern matches — callers should inspect rawHelp.
     private static func parseRegionBars(from help: String) -> (Int, Int) {
         // Korean: "리전은 1 마디 에서 시작하여 2 마디 에서 끝납니다."
-        // English (guessed, pending real-world sample): "Region starts at bar 1 and ends at bar 2"
+        // English: "Region starts at 128 bars and ends at 129 bars, MIDI region."
         let patterns = [
             #"리전은\s*(\d+)\s*마디.*?시작.*?(\d+)\s*마디.*?끝"#,
-            #"(?i)region\s+starts\s+at\s+bar\s+(\d+).*?ends\s+at\s+bar\s+(\d+)"#,
+            #"(?i)region\s+starts\s+at\s+(?:bar\s+)?(\d+)(?:\s*bars?)?.*?ends\s+at\s+(?:bar\s+)?(\d+)(?:\s*bars?)?"#,
         ]
         for pat in patterns {
             guard let rx = try? NSRegularExpression(pattern: pat, options: [.dotMatchesLineSeparators]) else { continue }

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -184,6 +184,7 @@ struct ProjectDispatcher {
             // verification of record_sequence region placement — without this
             // the only feedback loop was visual screenshots.
             let result = await router.route(operation: "region.get_regions")
+            await refreshRegionCache(from: result, cache: cache)
             return toolTextResult(result)
 
         case "launch":
@@ -239,6 +240,14 @@ struct ProjectDispatcher {
     private static func invalidateOnSuccess(_ result: ChannelResult, cache: StateCache) async {
         guard result.isSuccess else { return }
         await cache.clearProjectState()
+    }
+
+    private static func refreshRegionCache(from result: ChannelResult, cache: StateCache) async {
+        guard result.isSuccess,
+              let regions = try? RegionInfo.decodeToolPayload(result.message) else {
+            return
+        }
+        await cache.updateRegions(regions.map { $0.asRegionState() })
     }
 
     /// H-1 (2026-05-08 enterprise review): audit phases for L1+ project

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -124,7 +124,7 @@ extension ResourceHandlers {
             if remainder.hasSuffix("/regions") {
                 let indexStr = String(remainder.dropLast("/regions".count))
                 if let index = Int(indexStr) {
-                    return try await readTrackRegions(at: index, cache: cache, uri: uri)
+                    return try await readTrackRegions(at: index, cache: cache, router: router, uri: uri)
                 }
             }
             if let index = Int(remainder) {
@@ -754,7 +754,16 @@ extension ResourceHandlers {
         )
     }
 
-    private static func readTrackRegions(at index: Int, cache: StateCache, uri: String) async throws -> ReadResource.Result {
+    private static func readTrackRegions(
+        at index: Int,
+        cache: StateCache,
+        router: ChannelRouter,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        if case .success(let payload) = await router.route(operation: "region.get_regions"),
+           let liveRegions = try? RegionInfo.decodeToolPayload(payload) {
+            await cache.updateRegions(liveRegions.map { $0.asRegionState() })
+        }
         let regions = await cache.getRegions().filter { $0.trackIndex == index }
         let json = encodeJSON(regions)
         return ReadResource.Result(

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -220,6 +220,33 @@ struct RegionInfo: Sendable, Codable {
     var trackIndex: Int
     var startBar: Int
     var endBar: Int
-    var kind: String  // "midi" | "audio" | "unknown"
+    var kind: String  // "midi" | "audio" | "drummer" | "unknown"
     var rawHelp: String?  // raw AXHelp text — preserved for debugging parser misses
+}
+
+private struct RegionToolPayload: Decodable {
+    let regions: [RegionInfo]
+}
+
+extension RegionInfo {
+    static func decodeToolPayload(_ text: String) throws -> [RegionInfo] {
+        if let direct: [RegionInfo] = try? decodeJSON(text) {
+            return direct
+        }
+        let wrapped: RegionToolPayload = try decodeJSON(text)
+        return wrapped.regions
+    }
+
+    func asRegionState() -> RegionState {
+        let safeName = name.isEmpty ? "region" : name
+        let lengthBars = max(0, endBar - startBar)
+        return RegionState(
+            id: "\(trackIndex):\(startBar):\(endBar):\(safeName)",
+            name: safeName,
+            trackIndex: trackIndex,
+            startPosition: "\(startBar) 1 1 1",
+            endPosition: "\(endBar) 1 1 1",
+            length: "\(lengthBars) 0 0 0"
+        )
+    }
 }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -350,6 +350,101 @@ private func makeAXBackedAccessibilityChannel(
     #expect(regions[0].kind == "midi")
 }
 
+@Test func testAccessibilityChannelAXBackedRegionsRecognizeTracksContentsAndFilterOffscreen() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(900)
+    let window = builder.element(901)
+    let headerRail = builder.element(902)
+    let header0 = builder.element(903)
+    let header1 = builder.element(904)
+    let contentGroup = builder.element(905)
+    let visibleMIDI = builder.element(906)
+    let offscreenAudio = builder.element(907)
+    let visibleDrummer = builder.element(908)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [headerRail, contentGroup])
+    builder.setAttribute(window, kAXPositionAttribute as String, axPoint(0, 0))
+    builder.setAttribute(window, kAXSizeAttribute as String, axSize(1_200, 400))
+
+    builder.setAttribute(headerRail, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(headerRail, kAXDescriptionAttribute as String, "Tracks header")
+    builder.setChildren(headerRail, [header0, header1])
+
+    builder.setAttribute(header0, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header0, kAXPositionAttribute as String, axPoint(0, 100))
+    builder.setAttribute(header0, kAXSizeAttribute as String, axSize(200, 40))
+
+    builder.setAttribute(header1, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header1, kAXPositionAttribute as String, axPoint(0, 160))
+    builder.setAttribute(header1, kAXSizeAttribute as String, axSize(200, 40))
+
+    builder.setAttribute(contentGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(contentGroup, kAXDescriptionAttribute as String, "Tracks contents")
+    builder.setChildren(contentGroup, [visibleMIDI, offscreenAudio, visibleDrummer])
+
+    builder.setAttribute(visibleMIDI, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(visibleMIDI, kAXDescriptionAttribute as String, "MIDI Region")
+    builder.setAttribute(visibleMIDI, kAXHelpAttribute as String, "Region starts at 1 bars and ends at 2 bars, MIDI region.")
+    builder.setAttribute(visibleMIDI, kAXPositionAttribute as String, axPoint(240, 108))
+    builder.setAttribute(visibleMIDI, kAXSizeAttribute as String, axSize(320, 24))
+
+    builder.setAttribute(offscreenAudio, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(offscreenAudio, kAXDescriptionAttribute as String, "Audio Region")
+    builder.setAttribute(offscreenAudio, kAXHelpAttribute as String, "Region starts at 33 bars and ends at 34 bars, audio region.")
+    builder.setAttribute(offscreenAudio, kAXPositionAttribute as String, axPoint(2_500, 108))
+    builder.setAttribute(offscreenAudio, kAXSizeAttribute as String, axSize(320, 24))
+
+    builder.setAttribute(visibleDrummer, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(visibleDrummer, kAXDescriptionAttribute as String, "Session Player Region")
+    builder.setAttribute(visibleDrummer, kAXHelpAttribute as String, "Region starts at 9 bars and ends at 13 bars, Session Player region.")
+    builder.setAttribute(visibleDrummer, kAXPositionAttribute as String, axPoint(260, 168))
+    builder.setAttribute(visibleDrummer, kAXSizeAttribute as String, axSize(360, 24))
+
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let result = await channel.execute(operation: "region.get_regions", params: [:])
+
+    #expect(result.isSuccess)
+
+    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    #expect(regions.count == 2)
+    #expect(regions[0].name == "MIDI Region")
+    #expect(regions[0].trackIndex == 0)
+    #expect(regions[0].startBar == 1)
+    #expect(regions[0].endBar == 2)
+    #expect(regions[0].kind == "midi")
+    #expect(regions[1].name == "Session Player Region")
+    #expect(regions[1].trackIndex == 1)
+    #expect(regions[1].startBar == 9)
+    #expect(regions[1].endBar == 13)
+    #expect(regions[1].kind == "drummer")
+}
+
+@Test func testAccessibilityChannelAXBackedRegionsMissingContentGroupIncludesHint() async {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(950)
+    let window = builder.element(951)
+    let headerRail = builder.element(952)
+    let projectGroup = builder.element(953)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [headerRail, projectGroup])
+
+    builder.setAttribute(headerRail, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(headerRail, kAXDescriptionAttribute as String, "Tracks header")
+
+    builder.setAttribute(projectGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(projectGroup, kAXDescriptionAttribute as String, "Project")
+
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let result = await channel.execute(operation: "region.get_regions", params: [:])
+
+    #expect(!result.isSuccess)
+    #expect(result.message.contains("Track Content group not found"))
+    #expect(result.message.contains("Tracks header"))
+    #expect(result.message.contains("Recovery hint"))
+}
+
 @Test func testAccessibilityChannelAXBackedTransportDefaultsUseFakeAXTree() async throws {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(100)

--- a/Tests/LogicProMCPTests/RegionResourceRefreshTests.swift
+++ b/Tests/LogicProMCPTests/RegionResourceRefreshTests.swift
@@ -1,0 +1,132 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private func regionTestAXPoint(_ x: CGFloat, _ y: CGFloat) -> AXValue {
+    var point = CGPoint(x: x, y: y)
+    return AXValueCreate(.cgPoint, &point)!
+}
+
+private func regionTestAXSize(_ width: CGFloat, _ height: CGFloat) -> AXValue {
+    var size = CGSize(width: width, height: height)
+    return AXValueCreate(.cgSize, &size)!
+}
+
+private func makeRegionRefreshChannel(
+    builder: FakeAXRuntimeBuilder,
+    app: AXUIElement
+) -> AccessibilityChannel {
+    let runtime = AccessibilityChannel.Runtime.axBacked(
+        isTrusted: { true },
+        isLogicProRunning: { true },
+        logicRuntime: builder.makeLogicRuntime(appElement: app)
+    )
+    return AccessibilityChannel(runtime: runtime)
+}
+
+private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: AXUIElement) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1_200)
+    let window = builder.element(1_201)
+    let headerRail = builder.element(1_202)
+    let trackHeader = builder.element(1_203)
+    let contentGroup = builder.element(1_204)
+    let region = builder.element(1_205)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [headerRail, contentGroup])
+    builder.setAttribute(window, kAXPositionAttribute as String, regionTestAXPoint(0, 0))
+    builder.setAttribute(window, kAXSizeAttribute as String, regionTestAXSize(1_200, 400))
+
+    builder.setAttribute(headerRail, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(headerRail, kAXDescriptionAttribute as String, "Tracks header")
+    builder.setChildren(headerRail, [trackHeader])
+
+    builder.setAttribute(trackHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(trackHeader, kAXPositionAttribute as String, regionTestAXPoint(0, 100))
+    builder.setAttribute(trackHeader, kAXSizeAttribute as String, regionTestAXSize(200, 40))
+
+    builder.setAttribute(contentGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(contentGroup, kAXDescriptionAttribute as String, "Tracks contents")
+    builder.setChildren(contentGroup, [region])
+
+    builder.setAttribute(region, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(region, kAXDescriptionAttribute as String, "Live Region")
+    builder.setAttribute(region, kAXHelpAttribute as String, "Region starts at 1 bars and ends at 2 bars, MIDI region.")
+    builder.setAttribute(region, kAXPositionAttribute as String, regionTestAXPoint(240, 108))
+    builder.setAttribute(region, kAXSizeAttribute as String, regionTestAXSize(320, 24))
+
+    return (builder, app)
+}
+
+@Test func testProjectGetRegionsRefreshesRegionCache() async throws {
+    let fixture = makeRegionRefreshFixture()
+    let router = ChannelRouter()
+    await router.register(makeRegionRefreshChannel(builder: fixture.builder, app: fixture.app))
+
+    let cache = StateCache()
+    await cache.updateRegions([
+        RegionState(
+            id: "stale",
+            name: "stale region",
+            trackIndex: 0,
+            startPosition: "99 1 1 1",
+            endPosition: "100 1 1 1",
+            length: "1 0 0 0"
+        )
+    ])
+
+    let result = await ProjectDispatcher.handle(
+        command: "get_regions",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let text = sharedToolText(result)
+    let toolRegions = try JSONDecoder().decode([RegionInfo].self, from: Data(text.utf8))
+    #expect(toolRegions.count == 1)
+    #expect(toolRegions[0].name == "Live Region")
+    #expect(toolRegions[0].trackIndex == 0)
+
+    let cached = await cache.getRegions()
+    #expect(cached.count == 1)
+    #expect(cached[0].name == "Live Region")
+    #expect(cached[0].startPosition == "1 1 1 1")
+    #expect(cached[0].endPosition == "2 1 1 1")
+}
+
+@Test func testTrackRegionsResourceRefreshesLiveScanWhenCacheIsStale() async throws {
+    let fixture = makeRegionRefreshFixture()
+    let router = ChannelRouter()
+    await router.register(makeRegionRefreshChannel(builder: fixture.builder, app: fixture.app))
+
+    let cache = StateCache()
+    await cache.updateRegions([
+        RegionState(
+            id: "stale",
+            name: "stale region",
+            trackIndex: 0,
+            startPosition: "99 1 1 1",
+            endPosition: "100 1 1 1",
+            length: "1 0 0 0"
+        )
+    ])
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://tracks/0/regions",
+        cache: cache,
+        router: router
+    )
+
+    let regions = try JSONDecoder().decode([RegionState].self, from: Data(sharedResourceText(result).utf8))
+    #expect(regions.count == 1)
+    #expect(regions[0].name == "Live Region")
+    #expect(regions[0].trackIndex == 0)
+    #expect(regions[0].startPosition == "1 1 1 1")
+
+    let cached = await cache.getRegions()
+    #expect(cached.count == 1)
+    #expect(cached[0].name == "Live Region")
+}


### PR DESCRIPTION
Closes #37.

## Summary
- recognize Logic Pro 12.2's real arrange group labels including `Tracks contents`, improve the missing-group hint, and filter region reads to the visible arrange window
- classify Drummer / Session Player regions explicitly and accept the live English AXHelp phrasing (`starts at 1 bars ... ends at 2 bars`)
- refresh cached `RegionState` data from both `logic_project.get_regions` and `logic://tracks/{index}/regions` so per-track resources no longer stay empty/stale
- add focused tests for the new AX matcher, recovery hint, dispatcher cache refresh, and per-track resource self-refresh

## Verification
- `swift test --filter testAccessibilityChannelAXBackedRegionsRecognizeTracksContentsAndFilterOffscreen`
- `swift test --filter testAccessibilityChannelAXBackedRegionsMissingContentGroupIncludesHint`
- `swift test --filter RegionResourceRefreshTests`
- `swift test --filter ProjectDispatcherTests`
- `swift test --filter AccessibilityChannelTests`
- `swift build -c release`

## Live Logic 12.2 evidence (June 19, 2026)
- Fresh MCP server process: `logic_system.health` reported `logic_pro_running: true`, `logic_pro_version: "12.2"`, `logic_pro_has_document: true`, `logic_pro_has_window: true`, while the initial cache was still empty (`project: ""`, `track_count: 0`).
- Fresh MCP server process, before any `logic_project.get_regions` tool call: `logic://tracks/3/regions` returned one visible MIDI region with `startPosition: "1 1 1 1"`, `endPosition: "2 1 1 1"`; `logic://tracks/4/regions` returned the same for track `4`.
- Same release binary: `logic_project.get_regions` returned two visible regions from the live English UI, on tracks `3` and `4`, each parsed as `startBar: 1`, `endBar: 2`, `kind: "midi"`.
