### PR TITLE
fix(demo): verify record_sequence via region readback

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -773,6 +773,42 @@ def main():
     r = call_tool(client, "logic_tracks", "scan_plugin_presets", {"submenuOpenDelayMs": 300})
     T("track.scan_plugin_presets returns content or guidance", r, lambda _: len(tool_text(r)) > 0)
 
+    r = call_tool(client, "logic_tracks", "record_sequence", {
+        "bar": 1,
+        "notes": "60,0,500,100,1",
+    })
+    record_sequence_text = tool_text(r)
+    record_sequence_json = safe_json(record_sequence_text)
+    T_LIVE(
+        "track.record_sequence verifies imported region or returns structured readback failure",
+        r,
+        lambda _: (
+            isinstance(record_sequence_json, dict)
+            and record_sequence_json.get("success") is True
+            and record_sequence_json.get("verified") is True
+            and isinstance(record_sequence_json.get("created_track"), int)
+            and isinstance(record_sequence_json.get("target_track_index"), int)
+            and isinstance(record_sequence_json.get("region_name"), str)
+            and isinstance(record_sequence_json.get("start_bar"), int)
+            and isinstance(record_sequence_json.get("end_bar"), int)
+            and isinstance(record_sequence_json.get("note_count"), int)
+            and isinstance(record_sequence_json.get("verify_source"), str)
+        ) or (
+            isinstance(record_sequence_json, dict)
+            and record_sequence_json.get("success") is False
+            and record_sequence_json.get("error") in (
+                "import_failure",
+                "wrong_track_import",
+                "timing_mismatch",
+                "unreadable_readback",
+            )
+            and isinstance(record_sequence_json.get("note_count"), int)
+            and isinstance(record_sequence_json.get("method"), str)
+        ),
+        live_logic_ready and has_document,
+        "Logic Pro with an open project is required",
+    )
+
     # ═══════════════════════════════════════════════════════════════
     # §5 Mixer Live Operations (25 tests)
     # ═══════════════════════════════════════════════════════════════

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3070,7 +3070,9 @@ actor AccessibilityChannel: Channel {
             if !desc.isEmpty { groupDescSamples.append(desc) }
             let lower = desc.lowercased()
             if desc.contains("트랙 콘텐츠") || desc == "콘텐츠"
-                || lower == "track content" || lower == "content" {
+                || lower == "track content" || lower == "track contents"
+                || lower == "tracks content" || lower == "tracks contents"
+                || lower == "content" {
                 contentGroup = g
                 break
             }
@@ -3195,10 +3197,13 @@ actor AccessibilityChannel: Channel {
     /// Returns (-1, -1) if neither pattern matches — callers should inspect rawHelp.
     private static func parseRegionBars(from help: String) -> (Int, Int) {
         // Korean: "리전은 1 마디 에서 시작하여 2 마디 에서 끝납니다."
-        // English (guessed, pending real-world sample): "Region starts at bar 1 and ends at bar 2"
+        // English samples observed in Logic 12.x:
+        // - "Region starts at bar 1 and ends at bar 2"
+        // - "Region starts at 1 bar and ends at 2 bars"
         let patterns = [
             #"리전은\s*(\d+)\s*마디.*?시작.*?(\d+)\s*마디.*?끝"#,
             #"(?i)region\s+starts\s+at\s+bar\s+(\d+).*?ends\s+at\s+bar\s+(\d+)"#,
+            #"(?i)region\s+starts\s+at\s+(\d+)\s+bars?.*?ends\s+at\s+(\d+)\s+bars?"#,
         ]
         for pat in patterns {
             guard let rx = try? NSRegularExpression(pattern: pat, options: [.dotMatchesLineSeparators]) else { continue }

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -4,9 +4,14 @@ import MCP
 struct TrackDispatcher {
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename/mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } v3.0.8 SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`. The new track keeps Logic's default Software Instrument (Studio Grand piano on a fresh project); callers that want a specific patch must follow up with an explicit `set_instrument` AFTER ensuring the intended track is selected. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default ax — live Library Panel; disk reads ~/Music/Logic Pro Library.bundle for 5,400+ leaves with Panel-taxonomy remap; both returns diff summary); resolve_path -> { path: String } cache-backed read-only; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename/mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } v3.0.8 SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`. The new track keeps Logic's default Software Instrument (Studio Grand piano on a fresh project); callers that want a specific patch must follow up with an explicit `set_instrument` AFTER ensuring the intended track is selected. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default ax — live Library Panel; disk reads ~/Music/Logic Pro Library.bundle for 5,400+ leaves with Panel-taxonomy remap; both returns diff summary); resolve_path -> { path: String } cache-backed read-only; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
+
+    enum RecordSequenceRegionReadback {
+        case success([RegionInfo])
+        case failure(String)
+    }
 
     static func handle(
         command: String,
@@ -366,7 +371,18 @@ struct TrackDispatcher {
     static func handleRecordSequenceSMF(
         params: [String: MCP.Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        trackHeaderCount: @escaping @Sendable () -> Int = { AXLogicProElements.allTrackHeaders().count },
+        trackNameAt: @escaping @Sendable (Int) -> String? = { AXLogicProElements.trackName(at: $0) },
+        readRegions: @escaping @Sendable () -> RecordSequenceRegionReadback = {
+            switch AccessibilityChannel.enumerateRegionItems() {
+            case .success(let result):
+                return .success(result.regions.map { $0.info })
+            case .failure(let error):
+                return .failure(error.message)
+            }
+        },
+        settleReadback: @escaping @Sendable () async -> Void = { try? await Task.sleep(nanoseconds: 150_000_000) }
     ) async -> CallTool.Result {
         // T5 — record_sequence does not support `port` (no keycmd alternative
         // for SMF-import + AX menu navigation). Reject up-front rather than
@@ -503,6 +519,14 @@ struct TrackDispatcher {
             )
         }
 
+        let preImportRegions: [RegionInfo]?
+        switch readRegions() {
+        case .success(let regions):
+            preImportRegions = regions
+        case .failure:
+            preImportRegions = nil
+        }
+
         // v3.1.2 (P0-2) — verify track creation against LIVE AX, not the
         // 3-second StatePoller cache. The previous cache-poll loop (2s
         // window, 100ms granularity) was strictly shorter than the poller
@@ -514,38 +538,52 @@ struct TrackDispatcher {
         //
         // The downstream import handler (AccessibilityChannel
         // `defaultImportMIDIFile`) already validates the count delta against
-        // `AXLogicProElements.allTrackHeaders()` before returning success,
-        // so an `importResult.isSuccess` is itself a proof of new-track
-        // creation. We re-read the same live AX surface here only to
-        // discover the track index for the response payload — and we still
-        // ask the poller to refresh so the next cache read is fresh too.
-        let tracksBefore = AXLogicProElements.allTrackHeaders().count
+        // live AX before returning success, so an `importResult.isSuccess`
+        // proves a new track was created. We still re-read live track headers
+        // here to discover the new track index and then verify the imported
+        // region on that specific track.
+        let tracksBefore = trackHeaderCount()
         let importResult = await router.route(
             operation: "midi.import_file",
             params: ["path": path]
         )
         guard importResult.isSuccess else {
-            return toolTextResult(
-                "record_sequence failed at midi.import_file: \(importResult.message)",
-                isError: true
-            )
+            return jsonToolTextResult([
+                "success": false,
+                "verified": false,
+                "error": "import_failure",
+                "failure_stage": "midi.import_file",
+                "bar": bar,
+                "note_count": events.count,
+                "method": "smf_import",
+                "detail": importResult.message,
+                "hint": "record_sequence failed at midi.import_file: \(importResult.message)",
+            ], isError: true)
         }
 
         // Re-read live AX to confirm the new track index. Import handler has
         // already verified the delta, so we expect tracksAfter > tracksBefore
         // immediately; the small retry loop is purely defensive against AX
         // tree settle latency on slow machines (≤500ms total).
-        var tracksAfter = AXLogicProElements.allTrackHeaders().count
+        var tracksAfter = trackHeaderCount()
         for _ in 0..<5 {
             if tracksAfter > tracksBefore { break }
             try? await Task.sleep(nanoseconds: 100_000_000)
-            tracksAfter = AXLogicProElements.allTrackHeaders().count
+            tracksAfter = trackHeaderCount()
         }
         guard tracksAfter > tracksBefore else {
-            return toolTextResult(
-                "record_sequence: import handler reported success but live AX still shows \(tracksBefore) tracks (no delta within 500ms). Check Logic Pro UI and retry.",
-                isError: true
-            )
+            return jsonToolTextResult([
+                "success": false,
+                "verified": false,
+                "error": "import_failure",
+                "failure_stage": "track_creation",
+                "bar": bar,
+                "note_count": events.count,
+                "method": "smf_import",
+                "track_count_before": tracksBefore,
+                "track_count_after": tracksAfter,
+                "hint": "record_sequence: import handler reported success but live AX still shows \(tracksBefore) tracks (no delta within 500ms). Check Logic Pro UI and retry.",
+            ], isError: true)
         }
 
         let createdTrack = tracksAfter - 1
@@ -597,34 +635,264 @@ struct TrackDispatcher {
             instrumentStatus = "ignored:\(instrumentPath) (v3.0.8: internal auto-load removed to prevent corrupting a pre-existing track — call set_instrument explicitly; see CHANGELOG v3.0.8 for the selectTrackViaAX limitation on fresh SMF-created tracks)"
         }
 
-        return toolTextResult(.success(
-            "{\"recorded_to_track\":\(createdTrack),\"created_track\":\(createdTrack),\"bar\":\(bar),\"note_count\":\(events.count),\"method\":\"smf_import\",\"instrument\":\"\(escapeJSONString(instrumentStatus))\"}"
-        ))
+        return await verifyRecordSequenceImport(
+            createdTrack: createdTrack,
+            targetTrackName: trackNameAt(createdTrack),
+            requestedBar: bar,
+            noteCount: events.count,
+            instrumentStatus: instrumentStatus,
+            events: events,
+            preImportRegions: preImportRegions,
+            readRegions: readRegions,
+            settleReadback: settleReadback
+        )
     }
 
-    /// Minimal JSON string escape for the one field we embed verbatim. The
-    /// `instrumentStatus` text can legitimately contain `"`, `\\`, or
-    /// newlines (when it carries a forwarded error message), so we escape
-    /// rather than trust the source.
-    private static func escapeJSONString(_ s: String) -> String {
-        var out = ""
-        out.reserveCapacity(s.count)
-        for ch in s {
-            switch ch {
-            case "\\": out += "\\\\"
-            case "\"": out += "\\\""
-            case "\n": out += "\\n"
-            case "\r": out += "\\r"
-            case "\t": out += "\\t"
-            default:
-                if ch.asciiValue.map({ $0 < 0x20 }) == true {
-                    out += String(format: "\\u%04x", ch.asciiValue!)
-                } else {
-                    out.append(ch)
+    private enum RecordSequenceReadbackStatus {
+        case verified([String: Any])
+        case failed([String: Any])
+        case pending
+    }
+
+    private static func jsonToolTextResult(_ object: [String: Any], isError: Bool = false) -> CallTool.Result {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: []),
+              let text = String(data: data, encoding: .utf8) else {
+            return toolTextResult("record_sequence: failed to encode JSON response", isError: true)
+        }
+        return toolTextResult(text, isError: isError)
+    }
+
+    private static func verifyRecordSequenceImport(
+        createdTrack: Int,
+        targetTrackName: String?,
+        requestedBar: Int,
+        noteCount: Int,
+        instrumentStatus: String,
+        events: [SMFWriter.NoteEvent],
+        preImportRegions: [RegionInfo]?,
+        readRegions: @escaping @Sendable () -> RecordSequenceRegionReadback,
+        settleReadback: @escaping @Sendable () async -> Void
+    ) async -> CallTool.Result {
+        let expectedStartBar = 1
+        let expectedEndBar = recordSequenceExpectedEndBar(for: events, requestedBar: requestedBar)
+        let base: [String: Any] = [
+            "bar": requestedBar,
+            "created_track": createdTrack,
+            "recorded_to_track": createdTrack,
+            "target_track_index": createdTrack,
+            "target_track_name": targetTrackName ?? "",
+            "note_count": noteCount,
+            "method": "smf_import",
+            "instrument": instrumentStatus,
+            "expected_start_bar": expectedStartBar,
+            "expected_end_bar": expectedEndBar,
+        ]
+        let preRegionKeys = Set((preImportRegions ?? []).map(recordSequenceRegionKey))
+        let hasPreImportSnapshot = preImportRegions != nil
+        let verifySource = hasPreImportSnapshot ? "ax_region_delta" : "ax_region_readback"
+
+        var bestFailure: [String: Any]?
+        var lastReadbackError: String?
+        var lastRegionCount = 0
+        var lastNewRegionCount = 0
+
+        for attempt in 0..<10 {
+            switch readRegions() {
+            case .failure(let error):
+                lastReadbackError = error
+            case .success(let regions):
+                lastRegionCount = regions.count
+                lastNewRegionCount = hasPreImportSnapshot
+                    ? regions.filter { !preRegionKeys.contains(recordSequenceRegionKey($0)) }.count
+                    : 0
+
+                switch diagnoseRecordSequenceReadback(
+                    postImportRegions: regions,
+                    hasPreImportSnapshot: hasPreImportSnapshot,
+                    preImportRegionKeys: preRegionKeys,
+                    createdTrack: createdTrack,
+                    expectedStartBar: expectedStartBar,
+                    expectedEndBar: expectedEndBar,
+                    base: base,
+                    verifySource: verifySource
+                ) {
+                case .verified(let payload):
+                    return jsonToolTextResult(payload)
+                case .failed(let payload):
+                    if shouldPreferRecordSequenceFailure(candidate: payload, over: bestFailure) {
+                        bestFailure = payload
+                    }
+                case .pending:
+                    break
                 }
             }
+
+            if attempt < 9 {
+                await settleReadback()
+            }
         }
-        return out
+
+        if var bestFailure {
+            bestFailure["region_count"] = lastRegionCount
+            bestFailure["new_region_count"] = lastNewRegionCount
+            if let lastReadbackError {
+                bestFailure["readback_error"] = lastReadbackError
+            }
+            return jsonToolTextResult(bestFailure, isError: true)
+        }
+
+        var payload = base
+        payload["success"] = false
+        payload["verified"] = false
+        payload["error"] = "unreadable_readback"
+        payload["verify_source"] = verifySource
+        payload["region_count"] = lastRegionCount
+        payload["new_region_count"] = lastNewRegionCount
+        payload["hint"] = lastReadbackError.map {
+            "record_sequence region readback failed: \($0)"
+        } ?? "record_sequence imported a new track but no MIDI region could be verified from AX readback"
+        if let lastReadbackError {
+            payload["readback_error"] = lastReadbackError
+        }
+        return jsonToolTextResult(payload, isError: true)
+    }
+
+    private static func diagnoseRecordSequenceReadback(
+        postImportRegions: [RegionInfo],
+        hasPreImportSnapshot: Bool,
+        preImportRegionKeys: Set<String>,
+        createdTrack: Int,
+        expectedStartBar: Int,
+        expectedEndBar: Int,
+        base: [String: Any],
+        verifySource: String
+    ) -> RecordSequenceReadbackStatus {
+        let newRegions = hasPreImportSnapshot
+            ? postImportRegions.filter { !preImportRegionKeys.contains(recordSequenceRegionKey($0)) }
+            : []
+        let targetRegions = postImportRegions.filter { $0.trackIndex == createdTrack }
+
+        if let targetRegion = preferredRecordSequenceRegion(from: targetRegions) {
+            var payload = base
+            payload["verify_source"] = verifySource
+            for (key, value) in recordSequenceRegionFields(targetRegion) {
+                payload[key] = value
+            }
+            if targetRegion.startBar < 0 || targetRegion.endBar < 0 {
+                payload["success"] = false
+                payload["verified"] = false
+                payload["error"] = "unreadable_readback"
+                payload["hint"] = "record_sequence found a region on the created track, but AX did not expose readable start/end bars"
+                return .failed(payload)
+            }
+            if targetRegion.startBar == expectedStartBar && targetRegion.endBar == expectedEndBar {
+                payload["success"] = true
+                payload["verified"] = true
+                return .verified(payload)
+            }
+            payload["success"] = false
+            payload["verified"] = false
+            payload["error"] = "timing_mismatch"
+            payload["hint"] = "record_sequence region readback did not match the expected bar envelope"
+            return .failed(payload)
+        }
+
+        if let wrongTrackRegion = preferredRecordSequenceRegion(from: newRegions.filter { $0.trackIndex >= 0 && $0.trackIndex != createdTrack }) {
+            var payload = base
+            payload["success"] = false
+            payload["verified"] = false
+            payload["error"] = "wrong_track_import"
+            payload["verify_source"] = verifySource
+            payload["hint"] = "record_sequence imported a region, but AX readback placed it on track \(wrongTrackRegion.trackIndex) instead of the newly created track \(createdTrack)"
+            for (key, value) in recordSequenceRegionFields(wrongTrackRegion, prefix: "observed_") {
+                payload[key] = value
+            }
+            return .failed(payload)
+        }
+
+        if postImportRegions.isEmpty {
+            return .pending
+        }
+
+        var payload = base
+        payload["success"] = false
+        payload["verified"] = false
+        payload["error"] = "unreadable_readback"
+        payload["verify_source"] = verifySource
+        payload["hint"] = "record_sequence imported a new track but no MIDI region could be verified on the created track"
+        return .failed(payload)
+    }
+
+    private static func shouldPreferRecordSequenceFailure(
+        candidate: [String: Any],
+        over current: [String: Any]?
+    ) -> Bool {
+        guard let current else { return true }
+        return recordSequenceFailurePriority(candidate) > recordSequenceFailurePriority(current)
+    }
+
+    private static func recordSequenceFailurePriority(_ payload: [String: Any]) -> Int {
+        switch payload["error"] as? String {
+        case "wrong_track_import":
+            return 3
+        case "timing_mismatch":
+            return 2
+        case "unreadable_readback":
+            return 1
+        default:
+            return 0
+        }
+    }
+
+    private static func recordSequenceExpectedEndBar(
+        for events: [SMFWriter.NoteEvent],
+        requestedBar: Int,
+        timeSignatureNumerator: Int = 4,
+        ticksPerQuarter: Int = 480
+    ) -> Int {
+        let ticksPerBar = timeSignatureNumerator * ticksPerQuarter
+        let maxEndTicks = events.map { $0.offsetTicks + $0.durationTicks }.max() ?? 0
+        let absoluteEndTicks = maxEndTicks + max(0, requestedBar - 1) * ticksPerBar
+        return max(2, (absoluteEndTicks / ticksPerBar) + 2)
+    }
+
+    private static func recordSequenceRegionKey(_ region: RegionInfo) -> String {
+        [
+            region.name,
+            String(region.trackIndex),
+            String(region.startBar),
+            String(region.endBar),
+            region.kind,
+        ].joined(separator: "|")
+    }
+
+    private static func preferredRecordSequenceRegion(from regions: [RegionInfo]) -> RegionInfo? {
+        regions.max { lhs, rhs in
+            if lhs.trackIndex != rhs.trackIndex { return lhs.trackIndex < rhs.trackIndex }
+            if lhs.endBar != rhs.endBar { return lhs.endBar < rhs.endBar }
+            if lhs.startBar != rhs.startBar { return lhs.startBar < rhs.startBar }
+            return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    private static func recordSequenceRegionFields(
+        _ region: RegionInfo,
+        prefix: String = ""
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "\(prefix)region_name": region.name,
+            "\(prefix)start_bar": region.startBar,
+            "\(prefix)end_bar": region.endBar,
+            "\(prefix)region_kind": region.kind,
+        ]
+        if !prefix.isEmpty {
+            payload["\(prefix)track_index"] = region.trackIndex
+        }
+        if let rawHelp = region.rawHelp, !rawHelp.isEmpty {
+            payload["\(prefix)raw_help"] = rawHelp
+        }
+        return payload
     }
 
     private static func parseNotesToSMFEvents(

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -350,6 +350,98 @@ private func makeAXBackedAccessibilityChannel(
     #expect(regions[0].kind == "midi")
 }
 
+@Test func testAccessibilityChannelAXBackedRegionReadAcceptsPluralTracksContentsLabel() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(70)
+    let window = builder.element(71)
+    let headerRail = builder.element(72)
+    let trackHeader = builder.element(73)
+    let contentGroup = builder.element(74)
+    let region = builder.element(75)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [headerRail, contentGroup])
+
+    builder.setAttribute(headerRail, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(headerRail, kAXDescriptionAttribute as String, "Tracks header")
+    builder.setChildren(headerRail, [trackHeader])
+
+    builder.setAttribute(trackHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(trackHeader, kAXPositionAttribute as String, axPoint(0, 100))
+    builder.setAttribute(trackHeader, kAXSizeAttribute as String, axSize(200, 40))
+
+    builder.setAttribute(contentGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(contentGroup, kAXDescriptionAttribute as String, "Tracks contents")
+    builder.setChildren(contentGroup, [region])
+
+    builder.setAttribute(region, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(region, kAXDescriptionAttribute as String, "Imported Idea")
+    builder.setAttribute(region, kAXHelpAttribute as String, "Region starts at bar 1 and ends at bar 2, MIDI region.")
+    builder.setAttribute(region, kAXPositionAttribute as String, axPoint(240, 108))
+    builder.setAttribute(region, kAXSizeAttribute as String, axSize(320, 24))
+
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let result = await channel.execute(operation: "region.get_regions", params: [:])
+
+    #expect(result.isSuccess)
+
+    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    #expect(regions.count == 1)
+    #expect(regions[0].name == "Imported Idea")
+    #expect(regions[0].trackIndex == 0)
+    #expect(regions[0].startBar == 1)
+    #expect(regions[0].endBar == 2)
+    #expect(regions[0].kind == "midi")
+}
+
+@Test func testAccessibilityChannelAXBackedRegionReadAcceptsNumericBeforeBarEnglishHelp() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(76)
+    let window = builder.element(77)
+    let headerRail = builder.element(78)
+    let trackHeader = builder.element(79)
+    let contentGroup = builder.element(80)
+    let region = builder.element(81)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [headerRail, contentGroup])
+
+    builder.setAttribute(headerRail, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(headerRail, kAXDescriptionAttribute as String, "Tracks header")
+    builder.setChildren(headerRail, [trackHeader])
+
+    builder.setAttribute(trackHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(trackHeader, kAXPositionAttribute as String, axPoint(0, 100))
+    builder.setAttribute(trackHeader, kAXSizeAttribute as String, axSize(200, 40))
+
+    builder.setAttribute(contentGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(contentGroup, kAXDescriptionAttribute as String, "Tracks contents")
+    builder.setChildren(contentGroup, [region])
+
+    builder.setAttribute(region, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(region, kAXDescriptionAttribute as String, "Imported Idea")
+    builder.setAttribute(
+        region,
+        kAXHelpAttribute as String,
+        "Region starts at 1 bar  and ends at 2 bars , MIDI region."
+    )
+    builder.setAttribute(region, kAXPositionAttribute as String, axPoint(240, 108))
+    builder.setAttribute(region, kAXSizeAttribute as String, axSize(320, 24))
+
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let result = await channel.execute(operation: "region.get_regions", params: [:])
+
+    #expect(result.isSuccess)
+
+    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    #expect(regions.count == 1)
+    #expect(regions[0].name == "Imported Idea")
+    #expect(regions[0].trackIndex == 0)
+    #expect(regions[0].startBar == 1)
+    #expect(regions[0].endBar == 2)
+    #expect(regions[0].kind == "midi")
+}
+
 @Test func testAccessibilityChannelAXBackedTransportDefaultsUseFakeAXTree() async throws {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(100)

--- a/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
+++ b/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
@@ -44,6 +44,58 @@ private func minimalNoteSpec() -> Value {
     .string("60,0,500,100,1")
 }
 
+private final class SequentialIntBox: @unchecked Sendable {
+    private var values: [Int]
+
+    init(_ values: [Int]) {
+        self.values = values
+    }
+
+    func next() -> Int {
+        guard !values.isEmpty else { return 0 }
+        if values.count == 1 { return values[0] }
+        return values.removeFirst()
+    }
+}
+
+private final class SequentialRegionReadBox: @unchecked Sendable {
+    private var values: [TrackDispatcher.RecordSequenceRegionReadback]
+
+    init(_ values: [TrackDispatcher.RecordSequenceRegionReadback]) {
+        self.values = values
+    }
+
+    func next() -> TrackDispatcher.RecordSequenceRegionReadback {
+        guard !values.isEmpty else { return .success([]) }
+        if values.count == 1 { return values[0] }
+        return values.removeFirst()
+    }
+}
+
+private func makeRegion(
+    name: String = "Imported Idea",
+    trackIndex: Int,
+    startBar: Int,
+    endBar: Int,
+    kind: String = "midi",
+    rawHelp: String? = nil
+) -> RegionInfo {
+    RegionInfo(
+        name: name,
+        trackIndex: trackIndex,
+        startBar: startBar,
+        endBar: endBar,
+        kind: kind,
+        rawHelp: rawHelp
+    )
+}
+
+private func recordSequenceJSONObject(_ result: CallTool.Result) -> [String: Any] {
+    let text = sharedToolText(result)
+    let data = Data(text.utf8)
+    return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+}
+
 @Test func testRecordSequenceUsesLiveAXNotCache() async {
     // Pre-fill the cache with 2 tracks so that under the OLD cache-poll
     // verification, `tracksBefore = 2` and `tracksAfter` would also stay 2
@@ -125,4 +177,152 @@ private func minimalNoteSpec() -> Value {
         text.contains("midi.import_file"),
         "import-failure path must surface the import handler error, got: \(text)"
     )
+}
+
+@Test func testRecordSequenceReturnsVerifiedRegionReadbackPayload() async {
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .success("imported"))
+    await router.register(ax)
+
+    let trackCounts = SequentialIntBox([1, 2])
+    let regionReads = SequentialRegionReadBox([
+        .success([]),
+        .success([makeRegion(trackIndex: 1, startBar: 1, endBar: 2)]),
+    ])
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: [
+            "notes": minimalNoteSpec(),
+            "bar": .int(1),
+        ],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { trackCounts.next() },
+        trackNameAt: { $0 == 1 ? "Imported Piano" : nil },
+        readRegions: { regionReads.next() },
+        settleReadback: {}
+    )
+
+    #expect(result.isError == false)
+    let object = recordSequenceJSONObject(result)
+    #expect(object["success"] as? Bool == true)
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["created_track"] as? Int == 1)
+    #expect(object["recorded_to_track"] as? Int == 1)
+    #expect(object["target_track_index"] as? Int == 1)
+    #expect(object["target_track_name"] as? String == "Imported Piano")
+    #expect(object["region_name"] as? String == "Imported Idea")
+    #expect(object["start_bar"] as? Int == 1)
+    #expect(object["end_bar"] as? Int == 2)
+    #expect(object["note_count"] as? Int == 1)
+    #expect(object["verify_source"] as? String == "ax_region_delta")
+}
+
+@Test func testRecordSequenceDistinguishesWrongTrackImport() async {
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .success("imported"))
+    await router.register(ax)
+
+    let trackCounts = SequentialIntBox([1, 2])
+    let regionReads = SequentialRegionReadBox([
+        .success([]),
+        .success([makeRegion(trackIndex: 0, startBar: 1, endBar: 2)]),
+    ])
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: [
+            "notes": minimalNoteSpec(),
+            "bar": .int(1),
+        ],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { trackCounts.next() },
+        trackNameAt: { $0 == 1 ? "Imported Piano" : nil },
+        readRegions: { regionReads.next() },
+        settleReadback: {}
+    )
+
+    #expect(result.isError == true)
+    let object = recordSequenceJSONObject(result)
+    #expect(object["error"] as? String == "wrong_track_import")
+    #expect(object["target_track_index"] as? Int == 1)
+    #expect(object["observed_track_index"] as? Int == 0)
+    #expect(object["observed_region_name"] as? String == "Imported Idea")
+}
+
+@Test func testRecordSequenceDistinguishesTimingMismatch() async {
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .success("imported"))
+    await router.register(ax)
+
+    let trackCounts = SequentialIntBox([1, 2])
+    let regionReads = SequentialRegionReadBox([
+        .success([]),
+        .success([makeRegion(trackIndex: 1, startBar: 1, endBar: 3)]),
+    ])
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: [
+            "notes": minimalNoteSpec(),
+            "bar": .int(1),
+        ],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { trackCounts.next() },
+        trackNameAt: { $0 == 1 ? "Imported Piano" : nil },
+        readRegions: { regionReads.next() },
+        settleReadback: {}
+    )
+
+    #expect(result.isError == true)
+    let object = recordSequenceJSONObject(result)
+    #expect(object["error"] as? String == "timing_mismatch")
+    #expect(object["region_name"] as? String == "Imported Idea")
+    #expect(object["start_bar"] as? Int == 1)
+    #expect(object["end_bar"] as? Int == 3)
+    #expect(object["expected_end_bar"] as? Int == 2)
+}
+
+@Test func testRecordSequenceDistinguishesUnreadableReadback() async {
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .success("imported"))
+    await router.register(ax)
+
+    let trackCounts = SequentialIntBox([1, 2])
+    let regionReads = SequentialRegionReadBox([
+        .success([]),
+        .success([makeRegion(trackIndex: 1, startBar: -1, endBar: -1, rawHelp: "MIDI Region")]),
+    ])
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: [
+            "notes": minimalNoteSpec(),
+            "bar": .int(1),
+        ],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { trackCounts.next() },
+        trackNameAt: { $0 == 1 ? "Imported Piano" : nil },
+        readRegions: { regionReads.next() },
+        settleReadback: {}
+    )
+
+    #expect(result.isError == true)
+    let object = recordSequenceJSONObject(result)
+    #expect(object["error"] as? String == "unreadable_readback")
+    #expect(object["region_name"] as? String == "Imported Idea")
+    #expect(object["start_bar"] as? Int == -1)
+    #expect(object["end_bar"] as? Int == -1)
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -175,7 +175,7 @@ Clients can detect stale snapshots without cross-referencing `logic://system/hea
 | `solo` | `{ index: int, enabled?: bool }` | text | MCU → AX → CGEvent |
 | `arm` | `{ index: int, enabled?: bool }` | text | MCU → AX → CGEvent |
 | `arm_only` | `{ index: int }` | text on full success; **error** when target arm fails or any disarm fails | composite (disarm-all + arm target) |
-| `record_sequence` | `{ bar?: int, notes: "pitch,offsetMs,durMs[,vel[,ch]];...", tempo?: float }` (`ch` 1..16, SMF end ≤ 3,600,000 ms) | JSON on success; **error** when goto fails OR no new track is observed via live AX within 500 ms | **v2.3 rewrite**: SMF generation + AX `File → Import → MIDI File…` — byte-exact timing |
+| `record_sequence` | `{ bar?: int, notes: "pitch,offsetMs,durMs[,vel[,ch]];...", tempo?: float }` (`ch` 1..16, SMF end ≤ 3,600,000 ms) | Verified JSON on success (`created_track`, `target_track_index`, `region_name`, `start_bar`, `end_bar`, `note_count`, `verify_source`); structured JSON **error** on import/readback failure | **v2.3 rewrite**: SMF generation + AX `File → Import → MIDI File…` + AX region readback verification |
 | `set_automation` | `{ index: int, mode: "off"\|"read"\|"touch"\|"latch"\|"trim"\|"write" }` | text | MCU |
 | `set_instrument` | `{ index: int, path: string }` OR `{ index: int, category: string, preset: string }` — at least one path OR (category + preset) is required | text | Accessibility |
 | `list_library` | — | text | Accessibility |
@@ -230,7 +230,8 @@ The old real-time `goto → record → sleep → play_sequence → stop` pipelin
 2. Generates a Type 0 Standard MIDI File with `SMFWriter` — tempo and time-signature meta events + byte-exact note positions computed from `ms` offsets via round-half-up tick conversion.
 3. Writes to `/tmp/LogicProMCP/{uuid}.mid` (cleaned up via `defer` on return and via server-startup sweep for crash recovery).
 4. Routes `midi.import_file` → `AccessibilityChannel` which validates the `.mid` file after symlink/path cleanup, drives `파일 → 가져오기 → MIDI 파일… (File → Import → MIDI File…)` via AppleScript, dismisses the `템포 가져오기 (Import Tempo)` sub-dialog with `아니요 (No)`, and waits for a new live AX track before returning success.
-5. Reads the live AX track-header tree for up to 500 ms until a new track appears. Returns `{ recorded_to_track, created_track, bar, note_count, method: "smf_import" }`. If the new track never appears within the readback window, the command returns an error instead of lying about `created_track`. `recorded_to_track` is a legacy alias for `created_track`; new clients should prefer `created_track`.
+5. Reads the live AX track-header tree for up to 500 ms until a new track appears.
+6. Reads the arrange-area regions through AX and verifies that a MIDI region exists on the newly-created track with the expected bar envelope. Success returns `{ recorded_to_track, created_track, target_track_index, target_track_name, region_name, start_bar, end_bar, note_count, verify_source, method: "smf_import" }`. `recorded_to_track` is a legacy alias for `created_track`; new clients should prefer `created_track`.
 
 **Error conditions for `record_sequence`**:
 
@@ -238,14 +239,18 @@ The old real-time `goto → record → sleep → play_sequence → stop` pipelin
 - `notes` is empty, or no valid events parsed
 - `notes` exceeds the SMF safety cap (encoded sequence end > 3,600,000 ms)
 - Playhead reset (`transport.goto_position` with `bar=1`) fails — treated as a hard precondition because Logic's MIDI File Import anchors the region at playhead; without the reset, notes would land at the wrong bar
-- `midi.import_file` fails, rejects the path, or completes without a new live AX track
-- No new track is observed via live AX within 500 ms of import (v3.1.2+ switched from 2s cache polling to live `AXLogicProElements.allTrackHeaders` after the cache-poll race documented in CHANGELOG §3.1.2)
+- `midi.import_file` fails, rejects the path, or completes without a new live AX track (`error: "import_failure"`)
+- No new track is observed via live AX within 500 ms of import (still `error: "import_failure"` with `failure_stage: "track_creation"`)
+- A new region appears, but AX places it on a different track than the newly-created one (`error: "wrong_track_import"`)
+- The created-track region is readable, but its observed start/end bars do not match the expected SMF envelope (`error: "timing_mismatch"`)
+- The created-track region cannot be read back from AX at all, or its bar bounds are unreadable (`error: "unreadable_readback"`)
 
 **Strategy D — tick-0 padding CC**: Logic Pro's MIDI File import strips leading empty delta before the first MIDI channel event, which would silently place every imported region at bar 1 regardless of the caller's `bar` parameter. SMFWriter counters this by emitting `CC#110 value 0` on channel 0 at tick 0 whenever `bar > 1`. Logic preserves the full tick timeline because a MIDI channel event now exists at tick 0. The resulting region spans bar 1 through the target bar; the caller's notes land at exactly the encoded positions inside the region. Verified on Logic Pro 12 — a `bar=50` request produces a region that Logic describes as starting at bar 1 and ending at bar 51, with the note at the trailing edge.
 
 **Response caveats**:
 - The region's start is always bar 1 (cosmetic trade-off of the padding strategy). If you need the region itself trimmed, the caller can run `편집 → 이동 → 재생헤드로 (Edit → Move → To Playhead)` on the selected region after positioning the playhead.
 - `created_track` is always the 0-based index of the newly-created track (Logic always creates a new MIDI track per import). The v2.3.0 `track_index_confirmed` fallback was removed in v3.0.0; v3.1.2 then replaced the original 2-second cache-poll loop with a 500 ms live-AX read against `AXLogicProElements.allTrackHeaders` (cache-poll race fix). On success the field would always be `true` so it was dropped from the response.
+- `verify_source` is `ax_region_delta` when a pre-import region snapshot was readable and `ax_region_readback` when the dispatcher had to rely on post-import region enumeration alone.
 
 **`arm_only` behavior (v3.0.0+)**:
 


### PR DESCRIPTION
## Summary
- verify `logic_tracks.record_sequence` by reading back the imported MIDI region on the created track instead of only checking that a new track appeared
- return structured JSON success fields (`created_track`, `target_track_index`, `region_name`, `start_bar`, `end_bar`, `note_count`, `verify_source`) and structured failure codes (`import_failure`, `wrong_track_import`, `timing_mismatch`, `unreadable_readback`)
- broaden AX region parsing for live Logic 12.2 English strings (`Tracks contents`, `Region starts at 1 bar and ends at 2 bars`) and cover the new behavior in tests, docs, and the live harness

## Root cause
`record_sequence` previously treated "a new track appeared" as proof of success. In live runs, that left imported MIDI unverifiable, and region readback also missed current English AX strings from Logic 12.2.

## Verification
- `python3 -m py_compile Scripts/live-e2e-test.py`
- `swift test --filter AccessibilityChannelTests`
- `swift test --filter testRecordSequence`
- `swift build -c release`
- `git diff --check`
- live tmux probe with `.build/release/LogicProMCP`
  - `logic_tracks.record_sequence {bar:1, notes:'60,0,500,100,1'}` -> `success:true`, `verified:true`, `start_bar:1`, `end_bar:2`, `target_track_index:3`, `verify_source:"ax_region_delta"`
  - `logic_project.get_regions` returned parsed regions with `startBar:1`, `endBar:2`

Closes #42
