### PR TITLE
feat(audio): add read-only artifact analysis

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
                 .linkedFramework("CoreMIDI"),
                 .linkedFramework("ApplicationServices"),
                 .linkedFramework("CoreGraphics"),
+                .linkedFramework("AVFoundation"),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 
 | Surface | Current source tree |
 |---------|---------------------|
-| MCP tools | 9 tools covering transport, tracks, mixer, MIDI, edit, navigation, project lifecycle, system health, and verified plugin apply-back |
+| MCP tools | 10 tools covering transport, tracks, mixer, MIDI, edit, navigation, project lifecycle, audio artifact analysis, system health, and verified plugin apply-back |
 | Read resources | 14 static resources for health, transport, tracks, mixer, markers, project metadata, MIDI ports, MCU state, library inventory, stock plugin intelligence, and workflow skills |
 | Resource templates | 7 templates for track, region, mixer-strip, stock plugin detail/search, and workflow detail/search lookup |
 | Control channels | MCU, Accessibility, AppleScript, CoreMIDI, CGEvent, Scripter, MIDI Key Commands |
@@ -90,7 +90,7 @@ Logic Pro MCP uses a different model. It routes each operation to the strongest 
 
 ## Agent-Grade Surfaces
 
-**Tools are for actions.** The public write surface is intentionally small: `logic_transport`, `logic_tracks`, `logic_mixer`, `logic_plugins`, `logic_midi`, `logic_edit`, `logic_navigate`, `logic_project`, and `logic_system`.
+**Tools are for actions and local artifact checks.** The public write surface is intentionally small: `logic_transport`, `logic_tracks`, `logic_mixer`, `logic_plugins`, `logic_midi`, `logic_edit`, `logic_navigate`, `logic_project`, and `logic_system`. `logic_audio` is read-only and verifies exported files after Logic writes them.
 
 **Resources are for state.** Clients should read `logic://transport/state`, `logic://tracks`, `logic://mixer`, `logic://project/info`, `logic://midi/ports`, and related resources instead of burning tool calls on polling.
 
@@ -211,7 +211,7 @@ See [Architecture](docs/ARCHITECTURE.md) for channel priorities, state flow, cac
 | Document | Audience | Purpose |
 |----------|----------|---------|
 | [Setup Guide](docs/SETUP.md) | End users | One-page install + Logic Pro integration, ~10 min |
-| [API Reference](docs/API.md) | End users, MCP clients | All 9 tools, 14 resources, 7 templates, 130+ operations |
+| [API Reference](docs/API.md) | End users, MCP clients | All 10 tools, 14 resources, 7 templates, 130+ operations |
 | [Verified Apply-Back Guide](docs/guides/verified-apply-back.md) | Agent workflow authors | `logic_plugins` inventory, exact-slot insertion, Compressor threshold write/readback, HC v2 failure handling |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | End users | Common failures and fixes |
 | [Architecture](docs/ARCHITECTURE.md) | Contributors | Channel design, state flow, testing strategy |

