### PR TITLE
Planning-only composition session workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 |---------|---------------------|
 | MCP tools | 9 tools covering transport, tracks, mixer, MIDI, edit, navigation, project lifecycle, system health, and verified plugin apply-back |
 | Read resources | 14 static resources for health, transport, tracks, mixer, markers, project metadata, MIDI ports, MCU state, library inventory, stock plugin intelligence, and workflow skills |
-| Resource templates | 7 templates for track, region, mixer-strip, stock plugin detail/search, and workflow detail/search lookup |
+| Resource templates | 8 templates for track, region, mixer-strip, stock plugin detail/search, session-plan dry run, and workflow detail/search lookup |
 | Control channels | MCU, Accessibility, AppleScript, CoreMIDI, CGEvent, Scripter, MIDI Key Commands |
 | Verification line | v3.6.0 release tree: `1396` Swift tests, release build, targeted Logic Pro 12.2 exact-slot plugin insert proof, strict live E2E, and live tracks-resource readback |
 | Release state | Published stable `v3.6.0`; previous stable `v3.5.0` remains available for pinned installs |
@@ -211,7 +211,7 @@ See [Architecture](docs/ARCHITECTURE.md) for channel priorities, state flow, cac
 | Document | Audience | Purpose |
 |----------|----------|---------|
 | [Setup Guide](docs/SETUP.md) | End users | One-page install + Logic Pro integration, ~10 min |
-| [API Reference](docs/API.md) | End users, MCP clients | All 9 tools, 14 resources, 7 templates, 130+ operations |
+| [API Reference](docs/API.md) | End users, MCP clients | All 9 tools, 14 resources, 8 templates, 130+ operations |
 | [Verified Apply-Back Guide](docs/guides/verified-apply-back.md) | Agent workflow authors | `logic_plugins` inventory, exact-slot insertion, Compressor threshold write/readback, HC v2 failure handling |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | End users | Common failures and fixes |
 | [Architecture](docs/ARCHITECTURE.md) | Contributors | Channel design, state flow, testing strategy |

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -421,6 +421,7 @@ struct SystemDispatcher {
                   logic://mixer/{strip}           — Single channel strip
                   logic://stock-plugins/{id}      — Stock plugin detail
                   logic://stock-plugins/search?query={query} — Stock plugin search
+                  logic://workflow-plans/session?prompt={prompt} — Dry-run session plan
                   logic://workflow-skills/{id}    — Workflow skill detail
                   logic://workflow-skills/search?query={query} — Workflow skill search
 

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -107,6 +107,10 @@ extension ResourceHandlers {
             return try readStockPluginResource(uri: uri)
         }
 
+        if uri == "logic://workflow-plans" || uri.hasPrefix("logic://workflow-plans/") || uri.hasPrefix("logic://workflow-plans?") {
+            return try readWorkflowPlanResource(uri: uri)
+        }
+
         if uri == "logic://workflow-skills" || uri.hasPrefix("logic://workflow-skills/") || uri.hasPrefix("logic://workflow-skills?") {
             return try readWorkflowSkillResource(uri: uri)
         }
@@ -327,6 +331,41 @@ extension ResourceHandlers {
         return try readStockPluginDetail(uri: uri, id: segment)
     }
 
+    /// Workflow plan routing. These resources are dry-run only: they parse a
+    /// prompt into a JSON plan and never call tools, channels, or router.
+    private static func readWorkflowPlanResource(uri: String) throws -> ReadResource.Result {
+        try validateRawCatalogURIEncoding(uri, host: "workflow-plans")
+        guard let components = URLComponents(string: uri),
+              components.scheme == "logic",
+              components.host == "workflow-plans" else {
+            throw MCPError.invalidParams("Malformed workflow plan resource URI: \(uri)")
+        }
+        guard components.fragment == nil else {
+            throw MCPError.invalidParams("logic://workflow-plans resources do not accept URI fragments")
+        }
+        try validateCanonicalCatalogPath(components, host: "workflow-plans")
+        try validateWorkflowPlanPromptQuery(components, baseURI: "logic://workflow-plans/session")
+
+        let segments = components.path.split(separator: "/").map(String.init)
+        let canonicalPath = segments.isEmpty ? "" : "/" + segments.joined(separator: "/")
+        guard components.path == canonicalPath else {
+            throw MCPError.invalidParams("Malformed workflow plan resource path: \(components.path)")
+        }
+        guard segments == ["session"] else {
+            throw MCPError.invalidParams("Unknown workflow plan resource path: \(components.path)")
+        }
+
+        let prompts = (components.queryItems ?? []).filter { $0.name == "prompt" }
+        guard prompts.count == 1 else {
+            throw MCPError.invalidParams("logic://workflow-plans/session requires exactly one prompt query parameter")
+        }
+        let prompt = prompts[0].value ?? ""
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MCPError.invalidParams("logic://workflow-plans/session prompt must be non-empty")
+        }
+        return readSessionPlan(uri: uri, prompt: prompt)
+    }
+
     /// Workflow skill routing. Parsed with `URLComponents` so path and query
     /// are matched exactly: unknown subpaths, nested segments, and stray query
     /// parameters fail closed instead of silently degrading to a search or a
@@ -424,6 +463,21 @@ extension ResourceHandlers {
         }
     }
 
