### PR TITLE
fix: harden fresh-project tempo setup diagnostics

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -597,6 +597,45 @@ def main():
             time.sleep(0.2)
         return last
 
+    def safe_get_transport_state(client):
+        r = read_resource(client, "logic://transport/state")
+        envelope = safe_json(resource_text(r))
+        if not isinstance(envelope, dict):
+            return None
+        data = envelope.get("data", {})
+        if not isinstance(data, dict):
+            return None
+        state = data.get("state")
+        return state if isinstance(state, dict) else None
+
+    def safe_get_tracks(client):
+        r = read_resource(client, "logic://tracks")
+        envelope = safe_json(resource_text(r))
+        if not isinstance(envelope, dict):
+            return None
+        data = envelope.get("data")
+        return data if isinstance(data, list) else None
+
+    def approx_equal(value, expected, tolerance=0.01):
+        try:
+            return abs(float(value) - expected) <= tolerance
+        except (TypeError, ValueError):
+            return False
+
+    def has_tempo_landmarks(payload):
+        return (
+            isinstance(payload, dict)
+            and isinstance(payload.get("hint"), str)
+            and len(payload.get("hint", "")) > 0
+            and isinstance(payload.get("dialog_present"), bool)
+            and isinstance(payload.get("control_bar_found"), bool)
+            and isinstance(payload.get("transport_bar_found"), bool)
+            and isinstance(payload.get("track_header_count"), int)
+            and isinstance(payload.get("control_bar_slider_descriptions"), list)
+            and isinstance(payload.get("transport_slider_descriptions"), list)
+            and isinstance(payload.get("control_bar_checkbox_labels"), list)
+        )
+
     before = safe_get_cycle(client)
     call_tool(client, "logic_transport", "toggle_cycle")
     after = wait_for_cycle_change(client, before)
@@ -618,9 +657,62 @@ def main():
     r = call_tool(client, "logic_transport", "toggle_count_in")
     T("transport.toggle_count_in dispatches", r, lambda _: len(tool_text(r)) > 0)
 
+    fresh_tracks = safe_get_tracks(client)
+    if live_logic_ready and has_document and isinstance(fresh_tracks, list) and len(fresh_tracks) == 0:
+        r = call_tool(client, "logic_tracks", "create_instrument")
+        create_instrument_text = tool_text(r)
+        create_instrument_json = safe_json(create_instrument_text)
+        T_LIVE(
+            "transport.fresh_project bootstrap creates instrument track or returns explicit failure",
+            r,
+            lambda _: (
+                isinstance(create_instrument_json, dict)
+                and create_instrument_json.get("success") is True
+                and create_instrument_json.get("verified") is True
+                and create_instrument_json.get("observed_delta") == 1
+                and isinstance(create_instrument_json.get("track_count_after"), int)
+                and create_instrument_json.get("track_count_after", 0) >= 1
+            ) or (
+                is_error(r)
+                and isinstance(create_instrument_json, dict)
+                and isinstance(create_instrument_json.get("hint"), str)
+                and len(create_instrument_json.get("hint", "")) > 0
+            ),
+            live_logic_ready,
+            "Logic Pro + Accessibility are required",
+        )
+        time.sleep(0.4)
+
     # Set tempo
     r = call_tool(client, "logic_transport", "set_tempo", {"tempo": 128})
-    T("transport.set_tempo(128) dispatches", r, lambda _: len(tool_text(r)) > 0)
+    set_tempo_128_text = tool_text(r)
+    set_tempo_128_json = safe_json(set_tempo_128_text)
+    transport_after_128 = safe_get_transport_state(client) if live_logic_ready else None
+    T("transport.set_tempo(128) dispatches", r, lambda _: len(set_tempo_128_text) > 0)
+    T_LIVE(
+        "transport.set_tempo(128) verifies exact readback or fails closed with landmarks",
+        r,
+        lambda _: (
+            isinstance(set_tempo_128_json, dict)
+            and set_tempo_128_json.get("success") is True
+            and set_tempo_128_json.get("verified") is True
+            and approx_equal(set_tempo_128_json.get("observed"), 128.0)
+            and approx_equal(transport_after_128.get("tempo"), 128.0)
+        ) or (
+            isinstance(set_tempo_128_json, dict)
+            and set_tempo_128_json.get("success") is True
+            and set_tempo_128_json.get("verified") is False
+            and set_tempo_128_json.get("reason") in ("readback_unavailable", "unsupported", "ui_drift")
+            and has_tempo_landmarks(set_tempo_128_json)
+        ) or (
+            isinstance(set_tempo_128_json, dict)
+            and set_tempo_128_json.get("success") is False
+            and set_tempo_128_json.get("error") in ("element_not_found", "readback_unavailable")
+            and has_tempo_landmarks(set_tempo_128_json)
+        ),
+        live_logic_ready,
+        "Logic Pro + Accessibility are required",
+    )
 
     r = call_tool(client, "logic_transport", "set_tempo", {"tempo": 90.5})
     T("transport.set_tempo(90.5) handles decimal", r, lambda _: len(tool_text(r)) > 0)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -698,18 +698,116 @@ actor AccessibilityChannel: Channel {
             }
         }
 