--- a/Sources/LogicProMCP/Audio/AudioAnalyzer.swift
+++ b/Sources/LogicProMCP/Audio/AudioAnalyzer.swift
@@ -1,0 +1,440 @@
+import AVFoundation
+import Foundation
+
+enum AudioAnalyzer {
+    enum AnalysisError: Error, Equatable, Sendable {
+        case unsafePath(String)
+        case missingFile
+        case directoryPath
+        case unsupportedFormat(String)
+        case unreadableMetadata(String)
+        case zeroLengthFile
+        case decoderError(String)
+
+        var code: String {
+            switch self {
+            case .unsafePath: return "unsafe_path"
+            case .missingFile: return "missing_file"
+            case .directoryPath: return "directory_path"
+            case .unsupportedFormat: return "unsupported_format"
+            case .unreadableMetadata: return "unreadable_metadata"
+            case .zeroLengthFile: return "zero_length_file"
+            case .decoderError: return "decoder_error"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .unsafePath(let reason): return reason
+            case .missingFile: return "Audio file does not exist."
+            case .directoryPath: return "Path resolves to a directory, not an audio file."
+            case .unsupportedFormat(let ext): return "Unsupported audio format: \(ext.isEmpty ? "<none>" : ext)."
+            case .unreadableMetadata(let reason): return reason
+            case .zeroLengthFile: return "Audio file has zero bytes."
+            case .decoderError(let reason): return reason
+            }
+        }
+    }
+
+    enum VerificationStatus: String, Codable, Sendable {
+        case pass
+        case warn
+        case fail
+    }
+
+    struct Verification: Codable, Equatable, Sendable {
+        let status: VerificationStatus
+        let reasons: [String]
+    }
+
+    struct FrequencyPeak: Codable, Equatable, Sendable {
+        let frequencyHz: Double
+        let magnitude: Double
+
+        enum CodingKeys: String, CodingKey {
+            case frequencyHz = "frequency_hz"
+            case magnitude
+        }
+    }
+
+    struct AnalysisPolicy: Equatable, Sendable {
+        var minimumDurationSeconds: Double?
+        var maximumDurationDriftSeconds: Double?
+        var expectedDurationSeconds: Double?
+        var minimumFileSizeBytes: Int?
+        var maximumPeakDbfs: Double?
+        var nearSilenceThresholdDbfs: Double
+        var maximumSilenceRatio: Double
+        var expectedSampleRate: Int?
+        var expectedChannelCount: Int?
+        var outputRoot: String?
+
+        static let `default` = AnalysisPolicy(
+            minimumDurationSeconds: nil,
+            maximumDurationDriftSeconds: nil,
+            expectedDurationSeconds: nil,
+            minimumFileSizeBytes: nil,
+            maximumPeakDbfs: nil,
+            nearSilenceThresholdDbfs: -60.0,
+            maximumSilenceRatio: 0.98,
+            expectedSampleRate: nil,
+            expectedChannelCount: nil,
+            outputRoot: nil
+        )
+    }
+
+    struct Result: Codable, Equatable, Sendable {
+        let schema: String
+        let path: String
+        let exists: Bool
+        let format: String
+        let durationSeconds: Double
+        let sampleRate: Int
+        let channelCount: Int
+        let frameCount: Int64
+        let fileSizeBytes: Int64
+        let rmsDbfs: Double
+        let peakDbfs: Double
+        let truePeakDbfs: Double?
+        let loudnessEstimateLufs: Double?
+        let loudnessMethod: String
+        let silenceRatio: Double
+        let nonSilentDurationSeconds: Double
+        let spectralCentroidHz: Double?
+        let frequencyPeaks: [FrequencyPeak]
+        let verification: Verification
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case path
+            case exists
+            case format
+            case durationSeconds = "duration_seconds"
+            case sampleRate = "sample_rate"
+            case channelCount = "channel_count"
+            case frameCount = "frame_count"
+            case fileSizeBytes = "file_size_bytes"
+            case rmsDbfs = "rms_dbfs"
+            case peakDbfs = "peak_dbfs"
+            case truePeakDbfs = "true_peak_dbfs"
+            case loudnessEstimateLufs = "loudness_estimate_lufs"
+            case loudnessMethod = "loudness_method"
+            case silenceRatio = "silence_ratio"
+            case nonSilentDurationSeconds = "non_silent_duration_seconds"
+            case spectralCentroidHz = "spectral_centroid_hz"
+            case frequencyPeaks = "frequency_peaks"
+            case verification
+        }
+    }
+
+    struct Runtime: @unchecked Sendable {
+        let fileExists: (String, UnsafeMutablePointer<ObjCBool>?) -> Bool
+        let attributesOfItem: (String) throws -> [FileAttributeKey: Any]
+        let resolveSymlinks: (String) -> String
+
+        static let production = Runtime(
+            fileExists: { path, isDirectory in
+                FileManager.default.fileExists(atPath: path, isDirectory: isDirectory)
+            },
+            attributesOfItem: { path in
+                try FileManager.default.attributesOfItem(atPath: path)
+            },
+            resolveSymlinks: { path in
+                URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+            }
+        )
+    }
+
+    static let schema = "logic_pro_mcp_audio_analysis.v1"
+    private static let supportedExtensions: Set<String> = ["wav", "wave", "aif", "aiff", "aifc", "m4a", "mp3"]
+
+    static func analyzeFile(
+        path rawPath: String,
+        policy: AnalysisPolicy = .default,
+        runtime: Runtime = .production
+    ) -> Result {
+        do {
+            let safeURL = try validatedURL(rawPath, policy: policy, runtime: runtime)
+            let attributes = try runtime.attributesOfItem(safeURL.path)
+            let fileSize = Int64((attributes[.size] as? NSNumber)?.int64Value ?? 0)
+            guard fileSize > 0 else {
+                throw AnalysisError.zeroLengthFile
+            }
+
+            let ext = normalizedExtension(safeURL.path)
+            guard supportedExtensions.contains(ext) else {
+                throw AnalysisError.unsupportedFormat(ext)
+            }
+
+            let measurements = try measureAudio(
+                url: safeURL,
+                fileSizeBytes: fileSize,
+                silenceThresholdDbfs: policy.nearSilenceThresholdDbfs
+            )
+            let verification = evaluate(measurements, policy: policy)
+            return measurements.withVerification(verification)
+        } catch let error as AnalysisError {
+            return failureResult(path: rawPath, error: error)
+        } catch {
+            return failureResult(path: rawPath, error: .decoderError(error.localizedDescription))
+        }
+    }
+
+    private static func validatedURL(
+        _ rawPath: String,
+        policy: AnalysisPolicy,
+        runtime: Runtime
+    ) throws -> URL {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else {
+            throw AnalysisError.unsafePath("relative paths are rejected")
+        }
+        guard !pathContainsTraversal(trimmed) else {
+            throw AnalysisError.unsafePath("path traversal components are rejected")
+        }
+        guard !isICloudPath(trimmed) else {
+            throw AnalysisError.unsafePath("iCloud paths are rejected for local export verification")
+        }
+
+        let resolvedPath = runtime.resolveSymlinks(trimmed)
+        var isDirectory = ObjCBool(false)
+        guard runtime.fileExists(resolvedPath, &isDirectory) else {
+            throw AnalysisError.missingFile
+        }
+        guard !isDirectory.boolValue else {
+            throw AnalysisError.directoryPath
+        }
+
+        if let outputRoot = policy.outputRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !outputRoot.isEmpty {
+            guard outputRoot.hasPrefix("/") else {
+                throw AnalysisError.unsafePath("output_root must be absolute")
+            }
+            guard !pathContainsTraversal(outputRoot) else {
+                throw AnalysisError.unsafePath("output_root traversal components are rejected")
+            }
+            guard !isICloudPath(outputRoot) else {
+                throw AnalysisError.unsafePath("iCloud output roots are rejected")
+            }
+            let resolvedRoot = runtime.resolveSymlinks(outputRoot)
+            guard resolvedPath == resolvedRoot || resolvedPath.hasPrefix(resolvedRoot + "/") else {
+                throw AnalysisError.unsafePath("resolved file path escapes output_root")
+            }
+        }
+
+        return URL(fileURLWithPath: resolvedPath)
+    }
+
+    private static func measureAudio(
+        url: URL,
+        fileSizeBytes: Int64,
+        silenceThresholdDbfs: Double
+    ) throws -> Result {
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forReading: url)
+        } catch {
+            throw AnalysisError.decoderError(error.localizedDescription)
+        }
+
+        let processingFormat = file.processingFormat
+        let sampleRate = processingFormat.sampleRate
+        let channelCount = Int(processingFormat.channelCount)
+        let frameCount = file.length
+        guard sampleRate > 0, channelCount > 0 else {
+            throw AnalysisError.unreadableMetadata("sample rate or channel count is zero")
+        }
+        guard frameCount > 0 else {
+            throw AnalysisError.zeroLengthFile
+        }
+
+        let thresholdAmplitude = dbfsToAmplitude(silenceThresholdDbfs)
+        let frameCapacity: AVAudioFrameCount = 4096
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: processingFormat, frameCapacity: frameCapacity) else {
+            throw AnalysisError.decoderError("could not allocate PCM buffer")
+        }
+
+        var remaining = frameCount
+        var sampleCount = 0
+        var silentFrames = 0
+        var sumSquares = 0.0
+        var peak = 0.0
+
+        while remaining > 0 {
+            let framesToRead = AVAudioFrameCount(min(Int64(frameCapacity), remaining))
+            do {
+                try file.read(into: buffer, frameCount: framesToRead)
+            } catch {
+                throw AnalysisError.decoderError(error.localizedDescription)
+            }
+            let framesRead = Int(buffer.frameLength)
+            guard framesRead > 0 else { break }
+            remaining -= Int64(framesRead)
+
+            guard let channelData = buffer.floatChannelData else {
+                throw AnalysisError.decoderError("decoded audio is not float PCM")
+            }
+
+            for frame in 0..<framesRead {
+                var framePeak = 0.0
+                for channel in 0..<channelCount {
+                    let value = Double(channelData[channel][frame])
+                    let absValue = min(abs(value), 1.0)
+                    framePeak = max(framePeak, absValue)
+                    peak = max(peak, absValue)
+                    sumSquares += absValue * absValue
+                    sampleCount += 1
+                }
+                if framePeak < thresholdAmplitude {
+                    silentFrames += 1
+                }
+            }
+        }
+
+        guard sampleCount > 0 else {
+            throw AnalysisError.zeroLengthFile
+        }
+
+        let duration = Double(frameCount) / sampleRate
+        let rms = sqrt(sumSquares / Double(sampleCount))
+        let rmsDbfs = amplitudeToDbfs(rms)
+        let peakDbfs = amplitudeToDbfs(peak)
+        let silenceRatio = min(max(Double(silentFrames) / Double(frameCount), 0.0), 1.0)
+        let nonSilentDuration = duration * (1.0 - silenceRatio)
+
+        return Result(
+            schema: schema,
+            path: url.path,
+            exists: true,
+            format: normalizedExtension(url.path),
+            durationSeconds: rounded(duration),
+            sampleRate: Int(sampleRate.rounded()),
+            channelCount: channelCount,
+            frameCount: frameCount,
+            fileSizeBytes: fileSizeBytes,
+            rmsDbfs: rounded(rmsDbfs),
+            peakDbfs: rounded(peakDbfs),
+            truePeakDbfs: nil,
+            loudnessEstimateLufs: rounded(rmsDbfs),
+            loudnessMethod: "rms_estimate",
+            silenceRatio: rounded(silenceRatio),
+            nonSilentDurationSeconds: rounded(nonSilentDuration),
+            spectralCentroidHz: nil,
+            frequencyPeaks: [],
+            verification: Verification(status: .pass, reasons: [])
+        )
+    }
+
+    private static func evaluate(_ result: Result, policy: AnalysisPolicy) -> Verification {
+        var reasons: [String] = []
+
+        if let minimumFileSizeBytes = policy.minimumFileSizeBytes,
+           result.fileSizeBytes < Int64(minimumFileSizeBytes) {
+            reasons.append("file_size_below_minimum")
+        }
+        if let minimumDurationSeconds = policy.minimumDurationSeconds,
+           result.durationSeconds < minimumDurationSeconds {
+            reasons.append("duration_below_minimum")
+        }
+        if let expectedDuration = policy.expectedDurationSeconds,
+           let drift = policy.maximumDurationDriftSeconds,
+           abs(result.durationSeconds - expectedDuration) > drift {
+            reasons.append("duration_drift_exceeded")
+        }
+        if let maximumPeakDbfs = policy.maximumPeakDbfs,
+           result.peakDbfs > maximumPeakDbfs {
+            reasons.append("peak_above_threshold")
+        }
+        if result.peakDbfs <= policy.nearSilenceThresholdDbfs || result.silenceRatio >= policy.maximumSilenceRatio {
+            reasons.append("near_silent_output")
+        }
+        if let expectedSampleRate = policy.expectedSampleRate,
+           result.sampleRate != expectedSampleRate {
+            reasons.append("sample_rate_mismatch")
+        }
+        if let expectedChannelCount = policy.expectedChannelCount,
+           result.channelCount != expectedChannelCount {
+            reasons.append("channel_count_mismatch")
+        }
+
+        return Verification(status: reasons.isEmpty ? .pass : .fail, reasons: reasons)
+    }
+
+    private static func failureResult(path: String, error: AnalysisError) -> Result {
+        Result(
+            schema: schema,
+            path: path,
+            exists: false,
+            format: normalizedExtension(path).isEmpty ? "unknown" : normalizedExtension(path),
+            durationSeconds: 0,
+            sampleRate: 0,
+            channelCount: 0,
+            frameCount: 0,
+            fileSizeBytes: 0,
+            rmsDbfs: -120.0,
+            peakDbfs: -120.0,
+            truePeakDbfs: nil,
+            loudnessEstimateLufs: nil,
+            loudnessMethod: "none",
+            silenceRatio: 1.0,
+            nonSilentDurationSeconds: 0,
+            spectralCentroidHz: nil,
+            frequencyPeaks: [],
+            verification: Verification(status: .fail, reasons: [error.code, error.message])
+        )
+    }
+
+    private static func pathContainsTraversal(_ path: String) -> Bool {
+        path.split(separator: "/", omittingEmptySubsequences: false).contains("..")
+    }
+
+    private static func isICloudPath(_ path: String) -> Bool {
+        let lowercased = path.lowercased()
+        return lowercased.contains("/mobile documents/")
+            || lowercased.contains(".icloud")
+            || lowercased.contains("/icloud drive/")
+    }
+
+    private static func normalizedExtension(_ path: String) -> String {
+        URL(fileURLWithPath: path).pathExtension.lowercased()
+    }
+
+    private static func amplitudeToDbfs(_ amplitude: Double) -> Double {
+        guard amplitude > 0 else { return -120.0 }
+        return max(20.0 * log10(amplitude), -120.0)
+    }
+
+    private static func dbfsToAmplitude(_ dbfs: Double) -> Double {
+        pow(10.0, dbfs / 20.0)
+    }
+
+    private static func rounded(_ value: Double) -> Double {
+        guard value.isFinite else { return -120.0 }
+        return (value * 1000.0).rounded() / 1000.0
+    }
+}
+
+private extension AudioAnalyzer.Result {
+    func withVerification(_ verification: AudioAnalyzer.Verification) -> AudioAnalyzer.Result {
+        AudioAnalyzer.Result(
+            schema: schema,
+            path: path,
+            exists: exists,
+            format: format,
+            durationSeconds: durationSeconds,
+            sampleRate: sampleRate,
+            channelCount: channelCount,
+            frameCount: frameCount,
+            fileSizeBytes: fileSizeBytes,
+            rmsDbfs: rmsDbfs,
+            peakDbfs: peakDbfs,
+            truePeakDbfs: truePeakDbfs,
+            loudnessEstimateLufs: loudnessEstimateLufs,
+            loudnessMethod: loudnessMethod,
+            silenceRatio: silenceRatio,
+            nonSilentDurationSeconds: nonSilentDurationSeconds,
+            spectralCentroidHz: spectralCentroidHz,
+            frequencyPeaks: frequencyPeaks,
+            verification: verification
+        )
+    }
+}

--- a/Sources/LogicProMCP/Audio/AudioAnalyzer.swift
+++ b/Sources/LogicProMCP/Audio/AudioAnalyzer.swift
@@ -34,6 +34,22 @@ enum AudioAnalyzer {
             case .decoderError(let reason): return reason
             }
         }