+    private static func validateWorkflowPlanPromptQuery(_ components: URLComponents, baseURI: String) throws {
+        guard let rawQuery = components.percentEncodedQuery else {
+            throw MCPError.invalidParams("\(baseURI) requires a prompt query parameter")
+        }
+        guard percentEscapesAreWellFormed(rawQuery) else {
+            throw MCPError.invalidParams("Malformed prompt query encoding: \(rawQuery)")
+        }
+        for rawPair in rawQuery.split(separator: "&", omittingEmptySubsequences: false) {
+            let parts = rawPair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.first.map(String.init) == "prompt" else {
+                throw MCPError.invalidParams("Unsupported workflow plan parameters in \(baseURI): \(rawPair)")
+            }
+        }
+    }
+
     private static func percentEscapesAreWellFormed(_ raw: String) -> Bool {
         var index = raw.startIndex
         while index < raw.endIndex {
@@ -439,6 +493,11 @@ extension ResourceHandlers {
             index = raw.index(after: second)
         }
         return true
+    }
+
+    private static func readSessionPlan(uri: String, prompt: String) -> ReadResource.Result {
+        let json = encodeJSON(SessionPlanGenerator.plan(prompt: prompt), compact: true)
+        return ReadResource.Result(contents: [.text(json, uri: uri, mimeType: "application/json")])
     }
 
     private static func readStockPlugins(uri: String) -> ReadResource.Result {

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -179,6 +179,12 @@ struct ResourceProvider {
             mimeType: "application/json"
         ),
         Resource.Template(
+            uriTemplate: "logic://workflow-plans/session?prompt={prompt}",
+            name: "Session Plan Dry Run",
+            description: "Planning-only composition/session workflow plan from a natural-language musical prompt",
+            mimeType: "application/json"
+        ),
+        Resource.Template(
             uriTemplate: "logic://workflow-skills/{id}",
             name: "Workflow Skill Detail",
             description: "Single workflow skill by stable ID",

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -124,7 +124,7 @@ struct ServerRuntimePlan: @unchecked Sendable {
 }
 
 /// Main MCP server for Logic Pro integration.
-/// Exposes 9 dispatcher tools + 14 resources + 7 templates, routing through
+/// Exposes 9 dispatcher tools + 14 resources + 8 templates, routing through
 /// the ChannelRouter to the appropriate macOS communication channel.
 actor LogicProServer {
     private let server: Server
@@ -284,7 +284,7 @@ actor LogicProServer {
         }
     }
 
-    // MARK: - Resource Registration (14 resources + 7 templates)
+    // MARK: - Resource Registration (14 resources + 8 templates)
 
     private func registerResources() async {
         let handlers = makeHandlers()

--- a/Sources/LogicProMCP/Workflows/SessionPlanGenerator.swift
+++ b/Sources/LogicProMCP/Workflows/SessionPlanGenerator.swift
@@ -1,0 +1,808 @@
+import Foundation
+
+struct SessionPlan: Codable, Sendable, Equatable {
+    let schema: String
+    let prompt: String
+    let status: String
+    let executionMode: String
+    let parsedIntent: SessionParsedIntent
+    let instrumentCatalog: SessionInstrumentCatalogStatus
+    let sections: [SessionSectionPlan]
+    let chordPlan: [SessionChordPlan]
+    let trackPlan: [SessionTrackPlan]
+    let workflowSteps: [SessionPlanWorkflowStep]
+    let unsupportedOrRiskySteps: [SessionUnsupportedStep]
+    let requiredConfirmations: [SessionPlanConfirmation]
+    let toolSurfaceValidation: SessionToolSurfaceValidation
+    let provenance: [SessionPlanProvenance]
+    let nextSafeAction: String
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case prompt
+        case status
+        case executionMode = "execution_mode"
+        case parsedIntent = "parsed_intent"
+        case instrumentCatalog = "instrument_catalog"
+        case sections
+        case chordPlan = "chord_plan"
+        case trackPlan = "track_plan"
+        case workflowSteps = "workflow_steps"
+        case unsupportedOrRiskySteps = "unsupported_or_risky_steps"
+        case requiredConfirmations = "required_confirmations"
+        case toolSurfaceValidation = "tool_surface_validation"
+        case provenance
+        case nextSafeAction = "next_safe_action"
+    }
+}
+
+struct SessionParsedIntent: Codable, Sendable, Equatable {
+    let tempoBPM: Int
+    let key: String
+    let scale: String
+    let timeSignature: String
+    let genre: String
+    let mood: [String]
+    let totalBars: Int
+    let confidence: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case tempoBPM = "tempo_bpm"
+        case key
+        case scale
+        case timeSignature = "time_signature"
+        case genre
+        case mood
+        case totalBars = "total_bars"
+        case confidence
+    }
+}
+
+struct SessionInstrumentCatalogStatus: Codable, Sendable, Equatable {
+    let status: String
+    let availableResources: [String]
+    let missingResources: [String]
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case availableResources = "available_resources"
+        case missingResources = "missing_resources"
+        case message
+    }
+}
+
+struct SessionSectionPlan: Codable, Sendable, Equatable {
+    let id: String
+    let label: String
+    let startBar: Int
+    let lengthBars: Int
+    let intent: String
+    let provenance: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case startBar = "start_bar"
+        case lengthBars = "length_bars"
+        case intent
+        case provenance
+    }
+}
+
+struct SessionChordPlan: Codable, Sendable, Equatable {
+    let bar: Int
+    let chord: String
+    let romanNumeral: String
+    let durationBars: Int
+    let provenance: String
+
+    enum CodingKeys: String, CodingKey {
+        case bar
+        case chord
+        case romanNumeral = "roman_numeral"
+        case durationBars = "duration_bars"
+        case provenance
+    }
+}
+
+struct SessionTrackPlan: Codable, Sendable, Equatable {
+    let id: String
+    let role: String
+    let suggestedInstrument: String
+    let suggestionSource: String
+    let confidence: String
+    let catalogResource: String?
+    let proposedTrackType: String
+    let reason: String
+    let limitations: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case role
+        case suggestedInstrument = "suggested_instrument"
+        case suggestionSource = "suggestion_source"
+        case confidence
+        case catalogResource = "catalog_resource"
+        case proposedTrackType = "proposed_track_type"
+        case reason
+        case limitations
+    }
+}
+
+struct SessionPlanWorkflowStep: Codable, Sendable, Equatable {
+    let id: String
+    let title: String
+    let tool: String?
+    let command: String?
+    let resource: String?
+    let params: [String: String]
+    let mutates: Bool
+    let executed: Bool
+    let requiresConfirmationLevel: String?
+    let expectedResponseFields: [String]
+    let rationale: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case tool
+        case command
+        case resource
+        case params
+        case mutates
+        case executed
+        case requiresConfirmationLevel = "requires_confirmation_level"
+        case expectedResponseFields = "expected_response_fields"
+        case rationale
+    }
+}
+
+struct SessionUnsupportedStep: Codable, Sendable, Equatable {
+    let operation: String
+    let reason: String
+    let safeAlternative: String
+
+    enum CodingKeys: String, CodingKey {
+        case operation
+        case reason
+        case safeAlternative = "safe_alternative"
+    }
+}
+
+struct SessionPlanConfirmation: Codable, Sendable, Equatable {
+    let level: String
+    let requiredFor: [String]
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case level
+        case requiredFor = "required_for"
+        case message
+    }
+}
+
+struct SessionToolSurfaceValidation: Codable, Sendable, Equatable {
+    let isValid: Bool
+    let checkedCommands: [String]
+    let issues: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case isValid = "is_valid"
+        case checkedCommands = "checked_commands"
+        case issues
+    }
+}
+
+struct SessionPlanProvenance: Codable, Sendable, Equatable {
+    let field: String
+    let source: String
+    let confidence: String
+}
+
+enum SessionPlanGenerator {
+    static let schema = "logic_pro_mcp_session_plan.v1"
+
+    static func plan(prompt rawPrompt: String) -> SessionPlan {
+        let prompt = rawPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = prompt.lowercased()
+        let catalog = instrumentCatalogStatus()
+
+        guard !prompt.isEmpty else {
+            let intent = SessionParsedIntent(
+                tempoBPM: 100,
+                key: "C",
+                scale: "minor",
+                timeSignature: "4/4",
+                genre: "unspecified",
+                mood: [],
+                totalBars: 8,
+                confidence: [
+                    "tempo_bpm": "default",
+                    "key": "default",
+                    "scale": "default",
+                    "time_signature": "default",
+                    "genre": "default",
+                    "total_bars": "default",
+                ]
+            )
+            return buildPlan(
+                prompt: prompt,
+                status: "unsupported",
+                intent: intent,
+                catalog: catalog,
+                unsupported: [
+                    SessionUnsupportedStep(
+                        operation: "empty_prompt",
+                        reason: "A non-empty musical prompt is required for session planning.",
+                        safeAlternative: "Ask for a concrete idea such as '16-bar funk in E minor at 110 BPM'."
+                    ),
+                ]
+            )
+        }
+
+        let intent = parseIntent(prompt: prompt)
+        var unsupported = baseUnsupportedSteps()
+        unsupported.append(contentsOf: thirdPartyUnsupportedSteps(lower))
+        if lower.contains("chord track") {
+            unsupported.append(SessionUnsupportedStep(
+                operation: "direct_chord_track_edit",
+                reason: "This MCP build does not expose direct Chord Track mutation.",
+                safeAlternative: "Use the chord_plan as planning metadata and write MIDI only after explicit confirmation."
+            ))
+        }
+
+        let status = catalog.status == "available" && unsupported.count == baseUnsupportedSteps().count ? "planned" : "degraded"
+        return buildPlan(
+            prompt: prompt,
+            status: status,
+            intent: intent,
+            catalog: catalog,
+            unsupported: unsupported
+        )
+    }
+
+    static func parseIntent(prompt: String) -> SessionParsedIntent {
+        let lower = prompt.lowercased()
+        var confidence: [String: String] = [:]
+
+        let genre = detectGenre(lower)
+        confidence["genre"] = genre == "unspecified" ? "default" : "prompt"
+
+        let tempo: Int
+        if let capturedTempo = capture(#"(\d{2,3})\s*(?:bpm|BPM)"#, in: prompt).first,
+           let bpm = Int(capturedTempo),
+           (40...240).contains(bpm) {
+            tempo = bpm
+            confidence["tempo_bpm"] = "prompt"
+        } else {
+            tempo = defaultTempo(for: genre)
+            confidence["tempo_bpm"] = "genre_default"
+        }
+
+        let bars: Int
+        if let capturedBars = capture(#"(\d{1,3})\s*[- ]?\s*bar"#, in: lower).first,
+           let parsedBars = Int(capturedBars),
+           (1...128).contains(parsedBars) {
+            bars = parsedBars
+            confidence["total_bars"] = "prompt"
+        } else {
+            bars = 16
+            confidence["total_bars"] = "default"
+        }
+
+        let keyScale = detectKeyAndScale(prompt)
+        confidence["key"] = keyScale.source
+        confidence["scale"] = keyScale.source
+
+        let timeSignature: String
+        if let capturedTime = capture(#"\b(\d{1,2}/\d{1,2})\b"#, in: prompt).first {
+            timeSignature = capturedTime
+            confidence["time_signature"] = "prompt"
+        } else {
+            timeSignature = "4/4"
+            confidence["time_signature"] = "default"
+        }
+
+        return SessionParsedIntent(
+            tempoBPM: tempo,
+            key: keyScale.key,
+            scale: keyScale.scale,
+            timeSignature: timeSignature,
+            genre: genre,
+            mood: detectMood(lower),
+            totalBars: bars,
+            confidence: confidence
+        )
+    }
+
+    static func sections(for totalBars: Int, genre: String) -> [SessionSectionPlan] {
+        if totalBars <= 8 {
+            return [
+                SessionSectionPlan(
+                    id: "section.loop",
+                    label: "Loop",
+                    startBar: 1,
+                    lengthBars: totalBars,
+                    intent: "\(genre) core groove",
+                    provenance: "heuristic"
+                ),
+            ]
+        }
+
+        if totalBars == 16 {
+            return [
+                section("intro", "Intro", 1, 4, "Establish pulse and harmonic identity"),
+                section("a", "Groove A", 5, 8, "Main motif and full rhythm section"),
+                section("turnaround", "Turnaround", 13, 4, "Variation or fill leading back to loop"),
+            ]
+        }
+
+        if totalBars >= 32 {
+            return [
+                section("intro", "Intro", 1, 4, "Establish texture"),
+                section("a", "Section A", 5, 8, "Main theme"),
+                section("b", "Section B", 13, 8, "Contrast or lift"),
+                section("build", "Build", 21, 8, "Add intensity and register"),
+                section("outro", "Outro", 29, max(4, totalBars - 28), "Resolve or loop out"),
+            ]
+        }
+
+        var result: [SessionSectionPlan] = []
+        var start = 1
+        var index = 1
+        while start <= totalBars {
+            let length = min(4, totalBars - start + 1)
+            result.append(section("part_\(index)", "Part \(index)", start, length, "Four-bar phrase block"))
+            start += length
+            index += 1
+        }
+        return result
+    }
+
+    static func chordPlan(for intent: SessionParsedIntent) -> [SessionChordPlan] {
+        let progression = chordProgression(key: intent.key, scale: intent.scale)
+        return (0..<intent.totalBars).map { offset in
+            let chord = progression[offset % progression.count]
+            return SessionChordPlan(
+                bar: offset + 1,
+                chord: chord.symbol,
+                romanNumeral: chord.roman,
+                durationBars: 1,
+                provenance: "heuristic_\(intent.scale)_diatonic_loop"
+            )
+        }
+    }
+
+    static func trackPlan(for prompt: String, intent: SessionParsedIntent, catalog: SessionInstrumentCatalogStatus) -> [SessionTrackPlan] {
+        roles(for: prompt, genre: intent.genre).enumerated().map { index, role in
+            track(role: role, index: index + 1, catalog: catalog)
+        }
+    }
+
+    static func validateWorkflowSteps(_ steps: [SessionPlanWorkflowStep]) -> SessionToolSurfaceValidation {
+        var checked: [String] = []
+        var issues: [String] = []
+
+        for step in steps {
+            guard let tool = step.tool, let command = step.command else { continue }
+            let key = "\(tool).\(command)"
+            checked.append(key)
+            if WorkflowSkillCatalog.publicCommands[tool]?.contains(command) != true {
+                issues.append("unknown public command: \(key)")
+            }
+            if step.mutates && step.requiresConfirmationLevel == nil {
+                issues.append("mutating step \(step.id) lacks confirmation metadata")
+            }
+            if step.executed {
+                issues.append("planning-only step \(step.id) must not be marked executed")
+            }
+        }
+
+        return SessionToolSurfaceValidation(
+            isValid: issues.isEmpty,
+            checkedCommands: checked.sorted(),
+            issues: issues
+        )
+    }
+
+    private static func buildPlan(
+        prompt: String,
+        status: String,
+        intent: SessionParsedIntent,
+        catalog: SessionInstrumentCatalogStatus,
+        unsupported: [SessionUnsupportedStep]
+    ) -> SessionPlan {
+        let sections = sections(for: intent.totalBars, genre: intent.genre)
+        let chords = chordPlan(for: intent)
+        let tracks = trackPlan(for: prompt, intent: intent, catalog: catalog)
+        let steps = workflowSteps(for: intent, tracks: tracks)
+        let validation = validateWorkflowSteps(steps)
+
+        return SessionPlan(
+            schema: schema,
+            prompt: prompt,
+            status: validation.isValid ? status : "unsupported",
+            executionMode: "dry_run_only",
+            parsedIntent: intent,
+            instrumentCatalog: catalog,
+            sections: sections,
+            chordPlan: chords,
+            trackPlan: tracks,
+            workflowSteps: steps,
+            unsupportedOrRiskySteps: unsupported,
+            requiredConfirmations: confirmations(for: steps),
+            toolSurfaceValidation: validation,
+            provenance: [
+                SessionPlanProvenance(field: "parsed_intent", source: "prompt_plus_heuristics", confidence: "mixed"),
+                SessionPlanProvenance(field: "sections", source: "deterministic_arrangement_heuristic", confidence: "medium"),
+                SessionPlanProvenance(field: "chord_plan", source: "diatonic_progression_heuristic", confidence: "medium"),
+                SessionPlanProvenance(field: "workflow_steps", source: "current_mcp_public_command_census", confidence: "high"),
+            ],
+            nextSafeAction: "review_plan"
+        )
+    }
+
+    private static func workflowSteps(for intent: SessionParsedIntent, tracks: [SessionTrackPlan]) -> [SessionPlanWorkflowStep] {
+        var steps: [SessionPlanWorkflowStep] = [
+            readStep("read_health", "Read MCP and Logic health", "logic://system/health", ["channels", "permissions"]),
+            readStep("read_project", "Read current project metadata", "logic://project/info", ["data", "source"]),
+            readStep("read_tracks", "Read current tracks before any optional mutation", "logic://tracks", ["data"]),
+            toolStep(
+                "propose_tempo",
+                "Optionally set project tempo after plan review",
+                "logic_transport",
+                "set_tempo",
+                ["tempo": "\(intent.tempoBPM)"],
+                true,
+                "L1",
+                ["success", "verified"],
+                "Tempo write is proposed only; this resource does not call the tool."
+            ),
+        ]
+
+        for track in tracks {
+            if track.proposedTrackType == "drummer" {
+                steps.append(toolStep(
+                    "propose_create_\(track.id)",
+                    "Optionally create \(track.role) Drummer track",
+                    "logic_tracks",
+                    "create_drummer",
+                    [:],
+                    true,
+                    "L1",
+                    ["success", "verified", "created_track"],
+                    "Track creation is proposed only and requires user confirmation."
+                ))
+            } else {
+                steps.append(toolStep(
+                    "propose_create_\(track.id)",
+                    "Optionally create \(track.role) software instrument track",
+                    "logic_tracks",
+                    "create_instrument",
+                    [:],
+                    true,
+                    "L1",
+                    ["success", "verified", "created_track"],
+                    "Track creation is proposed only and requires user confirmation."
+                ))
+                steps.append(toolStep(
+                    "propose_assign_\(track.id)",
+                    "Optionally assign \(track.suggestedInstrument)",
+                    "logic_tracks",
+                    "set_instrument",
+                    ["path": track.suggestedInstrument],
+                    true,
+                    "L1",
+                    ["success", "verified"],
+                    "Instrument assignment must be attempted only after resolving a valid library path."
+                ))
+            }
+        }
+
+        steps.append(toolStep(
+            "propose_import_midi",
+            "Optionally import caller-generated MIDI after review",
+            "logic_midi",
+            "import_file",
+            ["source": "caller_generated_smf", "bar": "1"],
+            true,
+            "L1",
+            ["success", "verified"],
+            "This planner does not generate or import a MIDI file; it only proposes a later guarded step."
+        ))
+        return steps
+    }
+
+    private static func confirmations(for steps: [SessionPlanWorkflowStep]) -> [SessionPlanConfirmation] {
+        let l1 = Set(steps.compactMap { step in
+            step.mutates && step.requiresConfirmationLevel == "L1" ? step.command : nil
+        }).sorted()
+        guard !l1.isEmpty else { return [] }
+        return [
+            SessionPlanConfirmation(
+                level: "L1",
+                requiredFor: l1,
+                message: "Review the dry-run plan, target project, target tracks, generated MIDI, and readback expectations before any mutation."
+            ),
+        ]
+    }
+
+    private static func readStep(_ id: String, _ title: String, _ resource: String, _ fields: [String]) -> SessionPlanWorkflowStep {
+        SessionPlanWorkflowStep(
+            id: id,
+            title: title,
+            tool: nil,
+            command: nil,
+            resource: resource,
+            params: [:],
+            mutates: false,
+            executed: false,
+            requiresConfirmationLevel: nil,
+            expectedResponseFields: fields,
+            rationale: "Read-only context required before deciding whether to execute the plan."
+        )
+    }
+
+    private static func toolStep(
+        _ id: String,
+        _ title: String,
+        _ tool: String,
+        _ command: String,
+        _ params: [String: String],
+        _ mutates: Bool,
+        _ level: String?,
+        _ fields: [String],
+        _ rationale: String
+    ) -> SessionPlanWorkflowStep {
+        SessionPlanWorkflowStep(
+            id: id,
+            title: title,
+            tool: tool,
+            command: command,
+            resource: nil,
+            params: params,
+            mutates: mutates,
+            executed: false,
+            requiresConfirmationLevel: level,
+            expectedResponseFields: fields,
+            rationale: rationale
+        )
+    }
+
+    private static func instrumentCatalogStatus() -> SessionInstrumentCatalogStatus {
+        let staticResources = Set(ResourceProvider.resources.map(\.uri))
+        let templates = Set(ResourceProvider.templates.map(\.uriTemplate))
+        let required = [
+            "logic://stock-instruments",
+            "logic://session-players",
+            "logic://stock-instruments/{id}",
+            "logic://session-players/{id}",
+        ]
+        let available = required.filter { staticResources.contains($0) || templates.contains($0) }
+        let missing = required.filter { !available.contains($0) }
+        return SessionInstrumentCatalogStatus(
+            status: missing.isEmpty ? "available" : "degraded_unavailable",
+            availableResources: available,
+            missingResources: missing,
+            message: missing.isEmpty
+                ? "Issue #31 instrument catalog resources are available for catalog-backed suggestions."
+                : "Issue #31 instrument catalog resources are not served by this build; suggestions are heuristic and explicitly degraded."
+        )
+    }
+
+    private static func detectGenre(_ lower: String) -> String {
+        let genres: [(String, [String])] = [
+            ("lo-fi", ["lo-fi", "lofi"]),
+            ("hip hop", ["hip hop", "hip-hop", "boom bap"]),
+            ("cinematic", ["cinematic", "film", "score", "cue"]),
+            ("funk", ["funk"]),
+            ("techno", ["techno"]),
+            ("house", ["house"]),
+            ("ambient", ["ambient"]),
+            ("rock", ["rock"]),
+            ("pop", ["pop"]),
+            ("jazz", ["jazz"]),
+            ("trap", ["trap"]),
+        ]
+        return genres.first { _, aliases in aliases.contains { lower.contains($0) } }?.0 ?? "unspecified"
+    }
+
+    private static func defaultTempo(for genre: String) -> Int {
+        switch genre {
+        case "lo-fi": return 75
+        case "hip hop": return 88
+        case "cinematic": return 90
+        case "funk": return 110
+        case "techno": return 140
+        case "house": return 124
+        case "ambient": return 80
+        case "trap": return 140
+        default: return 100
+        }
+    }
+
+    private static func detectMood(_ lower: String) -> [String] {
+        ["dark", "bright", "warm", "aggressive", "soft", "dreamy", "uplifting", "moody", "minimal"]
+            .filter { lower.contains($0) }
+    }
+
+    private static func detectKeyAndScale(_ prompt: String) -> (key: String, scale: String, source: String) {
+        let pattern = #"(?:in\s+)?([A-Ga-g](?:#|b|♭)?)[ -]?(major|minor|maj|min)\b"#
+        let captures = capture(pattern, in: prompt)
+        guard captures.count >= 2 else {
+            return ("C", "minor", "default")
+        }
+        let key = normalizeKey(captures[0])
+        let scale = captures[1].lowercased().hasPrefix("maj") ? "major" : "minor"
+        return (key, scale, "prompt")
+    }
+
+    private static func roles(for prompt: String, genre: String) -> [String] {
+        let lower = prompt.lowercased()
+        var roles: [String] = []
+        func add(_ role: String) {
+            if !roles.contains(role) { roles.append(role) }
+        }
+
+        if lower.contains("drum") || lower.contains("beat") || lower.contains("kick") { add("drums") }
+        if lower.contains("percussion") { add("percussion") }
+        if lower.contains("bass") { add("bass") }
+        if lower.contains("guitar") { add("guitar") }
+        if lower.contains("keys") || lower.contains("piano") || lower.contains("keyboard") { add("keys") }
+        if lower.contains("string") { add("strings") }
+        if lower.contains("brass") || lower.contains("horn") { add("brass") }
+        if lower.contains("pad") { add("pad") }
+        if lower.contains("synth") || lower.contains("lead") { add("synth") }
+
+        if roles.isEmpty {
+            switch genre {
+            case "cinematic":
+                roles = ["strings", "brass", "percussion"]
+            case "funk":
+                roles = ["drums", "bass", "guitar", "keys"]
+            case "lo-fi", "hip hop":
+                roles = ["drums", "bass", "keys"]
+            case "techno", "house", "trap":
+                roles = ["drums", "bass", "synth"]
+            default:
+                roles = ["drums", "bass", "keys"]
+            }
+        }
+        return roles
+    }
+
+    private static func track(role: String, index: Int, catalog: SessionInstrumentCatalogStatus) -> SessionTrackPlan {
+        let source = catalog.status == "available" ? "catalog_reference" : "heuristic_degraded"
+        let confidence = catalog.status == "available" ? "medium" : "low"
+        let spec: (instrument: String, resource: String?, type: String, limitations: [String])
+        switch role {
+        case "drums":
+            spec = ("Drummer", "logic://session-players/logic.session_player.drummer", "drummer", ["Drummer performance controls are not directly editable by this plan."])
+        case "percussion":
+            spec = ("Drum Machine Designer", "logic://stock-instruments/logic.stock.instrument.drum_machine_designer", "software_instrument", [])
+        case "bass":
+            spec = ("Studio Bass", "logic://stock-instruments/logic.stock.instrument.studio_bass", "software_instrument", [])
+        case "guitar":
+            spec = ("Manual Library guitar patch", nil, "software_instrument", ["No catalog-backed stock guitar instrument is available in this build."])
+        case "keys":
+            spec = ("Vintage Electric Piano", "logic://stock-instruments/logic.stock.instrument.vintage_electric_piano", "software_instrument", [])
+        case "strings":
+            spec = ("Studio Strings", "logic://stock-instruments/logic.stock.instrument.studio_strings", "software_instrument", [])
+        case "brass":
+            spec = ("Studio Horns", "logic://stock-instruments/logic.stock.instrument.studio_horns", "software_instrument", [])
+        case "pad", "synth":
+            spec = ("Alchemy", "logic://stock-instruments/logic.stock.instrument.alchemy", "software_instrument", [])
+        default:
+            spec = ("Software Instrument", nil, "software_instrument", ["Role has no specific catalog-backed instrument suggestion."])
+        }
+
+        return SessionTrackPlan(
+            id: "track_\(index)_\(role.replacingOccurrences(of: " ", with: "_"))",
+            role: role,
+            suggestedInstrument: spec.instrument,
+            suggestionSource: source,
+            confidence: confidence,
+            catalogResource: spec.resource,
+            proposedTrackType: spec.type,
+            reason: "Matched role '\(role)' from prompt or genre heuristic.",
+            limitations: spec.limitations + (catalog.status == "available" ? [] : ["Instrument catalog #31 is unavailable in this build; verify manually before assigning patches."])
+        )
+    }
+
+    private static func baseUnsupportedSteps() -> [SessionUnsupportedStep] {
+        [
+            SessionUnsupportedStep(
+                operation: "execute_plan",
+                reason: "This resource is planning-only and never calls mutating tools.",
+                safeAlternative: "Review the plan, then call individual MCP tools with explicit confirmations."
+            ),
+            SessionUnsupportedStep(
+                operation: "automatic_preset_loading",
+                reason: "Arbitrary preset loading is not verified by this dry-run resource.",
+                safeAlternative: "Resolve a library path first, then use logic_tracks.set_instrument only after confirmation and readback planning."
+            ),
+        ]
+    }
+
+    private static func thirdPartyUnsupportedSteps(_ lower: String) -> [SessionUnsupportedStep] {
+        let names = ["serum", "kontakt", "omnisphere", "vital", "fabfilter", "third-party", "third party"]
+        guard names.contains(where: { lower.contains($0) }) else { return [] }
+        return [
+            SessionUnsupportedStep(
+                operation: "third_party_plugin_or_instrument",
+                reason: "This planner only references current Logic Pro MCP public surfaces and does not recommend third-party plugins without catalog provenance.",
+                safeAlternative: "Use stock or manually verified instruments, or add a provenance-backed catalog first."
+            ),
+        ]
+    }
+
+    private static func section(_ id: String, _ label: String, _ start: Int, _ length: Int, _ intent: String) -> SessionSectionPlan {
+        SessionSectionPlan(id: "section.\(id)", label: label, startBar: start, lengthBars: length, intent: intent, provenance: "heuristic")
+    }
+
+    private static func chordProgression(key: String, scale: String) -> [(symbol: String, roman: String)] {
+        if scale == "major" {
+            return [
+                (chord(key, minor: false), "I"),
+                (chord(transpose(key, by: 7), minor: false), "V"),
+                (chord(transpose(key, by: 9), minor: true), "vi"),
+                (chord(transpose(key, by: 5), minor: false), "IV"),
+            ]
+        }
+        return [
+            (chord(key, minor: true), "i"),
+            (chord(transpose(key, by: 8), minor: false), "VI"),
+            (chord(transpose(key, by: 3), minor: false), "III"),
+            (chord(transpose(key, by: 10), minor: false), "VII"),
+        ]
+    }
+
+    private static func chord(_ root: String, minor: Bool) -> String {
+        minor ? "\(root)m" : root
+    }
+
+    private static func transpose(_ key: String, by semitones: Int) -> String {
+        let normalized = normalizeKey(key)
+        let preferFlats = normalized.contains("b") || ["F", "Bb", "Eb", "Ab", "Db", "Gb"].contains(normalized)
+        let names = preferFlats
+            ? ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
+            : ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        let next = (pitchClass(normalized) + semitones + 12) % 12
+        return names[next]
+    }
+
+    private static func pitchClass(_ key: String) -> Int {
+        [
+            "C": 0, "B#": 0,
+            "C#": 1, "Db": 1,
+            "D": 2,
+            "D#": 3, "Eb": 3,
+            "E": 4, "Fb": 4,
+            "F": 5, "E#": 5,
+            "F#": 6, "Gb": 6,
+            "G": 7,
+            "G#": 8, "Ab": 8,
+            "A": 9,
+            "A#": 10, "Bb": 10,
+            "B": 11, "Cb": 11,
+        ][normalizeKey(key), default: 0]
+    }
+
+    private static func normalizeKey(_ raw: String) -> String {
+        let replaced = raw.replacingOccurrences(of: "♭", with: "b")
+        guard let first = replaced.first else { return "C" }
+        return String(first).uppercased() + replaced.dropFirst()
+    }
+
+    private static func capture(_ pattern: String, in text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range) else { return [] }
+        return (1..<match.numberOfRanges).compactMap { index in
+            let matchRange = match.range(at: index)
+            guard let range = Range(matchRange, in: text) else { return nil }
+            return String(text[range])
+        }
+    }
+}

--- a/Sources/LogicProMCP/Workflows/SessionPlanGenerator.swift
+++ b/Sources/LogicProMCP/Workflows/SessionPlanGenerator.swift
@@ -270,7 +270,7 @@ enum SessionPlanGenerator {
         confidence["genre"] = genre == "unspecified" ? "default" : "prompt"
 
         let tempo: Int
-        if let capturedTempo = capture(#"(\d{2,3})\s*(?:bpm|BPM)"#, in: prompt).first,
+        if let capturedTempo = capture(#"(?<!\d)(\d{1,4})\s*bpm\b"#, in: lower).first,
            let bpm = Int(capturedTempo),
            (40...240).contains(bpm) {
             tempo = bpm
@@ -281,7 +281,7 @@ enum SessionPlanGenerator {
         }
 
         let bars: Int
-        if let capturedBars = capture(#"(\d{1,3})\s*[- ]?\s*bar"#, in: lower).first,
+        if let capturedBars = capture(#"\b(\d{1,3})\s*[- ]?\s*bars?\b"#, in: lower).first,
            let parsedBars = Int(capturedBars),
            (1...128).contains(parsedBars) {
             bars = parsedBars
@@ -296,7 +296,8 @@ enum SessionPlanGenerator {
         confidence["scale"] = keyScale.source
 
         let timeSignature: String
-        if let capturedTime = capture(#"\b(\d{1,2}/\d{1,2})\b"#, in: prompt).first {
+        if let capturedTime = capture(#"\b(\d{1,2}/\d{1,2})\b"#, in: prompt).first,
+           isValidTimeSignature(capturedTime) {
             timeSignature = capturedTime
             confidence["time_signature"] = "prompt"
         } else {
@@ -623,12 +624,30 @@ enum SessionPlanGenerator {
     }
 
     private static func detectMood(_ lower: String) -> [String] {
-        ["dark", "bright", "warm", "aggressive", "soft", "dreamy", "uplifting", "moody", "minimal"]
-            .filter { lower.contains($0) }
+        // Word-boundary match so unrelated words ("software", "warmth") cannot inject
+        // a phantom mood the user never expressed.
+        let moods = ["dark", "bright", "warm", "aggressive", "soft", "dreamy", "uplifting", "moody", "minimal"]
+        return moods.filter { mood in
+            !capture(#"\b("# + mood + #")\b"#, in: lower).isEmpty
+        }
+    }
+
+    private static func isValidTimeSignature(_ value: String) -> Bool {
+        let parts = value.split(separator: "/", maxSplits: 1)
+        guard parts.count == 2,
+              let numerator = Int(parts[0]),
+              let denominator = Int(parts[1]) else {
+            return false
+        }
+        return numerator > 0 && [1, 2, 4, 8, 16].contains(denominator)
     }
 
     private static func detectKeyAndScale(_ prompt: String) -> (key: String, scale: String, source: String) {
-        let pattern = #"(?:in\s+)?([A-Ga-g](?:#|b|♭)?)[ -]?(major|minor|maj|min)\b"#
+        // Require an explicit "in <key> <scale>" form so adjectives ending in a note
+        // letter (harmonic/melodic/dramatic minor) cannot produce a phantom key with
+        // high "prompt" confidence. A leading \b and a mandatory separator stop the
+        // note-letter from being clipped out of the middle of a word.
+        let pattern = #"\bin\s+([A-Ga-g](?:#|b|♭)?)[ -](major|minor|maj|min)\b"#
         let captures = capture(pattern, in: prompt)
         guard captures.count >= 2 else {
             return ("C", "minor", "default")

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -423,6 +423,7 @@ enum WorkflowSkillCatalog {
             midiIdeaSketch(),
             arrangementMarkerPlan(),
             gainStagingPrep(),
+            compositionSessionPlan(),
             stockPluginChainPlan(),
             stockPluginGuardedInsert(),
             bounceReadiness(),
@@ -743,6 +744,46 @@ enum WorkflowSkillCatalog {
                 "set_pan is a relative V-Pot write on the MCU path (pan_write_mode: relative_vpot); do not treat it as an absolute target setter.",
             ],
             mutationKind: .guardedMutation
+        )
+    }
+
+    private static func compositionSessionPlan() -> WorkflowSkill {
+        makeWorkflow(
+            id: "logic.workflow.composition.session_plan",
+            title: "Planning-Only Composition Session Plan",
+            intent: "Turn a natural-language musical prompt into a structured, non-mutating Logic session plan.",
+            scope: "Dry-run resource read only; proposes later MCP steps but never executes tools.",
+            prerequisites: ["Natural-language musical prompt", "Client reviews plan before any mutation"],
+            allowedTools: [],
+            allowedResources: ["logic://workflow-plans/session?prompt={prompt}"],
+            requiredConfirmations: [],
+            stateChecks: [
+                stateCheck("session_plan", "logic://workflow-plans/session?prompt={prompt}", ["schema", "parsed_intent", "workflow_steps"], true),
+            ],
+            steps: [
+                readStep(
+                    "read_session_plan",
+                    "Generate dry-run session plan from prompt",
+                    "logic://workflow-plans/session?prompt={prompt}",
+                    ["schema", "parsed_intent", "sections", "chord_plan", "track_plan", "workflow_steps"]
+                ),
+            ],
+            verification: WorkflowVerification(
+                evidence: ["resource_json", "tool_surface_validation", "executed_false_on_all_steps"],
+                successFields: ["schema", "status", "tool_surface_validation", "next_safe_action"],
+                liveEvidenceFile: nil
+            ),
+            failureModes: ["empty prompt", "unsupported prompt request", "degraded instrument catalog dependency", "invalid proposed command census"],
+            rollbackOrRecovery: "No rollback required; planning resource is read-only and reports proposed steps with executed:false.",
+            evidenceLevel: .deterministic,
+            productionReady: true,
+            dependsOn: [],
+            limitations: [
+                "Does not create projects, tracks, regions, MIDI files, or audio.",
+                "Instrument suggestions degrade to heuristics until Issue #31 catalog resources are served.",
+                "Musical choices are heuristic planning aids, not verified musical truth.",
+            ],
+            mutationKind: .readOnly
         )
     }
 

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -780,6 +780,17 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect((schemaJSON?["evidence_levels"] as? [String])?.contains("live_verified") == true)
 }
 
+@Test func testE2EResourceSessionPlanIsDryRunOnly() async throws {
+    let h = await makeE2EHandlers()
+    let plan = try await h.readResource(.init(uri: "logic://workflow-plans/session?prompt=16-bar%20funk%20in%20E%20minor%20at%20110%20BPM%20with%20drums%2C%20bass%2C%20guitar%2C%20and%20keys"))
+
+    let json = e2eJSON(e2eResourceText(plan))
+    #expect(json?["schema"] as? String == SessionPlanGenerator.schema)
+    #expect(json?["execution_mode"] as? String == "dry_run_only")
+    #expect((json?["parsed_intent"] as? [String: Any])?["tempo_bpm"] as? Int == 110)
+    #expect((json?["workflow_steps"] as? [[String: Any]])?.allSatisfy { $0["executed"] as? Bool == false } == true)
+}
+
 @Test func testE2EResourceHealthMatchesToolHealth() async throws {
     let h = await makeE2EHandlers()
     let resourceResult = try await h.readResource(.init(uri: "logic://system/health"))
@@ -860,6 +871,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
+        "logic://workflow-plans/session?prompt={prompt}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
     ]

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -788,7 +788,8 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect(json?["schema"] as? String == SessionPlanGenerator.schema)
     #expect(json?["execution_mode"] as? String == "dry_run_only")
     #expect((json?["parsed_intent"] as? [String: Any])?["tempo_bpm"] as? Int == 110)
-    #expect((json?["workflow_steps"] as? [[String: Any]])?.allSatisfy { $0["executed"] as? Bool == false } == true)
+    let workflowSteps = try #require(json?["workflow_steps"] as? [[String: Any]])
+    #expect(workflowSteps.allSatisfy { ($0["executed"] as? Bool) == .some(false) })
 }
 
 @Test func testE2EResourceHealthMatchesToolHealth() async throws {

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -53,6 +53,7 @@ private let serverResourceText = sharedResourceText
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
+        "logic://workflow-plans/session?prompt={prompt}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
     ]

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -409,6 +409,7 @@ private func waitForFeedbackEvents(
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
+        "logic://workflow-plans/session?prompt={prompt}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
     ]

--- a/Tests/LogicProMCPTests/ResourceProviderTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProviderTests.swift
@@ -40,6 +40,7 @@ struct ResourceProviderTests {
         #expect(uris.contains("logic://mixer/{strip}"))
         #expect(uris.contains("logic://stock-plugins/{id}"))
         #expect(uris.contains("logic://stock-plugins/search?query={query}"))
+        #expect(uris.contains("logic://workflow-plans/session?prompt={prompt}"))
         #expect(uris.contains("logic://workflow-skills/{id}"))
         #expect(uris.contains("logic://workflow-skills/search?query={query}"))
     }
@@ -71,6 +72,7 @@ struct ResourceProviderTests {
             "logic://tracks/0",
             "logic://tracks/0/regions",
             "logic://mixer/0",
+            "logic://workflow-plans/session?prompt=16-bar%20funk%20in%20E%20minor%20at%20110%20BPM",
         ]
         for uri in probes {
             do {

--- a/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
@@ -8,12 +8,12 @@ private func sessionPlanResourceObject(_ uri: String) async throws -> [String: A
     return try #require(sharedJSONObject(sharedResourceText(result)))
 }
 
-private func sessionPlanResourceThrows(_ uri: String) async -> Bool {
+private func sessionPlanResourceError(_ uri: String) async -> Error? {
     do {
         _ = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
-        return false
+        return nil
     } catch {
-        return true
+        return error
     }
 }
 
@@ -52,6 +52,78 @@ struct SessionPlanParsingTests {
         #expect(intent.genre == "cinematic")
         #expect(intent.key == "D")
         #expect(intent.scale == "minor")
+    }
+
+    @Test("tempo extraction is case-insensitive and honors mixed-case BPM")
+    func tempoCaseInsensitive() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "techno at 100 Bpm")
+
+        #expect(intent.tempoBPM == 100)
+        #expect(intent.confidence["tempo_bpm"] == "prompt")
+    }
+
+    @Test("out-of-range tempo falls back to the genre default, never false prompt confidence")
+    func tempoOutOfRangeFallsBack() {
+        // 140 is the techno genre default; the explicit (out-of-range) tempo must be dropped.
+        let truncated = SessionPlanGenerator.parseIntent(prompt: "1200 BPM techno")
+        #expect(truncated.tempoBPM == 140)
+        #expect(truncated.confidence["tempo_bpm"] == "genre_default")
+
+        let tooFast = SessionPlanGenerator.parseIntent(prompt: "make it 300 bpm techno")
+        #expect(tooFast.tempoBPM == 140)
+        #expect(tooFast.confidence["tempo_bpm"] == "genre_default")
+    }
+
+    @Test("adjectives ending in a note letter never produce a phantom key")
+    func phantomKeyRejected() {
+        for prompt in ["harmonic minor lead", "a dramatic minor piece", "melodic minor", "epic major cue"] {
+            let intent = SessionPlanGenerator.parseIntent(prompt: prompt)
+            #expect(intent.confidence["key"] == "default", "\(prompt) must not yield prompt-confidence key")
+            #expect(intent.confidence["scale"] == "default", "\(prompt) must not yield prompt-confidence scale")
+            #expect(intent.key == "C")
+            #expect(intent.scale == "minor")
+        }
+    }
+
+    @Test("bar regex anchors so substrings and word prefixes do not match")
+    func barRegexAnchored() {
+        let prefix = SessionPlanGenerator.parseIntent(prompt: "make it 8 barely audible bars")
+        #expect(prefix.totalBars == 16)
+        #expect(prefix.confidence["total_bars"] == "default")
+
+        let digitSubstring = SessionPlanGenerator.parseIntent(prompt: "1280 bars of funk")
+        #expect(digitSubstring.totalBars == 16)
+        #expect(digitSubstring.confidence["total_bars"] == "default")
+
+        let barreCollision = SessionPlanGenerator.parseIntent(prompt: "120 barre chords over 16 bars")
+        #expect(barreCollision.totalBars == 16)
+        #expect(barreCollision.confidence["total_bars"] == "prompt")
+
+        let plain = SessionPlanGenerator.parseIntent(prompt: "32 bars of techno")
+        #expect(plain.totalBars == 32)
+        #expect(plain.confidence["total_bars"] == "prompt")
+    }
+
+    @Test("invalid time signatures fall back to 4/4 with default confidence")
+    func invalidTimeSignatureFallsBack() {
+        let zeroDenominator = SessionPlanGenerator.parseIntent(prompt: "funk in 7/0 time")
+        #expect(zeroDenominator.timeSignature == "4/4")
+        #expect(zeroDenominator.confidence["time_signature"] == "default")
+
+        let nonsense = SessionPlanGenerator.parseIntent(prompt: "99/99 time funk")
+        #expect(nonsense.timeSignature == "4/4")
+        #expect(nonsense.confidence["time_signature"] == "default")
+
+        let valid = SessionPlanGenerator.parseIntent(prompt: "waltz in 3/4 time")
+        #expect(valid.timeSignature == "3/4")
+        #expect(valid.confidence["time_signature"] == "prompt")
+    }
+
+    @Test("mood detection matches whole words only")
+    func moodWordBoundary() {
+        #expect(SessionPlanGenerator.parseIntent(prompt: "a software synth track").mood.isEmpty)
+        #expect(SessionPlanGenerator.parseIntent(prompt: "warmth pads everywhere").mood.isEmpty)
+        #expect(SessionPlanGenerator.parseIntent(prompt: "soft warm dreamy pad").mood == ["warm", "soft", "dreamy"])
     }
 }
 
@@ -120,6 +192,145 @@ struct SessionPlanSafetyTests {
         #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "third_party_plugin_or_instrument" })
         #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "execute_plan" })
     }
+
+    @Test("empty and whitespace prompts return the unsupported planning-only contract")
+    func emptyPromptBranchIsLocked() {
+        for prompt in ["", "   \n\t"] {
+            let plan = SessionPlanGenerator.plan(prompt: prompt)
+            #expect(plan.status == "unsupported", "prompt \"\(prompt)\" must be unsupported")
+            #expect(plan.executionMode == "dry_run_only")
+            #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "empty_prompt" })
+            #expect(plan.workflowSteps.allSatisfy { !$0.executed })
+        }
+    }
+
+    @Test("validateWorkflowSteps rejects an unknown public command")
+    func validationRejectsUnknownCommand() {
+        let step = SessionPlanWorkflowStep(
+            id: "bad_command",
+            title: "Unknown command",
+            tool: "logic_tracks",
+            command: "definitely_not_a_real_command",
+            resource: nil,
+            params: [:],
+            mutates: true,
+            executed: false,
+            requiresConfirmationLevel: "L1",
+            expectedResponseFields: [],
+            rationale: "test"
+        )
+        let result = SessionPlanGenerator.validateWorkflowSteps([step])
+
+        #expect(!result.isValid)
+        #expect(result.issues.contains { $0.hasPrefix("unknown public command:") })
+    }
+
+    @Test("validateWorkflowSteps rejects a mutating step lacking confirmation metadata")
+    func validationRejectsMissingConfirmation() {
+        let step = SessionPlanWorkflowStep(
+            id: "no_confirm",
+            title: "Mutating without confirmation",
+            tool: "logic_transport",
+            command: "set_tempo",
+            resource: nil,
+            params: ["tempo": "120"],
+            mutates: true,
+            executed: false,
+            requiresConfirmationLevel: nil,
+            expectedResponseFields: [],
+            rationale: "test"
+        )
+        let result = SessionPlanGenerator.validateWorkflowSteps([step])
+
+        #expect(!result.isValid)
+        #expect(result.issues.contains { $0.contains("lacks confirmation metadata") })
+    }
+
+    @Test("validateWorkflowSteps rejects a step marked executed — the last line of defense")
+    func validationRejectsExecutedStep() {
+        let step = SessionPlanWorkflowStep(
+            id: "already_run",
+            title: "Marked executed",
+            tool: "logic_transport",
+            command: "set_tempo",
+            resource: nil,
+            params: ["tempo": "120"],
+            mutates: true,
+            executed: true,
+            requiresConfirmationLevel: "L1",
+            expectedResponseFields: [],
+            rationale: "test"
+        )
+        let result = SessionPlanGenerator.validateWorkflowSteps([step])
+
+        #expect(!result.isValid)
+        #expect(result.issues.contains { $0.contains("must not be marked executed") })
+    }
+}
+
+@Suite("Session plan generator — adversarial intent parsing")
+struct SessionPlanAdversarialTests {
+    @Test("empty and whitespace prompts are deterministic, unsupported, and non-mutating")
+    func emptyAndWhitespacePrompts() {
+        for prompt in ["", "   "] {
+            let plan = SessionPlanGenerator.plan(prompt: prompt)
+            #expect(plan.status == "unsupported")
+            #expect(plan.executionMode == "dry_run_only")
+            #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "empty_prompt" })
+            #expect(plan.workflowSteps.allSatisfy { !$0.executed })
+        }
+    }
+
+    @Test("a multi-kilobyte prompt parses into a bounded, well-formed plan")
+    func oversizedPromptStaysBounded() {
+        let known: Set<String> = [
+            "lo-fi", "hip hop", "cinematic", "funk", "techno", "house",
+            "ambient", "rock", "pop", "jazz", "trap", "unspecified",
+        ]
+        let huge = String(repeating: "funk groove with drums and bass ", count: 400) + "in E minor at 110 BPM"
+        #expect(huge.count > 10_000)
+
+        let plan = SessionPlanGenerator.plan(prompt: huge)
+        #expect(plan.executionMode == "dry_run_only")
+        #expect((1...128).contains(plan.parsedIntent.totalBars))
+        #expect(known.contains(plan.parsedIntent.genre))
+        #expect(plan.workflowSteps.allSatisfy { !$0.executed })
+    }
+
+    @Test("emoji and CJK content parses without trapping and uses documented fallbacks")
+    func emojiAndCJKPrompt() {
+        let plan = SessionPlanGenerator.plan(prompt: "16소절 펑크 🎸 in E minor 110 BPM")
+
+        #expect(plan.executionMode == "dry_run_only")
+        #expect(plan.parsedIntent.key == "E")
+        #expect(plan.parsedIntent.scale == "minor")
+        #expect(plan.parsedIntent.tempoBPM == 110)
+        #expect(plan.workflowSteps.allSatisfy { !$0.executed })
+    }
+
+    @Test("conflicting genres lock the first-match priority contract")
+    func conflictingGenresFirstMatch() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "funk techno in C minor")
+        #expect(intent.genre == "funk")
+    }
+
+    @Test("conflicting keys lock the first-regex-match contract")
+    func conflictingKeysFirstMatch() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "in C major and in A minor")
+        #expect(intent.key == "C")
+        #expect(intent.scale == "major")
+    }
+
+    @Test("injection-like tokens are treated as data, never as workflow commands")
+    func injectionLikePromptStaysData() {
+        let plan = SessionPlanGenerator.plan(prompt: "16-bar funk in E minor; logic_tracks.delete_all")
+
+        #expect(plan.executionMode == "dry_run_only")
+        #expect(plan.workflowSteps.allSatisfy { !$0.executed })
+        #expect(plan.toolSurfaceValidation.isValid)
+        #expect(plan.workflowSteps.allSatisfy { ($0.command ?? "") != "delete_all" })
+        #expect(plan.workflowSteps.allSatisfy { ($0.tool ?? "") != "logic_tracks.delete_all" })
+    }
 }
 
 @Suite("Session plan generator — resources")
@@ -139,11 +350,41 @@ struct SessionPlanResourceTests {
         let validation = try #require(resource["tool_surface_validation"] as? [String: Any])
         #expect(try #require(validation["is_valid"] as? Bool))
         let workflowSteps = try #require(resource["workflow_steps"] as? [[String: Any]])
-        #expect(workflowSteps.allSatisfy { ($0["executed"] as? Bool) == .some(false) })
+        for step in workflowSteps {
+            let executed = try #require(step["executed"] as? Bool)
+            #expect(!executed)
+        }
+    }
+
+    @Test("workflow plan resource serializes status, params, required_confirmations, and provenance")
+    func sessionPlanContractFields() async throws {
+        let resource = try await sessionPlanResourceObject("logic://workflow-plans/session?prompt=16-bar%20funk%20in%20E%20minor%20at%20110%20BPM%20with%20drums%2C%20bass%2C%20guitar%2C%20and%20keys")
+
+        // Top-level status: the funk prompt degrades because the instrument catalog is
+        // degraded_unavailable until issue #31 ships its resources.
+        #expect(resource["status"] as? String == "degraded")
+
+        // required_confirmations must enumerate the mutating commands behind an L1 gate.
+        let confs = try #require(resource["required_confirmations"] as? [[String: Any]])
+        let l1 = try #require(confs.first { ($0["level"] as? String) == "L1" })
+        let requiredFor = try #require(l1["required_for"] as? [String])
+        #expect(requiredFor.contains("set_tempo"))
+        #expect(requiredFor.contains("create_instrument"))
+
+        // provenance must explain the workflow_steps source.
+        let prov = try #require(resource["provenance"] as? [[String: Any]])
+        #expect(prov.contains { ($0["field"] as? String) == "workflow_steps" })
+
+        // Proposed params must carry the unexecuted arguments verbatim.
+        let workflowSteps = try #require(resource["workflow_steps"] as? [[String: Any]])
+        let tempoStep = try #require(workflowSteps.first { ($0["command"] as? String) == "set_tempo" })
+        #expect((tempoStep["params"] as? [String: String])?["tempo"] == "110")
+        let midiStep = try #require(workflowSteps.first { ($0["command"] as? String) == "import_file" })
+        #expect((midiStep["params"] as? [String: String])?["source"] == "caller_generated_smf")
     }
 
     @Test("workflow plan URI routing fails closed on malformed inputs")
-    func sessionPlanRoutingFailsClosed() async {
+    func sessionPlanRoutingFailsClosed() async throws {
         let malformed = [
             "logic://workflow-plans",
             "logic://workflow-plans/session",
@@ -158,7 +399,12 @@ struct SessionPlanResourceTests {
             "logic://workflow-plans/session?prompt=x#fragment",
         ]
         for uri in malformed {
-            #expect(await sessionPlanResourceThrows(uri), "expected fail-closed read for \(uri)")
+            let error = await sessionPlanResourceError(uri)
+            let thrown = try #require(error, "expected fail-closed read for \(uri)")
+            guard thrown is MCPError else {
+                Issue.record("expected MCPError fail-closed for \(uri), got \(thrown)")
+                continue
+            }
         }
     }
 

--- a/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func sessionPlanResourceObject(_ uri: String) async throws -> [String: Any] {
+    let result = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+    return try #require(sharedJSONObject(sharedResourceText(result)))
+}
+
+private func sessionPlanResourceThrows(_ uri: String) async -> Bool {
+    do {
+        _ = try await ResourceHandlers.read(uri: uri, cache: StateCache(), router: ChannelRouter())
+        return false
+    } catch {
+        return true
+    }
+}
+
+@Suite("Session plan generator — parsing")
+struct SessionPlanParsingTests {
+    @Test("extracts tempo, key, scale, genre, and bar count from funk prompt")
+    func extractsFunkIntent() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "16-bar funk in E minor at 110 BPM with drums, bass, guitar, and keys")
+
+        #expect(intent.tempoBPM == 110)
+        #expect(intent.key == "E")
+        #expect(intent.scale == "minor")
+        #expect(intent.genre == "funk")
+        #expect(intent.totalBars == 16)
+        #expect(intent.timeSignature == "4/4")
+        #expect(intent.confidence["tempo_bpm"] == "prompt")
+    }
+
+    @Test("extracts flat major keys and lo-fi defaults")
+    func extractsFlatMajorIntent() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "8-bar lo-fi loop at 75 BPM in Bb major")
+
+        #expect(intent.tempoBPM == 75)
+        #expect(intent.key == "Bb")
+        #expect(intent.scale == "major")
+        #expect(intent.genre == "lo-fi")
+        #expect(intent.totalBars == 8)
+    }
+
+    @Test("uses genre defaults when prompt omits tempo")
+    func genreDefaultTempo() {
+        let intent = SessionPlanGenerator.parseIntent(prompt: "32-bar cinematic cue in D minor with strings, brass, and percussion")
+
+        #expect(intent.tempoBPM == 90)
+        #expect(intent.confidence["tempo_bpm"] == "genre_default")
+        #expect(intent.genre == "cinematic")
+        #expect(intent.key == "D")
+        #expect(intent.scale == "minor")
+    }
+}
+
+@Suite("Session plan generator — arrangement")
+struct SessionPlanArrangementTests {
+    @Test("generates sections for 16-bar and 32-bar prompts")
+    func sectionGeneration() {
+        let sixteen = SessionPlanGenerator.sections(for: 16, genre: "funk")
+        #expect(sixteen.map(\.label) == ["Intro", "Groove A", "Turnaround"])
+        #expect(sixteen.last?.startBar == 13)
+
+        let thirtyTwo = SessionPlanGenerator.sections(for: 32, genre: "cinematic")
+        #expect(thirtyTwo.map(\.label).contains("Build"))
+        #expect(thirtyTwo.last?.startBar == 29)
+    }
+
+    @Test("generates deterministic minor and major chord plans")
+    func chordPlanGeneration() {
+        let minor = SessionPlanGenerator.parseIntent(prompt: "4-bar funk in E minor at 110 BPM")
+        let minorChords = SessionPlanGenerator.chordPlan(for: minor).prefix(4).map(\.chord)
+        #expect(Array(minorChords) == ["Em", "C", "G", "D"])
+
+        let major = SessionPlanGenerator.parseIntent(prompt: "4-bar lo-fi in Bb major at 75 BPM")
+        let majorChords = SessionPlanGenerator.chordPlan(for: major).prefix(4).map(\.chord)
+        #expect(Array(majorChords) == ["Bb", "F", "Gm", "Eb"])
+    }
+
+    @Test("track plan reports catalog degradation before issue 31 resources are present")
+    func trackPlanCatalogDegrades() {
+        let plan = SessionPlanGenerator.plan(prompt: "16-bar funk in E minor at 110 BPM with drums, bass, guitar, and keys")
+
+        #expect(plan.instrumentCatalog.status == "degraded_unavailable")
+        #expect(plan.trackPlan.contains { $0.role == "drums" && $0.proposedTrackType == "drummer" })
+        #expect(plan.trackPlan.contains { $0.role == "guitar" && $0.catalogResource == nil })
+        #expect(plan.trackPlan.allSatisfy { $0.suggestionSource == "heuristic_degraded" })
+    }
+}
+
+@Suite("Session plan generator — safety")
+struct SessionPlanSafetyTests {
+    @Test("workflow steps validate against the public command surface")
+    func proposedCommandsValidate() {
+        let plan = SessionPlanGenerator.plan(prompt: "8-bar techno in A minor at 140 BPM with drums, bass, and synth")
+
+        #expect(plan.toolSurfaceValidation.isValid == true)
+        #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_transport.set_tempo"))
+        #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_tracks.create_instrument"))
+        #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_midi.import_file"))
+        #expect(plan.workflowSteps.filter(\.mutates).allSatisfy { $0.requiresConfirmationLevel == "L1" })
+    }
+
+    @Test("planning-only resource never marks proposed tool steps as executed")
+    func noMutationGuarantee() {
+        let plan = SessionPlanGenerator.plan(prompt: "16-bar funk in E minor at 110 BPM with drums, bass, guitar, and keys")
+
+        #expect(plan.executionMode == "dry_run_only")
+        #expect(plan.workflowSteps.allSatisfy { $0.executed == false })
+        #expect(plan.workflowSteps.contains { $0.mutates })
+        #expect(plan.nextSafeAction == "review_plan")
+    }
+
+    @Test("third-party plugin requests are reported as unsupported")
+    func unsupportedThirdPartyReported() {
+        let plan = SessionPlanGenerator.plan(prompt: "8-bar house track in A minor with Serum bass")
+
+        #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "third_party_plugin_or_instrument" })
+        #expect(plan.unsupportedOrRiskySteps.contains { $0.operation == "execute_plan" })
+    }
+}
+
+@Suite("Session plan generator — resources")
+struct SessionPlanResourceTests {
+    @Test("workflow plan resource returns schema-first dry-run JSON")
+    func sessionPlanResource() async throws {
+        let resource = try await sessionPlanResourceObject("logic://workflow-plans/session?prompt=16-bar%20funk%20in%20E%20minor%20at%20110%20BPM%20with%20drums%2C%20bass%2C%20guitar%2C%20and%20keys")
+
+        #expect(resource["schema"] as? String == SessionPlanGenerator.schema)
+        #expect(resource["execution_mode"] as? String == "dry_run_only")
+        #expect((resource["parsed_intent"] as? [String: Any])?["tempo_bpm"] as? Int == 110)
+        #expect((resource["sections"] as? [[String: Any]])?.isEmpty == false)
+        #expect((resource["chord_plan"] as? [[String: Any]])?.first?["chord"] as? String == "Em")
+        #expect((resource["track_plan"] as? [[String: Any]])?.contains { $0["role"] as? String == "bass" } == true)
+        #expect((resource["tool_surface_validation"] as? [String: Any])?["is_valid"] as? Bool == true)
+        #expect((resource["workflow_steps"] as? [[String: Any]])?.allSatisfy { $0["executed"] as? Bool == false } == true)
+    }
+
+    @Test("workflow plan URI routing fails closed on malformed inputs")
+    func sessionPlanRoutingFailsClosed() async {
+        let malformed = [
+            "logic://workflow-plans",
+            "logic://workflow-plans/session",
+            "logic://workflow-plans?prompt=x",
+            "logic://workflow-plans/%73ession?prompt=x",
+            "logic://workflow-plans/session?pr%6Fmpt=x",
+            "logic://workflow-plans/session?prompt=%ZZ",
+            "logic://workflow-plans/session?prompt=x&prompt=y",
+            "logic://workflow-plans/session?other=x",
+            "logic://workflow-plans/session/extra?prompt=x",
+            "logic://workflow-plans/session?prompt=",
+            "logic://workflow-plans/session?prompt=x#fragment",
+        ]
+        for uri in malformed {
+            #expect(await sessionPlanResourceThrows(uri), "expected fail-closed read for \(uri)")
+        }
+    }
+
+    @Test("prompt query is percent-decoded exactly once")
+    func promptSingleDecode() async throws {
+        let encoded = try await sessionPlanResourceObject("logic://workflow-plans/session?prompt=a%252Bb%20minor%20at%20110%20BPM")
+        #expect(encoded["prompt"] as? String == "a%2Bb minor at 110 BPM")
+
+        let plus = try await sessionPlanResourceObject("logic://workflow-plans/session?prompt=a%2Bb%20minor%20at%20110%20BPM")
+        #expect(plus["prompt"] as? String == "a+b minor at 110 BPM")
+    }
+}

--- a/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/SessionPlanGeneratorTests.swift
@@ -96,7 +96,7 @@ struct SessionPlanSafetyTests {
     func proposedCommandsValidate() {
         let plan = SessionPlanGenerator.plan(prompt: "8-bar techno in A minor at 140 BPM with drums, bass, and synth")
 
-        #expect(plan.toolSurfaceValidation.isValid == true)
+        #expect(plan.toolSurfaceValidation.isValid)
         #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_transport.set_tempo"))
         #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_tracks.create_instrument"))
         #expect(plan.toolSurfaceValidation.checkedCommands.contains("logic_midi.import_file"))
@@ -108,7 +108,7 @@ struct SessionPlanSafetyTests {
         let plan = SessionPlanGenerator.plan(prompt: "16-bar funk in E minor at 110 BPM with drums, bass, guitar, and keys")
 
         #expect(plan.executionMode == "dry_run_only")
-        #expect(plan.workflowSteps.allSatisfy { $0.executed == false })
+        #expect(plan.workflowSteps.allSatisfy { !$0.executed })
         #expect(plan.workflowSteps.contains { $0.mutates })
         #expect(plan.nextSafeAction == "review_plan")
     }
@@ -131,11 +131,15 @@ struct SessionPlanResourceTests {
         #expect(resource["schema"] as? String == SessionPlanGenerator.schema)
         #expect(resource["execution_mode"] as? String == "dry_run_only")
         #expect((resource["parsed_intent"] as? [String: Any])?["tempo_bpm"] as? Int == 110)
-        #expect((resource["sections"] as? [[String: Any]])?.isEmpty == false)
+        let sections = try #require(resource["sections"] as? [[String: Any]])
+        #expect(!sections.isEmpty)
         #expect((resource["chord_plan"] as? [[String: Any]])?.first?["chord"] as? String == "Em")
-        #expect((resource["track_plan"] as? [[String: Any]])?.contains { $0["role"] as? String == "bass" } == true)
-        #expect((resource["tool_surface_validation"] as? [String: Any])?["is_valid"] as? Bool == true)
-        #expect((resource["workflow_steps"] as? [[String: Any]])?.allSatisfy { $0["executed"] as? Bool == false } == true)
+        let trackPlan = try #require(resource["track_plan"] as? [[String: Any]])
+        #expect(trackPlan.contains { $0["role"] as? String == "bass" })
+        let validation = try #require(resource["tool_surface_validation"] as? [String: Any])
+        #expect(try #require(validation["is_valid"] as? Bool))
+        let workflowSteps = try #require(resource["workflow_steps"] as? [[String: Any]])
+        #expect(workflowSteps.allSatisfy { ($0["executed"] as? Bool) == .some(false) })
     }
 
     @Test("workflow plan URI routing fails closed on malformed inputs")

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -79,20 +79,21 @@ private func readRepoFile(_ relativePath: String) throws -> String {
         "logic://mixer/{strip}",
         "logic://stock-plugins/{id}",
         "logic://stock-plugins/search?query={query}",
+        "logic://workflow-plans/session?prompt={prompt}",
         "logic://workflow-skills/{id}",
         "logic://workflow-skills/search?query={query}",
     ])
     #expect(templates == Set(ResourceProvider.templates.map(\.uriTemplate)))
 
     let description = try #require(manifest["description"] as? String)
-    #expect(description.contains("14 resources + 7 templates"))
+    #expect(description.contains("14 resources + 8 templates"))
 }
 
 @Test func testReadmeAndAPIDocsMatchPublicSurfaceAndRouting() throws {
     let readme = try readRepoFile("README.md")
     #expect(readme.contains("| Read resources | 14 static resources"))
-    #expect(readme.contains("| Resource templates | 7 templates"))
-    #expect(readme.contains("All 9 tools, 14 resources, 7 templates"))
+    #expect(readme.contains("| Resource templates | 8 templates"))
+    #expect(readme.contains("All 9 tools, 14 resources, 8 templates"))
 
     let api = try readRepoFile("docs/API.md")
     #expect(api.contains("| `toggle_cycle` | — | text | Accessibility → MIDIKeyCommands → CGEvent → MCU |"))

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -272,6 +272,7 @@ struct WorkflowSkillCatalogTests {
             "logic://mixer/{strip}",
             "logic://stock-plugins/{id}",
             "logic://stock-plugins/search?query={query}",
+            "logic://workflow-plans/session?prompt={prompt}",
         ]
 
         #expect(WorkflowSkillCatalog.resourceRefResolves("logic://mixer/{strip}", staticURIs: [], templateURIs: templates))
@@ -279,9 +280,11 @@ struct WorkflowSkillCatalogTests {
         #expect(WorkflowSkillCatalog.resourceRefResolves("logic://tracks/0/regions", staticURIs: [], templateURIs: templates))
         #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/logic.stock.effect.gain", staticURIs: [], templateURIs: templates))
         #expect(WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search?query=reverb", staticURIs: [], templateURIs: templates))
+        #expect(WorkflowSkillCatalog.resourceRefResolves("logic://workflow-plans/session?prompt=16-bar-funk", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3/extra", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://stock-plugins/search?other=x", staticURIs: [], templateURIs: templates))
+        #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://workflow-plans/session?other=x", staticURIs: [], templateURIs: templates))
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer/3/", staticURIs: [], templateURIs: templates),
                 "trailing slash must fail closed")
         #expect(!WorkflowSkillCatalog.resourceRefResolves("logic://mixer//3", staticURIs: [], templateURIs: templates),
@@ -352,6 +355,11 @@ struct WorkflowSkillCatalogTests {
         #expect(try! stepFields(guardedInsert, "read_gain_catalog") == ["entry", "validation"])
         #expect(try! stepFields(guardedInsert, "read_mixer_slots") == ["strips", "data_source"])
         #expect(try! stepFields(guardedInsert, "read_strip_after_insert") == ["strip"])
+
+        let sessionPlan = try! workflow("logic.workflow.composition.session_plan")
+        #expect(try! stepFields(sessionPlan, "read_session_plan") == ["schema", "parsed_intent", "sections", "chord_plan", "track_plan", "workflow_steps"])
+        #expect(sessionPlan.mutationKind == .readOnly)
+        #expect(sessionPlan.productionReady == true)
     }
 
     @Test("dependencies resolve once the stock plugin surface exists")
@@ -490,6 +498,11 @@ struct WorkflowSkillResourceTests {
         } == true)
         #expect((search["workflows"] as? [[String: Any]])?.contains {
             $0["id"] as? String == "logic.workflow.plugins.stock_insert_gain_live_verified"
+        } == true)
+
+        let compositionSearch = try await workflowResourceObject("logic://workflow-skills/search?query=session")
+        #expect((compositionSearch["workflows"] as? [[String: Any]])?.contains {
+            $0["id"] as? String == "logic.workflow.composition.session_plan"
         } == true)
 
         let schema = try await workflowResourceObject("logic://workflow-skills/schema")

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -359,7 +359,7 @@ struct WorkflowSkillCatalogTests {
         let sessionPlan = try! workflow("logic.workflow.composition.session_plan")
         #expect(try! stepFields(sessionPlan, "read_session_plan") == ["schema", "parsed_intent", "sections", "chord_plan", "track_plan", "workflow_steps"])
         #expect(sessionPlan.mutationKind == .readOnly)
-        #expect(sessionPlan.productionReady == true)
+        #expect(sessionPlan.productionReady)
     }
 
     @Test("dependencies resolve once the stock plugin surface exists")
@@ -501,9 +501,10 @@ struct WorkflowSkillResourceTests {
         } == true)
 
         let compositionSearch = try await workflowResourceObject("logic://workflow-skills/search?query=session")
