### PR TITLE
fix: verify transport play stop and record state

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -369,21 +369,6 @@ def tool_json(resp):
     return value if isinstance(value, dict) else None
 
 
-def read_transport_envelope(client):
-    return safe_json(resource_text(read_resource(client, "logic://transport/state")))
-
-
-def read_transport_state(client):
-    envelope = read_transport_envelope(client)
-    if not isinstance(envelope, dict):
-        return None
-    data = envelope.get("data")
-    if not isinstance(data, dict) or data.get("has_document") is False:
-        return None
-    state = data.get("state")
-    return state if isinstance(state, dict) else None
-
-
 def read_tracks_data(client):
     envelope = safe_json(resource_text(read_resource(client, "logic://tracks")))
     if not isinstance(envelope, dict):
@@ -395,17 +380,6 @@ def read_tracks_data(client):
 def read_track_regions(client, index):
     regions = safe_json(resource_text(read_resource(client, f"logic://tracks/{index}/regions")))
     return regions if isinstance(regions, list) else None
-
-
-def wait_for_transport_state(client, predicate, timeout=6.0):
-    deadline = time.time() + timeout
-    last = None
-    while time.time() < deadline:
-        last = read_transport_state(client)
-        if last is not None and predicate(last):
-            return last
-        time.sleep(0.2)
-    return last
 
 
 def wait_for_track_arm(client, index, enabled, timeout=5.0):
@@ -434,6 +408,62 @@ def fresh_transport_bootstrap_status(client):
     if len(regions) != 0:
         return False, f"expected 0 regions on track 0, found {len(regions)}"
     return True, "fresh bootstrap detected"
+
+
+def transport_envelope(client):
+    return safe_json(resource_text(read_resource(client, "logic://transport/state")))
+
+
+def transport_state(client):
+    envelope = transport_envelope(client)
+    if not isinstance(envelope, dict):
+        return None, None
+    data = envelope.get("data", {})
+    if not isinstance(data, dict) or data.get("has_document") is False:
+        return envelope, None
+    state = data.get("state")
+    if not isinstance(state, dict):
+        return envelope, None
+    return envelope, state
+
+
+def wait_for_transport_state_envelope(client, predicate, timeout=5.0, interval=0.2):
+    deadline = time.time() + timeout
+    last_envelope = None
+    last_state = None
+    while time.time() < deadline:
+        last_envelope, last_state = transport_state(client)
+        if predicate(last_envelope, last_state):
+            return last_envelope, last_state
+        time.sleep(interval)
+    return last_envelope, last_state
+
+
+def wait_for_transport_state(client, predicate, timeout=6.0, interval=0.2):
+    deadline = time.time() + timeout
+    last_state = None
+    while time.time() < deadline:
+        _, last_state = transport_state(client)
+        if isinstance(last_state, dict) and predicate(last_state):
+            return last_state
+        time.sleep(interval)
+    return last_state
+
+
+def ui_stop_logic_transport():
+    script = """
+    tell application "Logic Pro" to activate
+    delay 0.1
+    tell application "System Events"
+        key code 49
+    end tell
+    """
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def is_library_root_json(value):
@@ -677,6 +707,84 @@ def main():
     else:
         T("cycle roundtrip (skipped — no project)", "ok", lambda _: True)
     call_tool(client, "logic_transport", "toggle_cycle")  # restore
