### PR TITLE
fix: verify target track before patch load

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -770,6 +770,75 @@ def main():
         ),
     )
 
+    probe_category = None
+    probe_preset = None
+    if tracks and isinstance(list_library_json, dict):
+        presets_by_category = list_library_json.get("presetsByCategory")
+        categories = list_library_json.get("categories")
+        candidate_categories = []
+        current_category = list_library_json.get("currentCategory")
+        if isinstance(current_category, str) and current_category:
+            candidate_categories.append(current_category)
+        if isinstance(categories, list):
+            for category in categories:
+                if isinstance(category, str) and category and category not in candidate_categories:
+                    candidate_categories.append(category)
+        if isinstance(presets_by_category, dict):
+            for category in candidate_categories:
+                presets = presets_by_category.get(category)
+                if not isinstance(presets, list):
+                    continue
+                preset = next((item for item in presets if isinstance(item, str) and item), None)
+                if preset:
+                    probe_category = category
+                    probe_preset = preset
+                    break
+
+    if tracks and probe_category and probe_preset:
+        r = call_tool(
+            client,
+            "logic_tracks",
+            "set_instrument",
+            {"index": 0, "category": probe_category, "preset": probe_preset},
+        )
+        set_instrument_text = tool_text(r)
+        set_instrument_json = safe_json(set_instrument_text)
+        T(
+            "track.set_instrument returns verification metadata or fail-closed selection error",
+            r,
+            lambda _: (
+                isinstance(set_instrument_json, dict)
+                and (
+                    (
+                        set_instrument_json.get("success") is True
+                        and set_instrument_json.get("requested_patch_name") == probe_preset
+                        and set_instrument_json.get("requested_category") == probe_category
+                        and set_instrument_json.get("target_track_index") == 0
+                        and "target_track_selection_verified" in set_instrument_json
+                        and "observed_patch_name" in set_instrument_json
+                        and "readback_state" in set_instrument_json
+                    )
+                    or (
+                        set_instrument_json.get("success") is False
+                        and set_instrument_json.get("error") in {
+                            "track_selection_failed",
+                            "ax_write_failed",
+                            "element_not_found",
+                            "permission_denied",
+                            "readback_unavailable",
+                            "readback_mismatch",
+                        }
+                        and set_instrument_json.get("requested_patch_name") == probe_preset
+                        and set_instrument_json.get("requested_category") == probe_category
+                        and set_instrument_json.get("target_track_index") == 0
+                    )
+                )
+            ) or "Library panel not found" in set_instrument_text
+              or "Accessibility not trusted" in set_instrument_text
+              or "Event-post permission required" in set_instrument_text
+              or "No document open" in set_instrument_text,
+        )
+
     r = call_tool(client, "logic_tracks", "scan_plugin_presets", {"submenuOpenDelayMs": 300})
     T("track.scan_plugin_presets returns content or guidance", r, lambda _: len(tool_text(r)) > 0)
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -2495,6 +2495,25 @@ actor AccessibilityChannel: Channel {
         }
         let category = pathSegments[0]
         let preset = pathSegments[pathSegments.count - 1]
+        let requestedTrackIndex: Int?
+        if let indexStr = params["index"] {
+            guard let index = Int(indexStr), index >= 0 else {
+                return .error(HonestContract.encodeStateC(
+                    error: .invalidParams,
+                    hint: "track.set_instrument 'index' must be a non-negative integer",
+                    extras: setInstrumentBaseExtras(
+                        requestedPath: resolvedPath,
+                        category: category,
+                        preset: preset,
+                        targetTrackIndex: NSNull(),
+                        targetTrackName: NSNull()
+                    )
+                ))
+            }
+            requestedTrackIndex = index
+        } else {
+            requestedTrackIndex = nil
+        }
 
         // v3.0.3+ — select target track via the Apple-public AX-first
         // selection ladder (AXPress → AXSelected → child AXPress → coord
