### PR TITLE
Fail closed on unverifiable cycle range

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -364,6 +364,32 @@ def safe_json(text):
     except: return None
 
 
+def cycle_range_result_ok(resp):
+    env = safe_json(tool_text(resp))
+    if not isinstance(env, dict):
+        return False
+    if env.get("success") is True:
+        requested = env.get("requested")
+        observed = env.get("observed")
+        return (
+            env.get("verified") is True
+            and isinstance(requested, dict)
+            and isinstance(observed, dict)
+            and requested.get("start") == observed.get("start")
+            and requested.get("end") == observed.get("end")
+        )
+    if env.get("success") is False:
+        return (
+            env.get("error") in ("not_implemented", "readback_unavailable")
+            and env.get("error") != "channels_exhausted"
+            and isinstance(env.get("requested"), dict)
+            and isinstance(env.get("observed"), dict)
+            and env.get("method") is not None
+            and isinstance(env.get("scanned_landmarks"), dict)
+        )
+    return False
+
+
 def is_library_root_json(value):
     return (
         isinstance(value, dict)
@@ -634,7 +660,7 @@ def main():
 
     # Set cycle range
     r = call_tool(client, "logic_transport", "set_cycle_range", {"start": 1, "end": 4})
-    T("transport.set_cycle_range dispatches", r, lambda _: len(tool_text(r)) > 0)
+    T("transport.set_cycle_range is verified or returns structured blocked state", r, cycle_range_result_ok)
 
     # ═══════════════════════════════════════════════════════════════
     # §4 Track Live Operations (25 tests)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -765,11 +765,16 @@ actor AccessibilityChannel: Channel {
         runFallback: @escaping @Sendable (String, String) -> Bool = runCycleRangeFallbackScript
     ) -> ChannelResult {
         guard let startStr = params["start"], let endStr = params["end"] else {
-            return .error("Missing 'start' and/or 'end' parameters")
+            return .error(HonestContract.encodeStateC(
+                error: .invalidParams,
+                hint: "set_cycle_range requires explicit 'start' and 'end'",
+                extras: ["operation": "transport.set_cycle_range"]
+            ))
         }
         // Normalise input: accept plain bar int ("5") or full bar/beat string ("5.1.1.1").
         let startPos = startStr.contains(".") ? startStr : "\(startStr).1.1.1"
         let endPos = endStr.contains(".") ? endStr : "\(endStr).1.1.1"
+        let requested = cycleRangeRequested(start: startPos, end: endPos)
 
         // AX path: locate cycle locator text fields in the transport bar.
         // Logic Pro exposes two text fields whose descriptions contain
@@ -810,10 +815,12 @@ actor AccessibilityChannel: Channel {
                 // matches the osascript fallback: both paths emit
                 // `{start, end, via, verified, requested, observed}`.
                 let extras: [String: Any] = [
+                    "operation": "transport.set_cycle_range",
                     "start": startPos,
                     "end": endPos,
                     "via": "ax",
-                    "requested": ["start": startPos, "end": endPos]
+                    "method": "ax_cycle_locator_text_fields",
+                    "requested": requested
                 ]
                 if !sSet || !eSet {
                     // v3.1.0 (Ralph-2 / M-1) — State C must route through
@@ -850,35 +857,152 @@ actor AccessibilityChannel: Channel {
                     reason: .readbackMismatch, extras: merged
                 ))
             }
-        }
 