+
+    def transport_playing_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is True
+        )
+
+    def transport_stopped_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is False
+            and state.get("isRecording") is False
+        )
+
+    stop_live_ready = live_logic_ready and has_document
+    ui_stop_envelope = None
+    ui_stop_state = None
+    mcp_stop_response = None
+    mcp_stop_envelope = None
+    mcp_stop_state = None
+    if stop_live_ready:
+        call_tool(client, "logic_transport", "play")
+        _, playing_state = wait_for_transport_state_envelope(client, transport_playing_verified, timeout=5.0)
+        if isinstance(playing_state, dict) and ui_stop_logic_transport():
+            ui_stop_envelope, ui_stop_state = wait_for_transport_state_envelope(
+                client, transport_stopped_verified, timeout=5.0
+            )
+
+        call_tool(client, "logic_transport", "play")
+        _, replay_state = wait_for_transport_state_envelope(client, transport_playing_verified, timeout=5.0)
+        if isinstance(replay_state, dict):
+            mcp_stop_response = call_tool(client, "logic_transport", "stop")
+            mcp_stop_envelope, mcp_stop_state = wait_for_transport_state_envelope(
+                client, transport_stopped_verified, timeout=5.0
+            )
+        call_tool(client, "logic_transport", "stop")
+
+    T_LIVE(
+        "transport readback reflects external UI stop",
+        {"envelope": ui_stop_envelope, "state": ui_stop_state},
+        lambda _: (
+            isinstance(ui_stop_envelope, dict)
+            and ui_stop_envelope.get("unverified") is not True
+            and isinstance(ui_stop_state, dict)
+            and ui_stop_state.get("isPlaying") is False
+            and ui_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "logic_transport.stop returns verified success after live readback",
+        mcp_stop_response,
+        lambda _: (
+            mcp_stop_response is not None
+            and not is_error(mcp_stop_response)
+            and (safe_json(tool_text(mcp_stop_response)) or {}).get("verified") is True
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "transport readback reflects logic_transport.stop immediately",
+        {"envelope": mcp_stop_envelope, "state": mcp_stop_state},
+        lambda _: (
+            isinstance(mcp_stop_envelope, dict)
+            and mcp_stop_envelope.get("unverified") is not True
+            and isinstance(mcp_stop_state, dict)
+            and mcp_stop_state.get("isPlaying") is False
+            and mcp_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
 
     # Transport commands that route to MCU/CoreMIDI
     r = call_tool(client, "logic_transport", "toggle_cycle")

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -364,6 +364,78 @@ def safe_json(text):
     except: return None
 
 
+def tool_json(resp):
+    value = safe_json(tool_text(resp))
+    return value if isinstance(value, dict) else None
+
+
+def read_transport_envelope(client):
+    return safe_json(resource_text(read_resource(client, "logic://transport/state")))
+
+
+def read_transport_state(client):
+    envelope = read_transport_envelope(client)
+    if not isinstance(envelope, dict):
+        return None
+    data = envelope.get("data")
+    if not isinstance(data, dict) or data.get("has_document") is False:
+        return None
+    state = data.get("state")
+    return state if isinstance(state, dict) else None
+
+
+def read_tracks_data(client):
+    envelope = safe_json(resource_text(read_resource(client, "logic://tracks")))
+    if not isinstance(envelope, dict):
+        return None
+    data = envelope.get("data")
+    return data if isinstance(data, list) else None
+
+
+def read_track_regions(client, index):
+    regions = safe_json(resource_text(read_resource(client, f"logic://tracks/{index}/regions")))
+    return regions if isinstance(regions, list) else None
+
+
+def wait_for_transport_state(client, predicate, timeout=6.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = read_transport_state(client)
+        if last is not None and predicate(last):
+            return last
+        time.sleep(0.2)
+    return last
+
+
+def wait_for_track_arm(client, index, enabled, timeout=5.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        call_tool(client, "logic_system", "refresh_cache", timeout=3)
+        tracks = read_tracks_data(client)
+        if isinstance(tracks, list) and 0 <= index < len(tracks):
+            last = tracks[index]
+            if last.get("isArmed") is enabled:
+                return last
+        time.sleep(0.2)
+    return last
+
+
+def fresh_transport_bootstrap_status(client):
+    tracks = read_tracks_data(client)
+    if not isinstance(tracks, list):
+        return False, "tracks resource unavailable"
+    if len(tracks) != 1:
+        return False, f"expected exactly 1 track, found {len(tracks)}"
+    regions = read_track_regions(client, 0)
+    if regions is None:
+        return False, "track 0 regions resource unavailable"
+    if len(regions) != 0:
+        return False, f"expected 0 regions on track 0, found {len(regions)}"
+    return True, "fresh bootstrap detected"
+
+
 def is_library_root_json(value):
     return (
         isinstance(value, dict)
@@ -615,8 +687,218 @@ def main():
     T_LIVE("transport.toggle_metronome returns non-error", r, lambda _: not is_error(r), live_logic_ready, "Logic Pro + Accessibility are required")
     call_tool(client, "logic_transport", "toggle_metronome")  # restore
 
+    fresh_transport_live_ready = False
+    fresh_transport_reason = "fresh Logic bootstrap with 1 track and 0 regions is required"
+    if live_logic_ready and has_document:
+        call_tool(client, "logic_system", "refresh_cache", timeout=3)
+        fresh_transport_live_ready, fresh_transport_reason = fresh_transport_bootstrap_status(client)
+        if not fresh_transport_live_ready:
+            fresh_transport_reason = f"fresh bootstrap not detected: {fresh_transport_reason}"
+
+    select_for_record = {"gate": fresh_transport_reason}
+    arm_for_record = {"gate": fresh_transport_reason}
+    arm_track = None
+    stop_unchanged = {"gate": fresh_transport_reason}
+    stop_unchanged_env = None
+    stop_unchanged_state = None
+    record_resp = {"gate": fresh_transport_reason}
+    record_env = None
+    record_state = None
+    stop_after_record = {"gate": fresh_transport_reason}
+    stop_after_record_env = None
+    stop_after_record_state = None
+    stop_after_record_unchanged = {"gate": fresh_transport_reason}
+    stop_after_record_unchanged_env = None
+    stop_after_record_unchanged_state = None
+    play_resp = {"gate": fresh_transport_reason}
+    play_env = None
+    play_state = None
+    play_unchanged = {"gate": fresh_transport_reason}
+    play_unchanged_env = None
+    play_unchanged_state = None
+    final_stop = {"gate": fresh_transport_reason}
+    final_stop_env = None
+    final_stop_state = None
+    disarm_after_transport = {"gate": fresh_transport_reason}
+    disarm_track = None
+
+    if fresh_transport_live_ready:
+        select_for_record = call_tool(client, "logic_tracks", "select", {"index": 0})
+        arm_for_record = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": True})
+        arm_track = wait_for_track_arm(client, 0, True)
+
+        stop_unchanged = call_tool(client, "logic_transport", "stop")
+        stop_unchanged_env = tool_json(stop_unchanged)
+        stop_unchanged_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is False and state.get("isRecording") is False,
+        )
+
+        record_resp = call_tool(client, "logic_transport", "record")
+        record_env = tool_json(record_resp)
+        record_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is True and state.get("isRecording") is True,
+            timeout=8.0,
+        )
+
+        stop_after_record = call_tool(client, "logic_transport", "stop")
+        stop_after_record_env = tool_json(stop_after_record)
+        stop_after_record_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is False and state.get("isRecording") is False,
+        )
+
+        stop_after_record_unchanged = call_tool(client, "logic_transport", "stop")
+        stop_after_record_unchanged_env = tool_json(stop_after_record_unchanged)
+        stop_after_record_unchanged_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is False and state.get("isRecording") is False,
+        )
+
+        play_resp = call_tool(client, "logic_transport", "play")
+        play_env = tool_json(play_resp)
+        play_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is True and state.get("isRecording") is False,
+        )
+
+        play_unchanged = call_tool(client, "logic_transport", "play")
+        play_unchanged_env = tool_json(play_unchanged)
+        play_unchanged_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is True and state.get("isRecording") is False,
+        )
+
+        final_stop = call_tool(client, "logic_transport", "stop")
+        final_stop_env = tool_json(final_stop)
+        final_stop_state = wait_for_transport_state(
+            client,
+            lambda state: state.get("isPlaying") is False and state.get("isRecording") is False,
+        )
+
+        disarm_after_transport = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": False})
+        disarm_track = wait_for_track_arm(client, 0, False)
+
+    T_LIVE(
+        "fresh transport bootstrap detected",
+        {"result": {"bootstrap": fresh_transport_reason}},
+        lambda _: fresh_transport_live_ready,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport record prep selects track 0",
+        select_for_record,
+        lambda _: not is_error(select_for_record),
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport record prep arms track 0",
+        arm_for_record,
+        lambda _: not is_error(arm_for_record) and isinstance(arm_track, dict) and arm_track.get("isArmed") is True,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.stop returns verified unchanged when already stopped",
+        stop_unchanged,
+        lambda _: isinstance(stop_unchanged_env, dict)
+        and stop_unchanged_env.get("verified") is True
+        and stop_unchanged_env.get("unchanged") is True
+        and stop_unchanged_env.get("operation") == "transport.stop"
+        and isinstance(stop_unchanged_state, dict)
+        and stop_unchanged_state.get("isPlaying") is False
+        and stop_unchanged_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.record reaches verified recording state",
+        record_resp,
+        lambda _: isinstance(record_env, dict)
+        and record_env.get("verified") is True
+        and record_env.get("operation") == "transport.record"
+        and isinstance(record_state, dict)
+        and record_state.get("isPlaying") is True
+        and record_state.get("isRecording") is True,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.stop reaches verified stopped state after record",
+        stop_after_record,
+        lambda _: isinstance(stop_after_record_env, dict)
+        and stop_after_record_env.get("verified") is True
+        and stop_after_record_env.get("operation") == "transport.stop"
+        and isinstance(stop_after_record_state, dict)
+        and stop_after_record_state.get("isPlaying") is False
+        and stop_after_record_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.stop stays verified unchanged after record stop",
+        stop_after_record_unchanged,
+        lambda _: isinstance(stop_after_record_unchanged_env, dict)
+        and stop_after_record_unchanged_env.get("verified") is True
+        and stop_after_record_unchanged_env.get("unchanged") is True
+        and stop_after_record_unchanged_env.get("operation") == "transport.stop"
+        and isinstance(stop_after_record_unchanged_state, dict)
+        and stop_after_record_unchanged_state.get("isPlaying") is False
+        and stop_after_record_unchanged_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.play reaches verified playback state",
+        play_resp,
+        lambda _: isinstance(play_env, dict)
+        and play_env.get("verified") is True
+        and play_env.get("operation") == "transport.play"
+        and isinstance(play_state, dict)
+        and play_state.get("isPlaying") is True
+        and play_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.play stays verified unchanged while already playing",
+        play_unchanged,
+        lambda _: isinstance(play_unchanged_env, dict)
+        and play_unchanged_env.get("verified") is True
+        and play_unchanged_env.get("unchanged") is True
+        and play_unchanged_env.get("operation") == "transport.play"
+        and isinstance(play_unchanged_state, dict)
+        and play_unchanged_state.get("isPlaying") is True
+        and play_unchanged_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport.stop reaches verified stopped state after play",
+        final_stop,
+        lambda _: isinstance(final_stop_env, dict)
+        and final_stop_env.get("verified") is True
+        and final_stop_env.get("operation") == "transport.stop"
+        and isinstance(final_stop_state, dict)
+        and final_stop_state.get("isPlaying") is False
+        and final_stop_state.get("isRecording") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+    T_LIVE(
+        "transport record prep disarms track 0 after transport checks",
+        disarm_after_transport,
+        lambda _: not is_error(disarm_after_transport) and isinstance(disarm_track, dict) and disarm_track.get("isArmed") is False,
+        fresh_transport_live_ready,
+        fresh_transport_reason,
+    )
+
     r = call_tool(client, "logic_transport", "toggle_count_in")
     T("transport.toggle_count_in dispatches", r, lambda _: len(tool_text(r)) > 0)
+    call_tool(client, "logic_transport", "toggle_count_in")  # restore
 
     # Set tempo
     r = call_tool(client, "logic_transport", "set_tempo", {"tempo": 128})

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -606,10 +606,14 @@ actor AccessibilityChannel: Channel {
         }
         // Legacy fallback: search by role=Button with title/description.
         guard let button = AXLogicProElements.findTransportButton(named: name, runtime: runtime) else {
+            var extras = transportLookupDiagnostics(named: name, runtime: runtime)
+            extras["button"] = name
+            extras["recovery_hint"] =
+                "Bring Logic's main arrange window frontmost and dismiss any plugin, chooser, or modal window covering the transport controls."
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "transport button '\(name)' not located in control bar",
-                extras: ["button": name]
+                hint: "transport button '\(name)' not located in the visible Logic transport UI",
+                extras: extras
             ))
         }
         guard AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax) else {
@@ -623,6 +627,57 @@ actor AccessibilityChannel: Channel {
             reason: .readbackUnavailable,
             extras: ["button": name, "via": "legacy-axpress"]
         ))