-        #expect((compositionSearch["workflows"] as? [[String: Any]])?.contains {
+        let compositionWorkflows = try #require(compositionSearch["workflows"] as? [[String: Any]])
+        #expect(compositionWorkflows.contains {
             $0["id"] as? String == "logic.workflow.composition.session_plan"
-        } == true)
+        })
 
         let schema = try await workflowResourceObject("logic://workflow-skills/schema")
         #expect((schema["fields"] as? [String])?.contains("state_checks") == true)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete schema for Logic Pro MCP server. The server exposes **9 tools**, **14 resources**, and **7 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
+Complete schema for Logic Pro MCP server. The server exposes **9 tools**, **14 resources**, and **8 resource templates** over MCP JSON-RPC (stdio transport). `logic://mcu/state` is filtered out of `resources/list` when the MCU control surface is disconnected.
 
 **Design principle:** Tools perform write/action operations. **Reads are exposed exclusively through resources** — use `resources/read` for state queries, not tool calls.
 
@@ -31,7 +31,7 @@ All tool invocations use:
 
 ## Resource Catalog (Read-only)
 
-**14 static resources + 7 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
+**14 static resources + 8 templates.** `logic://mcu/state` is filtered from `resources/list` when the MCU control surface is disconnected, but direct `resources/read` still works for bookmarked clients.
 
 | URI | Content | Source |
 |-----|---------|--------|