-        // Fallback: osascript using Logic's "Go To Position" dialog combined with
-        // "Set Cycle Locators by Selection" isn't reliable without a region.
-        // Use direct keystroke into the transport cycle display fields via
-        // `click at` on the transport strip. Success is reported as unverified
-        // because Logic's cycle locator state isn't readable via the cached
-        // transport snapshot (cycle bar positions aren't in the state schema).
-        if runFallback(startPos, endPos) {
-            // v3.1.0 (T5) — osascript path stays unverified (no read-back).
-            // Re-encode via HonestContract so the envelope matches the AX
-            // path: `verified:false + reason:"readback_unavailable"`.
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackUnavailable,
+            let transportLandmarks = cycleRangeLandmarks(
+                runtime: runtime,
+                transport: transport,
+                textFields: texts
+            )
+            if runFallback(startPos, endPos) {
+                return .error(HonestContract.encodeStateC(
+                    error: .readbackUnavailable,
+                    hint: "set_cycle_range could drive Logic's 'Set Locators' dialog fallback, but this build exposes no deterministic numeric locator readback; refusing to claim success without observed start/end locators",
+                    extras: [
+                        "operation": "transport.set_cycle_range",
+                        "method": "osascript_set_locators_dialog",
+                        "attempted_methods": ["ax_cycle_locator_text_fields", "osascript_set_locators_dialog"],
+                        "requested": requested,
+                        "observed": cycleRangeObserved(start: nil, end: nil),
+                        "write_attempted": true,
+                        "safe_to_retry": false,
+                        "what_was_attempted": "locate numeric cycle locator AX text fields, then drive Logic's 'Set Locators' dialog as a fallback",
+                        "what_was_observed": "Logic exposes no cycle start/end AX text fields in the transport bar, so the fallback write could not be independently read back",
+                        "scanned_landmarks": transportLandmarks,
+                        "recovery_hint": "Set the cycle range manually in Logic or select a region and use Logic's 'Set Locators by Selection' command before bounce/export."
+                    ]
+                ))
+            }
+
+            return .error(HonestContract.encodeStateC(
+                error: .notImplemented,
+                hint: "set_cycle_range could not find numeric cycle locator fields and could not complete the 'Set Locators' dialog fallback. This Logic build/session does not expose a verifiable numeric cycle locator automation path.",
                 extras: [
-                    "start": startPos,
-                    "end": endPos,
-                    "via": "osascript",
-                    "requested": ["start": startPos, "end": endPos],
-                    "observed": NSNull()
+                    "operation": "transport.set_cycle_range",
+                    "method": "ax_cycle_locator_text_fields",
+                    "attempted_methods": ["ax_cycle_locator_text_fields", "osascript_set_locators_dialog"],
+                    "requested": requested,
+                    "observed": cycleRangeObserved(start: nil, end: nil),
+                    "write_attempted": false,
+                    "safe_to_retry": false,
+                    "what_was_attempted": "locate numeric cycle locator AX text fields, then open Logic's 'Set Locators' dialog as a fallback",
+                    "what_was_observed": "Logic exposes no cycle start/end AX text fields in the transport bar and the fallback dialog could not be completed",
+                    "scanned_landmarks": transportLandmarks,
+                    "recovery_hint": "Set the cycle range manually in Logic or select a region and use Logic's 'Set Locators by Selection' command before bounce/export."
                 ]
             ))
         }