+    }
+
+    private static func transportLookupDiagnostics(
+        named name: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> [String: Any] {
+        let mainWindow = AXLogicProElements.mainWindow(runtime: runtime)
+        let windowTitle = mainWindow.flatMap { AXHelpers.getTitle($0, runtime: runtime.ax) } ?? ""
+        let controlBar = AXLogicProElements.getControlBar(runtime: runtime)
+        let transportBar = AXLogicProElements.getTransportBar(runtime: runtime)
+        return [
+            "requested_button": name,
+            "window_title": windowTitle,
+            "control_bar_present": controlBar != nil,
+            "transport_bar_present": transportBar != nil,
+            "control_bar_checkboxes": controlBar.map {
+                transportLandmarkLabels(root: $0, role: kAXCheckBoxRole, runtime: runtime)
+            } ?? [],
+            "transport_buttons": transportBar.map {
+                transportLandmarkLabels(root: $0, role: kAXButtonRole, runtime: runtime)
+            } ?? []
+        ]
+    }
+
+    private static func transportLandmarkLabels(
+        root: AXUIElement,
+        role: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> [String] {
+        let elements = AXHelpers.findAllDescendants(
+            of: root,
+            role: role,
+            maxDepth: 4,
+            runtime: runtime.ax
+        )
+        var seen = Set<String>()
+        var labels: [String] = []
+        for element in elements {
+            let candidates = [
+                AXHelpers.getTitle(element, runtime: runtime.ax),
+                AXHelpers.getDescription(element, runtime: runtime.ax),
+                AXHelpers.getIdentifier(element, runtime: runtime.ax)
+            ]
+            for candidate in candidates.compactMap({ $0?.trimmingCharacters(in: .whitespacesAndNewlines) }) {
+                guard !candidate.isEmpty, seen.insert(candidate).inserted else { continue }
+                labels.append(candidate)
+                break
+            }
+            if labels.count >= 12 { break }
+        }
+        return labels
     }
 
     private static func defaultSetTempo(

--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -41,6 +41,10 @@ actor AppleScriptChannel: Channel {
             },
             executeTransportAction: { action in
                 switch action {
+                case "play":
+                    return await AppleScriptChannel.executeAppleScript(
+                        AppleScriptChannel.transportScript(action: action)
+                    )
                 case "stop":
                     return await AppleScriptChannel.executeAppleScript(
                         AppleScriptChannel.transportScript(action: action)
@@ -133,7 +137,15 @@ actor AppleScriptChannel: Channel {
             let raw = await runtime.executeTransportAction(action)
             return Self.wrapMutatingResult(raw, operation: operation)
 
-        case "transport.play", "transport.pause":
+        case "transport.play":
+            let action = operation.replacingOccurrences(of: "transport.", with: "")
+            guard AppleScriptSafety.isAllowedTransportAction(action) else {
+                return .error("Transport action not in whitelist: \(action)")
+            }
+            let raw = await runtime.executeTransportAction(action)
+            return Self.wrapMutatingResult(raw, operation: operation)
+
+        case "transport.pause":
             return .error("Unsupported AppleScript operation: \(operation)")
 
         default:

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -23,6 +23,9 @@ actor ChannelRouter {
     private var channels: [ChannelID: any Channel] = [:]
 
     private static let transportToggleOpsAllowingAXElementFallback: Set<String> = [
+        "transport.play",
+        "transport.stop",
+        "transport.record",
         "transport.toggle_cycle",
         "transport.toggle_metronome",
         "transport.toggle_count_in",
@@ -33,7 +36,7 @@ actor ChannelRouter {
     static let v2RoutingTable: [String: [ChannelID]] = [
         // Transport — AX control-bar click primary (works without MCU / MIDI Learn),
         // MCU / CoreMIDI / CGEvent / AppleScript as fallbacks.
-        "transport.play":             [.accessibility, .mcu, .coreMIDI, .cgEvent],
+        "transport.play":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.stop":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.record":           [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.pause":            [.coreMIDI, .cgEvent],

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -37,7 +37,13 @@ actor ChannelRouter {
         // Transport — AX control-bar click primary (works without MCU / MIDI Learn),
         // MCU / CoreMIDI / CGEvent / AppleScript as fallbacks.
         "transport.play":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
-        "transport.stop":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
+        // Stop differs from Play/Record: in live 12.2 sessions the AX Play
+        // checkbox can refuse to clear while playback is active, and MMC /
+        // AppleScript "stop" can still leave transport running. The
+        // spacebar-equivalent CGEvent path proved to be the first reliable
+        // non-AX fallback, so prefer it before MIDI/AppleScript fallbacks and
+        // let the dispatcher's live readback gate decide success.
+        "transport.stop":             [.accessibility, .cgEvent, .mcu, .coreMIDI, .appleScript],
         "transport.record":           [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.pause":            [.coreMIDI, .cgEvent],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -12,20 +12,30 @@ struct TransportDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        sleep: @escaping (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) }
     ) async -> CallTool.Result {
         switch command {
         case "play":
-            let result = await router.route(operation: "transport.play")
-            return toolTextResult(result)
+            return await handleVerifiedTransportCommand(
+                action: .play,
+                router: router,
+                sleep: sleep
+            )
 
         case "stop":
-            let result = await router.route(operation: "transport.stop")
-            return toolTextResult(result)
+            return await handleVerifiedTransportCommand(
+                action: .stop,
+                router: router,
+                sleep: sleep
+            )
 
         case "record":
-            let result = await router.route(operation: "transport.record")
-            return toolTextResult(result)
+            return await handleVerifiedTransportCommand(
+                action: .record,
+                router: router,
+                sleep: sleep
+            )
 
         case "pause":
             let result = await router.route(operation: "transport.pause")
@@ -198,5 +208,135 @@ struct TransportDispatcher {
         }
 
         return false
+    }
+
+    private enum VerifiedTransportAction: String {
+        case play
+        case stop
+        case record
+
+        var operation: String { "transport.\(rawValue)" }
+
+        func matches(_ state: TransportState) -> Bool {
+            switch self {
+            case .play:
+                return state.isPlaying
+            case .stop:
+                return !state.isPlaying && !state.isRecording
+            case .record:
+                return state.isPlaying && state.isRecording
+            }
+        }
+    }
+
+    private static func handleVerifiedTransportCommand(
+        action: VerifiedTransportAction,
+        router: ChannelRouter,
+        sleep: @escaping (UInt64) async -> Void
+    ) async -> CallTool.Result {
+        let beforeState = await readTransportState(router: router)
+        if let beforeState, action.matches(beforeState) {
+            return toolTextResult(.success(HonestContract.encodeStateA(
+                extras: [
+                    "operation": action.operation,
+                    "verify_source": "transport_state",
+                    "write_attempted": false,
+                    "unchanged": true,
+                    "observed_before": transportStateSummary(beforeState),
+                    "observed_after": transportStateSummary(beforeState)
+                ]
+            )))
+        }
+
+        let writeResult = await router.route(operation: action.operation)
+        let writePayload = jsonValue(from: writeResult.message)
+        var attempts = 0
+        var afterState: TransportState?
+        for _ in 0..<12 {
+            attempts += 1
+            if let observed = await readTransportState(router: router) {
+                afterState = observed
+                if action.matches(observed) {
+                    var extras: [String: Any] = [
+                        "operation": action.operation,
+                        "verify_source": "transport_state",
+                        "write_attempted": true,
+                        "poll_attempts": attempts,
+                        "observed_after": transportStateSummary(observed),
+                        "write_result": writePayload
+                    ]
+                    if let beforeState {
+                        extras["observed_before"] = transportStateSummary(beforeState)
+                    }
+                    if !writeResult.isSuccess {
+                        extras["write_result_error"] = writeResult.message
+                    }
+                    return toolTextResult(.success(HonestContract.encodeStateA(extras: extras)))
+                }
+            }
+            await sleep(100_000_000)
+        }
+
+        guard writeResult.isSuccess else {
+            return toolTextResult(writeResult)
+        }
+
+        var extras: [String: Any] = [
+            "operation": action.operation,
+            "verify_source": "transport_state",
+            "write_attempted": true,
+            "poll_attempts": attempts,
+            "write_result": writePayload
+        ]
+        if let beforeState {
+            extras["observed_before"] = transportStateSummary(beforeState)
+        }
+        if let afterState {
+            extras["observed_after"] = transportStateSummary(afterState)
+            return toolTextResult(.success(HonestContract.encodeStateB(
+                reason: .readbackMismatch,
+                extras: extras
+            )))
+        }
+        return toolTextResult(.success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: extras
+        )))
+    }
+
+    private static func readTransportState(router: ChannelRouter) async -> TransportState? {
+        let result = await router.route(operation: "transport.get_state")
+        guard result.isSuccess,
+              let dict = jsonValue(from: result.message) as? [String: Any] else {
+            return nil
+        }
+        var state = TransportState()
+        if let isPlaying = dict["isPlaying"] as? Bool { state.isPlaying = isPlaying }
+        if let isRecording = dict["isRecording"] as? Bool { state.isRecording = isRecording }
+        if let isPaused = dict["isPaused"] as? Bool { state.isPaused = isPaused }
+        if let isCycleEnabled = dict["isCycleEnabled"] as? Bool { state.isCycleEnabled = isCycleEnabled }
+        if let isMetronomeEnabled = dict["isMetronomeEnabled"] as? Bool { state.isMetronomeEnabled = isMetronomeEnabled }
+        if let tempo = dict["tempo"] as? Double { state.tempo = tempo }
+        if let position = dict["position"] as? String { state.position = position }
+        if let timePosition = dict["timePosition"] as? String { state.timePosition = timePosition }
+        if let sampleRate = dict["sampleRate"] as? Int { state.sampleRate = sampleRate }
+        return state
+    }
+
+    private static func transportStateSummary(_ state: TransportState) -> [String: Any] {
+        [
+            "isPlaying": state.isPlaying,
+            "isRecording": state.isRecording,
+            "position": state.position,
+            "tempo": state.tempo
+        ]
+    }
+
+    private static func jsonValue(from text: String) -> Any {
+        guard let data = text.data(using: .utf8),
+              let value = try? JSONSerialization.jsonObject(with: data) else {
+            return text
+        }
+        return value
     }
 }

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -24,11 +24,7 @@ struct TransportDispatcher {
             )
 
         case "stop":
-            return await handleVerifiedTransportCommand(
-                action: .stop,
-                router: router,
-                sleep: sleep
-            )
+            return await verifiedStopResult(router: router, cache: cache)
 
         case "record":
             return await handleVerifiedTransportCommand(
@@ -176,6 +172,88 @@ struct TransportDispatcher {
         }
     }
 
+    private static func verifiedStopResult(
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        if let beforeState = await readTransportState(router: router),
+           beforeState.isPlaying == false,
+           beforeState.isRecording == false {
+            return toolTextResult(.success(HonestContract.encodeStateA(
+                extras: [
+                    "operation": "transport.stop",
+                    "requested_state": "stopped",
+                    "verify_source": "transport_state",
+                    "write_attempted": false,
+                    "unchanged": true,
+                    "observed_before": transportStateSummary(beforeState),
+                    "observed_after": transportStateSummary(beforeState)
+                ]
+            )))
+        }
+
+        let writeResult = await router.route(operation: "transport.stop")
+        guard writeResult.isSuccess else {
+            return toolTextResult(writeResult)
+        }
+
+        let liveRefresh = await ResourceHandlers.readLiveTransportState(router: router)
+        guard let liveState = liveRefresh.state else {
+            let cachedState = await cache.getTransport()
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "transport.stop executed, but live transport state could not be refreshed. Focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache.",
+                extras: stopReadbackUnavailableExtras(
+                    cachedState: cachedState,
+                    refreshError: liveRefresh.errorCode
+                )
+            ), isError: true)
+        }
+
+        await cache.updateTransport(liveState)
+        let observedExtras: [String: Any] = [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "ax_transport_state",
+            "observed_isPlaying": liveState.isPlaying,
+            "observed_isRecording": liveState.isRecording,
+            "observed_position": liveState.position,
+            "observed_time_position": liveState.timePosition,
+        ]
+
+        guard liveState.isPlaying == false, liveState.isRecording == false else {
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackMismatch,
+                hint: "transport.stop executed, but live transport state still reports playback or recording",
+                extras: observedExtras.merging(["safe_to_retry": true]) { _, new in new }
+            ), isError: true)
+        }
+
+        return toolTextResult(HonestContract.encodeStateA(extras: observedExtras))
+    }
+
+    private static func stopReadbackUnavailableExtras(
+        cachedState: TransportState,
+        refreshError: String?
+    ) -> [String: Any] {
+        [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "cache_only",
+            "cached_source": cachedState.lastUpdated > .distantPast ? "cache" : "default",
+            "cache_age_sec": cacheAgeExtra(for: cachedState),
+            "refresh_error": refreshError ?? "live_transport_read_failed",
+            "safe_to_retry": true,
+        ]
+    }
+
+    private static func cacheAgeExtra(for state: TransportState) -> Any {
+        guard state.lastUpdated > .distantPast else {
+            return NSNull()
+        }
+        return max(0, Date().timeIntervalSince(state.lastUpdated))
+    }
+
     /// Accept "bar.beat.sub.tick" (each positive) or "HH:MM:SS:FF" (with
     /// each field within its canonical range). Anything else — including
     /// empty string and malformed tokens like "99:99:99:99" — is rejected.
@@ -212,7 +290,6 @@ struct TransportDispatcher {
 
     private enum VerifiedTransportAction: String {
         case play
-        case stop
         case record
 
         var operation: String { "transport.\(rawValue)" }
@@ -221,8 +298,6 @@ struct TransportDispatcher {
             switch self {
             case .play:
                 return state.isPlaying
-            case .stop:
-                return !state.isPlaying && !state.isRecording
             case .record:
                 return state.isPlaying && state.isRecording
             }

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -173,7 +173,8 @@ extension ResourceHandlers {
     // MARK: - Individual resource handlers
 
     private static func readTransportState(cache: StateCache, router: ChannelRouter, uri: String) async throws -> ReadResource.Result {
-        if let liveState = await readLiveTransportState(router: router) {
+        let liveRefresh = await readLiveTransportState(router: router)
+        if let liveState = liveRefresh.state {
             await cache.updateTransport(liveState)
         }
 
@@ -188,18 +189,60 @@ extension ResourceHandlers {
         let body = """
             {"state":\(inner),"has_document":\(hasDocument)}
             """
-        let json = wrapWithCacheEnvelope(bodyJSON: body, fetchedAt: state.lastUpdated, axOccluded: axOccluded)
+        let json = wrapWithCacheEnvelope(
+            bodyJSON: body,
+            fetchedAt: state.lastUpdated,
+            axOccluded: axOccluded,
+            extras: transportStateEnvelopeExtras(liveRefresh: liveRefresh, cachedState: state)
+        )
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readLiveTransportState(router: ChannelRouter) async -> TransportState? {
-        guard case .success(let json) = await router.route(operation: "transport.get_state") else {
-            return nil
+    struct LiveTransportStateReadback: Sendable {
+        let state: TransportState?
+        let errorCode: String?
+    }
+
+    /// Live transport refresh shared by the `logic://transport/state`
+    /// resource and post-write dispatcher verification.
+    static func readLiveTransportState(router: ChannelRouter) async -> LiveTransportStateReadback {
+        let result = await router.route(operation: "transport.get_state")
+        guard result.isSuccess else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: HonestContract.stateCErrorCode(result.message) ?? "live_transport_read_failed"
+            )
+        }
+        guard let state = decodeTransportState(result.message) else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: "undecodable_live_transport_state"
+            )
+        }
+        return LiveTransportStateReadback(state: state, errorCode: nil)
+    }
+
+    private static func transportStateEnvelopeExtras(
+        liveRefresh: LiveTransportStateReadback,
+        cachedState: TransportState
+    ) -> [String: Any] {
+        if liveRefresh.state != nil {
+            return ["source": "ax_live"]
         }
 
-        return decodeTransportState(json)
+        let hasCachedState = cachedState.lastUpdated > .distantPast
+        var extras: [String: Any] = [
+            "source": hasCachedState ? "cache" : "default",
+            "unverified": true,
+            "stale": hasCachedState,
+            "recovery_hint": "live transport refresh unavailable; focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache."
+        ]
+        if let errorCode = liveRefresh.errorCode {
+            extras["refresh_error"] = errorCode
+        }
+        return extras
     }
 
     private static func decodeTransportState(_ json: String) -> TransportState? {

--- a/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
@@ -344,6 +344,7 @@ private func makeAppleScriptRuntime(
     let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(transportRecorder: recorder))
 
     let operations = [
+        "transport.play": "play",
         "transport.stop": "stop",
         "transport.record": "record",
     ]
@@ -356,12 +357,8 @@ private func makeAppleScriptRuntime(
     }
 }
 
-@Test func testAppleScriptTransportRejectsUnsupportedPlaybackCommands() async {
+@Test func testAppleScriptTransportRejectsUnsupportedPauseCommand() async {
     let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime())
-
-    let play = await channel.execute(operation: "transport.play", params: [:])
-    #expect(!play.isSuccess)
-    #expect(play.message.contains("Unsupported AppleScript operation"))
 
     let pause = await channel.execute(operation: "transport.pause", params: [:])
     #expect(!pause.isSuccess)

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -119,6 +119,34 @@ actor FailingStartChannel: Channel {
     #expect(appleScriptOps[0].0 == "transport.stop")
 }
 
+@Test func testRouterTransportPlayFallsBackToAppleScriptAfterAXLookupMiss() async {
+    let router = ChannelRouter()
+    let ax = TerminalStateCChannel(
+        id: .accessibility,
+        envelope: HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "transport button 'Play' not located in the visible Logic transport UI",
+            extras: ["button": "Play"]
+        )
+    )
+    let mcu = MockChannel(id: .mcu, available: false)
+    let coreMIDI = MockChannel(id: .coreMIDI, available: false)
+    let cgEvent = MockChannel(id: .cgEvent, available: false)
+    let appleScript = MockChannel(id: .appleScript)
+    await router.register(ax)
+    await router.register(mcu)
+    await router.register(coreMIDI)
+    await router.register(cgEvent)
+    await router.register(appleScript)
+
+    let result = await router.route(operation: "transport.play")
+    #expect(result.isSuccess, "transport.play should fall through after AX element_not_found")
+
+    let appleScriptOps = await appleScript.executedOps
+    #expect(appleScriptOps.count == 1)
+    #expect(appleScriptOps[0].0 == "transport.play")
+}
+
 @Test func testRouterSkipsManualValidationChannelsAndFallsBackToRuntimeReadyChannel() async {
     let router = ChannelRouter()
     let keyCmd = MockChannel(id: .midiKeyCommands, healthOverride: .healthy(

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -119,12 +119,43 @@ private actor TransportStateSequenceChannel: Channel {
     }
 }
 
+private actor ScriptedTransportChannel: Channel {
+    nonisolated let id: ChannelID
+    let results: [String: ChannelResult]
+    var executedOps: [String] = []
+
+    init(id: ChannelID, results: [String: ChannelResult]) {
+        self.id = id
+        self.results = results
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        executedOps.append(operation)
+        return results[operation] ?? .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "scripted transport channel")
+    }
+}
+
+private func liveTransportJSON(
+    isPlaying: Bool,
+    isRecording: Bool,
+    position: String = "1.1.1.1"
+) -> String {
+    """
+    {"isPlaying":\(isPlaying),"isRecording":\(isRecording),"isPaused":false,"tempo":120.0,"position":"\(position)","timePosition":"00:00:00.000","sampleRate":44100,"isCycleEnabled":false,"isMetronomeEnabled":false,"lastUpdated":"2026-06-19T02:17:42.000Z"}
+    """
+}
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
     let cases: [(command: String, operation: String)] = [
         ("play", "transport.play"),
-        ("stop", "transport.stop"),
         ("record", "transport.record"),
         ("pause", "transport.pause"),
         ("rewind", "transport.rewind"),
@@ -321,6 +352,131 @@ private actor TransportStateSequenceChannel: Channel {
         ("transport.goto_position", ["position": "00:00:10:12"]),
         ("transport.set_cycle_range", ["start": "4.1.1.1", "end": "12.1.1.1"]),
     ])
+}
+
+@Test func testTransportDispatcherStopPromotesFallbackWriteToVerifiedReadback() async {
+    let router = ChannelRouter()
+    let ax = TransportStateSequenceChannel(
+        id: .accessibility,
+        states: [
+            liveTransportJSON(
+                isPlaying: true,
+                isRecording: false,
+                position: "8.4.1.1"
+            ),
+            liveTransportJSON(
+                isPlaying: false,
+                isRecording: false,
+                position: "9.1.1.1"
+            )
+        ],
+        mutationResults: [
+            "transport.stop": .error(HonestContract.encodeStateC(
+                error: .readbackMismatch,
+                hint: "play checkbox did not clear on first AX attempt"
+            ))
+        ]
+    )
+    let mcu = MockChannel(id: .mcu)
+    await router.register(ax)
+    await router.register(mcu)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == false)
+    #expect(json["verified"] as? Bool == true)
+    #expect(json["verify_source"] as? String == "ax_transport_state")
+    #expect(json["observed_isPlaying"] as? Bool == false)
+    #expect(json["observed_isRecording"] as? Bool == false)
+    #expect(json["observed_position"] as? String == "9.1.1.1")
+    #expect(await ax.executedOps.map(\.0) == ["transport.get_state", "transport.stop", "transport.get_state"])
+    #expect(await mcu.executedOps.map(\.0) == ["transport.stop"])
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == false)
+    #expect(cached.isRecording == false)
+    #expect(cached.position == "9.1.1.1")
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveReadbackUnavailable() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "Cannot locate transport bar"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+    await cache.updateTransport(TransportState(
+        isPlaying: true,
+        isRecording: true,
+        position: "96.1.1.1",
+        lastUpdated: Date(timeIntervalSinceNow: -18)
+    ))
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_unavailable")
+    #expect(json["refresh_error"] as? String == "element_not_found")
+    #expect(json["cached_source"] as? String == "cache")
+    #expect((json["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect((json["hint"] as? String)?.contains("refresh_cache") == true)
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveStateStillReportsPlayback() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .success(liveTransportJSON(
+            isPlaying: true,
+            isRecording: true,
+            position: "96.1.1.1"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_mismatch")
+    #expect(json["observed_isPlaying"] as? Bool == true)
+    #expect(json["observed_isRecording"] as? Bool == true)
+    #expect(json["observed_position"] as? String == "96.1.1.1")
+    #expect(json["safe_to_retry"] as? Bool == true)
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == true)
+    #expect(cached.isRecording == true)
+    #expect(cached.position == "96.1.1.1")
 }
 
 @Test func testTransportDispatcherRejectsMissingSemanticPayloads() async {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -89,6 +89,36 @@ private actor FailingExecuteChannel: Channel {
     }
 }
 
+private actor TransportStateSequenceChannel: Channel {
+    nonisolated let id: ChannelID
+    private var states: [String]
+    private let mutationResults: [String: ChannelResult]
+    private(set) var executedOps: [(String, [String: String])] = []
+
+    init(id: ChannelID, states: [String], mutationResults: [String: ChannelResult]) {
+        self.id = id
+        self.states = states
+        self.mutationResults = mutationResults
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        if operation == "transport.get_state" {
+            guard !states.isEmpty else { return .error("transport state unavailable") }
+            let next = states.count > 1 ? states.removeFirst() : states[0]
+            return .success(next)
+        }
+        return mutationResults[operation] ?? .success("Mock: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "transport sequence")
+    }
+}
+
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
@@ -127,6 +157,108 @@ private actor FailingExecuteChannel: Channel {
         #expect(ops.count == 1)
         #expect(ops[0].0 == testCase.operation)
     }
+}
+
+@Test func testTransportDispatcherPlayFallsBackAndReturnsVerifiedStateA() async {
+    let router = ChannelRouter()
+    let ax = TransportStateSequenceChannel(
+        id: .accessibility,
+        states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#
+        ],
+        mutationResults: [
+            "transport.play": .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "transport button 'Play' not located"
+            ))
+        ]
+    )
+    let coreMIDI = MockChannel(id: .coreMIDI)
+    await router.register(ax)
+    await router.register(coreMIDI)
+
+    let result = await TransportDispatcher.handle(
+        command: "play",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError == false)
+    #expect(text.contains(#""verified":true"#))
+    #expect(text.contains(#""operation":"transport.play""#))
+    #expect(text.contains(#""write_attempted":true"#))
+    let coreOps = await coreMIDI.executedOps
+    #expect(coreOps.count == 1)
+    #expect(coreOps[0].0 == "transport.play")
+}
+
+@Test func testTransportDispatcherStopReturnsVerifiedUnchangedWhenAlreadyStopped() async {
+    let router = ChannelRouter()
+    let ax = TransportStateSequenceChannel(
+        id: .accessibility,
+        states: [#"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#],
+        mutationResults: [:]
+    )
+    let coreMIDI = MockChannel(id: .coreMIDI)
+    await router.register(ax)
+    await router.register(coreMIDI)
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError == false)
+    #expect(text.contains(#""verified":true"#))
+    #expect(text.contains(#""write_attempted":false"#))
+    #expect(text.contains(#""unchanged":true"#))
+    let coreOps = await coreMIDI.executedOps
+    #expect(coreOps.isEmpty)
+}
+
+@Test func testTransportDispatcherRecordReturnsReadbackMismatchWhenFallbackDoesNotRecord() async {
+    let router = ChannelRouter()
+    let ax = TransportStateSequenceChannel(
+        id: .accessibility,
+        states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#
+        ],
+        mutationResults: [
+            "transport.record": .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "transport button 'Record' not located"
+            ))
+        ]
+    )
+    let coreMIDI = MockChannel(id: .coreMIDI)
+    await router.register(ax)
+    await router.register(coreMIDI)
+
+    let result = await TransportDispatcher.handle(
+        command: "record",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    let text = dispatcherText(result)
+    #expect(result.isError == false)
+    #expect(text.contains(#""verified":false"#))
+    #expect(text.contains(#""reason":"readback_mismatch""#))
+    #expect(text.contains(#""operation":"transport.record""#))
+    let coreOps = await coreMIDI.executedOps
+    #expect(coreOps.count == 1)
+    #expect(coreOps[0].0 == "transport.record")
 }
 
 @Test func testTransportDispatcherSetTempoGotoPositionAndCycleRange() async {

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -61,6 +61,29 @@ private actor LiveTransportStateChannel: Channel {
     }
 }
 
+private actor FailingTransportStateChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private let errorMessage: String
+
+    init(errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        if operation == "transport.get_state" {
+            return .error(errorMessage)
+        }
+        return .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "failing transport test channel")
+    }
+}
+
 private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     var json = try sharedParseJSON(text) as! [String: Any]
 
@@ -155,6 +178,7 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     let state = json["state"] as! [String: Any]
 
     #expect(await channel.executedOperations() == ["transport.get_state"])
+    #expect(envelope["source"] as? String == "ax_live")
     #expect(state["isPlaying"] as? Bool == false)
     #expect(state["tempo"] as? Double == 90.5)
     #expect(state["isCycleEnabled"] as? Bool == true)
@@ -162,6 +186,39 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     #expect(cached.isPlaying == false)
     #expect(cached.tempo == 90.5)
     #expect(cached.isCycleEnabled == true)
+}
+
+@Test func testTransportStateResourceMarksCachedFallbackAsUnverifiedWhenLiveRefreshFails() async {
+    let cache = StateCache()
+    var staleTransport = TransportState()
+    staleTransport.isPlaying = true
+    staleTransport.isRecording = true
+    staleTransport.position = "96.1.1.1"
+    staleTransport.lastUpdated = Date(timeIntervalSinceNow: -42)
+    await cache.updateTransport(staleTransport)
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let channel = FailingTransportStateChannel(errorMessage: HonestContract.encodeStateC(
+        error: .elementNotFound,
+        hint: "Cannot locate transport bar"
+    ))
+    await router.register(channel)
+
+    let result = try! await ResourceHandlers.read(uri: "logic://transport/state", cache: cache, router: router)
+    let envelope = try! sharedParseJSON(resourceText(result)) as! [String: Any]
+    let json = envelope["data"] as! [String: Any]
+    let state = json["state"] as! [String: Any]
+
+    #expect(envelope["source"] as? String == "cache")
+    #expect(envelope["unverified"] as? Bool == true)
+    #expect(envelope["stale"] as? Bool == true)
+    #expect(envelope["refresh_error"] as? String == "element_not_found")
+    #expect((envelope["recovery_hint"] as? String)?.contains("refresh_cache") == true)
+    #expect((envelope["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect(state["isPlaying"] as? Bool == true)
+    #expect(state["isRecording"] as? Bool == true)
+    #expect(state["position"] as? String == "96.1.1.1")
 }
 
 @Test func testTransportStateResourceSignalsStaleAfterClose() async {


### PR DESCRIPTION
Refs #48.

## Root cause
- `transport.play`, `transport.stop`, and `transport.record` could die on an AX `element_not_found` before reaching a product-level fallback path.
- `transport.play` did not include AppleScript in the route chain, and `ChannelRouter` only treated AX lookup misses as fallthrough-worthy for a small subset of transport toggles.
- `TransportDispatcher` returned routed write results directly for mutating transport commands, so fallback writes could report success without proving the actual transport state, and redundant commands could not return a verified unchanged State A.
- The stop route was especially weak in live 12.2 sessions: MCU/CoreMIDI could report a sent stop while transport readback still showed playback running.
- The live harness had fresh-state transport assertions, but this PR initially lacked host evidence from a real 1-track / 0-region arrange-window state.

## What changed
- Allow AX `element_not_found` fallthrough for `transport.play`, `transport.stop`, and `transport.record` in `ChannelRouter`.
- Add AppleScript fallback to `transport.play` and keep the production AppleScript runtime handling `play` alongside `stop` and `record`.
- Prefer CGEvent ahead of MIDI/AppleScript for `transport.stop` after AX misses, because live 12.2 stop behavior proved that spacebar-style stop is the first reliable non-AX fallback.
- Add richer AX transport lookup diagnostics so hard misses include the requested button, visible landmarks, discovered controls, and a recovery hint.
- Wrap `transport.play` and `transport.record` in transport-state verification:
  - pre-read `transport.get_state`
  - return verified unchanged State A when already in the requested state
  - poll post-write transport state and only promote confirmed outcomes to verified State A
  - return honest State B `readback_mismatch` / `readback_unavailable` when fallback writes do not produce the requested state
- Add a dedicated verified stop path:
  - unchanged fast path when already stopped
  - post-write live `logic://transport/state` refresh through `ResourceHandlers.readLiveTransportState`
  - fail-closed State C `readback_unavailable` / `readback_mismatch` when live stop verification cannot prove transport actually stopped
- Extend the Python live harness with fresh-project transport checks for:
  - verified unchanged `stop`
  - verified `record`
  - verified `stop` after record
  - verified unchanged `stop` after stopping
  - verified `play`
  - verified unchanged `play`
  - verified `stop` after play
  - arm/disarm setup around track 0
- Add/merge unit coverage for dispatcher stop hardening, router fallback ordering, and transport state resource refresh behavior.

## Verification
Passed locally in `/private/tmp/logic-pro-mcp-issue48`:
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift test --filter testTransportDispatcherStop`
- `swift test --filter testTransportDispatcherPlayFallsBackAndReturnsVerifiedStateA`
- `swift test --filter testTransportDispatcherRecordReturnsReadbackMismatchWhenFallbackDoesNotRecord`
- `swift test --filter testTransportDispatcherRoutesPrimaryCommands`
- `swift test --filter testRouterTransport`
- `swift test --filter testTransportStateResource`
- `swift build -c release`
- `git diff --check`

## Live host evidence
Observed on June 20, 2026 (Asia/Seoul) against `/private/tmp/logic-pro-mcp-issue48/.build/release/LogicProMCP` via the tmux-backed stdio harness:

1. Starting point was a disposable `Untitled 4` scratch session with 4 tracks and 0 regions on track 0.
2. `logic_project.close {saving:"no", confirmed:true}` intentionally discarded that scratch state and left Logic running with no visible document window.
3. `logic_project.new` still surfaced the existing bootstrap brittleness tracked separately in #45 (`success:true, verified:false`, no visible window), so I used Logic's enabled `File -> New` menu item and one Return keypress to confirm the pending New Track dialog.
4. After that, the host reached the required fresh arrange-window state:
   - `logic_system.health.cache.track_count: 1`
   - `logic://tracks` returned one live track named `Deluxe Classic`
   - `logic://tracks/0/regions` returned `[]`
5. On that fresh 1-track / 0-region state, the new live transport sequence passed end-to-end:
   - `logic_transport.stop` while already stopped returned verified unchanged State A
   - `logic_transport.record` returned `verified:true` and read back `isPlaying:true`, `isRecording:true`
   - `logic_transport.stop` after record returned `verified:true` with `verify_source:"ax_transport_state"`
   - a second `stop` returned verified unchanged State A
   - `logic_transport.play` returned `verified:true` with `isPlaying:true`, `isRecording:false`
   - a second `play` returned verified unchanged State A
   - the final `stop` again returned `verified:true` with `verify_source:"ax_transport_state"`

The windowless fresh-bootstrap recovery itself is still tracked by #45, but once Logic is in the normal fresh arrange-window state, this PR now proves `play` / `stop` / `record` all work with honest readback and redundant-command verification.