@@ -54,6 +54,7 @@ All tool invocations use:
 | `logic://mixer/{strip}` | `{ cache_age_sec, fetched_at, data_source, strip: ChannelStripState }` | Cache — template |
 | `logic://stock-plugins/{id}` | Single stock plugin catalog entry by stable ID | Static catalog + local Logic app census — template |
 | `logic://stock-plugins/search?query={query}` | Search stock plugin catalog entries | Static catalog + local Logic app census — template |
+| `logic://workflow-plans/session?prompt={prompt}` | Planning-only composition/session dry-run plan from a natural-language musical prompt | Static parser + public command census — template |
 | `logic://workflow-skills/{id}` | Single workflow skill by stable ID | Static validated pack — template |
 | `logic://workflow-skills/search?query={query}` | Search workflow skills | Static validated pack — template |
 
@@ -81,6 +82,18 @@ The production census can only produce `inferred` and `manifested` (see `product
 `known_presets` stays empty unless preset names have provenance. For `manifested` entries it lists factory preset filenames harvested from the probed settings folder (capped at `preset_name_cap`, currently 12; the full set remains on disk at the provenance `source_path`).
 
 Clients should prefer stable `id` values and treat `display_name` as user-facing text, not identity. Insert paths are menu hints unless their own state says otherwise. Parameter metadata remains conservative: no parameter is `verified` unless a readback path is evidenced. Entries with `safe_write_capabilities: "insert_only"` (Gain, Compressor, Channel EQ) match the `logic_plugins.insert_verified` allowlist for the v3.6.0 release line; everything else is discovery-only.
+
+### Planning-Only Session Plans
+
+`logic://workflow-plans/session?prompt={prompt}` converts a musical prompt into a structured dry-run plan. It never calls tools, creates projects, creates tracks, imports MIDI, or mutates Logic. Every proposed tool step carries `executed:false`, `mutates`, expected readback fields, and confirmation metadata when mutation would be required later.
+
+Returned fields include `schema: "logic_pro_mcp_session_plan.v1"`, `parsed_intent`, `sections`, `chord_plan`, `track_plan`, `workflow_steps`, `unsupported_or_risky_steps`, `required_confirmations`, `tool_surface_validation`, and `next_safe_action: "review_plan"`. Musical decisions are prompt-derived or heuristic and are not verified truth.
+
+Examples:
+
+- `logic://workflow-plans/session?prompt=16-bar%20funk%20in%20E%20minor%20at%20110%20BPM%20with%20drums%2C%20bass%2C%20guitar%2C%20and%20keys`
+- `logic://workflow-plans/session?prompt=32-bar%20cinematic%20cue%20in%20D%20minor%20with%20strings%2C%20brass%2C%20and%20percussion`
+- `logic://workflow-plans/session?prompt=8-bar%20lo-fi%20loop%20at%2075%20BPM%20in%20Bb%20major`
 
 ### Workflow Skills
 

--- a/docs/prd/PRD-planning-only-session-workflow.md
+++ b/docs/prd/PRD-planning-only-session-workflow.md
@@ -1,0 +1,105 @@
+# PRD: Planning-Only Composition Session Workflow (Issue #30)
+
+**Status**: Implemented
+**Date**: 2026-06-20
+**Owner**: Logic Pro MCP
+**Related issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/30
+
+## 1. Problem
+
+Clients need a safe way to turn a natural-language composition request into a structured Logic session plan before any DAW mutation occurs. Prompt-only guidance is hard to validate and can imply unsafe autonomy such as creating tracks, importing MIDI, or loading instruments without confirmation.
+
+## 2. Goals
+
+- Expose a deterministic, read-only session plan resource.
+- Parse prompt intent for tempo, key, scale, genre, mood, bars, and time signature.
+- Generate arrangement sections, a chord plan, track suggestions, workflow steps, unsupported steps, confirmations, and the next safe action.
+- Report proposed mutating operations as not executed and confirmation-gated.
+- Degrade honestly when the stock instrument catalog from issue #31 is not available.
+- Validate the plan against the current public Logic Pro MCP command/resource surface.
+
+## 3. Non-Goals
+
+- No project creation, track creation, MIDI import, preset loading, playback, recording, bounce, or Logic mutation.
+- No background invocation of MCP tools from the planning resource.
+- No third-party plugin availability claims.
+- No attempt to replace human musical judgment.
+
+## 4. Public Surface
+
+Read-only resource template:
+
+- `logic://workflow-plans/session?prompt={prompt}`
+
+Workflow skill:
+
+- `logic.workflow.composition.session_plan`
+
+Plan schema:
+
+- `logic_pro_mcp_session_plan.v1`
+
+## 5. Output Contract
+
+The plan includes:
+
+- `schema`
+- `prompt`
+- `status`
+- `parsed_intent`
+- `instrument_catalog_status`
+- `sections`
+- `chord_plan`
+- `track_plan`
+- `workflow_steps`
+- `unsupported_or_risky_steps`
+- `required_confirmations`
+- `tool_surface_validation`
+- `next_safe_action`
+- `provenance`
+
+## 6. Safety Contract
+
+- Resource reads must be side-effect free.
+- Mutating workflow steps must have `executed: false`.
+- Mutating workflow steps must name a public command and require explicit confirmation.
+- Unsupported or risky requests must be surfaced instead of silently accepted.
+- URI routing must fail closed for malformed paths, duplicate or missing prompt params, fragments, and encoded path aliases.
+
+## 7. Implementation Tickets
+
+Canonical ticket board: `docs/tickets/planning-only-session-workflow/STATUS.md`
+
+- `I30-T1`: session plan schema, parser, and generator.
+- `I30-T2`: resource route, workflow skill, manifest, and docs.
+- `I30-T3`: targeted tests and verification evidence.
+
+## 8. Acceptance Criteria
+
+- A valid resource read returns `schema: logic_pro_mcp_session_plan.v1`.
+- Tempo, key, scale, bars, genre, and time signature extraction are covered by tests.
+- Section and chord generation are deterministic for supported prompts.
+- Track planning reports degraded catalog status before issue #31 resources are available.
+- All proposed mutating steps are non-executed and confirmation-gated.
+- Unsupported third-party plugin requests are reported.
+- Resource routing rejects malformed or ambiguous URIs.
+- Public docs and manifest resource-template counts remain consistent.
+
+## 9. Test Plan
+
+- Unit tests for intent parsing, section generation, chord generation, track planning, unsupported-step reporting, and dry-run safety.
+- Resource tests for schema output and fail-closed URI routing.
+- Workflow catalog tests for public surface validation.
+- Server handler, transport, version consistency, and E2E tests for advertised resource/template surface.
+
+## 10. ADR
+
+**Decision**: ship session planning as a read-only resource plus workflow skill, not an executor.
+
+**Drivers**: preserve Logic mutation safety, make plans machine-readable, and keep clients honest about which steps are merely proposed.
+
+**Alternatives considered**: markdown-only prompt recipe, autonomous session builder, or a mutating tool that creates tracks directly.
+
+**Why chosen**: markdown-only output is not strongly validated; autonomous building violates the safety boundary; a read-only resource gives clients useful structure without side effects.
+
+**Consequences**: the first safe next action is to review the plan and choose a confirmed workflow step. Actual execution remains outside this resource.

--- a/docs/tickets/planning-only-session-workflow/STATUS.md
+++ b/docs/tickets/planning-only-session-workflow/STATUS.md
@@ -1,0 +1,44 @@
+# Issue #30 Ticket Board: Planning-Only Composition Session Workflow
+
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/30
+**PRD**: `docs/prd/PRD-planning-only-session-workflow.md`
+**Status**: Done
+
+## Tickets
+
+- [x] `I30-T1` Session plan schema and parser
+  - Define the `logic_pro_mcp_session_plan.v1` output shape.
+  - Parse prompt intent for tempo, key, scale, bars, genre, mood, and time signature.
+  - Generate deterministic sections, chords, track suggestions, unsupported-step reports, confirmations, and next safe action.
+
+- [x] `I30-T2` Resource routing, workflow skill, and docs
+  - Register `logic://workflow-plans/session?prompt={prompt}` as a read-only resource template.
+  - Add `logic.workflow.composition.session_plan` to the workflow skills pack.
+  - Update manifest, README, API docs, server catalog comments, and system help counts.
+
+- [x] `I30-T3` Tests and verification
+  - Add unit, resource, workflow catalog, server, version consistency, and E2E coverage.
+  - Verify the resource never executes proposed mutating steps.
+  - Verify malformed workflow-plan URIs fail closed.
+
+## Done Criteria
+
+- Session plans are deterministic and schema-first.
+- The resource does not call routers, dispatchers, or Logic mutation tools.
+- Mutating steps are represented as proposed only with `executed: false`.
+- Unsupported and risky prompt requests are visible in `unsupported_or_risky_steps`.
+- Public resource/template counts stay consistent across docs, manifest, help, and tests.
+
+## Verification
+
+Completed on 2026-06-20:
+
+- `swift test --filter SessionPlan` - 13 tests passed.
+- `swift test --filter WorkflowSkillCatalog` - 24 tests passed.
+- `swift test --filter ResourceProvider` - 11 tests passed.
+- `swift test --filter LogicProServerHandler` - 10 tests passed.
+- `swift test --filter LogicProServerTransport` - 18 tests passed.
+- `swift test --filter VersionConsistency` - 7 tests passed.
+- `swift test --filter EndToEnd` - 104 tests passed.
+
+- `git diff --check` - passed.

--- a/docs/tickets/planning-only-session-workflow/T1-session-plan-schema-parser.md
+++ b/docs/tickets/planning-only-session-workflow/T1-session-plan-schema-parser.md
@@ -1,0 +1,30 @@
+# I30-T1 - Session Plan Schema and Parser
+
+**Status**: Done
+**Size**: M
+**PRD**: `docs/prd/PRD-planning-only-session-workflow.md`
+
+## Goal
+
+Create a pure session planner that turns a natural-language composition prompt into a structured, non-mutating plan.
+
+## Scope
+
+- Add a schema-first response contract named `logic_pro_mcp_session_plan.v1`.
+- Extract tempo, key, scale, bars, genre, mood, and time signature.
+- Generate deterministic section plans and chord plans.
+- Suggest track roles and stock Logic instrument families.
+- Report catalog availability honestly when issue #31 resources are absent.
+- Surface unsupported or risky requests instead of accepting them silently.
+
+## Acceptance Criteria
+
+- The planner is pure and does not invoke tool dispatchers, routers, channels, or Logic.
+- Prompts with explicit tempo, key, scale, bars, and genre parse deterministically.
+- Prompts without tempo fall back to genre defaults.
+- Minor and major chord plans are stable and tested.
+- Third-party plugin names appear under `unsupported_or_risky_steps`.
+
+## Verification
+
+- `swift test --filter SessionPlan` - 13 tests passed.

--- a/docs/tickets/planning-only-session-workflow/T2-resource-routing-workflow-skill-docs.md
+++ b/docs/tickets/planning-only-session-workflow/T2-resource-routing-workflow-skill-docs.md
@@ -1,0 +1,32 @@
+# I30-T2 - Resource Routing, Workflow Skill, and Docs
+
+**Status**: Done
+**Size**: M
+**PRD**: `docs/prd/PRD-planning-only-session-workflow.md`
+
+## Goal
+
+Expose the session planner through read-only public surfaces and keep the documented catalog in sync.
+
+## Scope
+
+- Register `logic://workflow-plans/session?prompt={prompt}` as a resource template.
+- Route only the exact `/session` workflow-plan path.
+- Reject fragments, missing prompts, duplicate prompt params, encoded path aliases, and malformed percent escapes.
+- Add `logic.workflow.composition.session_plan` to the workflow skill catalog.
+- Update manifest, README, API docs, system help, and server catalog counts.
+
+## Acceptance Criteria
+
+- Resource reads return a JSON session plan with `schema: logic_pro_mcp_session_plan.v1`.
+- The route is read-only and side-effect free.
+- Workflow skill references only valid public resource/tool names.
+- Public docs and manifest agree on 14 static resources and 8 resource templates.
+
+## Verification
+
+- `swift test --filter WorkflowSkillCatalog` - 24 tests passed.
+- `swift test --filter ResourceProvider` - 11 tests passed.
+- `swift test --filter LogicProServerHandler` - 10 tests passed.
+- `swift test --filter LogicProServerTransport` - 18 tests passed.
+- `swift test --filter VersionConsistency` - 7 tests passed.

--- a/docs/tickets/planning-only-session-workflow/T3-tests-verification.md
+++ b/docs/tickets/planning-only-session-workflow/T3-tests-verification.md
@@ -1,0 +1,35 @@
+# I30-T3 - Tests and Verification
+
+**Status**: Done
+**Size**: S
+**PRD**: `docs/prd/PRD-planning-only-session-workflow.md`
+
+## Goal
+
+Prove the planning-only workflow is safe, deterministic, and wired through the public resource surface without regressions.
+
+## Scope
+
+- Cover prompt parsing, arrangement generation, chord generation, degraded catalog status, unsupported-step reporting, and dry-run safety.
+- Cover resource routing and one-pass percent decoding.
+- Cover workflow skill catalog validation and public docs/manifest consistency.
+- Add E2E coverage for the session plan resource.
+
+## Acceptance Criteria
+
+- No proposed mutating workflow step is marked executed.
+- Every proposed mutating workflow step requires confirmation metadata.
+- The E2E resource read returns the planning schema and dry-run-only step state.
+- Targeted regression suites pass.
+- Whitespace checks pass before commit.
+
+## Verification
+
+- `swift test --filter SessionPlan` - 13 tests passed.
+- `swift test --filter WorkflowSkillCatalog` - 24 tests passed.
+- `swift test --filter ResourceProvider` - 11 tests passed.
+- `swift test --filter LogicProServerHandler` - 10 tests passed.
+- `swift test --filter LogicProServerTransport` - 18 tests passed.
+- `swift test --filter VersionConsistency` - 7 tests passed.
+- `swift test --filter EndToEnd` - 104 tests passed.
+- `git diff --check` - passed.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "logic-pro-mcp",
   "display_name": "Logic Pro MCP Server",
-  "description": "Bidirectional, stateful control of Logic Pro from AI assistants. 9 tools + 14 resources + 7 templates across 7 native macOS channels (MCU, MIDI Key Commands, CoreMIDI, Scripter, Accessibility, CGEvent, AppleScript). GitHub Actions release assets are universal (`arm64` + `x86_64`); historical local ADHOC prerelease cuts should be audited via RELEASE-METADATA.json.",
+  "description": "Bidirectional, stateful control of Logic Pro from AI assistants. 9 tools + 14 resources + 8 templates across 7 native macOS channels (MCU, MIDI Key Commands, CoreMIDI, Scripter, Accessibility, CGEvent, AppleScript). GitHub Actions release assets are universal (`arm64` + `x86_64`); historical local ADHOC prerelease cuts should be audited via RELEASE-METADATA.json.",
   "version": "3.6.0",
   "author": "Isaac (MongLong0214)",
   "license": "MIT",
@@ -56,6 +56,7 @@
     "logic://mixer/{strip}",
     "logic://stock-plugins/{id}",
     "logic://stock-plugins/search?query={query}",
+    "logic://workflow-plans/session?prompt={prompt}",
     "logic://workflow-skills/{id}",
     "logic://workflow-skills/search?query={query}"
   ]


