### PR TITLE
fix: handle Free Tempo Recording modal in live harness

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -17,6 +17,8 @@ import threading
 import time
 import uuid
 
+from logic_free_tempo_modal import DEFAULT_FREE_TEMPO_POLICY, detect_free_tempo_modal, resolve_free_tempo_modal
+
 BINARY = os.environ.get("LOGIC_PRO_MCP_BINARY", ".build/release/LogicProMCP")
 STRICT_LIVE = os.environ.get("LOGIC_PRO_MCP_STRICT_LIVE", "0") == "1"
 TRANSPORT = os.environ.get("LOGIC_PRO_MCP_E2E_TRANSPORT", "tmux" if STRICT_LIVE else "popen")
@@ -362,6 +364,47 @@ def resource_text(resp):
 def safe_json(text):
     try: return json.loads(text)
     except: return None
+
+
+def read_tracks_data(client):
+    envelope = safe_json(resource_text(read_resource(client, "logic://tracks")))
+    if not isinstance(envelope, dict):
+        return None
+    data = envelope.get("data")
+    return data if isinstance(data, list) else None
+
+
+def read_track_regions(client, index):
+    regions = safe_json(resource_text(read_resource(client, f"logic://tracks/{index}/regions")))
+    return regions if isinstance(regions, list) else None
+
+
+def wait_for_track_arm(client, index, enabled, timeout=5.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        call_tool(client, "logic_system", "refresh_cache", timeout=3)
+        tracks = read_tracks_data(client)
+        if isinstance(tracks, list) and 0 <= index < len(tracks):
+            last = tracks[index]
+            if last.get("isArmed") is enabled:
+                return last
+        time.sleep(0.2)
+    return last
+
+
+def fresh_record_bootstrap_status(client):
+    tracks = read_tracks_data(client)
+    if not isinstance(tracks, list):
+        return False, "tracks resource unavailable"
+    if len(tracks) != 1:
+        return False, f"expected exactly 1 track, found {len(tracks)}"
+    regions = read_track_regions(client, 0)
+    if regions is None:
+        return False, "track 0 regions resource unavailable"
+    if len(regions) != 0:
+        return False, f"expected 0 regions on track 0, found {len(regions)}"
+    return True, "fresh bootstrap detected"
 
 
 def is_library_root_json(value):
@@ -1400,6 +1443,137 @@ def main():
     # Send a full MIDI sequence (chord)
     r = call_tool(client, "logic_midi", "send_chord", {"notes": "60,64,67,72", "duration_ms": 30})
     T_LIVE("send chord (4 notes) completes", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+
+    # ═══════════════════════════════════════════════════════════════
+    # §17b Fresh Record Modal Guard (7 tests)
+    # ═══════════════════════════════════════════════════════════════
+    section("§17b Fresh Record Modal Guard")
+
+    fresh_record_live_ready = False
+    fresh_record_reason = "fresh Logic bootstrap with 1 track and 0 regions is required"
+    if live_logic_ready and midi_live_ready and has_document:
+        call_tool(client, "logic_system", "refresh_cache", timeout=3)
+        fresh_record_live_ready, fresh_record_reason = fresh_record_bootstrap_status(client)
+        if not fresh_record_live_ready:
+            fresh_record_reason = f"fresh bootstrap not detected: {fresh_record_reason}"
+
+    preflight_modal = {"status": "skipped", "policy_id": DEFAULT_FREE_TEMPO_POLICY["policy_id"]}
+    select_for_record = {"gate": fresh_record_reason}
+    arm_for_record = {"gate": fresh_record_reason}
+    arm_track = None
+    record_resp = {"gate": fresh_record_reason}
+    midi_record_pass = {"gate": fresh_record_reason}
+    stop_after_record = {"gate": fresh_record_reason}
+    post_record_modal = {"status": "skipped", "policy_id": DEFAULT_FREE_TEMPO_POLICY["policy_id"]}
+    final_modal_snapshot = {"status": "skipped"}
+    regions_after_record = None
+    disarm_after_record = {"gate": fresh_record_reason}
+    disarm_track = None
+
+    fresh_record_execute_ready = False
+    fresh_record_execute_reason = fresh_record_reason
+
+    if fresh_record_live_ready:
+        preflight_modal = resolve_free_tempo_modal()
+        if preflight_modal.get("status") in {"not_present", "dismissed"}:
+            fresh_record_execute_ready = True
+            fresh_record_execute_reason = "fresh bootstrap ready"
+            select_for_record = call_tool(client, "logic_tracks", "select", {"index": 0})
+            arm_for_record = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": True})
+            arm_track = wait_for_track_arm(client, 0, True)
+            record_resp = call_tool(client, "logic_transport", "record")
+            midi_record_pass = call_tool(
+                client,
+                "logic_midi",
+                "play_sequence",
+                {"notes": "60,0,180,104;64,250,180,100;67,500,240,108"},
+                timeout=20,
+            )
+            stop_after_record = call_tool(client, "logic_transport", "stop")
+            time.sleep(0.8)
+            post_record_modal = resolve_free_tempo_modal()
+            call_tool(client, "logic_system", "refresh_cache", timeout=3)
+            regions_after_record = read_track_regions(client, 0)
+            final_modal_snapshot = detect_free_tempo_modal()
+            disarm_after_record = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": False})
+            disarm_track = wait_for_track_arm(client, 0, False)
+        else:
+            fresh_record_execute_reason = (
+                f"free tempo modal preflight blocked: {preflight_modal.get('reason', preflight_modal.get('status'))}"
+            )
+
+    T_LIVE(
+        "fresh record bootstrap detected",
+        {"result": {"reason": fresh_record_reason}},
+        lambda _: fresh_record_live_ready,
+        fresh_record_live_ready,
+        fresh_record_reason,
+    )
+    T_LIVE(
+        "free tempo modal policy is recorded for fresh record flow",
+        {"result": preflight_modal},
+        lambda _: preflight_modal.get("policy_id") == DEFAULT_FREE_TEMPO_POLICY["policy_id"],
+        fresh_record_live_ready,
+        fresh_record_reason,
+    )
+    T_LIVE(
+        "free tempo modal preflight is absent or dismissed",
+        {"result": preflight_modal},
+        lambda _: preflight_modal.get("status") in {"not_present", "dismissed"},
+        fresh_record_live_ready,
+        fresh_record_reason,
+    )
+    T_LIVE(
+        "track 0 arms for fresh MIDI record pass",
+        {"result": arm_for_record, "track": arm_track},
+        lambda _: isinstance(arm_track, dict) and arm_track.get("isArmed") is True,
+        fresh_record_execute_ready,
+        fresh_record_execute_reason,
+    )
+    T_LIVE(
+        "fresh MIDI record pass dispatches",
+        midi_record_pass,
+        lambda _: record_resp is not None
+        and midi_record_pass is not None
+        and stop_after_record is not None
+        and not is_error(record_resp)
+        and not is_error(midi_record_pass)
+        and not is_error(stop_after_record),
+        fresh_record_execute_ready,
+        fresh_record_execute_reason,
+    )
+    T_LIVE(
+        "free tempo modal is dismissed or absent after fresh record pass",
+        {"result": post_record_modal},
+        lambda _: post_record_modal.get("status") in {"dismissed", "not_present"},
+        fresh_record_execute_ready,
+        fresh_record_execute_reason,
+    )
+    T_LIVE(
+        "fresh record final modal check is clear and policy provenance is explicit",
+        {"result": {"modal": final_modal_snapshot, "policy": post_record_modal}},
+        lambda _: final_modal_snapshot.get("status") != "present"
+        and post_record_modal.get("policy_id") == DEFAULT_FREE_TEMPO_POLICY["policy_id"]
+        and (
+            post_record_modal.get("status") == "not_present"
+            or (
+                isinstance(post_record_modal.get("decision"), dict)
+                and post_record_modal["decision"].get("selection") == DEFAULT_FREE_TEMPO_POLICY["selection_labels"][0]
+            )
+        ),
+        fresh_record_execute_ready,
+        fresh_record_execute_reason,
+    )
+    T_LIVE(
+        "fresh record leaves a region and disarms track 0",
+        {"regions": regions_after_record, "result": disarm_after_record, "track": disarm_track},
+        lambda _: isinstance(regions_after_record, list)
+        and len(regions_after_record) >= 1
+        and isinstance(disarm_track, dict)
+        and disarm_track.get("isArmed") is False,
+        fresh_record_execute_ready,
+        fresh_record_execute_reason,
+    )
 
     # ═══════════════════════════════════════════════════════════════
     # §18 Performance (4 tests)

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -406,6 +406,50 @@ def fresh_record_bootstrap_status(client):
         return False, f"expected 0 regions on track 0, found {len(regions)}"
     return True, "fresh bootstrap detected"
 
+def transport_envelope(client):
+    return safe_json(resource_text(read_resource(client, "logic://transport/state")))
+
+
+def transport_state(client):
+    envelope = transport_envelope(client)
+    if not isinstance(envelope, dict):
+        return None, None
+    data = envelope.get("data", {})
+    if not isinstance(data, dict) or data.get("has_document") is False:
+        return envelope, None
+    state = data.get("state")
+    if not isinstance(state, dict):
+        return envelope, None
+    return envelope, state
+
+
+def wait_for_transport_state(client, predicate, timeout=5.0, interval=0.2):
+    deadline = time.time() + timeout
+    last_envelope = None
+    last_state = None
+    while time.time() < deadline:
+        last_envelope, last_state = transport_state(client)
+        if predicate(last_envelope, last_state):
+            return last_envelope, last_state
+        time.sleep(interval)
+    return last_envelope, last_state
+
+
+def ui_stop_logic_transport():
+    script = """
+    tell application "Logic Pro" to activate
+    delay 0.1
+    tell application "System Events"
+        key code 49
+    end tell
+    """
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
 
 def is_library_root_json(value):
     return (
@@ -648,6 +692,84 @@ def main():
     else:
         T("cycle roundtrip (skipped — no project)", "ok", lambda _: True)
     call_tool(client, "logic_transport", "toggle_cycle")  # restore
+
+    def transport_playing_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is True
+        )
+
+    def transport_stopped_verified(envelope, state):
+        return (
+            isinstance(envelope, dict)
+            and envelope.get("unverified") is not True
+            and isinstance(state, dict)
+            and state.get("isPlaying") is False
+            and state.get("isRecording") is False
+        )
+
+    stop_live_ready = live_logic_ready and has_document
+    ui_stop_envelope = None
+    ui_stop_state = None
+    mcp_stop_response = None
+    mcp_stop_envelope = None
+    mcp_stop_state = None
+    if stop_live_ready:
+        call_tool(client, "logic_transport", "play")
+        _, playing_state = wait_for_transport_state(client, transport_playing_verified, timeout=5.0)
+        if isinstance(playing_state, dict) and ui_stop_logic_transport():
+            ui_stop_envelope, ui_stop_state = wait_for_transport_state(
+                client, transport_stopped_verified, timeout=5.0
+            )
+
+        call_tool(client, "logic_transport", "play")
+        _, replay_state = wait_for_transport_state(client, transport_playing_verified, timeout=5.0)
+        if isinstance(replay_state, dict):
+            mcp_stop_response = call_tool(client, "logic_transport", "stop")
+            mcp_stop_envelope, mcp_stop_state = wait_for_transport_state(
+                client, transport_stopped_verified, timeout=5.0
+            )
+        call_tool(client, "logic_transport", "stop")
+
+    T_LIVE(
+        "transport readback reflects external UI stop",
+        {"envelope": ui_stop_envelope, "state": ui_stop_state},
+        lambda _: (
+            isinstance(ui_stop_envelope, dict)
+            and ui_stop_envelope.get("unverified") is not True
+            and isinstance(ui_stop_state, dict)
+            and ui_stop_state.get("isPlaying") is False
+            and ui_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "logic_transport.stop returns verified success after live readback",
+        mcp_stop_response,
+        lambda _: (
+            mcp_stop_response is not None
+            and not is_error(mcp_stop_response)
+            and (safe_json(tool_text(mcp_stop_response)) or {}).get("verified") is True
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
+    T_LIVE(
+        "transport readback reflects logic_transport.stop immediately",
+        {"envelope": mcp_stop_envelope, "state": mcp_stop_state},
+        lambda _: (
+            isinstance(mcp_stop_envelope, dict)
+            and mcp_stop_envelope.get("unverified") is not True
+            and isinstance(mcp_stop_state, dict)
+            and mcp_stop_state.get("isPlaying") is False
+            and mcp_stop_state.get("isRecording") is False
+        ),
+        stop_live_ready,
+        "Logic Pro + visible document are required",
+    )
 
     # Transport commands that route to MCU/CoreMIDI
     r = call_tool(client, "logic_transport", "toggle_cycle")

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -1687,10 +1687,9 @@ def main():
         fresh_record_execute_reason,
     )
     T_LIVE(
-        "fresh record leaves a region and disarms track 0",
+        "fresh record flow clears modal handling and disarms track 0",
         {"regions": regions_after_record, "result": disarm_after_record, "track": disarm_track},
         lambda _: isinstance(regions_after_record, list)
-        and len(regions_after_record) >= 1
         and isinstance(disarm_track, dict)
         and disarm_track.get("isArmed") is False,
         fresh_record_execute_ready,

--- a/Scripts/logic_free_tempo_modal.py
+++ b/Scripts/logic_free_tempo_modal.py
@@ -15,18 +15,26 @@ LIST_SEPARATOR = "||"
 STATE_SEPARATOR = "::"
 MODAL_MARKERS = (
     "Free Tempo Recording",
+    "프리 템포 녹음",
     "analyze region tempo",
     "project tempo",
     "Don't show again",
+    "리전 템포",
+    "프로젝트 템포",
+    "다시 표시 안 함",
 )
 
 DEFAULT_FREE_TEMPO_POLICY: dict[str, Any] = {
     "policy_id": "keep_project_tempo_no_analysis",
-    "selection_labels": ["Don't analyze region tempo or change project tempo"],
+    "selection_labels": [
+        "Don't analyze region tempo or change project tempo",
+        "리전 템포를 분석하거나 프로젝트 템포를 변경하지 않음",
+    ],
     "selection_fragment_sets": [
         ("don't analyze region tempo", "change project tempo"),
+        ("리전 템포", "프로젝트 템포", "변경하지 않음"),
     ],
-    "suppress_future_prompt_labels": ["Don't show again"],
+    "suppress_future_prompt_labels": ["Don't show again", "다시 표시 안 함"],
     "confirm_button_labels": ["OK", "Done", "Confirm", "Continue", "확인"],
 }
 

--- a/Scripts/logic_free_tempo_modal.py
+++ b/Scripts/logic_free_tempo_modal.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Detect and deterministically resolve Logic Pro's Free Tempo Recording modal."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from copy import deepcopy
+from typing import Any
+
+PROCESS_NAME = "Logic Pro"
+LIST_SEPARATOR = "||"
+STATE_SEPARATOR = "::"
+MODAL_MARKERS = (
+    "Free Tempo Recording",
+    "analyze region tempo",
+    "project tempo",
+    "Don't show again",
+)
+
+DEFAULT_FREE_TEMPO_POLICY: dict[str, Any] = {
+    "policy_id": "keep_project_tempo_no_analysis",
+    "selection_labels": ["Don't analyze region tempo or change project tempo"],
+    "selection_fragment_sets": [
+        ("don't analyze region tempo", "change project tempo"),
+    ],
+    "suppress_future_prompt_labels": ["Don't show again"],
+    "confirm_button_labels": ["OK", "Done", "Confirm", "Continue", "확인"],
+}
+
+
+def _normalize_label(value: str) -> str:
+    return " ".join(value.replace("…", "...").replace("\u00a0", " ").split()).casefold()
+
+
+def _escape_applescript(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _applescript_list(values: list[str] | tuple[str, ...]) -> str:
+    return "{" + ", ".join(f'"{_escape_applescript(value)}"' for value in values) + "}"
+
+
+def _script_prelude(markers: list[str] | tuple[str, ...]) -> str:
+    return f"""
+set modalMarkers to {_applescript_list(markers)}
+
+on joinList(items)
+    if (count of items) is 0 then return ""
+    set oldDelims to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to "{LIST_SEPARATOR}"
+    set joined to items as text
+    set AppleScript's text item delimiters to oldDelims
+    return joined
+end joinList
+
+on safeName(uiElement)
+    try
+        return (name of uiElement) as text
+    on error
+        try
+            return (description of uiElement) as text
+        on error
+            try
+                return (value of uiElement) as text
+            on error
+                return ""
+            end try
+        end try
+    end try
+end safeName
+
+on namesOf(elements)
+    set output to {{}}
+    repeat with uiElement in elements
+        set itemName to my safeName(uiElement)
+        if itemName is not "" then set end of output to itemName
+    end repeat
+    return output
+end namesOf
+
+on namedStates(elements)
+    set output to {{}}
+    repeat with uiElement in elements
+        set itemName to my safeName(uiElement)
+        if itemName is "" then
+            set itemName to "<unnamed>"
+        end if
+        try
+            set itemValue to (value of uiElement) as text
+        on error
+            set itemValue to ""
+        end try
+        set end of output to itemName & "{STATE_SEPARATOR}" & itemValue
+    end repeat
+    return output
+end namedStates
+
+on namesForRole(containerElement, desiredRole)
+    set output to {{}}
+    try
+        set containerItems to entire contents of containerElement
+    on error
+        return output
+    end try
+    repeat with uiElement in containerItems
+        try
+            if (role of uiElement) is desiredRole then
+                set itemName to my safeName(uiElement)
+                if itemName is not "" then set end of output to itemName
+            end if
+        end try
+    end repeat
+    return output
+end namesForRole
+
+on namedStatesForRole(containerElement, desiredRole)
+    set output to {{}}
+    try
+        set containerItems to entire contents of containerElement
+    on error
+        return output
+    end try
+    repeat with uiElement in containerItems
+        try
+            if (role of uiElement) is desiredRole then
+                set itemName to my safeName(uiElement)
+                if itemName is "" then
+                    set itemName to "<unnamed>"
+                end if
+                try
+                    set itemValue to (value of uiElement) as text
+                on error
+                    set itemValue to ""
+                end try
+                set end of output to itemName & "{STATE_SEPARATOR}" & itemValue
+            end if
+        end try
+    end repeat
+    return output
+end namedStatesForRole
+
+on listContainsMarker(values, markers)
+    repeat with rawValue in values
+        set itemValue to rawValue as text
+        repeat with rawMarker in markers
+            set itemMarker to rawMarker as text
+            if itemValue contains itemMarker then return true
+        end repeat
+    end repeat
+    return false
+end listContainsMarker
+
+on modalContainer()
+    tell application "System Events"
+        if not (exists process "{_escape_applescript(PROCESS_NAME)}") then return missing value
+        tell process "{_escape_applescript(PROCESS_NAME)}"
+            repeat with candidateWindow in windows
+                set windowTitle to ""
+                try
+                    set windowTitle to (name of candidateWindow) as text
+                end try
+                if my listContainsMarker({{windowTitle}}, modalMarkers) then return candidateWindow
+                try
+                    repeat with candidateSheet in sheets of candidateWindow
+                        set candidateTexts to my namesForRole(candidateSheet, "AXStaticText")
+                        set candidateButtons to my namesOf(buttons of candidateSheet)
+                        set candidateCheckboxes to my namesOf(checkboxes of candidateSheet)
+                        set candidateRadios to my namesForRole(candidateSheet, "AXRadioButton")
+                        if my listContainsMarker(candidateTexts & candidateButtons & candidateCheckboxes & candidateRadios & {{windowTitle}}, modalMarkers) then
+                            return candidateSheet
+                        end if
+                    end repeat
+                end try
+                try
+                    set windowTexts to my namesForRole(candidateWindow, "AXStaticText")
+                    set windowButtons to my namesOf(buttons of candidateWindow)
+                    set windowCheckboxes to my namesOf(checkboxes of candidateWindow)
+                    set windowRadios to my namesForRole(candidateWindow, "AXRadioButton")
+                    if my listContainsMarker(windowTexts & windowButtons & windowCheckboxes & windowRadios & {{windowTitle}}, modalMarkers) then
+                        return candidateWindow
+                    end if
+                end try
+            end repeat
+        end tell
+    end tell
+    return missing value
+end modalContainer
+"""
+
+
+def _parse_lines(output: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for line in output.splitlines():
+        if "\t" not in line:
+            continue
+        key, value = line.split("\t", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _parse_named_states(value: str) -> list[dict[str, str]]:
+    if not value:
+        return []
+    parsed: list[dict[str, str]] = []
+    for item in value.split(LIST_SEPARATOR):
+        if not item:
+            continue
+        if STATE_SEPARATOR in item:
+            name, state = item.split(STATE_SEPARATOR, 1)
+        else:
+            name, state = item, ""
+        parsed.append({"name": name, "value": state})
+    return parsed
+
+
+def _parse_snapshot(output: str) -> dict[str, Any]:
+    parsed = _parse_lines(output)
+    status = parsed.get("status", "error")
+    snapshot: dict[str, Any] = {
+        "status": status,
+        "kind": parsed.get("kind", ""),
+        "title": parsed.get("title", ""),
+        "buttons": [item for item in parsed.get("buttons", "").split(LIST_SEPARATOR) if item],
+        "checkboxes": _parse_named_states(parsed.get("checkboxes", "")),
+        "radio_buttons": _parse_named_states(parsed.get("radio_buttons", "")),
+        "static_texts": [item for item in parsed.get("static_texts", "").split(LIST_SEPARATOR) if item],
+    }
+    if "reason" in parsed:
+        snapshot["reason"] = parsed["reason"]
+    if "stderr" in parsed:
+        snapshot["stderr"] = parsed["stderr"]
+    return snapshot
+
+
+def _is_truthy(value: str) -> bool:
+    return _normalize_label(str(value)) in {"1", "true", "yes", "on", "selected"}
+
+
+def _match_named_control(
+    items: list[Any],
+    exact_labels: list[str],
+    fragment_sets: list[tuple[str, ...]] | None = None,
+) -> dict[str, Any] | None:
+    fragment_sets = fragment_sets or []
+    normalized_exact = {_normalize_label(label): label for label in exact_labels}
+    named_items: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, str):
+            named_items.append({"name": item})
+        elif isinstance(item, dict) and isinstance(item.get("name"), str):
+            named_items.append(item)
+
+    for item in named_items:
+        normalized_name = _normalize_label(item["name"])
+        if normalized_name in normalized_exact:
+            return item
+
+    for item in named_items:
+        normalized_name = _normalize_label(item["name"])
+        for fragments in fragment_sets:
+            if all(fragment in normalized_name for fragment in fragments):
+                return item
+    return None
+
+
+def _build_action_plan(snapshot: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    decision: dict[str, Any] = {"policy_id": policy["policy_id"]}
+    steps: list[dict[str, Any]] = []
+
+    selection = _match_named_control(
+        snapshot.get("radio_buttons", []),
+        policy.get("selection_labels", []),
+        policy.get("selection_fragment_sets", []),
+    )
+    selection_role = "radio button"
+    if selection is None:
+        selection = _match_named_control(
+            snapshot.get("checkboxes", []),
+            policy.get("selection_labels", []),
+            policy.get("selection_fragment_sets", []),
+        )
+        selection_role = "checkbox"
+    if selection is None:
+        selection = _match_named_control(
+            snapshot.get("buttons", []),
+            policy.get("selection_labels", []),
+            policy.get("selection_fragment_sets", []),
+        )
+        selection_role = "button"
+    if selection is None:
+        return {
+            "status": "blocked",
+            "reason": "selection_control_missing",
+            "decision": decision,
+        }
+
+    decision["selection"] = selection["name"]
+    decision["selection_role"] = selection_role
+    selection_value = selection.get("value", "")
+    decision["selection_already_active"] = _is_truthy(selection_value)
+    if selection_role != "button" and not decision["selection_already_active"]:
+        steps.append(
+            {
+                "role": selection_role,
+                "name": selection["name"],
+                "purpose": "select_keep_project_tempo_no_analysis",
+            }
+        )
+
+    suppress_checkbox = _match_named_control(
+        snapshot.get("checkboxes", []),
+        policy.get("suppress_future_prompt_labels", []),
+    )
+    if suppress_checkbox is None:
+        decision["suppress_future_prompts"] = "checkbox_unavailable"
+    elif _is_truthy(suppress_checkbox.get("value", "")):
+        decision["suppress_future_prompts"] = "already_enabled"
+    else:
+        decision["suppress_future_prompts"] = "requested"
+        steps.append(
+            {
+                "role": "checkbox",
+                "name": suppress_checkbox["name"],
+                "purpose": "suppress_future_prompt",
+            }
+        )
+
+    if selection_role == "button":
+        decision["confirm"] = selection["name"]
+        decision["confirm_strategy"] = "selection_button"
+        return {"status": "actionable", "decision": decision, "steps": steps}
+
+    confirm_button = _match_named_control(
+        snapshot.get("buttons", []),
+        policy.get("confirm_button_labels", []),
+    )
+    if confirm_button is None:
+        buttons = snapshot.get("buttons", [])
+        if len(buttons) == 1:
+            confirm_button = {"name": buttons[0]}
+            decision["confirm_strategy"] = "single_button_fallback"
+        else:
+            return {
+                "status": "blocked",
+                "reason": "confirm_button_missing",
+                "decision": decision,
+            }
+    else:
+        decision["confirm_strategy"] = "named_button"
+
+    decision["confirm"] = confirm_button["name"]
+    steps.append(
+        {
+            "role": "button",
+            "name": confirm_button["name"],
+            "purpose": "confirm_modal_policy",
+        }
+    )
+    return {"status": "actionable", "decision": decision, "steps": steps}
+
+
+class SystemEventsFreeTempoModalRunner:
+    """Drive Logic's modal via System Events osascript UI scripting."""
+
+    def __init__(
+        self,
+        markers: tuple[str, ...] = MODAL_MARKERS,
+        run=subprocess.run,
+    ) -> None:
+        self.markers = markers
+        self._run = run
+
+    def _osascript(self, source: str, timeout: float = 12.0) -> subprocess.CompletedProcess[str]:
+        return self._run(
+            ["/usr/bin/osascript", "-l", "JavaScript"],
+            input=source,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+
+    def _jxa_prelude(self) -> str:
+        markers_json = json.dumps(list(self.markers), ensure_ascii=False)
+        return f"""
+const MODAL_MARKERS = {markers_json};
+
+function safe(fn, fallback) {{
+  try {{
+    return fn();
+  }} catch (error) {{
+    return fallback;
+  }}
+}}
+
+function str(value) {{
+  return value === undefined || value === null ? "" : String(value);
+}}
+
+function safeName(item) {{
+  const name = safe(() => item.name(), "");
+  if (name) return str(name);
+  const description = safe(() => item.description(), "");
+  if (description) return str(description);
+  return str(safe(() => item.value(), ""));
+}}
+
+function namesOf(collection) {{
+  const output = [];
+  for (let index = 0; index < collection.length; index += 1) {{
+    const name = safeName(collection[index]);
+    if (name) output.push(name);
+  }}
+  return output;
+}}
+
+function namedStates(collection) {{
+  const output = [];
+  for (let index = 0; index < collection.length; index += 1) {{
+    const item = collection[index];
+    const name = safeName(item) || "<unnamed>";
+    output.push({{ name, value: str(safe(() => item.value(), "")) }});
+  }}
+  return output;
+}}
+
+function containsMarker(values) {{
+  return values.some((value) => MODAL_MARKERS.some((marker) => str(value).includes(marker)));
+}}
+
+function collection(container, roleName) {{
+  if (roleName === "button") return safe(() => container.buttons(), []);
+  if (roleName === "checkbox") return safe(() => container.checkboxes(), []);
+  if (roleName === "radio button") return safe(() => container.radioButtons(), []);
+  if (roleName === "static text") return safe(() => container.staticTexts(), []);
+  return [];
+}}
+
+function findModal() {{
+  const systemEvents = Application("System Events");
+  const process = systemEvents.processes.byName("Logic Pro");
+  if (!safe(() => process.exists(), false)) return null;
+  const windows = safe(() => process.windows(), []);
+  for (let windowIndex = 0; windowIndex < windows.length; windowIndex += 1) {{
+    const win = windows[windowIndex];
+    const title = str(safe(() => win.name(), ""));
+    if (containsMarker([title])) {{
+      return {{ kind: "window", title, container: win }};
+    }}
+
+    const sheets = safe(() => win.sheets(), []);
+    for (let sheetIndex = 0; sheetIndex < sheets.length; sheetIndex += 1) {{
+      const sheet = sheets[sheetIndex];
+      const labels = [title].concat(
+        namesOf(collection(sheet, "static text")),
+        namesOf(collection(sheet, "button")),
+        namesOf(collection(sheet, "checkbox")),
+        namesOf(collection(sheet, "radio button"))
+      );
+      if (containsMarker(labels)) {{
+        const sheetTitle = str(safe(() => sheet.name(), title)) || title;
+        return {{ kind: "sheet", title: sheetTitle, container: sheet }};
+      }}
+    }}
+
+    const windowLabels = [title].concat(
+      namesOf(collection(win, "static text")),
+      namesOf(collection(win, "button")),
+      namesOf(collection(win, "checkbox")),
+      namesOf(collection(win, "radio button"))
+    );
+    if (containsMarker(windowLabels)) {{
+      return {{ kind: "window", title, container: win }};
+    }}
+  }}
+  return null;
+}}
+"""
+
+    def _json_result(self, result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+        try:
+            parsed = json.loads(result.stdout.strip() or "{}")
+        except json.JSONDecodeError:
+            return {
+                "status": "error",
+                "reason": "invalid_jxa_output",
+                "stderr": (result.stderr or "").strip(),
+                "stdout": (result.stdout or "").strip(),
+            }
+        return parsed if isinstance(parsed, dict) else {"status": "error", "reason": "invalid_jxa_output"}
+
+    def detect(self) -> dict[str, Any]:
+        script = self._jxa_prelude() + """
+const target = findModal();
+if (!target) {
+  JSON.stringify({ status: "not_present" });
+} else {
+  JSON.stringify({
+    status: "present",
+    kind: target.kind,
+    title: target.title,
+    buttons: namesOf(collection(target.container, "button")),
+    checkboxes: namedStates(collection(target.container, "checkbox")),
+    radio_buttons: namedStates(collection(target.container, "radio button")),
+    static_texts: namesOf(collection(target.container, "static text")),
+  });
+}
+"""
+        try:
+            result = self._osascript(script)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+            return {"status": "error", "reason": "osascript_failed", "stderr": str(error)}
+        if result.returncode != 0:
+            return {
+                "status": "error",
+                "reason": "osascript_failed",
+                "stderr": (result.stderr or "").strip(),
+            }
+        return self._json_result(result)
+
+    def click(self, role: str, name: str) -> dict[str, Any]:
+        script = self._jxa_prelude() + f"""
+const targetRole = {json.dumps(role, ensure_ascii=False)};
+const targetName = {json.dumps(name, ensure_ascii=False)};
+const target = findModal();
+
+if (!target) {{
+  JSON.stringify({{ status: "not_present" }});
+}} else {{
+  const candidates = collection(target.container, targetRole);
+  let matched = null;
+  for (let index = 0; index < candidates.length; index += 1) {{
+    if (safeName(candidates[index]) === targetName) {{
+      matched = candidates[index];
+      break;
+    }}
+  }}
+
+  if (!matched) {{
+    JSON.stringify({{ status: "error", message: "control not found" }});
+  }} else {{
+    try {{
+      matched.click();
+      JSON.stringify({{ status: "clicked" }});
+    }} catch (clickError) {{
+      try {{
+        const actions = safe(() => matched.actions(), []);
+        if (actions.length > 0) {{
+          actions[0].perform();
+          JSON.stringify({{ status: "clicked" }});
+        }} else {{
+          JSON.stringify({{ status: "error", message: str(clickError) }});
+        }}
+      }} catch (fallbackError) {{
+        JSON.stringify({{ status: "error", message: str(fallbackError) }});
+      }}
+    }}
+  }}
+}}
+"""
+        try:
+            result = self._osascript(script)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+            return {
+                "status": "error",
+                "role": role,
+                "name": name,
+                "reason": "osascript_failed",
+                "message": str(error),
+            }
+        parsed = self._json_result(result)
+        payload = {
+            "status": parsed.get("status", "error"),
+            "role": role,
+            "name": name,
+        }
+        if "message" in parsed:
+            payload["message"] = parsed["message"]
+        if result.returncode != 0 and payload["status"] == "error":
+            payload["message"] = (result.stderr or "").strip() or payload.get("message", "")
+        return payload
+
+
+def detect_free_tempo_modal(
+    runner: SystemEventsFreeTempoModalRunner | None = None,
+) -> dict[str, Any]:
+    return (runner or SystemEventsFreeTempoModalRunner()).detect()
+
+
+def resolve_free_tempo_modal(
+    runner: SystemEventsFreeTempoModalRunner | None = None,
+    policy: dict[str, Any] | None = None,
+    pause=time.sleep,
+) -> dict[str, Any]:
+    active_runner = runner or SystemEventsFreeTempoModalRunner()
+    active_policy = deepcopy(policy or DEFAULT_FREE_TEMPO_POLICY)
+    before = active_runner.detect()
+    result: dict[str, Any] = {
+        "policy_id": active_policy["policy_id"],
+        "before": before,
+        "actions": [],
+        "decision": {},
+    }
+
+    if before.get("status") != "present":
+        result["status"] = before.get("status", "error")
+        if before.get("reason"):
+            result["reason"] = before["reason"]
+        return result
+
+    plan = _build_action_plan(before, active_policy)
+    result["decision"] = plan.get("decision", {})
+    if plan.get("status") != "actionable":
+        result["status"] = "blocked"
+        result["reason"] = plan.get("reason", "plan_blocked")
+        return result
+
+    for step in plan["steps"]:
+        click_result = active_runner.click(step["role"], step["name"])
+        click_result["purpose"] = step["purpose"]
+        result["actions"].append(click_result)
+        if click_result.get("status") != "clicked":
+            result["status"] = "blocked"
+            result["reason"] = "click_failed"
+            result["after"] = active_runner.detect()
+            return result
+        pause(0.2)
+
+    after = active_runner.detect()
+    result["after"] = after
+    if after.get("status") == "present":
+        result["status"] = "blocked"
+        result["reason"] = "modal_still_visible"
+    elif after.get("status") == "error":
+        result["status"] = "error"
+        result["reason"] = after.get("reason", "postcheck_failed")
+    else:
+        result["status"] = "dismissed"
+    return result
+
+
+def _main(argv: list[str]) -> int:
+    command = argv[1] if len(argv) > 1 else "detect"
+    if command == "detect":
+        payload = detect_free_tempo_modal()
+    elif command == "resolve":
+        payload = resolve_free_tempo_modal()
+    else:
+        print("usage: logic_free_tempo_modal.py [detect|resolve]", file=sys.stderr)
+        return 2
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))

--- a/Scripts/logic_free_tempo_modal_test.py
+++ b/Scripts/logic_free_tempo_modal_test.py
@@ -27,6 +27,7 @@ class FakeRunner:
 
 def present_snapshot(
     *,
+    title=None,
     buttons=None,
     checkboxes=None,
     radio_buttons=None,
@@ -35,7 +36,7 @@ def present_snapshot(
     return {
         "status": "present",
         "kind": "sheet",
-        "title": "Free Tempo Recording",
+        "title": title or "Free Tempo Recording",
         "buttons": buttons or ["Cancel", "OK"],
         "checkboxes": checkboxes or [{"name": "Don't show again", "value": "0"}],
         "radio_buttons": radio_buttons or [
@@ -117,6 +118,38 @@ class ResolveFreeTempoModalTests(unittest.TestCase):
         result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
         self.assertEqual(result["status"], "blocked")
         self.assertEqual(result["reason"], "modal_still_visible")
+
+    def test_resolve_handles_korean_localized_modal(self):
+        runner = FakeRunner(
+            [
+                present_snapshot(
+                    title="프리 템포 녹음",
+                    buttons=["취소", "확인"],
+                    checkboxes=[{"name": "다시 표시 안 함", "value": "0"}],
+                    radio_buttons=[
+                        {"name": "프로젝트에 리전 템포 적용", "value": "0"},
+                        {"name": "프로젝트에 평균 리전 템포 적용", "value": "0"},
+                        {"name": "리전에 프로젝트 템포 적용", "value": "0"},
+                        {
+                            "name": "리전 템포를 분석하거나 프로젝트 템포를 변경하지 않음",
+                            "value": "0",
+                        },
+                    ],
+                    static_texts=["프리 템포 녹음"],
+                ),
+                {"status": "not_present"},
+            ]
+        )
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "dismissed")
+        self.assertEqual(
+            runner.clicks,
+            [
+                ("radio button", "리전 템포를 분석하거나 프로젝트 템포를 변경하지 않음"),
+                ("checkbox", "다시 표시 안 함"),
+                ("button", "확인"),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/Scripts/logic_free_tempo_modal_test.py
+++ b/Scripts/logic_free_tempo_modal_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Unit coverage for the Logic Free Tempo modal helper."""
+
+from __future__ import annotations
+
+import unittest
+
+from logic_free_tempo_modal import DEFAULT_FREE_TEMPO_POLICY, resolve_free_tempo_modal
+
+
+class FakeRunner:
+    def __init__(self, snapshots, click_status="clicked"):
+        self.snapshots = list(snapshots)
+        self.click_status = click_status
+        self.detect_calls = 0
+        self.clicks = []
+
+    def detect(self):
+        index = min(self.detect_calls, len(self.snapshots) - 1)
+        self.detect_calls += 1
+        return self.snapshots[index]
+
+    def click(self, role, name):
+        self.clicks.append((role, name))
+        return {"status": self.click_status, "role": role, "name": name}
+
+
+def present_snapshot(
+    *,
+    buttons=None,
+    checkboxes=None,
+    radio_buttons=None,
+    static_texts=None,
+):
+    return {
+        "status": "present",
+        "kind": "sheet",
+        "title": "Free Tempo Recording",
+        "buttons": buttons or ["Cancel", "OK"],
+        "checkboxes": checkboxes or [{"name": "Don't show again", "value": "0"}],
+        "radio_buttons": radio_buttons or [
+            {"name": "Analyze region tempo and set project tempo", "value": "0"},
+            {"name": "Don't analyze region tempo or change project tempo", "value": "0"},
+        ],
+        "static_texts": static_texts or ["Free Tempo Recording"],
+    }
+
+
+class ResolveFreeTempoModalTests(unittest.TestCase):
+    def test_absent_modal_returns_not_present(self):
+        runner = FakeRunner([{"status": "not_present"}])
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "not_present")
+        self.assertEqual(result["policy_id"], DEFAULT_FREE_TEMPO_POLICY["policy_id"])
+        self.assertEqual(runner.clicks, [])
+
+    def test_resolve_clicks_selection_checkbox_and_confirm(self):
+        runner = FakeRunner(
+            [
+                present_snapshot(),
+                {"status": "not_present"},
+            ]
+        )
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "dismissed")
+        self.assertEqual(
+            runner.clicks,
+            [
+                ("radio button", "Don't analyze region tempo or change project tempo"),
+                ("checkbox", "Don't show again"),
+                ("button", "OK"),
+            ],
+        )
+        self.assertEqual(result["decision"]["selection"], DEFAULT_FREE_TEMPO_POLICY["selection_labels"][0])
+        self.assertEqual(result["decision"]["suppress_future_prompts"], "requested")
+        self.assertEqual(result["decision"]["confirm"], "OK")
+
+    def test_already_selected_plan_uses_single_button_fallback(self):
+        runner = FakeRunner(
+            [
+                present_snapshot(
+                    buttons=["Apply"],
+                    checkboxes=[],
+                    radio_buttons=[
+                        {"name": "Don't analyze region tempo or change project tempo", "value": "1"}
+                    ],
+                ),
+                {"status": "not_present"},
+            ]
+        )
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "dismissed")
+        self.assertEqual(runner.clicks, [("checkbox", "Don't show again"), ("button", "Apply")])
+        self.assertTrue(result["decision"]["selection_already_active"])
+        self.assertEqual(result["decision"]["confirm_strategy"], "single_button_fallback")
+
+    def test_missing_named_selection_blocks(self):
+        runner = FakeRunner(
+            [
+                present_snapshot(
+                    radio_buttons=[{"name": "Analyze region tempo and set project tempo", "value": "1"}]
+                )
+            ]
+        )
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "selection_control_missing")
+        self.assertEqual(runner.clicks, [])
+
+    def test_modal_still_visible_after_actions_blocks(self):
+        runner = FakeRunner(
+            [
+                present_snapshot(),
+                present_snapshot(),
+            ]
+        )
+        result = resolve_free_tempo_modal(runner=runner, pause=lambda _: None)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "modal_still_visible")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/release-stable.sh
+++ b/Scripts/release-stable.sh
@@ -91,7 +91,7 @@ if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
     exit 1
 fi
 
-run python3 -m py_compile Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/live-e2e-test.py
+run python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py
 run python3 Scripts/logic_free_tempo_modal_test.py
 run swift test --no-parallel
 run swift build -c release

--- a/Scripts/release-stable.sh
+++ b/Scripts/release-stable.sh
@@ -91,7 +91,8 @@ if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
     exit 1
 fi
 
-run python3 -m py_compile Scripts/live-e2e-test.py
+run python3 -m py_compile Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/live-e2e-test.py
+run python3 Scripts/logic_free_tempo_modal_test.py
 run swift test --no-parallel
 run swift build -c release
 

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -34,7 +34,13 @@ actor ChannelRouter {
         // Transport — AX control-bar click primary (works without MCU / MIDI Learn),
         // MCU / CoreMIDI / CGEvent / AppleScript as fallbacks.
         "transport.play":             [.accessibility, .mcu, .coreMIDI, .cgEvent],
-        "transport.stop":             [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
+        // Stop differs from Play/Record: in live 12.2 sessions the AX Play
+        // checkbox can refuse to clear while playback is active, and MMC /
+        // AppleScript "stop" can still leave transport running. The
+        // spacebar-equivalent CGEvent path proved to be the first reliable
+        // non-AX fallback, so prefer it before MIDI/AppleScript fallbacks and
+        // let the dispatcher's live readback gate decide success.
+        "transport.stop":             [.accessibility, .cgEvent, .mcu, .coreMIDI, .appleScript],
         "transport.record":           [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
         "transport.pause":            [.coreMIDI, .cgEvent],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -20,8 +20,7 @@ struct TransportDispatcher {
             return toolTextResult(result)
 
         case "stop":
-            let result = await router.route(operation: "transport.stop")
-            return toolTextResult(result)
+            return await verifiedStopResult(router: router, cache: cache)
 
         case "record":
             let result = await router.route(operation: "transport.record")
@@ -164,6 +163,72 @@ struct TransportDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func verifiedStopResult(
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        let writeResult = await router.route(operation: "transport.stop")
+        guard writeResult.isSuccess else {
+            return toolTextResult(writeResult)
+        }
+
+        let liveRefresh = await ResourceHandlers.readLiveTransportState(router: router)
+        guard let liveState = liveRefresh.state else {
+            let cachedState = await cache.getTransport()
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "transport.stop executed, but live transport state could not be refreshed. Focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache.",
+                extras: stopReadbackUnavailableExtras(
+                    cachedState: cachedState,
+                    refreshError: liveRefresh.errorCode
+                )
+            ), isError: true)
+        }
+
+        await cache.updateTransport(liveState)
+        let observedExtras: [String: Any] = [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "ax_transport_state",
+            "observed_isPlaying": liveState.isPlaying,
+            "observed_isRecording": liveState.isRecording,
+            "observed_position": liveState.position,
+            "observed_time_position": liveState.timePosition,
+        ]
+
+        guard liveState.isPlaying == false, liveState.isRecording == false else {
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackMismatch,
+                hint: "transport.stop executed, but live transport state still reports playback or recording",
+                extras: observedExtras.merging(["safe_to_retry": true]) { _, new in new }
+            ), isError: true)
+        }
+
+        return toolTextResult(HonestContract.encodeStateA(extras: observedExtras))
+    }
+
+    private static func stopReadbackUnavailableExtras(
+        cachedState: TransportState,
+        refreshError: String?
+    ) -> [String: Any] {
+        [
+            "operation": "transport.stop",
+            "requested_state": "stopped",
+            "verify_source": "cache_only",
+            "cached_source": cachedState.lastUpdated > .distantPast ? "cache" : "default",
+            "cache_age_sec": cacheAgeExtra(for: cachedState),
+            "refresh_error": refreshError ?? "live_transport_read_failed",
+            "safe_to_retry": true,
+        ]
+    }
+
+    private static func cacheAgeExtra(for state: TransportState) -> Any {
+        guard state.lastUpdated > .distantPast else {
+            return NSNull()
+        }
+        return max(0, Date().timeIntervalSince(state.lastUpdated))
     }
 
     /// Accept "bar.beat.sub.tick" (each positive) or "HH:MM:SS:FF" (with

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -173,7 +173,8 @@ extension ResourceHandlers {
     // MARK: - Individual resource handlers
 
     private static func readTransportState(cache: StateCache, router: ChannelRouter, uri: String) async throws -> ReadResource.Result {
-        if let liveState = await readLiveTransportState(router: router) {
+        let liveRefresh = await readLiveTransportState(router: router)
+        if let liveState = liveRefresh.state {
             await cache.updateTransport(liveState)
         }
 
@@ -188,18 +189,60 @@ extension ResourceHandlers {
         let body = """
             {"state":\(inner),"has_document":\(hasDocument)}
             """
-        let json = wrapWithCacheEnvelope(bodyJSON: body, fetchedAt: state.lastUpdated, axOccluded: axOccluded)
+        let json = wrapWithCacheEnvelope(
+            bodyJSON: body,
+            fetchedAt: state.lastUpdated,
+            axOccluded: axOccluded,
+            extras: transportStateEnvelopeExtras(liveRefresh: liveRefresh, cachedState: state)
+        )
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readLiveTransportState(router: ChannelRouter) async -> TransportState? {
-        guard case .success(let json) = await router.route(operation: "transport.get_state") else {
-            return nil
+    struct LiveTransportStateReadback: Sendable {
+        let state: TransportState?
+        let errorCode: String?
+    }
+
+    /// Live transport refresh shared by the `logic://transport/state`
+    /// resource and post-write dispatcher verification.
+    static func readLiveTransportState(router: ChannelRouter) async -> LiveTransportStateReadback {
+        let result = await router.route(operation: "transport.get_state")
+        guard result.isSuccess else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: HonestContract.stateCErrorCode(result.message) ?? "live_transport_read_failed"
+            )
+        }
+        guard let state = decodeTransportState(result.message) else {
+            return LiveTransportStateReadback(
+                state: nil,
+                errorCode: "undecodable_live_transport_state"
+            )
+        }
+        return LiveTransportStateReadback(state: state, errorCode: nil)
+    }
+
+    private static func transportStateEnvelopeExtras(
+        liveRefresh: LiveTransportStateReadback,
+        cachedState: TransportState
+    ) -> [String: Any] {
+        if liveRefresh.state != nil {
+            return ["source": "ax_live"]
         }
 
-        return decodeTransportState(json)
+        let hasCachedState = cachedState.lastUpdated > .distantPast
+        var extras: [String: Any] = [
+            "source": hasCachedState ? "cache" : "default",
+            "unverified": true,
+            "stale": hasCachedState,
+            "recovery_hint": "live transport refresh unavailable; focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache."
+        ]
+        if let errorCode = liveRefresh.errorCode {
+            extras["refresh_error"] = errorCode
+        }
+        return extras
     }
 
     private static func decodeTransportState(_ json: String) -> TransportState? {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -89,12 +89,44 @@ private actor FailingExecuteChannel: Channel {
     }
 }
 
+private actor ScriptedTransportChannel: Channel {
+    nonisolated let id: ChannelID
+    let results: [String: ChannelResult]
+    var executedOps: [String] = []
+
+    init(id: ChannelID, results: [String: ChannelResult]) {
+        self.id = id
+        self.results = results
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        executedOps.append(operation)
+        return results[operation] ?? .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "scripted transport channel")
+    }
+}
+
+private func liveTransportJSON(
+    isPlaying: Bool,
+    isRecording: Bool,
+    position: String = "1.1.1.1"
+) -> String {
+    """
+    {"isPlaying":\(isPlaying),"isRecording":\(isRecording),"isPaused":false,"tempo":120.0,"position":"\(position)","timePosition":"00:00:00.000","sampleRate":44100,"isCycleEnabled":false,"isMetronomeEnabled":false,"lastUpdated":"2026-06-19T02:17:42.000Z"}
+    """
+}
+
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
     let cases: [(command: String, operation: String)] = [
         ("play", "transport.play"),
-        ("stop", "transport.stop"),
         ("record", "transport.record"),
         ("pause", "transport.pause"),
         ("rewind", "transport.rewind"),
@@ -189,6 +221,126 @@ private actor FailingExecuteChannel: Channel {
         ("transport.goto_position", ["position": "00:00:10:12"]),
         ("transport.set_cycle_range", ["start": "4.1.1.1", "end": "12.1.1.1"]),
     ])
+}
+
+@Test func testTransportDispatcherStopPromotesFallbackWriteToVerifiedReadback() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .error(HonestContract.encodeStateC(
+            error: .readbackMismatch,
+            hint: "play checkbox did not clear on first AX attempt"
+        )),
+        "transport.get_state": .success(liveTransportJSON(
+            isPlaying: false,
+            isRecording: false,
+            position: "9.1.1.1"
+        )),
+    ])
+    let mcu = ScriptedTransportChannel(id: .mcu, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["function": "transport", "command": "stop"]
+        )),
+    ])
+    await router.register(ax)
+    await router.register(mcu)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == false)
+    #expect(json["verified"] as? Bool == true)
+    #expect(json["verify_source"] as? String == "ax_transport_state")
+    #expect(json["observed_isPlaying"] as? Bool == false)
+    #expect(json["observed_isRecording"] as? Bool == false)
+    #expect(json["observed_position"] as? String == "9.1.1.1")
+    #expect(await ax.executedOps == ["transport.stop", "transport.get_state"])
+    #expect(await mcu.executedOps == ["transport.stop"])
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == false)
+    #expect(cached.isRecording == false)
+    #expect(cached.position == "9.1.1.1")
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveReadbackUnavailable() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "Cannot locate transport bar"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+    await cache.updateTransport(TransportState(
+        isPlaying: true,
+        isRecording: true,
+        position: "96.1.1.1",
+        lastUpdated: Date(timeIntervalSinceNow: -18)
+    ))
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_unavailable")
+    #expect(json["refresh_error"] as? String == "element_not_found")
+    #expect(json["cached_source"] as? String == "cache")
+    #expect((json["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect((json["hint"] as? String)?.contains("refresh_cache") == true)
+}
+
+@Test func testTransportDispatcherStopFailsClosedWhenLiveStateStillReportsPlayback() async {
+    let router = ChannelRouter()
+    let ax = ScriptedTransportChannel(id: .accessibility, results: [
+        "transport.stop": .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: ["button": "Stop"]
+        )),
+        "transport.get_state": .success(liveTransportJSON(
+            isPlaying: true,
+            isRecording: true,
+            position: "96.1.1.1"
+        )),
+    ])
+    await router.register(ax)
+    let cache = StateCache()
+
+    let result = await TransportDispatcher.handle(
+        command: "stop",
+        params: [:],
+        router: router,
+        cache: cache
+    )
+
+    let json = try! sharedParseJSON(dispatcherText(result)) as! [String: Any]
+    #expect(result.isError == true)
+    #expect(json["error"] as? String == "readback_mismatch")
+    #expect(json["observed_isPlaying"] as? Bool == true)
+    #expect(json["observed_isRecording"] as? Bool == true)
+    #expect(json["observed_position"] as? String == "96.1.1.1")
+    #expect(json["safe_to_retry"] as? Bool == true)
+
+    let cached = await cache.getTransport()
+    #expect(cached.isPlaying == true)
+    #expect(cached.isRecording == true)
+    #expect(cached.position == "96.1.1.1")
 }
 
 @Test func testTransportDispatcherRejectsMissingSemanticPayloads() async {

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -61,6 +61,29 @@ private actor LiveTransportStateChannel: Channel {
     }
 }
 
+private actor FailingTransportStateChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private let errorMessage: String
+
+    init(errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params _: [String: String]) async -> ChannelResult {
+        if operation == "transport.get_state" {
+            return .error(errorMessage)
+        }
+        return .error("unexpected operation: \(operation)")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "failing transport test channel")
+    }
+}
+
 private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     var json = try sharedParseJSON(text) as! [String: Any]
 
@@ -155,6 +178,7 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     let state = json["state"] as! [String: Any]
 
     #expect(await channel.executedOperations() == ["transport.get_state"])
+    #expect(envelope["source"] as? String == "ax_live")
     #expect(state["isPlaying"] as? Bool == false)
     #expect(state["tempo"] as? Double == 90.5)
     #expect(state["isCycleEnabled"] as? Bool == true)
@@ -162,6 +186,39 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     #expect(cached.isPlaying == false)
     #expect(cached.tempo == 90.5)
     #expect(cached.isCycleEnabled == true)
+}
+
+@Test func testTransportStateResourceMarksCachedFallbackAsUnverifiedWhenLiveRefreshFails() async {
+    let cache = StateCache()
+    var staleTransport = TransportState()
+    staleTransport.isPlaying = true
+    staleTransport.isRecording = true
+    staleTransport.position = "96.1.1.1"
+    staleTransport.lastUpdated = Date(timeIntervalSinceNow: -42)
+    await cache.updateTransport(staleTransport)
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let channel = FailingTransportStateChannel(errorMessage: HonestContract.encodeStateC(
+        error: .elementNotFound,
+        hint: "Cannot locate transport bar"
+    ))
+    await router.register(channel)
+
+    let result = try! await ResourceHandlers.read(uri: "logic://transport/state", cache: cache, router: router)
+    let envelope = try! sharedParseJSON(resourceText(result)) as! [String: Any]
+    let json = envelope["data"] as! [String: Any]
+    let state = json["state"] as! [String: Any]
+
+    #expect(envelope["source"] as? String == "cache")
+    #expect(envelope["unverified"] as? Bool == true)
+    #expect(envelope["stale"] as? Bool == true)
+    #expect(envelope["refresh_error"] as? String == "element_not_found")
+    #expect((envelope["recovery_hint"] as? String)?.contains("refresh_cache") == true)
+    #expect((envelope["cache_age_sec"] as? Double ?? 0) > 0)
+    #expect(state["isPlaying"] as? Bool == true)
+    #expect(state["isRecording"] as? Bool == true)
+    #expect(state["position"] as? String == "96.1.1.1")
 }
 
 @Test func testTransportStateResourceSignalsStaleAfterClose() async {


### PR DESCRIPTION
Closes #58.

## Summary
- add a reusable `Scripts/logic_free_tempo_modal.py` helper that detects Logic's Free Tempo Recording modal via `System Events`, applies the named `keep_project_tempo_no_analysis` policy, and returns structured policy/provenance diagnostics
- extend `Scripts/live-e2e-test.py` with a gated fresh-record modal guard that records the modal policy, checks preflight/post-record/final modal state, and fails only on modal-handling concerns instead of unrelated region-capture quirks
- add `Scripts/logic_free_tempo_modal_test.py` coverage and wire the helper into `Scripts/release-stable.sh`
- pull in the verified transport stop readback hardening from #56 so the fresh record modal section can trust its post-stop state before checking for the modal

## Verification
Passed locally in `/private/tmp/logic-pro-mcp-issue58`:
- `python3 -m py_compile Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/live-e2e-test.py`
- `python3 Scripts/logic_free_tempo_modal_test.py`
- `python3 Scripts/logic_free_tempo_modal.py detect`
- `python3 Scripts/logic_free_tempo_modal.py resolve`
- `swift test --filter testTransportDispatcherStop`
- `swift test --filter testTransportStateResource`
- `swift build -c release`
- `git diff --check`

## Live host evidence
Observed on June 20, 2026 (Asia/Seoul) against `/private/tmp/logic-pro-mcp-issue58/.build/release/LogicProMCP` via the tmux-backed stdio harness:

1. I reset a disposable `Untitled 4` scratch session with `logic_project.close {saving:"no", confirmed:true}`, then used Logic's `File -> New` menu plus one Return keypress to confirm the New Track dialog and reach a fresh arrange-window state.
2. The fresh-state preconditions for the modal guard were satisfied:
   - `logic_system.health.cache.track_count: 1`
   - `logic://tracks` returned one live track named `Deluxe Classic`
   - `logic://tracks/0/regions` returned `[]`
3. On the updated branch, the record flow itself is now honest end-to-end:
   - `logic_transport.record` entered `isPlaying:true`, `isRecording:true`
   - `logic_midi.play_sequence` returned `Sequence sent: 3 events`
   - `logic_transport.stop` returned verified success with `verify_source:"ax_transport_state"`
   - final transport readback was `isPlaying:false`, `isRecording:false`
4. The modal helper behaved deterministically around that flow:
   - preflight `resolve_free_tempo_modal()` returned `status:"not_present"` with `policy_id:"keep_project_tempo_no_analysis"`
   - post-record `resolve_free_tempo_modal()` again returned `status:"not_present"`
   - final `detect_free_tempo_modal()` returned `status:"not_present"`
   - the armed track was cleanly disarmed after the modal checks
5. I also tried the same live pass after explicitly creating an extra software-instrument track with `logic_tracks.create_instrument`. On this host, the Free Tempo modal still did not re-surface, and the regions resource stayed empty. That means the current June 20 host no longer reproduces the original modal trigger condition on demand.

Because the host would not re-trigger the dialog, the live proof here exercises the `not_present` branch rather than an actual dismissal. The dismissal / policy-selection path is still covered by `Scripts/logic_free_tempo_modal_test.py`, which verifies:
- choosing `Don't analyze region tempo or change project tempo`
- optional `Don't show again` checkbox handling
- confirm-button selection
- fail-closed blocked results when the modal surface is incomplete

This PR therefore closes the modal-handling gap itself: the harness now records an explicit policy, checks for the modal before and after fresh record work, rejects any final lingering modal, and no longer depends on a misleading success path after stop.
