### PR TITLE
fix: harden transport stop readback

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -364,6 +364,51 @@ def safe_json(text):
     except: return None
 
 
+def transport_envelope(client):
+    return safe_json(resource_text(read_resource(client, "logic://transport/state")))
+
+
+def transport_state(client):
+    envelope = transport_envelope(client)
+    if not isinstance(envelope, dict):
+        return None, None
+    data = envelope.get("data", {})
+    if not isinstance(data, dict) or data.get("has_document") is False:
+        return envelope, None
+    state = data.get("state")
+    if not isinstance(state, dict):
+        return envelope, None
+    return envelope, state
+
+
+def wait_for_transport_state(client, predicate, timeout=5.0, interval=0.2):
+    deadline = time.time() + timeout
+    last_envelope = None
+    last_state = None
+    while time.time() < deadline:
+        last_envelope, last_state = transport_state(client)
+        if predicate(last_envelope, last_state):
+            return last_envelope, last_state
+        time.sleep(interval)
+    return last_envelope, last_state
+
+
+def ui_stop_logic_transport():
+    script = """
+    tell application "Logic Pro" to activate
+    delay 0.1
+    tell application "System Events"
+        key code 49
+    end tell
+    """
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
 def is_library_root_json(value):
     return (
         isinstance(value, dict)
@@ -605,6 +650,84 @@ def main():
     else:
         T("cycle roundtrip (skipped — no project)", "ok", lambda _: True)
     call_tool(client, "logic_transport", "toggle_cycle")  # restore
+
+    def transport_playing_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is True
+        )
+
+    def transport_stopped_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is False
+            and state.get("isRecording") is False
+        )
+
+    stop_live_ready = live_logic_ready and has_document
+    ui_stop_envelope = None
+    ui_stop_state = None
+    mcp_stop_response = None
+    mcp_stop_envelope = None
+    mcp_stop_state = None
+    if stop_live_ready:
+        call_tool(client, "logic_transport", "play")
+        _, playing_state = wait_for_transport_state(client, transport_playing_verified, timeout=5.0)
+        if isinstance(playing_state, dict) and ui_stop_logic_transport():
+            ui_stop_envelope, ui_stop_state = wait_for_transport_state(
+                client, transport_stopped_verified, timeout=5.0
+            )
+
+        call_tool(client, "logic_transport", "play")
+        _, replay_state = wait_for_transport_state(client, transport_playing_verified, timeout=5.0)
+        if isinstance(replay_state, dict):
+            mcp_stop_response = call_tool(client, "logic_transport", "stop")
+            mcp_stop_envelope, mcp_stop_state = wait_for_transport_state(
+                client, transport_stopped_verified, timeout=5.0
+            )
+        call_tool(client, "logic_transport", "stop")
+
+    T_LIVE(
+        "transport readback reflects external UI stop",
+        {"envelope": ui_stop_envelope, "state": ui_stop_state},
+        lambda _: (
+            isinstance(ui_stop_envelope, dict)
+            and ui_stop_envelope.get("unverified") is not True
+            and isinstance(ui_stop_state, dict)
+            and ui_stop_state.get("isPlaying") is False
+            and ui_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "logic_transport.stop returns verified success after live readback",
+        mcp_stop_response,
+        lambda _: (
+            mcp_stop_response is not None
+            and not is_error(mcp_stop_response)
+            and (safe_json(tool_text(mcp_stop_response)) or {}).get("verified") is True
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "transport readback reflects logic_transport.stop immediately",
+        {"envelope": mcp_stop_envelope, "state": mcp_stop_state},
+        lambda _: (
+            isinstance(mcp_stop_envelope, dict)
+            and mcp_stop_envelope.get("unverified") is not True
+            and isinstance(mcp_stop_state, dict)
+            and mcp_stop_state.get("isPlaying") is False
+            and mcp_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
 
     # Transport commands that route to MCU/CoreMIDI
     r = call_tool(client, "logic_transport", "toggle_cycle")

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -34,7 +34,13 @@ actor ChannelRouter {
         // Transport — AX control-bar click primary (works without MCU / MIDI Learn),
         // MCU / CoreMIDI / CGEvent / AppleScript as fallbacks.
         "transport.play":             [.accessibility, .mcu, .coreMIDI, .cgEvent],
-        "transport.stop":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
+        // Stop differs from Play/Record: in live 12.2 sessions the AX Play
+        // checkbox can refuse to clear while playback is active, and MMC /
+        // AppleScript "stop" can still leave transport running. The
+        // spacebar-equivalent CGEvent path proved to be the first reliable
+        // non-AX fallback, so prefer it before MIDI/AppleScript fallbacks and
+        // let the dispatcher's live readback gate decide success.
+        "transport.stop":             [.accessibility, .cgEvent, .mcu, .coreMIDI, .appleScript],
         "transport.record":           [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.pause":            [.coreMIDI, .cgEvent],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -20,8 +20,7 @@ struct TransportDispatcher {
             return toolTextResult(result)
 
         case "stop":
-            let result = await router.route(operation: "transport.stop")
-            return toolTextResult(result)
+            return await verifiedStopResult(router: router, cache: cache)
 
         case "record":
             let result = await router.route(operation: "transport.record")
@@ -164,6 +163,72 @@ struct TransportDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func verifiedStopResult(
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        let writeResult = await router.route(operation: "transport.stop")
+        guard writeResult.isSuccess else {
+            return toolTextResult(writeResult)
+        }
+
+        let liveRefresh = await ResourceHandlers.readLiveTransportState(router: router)
+        guard let liveState = liveRefresh.state else {
+            let cachedState = await cache.getTransport()
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "transport.stop executed, but live transport state could not be refreshed. Focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache.",
+                extras: stopReadbackUnavailableExtras(
+                    cachedState: cachedState,
+                    refreshError: liveRefresh.errorCode
+                )
+            ), isError: true)
+        }
+
+        await cache.updateTransport(liveState)
+        let observedExtras: [String: Any] = [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "ax_transport_state",
+            "observed_isPlaying": liveState.isPlaying,
+            "observed_isRecording": liveState.isRecording,
+            "observed_position": liveState.position,
+            "observed_time_position": liveState.timePosition,
+        ]
+
+        guard liveState.isPlaying == false, liveState.isRecording == false else {
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackMismatch,
+                hint: "transport.stop executed, but live transport state still reports playback or recording",
+                extras: observedExtras.merging(["safe_to_retry": true]) { _, new in new }
+            ), isError: true)
+        }
+
+        return toolTextResult(HonestContract.encodeStateA(extras: observedExtras))
+    }
+
+    private static func stopReadbackUnavailableExtras(
+        cachedState: TransportState,
+        refreshError: String?
+    ) -> [String: Any] {
+        [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "cache_only",
+            "cached_source": cachedState.lastUpdated > .distantPast ? "cache" : "default",
+            "cache_age_sec": cacheAgeExtra(for: cachedState),
+            "refresh_error": refreshError ?? "live_transport_read_failed",
+            "safe_to_retry": true,
+        ]
+    }
+
+    private static func cacheAgeExtra(for state: TransportState) -> Any {
+        guard state.lastUpdated > .distantPast else {
+            return NSNull()
+        }
+        return max(0, Date().timeIntervalSince(state.lastUpdated))
     }
 
     /// Accept "bar.beat.sub.tick" (each positive) or "HH:MM:SS:FF" (with

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -173,7 +173,8 @@ extension ResourceHandlers {
     // MARK: - Individual resource handlers
 
     private static func readTransportState(cache: StateCache, router: ChannelRouter, uri: String) async throws -> ReadResource.Result {
-        if let liveState = await readLiveTransportState(router: router) {
+        let liveRefresh = await readLiveTransportState(router: router)
+        if let liveState = liveRefresh.state {
             await cache.updateTransport(liveState)
         }
 
@@ -188,18 +189,60 @@ extension ResourceHandlers {
         let body = """
             {"state":\(inner),"has_document":\(hasDocument)}
             """
-        let json = wrapWithCacheEnvelope(bodyJSON: body, fetchedAt: state.lastUpdated, axOccluded: axOccluded)
+        let json = wrapWithCacheEnvelope(
+            bodyJSON: body,
+            fetchedAt: state.lastUpdated,
+            axOccluded: axOccluded,
+            extras: transportStateEnvelopeExtras(liveRefresh: liveRefresh, cachedState: state)
+        )
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readLiveTransportState(router: ChannelRouter) async -> TransportState? {
-        guard case .success(let json) = await router.route(operation: "transport.get_state") else {
-            return nil
+    struct LiveTransportStateReadback: Sendable {
+        let state: TransportState?
+        let errorCode: String?
+    }
+
+    /// Live transport refresh shared by the `logic://transport/state`
+    /// resource and post-write dispatcher verification.
+    static func readLiveTransportState(router: ChannelRouter) async -> LiveTransportStateReadback {
+        let result = await router.route(operation: "transport.get_state")
+        guard result.isSuccess else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: HonestContract.stateCErrorCode(result.message) ?? "live_transport_read_failed"
+            )
+        }
+        guard let state = decodeTransportState(result.message) else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: "undecodable_live_transport_state"
+            )
+        }
+        return LiveTransportStateReadback(state: state, errorCode: nil)
+    }
+
+    private static func transportStateEnvelopeExtras(
+        liveRefresh: LiveTransportStateReadback,
+        cachedState: TransportState
+    ) -> [String: Any] {
+        if liveRefresh.state != nil {
+            return ["source": "ax_live"]
         }
 
-        return decodeTransportState(json)
+        let hasCachedState = cachedState.lastUpdated > .distantPast
+        var extras: [String: Any] = [
+            "source": hasCachedState ? "cache" : "default",
+            "unverified": true,
+            "stale": hasCachedState,
+            "recovery_hint": "live transport refresh unavailable; focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache."
+        ]
+        if let errorCode = liveRefresh.errorCode {
+            extras["refresh_error"] = errorCode
+        }
+        return extras
     }
 
     private static func decodeTransportState(_ json: String) -> TransportState? {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -89,12 +89,44 @@ private actor FailingExecuteChannel: Channel {
     }
 }
 
+private actor ScriptedTransportChannel: Channel {
+    nonisolated let id: ChannelID
+    let results: [String: ChannelResult]
+    var executedOps: [String] = []
+
+    init(id: ChannelID, results: [String: ChannelResult]) {
+        self.id = id
+        self.results = results
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        executedOps.append(operation)
+        return results[operation] ?? .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "scripted transport channel")
+    }
+}
+
+private func liveTransportJSON(
+    isPlaying: Bool,
+    isRecording: Bool,
+    position: String = "1.1.1.1"
+) -> String {
+    """
+    {"isPlaying":\(isPlaying),"isRecording":\(isRecording),"isPaused":false,"tempo":120.0,"position":"\(position)","timePosition":"00:00:00.000","sampleRate":44100,"isCycleEnabled":false,"isMetronomeEnabled":false,"lastUpdated":"2026-06-19T02:17:42.000Z"}
+    """
+}
+
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
     let cases: [(command: String, operation: String)] = [
         ("play", "transport.play"),
-        ("stop", "transport.stop"),
         ("record", "transport.record"),
         ("pause", "transport.pause"),
         ("rewind", "transport.rewind"),
@@ -189,6 +221,126 @@ private actor FailingExecuteChannel: Channel {
         ("transport.goto_position", ["position": "00:00:10:12"]),
         ("transport.set_cycle_range", ["start": "4.1.1.1", "end": "12.1.1.1"]),
     ])
+}
+
+@Test func testTransportDispatcherStopPromotesFallbackWriteToVerifiedReadback() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .error(HonestContract.encodeStateC(
+            error: .readbackMismatch,
+            hint: "play checkbox did not clear on first AX attempt"
+        )),
+        "transport.get_state": .success(liveTransportJSON(
+            isPlaying: false,
+            isRecording: false,
+            position: "9.1.1.1"
+        )),
+    ])
+    let mcu = ScriptedTransportChannel(id: .mcu, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["function": "transport", "command": "stop"]
+        )),
+    ])
+    await router.register(ax)
+    await router.register(mcu)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == false)
+    #expect(json["verified"] as? Bool == true)
+    #expect(json["verify_source"] as? String == "ax_transport_state")
+    #expect(json["observed_isPlaying"] as? Bool == false)
+    #expect(json["observed_isRecording"] as? Bool == false)
+    #expect(json["observed_position"] as? String == "9.1.1.1")
+    #expect(await ax.executedOps == ["transport.stop", "transport.get_state"])
+    #expect(await mcu.executedOps == ["transport.stop"])
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == false)
+    #expect(cached.isRecording == false)
+    #expect(cached.position == "9.1.1.1")
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveReadbackUnavailable() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "Cannot locate transport bar"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+    await cache.updateTransport(TransportState(
+        isPlaying: true,
+        isRecording: true,
+        position: "96.1.1.1",
+        lastUpdated: Date(timeIntervalSinceNow: -18)
+    ))
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_unavailable")
+    #expect(json["refresh_error"] as? String == "element_not_found")
+    #expect(json["cached_source"] as? String == "cache")
+    #expect((json["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect((json["hint"] as? String)?.contains("refresh_cache") == true)
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveStateStillReportsPlayback() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .success(liveTransportJSON(
+            isPlaying: true,
+            isRecording: true,
+            position: "96.1.1.1"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_mismatch")
+    #expect(json["observed_isPlaying"] as? Bool == true)
+    #expect(json["observed_isRecording"] as? Bool == true)
+    #expect(json["observed_position"] as? String == "96.1.1.1")
+    #expect(json["safe_to_retry"] as? Bool == true)
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == true)
+    #expect(cached.isRecording == true)
+    #expect(cached.position == "96.1.1.1")
 }
 
 @Test func testTransportDispatcherRejectsMissingSemanticPayloads() async {

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -61,6 +61,29 @@ private actor LiveTransportStateChannel: Channel {
     }
 }
 
