### PR TITLE
feat(setup): add doctor JSON foundation

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -20,11 +20,29 @@ enum MainEntrypoint {
         permissionCheck: () -> PermissionChecker.PermissionStatus = PermissionChecker.check,
         serverFactory: () -> any ServerStarting = { LogicProServer() },
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
+        doctorRuntime: SetupDoctor.Runtime = .production,
+        writeStdout: (String) -> Void = { message in
+            FileHandle.standardOutput.write(Data(message.utf8))
+        },
         writeStderr: (String) -> Void = { message in
             FileHandle.standardError.write(Data(message.utf8))
         }
     ) async -> Int {
         let approvalStore = approvalStoreFactory()
+
+        if isDoctorCommand(arguments) {
+            let report = SetupDoctor.generate(
+                arguments: arguments,
+                permissionStatus: permissionCheck(),
+                approvals: await approvalStore.list(),
+                runtime: doctorRuntime
+            )
+            let output = arguments.contains("--json")
+                ? encodeJSON(report)
+                : SetupDoctor.renderHuman(report)
+            writeStdout(output + "\n")
+            return SetupDoctor.shouldExitWithFailure(report) ? 1 : 0
+        }
 
         if arguments.contains("--list-approvals") {
             let approvals = await approvalStore.list()
@@ -122,5 +140,9 @@ enum MainEntrypoint {
             return nil
         }
         return arguments[index + 1]
+    }
+
+    private static func isDoctorCommand(_ arguments: [String]) -> Bool {
+        Array(arguments.dropFirst()).first == "doctor"
     }
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -68,6 +68,21 @@ enum SetupDoctor {
         let stderr: String
     }
 
+    /// Result of inspecting the Claude Code config for a logic-pro registration.
+    /// This is a pure config read — it never spawns the registered server, so the
+    /// doctor's read-only / run-before-startup contract is honored (no CoreMIDI
+    /// ports, no health sweep, no SIGKILL of an indirectly-spawned server).
+    enum ClaudeRegistration: Equatable, Sendable {
+        /// A logic-pro-style MCP entry resolving to a LogicProMCP binary was found.
+        /// `command` is the registered command string for evidence.
+        case registered(command: String)
+        /// The config was read successfully but no matching registration exists.
+        case notRegistered
+        /// The config file is absent / unreadable / not valid JSON.
+        /// `reason` is a short human-readable explanation for the evidence dict.
+        case configUnavailable(reason: String)
+    }
+
     struct Runtime: @unchecked Sendable {
         let resolveExecutablePath: (String?) -> String?
         let fileExists: (String) -> Bool
@@ -75,6 +90,7 @@ enum SetupDoctor {
         let logicProRunning: () -> Bool
         let logicProHasVisibleWindow: () -> Bool
         let runCommand: (String, [String]) -> CommandOutput?
+        let readClaudeRegistration: () -> ClaudeRegistration
 
         static let production = Runtime(
             resolveExecutablePath: { raw in
@@ -93,7 +109,10 @@ enum SetupDoctor {
                 ProcessUtils.hasVisibleWindow()
             },
             runCommand: { executable, arguments in
-                runProductionCommand(executable: executable, arguments: arguments, timeout: 1.5)
+                runProductionCommand(executable: executable, arguments: arguments, timeout: 1.5)?.output
+            },
+            readClaudeRegistration: {
+                readProductionClaudeRegistration()
             }
         )
     }
@@ -103,7 +122,6 @@ enum SetupDoctor {
     static let remediationAnchorsByCheckID: [String: String] = [
         "binary.path": "docs/SETUP.md#doctor-binarypath",
         "binary.executable": "docs/SETUP.md#doctor-binaryexecutable",
-        "binary.version": "docs/SETUP.md#doctor-binaryversion",
         "install.source": "docs/SETUP.md#doctor-installsource",
         "release.signature": "docs/SETUP.md#doctor-releasesignature",
         "release.quarantine": "docs/SETUP.md#doctor-releasequarantine",
@@ -225,13 +243,18 @@ enum SetupDoctor {
     }
 
     private static func binaryVersionCheck() -> Check {
+        // Honest reporting: this echoes the version compiled into the running
+        // doctor process, not the version of the binary at binary.path. It cannot
+        // detect a stale/mismatched install, so it never fails — the summary states
+        // exactly what it reports and the remediation is unconditionally .none
+        // rather than carrying a dead .fail branch + unreachable docs anchor.
         check(
             id: "binary.version",
             domain: "binary",
-            status: ServerConfig.serverVersion.isEmpty ? .fail : .pass,
-            summary: "Server version is available.",
+            status: .pass,
+            summary: "Running server version: \(ServerConfig.serverVersion).",
             evidence: ["version": ServerConfig.serverVersion],
-            remediationType: ServerConfig.serverVersion.isEmpty ? .docs : .none
+            remediationType: .none
         )
     }
 
@@ -303,42 +326,90 @@ enum SetupDoctor {
                 remediationType: .docs
             )
         }
-        let quarantined = output.exitCode == 0
+        // Distinguish three outcomes instead of folding everything but exit 0 into
+        // .pass. xattr exits non-zero both when the attribute is absent (exit 1,
+        // "No such xattr") AND on permission-denied or other errors; collapsing all
+        // of those to "not quarantined" would let the doctor affirm a clean state it
+        // never verified.
+        let trimmedStderr = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedStdout = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let evidence: [String: String] = [
+            "path": executablePath,
+            "exit_code": String(output.exitCode),
+            "stderr": trimmedStderr,
+        ]
+        if output.exitCode == 0 {
+            return check(
+                id: "release.quarantine",
+                domain: "release",
+                status: .warn,
+                summary: "Binary has a macOS quarantine attribute.",
+                evidence: evidence,
+                remediationType: .command,
+                remediationValueOverride: "xattr -d com.apple.quarantine \(executablePath)"
+            )
+        }
+        let attributeAbsent = output.exitCode == 1
+            && trimmedStdout.isEmpty
+            && trimmedStderr.localizedCaseInsensitiveContains("No such xattr")
+        if attributeAbsent {
+            return check(
+                id: "release.quarantine",
+                domain: "release",
+                status: .pass,
+                summary: "Binary is not quarantined.",
+                evidence: evidence,
+                remediationType: .none
+            )
+        }
         return check(
             id: "release.quarantine",
             domain: "release",
-            status: quarantined ? .warn : .pass,
-            summary: quarantined ? "Binary has a macOS quarantine attribute." : "Binary is not quarantined.",
-            evidence: ["path": executablePath, "quarantined": String(quarantined)],
-            remediationType: quarantined ? .command : .none,
-            remediationValueOverride: quarantined ? "xattr -d com.apple.quarantine \(executablePath)" : nil
+            status: .warn,
+            summary: "Quarantine state could not be determined.",
+            evidence: evidence,
+            remediationType: .docs
         )
     }
 
     private static func claudeRegistrationCheck(runtime: Runtime) -> Check {
-        guard let output = runtime.runCommand("/usr/bin/env", ["claude", "mcp", "list"]) else {
+        // Read-only registration detection: inspect the Claude Code config file
+        // directly instead of shelling out to `claude mcp list`. `claude mcp list`
+        // health-checks every registered MCP server, which spawns the registered
+        // LogicProMCP binary over stdio (creating CoreMIDI virtual ports + AX
+        // pollers) — a real side effect that violates the doctor's documented
+        // "read-only / run-before-startup" contract, and one the old 1.5s SIGKILL
+        // could orphan. Reading the config is fast, non-mutating, and spawns nothing.
+        switch runtime.readClaudeRegistration() {
+        case let .registered(command):
+            return check(
+                id: "mcp.claude_code_registration",
+                domain: "mcp",
+                status: .pass,
+                summary: "Claude Code MCP registration found.",
+                evidence: ["registered": "true", "command": command],
+                remediationType: .none
+            )
+        case .notRegistered:
+            return check(
+                id: "mcp.claude_code_registration",
+                domain: "mcp",
+                status: .warn,
+                summary: "Claude Code MCP registration was not found.",
+                evidence: ["registered": "false"],
+                remediationType: .command,
+                remediationValueOverride: "claude mcp add --scope user logic-pro -- LogicProMCP"
+            )
+        case let .configUnavailable(reason):
             return check(
                 id: "mcp.claude_code_registration",
                 domain: "mcp",
                 status: .manual,
-                summary: "Claude Code registration could not be checked because the Claude CLI was not available.",
-                evidence: [:],
+                summary: "Claude Code registration could not be checked because the Claude config could not be read.",
+                evidence: ["reason": reason],
                 remediationType: .manual
             )
         }
-        let combined = "\(output.stdout)\n\(output.stderr)"
-        let registered = output.exitCode == 0
-            && combined.localizedCaseInsensitiveContains("logic-pro")
-            && combined.localizedCaseInsensitiveContains("LogicProMCP")
-        return check(
-            id: "mcp.claude_code_registration",
-            domain: "mcp",
-            status: registered ? .pass : .warn,
-            summary: registered ? "Claude Code MCP registration found." : "Claude Code MCP registration was not found.",
-            evidence: ["exit_code": String(output.exitCode)],
-            remediationType: registered ? .none : .command,
-            remediationValueOverride: registered ? nil : "claude mcp add --scope user logic-pro -- LogicProMCP"
-        )
     }
 
     private static func accessibilityPermissionCheck(_ status: PermissionChecker.PermissionStatus) -> Check {
@@ -404,14 +475,23 @@ enum SetupDoctor {
     }
 
     private static func detectInstallSource(executablePath: String?, runtime: Runtime) -> InstallSource {
-        if let executablePath, executablePath.contains("/.build/") || executablePath.contains(".build/") {
+        // Match a real `.build` path component (SwiftPM's canonical build dir),
+        // not a bare substring — a path like `/Users/x/my.build/release/LogicProMCP`
+        // must NOT be misclassified as source_build.
+        if let executablePath, URL(fileURLWithPath: executablePath).pathComponents.contains(".build") {
             return .sourceBuild
         }
 
-        if let brew = runtime.runCommand("/usr/bin/env", ["brew", "list", "--versions", "logic-pro-mcp"]),
-           brew.exitCode == 0,
-           brew.stdout.contains("logic-pro-mcp") {
-            return .homebrew
+        // Probe brew at canonical absolute paths instead of resolving via PATH.
+        // A launchd/minimal-supervisor env often has a stripped PATH without
+        // /opt/homebrew/bin, which would otherwise make a genuine Homebrew install
+        // fall through to .releaseBinary based purely on ambient PATH.
+        for brewPath in ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"] {
+            if let brew = runtime.runCommand(brewPath, ["list", "--versions", "logic-pro-mcp"]),
+               brew.exitCode == 0,
+               brew.stdout.contains("logic-pro-mcp") {
+                return .homebrew
+            }
         }
 
         guard let executablePath else { return .unknown }
@@ -497,18 +577,35 @@ enum SetupDoctor {
             executable: "/usr/bin/which",
             arguments: [raw],
             timeout: 1.0
-        ), output.exitCode == 0 else {
+        )?.output, output.exitCode == 0 else {
             return nil
         }
         let path = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return path.isEmpty ? nil : path
     }
 
+    /// Outcome of running an external command, distinguishing the failure modes
+    /// so callers can message truthfully (timeout vs. could-not-spawn) rather than
+    /// collapsing both into a bare `nil`.
+    enum ProductionCommandResult: Equatable, Sendable {
+        case completed(CommandOutput)
+        /// The process did not finish within the timeout (terminated/killed).
+        case timedOut
+        /// The process could not be launched (e.g. executable not found).
+        case spawnFailed(String)
+
+        /// Convenience accessor for callers that only need the successful output.
+        var output: CommandOutput? {
+            if case let .completed(value) = self { return value }
+            return nil
+        }
+    }
+
     private static func runProductionCommand(
         executable: String,
         arguments: [String],
         timeout: TimeInterval
-    ) -> CommandOutput? {
+    ) -> ProductionCommandResult? {
         let process = Process()
         let stdout = Pipe()
         let stderr = Pipe()
@@ -520,14 +617,54 @@ enum SetupDoctor {
         process.standardOutput = stdout
         process.standardError = stderr
 
+        // Drain both pipes CONCURRENTLY with the child. Reading only after the
+        // process exits deadlocks when the child writes more than the OS pipe
+        // buffer (~16-64KB): its write() blocks, the child never exits, the
+        // termination handler never fires, and the timeout becomes the only exit
+        // path. Accumulating into thread-safe buffers from readabilityHandler
+        // removes that buffer-full deadlock and makes the timeout the only failure
+        // path. The buffer is a Sendable reference type so the @Sendable handler
+        // can mutate it safely.
+        let stdoutBuffer = PipeDrainBuffer()
+        let stderrBuffer = PipeDrainBuffer()
+
         let group = DispatchGroup()
+
+        group.enter()
+        stdout.fileHandleForReading.readabilityHandler = { fileHandle in
+            let chunk = fileHandle.availableData
+            if chunk.isEmpty {
+                fileHandle.readabilityHandler = nil
+                group.leave()
+                return
+            }
+            stdoutBuffer.append(chunk)
+        }
+        group.enter()
+        stderr.fileHandleForReading.readabilityHandler = { fileHandle in
+            let chunk = fileHandle.availableData
+            if chunk.isEmpty {
+                fileHandle.readabilityHandler = nil
+                group.leave()
+                return
+            }
+            stderrBuffer.append(chunk)
+        }
+
         group.enter()
         process.terminationHandler = { _ in group.leave() }
 
         do {
             try process.run()
         } catch {
-            return nil
+            // The readers never received data; clear them and balance the group so
+            // it cannot leak. terminationHandler will not fire because run() threw.
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            group.leave() // termination handler
+            group.leave() // stdout reader
+            group.leave() // stderr reader
+            return .spawnFailed(String(describing: error))
         }
 
         if group.wait(timeout: .now() + timeout) == .timedOut {
@@ -536,13 +673,108 @@ enum SetupDoctor {
             }
             if group.wait(timeout: .now() + 0.2) == .timedOut, process.isRunning {
                 kill(process.processIdentifier, SIGKILL)
-                _ = group.wait(timeout: .now() + 0.2)
+                _ = group.wait(timeout: .now() + 0.5)
             }
-            return nil
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            return .timedOut
         }
 
-        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        return CommandOutput(exitCode: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
+        let stdoutText = String(data: stdoutBuffer.snapshot(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderrBuffer.snapshot(), encoding: .utf8) ?? ""
+        return .completed(
+            CommandOutput(exitCode: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
+        )
+    }
+
+    /// Thread-safe Data accumulator for concurrent pipe draining. Reference type so
+    /// the `@Sendable` readabilityHandler can mutate shared state without capturing
+    /// a non-Sendable closure.
+    private final class PipeDrainBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func append(_ chunk: Data) {
+            lock.lock()
+            data.append(chunk)
+            lock.unlock()
+        }
+
+        func snapshot() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return data
+        }
+    }
+
+    /// Production reader for the Claude Code registration. Parses ~/.claude.json
+    /// directly (top-level `mcpServers` plus every `projects.<path>.mcpServers`)
+    /// and reports registration when a logic-pro-style entry resolves to a
+    /// LogicProMCP binary. This spawns nothing — honoring the read-only contract.
+    static func readProductionClaudeRegistration(
+        configURL: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude.json")
+    ) -> ClaudeRegistration {
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            return .configUnavailable(reason: "config file not found at \(configURL.path)")
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: configURL)
+        } catch {
+            return .configUnavailable(reason: "config file could not be read: \(String(describing: error))")
+        }
+        let root: Any
+        do {
+            root = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            return .configUnavailable(reason: "config file is not valid JSON: \(String(describing: error))")
+        }
+        guard let object = root as? [String: Any] else {
+            return .configUnavailable(reason: "config root is not a JSON object")
+        }
+
+        var serverScopes: [[String: Any]] = []
+        if let top = object["mcpServers"] as? [String: Any] {
+            serverScopes.append(top)
+        }
+        if let projects = object["projects"] as? [String: Any] {
+            for case let project as [String: Any] in projects.values {
+                if let scoped = project["mcpServers"] as? [String: Any] {
+                    serverScopes.append(scoped)
+                }
+            }
+        }
+
+        for scope in serverScopes {
+            for (name, rawEntry) in scope {
+                guard let entry = rawEntry as? [String: Any] else { continue }
+                let nameMatches = name.localizedCaseInsensitiveContains("logic-pro")
+                let command = (entry["command"] as? String) ?? ""
+                let commandMatches = command
+                    .localizedCaseInsensitiveContains("LogicProMCP")
+                if nameMatches && commandMatches {
+                    return .registered(command: command)
+                }
+            }
+        }
+        return .notRegistered
+    }
+
+    // MARK: - Test seams
+
+    /// Test-only access to the production subprocess runner so the concurrent-drain
+    /// and timeout/spawn-failure distinction can be exercised against real children.
+    static func runProductionCommandForTesting(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> ProductionCommandResult? {
+        runProductionCommand(executable: executable, arguments: arguments, timeout: timeout)
+    }
+
+    /// Test-only access to the config-based registration reader against a custom URL.
+    static func readClaudeRegistrationForTesting(configURL: URL) -> ClaudeRegistration {
+        readProductionClaudeRegistration(configURL: configURL)
     }
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -1,0 +1,548 @@
+import Darwin
+import Foundation
+
+enum SetupDoctor {
+    enum CheckStatus: String, Codable, Sendable {
+        case pass
+        case warn
+        case fail
+        case manual
+        case skipped
+    }
+
+    enum ReportStatus: String, Codable, Sendable {
+        case ok
+        case degraded
+        case failed
+        case manualActionRequired = "manual_action_required"
+    }
+
+    enum InstallSource: String, Codable, Sendable {
+        case homebrew
+        case releaseBinary = "release_binary"
+        case sourceBuild = "source_build"
+        case unknown
+    }
+
+    enum RemediationType: String, Codable, Sendable {
+        case command
+        case docs
+        case systemSettings = "system_settings"
+        case manual
+        case none
+    }
+
+    struct Remediation: Codable, Equatable, Sendable {
+        let type: RemediationType
+        let value: String
+    }
+
+    struct Check: Codable, Equatable, Sendable {
+        let id: String
+        let domain: String
+        let status: CheckStatus
+        let summary: String
+        let evidence: [String: String]
+        let remediation: Remediation
+    }
+
+    struct Report: Codable, Equatable, Sendable {
+        let schema: String
+        let status: ReportStatus
+        let version: String
+        let installSource: InstallSource
+        let checks: [Check]
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case status
+            case version
+            case installSource = "install_source"
+            case checks
+        }
+    }
+
+    struct CommandOutput: Equatable, Sendable {
+        let exitCode: Int32
+        let stdout: String
+        let stderr: String
+    }
+
+    struct Runtime: @unchecked Sendable {
+        let resolveExecutablePath: (String?) -> String?
+        let fileExists: (String) -> Bool
+        let isExecutableFile: (String) -> Bool
+        let logicProRunning: () -> Bool
+        let logicProHasVisibleWindow: () -> Bool
+        let runCommand: (String, [String]) -> CommandOutput?
+
+        static let production = Runtime(
+            resolveExecutablePath: { raw in
+                resolveProductionExecutablePath(raw)
+            },
+            fileExists: { path in
+                FileManager.default.fileExists(atPath: path)
+            },
+            isExecutableFile: { path in
+                FileManager.default.isExecutableFile(atPath: path)
+            },
+            logicProRunning: {
+                ProcessUtils.isLogicProRunning
+            },
+            logicProHasVisibleWindow: {
+                ProcessUtils.hasVisibleWindow()
+            },
+            runCommand: { executable, arguments in
+                runProductionCommand(executable: executable, arguments: arguments, timeout: 1.5)
+            }
+        )
+    }
+
+    static let schema = "logic_pro_mcp_doctor.v1"
+
+    static let remediationAnchorsByCheckID: [String: String] = [
+        "binary.path": "docs/SETUP.md#doctor-binarypath",
+        "binary.executable": "docs/SETUP.md#doctor-binaryexecutable",
+        "binary.version": "docs/SETUP.md#doctor-binaryversion",
+        "install.source": "docs/SETUP.md#doctor-installsource",
+        "release.signature": "docs/SETUP.md#doctor-releasesignature",
+        "release.quarantine": "docs/SETUP.md#doctor-releasequarantine",
+        "mcp.claude_code_registration": "docs/SETUP.md#doctor-mcpclaude-code-registration",
+        "permissions.accessibility": "docs/SETUP.md#doctor-permissionsaccessibility",
+        "permissions.automation_logic_pro": "docs/SETUP.md#doctor-permissionsautomation-logic-pro",
+        "logic.application_state": "docs/SETUP.md#doctor-logicapplication-state",
+        "channels.manual_validation": "docs/SETUP.md#doctor-channelsmanual-validation",
+    ]
+
+    static func generate(
+        arguments: [String],
+        permissionStatus: PermissionChecker.PermissionStatus,
+        approvals: [ManualValidationChannel: ManualValidationApproval],
+        runtime: Runtime = .production
+    ) -> Report {
+        let executablePath = runtime.resolveExecutablePath(arguments.first)
+        let installSource = detectInstallSource(executablePath: executablePath, runtime: runtime)
+        var checks: [Check] = []
+
+        checks.append(binaryPathCheck(executablePath: executablePath, runtime: runtime))
+        checks.append(binaryExecutableCheck(executablePath: executablePath, runtime: runtime))
+        checks.append(binaryVersionCheck())
+        checks.append(installSourceCheck(installSource: installSource, executablePath: executablePath))
+        checks.append(releaseSignatureCheck(executablePath: executablePath, runtime: runtime))
+        checks.append(releaseQuarantineCheck(executablePath: executablePath, runtime: runtime))
+        checks.append(claudeRegistrationCheck(runtime: runtime))
+        checks.append(accessibilityPermissionCheck(permissionStatus))
+        checks.append(automationPermissionCheck(permissionStatus))
+        checks.append(logicApplicationStateCheck(runtime: runtime))
+        checks.append(manualValidationCheck(approvals: approvals))
+
+        return Report(
+            schema: schema,
+            status: aggregateStatus(checks),
+            version: ServerConfig.serverVersion,
+            installSource: installSource,
+            checks: checks
+        )
+    }
+
+    static func renderHuman(_ report: Report) -> String {
+        var lines: [String] = [
+            "Logic Pro MCP doctor",
+            "schema: \(report.schema)",
+            "status: \(report.status.rawValue)",
+            "version: \(report.version)",
+            "install_source: \(report.installSource.rawValue)",
+            "",
+        ]
+        for check in report.checks {
+            lines.append("[\(check.status.rawValue)] \(check.id) - \(check.summary)")
+            if check.remediation.type != .none {
+                lines.append("  remediation: \(check.remediation.value)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func shouldExitWithFailure(_ report: Report) -> Bool {
+        report.status == .failed
+    }
+
+    private static func aggregateStatus(_ checks: [Check]) -> ReportStatus {
+        if checks.contains(where: { $0.status == .fail }) {
+            return .failed
+        }
+        if checks.contains(where: { $0.status == .manual }) {
+            return .manualActionRequired
+        }
+        if checks.contains(where: { $0.status == .warn || $0.status == .skipped }) {
+            return .degraded
+        }
+        return .ok
+    }
+
+    private static func binaryPathCheck(executablePath: String?, runtime: Runtime) -> Check {
+        guard let executablePath, runtime.fileExists(executablePath) else {
+            return check(
+                id: "binary.path",
+                domain: "binary",
+                status: .fail,
+                summary: "LogicProMCP binary could not be resolved from argv0 or PATH.",
+                evidence: ["argv0_resolved": executablePath ?? "<nil>"],
+                remediationType: .docs
+            )
+        }
+        return check(
+            id: "binary.path",
+            domain: "binary",
+            status: .pass,
+            summary: "LogicProMCP binary path resolved.",
+            evidence: ["path": executablePath],
+            remediationType: .none
+        )
+    }
+
+    private static func binaryExecutableCheck(executablePath: String?, runtime: Runtime) -> Check {
+        guard let executablePath, runtime.fileExists(executablePath) else {
+            return check(
+                id: "binary.executable",
+                domain: "binary",
+                status: .skipped,
+                summary: "Executable bit could not be checked because the binary path is missing.",
+                evidence: [:],
+                remediationType: .docs
+            )
+        }
+        let executable = runtime.isExecutableFile(executablePath)
+        return check(
+            id: "binary.executable",
+            domain: "binary",
+            status: executable ? .pass : .fail,
+            summary: executable ? "Binary has executable permission." : "Binary is not executable.",
+            evidence: ["path": executablePath, "executable": String(executable)],
+            remediationType: executable ? .none : .command,
+            remediationValueOverride: executable ? nil : "chmod +x \(executablePath)"
+        )
+    }
+
+    private static func binaryVersionCheck() -> Check {
+        check(
+            id: "binary.version",
+            domain: "binary",
+            status: ServerConfig.serverVersion.isEmpty ? .fail : .pass,
+            summary: "Server version is available.",
+            evidence: ["version": ServerConfig.serverVersion],
+            remediationType: ServerConfig.serverVersion.isEmpty ? .docs : .none
+        )
+    }
+
+    private static func installSourceCheck(installSource: InstallSource, executablePath: String?) -> Check {
+        let status: CheckStatus = installSource == .unknown ? .warn : .pass
+        return check(
+            id: "install.source",
+            domain: "install",
+            status: status,
+            summary: installSource == .unknown ? "Install source is unknown or manual." : "Install source detected as \(installSource.rawValue).",
+            evidence: ["install_source": installSource.rawValue, "path": executablePath ?? "<nil>"],
+            remediationType: installSource == .unknown ? .docs : .none
+        )
+    }
+
+    private static func releaseSignatureCheck(executablePath: String?, runtime: Runtime) -> Check {
+        guard let executablePath, runtime.fileExists(executablePath) else {
+            return check(
+                id: "release.signature",
+                domain: "release",
+                status: .skipped,
+                summary: "Signature verification skipped because the binary path is missing.",
+                evidence: [:],
+                remediationType: .docs
+            )
+        }
+        guard let output = runtime.runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", executablePath]) else {
+            return check(
+                id: "release.signature",
+                domain: "release",
+                status: .warn,
+                summary: "codesign verification could not be executed.",
+                evidence: ["path": executablePath],
+                remediationType: .docs
+            )
+        }
+        return check(
+            id: "release.signature",
+            domain: "release",
+            status: output.exitCode == 0 ? .pass : .warn,
+            summary: output.exitCode == 0 ? "Binary signature verifies." : "Binary signature did not verify.",
+            evidence: [
+                "path": executablePath,
+                "exit_code": String(output.exitCode),
+                "stderr": output.stderr.trimmingCharacters(in: .whitespacesAndNewlines),
+            ],
+            remediationType: output.exitCode == 0 ? .none : .docs
+        )
+    }
+
+    private static func releaseQuarantineCheck(executablePath: String?, runtime: Runtime) -> Check {
+        guard let executablePath, runtime.fileExists(executablePath) else {
+            return check(
+                id: "release.quarantine",
+                domain: "release",
+                status: .skipped,
+                summary: "Quarantine check skipped because the binary path is missing.",
+                evidence: [:],
+                remediationType: .docs
+            )
+        }
+        guard let output = runtime.runCommand("/usr/bin/xattr", ["-p", "com.apple.quarantine", executablePath]) else {
+            return check(
+                id: "release.quarantine",
+                domain: "release",
+                status: .warn,
+                summary: "xattr quarantine check could not be executed.",
+                evidence: ["path": executablePath],
+                remediationType: .docs
+            )
+        }
+        let quarantined = output.exitCode == 0
+        return check(
+            id: "release.quarantine",
+            domain: "release",
+            status: quarantined ? .warn : .pass,
+            summary: quarantined ? "Binary has a macOS quarantine attribute." : "Binary is not quarantined.",
+            evidence: ["path": executablePath, "quarantined": String(quarantined)],
+            remediationType: quarantined ? .command : .none,
+            remediationValueOverride: quarantined ? "xattr -d com.apple.quarantine \(executablePath)" : nil
+        )
+    }
+
+    private static func claudeRegistrationCheck(runtime: Runtime) -> Check {
+        guard let output = runtime.runCommand("/usr/bin/env", ["claude", "mcp", "list"]) else {
+            return check(
+                id: "mcp.claude_code_registration",
+                domain: "mcp",
+                status: .manual,
+                summary: "Claude Code registration could not be checked because the Claude CLI was not available.",
+                evidence: [:],
+                remediationType: .manual
+            )
+        }
+        let combined = "\(output.stdout)\n\(output.stderr)"
+        let registered = output.exitCode == 0
+            && combined.localizedCaseInsensitiveContains("logic-pro")
+            && combined.localizedCaseInsensitiveContains("LogicProMCP")
+        return check(
+            id: "mcp.claude_code_registration",
+            domain: "mcp",
+            status: registered ? .pass : .warn,
+            summary: registered ? "Claude Code MCP registration found." : "Claude Code MCP registration was not found.",
+            evidence: ["exit_code": String(output.exitCode)],
+            remediationType: registered ? .none : .command,
+            remediationValueOverride: registered ? nil : "claude mcp add --scope user logic-pro -- LogicProMCP"
+        )
+    }
+
+    private static func accessibilityPermissionCheck(_ status: PermissionChecker.PermissionStatus) -> Check {
+        check(
+            id: "permissions.accessibility",
+            domain: "permissions",
+            status: status.accessibility ? .pass : .fail,
+            summary: status.accessibility ? "Accessibility permission is granted." : "Accessibility permission is not granted.",
+            evidence: ["state": status.accessibilityState.rawValue],
+            remediationType: status.accessibility ? .none : .systemSettings
+        )
+    }
+
+    private static func automationPermissionCheck(_ status: PermissionChecker.PermissionStatus) -> Check {
+        let checkStatus: CheckStatus
+        switch status.automationState {
+        case .granted:
+            checkStatus = .pass
+        case .notGranted:
+            checkStatus = .fail
+        case .notVerifiable:
+            checkStatus = .manual
+        }
+        return check(
+            id: "permissions.automation_logic_pro",
+            domain: "permissions",
+            status: checkStatus,
+            summary: automationSummary(for: status.automationState),
+            evidence: ["state": status.automationState.rawValue],
+            remediationType: status.automationState == .granted ? .none : .systemSettings
+        )
+    }
+
+    private static func logicApplicationStateCheck(runtime: Runtime) -> Check {
+        let running = runtime.logicProRunning()
+        let visible = running && runtime.logicProHasVisibleWindow()
+        let status: CheckStatus = running ? (visible ? .pass : .warn) : .manual
+        return check(
+            id: "logic.application_state",
+            domain: "logic",
+            status: status,
+            summary: logicApplicationSummary(running: running, visible: visible),
+            evidence: ["running": String(running), "visible_window": String(visible)],
+            remediationType: running ? (visible ? .none : .manual) : .manual
+        )
+    }
+
+    private static func manualValidationCheck(approvals: [ManualValidationChannel: ManualValidationApproval]) -> Check {
+        let missing = ManualValidationChannel.allCases
+            .filter { approvals[$0] == nil }
+            .map(\.rawValue)
+        return check(
+            id: "channels.manual_validation",
+            domain: "channels",
+            status: missing.isEmpty ? .pass : .manual,
+            summary: missing.isEmpty
+                ? "Manual-validation channels have operator approvals."
+                : "Manual-validation channels need operator approval or an explicit decision to skip.",
+            evidence: ["missing": missing.joined(separator: ",")],
+            remediationType: missing.isEmpty ? .none : .command,
+            remediationValueOverride: missing.isEmpty ? nil : "LogicProMCP --approve-channel MIDIKeyCommands && LogicProMCP --approve-channel Scripter"
+        )
+    }
+
+    private static func detectInstallSource(executablePath: String?, runtime: Runtime) -> InstallSource {
+        if let executablePath, executablePath.contains("/.build/") || executablePath.contains(".build/") {
+            return .sourceBuild
+        }
+
+        if let brew = runtime.runCommand("/usr/bin/env", ["brew", "list", "--versions", "logic-pro-mcp"]),
+           brew.exitCode == 0,
+           brew.stdout.contains("logic-pro-mcp") {
+            return .homebrew
+        }
+
+        guard let executablePath else { return .unknown }
+        if executablePath.hasPrefix("/usr/local/bin/") || executablePath.hasPrefix("/opt/homebrew/bin/") {
+            return .releaseBinary
+        }
+        return .unknown
+    }
+
+    private static func automationSummary(for state: PermissionChecker.CheckState) -> String {
+        switch state {
+        case .granted:
+            return "Automation permission for Logic Pro is granted."
+        case .notGranted:
+            return "Automation permission for Logic Pro is not granted."
+        case .notVerifiable:
+            return "Automation permission could not be verified because Logic Pro is not running."
+        }
+    }
+
+    private static func logicApplicationSummary(running: Bool, visible: Bool) -> String {
+        if visible {
+            return "Logic Pro is running with a visible window."
+        }
+        if running {
+            return "Logic Pro is running, but no visible project window was detected."
+        }
+        return "Logic Pro is not running; live setup checks need manual validation."
+    }
+
+    private static func check(
+        id: String,
+        domain: String,
+        status: CheckStatus,
+        summary: String,
+        evidence: [String: String],
+        remediationType: RemediationType,
+        remediationValueOverride: String? = nil
+    ) -> Check {
+        let value = remediationValueOverride ?? defaultRemediationValue(for: id, type: remediationType)
+        return Check(
+            id: id,
+            domain: domain,
+            status: status,
+            summary: summary,
+            evidence: evidence,
+            remediation: Remediation(type: remediationType, value: value)
+        )
+    }
+
+    private static func defaultRemediationValue(for id: String, type: RemediationType) -> String {
+        switch type {
+        case .none:
+            return ""
+        case .systemSettings:
+            if id == "permissions.accessibility" {
+                return "System Settings > Privacy & Security > Accessibility"
+            }
+            if id == "permissions.automation_logic_pro" {
+                return "System Settings > Privacy & Security > Automation > Logic Pro"
+            }
+            return remediationAnchorsByCheckID[id] ?? "docs/SETUP.md#doctor"
+        case .command, .docs, .manual:
+            return remediationAnchorsByCheckID[id] ?? "docs/SETUP.md#doctor"
+        }
+    }
+
+    private static func resolveProductionExecutablePath(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+
+        if raw.contains("/") {
+            let url: URL
+            if raw.hasPrefix("/") {
+                url = URL(fileURLWithPath: raw)
+            } else {
+                url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                    .appendingPathComponent(raw)
+            }
+            return url.standardizedFileURL.path
+        }
+
+        guard let output = runProductionCommand(
+            executable: "/usr/bin/which",
+            arguments: [raw],
+            timeout: 1.0
+        ), output.exitCode == 0 else {
+            return nil
+        }
+        let path = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+
+    private static func runProductionCommand(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> CommandOutput? {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let stdin = Pipe()
+        stdin.fileHandleForWriting.closeFile()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let group = DispatchGroup()
+        group.enter()
+        process.terminationHandler = { _ in group.leave() }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            if process.isRunning {
+                process.terminate()
+            }
+            if group.wait(timeout: .now() + 0.2) == .timedOut, process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                _ = group.wait(timeout: .now() + 0.2)
+            }
+            return nil
+        }
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return CommandOutput(exitCode: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
+    }
+}

--- a/Sources/LogicProMCP/main.swift
+++ b/Sources/LogicProMCP/main.swift
@@ -6,6 +6,10 @@ enum LogicProMCPMain {
         permissionCheck: () -> PermissionChecker.PermissionStatus = PermissionChecker.check,
         serverFactory: () -> any ServerStarting = { LogicProServer() },
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
+        doctorRuntime: SetupDoctor.Runtime = .production,
+        writeStdout: (String) -> Void = { message in
+            FileHandle.standardOutput.write(Data(message.utf8))
+        },
         writeStderr: (String) -> Void = { message in
             FileHandle.standardError.write(Data(message.utf8))
         }
@@ -15,6 +19,8 @@ enum LogicProMCPMain {
             permissionCheck: permissionCheck,
             serverFactory: serverFactory,
             approvalStoreFactory: approvalStoreFactory,
+            doctorRuntime: doctorRuntime,
+            writeStdout: writeStdout,
             writeStderr: writeStderr
         )
     }

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -12,6 +12,7 @@ private func doctorRuntime(
     executable: Bool = true,
     logicRunning: Bool = true,
     visibleWindow: Bool = true,
+    registration: SetupDoctor.ClaudeRegistration = .registered(command: "/usr/local/bin/LogicProMCP"),
     commandHandler: @escaping (String, [String]) -> SetupDoctor.CommandOutput? = { executable, arguments in
         if executable == "/usr/bin/codesign" {
             return .init(exitCode: 0, stdout: "", stderr: "")
@@ -19,10 +20,8 @@ private func doctorRuntime(
         if executable == "/usr/bin/xattr" {
             return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
         }
-        if executable == "/usr/bin/env", arguments == ["claude", "mcp", "list"] {
-            return .init(exitCode: 0, stdout: "logic-pro  LogicProMCP\n", stderr: "")
-        }
-        if executable == "/usr/bin/env", arguments == ["brew", "list", "--versions", "logic-pro-mcp"] {
+        if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+           arguments == ["list", "--versions", "logic-pro-mcp"] {
             return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
         }
         return nil
@@ -34,7 +33,8 @@ private func doctorRuntime(
         isExecutableFile: { _ in executable },
         logicProRunning: { logicRunning },
         logicProHasVisibleWindow: { visibleWindow },
-        runCommand: commandHandler
+        runCommand: commandHandler,
+        readClaudeRegistration: { registration }
     )
 }
 
@@ -83,7 +83,23 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v1")
     #expect(object["status"] as? String == "ok")
     #expect(object["install_source"] as? String == "homebrew")
+    #expect(object["version"] as? String == ServerConfig.serverVersion)
     #expect((object["checks"] as? [[String: Any]])?.count == ids.count)
+
+    // Lock the per-check wire shape so a Codable key typo on a nested field cannot
+    // ship green. All assertions are live (force-unwrap / != nil), never dead forms.
+    let firstCheck = try #require((object["checks"] as? [[String: Any]])?.first)
+    #expect(firstCheck["id"] as? String == "binary.path")
+    #expect(firstCheck["domain"] as? String == "binary")
+    let firstStatus = try #require(firstCheck["status"] as? String)
+    #expect(firstStatus == "pass")
+    let firstSummary = try #require(firstCheck["summary"] as? String)
+    #expect(!firstSummary.isEmpty)
+    #expect(firstCheck["evidence"] as? [String: Any] != nil)
+    let remediation = try #require(firstCheck["remediation"] as? [String: Any])
+    let remediationType = try #require(remediation["type"] as? String)
+    #expect(remediationType == "none")
+    #expect(remediation["value"] as? String != nil)
 }
 
 @Test func testSetupDoctorReportsActionableRemediationForNonPassStates() {
@@ -144,7 +160,10 @@ private func issue26RepositoryRootURL() -> URL {
     let exitCode = await MainEntrypoint.run(
         arguments: ["LogicProMCP", "doctor"],
         permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
-        serverFactory: { DoctorMockMainServer() },
+        serverFactory: {
+            Issue.record("Server should not start for doctor")
+            return DoctorMockMainServer()
+        },
         approvalStoreFactory: {
             ManualValidationStore(
                 fileURL: FileManager.default.temporaryDirectory
@@ -173,4 +192,447 @@ private func issue26RepositoryRootURL() -> URL {
         let id = anchor.replacingOccurrences(of: "docs/SETUP.md#", with: "")
         #expect(setup.contains("id=\"\(id)\""), "Missing remediation anchor \(anchor)")
     }
+}
+
+// MARK: - Install-source classification
+
+@Test func testSetupDoctorClassifiesSourceBuildEvenWhenBrewProbeSucceeds() throws {
+    // .build path component must win over a succeeding brew probe (precedence pin).
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(executablePath: "/Users/x/proj/.build/release/LogicProMCP")
+    )
+    let src = report.installSource
+    #expect(src == .sourceBuild)
+    let object = try #require(sharedJSONObject(encodeJSON(report)))
+    #expect(object["install_source"] as? String == "source_build")
+}
+
+@Test func testSetupDoctorClassifiesReleaseBinaryWhenBrewProbeFails() {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: "/opt/homebrew/bin/LogicProMCP",
+            commandHandler: { _, _ in nil }
+        )
+    )
+    let src = report.installSource
+    #expect(src == .releaseBinary)
+    let installCheck = try? #require(report.checks.first { $0.id == "install.source" })
+    let status = installCheck?.status
+    #expect(status == .pass)
+}
+
+@Test func testSetupDoctorClassifiesUnknownWhenNoSignalMatches() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: "/Users/x/bin/LogicProMCP",
+            commandHandler: { _, _ in nil }
+        )
+    )
+    let src = report.installSource
+    #expect(src == .unknown)
+    let installCheck = try #require(report.checks.first { $0.id == "install.source" })
+    #expect(installCheck.status == .warn)
+    #expect(installCheck.remediation.type == .docs)
+}
+
+@Test func testSetupDoctorDoesNotMisclassifyDotBuildSuffixDirectoryAsSourceBuild() {
+    // A directory whose component merely ENDS in .build (not the SwiftPM `.build`
+    // component) must NOT be classified as source_build.
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: "/Users/x/my.build/release/LogicProMCP",
+            commandHandler: { _, _ in nil }
+        )
+    )
+    let src = report.installSource
+    #expect(src == .unknown)
+    #expect(src != .sourceBuild)
+}
+
+@Test func testSetupDoctorDetectsHomebrewViaCanonicalBrewPathWithStrippedEnvPath() {
+    // brew is NOT resolvable via /usr/bin/env (stripped PATH), only at its canonical
+    // absolute path — doctor must still classify .homebrew.
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: "/opt/homebrew/bin/LogicProMCP",
+            commandHandler: { executable, arguments in
+                if executable == "/opt/homebrew/bin/brew",
+                   arguments == ["list", "--versions", "logic-pro-mcp"] {
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+                }
+                return nil
+            }
+        )
+    )
+    let src = report.installSource
+    #expect(src == .homebrew)
+}
+
+// MARK: - Quarantine outcome distinction
+
+@Test func testReleaseQuarantineReportsPassOnlyWhenAttributeAbsent() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, arguments in
+            if executable == "/usr/bin/codesign" {
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            }
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+            }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+            }
+            return nil
+        })
+    )
+    let quarantine = try #require(report.checks.first { $0.id == "release.quarantine" })
+    #expect(quarantine.status == .pass)
+    #expect(quarantine.summary == "Binary is not quarantined.")
+}
+
+@Test func testReleaseQuarantineReportsWarnWhenAttributePresent() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, _ in
+            if executable == "/usr/bin/codesign" {
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            }
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 0, stdout: "0081;...;Safari;\n", stderr: "")
+            }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+            }
+            return nil
+        })
+    )
+    let quarantine = try #require(report.checks.first { $0.id == "release.quarantine" })
+    #expect(quarantine.status == .warn)
+    #expect(quarantine.summary == "Binary has a macOS quarantine attribute.")
+    #expect(quarantine.remediation.type == .command)
+}
+
+@Test func testReleaseQuarantineReportsWarnWhenStateUndeterminable() throws {
+    // Non-zero exit that is NOT the recognized "No such xattr" must NOT be reported
+    // as a clean pass — it conflates "not quarantined" with "could not determine".
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, _ in
+            if executable == "/usr/bin/codesign" {
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            }
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 13, stdout: "", stderr: "Operation not permitted")
+            }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+            }
+            return nil
+        })
+    )
+    let quarantine = try #require(report.checks.first { $0.id == "release.quarantine" })
+    #expect(quarantine.status == .warn)
+    #expect(quarantine.summary == "Quarantine state could not be determined.")
+    #expect(quarantine.evidence["exit_code"] == "13")
+}
+
+// MARK: - Claude registration (config-based, read-only)
+
+@Test func testClaudeRegistrationPassWhenConfigHasMatchingEntry() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(registration: .registered(command: "/usr/local/bin/some-wrapper/LogicProMCP"))
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+    #expect(registration.status == .pass)
+    #expect(registration.evidence["command"] == "/usr/local/bin/some-wrapper/LogicProMCP")
+}
+
+@Test func testClaudeRegistrationWarnWhenConfigHasNoMatchingEntry() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(registration: .notRegistered)
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+    #expect(registration.status == .warn)
+    #expect(registration.remediation.type == .command)
+    #expect(!registration.remediation.value.isEmpty)
+}
+
+@Test func testClaudeRegistrationManualWithConfigReasonWhenUnreadable() throws {
+    // The config-unavailable path must say the CONFIG could not be read — NOT that
+    // the Claude CLI was unavailable.
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(registration: .configUnavailable(reason: "config file not found at /x/.claude.json"))
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+    #expect(registration.status == .manual)
+    #expect(registration.summary.localizedCaseInsensitiveContains("config"))
+    #expect(!registration.summary.localizedCaseInsensitiveContains("CLI"))
+    #expect(registration.evidence["reason"] == "config file not found at /x/.claude.json")
+}
+
+@Test func testProductionClaudeRegistrationParsesTopLevelEntry() {
+    let json = """
+    {"mcpServers":{"logic-pro":{"type":"stdio","command":"/Users/x/bin/LogicProMCP","args":[]}}}
+    """
+    let result = registrationFromTemporaryConfig(json)
+    #expect(result == .registered(command: "/Users/x/bin/LogicProMCP"))
+}
+
+@Test func testProductionClaudeRegistrationParsesProjectScopedEntry() {
+    let json = """
+    {"projects":{"/p":{"mcpServers":{"logic-pro-mcp":{"command":"/opt/homebrew/bin/LogicProMCP"}}}}}
+    """
+    let result = registrationFromTemporaryConfig(json)
+    #expect(result == .registered(command: "/opt/homebrew/bin/LogicProMCP"))
+}
+
+@Test func testProductionClaudeRegistrationNotRegisteredWhenCommandDoesNotResolve() {
+    let json = """
+    {"mcpServers":{"logic-pro":{"command":"/usr/bin/other-tool"},"context7":{"command":"npx"}}}
+    """
+    let result = registrationFromTemporaryConfig(json)
+    #expect(result == .notRegistered)
+}
+
+@Test func testProductionClaudeRegistrationConfigUnavailableOnGarbage() {
+    let result = registrationFromTemporaryConfig("not json at all {{{")
+    guard case .configUnavailable = result else {
+        Issue.record("Expected configUnavailable, got \(result)")
+        return
+    }
+}
+
+// MARK: - runProductionCommand (production path) — pipe drain + spawn distinction
+
+@Test func testProductionCommandReturnsFullStdoutBeyondPipeBuffer() throws {
+    // >64KB output would deadlock a read-after-exit implementation; the concurrent
+    // drain must return the full payload non-nil.
+    let byteCount = 256 * 1024
+    let result = SetupDoctor.runProductionCommandForTesting(
+        executable: "/bin/sh",
+        arguments: ["-c", "head -c \(byteCount) /dev/zero | tr '\\0' 'a'"],
+        timeout: 10.0
+    )
+    let unwrapped = try #require(result)
+    let output = try #require(unwrapped.output)
+    #expect(output.stdout.count == byteCount)
+    #expect(output.exitCode == 0)
+}
+
+@Test func testProductionCommandReportsSpawnFailureForMissingExecutable() throws {
+    let result = SetupDoctor.runProductionCommandForTesting(
+        executable: "/nonexistent/definitely/not/here",
+        arguments: [],
+        timeout: 2.0
+    )
+    let unwrapped = try #require(result)
+    guard case .spawnFailed = unwrapped else {
+        Issue.record("Expected spawnFailed, got \(unwrapped)")
+        return
+    }
+    #expect(unwrapped.output == nil)
+}
+
+@Test func testProductionCommandReportsTimeoutForSlowChild() throws {
+    let result = SetupDoctor.runProductionCommandForTesting(
+        executable: "/bin/sh",
+        arguments: ["-c", "sleep 5"],
+        timeout: 0.3
+    )
+    let unwrapped = try #require(result)
+    #expect(unwrapped == .timedOut)
+    #expect(unwrapped.output == nil)
+}
+
+// MARK: - Entrypoint exit-code contract
+
+@Test func testMainEntrypointDoctorExitsOneAndReportsFailedStatus() async throws {
+    var stdout = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionCheck: { .init(accessibilityState: .notGranted, automationState: .notVerifiable) },
+        serverFactory: {
+            Issue.record("Server should not start for doctor")
+            return DoctorMockMainServer()
+        },
+        approvalStoreFactory: {
+            ManualValidationStore(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("doctor-failed-\(UUID().uuidString)")
+                    .appendingPathExtension("json")
+            )
+        },
+        doctorRuntime: doctorRuntime(
+            executablePath: nil,
+            exists: false,
+            executable: false,
+            logicRunning: false,
+            visibleWindow: false,
+            registration: .notRegistered,
+            commandHandler: { _, _ in nil }
+        ),
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 1)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["status"] as? String == "failed")
+}
+
+@Test func testMainEntrypointDoctorExitsZeroOnManualActionRequired() async throws {
+    // Manual channels unapproved -> manual_action_required -> exit 0 (do not fail CI
+    // just because operator approvals are outstanding).
+    var stdout = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for doctor")
+            return DoctorMockMainServer()
+        },
+        approvalStoreFactory: {
+            ManualValidationStore(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("doctor-manual-\(UUID().uuidString)")
+                    .appendingPathExtension("json")
+            )
+        },
+        doctorRuntime: doctorRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 0)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["status"] as? String == "manual_action_required")
+}
+
+@Test func testMainEntrypointDoctorExitsZeroOnDegraded() async throws {
+    // A warn (codesign uncheckable) with all manual channels approved and no fail
+    // -> degraded -> exit 0.
+    var stdout = ""
+    let store = ManualValidationStore(
+        fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("doctor-degraded-\(UUID().uuidString)")
+            .appendingPathExtension("json")
+    )
+    try await store.approve(.midiKeyCommands, note: "test")
+    try await store.approve(.scripter, note: "test")
+
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for doctor")
+            return DoctorMockMainServer()
+        },
+        approvalStoreFactory: { store },
+        doctorRuntime: doctorRuntime(commandHandler: { executable, arguments in
+            if executable == "/usr/bin/codesign" { return nil } // -> release.signature warn
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+            }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+               arguments == ["list", "--versions", "logic-pro-mcp"] {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+            }
+            return nil
+        }),
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 0)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["status"] as? String == "degraded")
+}
+
+// MARK: - aggregateStatus precedence
+
+@Test func testAggregateStatusManualOutranksWarn() {
+    // logic not running -> logic.application_state manual; codesign nil -> release
+    // .signature warn. manual must win.
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            logicRunning: false,
+            visibleWindow: false,
+            commandHandler: { executable, arguments in
+                if executable == "/usr/bin/codesign" { return nil }
+                if executable == "/usr/bin/xattr" {
+                    return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+                }
+                if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+                   arguments == ["list", "--versions", "logic-pro-mcp"] {
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+                }
+                return nil
+            }
+        )
+    )
+    #expect(report.status == .manualActionRequired)
+}
+
+@Test func testAggregateStatusWarnWithoutFailOrManualIsDegraded() {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, arguments in
+            if executable == "/usr/bin/codesign" { return nil } // -> warn
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+            }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+               arguments == ["list", "--versions", "logic-pro-mcp"] {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+            }
+            return nil
+        })
+    )
+    #expect(report.status == .degraded)
+}
+
+private func registrationFromTemporaryConfig(_ json: String) -> SetupDoctor.ClaudeRegistration {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("doctor-config-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let configURL = dir.appendingPathComponent(".claude.json")
+    try? Data(json.utf8).write(to: configURL)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    return SetupDoctor.readClaudeRegistrationForTesting(configURL: configURL)
 }

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private actor DoctorMockMainServer: ServerStarting {
+    func start() async throws {}
+}
+
+private func doctorRuntime(
+    executablePath: String? = "/usr/local/bin/LogicProMCP",
+    exists: Bool = true,
+    executable: Bool = true,
+    logicRunning: Bool = true,
+    visibleWindow: Bool = true,
+    commandHandler: @escaping (String, [String]) -> SetupDoctor.CommandOutput? = { executable, arguments in
+        if executable == "/usr/bin/codesign" {
+            return .init(exitCode: 0, stdout: "", stderr: "")
+        }
+        if executable == "/usr/bin/xattr" {
+            return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+        }
+        if executable == "/usr/bin/env", arguments == ["claude", "mcp", "list"] {
+            return .init(exitCode: 0, stdout: "logic-pro  LogicProMCP\n", stderr: "")
+        }
+        if executable == "/usr/bin/env", arguments == ["brew", "list", "--versions", "logic-pro-mcp"] {
+            return .init(exitCode: 0, stdout: "logic-pro-mcp 3.6.0\n", stderr: "")
+        }
+        return nil
+    }
+) -> SetupDoctor.Runtime {
+    SetupDoctor.Runtime(
+        resolveExecutablePath: { _ in executablePath },
+        fileExists: { _ in exists },
+        isExecutableFile: { _ in executable },
+        logicProRunning: { logicRunning },
+        logicProHasVisibleWindow: { visibleWindow },
+        runCommand: commandHandler
+    )
+}
+
+private func allApprovals() -> [ManualValidationChannel: ManualValidationApproval] {
+    Dictionary(uniqueKeysWithValues: ManualValidationChannel.allCases.map {
+        ($0, ManualValidationApproval(approvedAt: Date(timeIntervalSince1970: 0), note: "test"))
+    })
+}
+
+private func issue26RepositoryRootURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+@Test func testSetupDoctorJSONContractStableCheckIDsAndOKAggregation() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        approvals: allApprovals(),
+        runtime: doctorRuntime()
+    )
+
+    #expect(report.schema == "logic_pro_mcp_doctor.v1")
+    #expect(report.status == .ok)
+    #expect(report.installSource == .homebrew)
+
+    let ids = report.checks.map(\.id)
+    #expect(ids == [
+        "binary.path",
+        "binary.executable",
+        "binary.version",
+        "install.source",
+        "release.signature",
+        "release.quarantine",
+        "mcp.claude_code_registration",
+        "permissions.accessibility",
+        "permissions.automation_logic_pro",
+        "logic.application_state",
+        "channels.manual_validation",
+    ])
+
+    let json = encodeJSON(report)
+    let object = try #require(sharedJSONObject(json))
+    #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v1")
+    #expect(object["status"] as? String == "ok")
+    #expect(object["install_source"] as? String == "homebrew")
+    #expect((object["checks"] as? [[String: Any]])?.count == ids.count)
+}
+
+@Test func testSetupDoctorReportsActionableRemediationForNonPassStates() {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: .init(accessibilityState: .notGranted, automationState: .notVerifiable),
+        approvals: [:],
+        runtime: doctorRuntime(
+            executablePath: nil,
+            exists: false,
+            executable: false,
+            logicRunning: false,
+            visibleWindow: false,
+            commandHandler: { _, _ in nil }
+        )
+    )
+
+    #expect(report.status == .failed)
+    for check in report.checks where check.status != .pass {
+        #expect(check.remediation.type != .none, "\(check.id) has no remediation type")
+        #expect(!check.remediation.value.isEmpty, "\(check.id) has no remediation value")
+    }
+}
+
+@Test func testMainEntrypointDoctorJSONDoesNotStartServerAndWritesStdout() async throws {
+    let store = ManualValidationStore(
+        fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("doctor-cli-\(UUID().uuidString)")
+            .appendingPathExtension("json")
+    )
+    try await store.approve(.midiKeyCommands, note: "test")
+    try await store.approve(.scripter, note: "test")
+
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for doctor")
+            return DoctorMockMainServer()
+        },
+        approvalStoreFactory: { store },
+        doctorRuntime: doctorRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stderr.isEmpty)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["schema"] as? String == "logic_pro_mcp_doctor.v1")
+    #expect(json["status"] as? String == "ok")
+}
+
+@Test func testMainEntrypointDoctorHumanOutputIncludesStableIDs() async {
+    var stdout = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "doctor"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: { DoctorMockMainServer() },
+        approvalStoreFactory: {
+            ManualValidationStore(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("doctor-human-\(UUID().uuidString)")
+                    .appendingPathExtension("json")
+            )
+        },
+        doctorRuntime: doctorRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stdout.contains("Logic Pro MCP doctor"))
+    #expect(stdout.contains("binary.path"))
+    #expect(stdout.contains("mcp.claude_code_registration"))
+}
+
+@Test func testSetupDocsContainEveryDoctorRemediationAnchor() throws {
+    let setup = try String(
+        contentsOf: issue26RepositoryRootURL().appendingPathComponent("docs/SETUP.md"),
+        encoding: .utf8
+    )
+
+    for anchor in SetupDoctor.remediationAnchorsByCheckID.values.sorted() {
+        let id = anchor.replacingOccurrences(of: "docs/SETUP.md#", with: "")
+        #expect(setup.contains("id=\"\(id)\""), "Missing remediation anchor \(anchor)")
+    }
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -73,6 +73,114 @@ LogicProMCP --check-permissions
 # Expected: Accessibility: granted / Automation (Logic Pro): granted
 ```
 
+### 2.1 Setup Doctor
+
+Run the non-mutating setup doctor any time install, MCP registration, permissions, or Logic readiness is ambiguous:
+
+```bash
+LogicProMCP doctor
+LogicProMCP doctor --json
+```
+
+`doctor --json` emits the stable schema `logic_pro_mcp_doctor.v1`. Every check has a stable `id`, `domain`, `status`, `evidence`, and `remediation` so support answers and MCP clients can link to exact remediation steps.
+
+#### Doctor Remediation Anchors
+
+<a id="doctor-binarypath"></a>
+##### `binary.path`
+
+The binary could not be resolved from the launched executable path or `PATH`. Reinstall with Homebrew, copy the release binary into `/usr/local/bin`, or run the source-built binary by absolute path:
+
+```bash
+swift build -c release
+.build/release/LogicProMCP doctor --json
+```
+
+<a id="doctor-binaryexecutable"></a>
+##### `binary.executable`
+
+The resolved binary is not executable. Fix the executable bit on the exact path reported by doctor:
+
+```bash
+chmod +x /path/to/LogicProMCP
+```
+
+<a id="doctor-binaryversion"></a>
+##### `binary.version`
+
+The binary did not report the compiled server version. Rebuild or reinstall from a pinned release and rerun:
+
+```bash
+LogicProMCP doctor --json
+```
+
+<a id="doctor-installsource"></a>
+##### `install.source`
+
+Doctor could not determine whether the binary came from Homebrew, a release binary, or a source build. Prefer Homebrew for production installs:
+
+```bash
+brew tap MongLong0214/logic-pro-mcp https://github.com/MongLong0214/logic-pro-mcp
+brew install logic-pro-mcp
+```
+
+<a id="doctor-releasesignature"></a>
+##### `release.signature`
+
+The binary signature could not be verified. For release binaries, compare the artifact with the release metadata and reinstall from a pinned source. Source builds may need local ad-hoc signing:
+
+```bash
+codesign --force --sign - /path/to/LogicProMCP
+```
+
+<a id="doctor-releasequarantine"></a>
+##### `release.quarantine`
+
+macOS quarantine can block first launch. Only remove it after verifying the release SHA256 and signature:
+
+```bash
+xattr -d com.apple.quarantine /path/to/LogicProMCP
+```
+
+<a id="doctor-mcpclaude-code-registration"></a>
+##### `mcp.claude_code_registration`
+
+Claude Code does not appear to have a `logic-pro` MCP registration. Register explicitly:
+
+```bash
+claude mcp add --scope user logic-pro -- LogicProMCP
+claude mcp list
+```
+
+<a id="doctor-permissionsaccessibility"></a>
+##### `permissions.accessibility`
+
+Grant Accessibility access in **System Settings -> Privacy & Security -> Accessibility** for the parent app that launches `LogicProMCP` (Claude Code, terminal, or your MCP client).
+
+<a id="doctor-permissionsautomation-logic-pro"></a>
+##### `permissions.automation_logic_pro`
+
+Grant Automation access in **System Settings -> Privacy & Security -> Automation -> Logic Pro**. If doctor reports `not_verifiable`, launch Logic Pro once and rerun:
+
+```bash
+LogicProMCP doctor --json
+```
+
+<a id="doctor-logicapplication-state"></a>
+##### `logic.application_state`
+
+Launch Logic Pro and open or create a project before expecting live readiness checks to pass. Doctor stays read-only and will not launch or focus Logic for you.
+
+<a id="doctor-channelsmanual-validation"></a>
+##### `channels.manual_validation`
+
+MIDIKeyCommands and Scripter are manual-validation channels. Approve them only after completing the corresponding Logic-side setup:
+
+```bash
+LogicProMCP --approve-channel MIDIKeyCommands --approval-note "Manual MIDI Learn completed"
+LogicProMCP --approve-channel Scripter --approval-note "Scripter inserted on intended tracks"
+```
+
 ---
 
 ## 3. Register MCU Control Surface (mandatory for mixer control)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -84,6 +84,8 @@ LogicProMCP doctor --json
 
 `doctor --json` emits the stable schema `logic_pro_mcp_doctor.v1`. Every check has a stable `id`, `domain`, `status`, `evidence`, and `remediation` so support answers and MCP clients can link to exact remediation steps.
 
+Doctor is strictly read-only and runs **before** any server, channel, or MIDI-port startup. It never mutates the install or Logic state, and it does not launch or focus Logic for you. In particular, the MCP registration check reads the Claude Code config file (`~/.claude.json`) directly rather than running `claude mcp list`, so it never spawns the registered server, never opens CoreMIDI virtual ports, and never triggers Claude's connectivity health sweep.
+
 #### Doctor Remediation Anchors
 
 <a id="doctor-binarypath"></a>
@@ -103,15 +105,6 @@ The resolved binary is not executable. Fix the executable bit on the exact path 
 
 ```bash
 chmod +x /path/to/LogicProMCP
-```
-
-<a id="doctor-binaryversion"></a>
-##### `binary.version`
-
-The binary did not report the compiled server version. Rebuild or reinstall from a pinned release and rerun:
-
-```bash
-LogicProMCP doctor --json
 ```
 
 <a id="doctor-installsource"></a>
@@ -145,12 +138,13 @@ xattr -d com.apple.quarantine /path/to/LogicProMCP
 <a id="doctor-mcpclaude-code-registration"></a>
 ##### `mcp.claude_code_registration`
 
-Claude Code does not appear to have a `logic-pro` MCP registration. Register explicitly:
+Doctor reads `~/.claude.json` directly (top-level `mcpServers` plus every `projects.<path>.mcpServers`) and looks for a `logic-pro`-style entry whose `command` resolves to a `LogicProMCP` binary. If no such entry is found, register explicitly:
 
 ```bash
 claude mcp add --scope user logic-pro -- LogicProMCP
-claude mcp list
 ```
+
+If doctor reports this check as `manual` (status `manual_action_required`), the Claude config file could not be read (missing, unreadable, or not valid JSON) — confirm `~/.claude.json` exists and is well-formed, then rerun.
 
 <a id="doctor-permissionsaccessibility"></a>
 ##### `permissions.accessibility`

--- a/docs/prd/PRD-setup-lifecycle-doctor-foundation.md
+++ b/docs/prd/PRD-setup-lifecycle-doctor-foundation.md
@@ -1,0 +1,91 @@
+# PRD: Setup Lifecycle Doctor Foundation
+
+**Version**: 0.1
+**Author**: Codex
+**Date**: 2026-06-20
+**Status**: Done
+**Size**: M
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Issue #26 identifies setup lifecycle as the highest-priority adoption blocker. The first safe PR scope is a read-only `doctor --json` foundation with stable check IDs and docs remediation anchors.
+
+### 1.2 Problem Definition
+Users need a non-mutating command that explains whether the binary, MCP registration, permissions, Logic readiness, and manual-validation setup are healthy.
+
+### 1.3 Impact of Not Solving
+Users must infer setup state from scripts and source code, increasing support burden and time-to-first-success.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [x] G1: Add `LogicProMCP doctor` and `LogicProMCP doctor --json`.
+- [x] G2: Emit `logic_pro_mcp_doctor.v1` with stable check IDs.
+- [x] G3: Provide actionable remediation for every non-pass state.
+- [x] G4: Add docs anchors for every check ID.
+
+### 2.2 Non-Goals
+- NG1: Full install/update/uninstall binary command surface.
+- NG2: Mutating repair actions from doctor.
+- NG3: Closing #26 in one PR.
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Read Setup State
+**As a** user, **I want** `doctor --json`, **so that** I can diagnose setup without mutating my machine.
+
+**Acceptance Criteria:**
+- [x] AC-1.1: `doctor --json` returns `schema: "logic_pro_mcp_doctor.v1"`.
+- [x] AC-1.2: Doctor does not start the MCP server.
+- [x] AC-1.3: Every non-pass check includes remediation.
+
+### US-2: Follow Stable Remediation
+**As a** support or MCP client author, **I want** stable check IDs and docs anchors, **so that** failures link to exact fixes.
+
+**Acceptance Criteria:**
+- [x] AC-2.1: Check IDs are stable and covered by tests.
+- [x] AC-2.2: Docs contain an anchor for every doctor check ID.
+
+## 4. Technical Design
+
+### 4.1 Architecture Overview
+Add `SetupDoctor` as a pure/read-only utility used by `MainEntrypoint` before server startup. The doctor runtime is injectable for deterministic tests.
+
+### 4.2 Data Model Changes
+N/A
+
+### 4.3 API Design
+
+| Method | Endpoint | Description | Auth |
+|--------|----------|-------------|------|
+| CLI | `LogicProMCP doctor` | Human-readable setup doctor | Local process |
+| CLI | `LogicProMCP doctor --json` | Stable JSON setup doctor | Local process |
+
+### 4.4 Key Technical Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Startup isolation | Reuse system health vs standalone doctor | Standalone doctor | `doctor` must not start channels, pollers, or mutate state. |
+| Remediation | Free text only vs stable docs anchors | Stable anchors | Enables support links and schema tests. |
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | Binary path missing | `binary.path` fails with docs remediation | High |
+| E2 | Logic not running | Automation is manual/not-verifiable, not falsely failed as installed-broken | Medium |
+| E3 | Claude CLI missing | Registration check becomes manual with explicit registration command/docs | Medium |
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+Doctor schema, check ID ordering, status aggregation, main entrypoint no-server-start behavior, docs anchor coverage.
+
+### 8.2 Integration Tests
+Existing installer fail-closed tests remain in place.
+
+### 8.3 Edge Case Tests
+Missing binary, missing permissions, no approvals, missing command probes.

--- a/docs/tickets/setup-lifecycle-doctor-foundation/STATUS.md
+++ b/docs/tickets/setup-lifecycle-doctor-foundation/STATUS.md
@@ -1,0 +1,27 @@
+# Pipeline Status: Setup Lifecycle Doctor Foundation
+
+**PRD**: docs/prd/PRD-setup-lifecycle-doctor-foundation.md
+**Size**: M
+**Current Phase**: 7
+
+## Ticket Status 정의
+- **Todo**: 미착수
+- **In Progress**: 구현 중
+- **In Review**: 리뷰 진행 중
+- **Done**: 완료 (AC 충족 + 테스트 PASS)
+- **Invalidated**: 역행으로 무효화됨
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | Doctor JSON command surface | Done | PASS | Red/green covered by SetupDoctorTests |
+| T2 | Remediation docs anchors | Done | PASS | Docs anchor coverage test added |
+
+## Review History
+
+| Phase | Round | Verdict | P0 | P1 | P2 | Notes |
+|-------|-------|---------|----|----|----|-------|
+| 2 | 1 | ALL PASS | 0 | 0 | 0 | Orchestrator review, #26 scoped to doctor foundation |
+| 4 | 1 | ALL PASS | 0 | 0 | 0 | TDD specs map to issue acceptance criteria |
+| 6 | 1 | ALL PASS | 0 | 0 | 0 | BOOMER-6 self-review: no mutation path in doctor |

--- a/docs/tickets/setup-lifecycle-doctor-foundation/T1-doctor-json-command-surface.md
+++ b/docs/tickets/setup-lifecycle-doctor-foundation/T1-doctor-json-command-surface.md
@@ -1,0 +1,67 @@
+# T1: Doctor JSON Command Surface
+
+**PRD Ref**: PRD-setup-lifecycle-doctor-foundation > US-1
+**Priority**: P1 (High)
+**Size**: M (2-4h)
+**Status**: Done
+**Depends On**: None
+
+---
+
+## 1. Objective
+Add a read-only `LogicProMCP doctor` / `doctor --json` CLI path that executes before server startup.
+
+## 2. Acceptance Criteria
+- [x] AC-1: `doctor --json` returns `logic_pro_mcp_doctor.v1`.
+- [x] AC-2: Doctor does not start the server.
+- [x] AC-3: Stable check IDs cover binary, install source, release, MCP registration, permissions, Logic state, and manual-validation channels.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `testSetupDoctorJSONContractStableCheckIDsAndOKAggregation` | Unit | Stable schema and check order | PASS after implementation |
+| 2 | `testMainEntrypointDoctorJSONDoesNotStartServerAndWritesStdout` | Unit | CLI route does not create/start server | PASS after implementation |
+| 3 | `testSetupDoctorReportsActionableRemediationForNonPassStates` | Unit | Non-pass checks have remediation | PASS after implementation |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/SetupDoctorTests.swift`
+
+### 3.3 Mock/Setup Required
+- Injectable `SetupDoctor.Runtime`
+- Temporary `ManualValidationStore`
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `Sources/LogicProMCP/Utilities/SetupDoctor.swift` | Create | Doctor report model and read-only probes |
+| `Sources/LogicProMCP/MainEntrypoint.swift` | Modify | Route `doctor` before server startup |
+| `Sources/LogicProMCP/main.swift` | Modify | Add stdout injection passthrough |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Add doctor report model and aggregation.
+2. Add read-only runtime probes with test injection.
+3. Route CLI command before approval mutations and server startup.
+
+### 4.3 Refactor Phase
+- Keep remediation values centralized in `SetupDoctor.remediationAnchorsByCheckID`.
+
+## 5. Edge Cases
+- Missing binary path
+- Missing executable bit
+- Missing Claude CLI
+- Logic not running
+- Missing manual-validation approvals
+
+## 6. Review Checklist
+- [x] Red: tests specified before implementation
+- [x] Green: targeted tests pass
+- [x] Refactor: doctor remains isolated from server startup
+- [x] AC 전부 충족
+- [x] 기존 테스트 깨지지 않음
+- [x] 코드 스타일 준수
+- [x] 불필요한 변경 없음

--- a/docs/tickets/setup-lifecycle-doctor-foundation/T2-remediation-docs-anchors.md
+++ b/docs/tickets/setup-lifecycle-doctor-foundation/T2-remediation-docs-anchors.md
@@ -1,0 +1,60 @@
+# T2: Remediation Docs Anchors
+
+**PRD Ref**: PRD-setup-lifecycle-doctor-foundation > US-2
+**Priority**: P1 (High)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: T1
+
+---
+
+## 1. Objective
+Document exact remediation anchors for every stable doctor check ID.
+
+## 2. Acceptance Criteria
+- [x] AC-1: Every doctor check ID has a docs anchor.
+- [x] AC-2: Docs include commands or manual System Settings paths for non-pass states.
+- [x] AC-3: Anchor coverage is enforced by test.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `testSetupDocsContainEveryDoctorRemediationAnchor` | Unit/docs | Check every configured anchor exists in docs/SETUP.md | PASS after docs update |
+| 2 | `testMainEntrypointDoctorHumanOutputIncludesStableIDs` | Unit | Human output exposes stable IDs | PASS after implementation |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/SetupDoctorTests.swift`
+
+### 3.3 Mock/Setup Required
+- None beyond local docs file read.
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `docs/SETUP.md` | Modify | Add setup doctor section and remediation anchors |
+| `Tests/LogicProMCPTests/SetupDoctorTests.swift` | Modify | Add docs coverage test |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Add `Setup Doctor` section.
+2. Add explicit HTML anchors so links are stable.
+3. Add test linking every configured anchor to docs.
+
+### 4.3 Refactor Phase
+- Keep docs anchor names aligned with check IDs.
+
+## 5. Edge Cases
+- Markdown-generated anchors may drift; use explicit HTML `id` attributes instead.
+
+## 6. Review Checklist
+- [x] Red: docs anchor coverage test specified
+- [x] Green: docs coverage passes
+- [x] Refactor: anchors centralized in code
+- [x] AC 전부 충족
+- [x] 기존 테스트 깨지지 않음
+- [x] 코드 스타일 준수
+- [x] 불필요한 변경 없음


### PR DESCRIPTION
## Summary

- Add read-only `LogicProMCP doctor` and `doctor --json` before server startup.
- Emit stable `logic_pro_mcp_doctor.v1` checks with stable IDs, evidence, and remediation.
- Document remediation anchors for every check ID and add dev-pipeline PRD/ticket artifacts.

## Linked issue

- Refs #26

## Risk

- Priority: P1
- Area: setup-release
- User-visible impact: adds a new setup diagnostics CLI command; existing flags remain unchanged.
- Contract impact: new CLI JSON schema `logic_pro_mcp_doctor.v1`; no State A-B-C changes.

## Verification

- [x] `swift run LogicProMCP doctor --json`
- [x] Targeted test: `swift test --filter SetupDoctor`
- [x] Targeted test: `swift test --filter MainEntrypoint`
- [x] Targeted test: `swift test --filter InstallScriptContract`
- [x] Targeted test: `swift test --filter VersionConsistency`
- [ ] `swift build`
- [ ] `swift test --no-parallel`
- [ ] `swift build -c release`
- [x] Live Logic evidence: not required; doctor is read-only setup diagnostics.

Evidence:
```text
SetupDoctor: 5 tests passed
MainEntrypoint: 15 tests passed
InstallScriptContract: 12 tests passed
VersionConsistency: 7 tests passed
CLI smoke: emitted schema logic_pro_mcp_doctor.v1 with source_build classification from .build binary
```

## Release readiness

- [x] Public setup docs are updated for the new doctor command and remediation anchors.
- [x] Mutating or destructive behavior has explicit target validation, confirmation, and readback. N/A: doctor is non-mutating and runs before server startup.
- [x] Known limitations are documented in the PR or docs.

## Reviewer focus

- Confirm `doctor` remains isolated from server/channel startup and does not mutate install or Logic state.
- Confirm the check IDs and docs anchors are stable enough for support links.