+
+        /// Honest disk-presence for the `exists` contract field. `directoryPath`,
+        /// `zeroLengthFile`, `unsupportedFormat`, `unreadableMetadata`, and
+        /// `decoderError` are all reached only after the path was confirmed present
+        /// (an addressable item exists on disk), so reporting exists:false for those
+        /// would lie about a file an agent may otherwise needlessly re-export.
+        /// `unsafePath` is rejected before any existence check; `missingFile` is the
+        /// genuine not-present case.
+        var pathExists: Bool {
+            switch self {
+            case .unsafePath, .missingFile:
+                return false
+            case .directoryPath, .zeroLengthFile, .unsupportedFormat, .unreadableMetadata, .decoderError:
+                return true
+            }
+        }
     }
 
     enum VerificationStatus: String, Codable, Sendable {
@@ -45,6 +61,16 @@ enum AudioAnalyzer {
     struct Verification: Codable, Equatable, Sendable {
         let status: VerificationStatus
         let reasons: [String]
+        /// Optional human-readable message for the error path. `reasons` is always a
+        /// uniform list of stable machine codes; `detail` is the only place a free-text
+        /// sentence appears, so consumers can parse codes without special-casing.
+        let detail: String?
+
+        init(status: VerificationStatus, reasons: [String], detail: String? = nil) {
+            self.status = status
+            self.reasons = reasons
+            self.detail = detail
+        }
     }
 
     struct FrequencyPeak: Codable, Equatable, Sendable {
@@ -255,6 +281,7 @@ enum AudioAnalyzer {
 
         var remaining = frameCount
         var sampleCount = 0
+        var framesProcessed: Int64 = 0
         var silentFrames = 0
         var sumSquares = 0.0
         var peak = 0.0
@@ -269,6 +296,7 @@ enum AudioAnalyzer {
             let framesRead = Int(buffer.frameLength)
             guard framesRead > 0 else { break }
             remaining -= Int64(framesRead)
+            framesProcessed += Int64(framesRead)
 
             guard let channelData = buffer.floatChannelData else {
                 throw AnalysisError.decoderError("decoded audio is not float PCM")
@@ -277,8 +305,11 @@ enum AudioAnalyzer {
             for frame in 0..<framesRead {
                 var framePeak = 0.0
                 for channel in 0..<channelCount {
-                    let value = Double(channelData[channel][frame])
-                    let absValue = min(abs(value), 1.0)
+                    // Measure the raw magnitude — do NOT clamp to 1.0. Float PCM from a
+                    // bounce can legitimately exceed full scale (digital/inter-sample overs),
+                    // and clamping would make true overs report as exactly 0 dBFS, hiding
+                    // destructive clipping from the max_peak_dbfs gate.
+                    let absValue = abs(Double(channelData[channel][frame]))
                     framePeak = max(framePeak, absValue)
                     peak = max(peak, absValue)
                     sumSquares += absValue * absValue
@@ -290,16 +321,21 @@ enum AudioAnalyzer {
             }
         }
 
-        guard sampleCount > 0 else {
+        guard sampleCount > 0, framesProcessed > 0 else {
             throw AnalysisError.zeroLengthFile
         }
 
-        let duration = Double(frameCount) / sampleRate
+        // Duration and silenceRatio are derived from frames ACTUALLY decoded, not the
+        // header frame count. A truncated/short-data-chunk file (header claims more frames
+        // than the data contains) otherwise reports overstated duration and understated
+        // silenceRatio, letting a missing-audio export pass near-silence/duration checks.
+        let duration = Double(framesProcessed) / sampleRate
         let rms = sqrt(sumSquares / Double(sampleCount))
         let rmsDbfs = amplitudeToDbfs(rms)
         let peakDbfs = amplitudeToDbfs(peak)
-        let silenceRatio = min(max(Double(silentFrames) / Double(frameCount), 0.0), 1.0)
+        let silenceRatio = min(max(Double(silentFrames) / Double(framesProcessed), 0.0), 1.0)
         let nonSilentDuration = duration * (1.0 - silenceRatio)
+        let truncated = framesProcessed != frameCount
 
         return Result(
             schema: schema,
@@ -309,7 +345,7 @@ enum AudioAnalyzer {
             durationSeconds: rounded(duration),
             sampleRate: Int(sampleRate.rounded()),
             channelCount: channelCount,
-            frameCount: frameCount,
+            frameCount: framesProcessed,
             fileSizeBytes: fileSizeBytes,
             rmsDbfs: rounded(rmsDbfs),
             peakDbfs: rounded(peakDbfs),
@@ -320,12 +356,16 @@ enum AudioAnalyzer {
             nonSilentDurationSeconds: rounded(nonSilentDuration),
             spectralCentroidHz: nil,
             frequencyPeaks: [],
-            verification: Verification(status: .pass, reasons: [])
+            // Seed truncation as a verification reason so evaluate() can fail-close when
+            // the decoder yielded fewer frames than the header declared.
+            verification: Verification(status: .pass, reasons: truncated ? ["truncated_or_short_data"] : [])
         )
     }
 
     private static func evaluate(_ result: Result, policy: AnalysisPolicy) -> Verification {
-        var reasons: [String] = []
+        // Carry forward any measurement-time reasons (e.g. truncated_or_short_data) so a
+        // truncated file cannot pass even when every policy check is satisfied.
+        var reasons: [String] = result.verification.reasons
 
         if let minimumFileSizeBytes = policy.minimumFileSizeBytes,
            result.fileSizeBytes < Int64(minimumFileSizeBytes) {
@@ -363,7 +403,7 @@ enum AudioAnalyzer {
         Result(
             schema: schema,
             path: path,
-            exists: false,
+            exists: error.pathExists,
             format: normalizedExtension(path).isEmpty ? "unknown" : normalizedExtension(path),
             durationSeconds: 0,
             sampleRate: 0,
@@ -379,7 +419,10 @@ enum AudioAnalyzer {
             nonSilentDurationSeconds: 0,
             spectralCentroidHz: nil,
             frequencyPeaks: [],
-            verification: Verification(status: .fail, reasons: [error.code, error.message])
+            // reasons stays a uniform machine-code list (v1 schema contract); the human
+            // sentence goes in the optional `detail` field so a client parsing reasons
+            // never hits free text on the error path.
+            verification: Verification(status: .fail, reasons: [error.code], detail: error.message)
         )
     }
 
@@ -389,8 +432,12 @@ enum AudioAnalyzer {
 
     private static func isICloudPath(_ path: String) -> Bool {
         let lowercased = path.lowercased()
+        // Genuine iCloud placeholder stubs use the `<name>.icloud` extension; match by
+        // extension, not an unanchored substring, so a legitimate local path that merely
+        // contains the literal text ".icloud" in a directory component is not rejected.
+        let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
         return lowercased.contains("/mobile documents/")
-            || lowercased.contains(".icloud")
+            || ext == "icloud"
             || lowercased.contains("/icloud drive/")
     }
 

--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -2,6 +2,11 @@ import Foundation
 import MCP
 
 struct AudioDispatcher {
+    /// Non-absolute marker assigned to outputRoot when the caller sent a present-but-malformed
+    /// output_root. validatedURL rejects it (does not begin with "/") so confinement fails
+    /// closed as unsafe_path instead of being silently disabled.
+    static let invalidOutputRootSentinel = "__invalid_output_root__"
+
     static let tool = commandTool(
         name: "logic_audio",
         description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }. Returns schema logic_pro_mcp_audio_analysis.v1 and never mutates files or Logic Pro.",
@@ -45,9 +50,24 @@ struct AudioDispatcher {
         policy.maximumPeakDbfs = doubleParamOrNil(params, "max_peak_dbfs", "maximum_peak_dbfs")
         policy.expectedSampleRate = intParamOrNil(params, "expected_sample_rate")
         policy.expectedChannelCount = intParamOrNil(params, "expected_channel_count")
-        policy.outputRoot = params["output_root"]?.stringValue
+        // output_root is a security confinement param. Fail CLOSED: if the key is present
+        // but not a usable non-empty string, force a sentinel that validatedURL rejects as
+        // unsafe_path rather than silently dropping the allowlist (raw .stringValue would
+        // return nil for any non-string JSON, disabling confinement without an error).
+        if let raw = params["output_root"] {
+            if let s = raw.stringValue, !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                policy.outputRoot = s
+            } else {
+                policy.outputRoot = invalidOutputRootSentinel
+            }
+        }
 
-        if let nearSilence = doubleParamOrNil(params, "near_silence_dbfs", "near_silence_threshold_dbfs") {
+        if let nearSilence = doubleParamOrNil(params, "near_silence_dbfs", "near_silence_threshold_dbfs"),
+           nearSilence <= 0.0 {
+            // dBFS thresholds are <= 0 by definition. A positive value would push the
+            // silence threshold to/above full scale and flag every valid bounce as silent,
+            // so an out-of-range value is ignored and the safe default is kept rather than
+            // silently flipping a good export to near_silent_output.
             policy.nearSilenceThresholdDbfs = nearSilence
         }
         if let maxSilenceRatio = doubleParamOrNil(params, "max_silence_ratio", "maximum_silence_ratio") {

--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MCP
+
+struct AudioDispatcher {
+    static let tool = commandTool(
+        name: "logic_audio",
+        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }. Returns schema logic_pro_mcp_audio_analysis.v1 and never mutates files or Logic Pro.",
+        commandDescription: "Audio command to execute"
+    )
+
+    static func handle(
+        command: String,
+        params: [String: Value],
+        runtime: AudioAnalyzer.Runtime = .production
+    ) -> CallTool.Result {
+        switch command {
+        case "analyze_file":
+            let path = stringParam(params, "path")
+            guard !path.isEmpty else {
+                let result = AudioAnalyzer.analyzeFile(path: "", policy: .default, runtime: runtime)
+                return toolTextResult(encodeJSON(result), isError: true)
+            }
+
+            let policy = policy(from: params)
+            let result = AudioAnalyzer.analyzeFile(path: path, policy: policy, runtime: runtime)
+            return toolTextResult(
+                encodeJSON(result),
+                isError: result.verification.status == .fail
+            )
+
+        default:
+            return toolTextResult(
+                "Unknown audio command: \(command). Available: analyze_file",
+                isError: true
+            )
+        }
+    }
+
+    private static func policy(from params: [String: Value]) -> AudioAnalyzer.AnalysisPolicy {
+        var policy = AudioAnalyzer.AnalysisPolicy.default
+        policy.minimumDurationSeconds = doubleParamOrNil(params, "min_duration_seconds", "minimum_duration_seconds")
+        policy.expectedDurationSeconds = doubleParamOrNil(params, "expected_duration_seconds")
+        policy.maximumDurationDriftSeconds = doubleParamOrNil(params, "max_duration_drift_seconds", "maximum_duration_drift_seconds")
+        policy.minimumFileSizeBytes = intParamOrNil(params, "min_file_size_bytes", "minimum_file_size_bytes")
+        policy.maximumPeakDbfs = doubleParamOrNil(params, "max_peak_dbfs", "maximum_peak_dbfs")
+        policy.expectedSampleRate = intParamOrNil(params, "expected_sample_rate")
+        policy.expectedChannelCount = intParamOrNil(params, "expected_channel_count")
+        policy.outputRoot = params["output_root"]?.stringValue
+
+        if let nearSilence = doubleParamOrNil(params, "near_silence_dbfs", "near_silence_threshold_dbfs") {
+            policy.nearSilenceThresholdDbfs = nearSilence
+        }
+        if let maxSilenceRatio = doubleParamOrNil(params, "max_silence_ratio", "maximum_silence_ratio") {
+            policy.maximumSilenceRatio = min(max(maxSilenceRatio, 0.0), 1.0)
+        }
+        return policy
+    }
+}

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,7 @@ struct SystemDispatcher {
 
         default:
             return """
-                Logic Pro MCP — 9 dispatcher tools + \(ResourceProvider.resources.count) resources + \(ResourceProvider.templates.count) templates
+                Logic Pro MCP — 10 dispatcher tools + \(ResourceProvider.resources.count) resources + \(ResourceProvider.templates.count) templates
 
                 Tools (actions):
                   logic_transport  — Transport control (play, stop, record, tempo...)
@@ -396,6 +396,7 @@ struct SystemDispatcher {
                   logic_edit       — Editing (undo, cut, quantize...)
                   logic_navigate   — Navigation + views (markers, zoom, toggle views...)
                   logic_project    — Project lifecycle (open, save, bounce...)
+                  logic_audio      — Read-only audio artifact analysis
                   logic_system     — Diagnostics + help
                   logic_plugins    — Verified plugin apply-back (inventory, set_param_verified, insert_verified)
 

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -33,6 +33,7 @@ enum ServerCatalog {
         EditDispatcher.tool,
         NavigateDispatcher.tool,
         ProjectDispatcher.tool,
+        AudioDispatcher.tool,
         SystemDispatcher.tool,
         PluginsDispatcher.tool,
     ]
@@ -124,7 +125,7 @@ struct ServerRuntimePlan: @unchecked Sendable {
 }
 
 /// Main MCP server for Logic Pro integration.
-/// Exposes 9 dispatcher tools + 14 resources + 7 templates, routing through
+/// Exposes 10 dispatcher tools + 14 resources + 7 templates, routing through
 /// the ChannelRouter to the appropriate macOS communication channel.
 actor LogicProServer {
     private let server: Server
@@ -213,7 +214,7 @@ actor LogicProServer {
         }
     }
 
-    // MARK: - Tool Registration (9 dispatchers)
+    // MARK: - Tool Registration (10 dispatchers)
 
     func makeHandlers() -> LogicProServerHandlers {
         let router = self.router
@@ -245,6 +246,8 @@ actor LogicProServer {
                     return await NavigateDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                 case "logic_project":
                     return await ProjectDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                case "logic_audio":
+                    return AudioDispatcher.handle(command: command, params: cmdParams)
                 case "logic_system":
                     return await SystemDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, poller: self.poller)
                 case "logic_plugins":

--- a/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
+++ b/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
@@ -1,0 +1,173 @@
+import AVFoundation
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func writeAudioFixture(
+    named name: String,
+    sampleRate: Double = 44_100,
+    durationSeconds: Double = 0.1,
+    channels: AVAudioChannelCount = 2,
+    sample: (Int) -> Float
+) throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent(name)
+    let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channels)!
+    let frameCount = AVAudioFrameCount(sampleRate * durationSeconds)
+    let file = try AVAudioFile(forWriting: url, settings: format.settings)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+    buffer.frameLength = frameCount
+    let channelData = buffer.floatChannelData!
+    for channel in 0..<Int(channels) {
+        for frame in 0..<Int(frameCount) {
+            channelData[channel][frame] = sample(frame)
+        }
+    }
+    try file.write(from: buffer)
+    return url
+}
+
+@Test func testAudioAnalyzerValidWAVSchemaAndMeasurements() throws {
+    let url = try writeAudioFixture(named: "tone.wav") { frame in
+        Float(sin(2.0 * Double.pi * 440.0 * Double(frame) / 44_100.0) * 0.5)
+    }
+
+    let result = AudioAnalyzer.analyzeFile(
+        path: url.path,
+        policy: .init(
+            minimumDurationSeconds: 0.05,
+            maximumDurationDriftSeconds: nil,
+            expectedDurationSeconds: nil,
+            minimumFileSizeBytes: 128,
+            maximumPeakDbfs: -0.1,
+            nearSilenceThresholdDbfs: -60,
+            maximumSilenceRatio: 0.98,
+            expectedSampleRate: 44_100,
+            expectedChannelCount: 2,
+            outputRoot: url.deletingLastPathComponent().path
+        )
+    )
+
+    #expect(result.schema == "logic_pro_mcp_audio_analysis.v1")
+    #expect(result.exists == true)
+    #expect(result.format == "wav")
+    #expect(result.sampleRate == 44_100)
+    #expect(result.channelCount == 2)
+    #expect(result.durationSeconds >= 0.09)
+    #expect(result.peakDbfs < 0)
+    #expect(result.loudnessMethod == "rms_estimate")
+    #expect(result.verification.status == .pass)
+}
+
+@Test func testAudioAnalyzerRejectsUnsafeAndUnsupportedPaths() throws {
+    let relative = AudioAnalyzer.analyzeFile(path: "relative.wav")
+    #expect(relative.verification.status == .fail)
+    #expect(relative.verification.reasons.contains("unsafe_path"))
+
+    let traversal = AudioAnalyzer.analyzeFile(path: "/tmp/../evil.wav")
+    #expect(traversal.verification.status == .fail)
+    #expect(traversal.verification.reasons.contains("unsafe_path"))
+
+    let iCloud = AudioAnalyzer.analyzeFile(path: "/Users/test/Library/Mobile Documents/song.wav")
+    #expect(iCloud.verification.status == .fail)
+    #expect(iCloud.verification.reasons.contains("unsafe_path"))
+
+    let txtURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-\(UUID().uuidString).txt")
+    try Data("not audio".utf8).write(to: txtURL)
+    let unsupported = AudioAnalyzer.analyzeFile(path: txtURL.path)
+    #expect(unsupported.verification.status == .fail)
+    #expect(unsupported.verification.reasons.contains("unsupported_format"))
+}
+
+@Test func testAudioAnalyzerPolicyFlagsSilenceClippingAndDuration() throws {
+    let silent = try writeAudioFixture(named: "silent.wav") { _ in 0.0 }
+    let silentResult = AudioAnalyzer.analyzeFile(path: silent.path)
+    #expect(silentResult.verification.status == .fail)
+    #expect(silentResult.verification.reasons.contains("near_silent_output"))
+
+    let clipped = try writeAudioFixture(named: "clipped.wav") { _ in 1.0 }
+    let clippedResult = AudioAnalyzer.analyzeFile(
+        path: clipped.path,
+        policy: .init(
+            minimumDurationSeconds: 1.0,
+            maximumDurationDriftSeconds: nil,
+            expectedDurationSeconds: nil,
+            minimumFileSizeBytes: nil,
+            maximumPeakDbfs: -0.1,
+            nearSilenceThresholdDbfs: -60,
+            maximumSilenceRatio: 0.98,
+            expectedSampleRate: nil,
+            expectedChannelCount: nil,
+            outputRoot: nil
+        )
+    )
+    #expect(clippedResult.verification.status == .fail)
+    #expect(clippedResult.verification.reasons.contains("peak_above_threshold"))
+    #expect(clippedResult.verification.reasons.contains("duration_below_minimum"))
+
+    let quiet = try writeAudioFixture(named: "quiet.wav") { _ in 0.01 }
+    let quietResult = AudioAnalyzer.analyzeFile(
+        path: quiet.path,
+        policy: .init(
+            minimumDurationSeconds: nil,
+            maximumDurationDriftSeconds: nil,
+            expectedDurationSeconds: nil,
+            minimumFileSizeBytes: nil,
+            maximumPeakDbfs: nil,
+            nearSilenceThresholdDbfs: -30,
+            maximumSilenceRatio: 0.98,
+            expectedSampleRate: nil,
+            expectedChannelCount: nil,
+            outputRoot: nil
+        )
+    )
+    #expect(quietResult.silenceRatio == 1.0)
+    #expect(quietResult.verification.reasons.contains("near_silent_output"))
+}
+
+@Test func testAudioAnalyzerRejectsOutputRootEscapesAndZeroLength() throws {
+    let outside = try writeAudioFixture(named: "outside.wav") { _ in 0.25 }
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-approved-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let escaped = AudioAnalyzer.analyzeFile(
+        path: outside.path,
+        policy: .init(
+            minimumDurationSeconds: nil,
+            maximumDurationDriftSeconds: nil,
+            expectedDurationSeconds: nil,
+            minimumFileSizeBytes: nil,
+            maximumPeakDbfs: nil,
+            nearSilenceThresholdDbfs: -60,
+            maximumSilenceRatio: 0.98,
+            expectedSampleRate: nil,
+            expectedChannelCount: nil,
+            outputRoot: root.path
+        )
+    )
+    #expect(escaped.verification.status == .fail)
+    #expect(escaped.verification.reasons.contains("unsafe_path"))
+
+    let zero = root.appendingPathComponent("zero.wav")
+    FileManager.default.createFile(atPath: zero.path, contents: Data())
+    let zeroResult = AudioAnalyzer.analyzeFile(path: zero.path)
+    #expect(zeroResult.verification.status == .fail)
+    #expect(zeroResult.verification.reasons.contains("zero_length_file"))
+}
+
+@Test func testAudioDispatcherAnalyzeFileReturnsJSONAndErrorsOnFailedVerification() throws {
+    let silent = try writeAudioFixture(named: "dispatcher-silent.wav") { _ in 0.0 }
+    let result = AudioDispatcher.handle(
+        command: "analyze_file",
+        params: ["path": .string(silent.path)]
+    )
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(json["schema"] as? String == "logic_pro_mcp_audio_analysis.v1")
+    let verification = try #require(json["verification"] as? [String: Any])
+    #expect(verification["status"] as? String == "fail")
+}

--- a/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
+++ b/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
@@ -52,7 +52,7 @@ private func writeAudioFixture(
     )
 
     #expect(result.schema == "logic_pro_mcp_audio_analysis.v1")
-    #expect(result.exists == true)
+    #expect(result.exists)
     #expect(result.format == "wav")
     #expect(result.sampleRate == 44_100)
     #expect(result.channelCount == 2)
@@ -165,7 +165,7 @@ private func writeAudioFixture(
         command: "analyze_file",
         params: ["path": .string(silent.path)]
     )
-    #expect(result.isError == true)
+    #expect(try #require(result.isError))
     let json = try #require(sharedJSONObject(sharedToolText(result)))
     #expect(json["schema"] as? String == "logic_pro_mcp_audio_analysis.v1")
     let verification = try #require(json["verification"] as? [String: Any])

--- a/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
+++ b/Tests/LogicProMCPTests/AudioAnalyzerTests.swift
@@ -11,6 +11,23 @@ private func writeAudioFixture(
     channels: AVAudioChannelCount = 2,
     sample: (Int) -> Float
 ) throws -> URL {
+    try writeAudioFixture(
+        named: name,
+        sampleRate: sampleRate,
+        durationSeconds: durationSeconds,
+        channels: channels
+    ) { _, frame in sample(frame) }
+}
+
+/// Per-channel variant so tests can write asymmetric channel content (e.g. a loud
+/// left and a silent right) and prove cross-channel RMS/peak handling.
+private func writeAudioFixture(
+    named name: String,
+    sampleRate: Double = 44_100,
+    durationSeconds: Double = 0.1,
+    channels: AVAudioChannelCount = 2,
+    perChannelSample: (Int, Int) -> Float
+) throws -> URL {
     let dir = FileManager.default.temporaryDirectory
         .appendingPathComponent("logicpromcp-audio-tests-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -23,11 +40,20 @@ private func writeAudioFixture(
     let channelData = buffer.floatChannelData!
     for channel in 0..<Int(channels) {
         for frame in 0..<Int(frameCount) {
-            channelData[channel][frame] = sample(frame)
+            channelData[channel][frame] = perChannelSample(channel, frame)
         }
     }
     try file.write(from: buffer)
     return url
+}
+
+/// Loose policy that disables silence/peak gating so DSP value tests inspect the
+/// measured numbers without a verification failure masking them.
+private func measureOnlyPolicy() -> AudioAnalyzer.AnalysisPolicy {
+    var policy = AudioAnalyzer.AnalysisPolicy.default
+    policy.nearSilenceThresholdDbfs = -120
+    policy.maximumSilenceRatio = 1.0
+    return policy
 }
 
 @Test func testAudioAnalyzerValidWAVSchemaAndMeasurements() throws {
@@ -57,9 +83,26 @@ private func writeAudioFixture(
     #expect(result.sampleRate == 44_100)
     #expect(result.channelCount == 2)
     #expect(result.durationSeconds >= 0.09)
-    #expect(result.peakDbfs < 0)
     #expect(result.loudnessMethod == "rms_estimate")
     #expect(result.verification.status == .pass)
+
+    // Pin the dBFS formula numerically. A 0.5-amplitude sine peaks at 20·log10(0.5) =
+    // -6.0206 dBFS and its RMS is 0.5/√2 → -9.031 dBFS. `< 0` would pass for any
+    // non-clipped signal and would not catch a wrong base/coefficient.
+    #expect(abs(result.peakDbfs - (-6.0206)) < 0.1)
+    #expect(abs(result.rmsDbfs - (-9.031)) < 0.15)
+
+    // Honesty contract: LUFS/true-peak/spectral stay unmeasured (null/empty); the
+    // loudness estimate is exactly the RMS dBFS value, not a real LUFS measurement.
+    #expect(result.truePeakDbfs == nil)
+    #expect(result.spectralCentroidHz == nil)
+    #expect(result.frequencyPeaks.isEmpty)
+    #expect(result.loudnessEstimateLufs == result.rmsDbfs)
+
+    // The remaining Result fields are populated for a real bounce.
+    #expect(result.frameCount > 0)
+    #expect(result.fileSizeBytes > 0)
+    #expect(result.nonSilentDurationSeconds > 0)
 }
 
 @Test func testAudioAnalyzerRejectsUnsafeAndUnsupportedPaths() throws {
@@ -170,4 +213,295 @@ private func writeAudioFixture(
     #expect(json["schema"] as? String == "logic_pro_mcp_audio_analysis.v1")
     let verification = try #require(json["verification"] as? [String: Any])
     #expect(verification["status"] as? String == "fail")
+}
+
+// MARK: - DSP value tests (pin the dBFS math, multichannel averaging)
+
+@Test func testAudioAnalyzerConstantAmplitudePinsDbfsFormula() throws {
+    // A constant 0.5 signal has peak == RMS == 0.5, so both must be exactly
+    // 20·log10(0.5) = -6.0206 dBFS. This pins the base/coefficient with no √2 or
+    // discretization ambiguity — a 10·log10 or natural-log formula would fail.
+    let flat = try writeAudioFixture(named: "flat.wav") { _ in 0.5 }
+    let result = AudioAnalyzer.analyzeFile(path: flat.path, policy: measureOnlyPolicy())
+    #expect(result.verification.status == .pass)
+    #expect(abs(result.peakDbfs - (-6.0206)) < 0.05)
+    #expect(abs(result.rmsDbfs - (-6.0206)) < 0.05)
+}
+
+@Test func testAudioAnalyzerReportsTrueOverUnityPeakAboveZeroDbfs() throws {
+    // Float PCM from a bounce can exceed full scale (digital overs). Peak must NOT be
+    // clamped to 1.0 — a 1.5 sample is 20·log10(1.5) = +3.52 dBFS, and the
+    // max_peak_dbfs gate must still flag it even with maximumPeakDbfs: 0.0.
+    let hot = try writeAudioFixture(named: "over.wav") { _ in 1.5 }
+    var policy = measureOnlyPolicy()
+    policy.maximumPeakDbfs = 0.0
+    let result = AudioAnalyzer.analyzeFile(path: hot.path, policy: policy)
+    #expect(result.peakDbfs > 0)
+    #expect(abs(result.peakDbfs - 3.5218) < 0.1)
+    #expect(result.verification.status == .fail)
+    #expect(result.verification.reasons.contains("peak_above_threshold"))
+}
+
+@Test func testAudioAnalyzerMonoRmsMatchesConstant() throws {
+    let mono = try writeAudioFixture(named: "mono.wav", channels: 1) { _ in 0.5 }
+    let result = AudioAnalyzer.analyzeFile(path: mono.path, policy: measureOnlyPolicy())
+    #expect(result.channelCount == 1)
+    #expect(abs(result.peakDbfs - (-6.0206)) < 0.05)
+    #expect(abs(result.rmsDbfs - (-6.0206)) < 0.05)
+}
+
+@Test func testAudioAnalyzerAsymmetricChannelsAverageRmsAcrossChannels() throws {
+    // Left = 0.5 constant, Right = silent. Per-frame peak across channels = 0.5 ->
+    // -6.0206 dBFS. RMS sums squares over BOTH channels (0.25 + 0) / 2 samples =
+    // 0.125 -> sqrt = 0.35355 -> -9.031 dBFS. A bug that only read channel 0 (or
+    // double-counted) would not produce -9.031, so this proves cross-channel averaging.
+    let asym = try writeAudioFixture(named: "asym.wav", channels: 2) { channel, _ in
+        channel == 0 ? 0.5 : 0.0
+    }
+    let result = AudioAnalyzer.analyzeFile(path: asym.path, policy: measureOnlyPolicy())
+    #expect(result.channelCount == 2)
+    #expect(abs(result.peakDbfs - (-6.0206)) < 0.05)
+    #expect(abs(result.rmsDbfs - (-9.031)) < 0.05)
+}
+
+// MARK: - Verification / failure reason coverage
+
+@Test func testAudioAnalyzerVerificationReasonCodes() throws {
+    let tone = try writeAudioFixture(named: "reasons-tone.wav") { frame in
+        Float(sin(2.0 * Double.pi * 440.0 * Double(frame) / 44_100.0) * 0.5)
+    }
+
+    var sampleRatePolicy = AudioAnalyzer.AnalysisPolicy.default
+    sampleRatePolicy.expectedSampleRate = 48_000
+    let sampleRateResult = AudioAnalyzer.analyzeFile(path: tone.path, policy: sampleRatePolicy)
+    #expect(sampleRateResult.verification.reasons.contains("sample_rate_mismatch"))
+
+    var channelPolicy = AudioAnalyzer.AnalysisPolicy.default
+    channelPolicy.expectedChannelCount = 1
+    let channelResult = AudioAnalyzer.analyzeFile(path: tone.path, policy: channelPolicy)
+    #expect(channelResult.verification.reasons.contains("channel_count_mismatch"))
+
+    var driftPolicy = AudioAnalyzer.AnalysisPolicy.default
+    driftPolicy.expectedDurationSeconds = 10
+    driftPolicy.maximumDurationDriftSeconds = 0.001
+    let driftResult = AudioAnalyzer.analyzeFile(path: tone.path, policy: driftPolicy)
+    #expect(driftResult.verification.reasons.contains("duration_drift_exceeded"))
+
+    var sizePolicy = AudioAnalyzer.AnalysisPolicy.default
+    sizePolicy.minimumFileSizeBytes = Int.max
+    let sizeResult = AudioAnalyzer.analyzeFile(path: tone.path, policy: sizePolicy)
+    #expect(sizeResult.verification.reasons.contains("file_size_below_minimum"))
+}
+
+@Test func testAudioAnalyzerErrorReasonCodes() throws {
+    let missing = AudioAnalyzer.analyzeFile(path: "/private/var/nonexistent-\(UUID().uuidString).wav")
+    #expect(missing.verification.status == .fail)
+    #expect(missing.verification.reasons.contains("missing_file"))
+
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-dir-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let dirResult = AudioAnalyzer.analyzeFile(path: dir.path)
+    #expect(dirResult.verification.status == .fail)
+    #expect(dirResult.verification.reasons.contains("directory_path"))
+
+    // Garbage bytes under a supported extension: AVAudioFile fails to open -> decoder_error.
+    let garbageDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-garbage-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: garbageDir, withIntermediateDirectories: true)
+    let garbage = garbageDir.appendingPathComponent("corrupt.wav")
+    try Data("this is not a real RIFF/WAVE payload at all".utf8).write(to: garbage)
+    let garbageResult = AudioAnalyzer.analyzeFile(path: garbage.path)
+    #expect(garbageResult.verification.status == .fail)
+    #expect(garbageResult.verification.reasons.contains("decoder_error"))
+}
+
+@Test func testAudioAnalyzerReasonsAreCodeOnlyWithDetailOnErrorPath() throws {
+    // The error path must emit a uniform machine-code list and carry the human sentence
+    // in `detail`, not mix free text into reasons (v1 schema is a parseable contract).
+    let txtURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-codeonly-\(UUID().uuidString).txt")
+    try Data("not audio".utf8).write(to: txtURL)
+    let unsupported = AudioAnalyzer.analyzeFile(path: txtURL.path)
+    #expect(unsupported.verification.reasons == ["unsupported_format"])
+    let detail = try #require(unsupported.verification.detail)
+    #expect(detail.contains("Unsupported audio format"))
+}
+
+// MARK: - exists honesty per error kind
+
+@Test func testAudioAnalyzerExistsHonestForPresentButUnanalyzableFiles() throws {
+    // An existing unsupported file is present on disk: exists must be true even though
+    // verification fails, so an agent does not wrongly conclude "no file produced".
+    let txtURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-exists-\(UUID().uuidString).txt")
+    try Data("not audio".utf8).write(to: txtURL)
+    let unsupported = AudioAnalyzer.analyzeFile(path: txtURL.path)
+    #expect(unsupported.exists)
+    #expect(unsupported.verification.status == .fail)
+
+    // Existing zero-length file: present, but fails.
+    let zeroDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-zero-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: zeroDir, withIntermediateDirectories: true)
+    let zero = zeroDir.appendingPathComponent("zero.wav")
+    FileManager.default.createFile(atPath: zero.path, contents: Data())
+    let zeroResult = AudioAnalyzer.analyzeFile(path: zero.path)
+    #expect(zeroResult.exists)
+    #expect(zeroResult.verification.status == .fail)
+
+    // A directory input is present on disk (an item exists at that path), so exists is
+    // true even though it is not an analyzable audio file.
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-existsdir-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let dirResult = AudioAnalyzer.analyzeFile(path: dir.path)
+    #expect(dirResult.exists)
+    #expect(dirResult.verification.reasons.contains("directory_path"))
+
+    // A genuinely missing path: exists false.
+    let missing = AudioAnalyzer.analyzeFile(path: "/private/var/nonexistent-\(UUID().uuidString).wav")
+    #expect(!missing.exists)
+
+    // An unsafe (relative) path is rejected before any presence check: exists false.
+    let unsafe = AudioAnalyzer.analyzeFile(path: "relative.wav")
+    #expect(!unsafe.exists)
+}
+
+// MARK: - iCloud path matching (extension, not substring)
+
+@Test func testAudioAnalyzerICloudMatchByExtensionNotSubstring() throws {
+    // A legitimate local path that merely contains the text ".icloud" in a directory
+    // component must NOT be rejected as unsafe — it should fall through to missing_file.
+    let local = AudioAnalyzer.analyzeFile(path: "/Users/x/Music/my.icloud.backup/song.wav")
+    #expect(local.verification.reasons.contains("missing_file"))
+    #expect(!local.verification.reasons.contains("unsafe_path"))
+
+    // A genuine `<name>.icloud` placeholder stub is still rejected as unsafe.
+    let stub = AudioAnalyzer.analyzeFile(path: "/Users/x/Music/song.wav.icloud")
+    #expect(stub.verification.status == .fail)
+    #expect(stub.verification.reasons.contains("unsafe_path"))
+}
+
+// MARK: - format-field / case normalization / non-wav supported extension
+
+@Test func testAudioAnalyzerAcceptsAiffAndNormalizesUppercaseExtension() throws {
+    let aiff = try writeAudioFixture(named: "tone.aiff") { _ in 0.5 }
+    let aiffResult = AudioAnalyzer.analyzeFile(path: aiff.path, policy: measureOnlyPolicy())
+    #expect(aiffResult.verification.status == .pass)
+    #expect(aiffResult.format == "aiff")
+
+    let upper = try writeAudioFixture(named: "Tone.WAV") { _ in 0.5 }
+    let upperResult = AudioAnalyzer.analyzeFile(path: upper.path, policy: measureOnlyPolicy())
+    #expect(upperResult.format == "wav")
+}
+
+// MARK: - decode-path zero-frame guard (valid container, no PCM)
+
+@Test func testAudioAnalyzerZeroFrameDecodableFileTripsDecodeGuard() throws {
+    // A non-empty WAV with zero audio frames passes the byte-size guard but must fail at
+    // the decode-frame guard (file.length == 0), exercising a path the 0-byte test cannot.
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-audio-emptyframes-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("empty-frames.wav")
+    let format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2)!
+    let file = try AVAudioFile(forWriting: url, settings: format.settings)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1)!
+    buffer.frameLength = 0
+    try file.write(from: buffer)
+
+    let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+    let size = (attrs[.size] as? NSNumber)?.int64Value ?? 0
+    #expect(size > 0)
+
+    let result = AudioAnalyzer.analyzeFile(path: url.path)
+    #expect(result.verification.status == .fail)
+    #expect(result.verification.reasons.contains("zero_length_file"))
+}
+
+// MARK: - Dispatcher branch coverage
+
+@Test func testAudioDispatcherEmptyPathReturnsError() throws {
+    let result = AudioDispatcher.handle(command: "analyze_file", params: ["path": .string("")])
+    #expect(try #require(result.isError))
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(json["verification"] != nil)
+}
+
+@Test func testAudioDispatcherUnknownCommandReturnsError() throws {
+    let result = AudioDispatcher.handle(command: "bogus", params: [:])
+    #expect(try #require(result.isError))
+    #expect(sharedToolText(result).contains("Unknown audio command"))
+}
+
+@Test func testAudioDispatcherSuccessPathOnLoudTone() throws {
+    let tone = try writeAudioFixture(named: "dispatcher-loud.wav") { frame in
+        Float(sin(2.0 * Double.pi * 440.0 * Double(frame) / 44_100.0) * 0.7)
+    }
+    let result = AudioDispatcher.handle(
+        command: "analyze_file",
+        params: ["path": .string(tone.path)]
+    )
+    #expect(!(try #require(result.isError)))
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    let verification = try #require(json["verification"] as? [String: Any])
+    #expect(verification["status"] as? String == "pass")
+}
+
+@Test func testAudioDispatcherAliasParamsAreParsed() throws {
+    let tone = try writeAudioFixture(named: "dispatcher-alias.wav") { frame in
+        Float(sin(2.0 * Double.pi * 440.0 * Double(frame) / 44_100.0) * 0.5)
+    }
+    // Drive the canonical alias keys: max_peak_dbfs (so the loud tone trips the peak gate)
+    // and expected_sample_rate (so the 44_100 fixture trips the rate gate). If either alias
+    // key were broken the corresponding reason would be absent.
+    let result = AudioDispatcher.handle(
+        command: "analyze_file",
+        params: [
+            "path": .string(tone.path),
+            "max_peak_dbfs": .double(-30.0),
+            "expected_sample_rate": .int(48_000),
+        ]
+    )
+    #expect(try #require(result.isError))
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    let verification = try #require(json["verification"] as? [String: Any])
+    let reasons = try #require(verification["reasons"] as? [String])
+    #expect(reasons.contains("peak_above_threshold"))
+    #expect(reasons.contains("sample_rate_mismatch"))
+}
+
+@Test func testAudioDispatcherOutputRootNonStringFailsClosed() throws {
+    let tone = try writeAudioFixture(named: "dispatcher-confined.wav") { _ in 0.5 }
+
+    // A present-but-non-string output_root must fail CLOSED as unsafe_path, never silently
+    // drop the allowlist confinement.
+    for malformed in [Value.int(123), Value.bool(true), Value.string("   ")] {
+        let result = AudioDispatcher.handle(
+            command: "analyze_file",
+            params: ["path": .string(tone.path), "output_root": malformed]
+        )
+        #expect(try #require(result.isError))
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        let verification = try #require(json["verification"] as? [String: Any])
+        let reasons = try #require(verification["reasons"] as? [String])
+        #expect(reasons.contains("unsafe_path"))
+    }
+}
+
+@Test func testAudioDispatcherClampsPositiveNearSilenceThreshold() throws {
+    // near_silence_dbfs > 0 must be clamped to 0.0 so a full-scale tone is not falsely
+    // flagged near-silent (positive dBFS would push the threshold above full scale).
+    let full = try writeAudioFixture(named: "dispatcher-fullscale.wav") { _ in 1.0 }
+    let result = AudioDispatcher.handle(
+        command: "analyze_file",
+        params: ["path": .string(full.path), "near_silence_dbfs": .double(6.0)]
+    )
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    let silenceRatio = try #require(json["silence_ratio"] as? Double)
+    #expect(silenceRatio < 1.0)
+    let verification = try #require(json["verification"] as? [String: Any])
+    let reasons = try #require(verification["reasons"] as? [String])
+    #expect(!reasons.contains("near_silent_output"))
 }

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -820,11 +820,11 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 // MARK: - §11 Server Composition & Catalog (5 tests)
 // ═══════════════════════════════════════════════════════════════════════
 
-@Test func testE2EServerCatalogHas9Tools() async {
+@Test func testE2EServerCatalogHas10Tools() async {
     let snapshot = await LogicProServer().compositionSnapshot()
-    #expect(snapshot.toolNames.count == 9)
+    #expect(snapshot.toolNames.count == 10)
     let expected = Set(["logic_transport", "logic_tracks", "logic_mixer", "logic_midi",
-                        "logic_edit", "logic_navigate", "logic_project", "logic_system",
+                        "logic_edit", "logic_navigate", "logic_project", "logic_audio", "logic_system",
                         "logic_plugins"])
     #expect(Set(snapshot.toolNames) == expected)
 }

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -23,6 +23,7 @@ private let serverResourceText = sharedResourceText
         "logic_edit",
         "logic_navigate",
         "logic_project",
+        "logic_audio",
         "logic_system",
         "logic_plugins",
     ])
@@ -70,6 +71,7 @@ private let serverResourceText = sharedResourceText
         "logic_edit",
         "logic_navigate",
         "logic_project",
+        "logic_audio",
         "logic_system",
     ]
 
@@ -195,7 +197,7 @@ private let serverResourceText = sharedResourceText
 
     let handlers = await server.makeHandlers()
     let toolNames = await handlers.listTools(ListTools.Parameters())
-    #expect(toolNames.tools.count == 9)
+    #expect(toolNames.tools.count == 10)
 }
 
 @Test func testLogicProServerStartUsesDefaultRegisterAndCleanupPaths() async throws {

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -383,6 +383,7 @@ private func waitForFeedbackEvents(
         "logic_edit",
         "logic_navigate",
         "logic_project",
+        "logic_audio",
         "logic_system",
         "logic_plugins",
     ])
@@ -413,12 +414,12 @@ private func waitForFeedbackEvents(
         "logic://workflow-skills/search?query={query}",
     ]
     #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.6.0 — 9 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.6.0 — 10 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {
     let banner = ServerCatalog.startupBanner(channelCount: 7)
-    #expect(banner == "Starting logic-pro-mcp v3.6.0 — 9 tools, \(ResourceProvider.resources.count) resources, 7 channels")
+    #expect(banner == "Starting logic-pro-mcp v3.6.0 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }
 
 @Test func testLogicProServerCompositionSnapshotMatchesExpectedOrder() async {
@@ -435,7 +436,7 @@ private func waitForFeedbackEvents(
         .cgEvent,
         .appleScript,
     ])
-    #expect(snapshot.toolNames.count == 9)
+    #expect(snapshot.toolNames.count == 10)
     #expect(snapshot.resourceURIs.contains("logic://system/health"))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.6.0 — 9 tools, \(ResourceProvider.resources.count) resources, 7 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.6.0 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -53,6 +53,12 @@ private func readRepoFile(_ relativePath: String) throws -> String {
 @Test func testManifestResourceSurfaceMatchesPublishedStableRelease() throws {
     let manifest = try sharedParseJSON(readRepoFile("manifest.json")) as! [String: Any]
 
+    // The manifest tools array is the published MCP-registry surface; it must equal the
+    // server catalog exactly so it can never silently drift (e.g. omit logic_audio).
+    let tools = Set(try #require(manifest["tools"] as? [String]))
+    #expect(tools == Set(ServerCatalog.tools.map(\.name)))
+    #expect(tools.count == 10)
+
     let resources = Set(try #require(manifest["resources"] as? [String]))
     #expect(resources == [
         "logic://system/health",
@@ -85,7 +91,7 @@ private func readRepoFile(_ relativePath: String) throws -> String {
     #expect(templates == Set(ResourceProvider.templates.map(\.uriTemplate)))
 
     let description = try #require(manifest["description"] as? String)
-    #expect(description.contains("14 resources + 7 templates"))
+    #expect(description.contains("10 tools + 14 resources + 7 templates"))
 }
 
 @Test func testReadmeAndAPIDocsMatchPublicSurfaceAndRouting() throws {

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -92,7 +92,7 @@ private func readRepoFile(_ relativePath: String) throws -> String {
     let readme = try readRepoFile("README.md")
     #expect(readme.contains("| Read resources | 14 static resources"))
     #expect(readme.contains("| Resource templates | 7 templates"))
-    #expect(readme.contains("All 9 tools, 14 resources, 7 templates"))
+    #expect(readme.contains("All 10 tools, 14 resources, 7 templates"))
 
     let api = try readRepoFile("docs/API.md")
     #expect(api.contains("| `toggle_cycle` | — | text | Accessibility → MIDIKeyCommands → CGEvent → MCU |"))

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete schema for Logic Pro MCP server. The server exposes **9 tools**, **14 resources**, and **7 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
+Complete schema for Logic Pro MCP server. The server exposes **10 tools**, **14 resources**, and **7 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
 
 **Design principle:** Tools perform write/action operations. **Reads are exposed exclusively through resources** — use `resources/read` for state queries, not tool calls.
 
@@ -20,6 +20,7 @@ Every tool call returns a `CallTool.Result` with `content: [{ type: "text", text
 | [`logic_edit`](#logic_edit) | Undo/redo/cut/copy/paste/quantize | Write |
 | [`logic_navigate`](#logic_navigate) | Bar navigation, markers, zoom, view toggles | Write |
 | [`logic_project`](#logic_project) | Open, save, close, bounce, quit | Write |
+| [`logic_audio`](#logic_audio) | Read-only exported audio artifact analysis | Read |
 | [`logic_system`](#logic_system) | Health, permissions, help, cache refresh | Mixed |
 
 All tool invocations use:
@@ -710,6 +711,43 @@ Envelope `source` values:
 On Logic Pro 12.x the new `AXRuler`-structural walker (v3.1.8) succeeds for typical projects but a 12.2-specific marker hierarchy variant has been observed where the walk fails; tracked separately. When `source: "default"` appears on a project that visibly has markers, the AX subtree on that Logic build hasn't been characterized yet.
 
 ---
+
+## logic_audio
+
+Read-only post-export audio artifact analysis. This tool never mutates Logic projects or audio files.
+
+| Command | Params | Returns | Level |
+|---------|--------|---------|-------|
+| `analyze_file` | `{ path: string, output_root?: string, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }` | JSON `logic_pro_mcp_audio_analysis.v1` | L0 |
+
+Path safety:
+- `path` must be absolute.
+- `..` traversal and iCloud paths are rejected.
+- `output_root`, when supplied, is resolved after symlink cleanup and the analyzed file must remain inside it.
+- Unsupported formats, missing files, zero-byte files, and decoder errors fail closed with `verification.status:"fail"`.
+
+Loudness honesty:
+- `loudness_method:"rms_estimate"` is an RMS-derived estimate, not EBU R128 LUFS.
+- `true_peak_dbfs` and spectral fields are not claimed when not measured.
+
+Example:
+
+```json
+{
+  "name": "logic_audio",
+  "arguments": {
+    "command": "analyze_file",
+    "params": {
+      "path": "/tmp/LogicProMCP/export.wav",
+      "output_root": "/tmp/LogicProMCP",
+      "min_duration_seconds": 10,
+      "max_peak_dbfs": -0.1,
+      "expected_sample_rate": 48000,
+      "expected_channel_count": 2
+    }
+  }
+}
+```
 
 ## logic_project
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -726,9 +726,18 @@ Path safety:
 - `output_root`, when supplied, is resolved after symlink cleanup and the analyzed file must remain inside it.
 - Unsupported formats, missing files, zero-byte files, and decoder errors fail closed with `verification.status:"fail"`.
 
+Measurement honesty:
+- `peak_dbfs` is measured from raw sample magnitude and is **not clamped to 0 dBFS** — true digital overs report positive dBFS so clipping is visible to `max_peak_dbfs`.
+- `duration_seconds`, `silence_ratio`, and `frame_count` are derived from frames actually decoded, not the header's declared length. If the decoder yields fewer frames than the header claims, `verification.reasons` includes `truncated_or_short_data` and the status is `fail`.
+- `exists` reflects on-disk presence honestly per error kind: an existing-but-unanalyzable artifact (unsupported format, zero bytes, directory, decoder/metadata error) reports `exists:true` with `verification.status:"fail"`; only a missing or rejected (unsafe) path reports `exists:false`.
+
 Loudness honesty:
 - `loudness_method:"rms_estimate"` is an RMS-derived estimate, not EBU R128 LUFS.
-- `true_peak_dbfs` and spectral fields are not claimed when not measured.
+- `loudness_estimate_lufs` carries the RMS dBFS estimate (equal to `rms_dbfs`); `true_peak_dbfs` and spectral fields are not claimed when not measured.
+
+Verification schema:
+- `verification.reasons` is always a list of stable machine codes (e.g. `peak_above_threshold`, `near_silent_output`, `sample_rate_mismatch`, `unsupported_format`, `missing_file`, `directory_path`, `decoder_error`, `zero_length_file`, `truncated_or_short_data`).
+- `verification.detail` is an optional human-readable message present only on the error path; clients should parse `reasons`, not `detail`.
 
 Example:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Logic Pro MCP Server is a Swift 6 actor-based system that multiplexes **7 native
        │                  │                   │                    │
 ┌──────▼────────┐  ┌──────▼────────┐  ┌───────▼────────┐  ┌────────▼──────┐
 │  Dispatchers  │  │ ResourceHandlers │ │   StateCache   │  │  StatePoller  │
-│ (9 tools)     │  │ (14 + 7 templ.) │ │   (actor)      │  │ (3s AX poll)  │
+│ (10 tools)    │  │ (14 + 7 templ.) │ │   (actor)      │  │ (3s AX poll)  │
 └──────┬────────┘  └──────┬────────┘  └───────▲────────┘  └────────┬──────┘
        │                  │                   │                    │
        │                  │                   │                    │

--- a/docs/prd/PRD-audio-analysis-foundation.md
+++ b/docs/prd/PRD-audio-analysis-foundation.md
@@ -1,0 +1,42 @@
+# PRD: Audio Analysis Foundation
+
+**Issue**: #29 Export verification: post-bounce audio analysis
+**Status**: Approved / Implemented
+**Date**: 2026-06-20
+**Size**: M
+
+## Problem
+
+LogicProMCP can drive export workflows, but it did not have a local, machine-checkable way to inspect the bounced audio artifact afterward. Users need a read-only verification surface that can confirm an exported file exists, decodes, is not silent, and roughly matches expected export constraints without claiming higher precision than the implementation supports.
+
+## Goals
+
+- Add a read-only `logic_audio` MCP tool with `analyze_file`.
+- Return a stable JSON schema for local audio artifacts.
+- Enforce path safety: absolute paths only, no traversal, no iCloud paths, and optional `output_root` allowlisting after symlink resolution.
+- Measure file size, duration, sample rate, channel count, frame count, peak dBFS, RMS dBFS, silence ratio, and non-silent duration.
+- Evaluate caller-provided verification policy and fail closed with structured reasons.
+- Document that loudness is an RMS estimate, not true LUFS/true-peak/spectral analysis.
+
+## Non-Goals
+
+- Starting, controlling, or mutating Logic Pro.
+- Performing the bounce/export action itself.
+- Claiming integrated LUFS, true peak, spectral centroid, or frequency peak accuracy before those analyzers exist.
+- Reading cloud-only or remote placeholder files.
+
+## Acceptance Criteria
+
+- `logic_audio analyze_file` is listed in the server tool catalog and dispatches without requiring the server to start transports.
+- Unsafe paths, missing files, directories, unsupported formats, and zero-byte files return schema-valid failures.
+- A valid WAV fixture returns schema `logic_pro_mcp_audio_analysis.v1` with pass/fail verification.
+- Silent, clipped, too-short, size-mismatched, sample-rate-mismatched, and channel-count-mismatched outputs can be detected through policy reasons.
+- Public README/API/architecture docs describe the new surface and its honesty limits.
+
+## Verification
+
+- `swift test --filter AudioAnalyzer`
+- `swift test --filter LogicProServerTransport`
+- `swift test --filter LogicProServerHandler`
+- `swift test --filter EndToEnd`
+- `swift test --filter VersionConsistency`

--- a/docs/tickets/audio-analysis-foundation/STATUS.md
+++ b/docs/tickets/audio-analysis-foundation/STATUS.md
@@ -1,0 +1,31 @@
+# Pipeline Status: Audio Analysis Foundation
+
+**Issue**: #29 Export verification: post-bounce audio analysis
+**PRD**: docs/prd/PRD-audio-analysis-foundation.md
+**Size**: M
+**Current Phase**: Done
+**Started**: 2026-06-20
+**Completed**: 2026-06-20
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | audio analyzer schema and policy | Done | PASS | Read-only local analyzer, path allowlisting, schema-valid failure envelopes |
+| T2 | logic_audio tool and public docs | Done | PASS | Tool catalog, dispatcher, README/API/architecture docs, catalog tests |
+
+## Verification
+
+| Command | Result |
+|---------|--------|
+| `swift test --filter AudioAnalyzer` | PASS |
+| `swift test --filter LogicProServerTransport` | PASS |
+| `swift test --filter LogicProServerHandler` | PASS |
+| `swift test --filter EndToEnd` | PASS |
+| `swift test --filter VersionConsistency` | PASS |
+
+## Decisions
+
+- Loudness is exposed as `rms_estimate` only. True LUFS, true peak, spectral centroid, and frequency peaks remain null/empty until implemented by a dedicated analyzer.
+- `CallTool.Result.isError` is true when verification status is `fail`, while the response body remains structured JSON.
+- `output_root` is optional but resolved after symlinks before allowlist comparison.

--- a/docs/tickets/audio-analysis-foundation/T1-audio-analyzer-schema-policy.md
+++ b/docs/tickets/audio-analysis-foundation/T1-audio-analyzer-schema-policy.md
@@ -1,0 +1,20 @@
+# T1: Audio Analyzer Schema And Policy
+
+**Status**: Done
+**Issue**: #29
+
+## Scope
+
+Implement the read-only audio artifact analyzer behind `logic_audio analyze_file`.
+
+## Acceptance Criteria
+
+- Absolute-path validation rejects relative paths, traversal, iCloud paths, missing files, directories, unsupported extensions, and zero-byte files.
+- Optional `output_root` is enforced after symlink resolution.
+- Successful analysis returns `logic_pro_mcp_audio_analysis.v1`.
+- Measurements include duration, sample rate, channels, frame count, file size, RMS dBFS, peak dBFS, silence ratio, and non-silent duration.
+- Verification policies emit structured fail reasons instead of free-form success claims.
+
+## Verification
+
+- `swift test --filter AudioAnalyzer`

--- a/docs/tickets/audio-analysis-foundation/T2-logic-audio-tool-docs.md
+++ b/docs/tickets/audio-analysis-foundation/T2-logic-audio-tool-docs.md
@@ -1,0 +1,22 @@
+# T2: logic_audio Tool And Public Docs
+
+**Status**: Done
+**Issue**: #29
+
+## Scope
+
+Expose the analyzer through the MCP tool catalog and document the public API.
+
+## Acceptance Criteria
+
+- `logic_audio` is registered with the server tool list and dispatcher switch.
+- Help text and server catalog counts include ten tools.
+- README, API docs, architecture docs, and consistency tests mention the read-only audio surface.
+- Public docs state that loudness is an RMS estimate and true peak/LUFS/spectral claims are not made.
+
+## Verification
+
+- `swift test --filter LogicProServerTransport`
+- `swift test --filter LogicProServerHandler`
+- `swift test --filter EndToEnd`
+- `swift test --filter VersionConsistency`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "logic-pro-mcp",
   "display_name": "Logic Pro MCP Server",
-  "description": "Bidirectional, stateful control of Logic Pro from AI assistants. 9 tools + 14 resources + 7 templates across 7 native macOS channels (MCU, MIDI Key Commands, CoreMIDI, Scripter, Accessibility, CGEvent, AppleScript). GitHub Actions release assets are universal (`arm64` + `x86_64`); historical local ADHOC prerelease cuts should be audited via RELEASE-METADATA.json.",
+  "description": "Bidirectional, stateful control of Logic Pro from AI assistants. 10 tools + 14 resources + 7 templates across 7 native macOS channels (MCU, MIDI Key Commands, CoreMIDI, Scripter, Accessibility, CGEvent, AppleScript). GitHub Actions release assets are universal (`arm64` + `x86_64`); historical local ADHOC prerelease cuts should be audited via RELEASE-METADATA.json.",
   "version": "3.6.0",
   "author": "Isaac (MongLong0214)",
   "license": "MIT",
@@ -31,6 +31,7 @@
     "logic_edit",
     "logic_navigate",
     "logic_project",
+    "logic_audio",
     "logic_system",
     "logic_plugins"
   ],


### PR DESCRIPTION
Summary
- Adds read-only `logic_audio analyze_file` for local post-bounce artifact verification.
- Measures duration, sample rate, channels, frame count, file size, RMS/peak dBFS, silence ratio, and non-silent duration with schema-valid fail reasons.
- Updates tool catalog/docs to 10 tools and adds dev-pipeline PRD/ticket artifacts.

Verification
- `swift test --filter AudioAnalyzer`
- `swift test --filter LogicProServerTransport`
- `swift test --filter LogicProServerHandler`
- `swift test --filter EndToEnd`
- `swift test --filter VersionConsistency`
- `git diff --cached --check`

Notes
- Loudness is explicitly `rms_estimate`; true LUFS/true peak/spectral fields remain null/empty until implemented by dedicated analyzers.
- Refs #29