@@ -2504,15 +2523,102 @@ actor AccessibilityChannel: Channel {
         _ = ProcessUtils.Runtime.production.activateLogicPro()
         try? await Task.sleep(nanoseconds: 150_000_000)   // window raise settle
 
-        if let indexStr = params["index"], let index = Int(indexStr) {
+        var targetTrackIndex = requestedTrackIndex
+        var targetTrackName: Any = NSNull()
+
+        if let index = requestedTrackIndex {
             guard AXLogicProElements.findTrackHeader(at: index, runtime: runtime) != nil else {
-                return .error("Track at index \(index) not found")
+                return .error(HonestContract.encodeStateC(
+                    error: .elementNotFound,
+                    hint: "Track at index \(index) not found",
+                    extras: setInstrumentBaseExtras(
+                        requestedPath: resolvedPath,
+                        category: category,
+                        preset: preset,
+                        targetTrackIndex: index,
+                        targetTrackName: NSNull()
+                    )
+                ))
+            }
+            if let name = AXLogicProElements.trackName(at: index, runtime: runtime) {
+                targetTrackName = name
             }
             if !CGPreflightPostEventAccess() {
                 return .error("Event-post permission required (Accessibility → Input Monitoring). Grant in System Settings.")
             }
-            _ = AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime)
+            guard AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime) else {
+                return .error(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: "Failed to select track \(index) before instrument load",
+                    extras: setInstrumentBaseExtras(
+                        requestedPath: resolvedPath,
+                        category: category,
+                        preset: preset,
+                        targetTrackIndex: index,
+                        targetTrackName: targetTrackName
+                    )
+                ))
+            }
+
+            let selectionVerification = await verifyTrackSelection(index: index, runtime: runtime)
+            if let refreshedName = AXLogicProElements.trackName(at: index, runtime: runtime) {
+                targetTrackName = refreshedName
+            }
+            let selectionBase = setInstrumentBaseExtras(
+                requestedPath: resolvedPath,
+                category: category,
+                preset: preset,
+                targetTrackIndex: index,
+                targetTrackName: targetTrackName
+            )
+            switch selectionVerification {
+            case .verified:
+                break
+            case .selectionMetadataUnavailable:
+                return .error(HonestContract.encodeStateC(
+                    error: .trackSelectionFailed,
+                    hint: "Track \(index) selection could not be verified before instrument load",
+                    extras: selectionBase.merging([
+                        "observed": NSNull(),
+                        "observed_patch_name": NSNull(),
+                        "target_track_selection_verified": false,
+                        "target_track_selection_reason": HonestContract.UncertainReason.retryExhausted.rawValue,
+                        "target_track_selection_observed_index": NSNull(),
+                        "target_track_selection_verify_source": "ax_selected"
+                    ]) { _, new in new }
+                ))
+            case .mismatch(let selectedIndex):
+                return .error(HonestContract.encodeStateC(
+                    error: .trackSelectionFailed,
+                    hint: "Track \(index) selection settled on a different track before instrument load",
+                    extras: selectionBase.merging([
+                        "observed": NSNull(),
+                        "observed_patch_name": NSNull(),
+                        "target_track_selection_verified": false,
+                        "target_track_selection_reason": HonestContract.UncertainReason.readbackMismatch.rawValue,
+                        "target_track_selection_observed_index": selectedIndex as Any? ?? NSNull(),
+                        "target_track_selection_verify_source": "ax_selected"
+                    ]) { _, new in new }
+                ))
+            case .trackDisappeared:
+                return .error(HonestContract.encodeStateC(
+                    error: .elementNotFound,
+                    hint: "Track at index \(index) disappeared during selection verification",
+                    extras: selectionBase.merging([
+                        "observed": NSNull(),
+                        "observed_patch_name": NSNull(),
+                        "target_track_selection_verified": false,
+                        "target_track_selection_reason": HonestContract.UncertainReason.readbackUnavailable.rawValue,
+                        "target_track_selection_observed_index": NSNull(),
+                        "target_track_selection_verify_source": "ax_selected"
+                    ]) { _, new in new }
+                ))
+            }
+
             try? await Task.sleep(nanoseconds: 300_000_000)   // Library rebind to new track
+        } else if let selectedTrack = selectedTrackIdentity(runtime: runtime) {
+            targetTrackIndex = selectedTrack.index
+            targetTrackName = selectedTrack.name ?? NSNull()
         }
 
         // v3.0.4 — walk every segment in order. For 2-segment paths this
