### PR TITLE
Centralize locale policy for AX label fallbacks

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -137,19 +137,6 @@ enum AXLocalePolicy {
     static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)
     static let editUndoMenuPath = MenuPath(bar: editMenuBar, item: undoMenuItemPrefix, itemMode: .prefix)
 
-    static func elementLabel(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> String? {
-        for text in [
-            AXHelpers.getTitle(element, runtime: runtime),
-            AXHelpers.getDescription(element, runtime: runtime),
-        ] {
-            if let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !trimmed.isEmpty {
-                return trimmed
-            }
-        }
-        return nil
-    }
-
     static func elementMatches(
         _ element: AXUIElement,
         _ labels: LabelSet,

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1,0 +1,202 @@
+import ApplicationServices
+import Foundation
+
+/// Central policy for unavoidable Logic UI text matching.
+///
+/// Callers should prefer AX structure, identifiers, roles, geometry, selected
+/// state, and post-write readback. Use these label sets only where Logic exposes
+/// no stable non-localized AX handle, and keep State A gated by independent
+/// readback on write paths.
+enum AXLocalePolicy {
+    enum MatchMode {
+        case exact
+        case prefix
+        case contains
+    }
+
+    struct LabelSet: Sendable, Equatable {
+        let canonical: String
+        let variants: [String]
+        let rationale: String
+
+        init(canonical: String, variants: [String], rationale: String) {
+            self.canonical = canonical
+            self.variants = variants
+            self.rationale = rationale
+        }
+
+        var labels: [String] {
+            var result: [String] = []
+            for label in [canonical] + variants {
+                let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty, !result.contains(trimmed) {
+                    result.append(trimmed)
+                }
+            }
+            return result
+        }
+
+        func matches(_ text: String?, mode: MatchMode = .exact) -> Bool {
+            guard let text else { return false }
+            let candidate = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !candidate.isEmpty else { return false }
+
+            return labels.contains { label in
+                switch mode {
+                case .exact:
+                    candidate.caseInsensitiveCompare(label) == .orderedSame
+                case .prefix:
+                    candidate.range(
+                        of: label,
+                        options: [.anchored, .caseInsensitive, .diacriticInsensitive]
+                    ) != nil
+                case .contains:
+                    candidate.range(
+                        of: label,
+                        options: [.caseInsensitive, .diacriticInsensitive]
+                    ) != nil
+                }
+            }
+        }
+    }
+
+    struct MenuPath: Sendable, Equatable {
+        let bar: LabelSet
+        let item: LabelSet
+        let itemMode: MatchMode
+
+        init(bar: LabelSet, item: LabelSet, itemMode: MatchMode = .exact) {
+            self.bar = bar
+            self.item = item
+            self.itemMode = itemMode
+        }
+    }
+
+    static let viewMenuBar = LabelSet(
+        canonical: "View",
+        variants: ["보기"],
+        rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
+    )
+
+    static let showMixerMenuItem = LabelSet(
+        canonical: "Show Mixer",
+        variants: ["믹서 보기"],
+        rationale: "Used only as a best-effort mixer reveal before structural mixer readback."
+    )
+
+    static let windowMenuBar = LabelSet(
+        canonical: "Window",
+        variants: ["윈도우"],
+        rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
+    )
+
+    static let hideAllPluginWindowsMenuItem = LabelSet(
+        canonical: "Hide All Plug-in Windows",
+        variants: ["모든 플러그인 윈도우 가리기"],
+        rationale: "Best-effort cleanup so stale plugin windows do not steal later menu focus."
+    )
+
+    static let editMenuBar = LabelSet(
+        canonical: "Edit",
+        variants: ["편집"],
+        rationale: "Undo is menu-only in the rollback path; post-undo inventory readback verifies outcome."
+    )
+
+    static let undoMenuItemPrefix = LabelSet(
+        canonical: "Undo",
+        variants: ["실행 취소"],
+        rationale: "Menu item includes the operation name after the localized Undo prefix."
+    )
+
+    static let goToPositionDialogTitle = LabelSet(
+        canonical: "Go to Position",
+        variants: ["위치로 이동"],
+        rationale: "Used only to dismiss a stale dialog before another verified operation."
+    )
+
+    static let cancelButton = LabelSet(
+        canonical: "Cancel",
+        variants: ["취소"],
+        rationale: "Dialog dismissal fallback; no success state is inferred from this click."
+    )
+
+    static let saveConfirmationButton = LabelSet(
+        canonical: "Save",
+        variants: ["저장", "OK", "확인"],
+        rationale: "Save As dialog commit button; file existence verifies the result."
+    )
+
+    static let pluginFormatLeafPriority: [LabelSet] = [
+        LabelSet(canonical: "Stereo", variants: ["스테레오"], rationale: "Plugin format leaf after exact plugin selection."),
+        LabelSet(canonical: "Mono", variants: ["모노"], rationale: "Plugin format leaf after exact plugin selection."),
+        LabelSet(canonical: "Mono->Stereo", variants: ["모노->스테레오"], rationale: "Plugin format leaf after exact plugin selection."),
+        LabelSet(canonical: "Dual Mono", variants: ["듀얼 모노"], rationale: "Plugin format leaf after exact plugin selection."),
+    ]
+
+    static let showMixerMenuPath = MenuPath(bar: viewMenuBar, item: showMixerMenuItem)
+    static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)
+    static let editUndoMenuPath = MenuPath(bar: editMenuBar, item: undoMenuItemPrefix, itemMode: .prefix)
+
+    static func elementLabel(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> String? {
+        for text in [
+            AXHelpers.getTitle(element, runtime: runtime),
+            AXHelpers.getDescription(element, runtime: runtime),
+        ] {
+            if let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    static func elementMatches(
+        _ element: AXUIElement,
+        _ labels: LabelSet,
+        mode: MatchMode = .exact,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        labels.matches(AXHelpers.getTitle(element, runtime: runtime), mode: mode)
+            || labels.matches(AXHelpers.getDescription(element, runtime: runtime), mode: mode)
+    }
+
+    static func findMenuBarItem(
+        in menuBar: AXUIElement,
+        matching labels: LabelSet,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.getChildren(menuBar, runtime: runtime).first {
+            elementMatches($0, labels, runtime: runtime)
+        }
+    }
+
+    static func findMenuItem(
+        under menuBarItem: AXUIElement,
+        matching labels: LabelSet,
+        mode: MatchMode = .exact,
+        maxDepth: Int = 5,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.findAllDescendants(
+            of: menuBarItem,
+            role: kAXMenuItemRole as String,
+            maxDepth: maxDepth,
+            runtime: runtime
+        ).first {
+            elementMatches($0, labels, mode: mode, runtime: runtime)
+        }
+    }
+
+    static func findDescendant(
+        of element: AXUIElement,
+        role: String,
+        matching labels: LabelSet,
+        mode: MatchMode = .exact,
+        maxDepth: Int = 5,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.findAllDescendants(of: element, role: role, maxDepth: maxDepth, runtime: runtime).first {
+            elementMatches($0, labels, mode: mode, runtime: runtime)
+        }
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -49,11 +49,6 @@ extension AccessibilityChannel {
         _ runtime: AXLogicProElements.Runtime
     ) async -> (mixer: AXUIElement?, result: MixerRevealResult)
 
-    private static let showMixerMenuCandidates: [(bar: String, item: String)] = [
-        ("View", "Show Mixer"),
-        ("보기", "믹서 보기"),
-    ]
-
     /// Build the `plugins[]` array for one strip from its drift-safe slot
     /// enumeration. Pure + deterministic so it can be unit-tested against a
     /// strip element without a full mixer fixture.
@@ -196,7 +191,7 @@ extension AccessibilityChannel {
         _ = ProcessUtils.Runtime.production.activateLogicPro()
 
         let menuAttempt = await clickTopLevelMenuItemViaAXMenuClick(
-            candidates: showMixerMenuCandidates,
+            candidates: [AXLocalePolicy.showMixerMenuPath],
             runtime: runtime,
             maxEnabledRetries: 1,
             focusBetweenAttempts: false
@@ -1187,12 +1182,6 @@ extension AccessibilityChannel {
 
     // MARK: - insert_verified live drivers
 
-    /// Window-menu "hide all plug-in windows" (menu-bar, menu-item) pairs.
-    private static let hidePluginWindowsMenuCandidates: [(bar: String, item: String)] = [
-        ("윈도우", "모든 플러그인 윈도우 가리기"),
-        ("Window", "Hide All Plug-in Windows"),
-    ]
-
     /// Production exact-slot popup insert driver. Drives the target insert slot's
     /// own popup menu and returns a structured outcome plus a `select_trace`
     /// diagnostic dict. This is the default path that issues real slot/menu
@@ -1375,7 +1364,7 @@ extension AccessibilityChannel {
     @discardableResult
     private static func hideAllPluginWindows(runtime: AXLogicProElements.Runtime) async -> Bool {
         let result = await clickTopLevelMenuItemViaAXMenuClick(
-            candidates: hidePluginWindowsMenuCandidates,
+            candidates: [AXLocalePolicy.hidePluginWindowsMenuPath],
             runtime: runtime,
             maxEnabledRetries: 1,
             focusBetweenAttempts: false
@@ -1384,7 +1373,7 @@ extension AccessibilityChannel {
     }
 
     private static func clickTopLevelMenuItemViaAXMenuClick(
-        candidates: [(bar: String, item: String)],
+        candidates: [AXLocalePolicy.MenuPath],
         runtime: AXLogicProElements.Runtime,
         maxEnabledRetries: Int,
         focusBetweenAttempts: Bool
@@ -1393,7 +1382,7 @@ extension AccessibilityChannel {
         for attempt in 0..<maxEnabledRetries {
             _ = ProcessUtils.Runtime.production.activateLogicPro()
             for candidate in candidates {
-                guard let barItem = menuBarItem(titled: candidate.bar, runtime: runtime) else {
+                guard let barItem = menuBarItem(matching: candidate.bar, runtime: runtime) else {
                     continue
                 }
 
@@ -1402,7 +1391,12 @@ extension AccessibilityChannel {
                 }
                 try? await Task.sleep(for: .milliseconds(120))
 
-                guard let item = menuItem(titled: candidate.item, under: barItem, runtime: runtime.ax) else {
+                guard let item = menuItem(
+                    matching: candidate.item,
+                    mode: candidate.itemMode,
+                    under: barItem,
+                    runtime: runtime.ax
+                ) else {
                     AXMouseHelper.pressEscape()
                     continue
                 }
@@ -1429,13 +1423,11 @@ extension AccessibilityChannel {
     }
 
     private static func menuBarItem(
-        titled title: String,
+        matching labels: AXLocalePolicy.LabelSet,
         runtime: AXLogicProElements.Runtime
     ) -> AXUIElement? {
         guard let menuBar = AXLogicProElements.getMenuBar(runtime: runtime) else { return nil }
-        return AXHelpers.getChildren(menuBar, runtime: runtime.ax).first {
-            AXHelpers.getTitle($0, runtime: runtime.ax) == title
-        }
+        return AXLocalePolicy.findMenuBarItem(in: menuBar, matching: labels, runtime: runtime.ax)
     }
 
     private static func openMenuBarItem(
@@ -1449,44 +1441,12 @@ extension AccessibilityChannel {
     }
 
     private static func menuItem(
-        titled title: String,
+        matching labels: AXLocalePolicy.LabelSet,
+        mode: AXLocalePolicy.MatchMode = .exact,
         under menuBarItem: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> AXUIElement? {
-        if let direct = AXHelpers.findDescendant(
-            of: menuBarItem,
-            role: kAXMenuItemRole as String,
-            title: title,
-            maxDepth: 5,
-            runtime: runtime
-        ) {
-            return direct
-        }
-        return AXHelpers.findAllDescendants(
-            of: menuBarItem,
-            role: kAXMenuItemRole as String,
-            maxDepth: 5,
-            runtime: runtime
-        ).first { item in
-            AXHelpers.getTitle(item, runtime: runtime) == title
-                || AXHelpers.getDescription(item, runtime: runtime) == title
-        }
-    }
-
-    private static func menuItem(
-        titleStartingWith prefix: String,
-        under menuBarItem: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> AXUIElement? {
-        AXHelpers.findAllDescendants(
-            of: menuBarItem,
-            role: kAXMenuItemRole as String,
-            maxDepth: 5,
-            runtime: runtime
-        ).first { item in
-            (AXHelpers.getTitle(item, runtime: runtime) ?? "").hasPrefix(prefix)
-                || (AXHelpers.getDescription(item, runtime: runtime) ?? "").hasPrefix(prefix)
-        }
+        AXLocalePolicy.findMenuItem(under: menuBarItem, matching: labels, mode: mode, runtime: runtime)
     }
 
     /// Outcome of a menu-item probe/click.
@@ -1500,32 +1460,33 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime = .production
     ) async -> MenuItemScriptResult {
         _ = ProcessUtils.Runtime.production.activateLogicPro()
-        for bar in ["편집", "Edit"] {
-            guard let barItem = menuBarItem(titled: bar, runtime: runtime) else {
+        for candidate in [AXLocalePolicy.editUndoMenuPath] {
+            guard let barItem = menuBarItem(matching: candidate.bar, runtime: runtime) else {
                 continue
             }
-            for prefix in ["실행 취소", "Undo"] {
-                if !openMenuBarItem(barItem, runtime: runtime.ax) {
-                    continue
-                }
-                try? await Task.sleep(for: .milliseconds(120))
-                guard let item = menuItem(
-                    titleStartingWith: prefix, under: barItem, runtime: runtime.ax
-                ) else {
-                    AXMouseHelper.pressEscape()
-                    continue
-                }
-                if let enabled: Bool = AXHelpers.getAttribute(
-                    item, kAXEnabledAttribute, runtime: runtime.ax
-                ), enabled == false {
-                    AXMouseHelper.pressEscape()
-                    return .disabled
-                }
-                if clickElementCenter(item, runtime: runtime.ax) {
-                    return .ok
-                }
-                AXMouseHelper.pressEscape()
+            if !openMenuBarItem(barItem, runtime: runtime.ax) {
+                continue
             }
+            try? await Task.sleep(for: .milliseconds(120))
+            guard let item = menuItem(
+                matching: candidate.item,
+                mode: candidate.itemMode,
+                under: barItem,
+                runtime: runtime.ax
+            ) else {
+                AXMouseHelper.pressEscape()
+                continue
+            }
+            if let enabled: Bool = AXHelpers.getAttribute(
+                item, kAXEnabledAttribute, runtime: runtime.ax
+            ), enabled == false {
+                AXMouseHelper.pressEscape()
+                return .disabled
+            }
+            if clickElementCenter(item, runtime: runtime.ax) {
+                return .ok
+            }
+            AXMouseHelper.pressEscape()
         }
         return .missing
     }
@@ -1897,16 +1858,9 @@ extension AccessibilityChannel {
             (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
                 && elementCenter($0, runtime: runtime) != nil
         }
-        let preferredTitles = [
-            "스테레오", "Stereo",
-            "모노", "Mono",
-            "모노->스테레오", "Mono->Stereo",
-            "듀얼 모노", "Dual Mono",
-        ]
-        for title in preferredTitles {
+        for labels in AXLocalePolicy.pluginFormatLeafPriority {
             if let match = items.first(where: {
-                AXHelpers.getTitle($0, runtime: runtime) == title
-                    || AXHelpers.getDescription($0, runtime: runtime) == title
+                AXLocalePolicy.elementMatches($0, labels, runtime: runtime)
             }) {
                 return match
             }
@@ -2086,16 +2040,16 @@ extension AccessibilityChannel {
         var found = false
         for window in windows {
             let title = AXHelpers.getTitle(window, runtime: runtime.ax) ?? ""
-            guard title.contains("위치") || title.localizedCaseInsensitiveContains("Go to Position") else {
+            guard AXLocalePolicy.goToPositionDialogTitle.matches(title, mode: .contains) else {
                 continue
             }
             found = true
-            if let cancel = AXHelpers.findDescendant(
-                of: window, role: kAXButtonRole as String, title: "취소",
-                maxDepth: 4, runtime: runtime.ax
-            ) ?? AXHelpers.findDescendant(
-                of: window, role: kAXButtonRole as String, title: "Cancel",
-                maxDepth: 4, runtime: runtime.ax
+            if let cancel = AXLocalePolicy.findDescendant(
+                of: window,
+                role: kAXButtonRole as String,
+                matching: AXLocalePolicy.cancelButton,
+                maxDepth: 4,
+                runtime: runtime.ax
             ) {
                 if AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax)
                     || clickElementCenter(cancel, runtime: runtime.ax) {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -1705,8 +1705,7 @@ actor AccessibilityChannel: Channel {
         func dismissDialog() {
             let cancelButtons = AXHelpers.findAllDescendants(of: saveSheet, role: "AXButton", runtime: runtime.ax)
             for btn in cancelButtons {
-                let title = AXHelpers.getTitle(btn, runtime: runtime.ax) ?? ""
-                if title.contains("취소") || title.contains("Cancel") {
+                if AXLocalePolicy.elementMatches(btn, AXLocalePolicy.cancelButton, runtime: runtime.ax) {
                     AXHelpers.performAction(btn, kAXPressAction, runtime: runtime.ax)
                     return
                 }
@@ -1729,8 +1728,7 @@ actor AccessibilityChannel: Channel {
         let buttons = AXHelpers.findAllDescendants(of: saveSheet, role: "AXButton", runtime: runtime.ax)
         var saveClicked = false
         for button in buttons {
-            let title = AXHelpers.getTitle(button, runtime: runtime.ax) ?? ""
-            if title.contains("저장") || title.contains("Save") || title == "확인" || title == "OK" {
+            if AXLocalePolicy.elementMatches(button, AXLocalePolicy.saveConfirmationButton, runtime: runtime.ax) {
                 AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax)
                 saveClicked = true
                 break

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -1,0 +1,89 @@
+@preconcurrency import ApplicationServices
+import Testing
+@testable import LogicProMCP
+
+private func addPolicyMenuItem(
+    _ builder: FakeAXRuntimeBuilder,
+    _ id: Int,
+    title: String,
+    children: [AXUIElement] = []
+) -> AXUIElement {
+    let item = builder.element(id)
+    builder.setAttribute(item, kAXRoleAttribute as String, kAXMenuItemRole as String)
+    builder.setAttribute(item, kAXTitleAttribute as String, title)
+    builder.setChildren(item, children)
+    return item
+}
+
+@Suite("AX locale policy")
+struct AXLocalePolicyTests {
+    @Test("localized label sets cover English and Korean without broad false positives")
+    func labelSetMatching() {
+        #expect(AXLocalePolicy.cancelButton.matches("Cancel"))
+        #expect(AXLocalePolicy.cancelButton.matches("취소"))
+        #expect(!AXLocalePolicy.cancelButton.matches("Do Not Save"))
+
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("Save"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("저장"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("확인"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Don't Save"))
+
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("Undo Insert Plug-in", mode: .prefix))
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("실행 취소 플러그인 삽입", mode: .prefix))
+        #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Redo Insert Plug-in", mode: .prefix))
+    }
+
+    @Test("menu path lookup resolves English and Korean titles through one policy")
+    func menuPathLookup() {
+        let builder = FakeAXRuntimeBuilder()
+        let menuBar = builder.element(1)
+        let view = addPolicyMenuItem(builder, 2, title: "View")
+        let showMixer = addPolicyMenuItem(builder, 3, title: "Show Mixer")
+        let koreanWindow = addPolicyMenuItem(builder, 4, title: "윈도우")
+        let hidePlugins = addPolicyMenuItem(builder, 5, title: "모든 플러그인 윈도우 가리기")
+        builder.setChildren(menuBar, [view, koreanWindow])
+        builder.setChildren(view, [showMixer])
+        builder.setChildren(koreanWindow, [hidePlugins])
+
+        let runtime = builder.makeAXRuntime()
+        let viewMatch = AXLocalePolicy.findMenuBarItem(
+            in: menuBar,
+            matching: AXLocalePolicy.viewMenuBar,
+            runtime: runtime
+        )
+        let windowMatch = AXLocalePolicy.findMenuBarItem(
+            in: menuBar,
+            matching: AXLocalePolicy.windowMenuBar,
+            runtime: runtime
+        )
+
+        #expect(viewMatch == view)
+        #expect(windowMatch == koreanWindow)
+        #expect(AXLocalePolicy.findMenuItem(
+            under: view,
+            matching: AXLocalePolicy.showMixerMenuItem,
+            runtime: runtime
+        ) == showMixer)
+        #expect(AXLocalePolicy.findMenuItem(
+            under: koreanWindow,
+            matching: AXLocalePolicy.hideAllPluginWindowsMenuItem,
+            runtime: runtime
+        ) == hidePlugins)
+    }
+
+    @Test("element matching checks title and description")
+    func elementMatchingUsesTitleAndDescription() {
+        let builder = FakeAXRuntimeBuilder()
+        let titleButton = builder.element(20)
+        let descriptionButton = builder.element(21)
+        builder.setAttribute(titleButton, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(descriptionButton, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(titleButton, kAXTitleAttribute as String, "Cancel")
+        builder.setAttribute(descriptionButton, kAXDescriptionAttribute as String, "취소")
+
+        let runtime = builder.makeAXRuntime()
+
+        #expect(AXLocalePolicy.elementMatches(titleButton, AXLocalePolicy.cancelButton, runtime: runtime))
+        #expect(AXLocalePolicy.elementMatches(descriptionButton, AXLocalePolicy.cancelButton, runtime: runtime))
+    }
+}

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -15,6 +15,22 @@ private func addPolicyMenuItem(
     return item
 }
 
+private func addPolicyElement(
+    _ builder: FakeAXRuntimeBuilder,
+    _ id: Int,
+    role: String,
+    title: String? = nil,
+    children: [AXUIElement] = []
+) -> AXUIElement {
+    let item = builder.element(id)
+    builder.setAttribute(item, kAXRoleAttribute as String, role)
+    if let title {
+        builder.setAttribute(item, kAXTitleAttribute as String, title)
+    }
+    builder.setChildren(item, children)
+    return item
+}
+
 @Suite("AX locale policy")
 struct AXLocalePolicyTests {
     @Test("localized label sets cover English and Korean without broad false positives")
@@ -86,4 +102,350 @@ struct AXLocalePolicyTests {
         #expect(AXLocalePolicy.elementMatches(titleButton, AXLocalePolicy.cancelButton, runtime: runtime))
         #expect(AXLocalePolicy.elementMatches(descriptionButton, AXLocalePolicy.cancelButton, runtime: runtime))
     }
+
+    // MARK: - Deliberate Save/Cancel narrowing (contains -> exact)
+
+    /// PR #98 narrowed the Save-As commit match from substring `contains`
+    /// ("저장"/"Save") to whole-string `.exact`. These cases pin that the
+    /// narrowing is deliberate: a decorated/superset title that the OLD
+    /// `.contains` logic accepted must now be REJECTED, so a verified Save
+    /// commit can never click the wrong button. State A on this path is gated
+    /// only by `FileManager.fileExists`, so a missed match is an honest
+    /// State C error, never a false success.
+    @Test("save confirmation button narrows from contains to exact")
+    func saveConfirmationButtonNarrowing() {
+        // Exact canonical/variant titles still match (case-insensitive).
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("Save"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("저장"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("OK"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("확인"))
+
+        // New case-insensitivity is intentional and documented.
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("SAVE"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("save"))
+
+        // Deliberate narrowing: decorated/superset titles the OLD `.contains`
+        // logic matched must now be rejected by `.exact`.
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Save As…"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Save…"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Save As"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("저장하기"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("저장..."))
+
+        // The "Don't Save" decoy is excluded regardless of mode.
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Don't Save"))
+    }
+
+    /// The bare `OK`/`확인` variants are the broadest entries in
+    /// `saveConfirmationButton`. They are kept deliberately because some
+    /// localized Logic save panels commit via an "OK"/"확인" button rather
+    /// than "Save". Pinning the positive bare-OK match and a realistic
+    /// negative guard prevents an accidental change to the variant set going
+    /// uncaught. The wrong-button risk is bounded: the Save path verifies
+    /// via `FileManager.fileExists`, never by the click itself.
+    @Test("save confirmation OK/확인 variants are deliberately broad but bounded")
+    func saveConfirmationOKVariant() {
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("OK"))
+        #expect(AXLocalePolicy.saveConfirmationButton.matches("확인"))
+
+        // Decorated OK titles do not match under `.exact`.
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("OK, got it"))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("확인하기"))
+        // An unrelated dialog action is not mistaken for a Save commit.
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("Replace"))
+    }
+
+    /// Lock the Cancel button nil/empty/whitespace fail-closed guard and the
+    /// whitespace-trimming contract. `matches` must reject garbage AX titles
+    /// (nil, "", "   ") and must trim a real title before comparing.
+    @Test("cancel button fail-closed guards and whitespace trimming")
+    func cancelButtonGuards() {
+        #expect(!AXLocalePolicy.cancelButton.matches(nil))
+        #expect(!AXLocalePolicy.cancelButton.matches(""))
+        #expect(!AXLocalePolicy.cancelButton.matches("   "))
+        #expect(!AXLocalePolicy.cancelButton.matches("\n\t "))
+
+        // Real titles with surrounding whitespace/newlines still match.
+        #expect(AXLocalePolicy.cancelButton.matches(" Cancel "))
+        #expect(AXLocalePolicy.cancelButton.matches("\t취소\n"))
+        #expect(AXLocalePolicy.cancelButton.matches("CANCEL"))
+
+        // Save button shares the same nil/empty guard.
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches(nil))
+        #expect(!AXLocalePolicy.saveConfirmationButton.matches("   "))
+    }
+
+    /// Pin the `.prefix` mode's case- and diacritic-insensitive matching used
+    /// by the Undo rollback path. The anchored option means the label must be
+    /// a true prefix; case/diacritics are folded.
+    @Test("prefix mode is anchored, case- and diacritic-insensitive")
+    func prefixModeWidening() {
+        // Real prefixes match (operation name follows the localized prefix).
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("Undo Insert Plug-in", mode: .prefix))
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("실행 취소 플러그인 삽입", mode: .prefix))
+
+        // Case-insensitive prefix.
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("UNDO Insert Plug-in", mode: .prefix))
+
+        // Diacritic-insensitive prefix (an accented homograph still matches).
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("Ündo Insert Plug-in", mode: .prefix))
+
+        // NFD vs NFC variant of an accented prefix still matches.
+        let undoNFD = "U\u{0308}ndo Insert Plug-in" // U + combining diaeresis
+        #expect(AXLocalePolicy.undoMenuItemPrefix.matches(undoNFD, mode: .prefix))
+
+        // Anchored: a label that appears mid-string is NOT a prefix match.
+        #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Redo then Undo", mode: .prefix))
+        #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Redo Insert Plug-in", mode: .prefix))
+    }
+
+    // MARK: - Go-to-Position dialog dismissal (.contains mode)
+
+    /// The stale Go-to-Position dialog dismissal matches the window title with
+    /// `.contains`. Pin that the live-verified real titles ("Go to Position",
+    /// "위치로 이동") match even when wrapped in a window title, and that an
+    /// unrelated window is rejected.
+    @Test("go-to-position dialog title matches in contains mode")
+    func goToPositionContainsMode() {
+        #expect(AXLocalePolicy.goToPositionDialogTitle.matches("Go to Position", mode: .contains))
+        #expect(AXLocalePolicy.goToPositionDialogTitle.matches("위치로 이동", mode: .contains))
+        // Windowed title containing the phrase still matches.
+        #expect(AXLocalePolicy.goToPositionDialogTitle.matches("Untitled — 위치로 이동", mode: .contains))
+        #expect(AXLocalePolicy.goToPositionDialogTitle.matches("go to position", mode: .contains))
+
+        // Unrelated window titles are rejected.
+        #expect(!AXLocalePolicy.goToPositionDialogTitle.matches("Some Other Window", mode: .contains))
+        // Deliberate narrowing: a bare "위치" without the full phrase is not a
+        // recognized Go-to-Position dialog state.
+        #expect(!AXLocalePolicy.goToPositionDialogTitle.matches("위치", mode: .contains))
+        // nil/empty window titles fail closed.
+        #expect(!AXLocalePolicy.goToPositionDialogTitle.matches(nil, mode: .contains))
+        #expect(!AXLocalePolicy.goToPositionDialogTitle.matches("", mode: .contains))
+    }
+
+    // MARK: - Plugin format-leaf priority (live insert mutation path)
+
+    /// Each entry in `pluginFormatLeafPriority` must resolve both its canonical
+    /// (English) and Korean variant. A dropped variant would silently fail to
+    /// select the right plugin format on a live insert.
+    @Test("plugin format leaf priority resolves English and Korean variants")
+    func pluginFormatLeafVariants() {
+        let priority = AXLocalePolicy.pluginFormatLeafPriority
+        // Guard against an accidental array truncation.
+        #expect(priority.count == 4)
+
+        for entry in priority {
+            #expect(entry.matches(entry.canonical))
+            let firstVariant = try! #require(entry.variants.first)
+            #expect(entry.matches(firstVariant))
+        }
+
+        // Spot-check the canonical ordering by index.
+        #expect(priority[0].matches("Stereo"))
+        #expect(priority[0].matches("스테레오"))
+        #expect(priority[1].matches("Mono"))
+        #expect(priority[1].matches("모노"))
+        #expect(priority[2].matches("Mono->Stereo"))
+        #expect(priority[3].matches("Dual Mono"))
+        #expect(priority[3].matches("듀얼 모노"))
+    }
+
+    /// Fixture priority test: when a submenu contains BOTH a Mono and a Stereo
+    /// leaf, the first-match loop over `pluginFormatLeafPriority` must resolve
+    /// to Stereo (higher priority wins over Mono). This pins the load-bearing
+    /// ORDER that the insert driver (`preferredFormatLeaf`) depends on. The
+    /// priority loop is replicated here (the production helper is private and
+    /// requires CGEvent geometry); it exercises the exact same policy array
+    /// and `elementMatches` resolution used live.
+    @Test("plugin format leaf priority selects Stereo over Mono")
+    func pluginFormatLeafPriorityStereoWins() {
+        let builder = FakeAXRuntimeBuilder()
+        // Intentionally place Mono BEFORE Stereo in child order to prove the
+        // priority comes from the policy array, not menu order.
+        let mono = addPolicyMenuItem(builder, 30, title: "Mono")
+        let stereo = addPolicyMenuItem(builder, 31, title: "Stereo")
+        let dualMono = addPolicyMenuItem(builder, 32, title: "Dual Mono")
+        let submenu = builder.element(33)
+        builder.setAttribute(submenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        builder.setChildren(submenu, [mono, stereo, dualMono])
+        let runtime = builder.makeAXRuntime()
+
+        let items = AXHelpers.getChildren(submenu, runtime: runtime)
+        let selected = selectFormatLeaf(in: items, runtime: runtime)
+        #expect(selected == stereo)
+    }
+
+    /// Korean variants resolve through the same priority ordering: a submenu
+    /// with 모노 and 스테레오 must still pick 스테레오 (Stereo).
+    @Test("plugin format leaf priority selects Stereo over Mono in Korean")
+    func pluginFormatLeafPriorityStereoWinsKorean() {
+        let builder = FakeAXRuntimeBuilder()
+        let mono = addPolicyMenuItem(builder, 40, title: "모노")
+        let stereo = addPolicyMenuItem(builder, 41, title: "스테레오")
+        let submenu = builder.element(42)
+        builder.setAttribute(submenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        builder.setChildren(submenu, [mono, stereo])
+        let runtime = builder.makeAXRuntime()
+
+        let items = AXHelpers.getChildren(submenu, runtime: runtime)
+        let selected = selectFormatLeaf(in: items, runtime: runtime)
+        #expect(selected == stereo)
+    }
+
+    /// Negative/equivalence guard: a submenu with ONLY the lowest-priority
+    /// Dual Mono leaf still resolves to Dual Mono (lowest priority still
+    /// selected when alone), guarding against accidental array truncation.
+    @Test("plugin format leaf priority selects lone Dual Mono")
+    func pluginFormatLeafPriorityLoneDualMono() {
+        let builder = FakeAXRuntimeBuilder()
+        let dualMono = addPolicyMenuItem(builder, 50, title: "Dual Mono")
+        let submenu = builder.element(51)
+        builder.setAttribute(submenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        builder.setChildren(submenu, [dualMono])
+        let runtime = builder.makeAXRuntime()
+
+        let items = AXHelpers.getChildren(submenu, runtime: runtime)
+        let selected = selectFormatLeaf(in: items, runtime: runtime)
+        #expect(selected == dualMono)
+    }
+
+    // MARK: - Composed mutation-path equivalence (Undo / Save-As)
+
+    /// Edit-menu Undo resolver: an enabled `Undo X` / `실행 취소 X` item must be
+    /// found via the policy prefix lookup, and a disabled item's enablement
+    /// can be read so the caller's `.disabled` branch fires. This pins the
+    /// rollback wrapper control flow that pure-helper tests leave uncovered.
+    @Test("edit-menu undo resolver finds enabled item and reads disabled state")
+    func editUndoResolverEnablement() {
+        let builder = FakeAXRuntimeBuilder()
+        let undoItem = addPolicyMenuItem(builder, 60, title: "Undo Insert Plug-in")
+        builder.setAttribute(undoItem, kAXEnabledAttribute as String, true)
+        let koreanUndo = addPolicyMenuItem(builder, 61, title: "실행 취소 플러그인 삽입")
+        builder.setAttribute(koreanUndo, kAXEnabledAttribute as String, false)
+        let menu = builder.element(62)
+        builder.setAttribute(menu, kAXRoleAttribute as String, kAXMenuRole as String)
+        builder.setChildren(menu, [undoItem])
+        let editBarItem = addPolicyMenuItem(builder, 63, title: "Edit", children: [menu])
+
+        let koreanMenu = builder.element(64)
+        builder.setAttribute(koreanMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        builder.setChildren(koreanMenu, [koreanUndo])
+        let koreanEditBarItem = addPolicyMenuItem(builder, 65, title: "편집", children: [koreanMenu])
+
+        let runtime = builder.makeAXRuntime()
+
+        let foundEnabled = AXLocalePolicy.findMenuItem(
+            under: editBarItem,
+            matching: AXLocalePolicy.undoMenuItemPrefix,
+            mode: .prefix,
+            runtime: runtime
+        )
+        #expect(foundEnabled == undoItem)
+        let enabled: Bool = try! #require(
+            AXHelpers.getAttribute(foundEnabled!, kAXEnabledAttribute as String, runtime: runtime)
+        )
+        #expect(enabled)
+
+        let foundDisabled = AXLocalePolicy.findMenuItem(
+            under: koreanEditBarItem,
+            matching: AXLocalePolicy.undoMenuItemPrefix,
+            mode: .prefix,
+            runtime: runtime
+        )
+        #expect(foundDisabled == koreanUndo)
+        let disabledFlag: Bool = try! #require(
+            AXHelpers.getAttribute(foundDisabled!, kAXEnabledAttribute as String, runtime: runtime)
+        )
+        #expect(!disabledFlag)
+    }
+
+    /// Save-As commit equivalence: among a button set containing `Save` and a
+    /// `Don't Save` decoy, the policy resolves the Save button and rejects the
+    /// decoy. This pins the commit-button selection on the file-writing path.
+    @Test("save-as commit resolves Save button and rejects Don't Save decoy")
+    func saveAsCommitButtonSelection() {
+        let builder = FakeAXRuntimeBuilder()
+        let dontSave = addPolicyElement(builder, 70, role: kAXButtonRole as String, title: "Don't Save")
+        let saveButton = addPolicyElement(builder, 71, role: kAXButtonRole as String, title: "Save")
+        let cancelButton = addPolicyElement(builder, 72, role: kAXButtonRole as String, title: "Cancel")
+        let sheet = builder.element(73)
+        builder.setAttribute(sheet, kAXRoleAttribute as String, kAXSheetRole as String)
+        builder.setChildren(sheet, [dontSave, saveButton, cancelButton])
+        let runtime = builder.makeAXRuntime()
+
+        let buttons = AXHelpers.findAllDescendants(
+            of: sheet,
+            role: kAXButtonRole as String,
+            runtime: runtime
+        )
+        let matched = buttons.first {
+            AXLocalePolicy.elementMatches($0, AXLocalePolicy.saveConfirmationButton, runtime: runtime)
+        }
+        #expect(matched == saveButton)
+        #expect(!AXLocalePolicy.elementMatches(dontSave, AXLocalePolicy.saveConfirmationButton, runtime: runtime))
+        // The Cancel decoy is also not mistaken for a Save commit.
+        #expect(!AXLocalePolicy.elementMatches(cancelButton, AXLocalePolicy.saveConfirmationButton, runtime: runtime))
+    }
+
+    // MARK: - findDescendant (live Cancel-button dismissal path)
+
+    /// `findDescendant` is the role-scoped, depth-bounded helper that drives the
+    /// Cancel-button lookup in `closeGoToPositionDialog`. Pin that it returns
+    /// the nested Cancel BUTTON (not a same-titled non-button, not a deeper
+    /// button beyond maxDepth) and respects maxDepth.
+    @Test("findDescendant returns role-scoped, depth-bounded Cancel button")
+    func findDescendantRoleAndDepth() {
+        let builder = FakeAXRuntimeBuilder()
+        // Same-titled non-button at shallow depth must be ignored (role filter).
+        let decoyText = addPolicyElement(builder, 80, role: kAXStaticTextRole as String, title: "취소")
+        // The real nested Cancel button lives at depth 3 inside two groups.
+        let cancelButton = addPolicyElement(builder, 81, role: kAXButtonRole as String, title: "취소")
+        let innerGroup = addPolicyElement(builder, 82, role: kAXGroupRole as String, children: [cancelButton])
+        let outerGroup = addPolicyElement(
+            builder, 83, role: kAXGroupRole as String, children: [decoyText, innerGroup]
+        )
+        let window = addPolicyElement(
+            builder, 84, role: kAXWindowRole as String, children: [outerGroup]
+        )
+        let runtime = builder.makeAXRuntime()
+
+        let found = AXLocalePolicy.findDescendant(
+            of: window,
+            role: kAXButtonRole as String,
+            matching: AXLocalePolicy.cancelButton,
+            maxDepth: 4,
+            runtime: runtime
+        )
+        #expect(found == cancelButton)
+
+        // maxDepth: 1 only reaches the window's direct children (the outer
+        // group), so the nested button is out of range and nothing matches.
+        let shallow = AXLocalePolicy.findDescendant(
+            of: window,
+            role: kAXButtonRole as String,
+            matching: AXLocalePolicy.cancelButton,
+            maxDepth: 1,
+            runtime: runtime
+        )
+        #expect(shallow == nil)
+    }
+}
+
+/// Replicates the first-match priority loop from
+/// `AccessibilityChannel.preferredFormatLeaf` (which is private and additionally
+/// gated by CGEvent geometry) against a list of candidate menu items. Exercises
+/// the exact same `AXLocalePolicy.pluginFormatLeafPriority` array and
+/// `elementMatches` resolution used on the live insert path.
+private func selectFormatLeaf(
+    in items: [AXUIElement],
+    runtime: AXHelpers.Runtime
+) -> AXUIElement? {
+    for labels in AXLocalePolicy.pluginFormatLeafPriority {
+        if let match = items.first(where: {
+            AXLocalePolicy.elementMatches($0, labels, runtime: runtime)
+        }) {
+            return match
+        }
+    }
+    return items.first
 }

--- a/docs/locale-agnostic-ax-policy.md
+++ b/docs/locale-agnostic-ax-policy.md
@@ -1,0 +1,38 @@
+# Locale-Agnostic AX Policy
+
+Logic Pro MCP must not treat localized UI text as proof that a UI mutation succeeded. Localized labels are compatibility hints only.
+
+## Matching Order
+
+1. Prefer structural AX relationships: role, subrole, direct children, selected children, parent/child context, and stable layout position.
+2. Prefer stable AX identifiers where Logic exposes them.
+3. Use geometry only to anchor a known control to a known context, such as a plugin popup near the requested insert slot.
+4. Use localized title/description text only when Logic exposes no stable non-localized handle.
+5. Keep all unavoidable localized text in `AXLocalePolicy`.
+6. On mutating paths, State A requires independent readback after the write.
+
+## Centralized Compatibility Labels
+
+`AXLocalePolicy` currently owns English/Korean labels for:
+
+- View > Show Mixer
+- Window > Hide All Plug-in Windows
+- Edit > Undo prefix
+- Go to Position dialog title
+- Cancel buttons
+- Save/OK confirmation buttons
+- Plugin format leaves: Stereo, Mono, Mono->Stereo, Dual Mono
+
+These labels are allowed because each use is either best-effort cleanup/reveal or followed by independent file, project, track, plugin, or inventory readback.
+
+## Adding New Labels
+
+- First try to solve the lookup structurally.
+- If a localized label is unavoidable, add it to `AXLocalePolicy` with a rationale.
+- Add deterministic tests for English and Korean at minimum.
+- Do not infer State A from the click itself.
+- Include a failure mode that returns State B/C when readback is unavailable or ambiguous.
+
+## Known Remaining Surfaces
+
+Some AppleScript fallback snippets still contain explicit menu labels because System Events menu addressing is text-based. Those fallbacks must remain guarded by post-action readback and should be migrated to policy-owned helpers when the AX path can replace the script path.

--- a/docs/prd/PRD-issue60-locale-agnostic-ui.md
+++ b/docs/prd/PRD-issue60-locale-agnostic-ui.md
@@ -1,0 +1,105 @@
+# PRD: Issue 60 Locale-Agnostic UI Policy Foundation
+
+**Version**: 0.1
+**Author**: Codex
+**Date**: 2026-06-20
+**Status**: Done
+**Size**: M
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Issue #60 is an epic to make Logic UI automation fully locale-agnostic. The full epic cannot be closed by one PR because the repository still contains many historical AX and AppleScript label matchers. A safe first PR should harden the touched surfaces and establish a central policy for unavoidable localized labels.
+
+### 1.2 Problem Definition
+Touched AX code paths used English/Korean labels inline, which made fallback behavior hard to audit and easy to expand without readback evidence. The first policy PR needs to move those labels behind a single source of truth and document that labels are compatibility hints, not proof of success.
+
+### 1.3 Impact of Not Solving
+Locale-specific ad hoc matching can silently regress non-English Logic UI sessions, make reviews miss unsafe matchers, and weaken the project's State A readback contract.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [x] G1: Add a central `AXLocalePolicy` for touched AX localized labels and menu path helpers.
+- [x] G2: Move verified-plugin, dialog cleanup, Save/Cancel, and plugin-format label matching in touched paths to the policy.
+- [x] G3: Add deterministic tests for English/Korean policy behavior.
+- [x] G4: Document that localized labels are fallback hints and mutating paths still require readback.
+
+### 2.2 Non-Goals
+- NG1: Do not claim the entire #60 epic is complete.
+- NG2: Do not migrate every historical AX or AppleScript label matcher in this PR.
+- NG3: Do not add new live UI automation behavior.
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Central locale policy
+**As a** maintainer, **I want** touched localized AX labels to live in one policy module, **so that** future review can see and constrain locale assumptions.
+
+**Acceptance Criteria:**
+- [x] AC-1.1: Given touched AX menu/dialog code, when it needs English/Korean labels, then it reads them from `AXLocalePolicy`.
+- [x] AC-1.2: Given policy tests, when English/Korean variants are checked, then expected labels and menu paths match.
+- [x] AC-1.3: Given mutating UI paths, when label fallback is used, then success is still gated by existing readback behavior.
+
+### US-2: Epic-safe scope
+**As a** reviewer, **I want** the PR to state remaining #60 work, **so that** this policy foundation is not mistaken for closing the epic.
+
+**Acceptance Criteria:**
+- [x] AC-2.1: Ticket status lists remaining audit/migration/live-verification work.
+- [x] AC-2.2: PR body references #60 without closing it.
+
+## 4. Technical Design
+
+### 4.1 Architecture Overview
+`AXLocalePolicy` centralizes label sets and helper behavior for the touched AX paths. Callers keep their existing control flow and readback gates, but stop carrying scattered label arrays inline.
+
+### 4.2 Data Model Changes
+No persisted data model changes.
+
+### 4.3 API Design
+No public MCP API change.
+
+### 4.4 Key Technical Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Scope | Full epic migration vs touched-surface foundation | Touched-surface foundation | #60 is an epic; a focused PR is reviewable and safer. |
+| Evidence | Treat labels as success evidence vs compatibility hints | Compatibility hints | Project policy requires State A readback for successful mutation claims. |
+| Placement | Inline arrays vs central policy | Central policy | Makes locale assumptions auditable. |
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | Unknown locale label | Existing fail-closed behavior remains; no success without readback | P1 |
+| E2 | Dialog cleanup label differs | Policy can be extended in one place after evidence | P2 |
+| E3 | Untouched matcher remains inline | Listed as remaining epic work, not hidden by this PR | P2 |
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+- `AXLocalePolicy` deterministic policy tests.
+
+### 8.2 Integration Tests
+- Existing AX element, verified plugin insert, accessibility channel, and inventory tests cover touched call paths.
+
+### 8.3 Edge Case Tests
+- English and Korean labels.
+- Mutating path readback-gated behavior remains covered by existing plugin tests.
+
+## 10. Dependencies & Risks
+
+### 10.1 Dependencies
+
+| Dependency | Owner | Status | Risk if Delayed |
+|------------|-------|--------|-----------------|
+| Full AX matcher audit | Project | Remaining epic work | #60 cannot be closed yet. |
+| English/Korean live verification notes | Project | Remaining epic work | Policy confidence remains deterministic until live notes land. |
+
+### 10.2 Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Reviewers mistake this for full epic completion | Medium | Medium | STATUS and PR body state partial scope. |
+| Central policy grows without evidence | Medium | High | Documentation says labels are hints, not success evidence. |

--- a/docs/tickets/issue60-locale-agnostic-ui/STATUS.md
+++ b/docs/tickets/issue60-locale-agnostic-ui/STATUS.md
@@ -1,0 +1,28 @@
+# Issue #60 Ticket Board: Locale-Agnostic Logic UI Automation
+
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/60
+**Status**: Partial - focused policy hardening PR
+
+## Tickets
+
+- [x] `I60-T1` Central AX locale policy and deterministic tests
+  - Add `AXLocalePolicy` as the single home for unavoidable English/Korean UI labels in touched AX paths.
+  - Move verified-plugin menu/dialog label matching and Save/Cancel button matching to the policy.
+  - Document the matching order and State A readback requirement.
+
+## Remaining Epic Work
+
+- Audit every remaining AX text matcher outside the touched surfaces.
+- Migrate AppleScript menu-label fallbacks where a safe AX replacement exists.
+- Add live verification notes for English and Korean Logic UI before closing the epic.
+
+## Verification
+
+Completed on 2026-06-20:
+
+- `swift test --filter AXLocalePolicy` - 3 tests passed.
+- `swift test --filter AXLogicProElements` - 24 tests passed.
+- `swift test --filter PluginInsertVerified` - 32 tests passed.
+- `swift test --filter AccessibilityChannel` - 70 tests passed.
+- `swift test --filter PluginGetInventory` - 12 tests passed.
+- `git diff --check` - passed.

--- a/docs/tickets/issue60-locale-agnostic-ui/STATUS.md
+++ b/docs/tickets/issue60-locale-agnostic-ui/STATUS.md
@@ -1,7 +1,9 @@
 # Issue #60 Ticket Board: Locale-Agnostic Logic UI Automation
 
 **Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/60
+**PRD**: docs/prd/PRD-issue60-locale-agnostic-ui.md
 **Status**: Partial - focused policy hardening PR
+**Current Phase**: 7
 
 ## Tickets
 
@@ -15,6 +17,14 @@
 - Audit every remaining AX text matcher outside the touched surfaces.
 - Migrate AppleScript menu-label fallbacks where a safe AX replacement exists.
 - Add live verification notes for English and Korean Logic UI before closing the epic.
+
+## Review History
+
+| Phase | Round | Verdict | P0 | P1 | P2 | Notes |
+|-------|-------|---------|----|----|----|-------|
+| 2 | 1 | PASS | 0 | 0 | 0 | Scope is a policy foundation, not full epic closure. |
+| 4 | 1 | PASS | 0 | 0 | 0 | T1 covers central policy, touched callers, docs, and deterministic tests. |
+| 6 | 1 | PASS | 0 | 0 | 0 | No new mutation behavior; existing readback gates retained. |
 
 ## Verification
 

--- a/docs/tickets/issue60-locale-agnostic-ui/T1-centralized-ax-locale-policy.md
+++ b/docs/tickets/issue60-locale-agnostic-ui/T1-centralized-ax-locale-policy.md
@@ -1,0 +1,33 @@
+# I60-T1 - Centralized AX Locale Policy
+
+**Status**: Done
+**Size**: M
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/60
+
+## Goal
+
+Centralize unavoidable localized UI labels used by touched AX paths and make the safety policy explicit.
+
+## Scope
+
+- Add `AXLocalePolicy` with label sets, menu paths, and AX element matching helpers.
+- Cover English and Korean labels for verified-plugin menu reveal/cleanup, Undo rollback, Go to Position dialog dismissal, Save/Cancel buttons, and plugin format leaves.
+- Update touched callers to use the central policy.
+- Add deterministic tests for label and menu matching.
+- Add a repo-level policy document.
+
+## Acceptance Criteria
+
+- Touched AX paths no longer carry ad hoc English/Korean label arrays inline.
+- Tests cover English and Korean variants for the centralized policy.
+- Documentation states localized labels are compatibility hints, not success evidence.
+- Mutating paths remain readback-gated.
+
+## Verification
+
+- `swift test --filter AXLocalePolicy` - 3 tests passed.
+- `swift test --filter AXLogicProElements` - 24 tests passed.
+- `swift test --filter PluginInsertVerified` - 32 tests passed.
+- `swift test --filter AccessibilityChannel` - 70 tests passed.
+- `swift test --filter PluginGetInventory` - 12 tests passed.
+- `git diff --check` - passed.


### PR DESCRIPTION
## Summary
- Add `AXLocalePolicy` as the central home for unavoidable English/Korean Logic UI labels in touched AX paths.
- Move verified-plugin menu reveal/cleanup, Undo rollback, Go-to-Position dialog dismissal, plugin format leaves, and Save/Cancel button matching onto the policy helpers.
- Document the locale-agnostic AX matching order and add issue #60 ticket notes.

## Safety contract
- Structural AX relationships, identifiers, geometry, and post-write readback remain preferred over text matching.
- Localized labels are compatibility hints only; they do not create a State A success path.
- Existing mutating paths remain readback-gated.
- This is a focused partial PR for the epic; remaining AppleScript text-addressed menu fallbacks are documented as future migration work.

## Verification
- `swift test --filter AXLocalePolicy` - 3 tests passed.
- `swift test --filter AXLogicProElements` - 24 tests passed.
- `swift test --filter PluginInsertVerified` - 32 tests passed.
- `swift test --filter AccessibilityChannel` - 70 tests passed.
- `swift test --filter PluginGetInventory` - 12 tests passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed.

Refs #60
