### PR TITLE
Fix hidden-mixer plugin inventory readback

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -364,6 +364,18 @@ def safe_json(text):
     except: return None
 
 
+def plugin_inventory_result_ok(resp):
+    env = safe_json(tool_text(resp))
+    return (
+        isinstance(env, dict)
+        and env.get("success") is True
+        and env.get("verified") is True
+        and env.get("operation") == "logic_plugins.get_inventory"
+        and env.get("plugins_source") == "ax"
+        and isinstance(env.get("plugins"), list)
+    )
+
+
 def is_library_root_json(value):
     return (
         isinstance(value, dict)
@@ -788,6 +800,15 @@ def main():
     # B1 (#11): provenance — data_source present on the new build's envelope.
     T("logic://mixer carries data_source provenance (B1/#11)", r,
       lambda _: "data_source" in mix_text or "No Logic Pro document is open" in response_dump(r))
+
+    r = call_tool(client, "logic_plugins", "get_inventory", {"track": 0})
+    T_LIVE(
+        "logic_plugins.get_inventory(track=0) returns verified visible-mixer inventory",
+        r,
+        plugin_inventory_result_ok,
+        live_logic_ready,
+        "Logic Pro + Accessibility are required",
+    )
 
     # Volume range testing
     for vol in [0.0, 0.25, 0.5, 0.75, 1.0]:

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -25,6 +25,35 @@ extension AccessibilityChannel {
 
     // MARK: - get_inventory (R3, AC2/AC12/AC22)
 
+    struct MixerRevealResult: Sendable {
+        let attempted: Bool
+        let alreadyVisible: Bool
+        let strategies: [String]
+        let menuItemFound: Bool
+        let menuClicked: Bool
+        let keySent: Bool
+        let mixerVisible: Bool
+
+        static let alreadyVisible = MixerRevealResult(
+            attempted: false,
+            alreadyVisible: true,
+            strategies: [],
+            menuItemFound: false,
+            menuClicked: false,
+            keySent: false,
+            mixerVisible: true
+        )
+    }
+
+    typealias MixerRevealAction = @Sendable (
+        _ runtime: AXLogicProElements.Runtime
+    ) async -> (mixer: AXUIElement?, result: MixerRevealResult)
+
+    private static let showMixerMenuCandidates: [(bar: String, item: String)] = [
+        ("View", "Show Mixer"),
+        ("보기", "믹서 보기"),
+    ]
+
     /// Build the `plugins[]` array for one strip from its drift-safe slot
     /// enumeration. Pure + deterministic so it can be unit-tested against a
     /// strip element without a full mixer fixture.
@@ -74,8 +103,9 @@ extension AccessibilityChannel {
     /// at all (AC2).
     static func defaultGetPluginInventory(
         params: [String: String],
-        runtime: AXLogicProElements.Runtime = .production
-    ) -> ChannelResult {
+        runtime: AXLogicProElements.Runtime = .production,
+        revealMixer: MixerRevealAction = ensureMixerAreaVisibleForInventory
+    ) async -> ChannelResult {
         let operation = "logic_plugins.get_inventory"
         guard let trackRaw = params["track"] ?? params["track_index"] ?? params["index"],
               let track = Int(trackRaw), track >= 0 else {
@@ -95,7 +125,9 @@ extension AccessibilityChannel {
         // The AX insert subtree is unreadable when the mixer or the requested
         // strip cannot be located — there is nothing to enumerate, so this is
         // State B `readback_unavailable` rather than a fabricated empty chain.
-        guard let mixer = AXLogicProElements.getMixerArea(runtime: runtime) else {
+        let ensuredMixer = await revealMixer(runtime)
+        let reveal = ensuredMixer.result
+        guard let mixer = ensuredMixer.mixer else {
             return .success(HonestContract.encodeV2StateB(
                 reason: .readbackUnavailable,
                 extras: [
@@ -103,9 +135,19 @@ extension AccessibilityChannel {
                     "track": track,
                     "plugins_source": "ax",
                     "plugins_fetched_at": fetchedAt,
-                    "plugins_unknown_reason": "ax_subtree_unreadable",
-                    "what_was_attempted": "read insert chain inventory for track \(track)",
-                    "what_was_observed": "mixer area was not locatable in the AX tree",
+                    "plugins_unknown_reason": "mixer_not_visible",
+                    "mixer_reveal_attempted": reveal.attempted,
+                    "mixer_reveal_strategies": reveal.strategies,
+                    "mixer_reveal_menu_item_found": reveal.menuItemFound,
+                    "mixer_reveal_menu_clicked": reveal.menuClicked,
+                    "mixer_reveal_key_sent": reveal.keySent,
+                    "what_was_attempted": reveal.attempted
+                        ? "reveal the mixer, then read insert chain inventory for track \(track)"
+                        : "read insert chain inventory for track \(track)",
+                    "what_was_observed": reveal.attempted
+                        ? "the mixer remained hidden after the reveal attempt, so the insert subtree could not be read"
+                        : "mixer area was not locatable in the AX tree",
+                    "recovery_hint": "Open View > Show Mixer in Logic Pro and retry the inventory read.",
                     "safe_to_retry": true,
                 ]
             ))
@@ -136,9 +178,94 @@ extension AccessibilityChannel {
             "plugins_source": "ax",
             "plugins_fetched_at": fetchedAt,
             "plugins_unknown_reason": NSNull(),
+            "mixer_reveal_attempted": reveal.attempted,
+            "mixer_reveal_strategies": reveal.strategies,
             "complete": built.complete,
             "plugins": built.items,
         ]))
+    }
+
+    private static func ensureMixerAreaVisibleForInventory(
+        runtime: AXLogicProElements.Runtime
+    ) async -> (mixer: AXUIElement?, result: MixerRevealResult) {
+        if let mixer = AXLogicProElements.getMixerArea(runtime: runtime) {
+            return (mixer, .alreadyVisible)
+        }
+
+        var strategies: [String] = []
+        _ = ProcessUtils.Runtime.production.activateLogicPro()
+
+        let menuAttempt = await clickTopLevelMenuItemViaAXMenuClick(
+            candidates: showMixerMenuCandidates,
+            runtime: runtime,
+            maxEnabledRetries: 1,
+            focusBetweenAttempts: false
+        )
+        if menuAttempt.clicked {
+            strategies.append("ax_menu_view_show_mixer")
+            if let mixer = await pollMixerAreaVisible(runtime: runtime, timeoutMs: 1_500) {
+                return (
+                    mixer,
+                    MixerRevealResult(
+                        attempted: true,
+                        alreadyVisible: false,
+                        strategies: strategies,
+                        menuItemFound: menuAttempt.itemFound,
+                        menuClicked: true,
+                        keySent: false,
+                        mixerVisible: true
+                    )
+                )
+            }
+        }
+
+        var keySent = false
+        if let pid = runtime.logicProPID(),
+           CGEventChannel.Runtime.production.postKeyEvent(7, [], pid) {
+            keySent = true
+            strategies.append("cgevent_x")
+            if let mixer = await pollMixerAreaVisible(runtime: runtime, timeoutMs: 1_500) {
+                return (
+                    mixer,
+                    MixerRevealResult(
+                        attempted: true,
+                        alreadyVisible: false,
+                        strategies: strategies,
+                        menuItemFound: menuAttempt.itemFound,
+                        menuClicked: menuAttempt.clicked,
+                        keySent: true,
+                        mixerVisible: true
+                    )
+                )
+            }
+        }
+
+        return (
+            nil,
+            MixerRevealResult(
+                attempted: true,
+                alreadyVisible: false,
+                strategies: strategies,
+                menuItemFound: menuAttempt.itemFound,
+                menuClicked: menuAttempt.clicked,
+                keySent: keySent,
+                mixerVisible: false
+            )
+        )
+    }
+
+    private static func pollMixerAreaVisible(
+        runtime: AXLogicProElements.Runtime,
+        timeoutMs: Int
+    ) async -> AXUIElement? {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        repeat {
+            if let mixer = AXLogicProElements.getMixerArea(runtime: runtime) {
+                return mixer
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        } while Date() < deadline
+        return nil
     }
 
     // MARK: - Shared validation inputs

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -492,7 +492,7 @@ actor AccessibilityChannel: Channel {
         // through AX/CGEvent only, with readback as the only State-A authority
         // and State-C fail-closed behavior for unsupported or drifting UI.
         case "plugin.get_inventory":
-            return AccessibilityChannel.defaultGetPluginInventory(params: params, runtime: runtime.logicRuntime)
+            return await AccessibilityChannel.defaultGetPluginInventory(params: params, runtime: runtime.logicRuntime)
         case "plugin.set_param_verified":
             return await AccessibilityChannel.defaultSetParamVerified(params: params, runtime: runtime.logicRuntime)
         case "plugin.insert_verified":

--- a/Tests/LogicProMCPTests/PluginGetInventoryTests.swift
+++ b/Tests/LogicProMCPTests/PluginGetInventoryTests.swift
@@ -146,7 +146,7 @@ private func makeMixerFixture(
     return b.makeLogicRuntime(appElement: app)
 }
 
-@Test func testGetInventoryMixedSequencePreservesPhysicalIndex() {
+@Test func testGetInventoryMixedSequencePreservesPhysicalIndex() async {
     // [occupied-readable Gain, empty, occupied-unreadable] — physical index
     // preserved, unreadable placeholder, complete:false (AC2/AC12).
     let b = FakeAXRuntimeBuilder()
@@ -158,7 +158,7 @@ private func makeMixerFixture(
         ]
     }
 
-    let result = AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
+    let result = await AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
     #expect(result.isSuccess)
     let obj = decodeObject(result.message)
 
@@ -182,7 +182,7 @@ private func makeMixerFixture(
     #expect(plugins[2]["name"] is NSNull)
 }
 
-@Test func testGetInventorySkipsNonWritableShortEmptySlotStub() {
+@Test func testGetInventorySkipsNonWritableShortEmptySlotStub() async {
     // Logic Pro 12.2 exposes a 9px "Audio Plug-in" button at the bottom of some
     // strips. Live E2E showed that clicking it does NOT insert into that physical
     // row; Logic appends into a different real slot. It must not be exposed as an
@@ -196,7 +196,7 @@ private func makeMixerFixture(
         ]
     }
 
-    let result = AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
+    let result = await AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
     #expect(result.isSuccess)
     let obj = decodeObject(result.message)
     let plugins = obj["plugins"] as! [[String: Any]]
@@ -207,12 +207,12 @@ private func makeMixerFixture(
     #expect(plugins[1]["read_status"] as? String == "empty")
 }
 
-@Test func testGetInventoryAllReadableIsComplete() {
+@Test func testGetInventoryAllReadableIsComplete() async {
     let b = FakeAXRuntimeBuilder()
     let runtime = makeMixerFixture(b) { b in
         [addOccupiedSlot(b, 720, name: "Noise Gate"), addEmptySlot(b, 721)]
     }
-    let result = AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
+    let result = await AccessibilityChannel.defaultGetPluginInventory(params: ["track": "0"], runtime: runtime)
     let obj = decodeObject(result.message)
     #expect(obj["state"] as? String == "A")
     #expect(obj["success"] as? Bool == true)
@@ -223,14 +223,14 @@ private func makeMixerFixture(
     #expect(plugins[0]["plugin_id"] as? String == "logic.stock.effect.noise_gate")
 }
 
-@Test func testGetInventoryStateBWhenSubtreeUnreadable() {
+@Test func testGetInventoryStateBWhenSubtreeUnreadable() async {
     // Track index out of range → the AX subtree cannot be read → State B
     // readback_unavailable + plugins_unknown_reason (AC2). Not a fabricated
     // empty chain.
     let b = FakeAXRuntimeBuilder()
     let runtime = makeMixerFixture(b) { b in [addEmptySlot(b, 730)] }
 
-    let result = AccessibilityChannel.defaultGetPluginInventory(params: ["track": "5"], runtime: runtime)
+    let result = await AccessibilityChannel.defaultGetPluginInventory(params: ["track": "5"], runtime: runtime)
     #expect(result.isSuccess) // State B is success:true, verified:false
     let obj = decodeObject(result.message)
     #expect(obj["state"] as? String == "B")
@@ -241,12 +241,97 @@ private func makeMixerFixture(
     #expect(obj["plugins"] == nil, "State B carries no plugins array")
 }
 
-@Test func testGetInventoryRejectsMissingTrack() {
+@Test func testGetInventoryRejectsMissingTrack() async {
     let b = FakeAXRuntimeBuilder()
     let runtime = makeMixerFixture(b) { b in [addEmptySlot(b, 740)] }
-    let result = AccessibilityChannel.defaultGetPluginInventory(params: [:], runtime: runtime)
+    let result = await AccessibilityChannel.defaultGetPluginInventory(params: [:], runtime: runtime)
     #expect(!result.isSuccess)
     let obj = decodeObject(result.message)
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "invalid_params")
+}
+
+@Test func testGetInventoryRevealsMixerWhenInitiallyHidden() async {
+    let b = FakeAXRuntimeBuilder()
+    let app = b.element(760)
+    let window = b.element(761)
+    let runtime = b.makeLogicRuntime(appElement: app)
+    b.setAttribute(app, kAXMainWindowAttribute as String, window)
+    b.setChildren(window, [])
+
+    let result = await AccessibilityChannel.defaultGetPluginInventory(
+        params: ["track": "0"],
+        runtime: runtime,
+        revealMixer: { _ in
+            let mixer = b.element(762)
+            let strip = b.element(763)
+            let slot = addOccupiedSlot(b, 764, name: "Gain")
+            b.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
+            b.setAttribute(mixer, kAXDescriptionAttribute as String, "Mixer")
+            b.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            b.setChildren(strip, [slot])
+            b.setChildren(mixer, [strip])
+            b.setChildren(window, [mixer])
+            return (
+                mixer,
+                .init(
+                    attempted: true,
+                    alreadyVisible: false,
+                    strategies: ["ax_menu_view_show_mixer"],
+                    menuItemFound: true,
+                    menuClicked: true,
+                    keySent: false,
+                    mixerVisible: true
+                )
+            )
+        }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeObject(result.message)
+    #expect(obj["state"] as? String == "A")
+    #expect(obj["mixer_reveal_attempted"] as? Bool == true)
+    #expect((obj["mixer_reveal_strategies"] as? [String]) == ["ax_menu_view_show_mixer"])
+    let plugins = obj["plugins"] as? [[String: Any]]
+    #expect(plugins?.count == 1)
+    #expect(plugins?.first?["plugin_id"] as? String == "logic.stock.effect.gain")
+}
+
+@Test func testGetInventoryReportsMixerNotVisibleDirectlyWhenRevealFails() async {
+    let b = FakeAXRuntimeBuilder()
+    let app = b.element(770)
+    let window = b.element(771)
+    let runtime = b.makeLogicRuntime(appElement: app)
+    b.setAttribute(app, kAXMainWindowAttribute as String, window)
+    b.setChildren(window, [])
+
+    let result = await AccessibilityChannel.defaultGetPluginInventory(
+        params: ["track": "0"],
+        runtime: runtime,
+        revealMixer: { _ in
+            (
+                nil,
+                .init(
+                    attempted: true,
+                    alreadyVisible: false,
+                    strategies: ["ax_menu_view_show_mixer", "cgevent_x"],
+                    menuItemFound: true,
+                    menuClicked: true,
+                    keySent: true,
+                    mixerVisible: false
+                )
+            )
+        }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeObject(result.message)
+    #expect(obj["state"] as? String == "B")
+    #expect(obj["reason"] as? String == "readback_unavailable")
+    #expect(obj["plugins_unknown_reason"] as? String == "mixer_not_visible")
+    #expect(obj["mixer_reveal_attempted"] as? Bool == true)
+    #expect(obj["mixer_reveal_menu_item_found"] as? Bool == true)
+    #expect(obj["mixer_reveal_menu_clicked"] as? Bool == true)
+    #expect(obj["mixer_reveal_key_sent"] as? Bool == true)
+    #expect((obj["recovery_hint"] as? String)?.contains("Show Mixer") == true)
 }


### PR DESCRIPTION
Fixes #38

## Summary
- make `logic_plugins.get_inventory` await a mixer-visibility recovery step before reading AX insert slots
- try `View > Show Mixer` first, then fall back to the `X` key command, and report direct `mixer_not_visible` diagnostics with a recovery hint if the mixer still cannot be found
- add unit coverage for both reveal-success and reveal-failure cases, plus a live E2E inventory assertion

## Verification
- `swift test --filter PluginGetInventory`
- `swift build -c release`
- `python3 -m py_compile Scripts/live-e2e-test.py`
- focused live probe against `.build/release/LogicProMCP` on Logic Pro 12.2

## Live Evidence
- after manually hiding the mixer via `View > Hide Mixer`, `logic://mixer` returned `data_source: "mixer_not_visible"` with `strips: []`
- `logic_plugins.get_inventory(track=0)` then returned State A with `success: true`, `verified: true`, `mixer_reveal_attempted: true`, and `mixer_reveal_strategies: ["ax_menu_view_show_mixer"]`
- a follow-up `logic://mixer` read returned `data_source: "ax_poll"` with populated AX strip/plugin data, confirming the inventory read revealed the mixer