@@ -2533,12 +2639,13 @@ actor AccessibilityChannel: Channel {
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "Library path not fully resolvable: \(resolvedPath)",
-                extras: [
-                    "requested": resolvedPath,
-                    "category": category,
-                    "preset": preset,
-                    "path": resolvedPath
-                ]
+                extras: setInstrumentBaseExtras(
+                    requestedPath: resolvedPath,
+                    category: category,
+                    preset: preset,
+                    targetTrackIndex: targetTrackIndex as Any? ?? NSNull(),
+                    targetTrackName: targetTrackName
+                )
             ))
         }
         try? await Task.sleep(nanoseconds: 800_000_000) // let Logic load the instrument
@@ -2550,24 +2657,76 @@ actor AccessibilityChannel: Channel {
         // B with `readback_mismatch`. When not exposed at all (Logic build
         // dependent), State B with `readback_unavailable`.
         let observed = AccessibilityChannel.readBackLibraryPreset(runtime: runtime)
-        let base: [String: Any] = [
-            "requested": preset,
-            "observed": observed ?? NSNull(),
-            "category": category,
-            "preset": preset,
-            "path": resolvedPath
-        ]
+        var base = setInstrumentBaseExtras(
+            requestedPath: resolvedPath,
+            category: category,
+            preset: preset,
+            targetTrackIndex: targetTrackIndex as Any? ?? NSNull(),
+            targetTrackName: targetTrackName
+        )
+        base["observed"] = observed ?? NSNull()
+        base["observed_patch_name"] = observed ?? NSNull()
+        base["verify_source"] = "library_selected_children"
+        if requestedTrackIndex != nil {
+            base["target_track_selection_verified"] = true
+            base["target_track_selection_reason"] = "verified"
+            base["target_track_selection_observed_index"] = targetTrackIndex as Any? ?? NSNull()
+            base["target_track_selection_verify_source"] = "ax_selected"
+        }
         if let observed {
             if observed == preset {
-                return .success(HonestContract.encodeStateA(extras: base))
+                return .success(HonestContract.encodeStateA(
+                    extras: base.merging(["readback_state": "verified"]) { _, new in new }
+                ))
             }
             return .success(HonestContract.encodeStateB(
-                reason: .readbackMismatch, extras: base
+                reason: .readbackMismatch,
+                extras: base.merging([
+                    "readback_state": HonestContract.UncertainReason.readbackMismatch.rawValue
+                ]) { _, new in new }
             ))
         }
         return .success(HonestContract.encodeStateB(
-            reason: .readbackUnavailable, extras: base
+            reason: .readbackUnavailable,
+            extras: base.merging([
+                "readback_state": HonestContract.UncertainReason.readbackUnavailable.rawValue
+            ]) { _, new in new }
         ))
+    }
+
+    private static func setInstrumentBaseExtras(
+        requestedPath: String,
+        category: String,
+        preset: String,
+        targetTrackIndex: Any,
+        targetTrackName: Any
+    ) -> [String: Any] {
+        [
+            "requested": preset,
+            "requested_patch_name": preset,
+            "requested_category": category,
+            "requested_path": requestedPath,
+            "category": category,
+            "preset": preset,
+            "path": requestedPath,
+            "target_track_index": targetTrackIndex,
+            "target_track_name": targetTrackName
+        ]
+    }
+
+    private static func selectedTrackIdentity(
+        runtime: AXLogicProElements.Runtime
+    ) -> (index: Int, name: String?)? {
+        let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+        for (index, header) in headers.enumerated() {
+            guard AXValueExtractors.extractSelectedState(header, runtime: runtime.ax) == true else {
+                continue
+            }
+            let state = AXValueExtractors.extractTrackState(from: header, index: index, runtime: runtime.ax)
+            let trimmed = state.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (index, trimmed.isEmpty ? nil : trimmed)
+        }
+        return nil
     }
 
     // MARK: - Control-bar playhead position helper

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -137,6 +137,76 @@ private func makeAXBackedAccessibilityChannel(
     return AccessibilityChannel(runtime: runtime)
 }
 