-        if runFallback(tempoStr) {
+        let tempoLandmarks = tempoControlLandmarks(runtime: runtime)
+        let missingHint = tempoControlMissingHint(landmarks: tempoLandmarks)
+        let missingExtras = baseExtras.merging(tempoLandmarks) { _, new in new }
+
+        if shouldAttemptTempoFallback(landmarks: tempoLandmarks) && runFallback(tempoStr) {
             return .error(HonestContract.encodeStateC(
                 error: .readbackUnavailable,
                 hint: "tempo fallback executed but no tempo readback was available",
-                extras: baseExtras.merging(["via": "keyboard-fallback"]) { _, new in new }
+                extras: missingExtras.merging(["via": "keyboard-fallback"]) { _, new in new }
             ))
         }
         return .error(HonestContract.encodeStateC(
             error: .elementNotFound,
-            hint: "tempo slider not located in Logic control bar; ensure Logic Pro is frontmost with an open project",
-            extras: baseExtras
+            hint: missingHint,
+            extras: missingExtras
         ))
+    }
+
+    private static func tempoControlLandmarks(
+        runtime: AXLogicProElements.Runtime
+    ) -> [String: Any] {
+        let window = AXLogicProElements.mainWindow(runtime: runtime)
+        let controlBar = AXLogicProElements.getControlBar(runtime: runtime)
+        let transportBar = AXLogicProElements.getTransportBar(runtime: runtime)
+
+        return [
+            "main_window_title": (window.flatMap { AXHelpers.getTitle($0, runtime: runtime.ax) } ?? "") as Any,
+            "dialog_present": AXLogicProElements.dialogPresent(runtime: runtime),
+            "control_bar_found": controlBar != nil,
+            "transport_bar_found": transportBar != nil,
+            "track_header_count": AXLogicProElements.allTrackHeaders(runtime: runtime).count,
+            "control_bar_slider_descriptions": tempoLandmarkStrings(
+                in: controlBar,
+                role: kAXSliderRole,
+                runtime: runtime.ax
+            ),
+            "transport_slider_descriptions": tempoLandmarkStrings(
+                in: transportBar,
+                role: kAXSliderRole,
+                runtime: runtime.ax
+            ),
+            "control_bar_checkbox_labels": tempoLandmarkCheckboxLabels(
+                in: controlBar,
+                runtime: runtime.ax
+            ),
+        ]
+    }
+
+    private static func tempoControlMissingHint(landmarks: [String: Any]) -> String {
+        let dialogPresent = landmarks["dialog_present"] as? Bool ?? false
+        let trackHeaderCount = landmarks["track_header_count"] as? Int ?? 0
+        let controlBarFound = landmarks["control_bar_found"] as? Bool ?? false
+        let transportBarFound = landmarks["transport_bar_found"] as? Bool ?? false
+
+        if dialogPresent {
+            return "tempo slider not located while a Logic dialog is present. Dismiss the dialog, clear the Create New Track prompt if visible, and retry."
+        }
+        if trackHeaderCount == 0 {
+            return "tempo slider not located: no track headers are visible yet. Clear the Create New Track dialog or create a software instrument track first."
+        }
+        if !controlBarFound && !transportBarFound {
+            return "tempo slider not located: Logic's Control Bar and transport UI were both absent from the AX tree. Ensure the project window is frontmost and fully loaded, then retry."
+        }
+        if !controlBarFound {
+            return "tempo slider not located in Logic's Control Bar. Ensure the project window is frontmost and the Control Bar is visible, then retry."
+        }
+        return "tempo slider not located in Logic control bar; ensure Logic Pro is frontmost with an open project"
+    }
+
+    private static func shouldAttemptTempoFallback(landmarks: [String: Any]) -> Bool {
+        let dialogPresent = landmarks["dialog_present"] as? Bool ?? false
+        let trackHeaderCount = landmarks["track_header_count"] as? Int ?? 0
+        let controlBarFound = landmarks["control_bar_found"] as? Bool ?? false
+        let transportBarFound = landmarks["transport_bar_found"] as? Bool ?? false
+
+        return !dialogPresent && trackHeaderCount > 0 && (controlBarFound || transportBarFound)
+    }
+
+    private static func tempoLandmarkStrings(
+        in root: AXUIElement?,
+        role: String,
+        runtime: AXHelpers.Runtime
+    ) -> [String] {
+        guard let root else { return [] }
+        let descendants = AXHelpers.findAllDescendants(
+            of: root,
+            role: role,
+            maxDepth: 6,
+            runtime: runtime
+        )
+        var values: [String] = []
+        for element in descendants {
+            let label = [
+                AXHelpers.getDescription(element, runtime: runtime),
+                AXHelpers.getTitle(element, runtime: runtime),
+            ]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+            if let label, !values.contains(label) {
+                values.append(label)
+            }
+        }
+        return values
+    }
+
+    private static func tempoLandmarkCheckboxLabels(
+        in root: AXUIElement?,
+        runtime: AXHelpers.Runtime
+    ) -> [String] {
+        tempoLandmarkStrings(in: root, role: kAXCheckBoxRole, runtime: runtime)
     }
 
     private static func runTempoFallbackScript(tempo: String) -> Bool {

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -661,12 +661,23 @@ private func makeAXBackedAccessibilityChannel(
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(160)
     let window = builder.element(161)
-    let transport = builder.element(162)
+    let controlBar = builder.element(162)
+    let trackList = builder.element(163)
+    let trackHeader = builder.element(164)
+    let barSlider = builder.element(165)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
-    builder.setChildren(window, [transport])
-    builder.setAttribute(transport, kAXRoleAttribute as String, kAXGroupRole as String)
-    builder.setAttribute(transport, kAXIdentifierAttribute as String, "Transport")
+    builder.setChildren(window, [controlBar, trackList])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [barSlider])
+    builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [trackHeader])
+    builder.setAttribute(trackHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(trackHeader, kAXSelectedAttribute as String, true)
 
     let channel = makeAXBackedAccessibilityChannel(
         builder: builder,
@@ -679,6 +690,9 @@ private func makeAXBackedAccessibilityChannel(
     #expect(result.message.contains("\"error\":\"readback_unavailable\""))
     #expect(result.message.contains("\"via\":\"keyboard-fallback\""))
     #expect(result.message.contains("\"requested\":126"))
+    #expect(result.message.contains("\"track_header_count\":1"))
+    #expect(result.message.contains("\"control_bar_found\":true"))
+    #expect(result.message.contains("\"control_bar_slider_descriptions\":[\"Bar\"]"))
 }
 
 @Test func testAccessibilityChannelImportMIDIFileReturnsErrorWhenTrackCountDoesNotIncrease() async throws {
@@ -769,6 +783,8 @@ private func makeAXBackedAccessibilityChannel(
     let app = builder.element(700)
     let window = builder.element(701)
     let transport = builder.element(702)
+    final class FallbackBox: @unchecked Sendable { var called = false }
+    let fallbackBox = FallbackBox()
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
     builder.setChildren(window, [transport])
     builder.setAttribute(transport, kAXRoleAttribute as String, kAXGroupRole as String)
@@ -777,13 +793,25 @@ private func makeAXBackedAccessibilityChannel(
     let channel = makeAXBackedAccessibilityChannel(
         builder: builder,
         app: app,
-        runTempoFallback: { _ in false }
+        runTempoFallback: { _ in
+            fallbackBox.called = true
+            return true
+        }
     )
 
     let result = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "126"])
     #expect(!result.isSuccess)
     #expect(result.message.contains("\"error\":\"element_not_found\""))
     #expect(result.message.contains("tempo slider not located"))
+    #expect(result.message.contains("create a software instrument track first"))
+    let object = decodeAccessibilityJSON(result.message)
+    #expect(object["track_header_count"] as? Int == 0)
+    #expect(object["transport_bar_found"] as? Bool == true)
+    #expect(object["control_bar_found"] as? Bool == false)
+    #expect(object["dialog_present"] as? Bool == false)
+    #expect((object["transport_slider_descriptions"] as? [String]) == [])
+    #expect((object["control_bar_checkbox_labels"] as? [String]) == [])
+    #expect(fallbackBox.called == false)
 }
 
 @Test func testAccessibilityChannelCreateInstrumentVerifiesTrackCountIncrease() async {


### PR DESCRIPTION
## Summary
- add tempo-control landmark scanning so `logic_transport.set_tempo` reports the current Logic UI surface instead of a generic missing-slider failure
- only allow the blind keyboard fallback when a project surface is actually ready, and otherwise fail closed with targeted recovery hints
- extend AX tests and the live E2E harness with fresh-project tempo coverage

## Root cause
`logic_transport.set_tempo` previously either found the tempo slider or immediately fell back to a blind keyboard path. In fresh Logic sessions, the control bar can still be hidden behind the Create New Track flow or an incompletely loaded project surface, so the command returned a generic `element_not_found` without enough UI context and could still try the unsafe fallback.

## Verification
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift test --filter AccessibilityChannelTests`
- `swift test --filter HonestContractOpTests`
- `swift build -c release`
- `git diff --check`
- live probe on 2026-06-20: `logic_transport.set_tempo {tempo:128}` returned `{"observed":128,"requested":128,"success":true,"verified":true,"via":"slider"}` and `logic://transport/state` read back `tempo:128`

Closes #47