-        return .error(
-            "set_cycle_range: Logic's cycle locators aren't exposed as AX text fields in this build (tried ko/en locales). " +
-            "Workarounds: (1) select the region covering the desired cycle and use Navigate > '선택 범위로 로케이터 설정 및 사이클 활성화'. " +
-            "(2) Drag the upper ruler to set locators manually. " +
-            "The MCP server cannot currently set numeric cycle locators programmatically."
+
+        let missingTransportLandmarks = cycleRangeLandmarks(runtime: runtime)
+        if runFallback(startPos, endPos) {
+            // Fail closed when the fallback may have written but we still have
+            // no observed numeric locator readback surface.
+            return .error(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "set_cycle_range could drive Logic's 'Set Locators' dialog fallback, but no transport bar was locatable for independent numeric locator readback",
+                extras: [
+                    "operation": "transport.set_cycle_range",
+                    "method": "osascript_set_locators_dialog",
+                    "attempted_methods": ["ax_cycle_locator_text_fields", "osascript_set_locators_dialog"],
+                    "requested": requested,
+                    "observed": cycleRangeObserved(start: nil, end: nil),
+                    "write_attempted": true,
+                    "safe_to_retry": false,
+                    "what_was_attempted": "find the transport bar, then drive Logic's 'Set Locators' dialog as a fallback",
+                    "what_was_observed": "no transport bar was locatable for AX readback, so the fallback write could not be independently verified",
+                    "scanned_landmarks": missingTransportLandmarks,
+                    "recovery_hint": "Bring the arrange window to the front and set the cycle range manually before bounce/export."
+                ]
+            ))
+        }
+        return .error(HonestContract.encodeStateC(
+            error: .notImplemented,
+            hint: "set_cycle_range could not locate Logic's transport bar or a verifiable numeric cycle locator surface. The MCP server cannot currently set numeric cycle locators programmatically in this UI state.",
+            extras: [
+                "operation": "transport.set_cycle_range",
+                "method": "ax_cycle_locator_text_fields",
+                "attempted_methods": ["ax_cycle_locator_text_fields", "osascript_set_locators_dialog"],
+                "requested": requested,
+                "observed": cycleRangeObserved(start: nil, end: nil),
+                "write_attempted": false,
+                "safe_to_retry": false,
+                "what_was_attempted": "find Logic's transport bar and numeric cycle locator fields",
+                "what_was_observed": "no transport bar was locatable and the fallback dialog path could not be completed",
+                "scanned_landmarks": missingTransportLandmarks,
+                "recovery_hint": "Bring the arrange window to the front and set the cycle range manually before bounce/export."
+            ]
+        ))
+    }
+
+    private static func cycleRangeRequested(start: String, end: String) -> [String: Any] {
+        ["start": start, "end": end]
+    }
+
+    private static func cycleRangeObserved(start: String?, end: String?) -> [String: Any] {
+        ["start": start ?? NSNull(), "end": end ?? NSNull()]
+    }
+
+    private static func cycleRangeLandmarks(
+        runtime: AXLogicProElements.Runtime,
+        transport: AXUIElement? = nil,
+        textFields: [AXUIElement]? = nil
+    ) -> [String: Any] {
+        let window = AXLogicProElements.mainWindow(runtime: runtime)
+        let resolvedTransport = transport ?? AXLogicProElements.getTransportBar(runtime: runtime)
+        let resolvedTextFields: [AXUIElement]
+        if let textFields {
+            resolvedTextFields = textFields
+        } else if let resolvedTransport {
+            resolvedTextFields = AXHelpers.findAllDescendants(
+                of: resolvedTransport,
+                role: kAXTextFieldRole,
+                maxDepth: 6,
+                runtime: runtime.ax
+            )
+        } else {
+            resolvedTextFields = []
+        }
+
+        let textFieldSnapshots: [[String: Any]] = Array(resolvedTextFields.prefix(6)).map { field in
+            let value: String? = AXHelpers.getAttribute(field, kAXValueAttribute, runtime: runtime.ax)
+            return [
+                "role": AXHelpers.getRole(field, runtime: runtime.ax) ?? NSNull(),
+                "title": AXHelpers.getTitle(field, runtime: runtime.ax) ?? NSNull(),
+                "description": AXHelpers.getDescription(field, runtime: runtime.ax) ?? NSNull(),
+                "identifier": AXHelpers.getIdentifier(field, runtime: runtime.ax) ?? NSNull(),
+                "value": value ?? NSNull(),
+            ]
+        }
+
+        let cycleCheckbox = AXLogicProElements.findControlBarCheckbox(
+            named: "사이클",
+            englishName: "Cycle",
+            runtime: runtime
         )
+
+        return [
+            "main_window_found": window != nil,
+            "main_window_title": window.flatMap { AXHelpers.getTitle($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_bar_found": resolvedTransport != nil,
+            "transport_role": resolvedTransport.flatMap { AXHelpers.getRole($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_title": resolvedTransport.flatMap { AXHelpers.getTitle($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_description": resolvedTransport.flatMap { AXHelpers.getDescription($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_identifier": resolvedTransport.flatMap { AXHelpers.getIdentifier($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_child_count": resolvedTransport.flatMap { AXHelpers.getChildCount($0, runtime: runtime.ax) } ?? NSNull(),
+            "transport_text_field_count": resolvedTextFields.count,
+            "transport_text_fields": textFieldSnapshots,
+            "cycle_checkbox_found": cycleCheckbox != nil,
+            "cycle_checkbox_value": cycleCheckbox.flatMap { AXHelpers.getValue($0, runtime: runtime.ax) } ?? NSNull(),
+        ]
     }
 
     private static func runCycleRangeFallbackScript(startPos: String, endPos: String) -> Bool {

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -425,17 +425,20 @@ private func makeAXBackedAccessibilityChannel(
 
     let cycleMissing = await channel.execute(operation: "transport.set_cycle_range", params: [:])
     #expect(!cycleMissing.isSuccess)
-    #expect(cycleMissing.message.contains("Missing 'start'"))
+    #expect(cycleMissing.message.contains("\"error\":\"invalid_params\""))
 
     let cycleUnsupported = await channel.execute(
         operation: "transport.set_cycle_range",
         params: ["start": "1.1.1.1", "end": "9.1.1.1"]
     )
     // With the fake AX tree (no transport bar cycle fields) and osascript
-    // fallback unavailable in unit tests, the handler now returns a descriptive
-    // "locator fields not found" error rather than "not yet implemented".
+    // fallback unavailable in unit tests, the handler must fail closed with a
+    // specific structured envelope rather than a free-form string.
     #expect(!cycleUnsupported.isSuccess)
-    #expect(cycleUnsupported.message.contains("Cycle range") || cycleUnsupported.message.contains("locator"))
+    #expect(cycleUnsupported.message.contains("\"error\":\"not_implemented\""))
+    #expect(cycleUnsupported.message.contains("\"requested\""))
+    #expect(cycleUnsupported.message.contains("\"observed\""))
+    #expect(cycleUnsupported.message.contains("\"scanned_landmarks\""))
 }
 
 @Test func testAccessibilityChannelTransportStatePrefersLiveControlBarOverStaleTransportGroup() async throws {

--- a/Tests/LogicProMCPTests/HonestContractOpTests.swift
+++ b/Tests/LogicProMCPTests/HonestContractOpTests.swift
@@ -133,8 +133,9 @@ private func decodeJSON(_ s: String) -> [String: Any] {
 // MARK: - T5 set_cycle_range
 //
 // AX-path read-back is exercised through `defaultSetCycleRange`. When the
-// transport bar isn't wired we hit the fallback; when read-back fields are
-// absent we return State B `readback_unavailable`.
+// transport bar doesn't expose numeric locator fields we must fail closed with
+// a structured State C payload instead of letting the router wrap a free-form
+// string in `channels_exhausted`.
 
 @Test func testSetCycleRangeReturnsErrorWhenNoTransportFields() {
     let builder = FakeAXRuntimeBuilder()
@@ -149,10 +150,19 @@ private func decodeJSON(_ s: String) -> [String: Any] {
         runtime: runtime,
         runFallback: { _, _ in false }
     )
-    #expect(!res.isSuccess, "No transport bar + no fallback → hard error")
+    #expect(!res.isSuccess, "No transport bar + no fallback → structured State C")
+    let obj = decodeJSON(res.message)
+    #expect(obj["success"] as? Bool == false)
+    #expect(obj["error"] as? String == "not_implemented")
+    #expect(obj["operation"] as? String == "transport.set_cycle_range")
+    #expect(obj["method"] as? String == "ax_cycle_locator_text_fields")
+    #expect(obj["requested"] as? [String: Any] != nil)
+    #expect(obj["observed"] as? [String: Any] != nil)
+    #expect(obj["scanned_landmarks"] as? [String: Any] != nil)
+    #expect(obj["safe_to_retry"] as? Bool == false)
 }
 
-@Test func testSetCycleRangeOsascriptFallbackReturnsStateB() {
+@Test func testSetCycleRangeOsascriptFallbackFailsClosedWithoutReadback() {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(750)
     let window = builder.element(751)
@@ -165,12 +175,13 @@ private func decodeJSON(_ s: String) -> [String: Any] {
         runtime: runtime,
         runFallback: { _, _ in true }
     )
-    #expect(res.isSuccess)
+    #expect(!res.isSuccess)
     let obj = decodeJSON(res.message)
-    #expect(obj["success"] as? Bool == true)
-    #expect(obj["verified"] as? Bool == false)
-    #expect(obj["reason"] as? String == "readback_unavailable")
-    #expect(obj["via"] as? String == "osascript")
+    #expect(obj["success"] as? Bool == false)
+    #expect(obj["error"] as? String == "readback_unavailable")
+    #expect(obj["method"] as? String == "osascript_set_locators_dialog")
+    #expect(obj["write_attempted"] as? Bool == true)
+    #expect(obj["observed"] as? [String: Any] != nil)
 }
 
 // MARK: - T-3 (v3.1.1): track.rename — HC envelope


### PR DESCRIPTION
Fixes #51.

## Summary
- replace the raw `set_cycle_range` AX failure string with structured Honest Contract State C envelopes
- fail closed when Logic 12.2 exposes no numeric cycle locator AX fields or when the AppleScript fallback cannot be independently read back
- attach requested/observed payloads, attempted method info, and scanned UI landmarks so callers can branch before bounce/export
- tighten unit coverage for the missing-field and fallback-without-readback cases
- update the live E2E harness to require either verified locator readback or the new structured blocked state

## Verification
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift test --filter SetCycleRange`
- `swift test --filter 'testAccessibilityChannelAXBackedTransportDefaultsUseFakeAXTree|testAccessibilityChannelAXBackedTransportErrorPaths'`
- `swift build -c release`

## Live Evidence
On June 19, 2026, against Logic Pro 12.2 in the current arrange session:

`logic_system.health` reported:
- `logic_pro_running: true`
- `logic_pro_version: "12.2"`
- `logic_pro_has_document: true`
- `logic_pro_has_window: true`

`logic_transport.set_cycle_range {start:1,end:4}` now returns a structured blocked state instead of `channels_exhausted`:

```json
{
  "success": false,
  "error": "not_implemented",
  "method": "ax_cycle_locator_text_fields",
  "requested": {"start": "1.1.1.1", "end": "4.1.1.1"},
  "observed": {"start": null, "end": null},
  "safe_to_retry": false,
  "scanned_landmarks": {
    "main_window_title": "Untitled 3 - Tracks",
    "transport_bar_found": true,
    "transport_description": "Control Bar",
    "transport_text_field_count": 0,
    "cycle_checkbox_found": true
  }
}
```