+private func makeSetInstrumentFixture() -> (
+    builder: FakeAXRuntimeBuilder,
+    app: AXUIElement,
+    firstHeader: AXUIElement,
+    secondHeader: AXUIElement,
+    category: AXUIElement,
+    preset: AXUIElement
+) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(20_000)
+    let window = builder.element(20_001)
+    let trackList = builder.element(20_002)
+    let firstHeader = builder.element(20_003)
+    let firstName = builder.element(20_004)
+    let secondHeader = builder.element(20_005)
+    let secondName = builder.element(20_006)
+    let browser = builder.element(20_007)
+    let categoryList = builder.element(20_008)
+    let presetList = builder.element(20_009)
+    let category = builder.element(20_010)
+    let preset = builder.element(20_011)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [trackList, browser])
+
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [firstHeader, secondHeader])
+
+    builder.setAttribute(firstHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(firstHeader, kAXTitleAttribute as String, "Kick")
+    builder.setAttribute(firstHeader, kAXSelectedAttribute as String, true)
+    builder.setChildren(firstHeader, [firstName])
+    builder.setAttribute(firstName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(firstName, kAXValueAttribute as String, "Kick")
+
+    builder.setAttribute(secondHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(secondHeader, kAXTitleAttribute as String, "Bass Track")
+    builder.setAttribute(secondHeader, kAXSelectedAttribute as String, false)
+    builder.setChildren(secondHeader, [secondName])
+    builder.setAttribute(secondName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(secondName, kAXValueAttribute as String, "Bass Track")
+
+    builder.setAttribute(browser, kAXRoleAttribute as String, kAXBrowserRole as String)
+    builder.setAttribute(browser, kAXDescriptionAttribute as String, "Library")
+    builder.setChildren(browser, [categoryList, presetList])
+
+    builder.setAttribute(categoryList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setChildren(categoryList, [category])
+    builder.setAttribute(presetList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setChildren(presetList, [preset])
+
+    builder.setAttribute(category, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(category, kAXValueAttribute as String, "Bass")
+    builder.setAttribute(category, kAXPositionAttribute as String, axPoint(120, 120))
+    builder.setAttribute(category, kAXSizeAttribute as String, axSize(90, 22))
+    builder.setAttribute(category, kAXParentAttribute as String, categoryList)
+
+    builder.setAttribute(preset, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(preset, kAXValueAttribute as String, "Sub Bass")
+    builder.setAttribute(preset, kAXPositionAttribute as String, axPoint(300, 120))
+    builder.setAttribute(preset, kAXSizeAttribute as String, axSize(120, 22))
+    builder.setAttribute(preset, kAXParentAttribute as String, presetList)
+
+    builder.setAttribute(categoryList, kAXSelectedChildrenAttribute as String, [category])
+    builder.setAttribute(presetList, kAXSelectedChildrenAttribute as String, [preset])
+
+    return (builder, app, firstHeader, secondHeader, category, preset)
+}
+
 @Test func testAccessibilityChannelStartRequiresTrustAndAllowsMissingLogic() async throws {
     let untrusted = AccessibilityChannel(runtime: makeAccessibilityRuntime(isTrusted: false))
     await #expect(throws: AccessibilityError.notTrusted) {
@@ -1029,6 +1099,71 @@ private func makeAXBackedAccessibilityChannel(
     #expect(obj["reason"] as? String == "readback_mismatch")
     #expect(obj["requested"] as? Int == 1)
     #expect(obj["observed"] as? Int == 0)
+}
+
+@Test func testAccessibilityChannelSetInstrumentReturnsTargetAndPatchVerificationMetadata() async {
+    let fixture = makeSetInstrumentFixture()
+    let logicRuntime = fixture.builder.makeLogicRuntime(
+        appElement: fixture.app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            guard action == kAXPressAction as String else { return true }
+            if element == fixture.secondHeader {
+                fixture.builder.setAttribute(fixture.firstHeader, kAXSelectedAttribute as String, false)
+                fixture.builder.setAttribute(fixture.secondHeader, kAXSelectedAttribute as String, true)
+            }
+            return true
+        }
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: fixture.builder,
+        app: fixture.app,
+        logicRuntime: logicRuntime
+    )
+
+    let result = await channel.execute(
+        operation: "track.set_instrument",
+        params: ["index": "1", "path": "Bass/Sub Bass"]
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["verified"] as? Bool == true)
+    #expect(obj["requested_patch_name"] as? String == "Sub Bass")
+    #expect(obj["requested_path"] as? String == "Bass/Sub Bass")
+    #expect(obj["observed_patch_name"] as? String == "Sub Bass")
+    #expect(obj["target_track_index"] as? Int == 1)
+    #expect(obj["target_track_name"] as? String == "Bass Track")
+    #expect(obj["target_track_selection_verified"] as? Bool == true)
+    #expect(obj["target_track_selection_reason"] as? String == "verified")
+    #expect(obj["target_track_selection_observed_index"] as? Int == 1)
+    #expect(obj["target_track_selection_verify_source"] as? String == "ax_selected")
+    #expect(obj["verify_source"] as? String == "library_selected_children")
+    #expect(obj["readback_state"] as? String == "verified")
+}
+
+@Test func testAccessibilityChannelSetInstrumentFailsClosedWhenTrackSelectionIsUnverified() async {
+    let fixture = makeSetInstrumentFixture()
+    let channel = makeAXBackedAccessibilityChannel(builder: fixture.builder, app: fixture.app)
+
+    let result = await channel.execute(
+        operation: "track.set_instrument",
+        params: ["index": "1", "path": "Bass/Sub Bass"]
+    )
+
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["error"] as? String == "track_selection_failed")
+    #expect(obj["requested_patch_name"] as? String == "Sub Bass")
+    #expect(obj["requested_path"] as? String == "Bass/Sub Bass")
+    #expect(obj["target_track_index"] as? Int == 1)
+    #expect(obj["target_track_name"] as? String == "Bass Track")
+    #expect(obj["target_track_selection_verified"] as? Bool == false)
+    #expect(obj["target_track_selection_reason"] as? String == "readback_mismatch")
+    #expect(obj["target_track_selection_observed_index"] as? Int == 0)
+    #expect(obj["target_track_selection_verify_source"] as? String == "ax_selected")
+    #expect(!fixture.builder.actionCalls.map(\.elementID).contains(fixture.builder.elementID(fixture.category)))
+    #expect(!fixture.builder.actionCalls.map(\.elementID).contains(fixture.builder.elementID(fixture.preset)))
 }
 
 @Test func testAccessibilityChannelAXBackedTrackErrorPaths() async {


### PR DESCRIPTION
## Summary
- fail closed in `track.set_instrument` unless the requested target track selection is AX-verified before any Library patch load
- return explicit requested/observed patch metadata plus target track selection metadata in the `set_instrument` response
- add focused `AccessibilityChannelTests` coverage and a guarded live E2E probe for the verified patch-assignment contract

## Root cause
`track.set_instrument` still attempted Library patch loading after only best-effort track selection. If Logic kept a different track selected, the product could mutate the wrong track and still report only patch-level readback. The demo scripts therefore stayed on manual visible Library clicks instead of trusting the MCP workflow.

## What changed
- validate `index` when present and surface State C for invalid/missing track targets
- verify target track selection via existing AX-selected readback before patch load
- return `track_selection_failed` when selection settles elsewhere or cannot be verified, before any Library mutation is attempted
- include `requested_patch_name`, `requested_category`, `requested_path`, `observed_patch_name`, `target_track_index`, `target_track_name`, `target_track_selection_*`, `verify_source`, and `readback_state` in `track.set_instrument` responses
- extend `Scripts/live-e2e-test.py` to probe a real `set_instrument` call whenever the session exposes tracks plus visible Library presets

## Verification
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift test --filter AccessibilityChannelTests`
- `swift test --filter HonestContractOpTests`
- `swift build -c release`
- `git diff --check`
- Live tmux-backed probe on the host:
  - `logic_tracks.create_instrument` returned `success:true verified:true observed_delta:1 track_count_before:0 track_count_after:1`
  - `logic_navigate.toggle_view {view:"library"}` returned State B `readback_unavailable` while still opening the Library
  - `logic_tracks.list_library` returned real categories/presets from Logic
  - `logic_tracks.set_instrument {index:0, category:"Electric Piano", preset:"Bright Suitcase"}` returned `success:true`, `verified:true`, `observed_patch_name:"Bright Suitcase"`, `target_track_index:0`, `target_track_selection_verified:true`, `verify_source:"library_selected_children"`

Closes #43