+private actor FailingTransportStateChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private let errorMessage: String
+
+    init(errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        if operation == "transport.get_state" {
+            return .error(errorMessage)
+        }
+        return .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "failing transport test channel")
+    }
+}
+
 private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     var json = try sharedParseJSON(text) as! [String: Any]
 
@@ -155,6 +178,7 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     let state = json["state"] as! [String: Any]
 
     #expect(await channel.executedOperations() == ["transport.get_state"])
+    #expect(envelope["source"] as? String == "ax_live")
     #expect(state["isPlaying"] as? Bool == false)
     #expect(state["tempo"] as? Double == 90.5)
     #expect(state["isCycleEnabled"] as? Bool == true)
@@ -162,6 +186,39 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     #expect(cached.isPlaying == false)
     #expect(cached.tempo == 90.5)
     #expect(cached.isCycleEnabled == true)
+}
+
+@Test func testTransportStateResourceMarksCachedFallbackAsUnverifiedWhenLiveRefreshFails() async {
+    let cache = StateCache()
+    var staleTransport = TransportState()
+    staleTransport.isPlaying = true
+    staleTransport.isRecording = true
+    staleTransport.position = "96.1.1.1"
+    staleTransport.lastUpdated = Date(timeIntervalSinceNow: -42)
+    await cache.updateTransport(staleTransport)
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let channel = FailingTransportStateChannel(errorMessage: HonestContract.encodeStateC(
+        error: .elementNotFound,
+        hint: "Cannot locate transport bar"
+    ))
+    await router.register(channel)
+
+    let result = try! await ResourceHandlers.read(uri: "logic://transport/state", cache: cache, router: router)
+    let envelope = try! sharedParseJSON(resourceText(result)) as! [String: Any]
+    let json = envelope["data"] as! [String: Any]
+    let state = json["state"] as! [String: Any]
+
+    #expect(envelope["source"] as? String == "cache")
+    #expect(envelope["unverified"] as? Bool == true)
+    #expect(envelope["stale"] as? Bool == true)
+    #expect(envelope["refresh_error"] as? String == "element_not_found")
+    #expect((envelope["recovery_hint"] as? String)?.contains("refresh_cache") == true)
+    #expect((envelope["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect(state["isPlaying"] as? Bool == true)
+    #expect(state["isRecording"] as? Bool == true)
+    #expect(state["position"] as? String == "96.1.1.1")
 }
 
 @Test func testTransportStateResourceSignalsStaleAfterClose() async {


### PR DESCRIPTION
## Summary
- verify `logic_transport.stop` against a fresh live `transport.get_state` readback and fail closed on stale or mismatched post-stop state
- mark `logic://transport/state` cache fallback explicitly with `source`, `unverified`, `stale`, `refresh_error`, and `recovery_hint`
- prefer the UI-equivalent CGEvent stop fallback after AX and add live harness coverage for external UI stop plus immediate MCP stop readback

## Testing
- `swift test --filter TransportDispatcher`
- `swift test --filter TransportStateResource`
- `swift test --filter testRouterTransportFallsBackToAppleScript`
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift build -c release`

## Live verification (Logic Pro 12.2)
- `logic_system.health` reported `logic_pro_running:true`, `logic_pro_has_document:true`, and `logic_pro_has_window:true`
- After `logic_transport.play`, an external UI stop refreshed `logic://transport/state` from `source:"ax_live"` with `isPlaying:false` and `isRecording:false`
- `logic_transport.stop` returned State A with live readback:
  - `{"success":true,"verified":true,"verify_source":"ax_transport_state","observed_isPlaying":false,"observed_isRecording":false,"observed_position":"128.2.1.1"}`
- Immediate `logic://transport/state` after MCP stop returned `source:"ax_live"` with `isPlaying:false` and `isRecording:false`
- Pre-fix live repro: AX stop failed to clear the Play checkbox, CoreMIDI claimed success, and live readback still showed `isPlaying:true` at `128.2.1.1`; this branch now prefers the UI-equivalent CGEvent stop before MIDI fallbacks

Closes #56