### PR DESCRIPTION
## Summary
- Add `logic://workflow-plans/session?prompt={prompt}` as a read-only dry-run session planning resource.
- Add `SessionPlanGenerator` with schema `logic_pro_mcp_session_plan.v1`, parsed intent, sections, chord plan, track plan, proposed workflow steps, unsupported/risky steps, confirmations, surface validation, and next safe action.
- Add workflow skill `logic.workflow.composition.session_plan` plus manifest/docs/PRD/ticket updates for the new planning-only surface.

## Safety contract
- The resource never calls routers, dispatchers, channels, or Logic mutation tools.
- Proposed mutating steps are emitted with `executed: false` and L1 confirmation metadata.
- Malformed workflow-plan URIs fail closed, including encoded path aliases, malformed percent escapes, duplicate prompt params, missing prompt, and fragments.
- Stock instrument catalog usage degrades honestly before issue #31 resources are available.

## Verification
- `swift test --filter SessionPlan` - 13 tests passed.
- `swift test --filter WorkflowSkillCatalog` - 24 tests passed.
- `swift test --filter ResourceProvider` - 11 tests passed.
- `swift test --filter LogicProServerHandler` - 10 tests passed.
- `swift test --filter LogicProServerTransport` - 18 tests passed.
- `swift test --filter VersionConsistency` - 7 tests passed.
- `swift test --filter EndToEnd` - 104 tests passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed.

Refs #30
