### PR TITLE
feat(project): add dry-run export plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Logic Pro MCP uses a different model. It routes each operation to the strongest 
 | Mixer | Volume, pan, plugin snapshots, guarded stock plugin insertion | MCU writes plus AX readback/provenance; occupied plugin slots refuse replacement |
 | Library | Scan Logic's instrument library and load patches by path | Disk/AX inventory is cached and path-allowlisted |
 | Navigation | Bars, markers, zoom, view toggles | Marker navigation is target-faithful; cold-cache misses return failure instead of "next marker" |
-| Project lifecycle | New, open, save, save-as, close, bounce, quit | Destructive operations require confirmation; saves verify package existence/mtime |
+| Project lifecycle | New, open, save, save-as, close, bounce, export plan, quit | Destructive operations require confirmation; dry-run export plans do not open Logic or write artifacts |
 
 ## Agent-Grade Surfaces
 

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -73,7 +73,10 @@ struct ProjectDispatcher {
         case "export_plan":
             do {
                 let plan = try ProjectExportPlanner.plan(params: params)
-                return toolTextResult(encodeJSON(plan, compact: true))
+                // PR99-C5 / C2-nit (HC): use the throwing encoder so an encode
+                // failure fails closed (isError=true) via the catch below instead
+                // of returning an error-shaped, non-manifest body as a success.
+                return toolTextResult(try encodeJSONStrict(plan, compact: true))
             } catch {
                 audit(command, phase: .rejected, reason: "invalid export plan")
                 return toolTextResult("export_plan invalid_params: \(error)", isError: true)

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -11,7 +11,7 @@ struct ProjectDispatcher {
 
     static let tool = commandTool(
         name: "logic_project",
-        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); others -> {}.",
+        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; others -> {}.",
         commandDescription: "Project command to execute"
     )
 
@@ -70,6 +70,15 @@ struct ProjectDispatcher {
         // anomaly during review.
 
         switch command {
+        case "export_plan":
+            do {
+                let plan = try ProjectExportPlanner.plan(params: params)
+                return toolTextResult(encodeJSON(plan, compact: true))
+            } catch {
+                audit(command, phase: .rejected, reason: "invalid export plan")
+                return toolTextResult("export_plan invalid_params: \(error)", isError: true)
+            }
+
         case "new":
             audit(command, phase: .executed)
             let result = await router.route(operation: "project.new")
@@ -227,7 +236,7 @@ struct ProjectDispatcher {
 
         default:
             return toolTextResult(
-                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions",
+                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan",
                 isError: true
             )
         }

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -359,6 +359,8 @@ struct SystemDispatcher {
                   save_as           -> { path: String } — Save to new path
                   close             -> {} — Close project
                   bounce            -> {} — Open bounce dialog
+                  get_regions       -> {} — Read arrange regions
+                  export_plan       -> { projects, output_root, artifacts? } — Dry-run export manifest plan
                   launch            -> {} — Launch Logic Pro
                   quit              -> {} — Quit Logic Pro
 

--- a/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
@@ -1,0 +1,420 @@
+import Foundation
+import MCP
+
+struct ProjectExportPlan: Codable, Sendable, Equatable {
+    let schema: String
+    let runID: String
+    let status: String
+    let executionMode: String
+    let outputRoot: String
+    let collisionPolicy: String
+    let namingPolicy: String
+    let projectCount: Int
+    let projects: [ProjectExportPlanProject]
+    let requiredConfirmations: [ProjectExportConfirmation]
+    let unsupportedOrBlockedSteps: [ProjectExportBlockedStep]
+    let baselineVerification: [String]
+    let enhancementPath: [String]
+    let nextSafeAction: String
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case runID = "run_id"
+        case status
+        case executionMode = "execution_mode"
+        case outputRoot = "output_root"
+        case collisionPolicy = "collision_policy"
+        case namingPolicy = "naming_policy"
+        case projectCount = "project_count"
+        case projects
+        case requiredConfirmations = "required_confirmations"
+        case unsupportedOrBlockedSteps = "unsupported_or_blocked_steps"
+        case baselineVerification = "baseline_verification"
+        case enhancementPath = "enhancement_path"
+        case nextSafeAction = "next_safe_action"
+    }
+}
+
+struct ProjectExportPlanProject: Codable, Sendable, Equatable {
+    let index: Int
+    let projectPath: String
+    let displayName: String
+    let validationStatus: String
+    let validationIssues: [String]
+    let expectedArtifacts: [ProjectExportPlanArtifact]
+    let workflowSteps: [ProjectExportWorkflowStep]
+    let manifestStatus: String
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case projectPath = "project_path"
+        case displayName = "display_name"
+        case validationStatus = "validation_status"
+        case validationIssues = "validation_issues"
+        case expectedArtifacts = "expected_artifacts"
+        case workflowSteps = "workflow_steps"
+        case manifestStatus = "manifest_status"
+    }
+}
+
+struct ProjectExportPlanArtifact: Codable, Sendable, Equatable {
+    let kind: String
+    let path: String
+    let status: String
+    let verification: ProjectExportArtifactVerification
+    let analysis: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case status
+        case verification
+        case analysis
+    }
+}
+
+struct ProjectExportArtifactVerification: Codable, Sendable, Equatable {
+    let exists: Bool
+    let fileSizeBytes: Int64?
+    let mtime: String?
+    let pathUnderOutputRoot: Bool
+    let wouldOverwrite: Bool
+    let issues: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case exists
+        case fileSizeBytes = "file_size_bytes"
+        case mtime
+        case pathUnderOutputRoot = "path_under_output_root"
+        case wouldOverwrite = "would_overwrite"
+        case issues
+    }
+}
+
+struct ProjectExportWorkflowStep: Codable, Sendable, Equatable {
+    let id: String
+    let title: String
+    let tool: String?
+    let command: String?
+    let mutates: Bool
+    let executed: Bool
+    let requiresConfirmationLevel: String?
+    let stopConditions: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case tool
+        case command
+        case mutates
+        case executed
+        case requiresConfirmationLevel = "requires_confirmation_level"
+        case stopConditions = "stop_conditions"
+    }
+}
+
+struct ProjectExportConfirmation: Codable, Sendable, Equatable {
+    let level: String
+    let requiredFor: [String]
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case level
+        case requiredFor = "required_for"
+        case message
+    }
+}
+
+struct ProjectExportBlockedStep: Codable, Sendable, Equatable {
+    let operation: String
+    let reason: String
+    let safeAlternative: String
+
+    enum CodingKeys: String, CodingKey {
+        case operation
+        case reason
+        case safeAlternative = "safe_alternative"
+    }
+}
+
+enum ProjectExportPlanner {
+    static let schema = "logic_pro_mcp_export_manifest.v1"
+    static let supportedArtifactKinds: Set<String> = ["bounce", "stem", "preview", "variant"]
+
+    static func plan(params: [String: Value], fileManager: FileManager = .default) throws -> ProjectExportPlan {
+        let projects = try projectPaths(from: params)
+        let outputRoot = try outputRoot(from: params)
+        let artifacts = try artifactKinds(from: params)
+        let collisionPolicy = stringParam(params, "collision_policy", default: "fail_if_exists")
+        guard ["fail_if_exists", "skip_existing"].contains(collisionPolicy) else {
+            throw ExportPlanError.invalid("collision_policy must be fail_if_exists or skip_existing")
+        }
+        let namingPolicy = stringParam(params, "naming_policy", default: "project-name-kind")
+
+        let rootURL = URL(fileURLWithPath: outputRoot).standardizedFileURL
+        let projectPlans = projects.enumerated().map { index, path in
+            projectPlan(
+                index: index,
+                path: path,
+                outputRoot: rootURL,
+                artifactKinds: artifacts,
+                collisionPolicy: collisionPolicy,
+                fileManager: fileManager
+            )
+        }
+
+        let blocked = blockedSteps()
+        let status = projectPlans.contains { project in
+            project.validationStatus != "valid" ||
+                project.expectedArtifacts.contains { !$0.verification.issues.isEmpty }
+        }
+            ? "degraded"
+            : "planned"
+
+        return ProjectExportPlan(
+            schema: schema,
+            runID: deterministicRunID(projects: projects, outputRoot: outputRoot, artifacts: artifacts),
+            status: status,
+            executionMode: "dry_run_only",
+            outputRoot: outputRoot,
+            collisionPolicy: collisionPolicy,
+            namingPolicy: namingPolicy,
+            projectCount: projectPlans.count,
+            projects: projectPlans,
+            requiredConfirmations: [
+                ProjectExportConfirmation(
+                    level: "L2",
+                    requiredFor: ["open", "bounce", "close"],
+                    message: "Batch export execution must confirm every project open, export/bounce, and close boundary before mutation."
+                ),
+            ],
+            unsupportedOrBlockedSteps: blocked,
+            baselineVerification: [
+                "artifact_exists",
+                "file_size_non_zero",
+                "mtime_within_run_window",
+                "path_under_output_root",
+                "no_silent_overwrite",
+            ],
+            enhancementPath: [
+                "Integrate Issue #29 audio analysis for duration, non-silence, peak/clipping, sample-rate, channels, and honest loudness estimates.",
+            ],
+            nextSafeAction: "review_export_plan"
+        )
+    }
+
+    private static func projectPlan(
+        index: Int,
+        path: String,
+        outputRoot: URL,
+        artifactKinds: [String],
+        collisionPolicy: String,
+        fileManager: FileManager
+    ) -> ProjectExportPlanProject {
+        var issues: [String] = []
+        if !AppleScriptSafety.isValidProjectPath(path, requireExisting: false) {
+            issues.append("project_path_must_be_absolute_logicx")
+        }
+        if !fileManager.fileExists(atPath: path) {
+            issues.append("project_path_not_found")
+        }
+
+        let projectURL = URL(fileURLWithPath: path).standardizedFileURL
+        let displayName = projectURL.deletingPathExtension().lastPathComponent
+        let artifactPlans = artifactKinds.map { kind in
+            artifact(
+                kind: kind,
+                displayName: displayName,
+                outputRoot: outputRoot,
+                collisionPolicy: collisionPolicy,
+                fileManager: fileManager
+            )
+        }
+
+        return ProjectExportPlanProject(
+            index: index,
+            projectPath: path,
+            displayName: displayName,
+            validationStatus: issues.isEmpty ? "valid" : "invalid",
+            validationIssues: issues,
+            expectedArtifacts: artifactPlans,
+            workflowSteps: workflowSteps(for: index),
+            manifestStatus: "pending"
+        )
+    }
+
+    private static func artifact(
+        kind: String,
+        displayName: String,
+        outputRoot: URL,
+        collisionPolicy: String,
+        fileManager: FileManager
+    ) -> ProjectExportPlanArtifact {
+        let safeProject = sanitizeFileComponent(displayName)
+        let url = outputRoot.appendingPathComponent("\(safeProject)-\(kind).wav").standardizedFileURL
+        let exists = fileManager.fileExists(atPath: url.path)
+        let attrs = try? fileManager.attributesOfItem(atPath: url.path)
+        let size = (attrs?[.size] as? NSNumber)?.int64Value
+        let mtime = (attrs?[.modificationDate] as? Date).map {
+            ISO8601DateFormatter.cacheFormatter.string(from: $0)
+        }
+        let underRoot = url.path == outputRoot.path || url.path.hasPrefix(outputRoot.path + "/")
+        var issues: [String] = []
+        if !underRoot {
+            issues.append("artifact_path_outside_output_root")
+        }
+        if exists && collisionPolicy == "fail_if_exists" {
+            issues.append("artifact_would_overwrite")
+        }
+        if exists && (size ?? 0) == 0 {
+            issues.append("artifact_zero_bytes")
+        }
+
+        return ProjectExportPlanArtifact(
+            kind: kind,
+            path: url.path,
+            status: exists ? "existing" : "pending",
+            verification: ProjectExportArtifactVerification(
+                exists: exists,
+                fileSizeBytes: size,
+                mtime: mtime,
+                pathUnderOutputRoot: underRoot,
+                wouldOverwrite: exists && collisionPolicy == "fail_if_exists",
+                issues: issues
+            ),
+            analysis: ["issue_29": "not_run_in_dry_run"]
+        )
+    }
+
+    private static func workflowSteps(for index: Int) -> [ProjectExportWorkflowStep] {
+        [
+            ProjectExportWorkflowStep(
+                id: "project_\(index)_open",
+                title: "Open project after confirming expected path",
+                tool: "logic_project",
+                command: "open",
+                mutates: true,
+                executed: false,
+                requiresConfirmationLevel: "L2",
+                stopConditions: ["wrong_project_observed", "open_failed", "ambiguous_save_state"]
+            ),
+            ProjectExportWorkflowStep(
+                id: "project_\(index)_export",
+                title: "Trigger approved bounce/export operation",
+                tool: "logic_project",
+                command: "bounce",
+                mutates: true,
+                executed: false,
+                requiresConfirmationLevel: "L2",
+                stopConditions: ["missing_output", "stale_output", "overwrite_risk"]
+            ),
+            ProjectExportWorkflowStep(
+                id: "project_\(index)_close",
+                title: "Close or leave project according to explicit policy",
+                tool: "logic_project",
+                command: "close",
+                mutates: true,
+                executed: false,
+                requiresConfirmationLevel: "L2",
+                stopConditions: ["ambiguous_close_state", "save_prompt_unresolved"]
+            ),
+        ]
+    }
+
+    private static func blockedSteps() -> [ProjectExportBlockedStep] {
+        [
+            ProjectExportBlockedStep(
+                operation: "export_run",
+                reason: "Guarded execution requires scoped live Logic export evidence before production-ready exposure.",
+                safeAlternative: "Use export_plan to review paths, artifacts, confirmations, and manifest expectations."
+            ),
+            ProjectExportBlockedStep(
+                operation: "export_resume",
+                reason: "Resume must reconcile against durable manifests and post-export analysis before skipping work.",
+                safeAlternative: "Use the dry-run plan as the manifest contract until execution evidence lands."
+            ),
+            ProjectExportBlockedStep(
+                operation: "cloud_delivery",
+                reason: "Cloud upload, email, and external sharing are explicitly out of scope.",
+                safeAlternative: "Write artifacts only under the approved local output root."
+            ),
+        ]
+    }
+
+    private static func projectPaths(from params: [String: Value]) throws -> [String] {
+        if let array = params["projects"]?.arrayValue {
+            let paths = array.compactMap { $0.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard paths.count == array.count, !paths.isEmpty else {
+                throw ExportPlanError.invalid("projects must be a non-empty array of absolute .logicx paths")
+            }
+            return paths
+        }
+        let path = stringParam(params, "project", "path")
+        guard !path.isEmpty else {
+            throw ExportPlanError.invalid("export_plan requires projects or project/path")
+        }
+        return [path]
+    }
+
+    private static func outputRoot(from params: [String: Value]) throws -> String {
+        let root = stringParam(params, "output_root", "outputRoot")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard root.hasPrefix("/") else {
+            throw ExportPlanError.invalid("output_root must be an absolute local path")
+        }
+        let standardized = URL(fileURLWithPath: root).standardizedFileURL.path
+        guard !standardized.hasPrefix("/dev/") else {
+            throw ExportPlanError.invalid("output_root must not be under /dev")
+        }
+        return standardized
+    }
+
+    private static func artifactKinds(from params: [String: Value]) throws -> [String] {
+        let raw: [String]
+        if let array = params["artifacts"]?.arrayValue {
+            raw = array.compactMap { $0.stringValue?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard raw.count == array.count else {
+                throw ExportPlanError.invalid("artifacts must be an array of strings")
+            }
+        } else {
+            raw = [stringParam(params, "artifact", "kind", default: "bounce").lowercased()]
+        }
+        let cleaned = raw.filter { !$0.isEmpty }
+        guard !cleaned.isEmpty else {
+            throw ExportPlanError.invalid("at least one artifact kind is required")
+        }
+        let unsupported = cleaned.filter { !supportedArtifactKinds.contains($0) }
+        guard unsupported.isEmpty else {
+            throw ExportPlanError.invalid("unsupported artifact kind(s): \(unsupported.joined(separator: ","))")
+        }
+        return Array(Set(cleaned)).sorted()
+    }
+
+    private static func deterministicRunID(projects: [String], outputRoot: String, artifacts: [String]) -> String {
+        let seed = ([outputRoot] + projects + artifacts).joined(separator: "|")
+        let hash = seed.utf8.reduce(UInt32(2166136261)) { partial, byte in
+            (partial ^ UInt32(byte)) &* 16777619
+        }
+        return "export-\(String(hash, radix: 16))"
+    }
+
+    private static func sanitizeFileComponent(_ raw: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let scalars = raw.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : Character("-")
+        }
+        let value = String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return value.isEmpty ? "project" : value
+    }
+}
+
+enum ExportPlanError: Error, CustomStringConvertible {
+    case invalid(String)
+
+    var description: String {
+        switch self {
+        case .invalid(let message):
+            return message
+        }
+    }
+}

--- a/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
@@ -4,6 +4,7 @@ import MCP
 struct ProjectExportPlan: Codable, Sendable, Equatable {
     let schema: String
     let runID: String
+    let generatedAt: String
     let status: String
     let executionMode: String
     let outputRoot: String
@@ -20,6 +21,7 @@ struct ProjectExportPlan: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey {
         case schema
         case runID = "run_id"
+        case generatedAt = "generated_at"
         case status
         case executionMode = "execution_mode"
         case outputRoot = "output_root"
@@ -163,8 +165,17 @@ enum ProjectExportPlanner {
             )
         }
 
+        // PR99-C1 / PR99-edge-2 / PR99-edge-3: aggregate every resolved artifact
+        // path across ALL projects and flag any path produced by 2+ artifacts so
+        // batch exports cannot silently overwrite each other (defeating
+        // no_silent_overwrite). Comparison is case-insensitive because the default
+        // macOS volumes (APFS/HFS+) are case-insensitive, so 'Song' and 'song'
+        // collide on disk too. Each colliding artifact gets a forced issue, which
+        // flips the plan to "degraded" via the existing non-empty-issues predicate.
+        let resolvedProjectPlans = flagIntraPlanCollisions(projectPlans)
+
         let blocked = blockedSteps()
-        let status = projectPlans.contains { project in
+        let status = resolvedProjectPlans.contains { project in
             project.validationStatus != "valid" ||
                 project.expectedArtifacts.contains { !$0.verification.issues.isEmpty }
         }
@@ -174,18 +185,28 @@ enum ProjectExportPlanner {
         return ProjectExportPlan(
             schema: schema,
             runID: deterministicRunID(projects: projects, outputRoot: outputRoot, artifacts: artifacts),
+            // C3: real run-window anchor so the advertised mtime_within_run_window
+            // gate is evaluable — an executor bounds post-export mtime to >= this.
+            generatedAt: ISO8601DateFormatter.cacheFormatter.string(from: Date()),
             status: status,
             executionMode: "dry_run_only",
             outputRoot: outputRoot,
             collisionPolicy: collisionPolicy,
             namingPolicy: namingPolicy,
-            projectCount: projectPlans.count,
-            projects: projectPlans,
+            projectCount: resolvedProjectPlans.count,
+            projects: resolvedProjectPlans,
             requiredConfirmations: [
                 ProjectExportConfirmation(
                     level: "L2",
-                    requiredFor: ["open", "bounce", "close"],
-                    message: "Batch export execution must confirm every project open, export/bounce, and close boundary before mutation."
+                    requiredFor: ["open", "bounce"],
+                    message: "Batch export execution must confirm every project open and export/bounce boundary before mutation."
+                ),
+                // C1: close is canonically gated at L3 by DestructivePolicy; the
+                // manifest must declare the SAME boundary a future executor enforces.
+                ProjectExportConfirmation(
+                    level: confirmationLabel(for: "close"),
+                    requiredFor: ["close"],
+                    message: "Closing a project may discard unsaved changes; confirm the close/save-prompt boundary before mutation."
                 ),
             ],
             unsupportedOrBlockedSteps: blocked,
@@ -250,6 +271,14 @@ enum ProjectExportPlanner {
         collisionPolicy: String,
         fileManager: FileManager
     ) -> ProjectExportPlanArtifact {
+        // PR99-C2: validate containment against the PRE-sanitization candidate so
+        // the check is non-vacuous. A raw displayName containing ".." or a path
+        // separator can resolve outside outputRoot once standardized; the sanitized
+        // url below can never express that, so it alone could only ever be true.
+        let rawComponent = "\(displayName)-\(kind).wav"
+        let candidate = outputRoot.appendingPathComponent(rawComponent).standardizedFileURL
+        let underRoot = candidate.path == outputRoot.path || candidate.path.hasPrefix(outputRoot.path + "/")
+
         let safeProject = sanitizeFileComponent(displayName)
         let url = outputRoot.appendingPathComponent("\(safeProject)-\(kind).wav").standardizedFileURL
         let exists = fileManager.fileExists(atPath: url.path)
@@ -258,7 +287,6 @@ enum ProjectExportPlanner {
         let mtime = (attrs?[.modificationDate] as? Date).map {
             ISO8601DateFormatter.cacheFormatter.string(from: $0)
         }
-        let underRoot = url.path == outputRoot.path || url.path.hasPrefix(outputRoot.path + "/")
         var issues: [String] = []
         if !underRoot {
             issues.append("artifact_path_outside_output_root")
@@ -266,8 +294,14 @@ enum ProjectExportPlanner {
         if exists && collisionPolicy == "fail_if_exists" {
             issues.append("artifact_would_overwrite")
         }
-        if exists && (size ?? 0) == 0 {
+        // PR99-C3: only assert a definite zero-byte artifact when the size is a
+        // concrete value. A vanished/unreadable file (TOCTOU, permissions, or a
+        // directory/special file at the path) yields a nil size — that is
+        // "unknown", not "zero", so emit a distinct token instead of lying.
+        if exists, let size, size == 0 {
             issues.append("artifact_zero_bytes")
+        } else if exists, size == nil {
+            issues.append("artifact_size_unreadable")
         }
 
         return ProjectExportPlanArtifact(
@@ -295,7 +329,7 @@ enum ProjectExportPlanner {
                 command: "open",
                 mutates: true,
                 executed: false,
-                requiresConfirmationLevel: "L2",
+                requiresConfirmationLevel: confirmationLabel(for: "open"),
                 stopConditions: ["wrong_project_observed", "open_failed", "ambiguous_save_state"]
             ),
             ProjectExportWorkflowStep(
@@ -305,7 +339,7 @@ enum ProjectExportPlanner {
                 command: "bounce",
                 mutates: true,
                 executed: false,
-                requiresConfirmationLevel: "L2",
+                requiresConfirmationLevel: confirmationLabel(for: "bounce"),
                 stopConditions: ["missing_output", "stale_output", "overwrite_risk"]
             ),
             ProjectExportWorkflowStep(
@@ -315,10 +349,70 @@ enum ProjectExportPlanner {
                 command: "close",
                 mutates: true,
                 executed: false,
-                requiresConfirmationLevel: "L2",
+                // C1: drive from the canonical policy (close == L3) instead of
+                // hardcoding L2, so the contract matches the enforced boundary.
+                requiresConfirmationLevel: confirmationLabel(for: "close"),
                 stopConditions: ["ambiguous_close_state", "save_prompt_unresolved"]
             ),
         ]
+    }
+
+    /// Map a lifecycle command to its manifest confirmation label using the
+    /// canonical DestructivePolicy as the single source of truth (close/quit ==
+    /// L3, open/bounce/save_as == L2). Keeps the dry-run contract in lockstep
+    /// with the boundary the live dispatcher actually enforces.
+    private static func confirmationLabel(for command: String) -> String {
+        DestructivePolicy.level(for: command) == .l3 ? "L3" : "L2"
+    }
+
+    /// PR99-C1 / PR99-edge-2 / PR99-edge-3: detect artifact paths that two or
+    /// more planned artifacts resolve to (across all projects in the batch) and
+    /// append a collision issue to each, forcing the plan to "degraded". Path
+    /// comparison is case-insensitive to match the case-insensitive default
+    /// macOS volume, so distinct-cased slugs that map to the same on-disk file
+    /// are caught. Artifacts are immutable value types, so this is a rebuild pass.
+    private static func flagIntraPlanCollisions(
+        _ plans: [ProjectExportPlanProject]
+    ) -> [ProjectExportPlanProject] {
+        var pathCounts: [String: Int] = [:]
+        for project in plans {
+            for art in project.expectedArtifacts {
+                pathCounts[art.path.lowercased(), default: 0] += 1
+            }
+        }
+        let collidingPaths = Set(pathCounts.filter { $0.value > 1 }.keys)
+        guard !collidingPaths.isEmpty else { return plans }
+
+        return plans.map { project in
+            let arts = project.expectedArtifacts.map { art -> ProjectExportPlanArtifact in
+                guard collidingPaths.contains(art.path.lowercased()) else { return art }
+                let v = art.verification
+                return ProjectExportPlanArtifact(
+                    kind: art.kind,
+                    path: art.path,
+                    status: art.status,
+                    verification: ProjectExportArtifactVerification(
+                        exists: v.exists,
+                        fileSizeBytes: v.fileSizeBytes,
+                        mtime: v.mtime,
+                        pathUnderOutputRoot: v.pathUnderOutputRoot,
+                        wouldOverwrite: v.wouldOverwrite,
+                        issues: v.issues + ["artifact_path_collides_in_plan"]
+                    ),
+                    analysis: art.analysis
+                )
+            }
+            return ProjectExportPlanProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                validationStatus: project.validationStatus,
+                validationIssues: project.validationIssues,
+                expectedArtifacts: arts,
+                workflowSteps: project.workflowSteps,
+                manifestStatus: project.manifestStatus
+            )
+        }
     }
 
     private static func blockedSteps() -> [ProjectExportBlockedStep] {
@@ -349,7 +443,11 @@ enum ProjectExportPlanner {
             }
             return paths
         }
+        // PR99-edge-1: trim identically to the array branch so a stray leading
+        // space cannot make `project` resolve relative to CWD while `projects:[...]`
+        // resolves absolutely — the two input shapes must normalize the same way.
         let path = stringParam(params, "project", "path")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !path.isEmpty else {
             throw ExportPlanError.invalid("export_plan requires projects or project/path")
         }
@@ -362,9 +460,16 @@ enum ProjectExportPlanner {
         guard root.hasPrefix("/") else {
             throw ExportPlanError.invalid("output_root must be an absolute local path")
         }
+        // PR99-edge-4: `standardizedFileURL` collapses `..` segments, so a root
+        // like "/Users/x/../../etc/out" resolves to "/etc/out". We do NOT silently
+        // honor traversal — block roots that resolve under known system prefixes
+        // (beyond the existing /dev guard) so a malformed/abusive output_root
+        // cannot target system locations. The emitted output_root is always the
+        // standardized (post-collapse) path, which is what callers/executors see.
         let standardized = URL(fileURLWithPath: root).standardizedFileURL.path
-        guard !standardized.hasPrefix("/dev/") else {
-            throw ExportPlanError.invalid("output_root must not be under /dev")
+        let blockedPrefixes = ["/dev/", "/System/", "/private/var/db/", "/etc/", "/bin/", "/sbin/", "/usr/bin/", "/usr/sbin/"]
+        guard !blockedPrefixes.contains(where: { standardized == String($0.dropLast()) || standardized.hasPrefix($0) }) else {
+            throw ExportPlanError.invalid("output_root must not resolve to a system location: \(standardized)")
         }
         return standardized
     }
@@ -391,11 +496,15 @@ enum ProjectExportPlanner {
     }
 
     private static func deterministicRunID(projects: [String], outputRoot: String, artifacts: [String]) -> String {
+        // PR99-C4: 64-bit FNV-1a, zero-padded to 16 hex. The prior 32-bit digest
+        // had a ~50% birthday-collision probability at only ~77k distinct inputs;
+        // run_id is part of the v1 manifest contract a future resume consumer keys
+        // off, so widen now while no reconciliation consumer has shipped.
         let seed = ([outputRoot] + projects + artifacts).joined(separator: "|")
-        let hash = seed.utf8.reduce(UInt32(2166136261)) { partial, byte in
-            (partial ^ UInt32(byte)) &* 16777619
+        let hash = seed.utf8.reduce(UInt64(14695981039346656037)) { partial, byte in
+            (partial ^ UInt64(byte)) &* 1099511628211
         }
-        return "export-\(String(hash, radix: 16))"
+        return "export-" + String(format: "%016llx", hash)
     }
 
     private static func sanitizeFileComponent(_ raw: String) -> String {

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -426,6 +426,7 @@ enum WorkflowSkillCatalog {
             stockPluginChainPlan(),
             stockPluginGuardedInsert(),
             bounceReadiness(),
+            batchExportPlan(),
         ]
     }
 
@@ -531,7 +532,7 @@ enum WorkflowSkillCatalog {
         ],
         "logic_project": [
             "new", "open", "save", "save_as", "close", "bounce",
-            "is_running", "get_regions", "launch", "quit",
+            "is_running", "get_regions", "export_plan", "launch", "quit",
         ],
         "logic_system": [
             "health", "permissions", "refresh_cache", "help",
@@ -873,6 +874,53 @@ enum WorkflowSkillCatalog {
             productionReady: true,
             dependsOn: [],
             limitations: ["Does not perform a bounce/export; project.bounce is keycmd-only on Logic 12.2."],
+            mutationKind: .readOnly
+        )
+    }
+
+    private static func batchExportPlan() -> WorkflowSkill {
+        makeWorkflow(
+            id: "logic.workflow.export.batch_plan",
+            title: "Batch Export Manifest Plan",
+            intent: "Generate a dry-run batch export manifest before any Logic project is opened, bounced, or closed.",
+            scope: "Read-only planning; returns expected artifact paths, verification gates, and blocked execution steps.",
+            prerequisites: ["Explicit .logicx project paths", "Absolute local output root", "Caller accepts dry-run-only execution"],
+            allowedTools: ["logic_project"],
+            allowedResources: [],
+            requiredConfirmations: [],
+            stateChecks: [],
+            steps: [
+                toolStep(
+                    "plan_exports",
+                    "Build export manifest plan without touching Logic",
+                    "logic_project",
+                    command: "export_plan",
+                    false,
+                    nil,
+                    ["schema", "projects", "baseline_verification", "required_confirmations"],
+                    ["invalid project path", "output root rejected", "collision risk reported"]
+                ),
+            ],
+            verification: WorkflowVerification(
+                evidence: ["export_manifest_json"],
+                successFields: ["schema", "execution_mode", "projects", "unsupported_or_blocked_steps"],
+                liveEvidenceFile: nil
+            ),
+            failureModes: [
+                "project path missing or not absolute .logicx",
+                "output root is relative or unsafe",
+                "planned artifact already exists under fail_if_exists",
+                "requested artifact kind is unsupported",
+            ],
+            rollbackOrRecovery: "No rollback required; export_plan is dry-run-only and does not write manifests or audio.",
+            evidenceLevel: .deterministic,
+            productionReady: true,
+            dependsOn: [],
+            limitations: [
+                "Does not open Logic, bounce, resume, or write manifests.",
+                "Post-export audio analysis remains an Issue #29 integration path, not part of this dry-run planner.",
+                "Cloud upload, email, and external delivery are out of scope.",
+            ],
             mutationKind: .readOnly
         )
     }

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -3103,6 +3103,7 @@ private actor SelectiveFailChannel: Channel {
     #expect(tool.name == "logic_project")
     #expect(description.contains("save_as"))
     #expect(description.contains("launch"))
+    #expect(description.contains("export_plan"))
     _ = tool.inputSchema
 }
 

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -565,6 +565,35 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect(text == "true" || text == "false" || text.contains("running"))
 }
 
+@Test func testE2EProjectExportPlanReturnsDryRunManifest() async throws {
+    let h = await makeE2EHandlers()
+    let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    let project = tempRoot.appendingPathComponent("E2E Export.logicx", isDirectory: true)
+    let outputRoot = tempRoot.appendingPathComponent("exports", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: outputRoot, withIntermediateDirectories: true)
+
+    let r = await e2eCall(
+        h,
+        tool: "logic_project",
+        command: "export_plan",
+        params: [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+        ]
+    )
+
+    #expect(r.isError != true)
+    let json = try #require(e2eJSON(e2eText(r)))
+    #expect(json["schema"] as? String == "logic_pro_mcp_export_manifest.v1")
+    #expect(json["execution_mode"] as? String == "dry_run_only")
+    #expect(json["project_count"] as? Int == 1)
+    let projects = try #require(json["projects"] as? [[String: Any]])
+    let steps = try #require(projects.first?["workflow_steps"] as? [[String: Any]])
+    #expect(steps.allSatisfy { $0["executed"] as? Bool == false })
+}
+
 @Test func testE2EProjectUnknownCommandFails() async {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_project", command: "reformat_hard_drive")

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -591,7 +591,7 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect(json["project_count"] as? Int == 1)
     let projects = try #require(json["projects"] as? [[String: Any]])
     let steps = try #require(projects.first?["workflow_steps"] as? [[String: Any]])
-    #expect(steps.allSatisfy { $0["executed"] as? Bool == false })
+    #expect(steps.allSatisfy { ($0["executed"] as? Bool) == .some(false) })
 }
 
 @Test func testE2EProjectUnknownCommandFails() async {

--- a/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
@@ -43,7 +43,8 @@ struct ProjectExportPlannerTests {
 
         let artifacts = try #require(plan.projects.first?.expectedArtifacts)
         #expect(artifacts.map(\.kind) == ["bounce", "stem"])
-        #expect(artifacts.first?.path.hasSuffix("/Planner-Song-bounce.wav") == true)
+        let firstArtifact = try #require(artifacts.first)
+        #expect(firstArtifact.path.hasSuffix("/Planner-Song-bounce.wav"))
         #expect(artifacts.allSatisfy { $0.verification.pathUnderOutputRoot })
         #expect(artifacts.allSatisfy { $0.status == "pending" })
 

--- a/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func makeExportPlannerDirectory(_ name: String = UUID().uuidString) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func makeExportPlannerProject(named name: String = "Planner Song") throws -> URL {
+    let url = try makeExportPlannerDirectory()
+        .appendingPathComponent(name)
+        .appendingPathExtension("logicx")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+@Suite("Project export planner")
+struct ProjectExportPlannerTests {
+    @Test("builds a dry-run export manifest without executing workflow steps")
+    func dryRunManifestPlan() throws {
+        let project = try makeExportPlannerProject(named: "Planner Song")
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("stem"), .string("bounce")]),
+        ])
+
+        #expect(plan.schema == "logic_pro_mcp_export_manifest.v1")
+        #expect(plan.status == "planned")
+        #expect(plan.executionMode == "dry_run_only")
+        #expect(plan.projectCount == 1)
+        #expect(plan.projects.first?.validationStatus == "valid")
+        #expect(plan.projects.first?.manifestStatus == "pending")
+        #expect(plan.requiredConfirmations.contains { $0.level == "L2" })
+        #expect(plan.unsupportedOrBlockedSteps.map(\.operation).contains("export_run"))
+        #expect(plan.baselineVerification.contains("artifact_exists"))
+        #expect(plan.baselineVerification.contains("no_silent_overwrite"))
+
+        let artifacts = try #require(plan.projects.first?.expectedArtifacts)
+        #expect(artifacts.map(\.kind) == ["bounce", "stem"])
+        #expect(artifacts.first?.path.hasSuffix("/Planner-Song-bounce.wav") == true)
+        #expect(artifacts.allSatisfy { $0.verification.pathUnderOutputRoot })
+        #expect(artifacts.allSatisfy { $0.status == "pending" })
+
+        let steps = try #require(plan.projects.first?.workflowSteps)
+        #expect(steps.allSatisfy { !$0.executed })
+        #expect(steps.allSatisfy { $0.requiresConfirmationLevel == "L2" })
+        #expect(steps.map(\.command) == ["open", "bounce", "close"])
+    }
+
+    @Test("reports collision and zero-byte artifact risks without mutating files")
+    func collisionAndZeroByteRisks() throws {
+        let project = try makeExportPlannerProject(named: "Collision Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let existingArtifact = outputRoot.appendingPathComponent("Collision-Song-bounce.wav")
+        try Data().write(to: existingArtifact)
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "project": .string(project.path),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+        ])
+
+        let artifact = try #require(plan.projects.first?.expectedArtifacts.first)
+        #expect(plan.status == "degraded")
+        #expect(artifact.status == "existing")
+        #expect(artifact.verification.exists)
+        #expect(artifact.verification.fileSizeBytes == 0)
+        #expect(artifact.verification.wouldOverwrite)
+        #expect(artifact.verification.issues.contains("artifact_would_overwrite"))
+        #expect(artifact.verification.issues.contains("artifact_zero_bytes"))
+    }
+
+    @Test("rejects invalid parameter shapes before producing a plan")
+    func rejectsInvalidParams() {
+        #expect(throws: ExportPlanError.self) {
+            _ = try ProjectExportPlanner.plan(params: [
+                "project": .string("/tmp/Nope.logicx"),
+                "output_root": .string("relative/out"),
+            ])
+        }
+        #expect(throws: ExportPlanError.self) {
+            _ = try ProjectExportPlanner.plan(params: [
+                "project": .string("/tmp/Nope.logicx"),
+                "output_root": .string("/tmp/out"),
+                "artifacts": .array([.string("cloud_upload")]),
+            ])
+        }
+        #expect(throws: ExportPlanError.self) {
+            _ = try ProjectExportPlanner.plan(params: [
+                "projects": .array([]),
+                "output_root": .string("/tmp/out"),
+            ])
+        }
+    }
+
+    @Test("dispatcher returns manifest JSON and never routes channels")
+    func dispatcherDoesNotRoute() async throws {
+        let project = try makeExportPlannerProject(named: "Dispatcher Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let router = ChannelRouter()
+        let keyCmd = MockChannel(id: .midiKeyCommands)
+        let appleScript = MockChannel(id: .appleScript)
+        await router.register(keyCmd)
+        await router.register(appleScript)
+
+        let result = await ProjectDispatcher.handle(
+            command: "export_plan",
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+            ],
+            router: router,
+            cache: StateCache()
+        )
+
+        #expect(result.isError != true)
+        let data = try #require(sharedToolText(result).data(using: .utf8))
+        let plan = try JSONDecoder().decode(ProjectExportPlan.self, from: data)
+        #expect(plan.schema == ProjectExportPlanner.schema)
+        #expect(plan.executionMode == "dry_run_only")
+        #expect(await keyCmd.executedOps.isEmpty)
+        #expect(await appleScript.executedOps.isEmpty)
+    }
+}

--- a/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
@@ -17,6 +17,15 @@ private func makeExportPlannerProject(named name: String = "Planner Song") throw
     return url
 }
 
+/// FileManager whose `fileExists` behaves normally (so the artifact reports
+/// exists=true) but whose attribute read always fails — reproduces the
+/// TOCTOU / unreadable case PR99-C3 must report as "size unknown", not "0 bytes".
+private final class UnreadableAttributesFileManager: FileManager {
+    override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any] {
+        throw CocoaError(.fileReadUnknown)
+    }
+}
+
 @Suite("Project export planner")
 struct ProjectExportPlannerTests {
     @Test("builds a dry-run export manifest without executing workflow steps")
@@ -24,11 +33,18 @@ struct ProjectExportPlannerTests {
         let project = try makeExportPlannerProject(named: "Planner Song")
         let outputRoot = try makeExportPlannerDirectory()
 
+        // PR99-T2: snapshot the output dir to prove the dry run mutates no files,
+        // rather than trusting the hardcoded `executed: false` flag.
+        let before = Set(try FileManager.default.contentsOfDirectory(atPath: outputRoot.path))
+
         let plan = try ProjectExportPlanner.plan(params: [
             "projects": .array([.string(project.path)]),
             "output_root": .string(outputRoot.path),
             "artifacts": .array([.string("stem"), .string("bounce")]),
         ])
+
+        let after = Set(try FileManager.default.contentsOfDirectory(atPath: outputRoot.path))
+        #expect(before == after)
 
         #expect(plan.schema == "logic_pro_mcp_export_manifest.v1")
         #expect(plan.status == "planned")
@@ -36,7 +52,18 @@ struct ProjectExportPlannerTests {
         #expect(plan.projectCount == 1)
         #expect(plan.projects.first?.validationStatus == "valid")
         #expect(plan.projects.first?.manifestStatus == "pending")
-        #expect(plan.requiredConfirmations.contains { $0.level == "L2" })
+        // C3: run-window anchor is present and non-empty so the advertised
+        // mtime_within_run_window gate has something to bound against.
+        #expect(!plan.generatedAt.isEmpty)
+        #expect(plan.baselineVerification.contains("mtime_within_run_window"))
+        // C1: open/bounce confirm at L2, close confirms at L3 (canonical policy).
+        let l2 = try #require(plan.requiredConfirmations.first { $0.level == "L2" })
+        #expect(l2.requiredFor.contains("open"))
+        #expect(l2.requiredFor.contains("bounce"))
+        #expect(!l2.requiredFor.contains("close"))
+        let l3 = try #require(plan.requiredConfirmations.first { $0.level == "L3" })
+        #expect(l3.requiredFor.contains("close"))
+        #expect(!l3.requiredFor.contains("open"))
         #expect(plan.unsupportedOrBlockedSteps.map(\.operation).contains("export_run"))
         #expect(plan.baselineVerification.contains("artifact_exists"))
         #expect(plan.baselineVerification.contains("no_silent_overwrite"))
@@ -47,10 +74,18 @@ struct ProjectExportPlannerTests {
         #expect(firstArtifact.path.hasSuffix("/Planner-Song-bounce.wav"))
         #expect(artifacts.allSatisfy { $0.verification.pathUnderOutputRoot })
         #expect(artifacts.allSatisfy { $0.status == "pending" })
+        // PR99-T2: no .wav was actually written for the planned artifact.
+        #expect(!FileManager.default.fileExists(atPath: firstArtifact.path))
 
         let steps = try #require(plan.projects.first?.workflowSteps)
         #expect(steps.allSatisfy { !$0.executed })
-        #expect(steps.allSatisfy { $0.requiresConfirmationLevel == "L2" })
+        // C1: per-command confirmation level — open/bounce L2, close L3.
+        let openStep = try #require(steps.first { $0.command == "open" })
+        let bounceStep = try #require(steps.first { $0.command == "bounce" })
+        let closeStep = try #require(steps.first { $0.command == "close" })
+        #expect(openStep.requiresConfirmationLevel == "L2")
+        #expect(bounceStep.requiresConfirmationLevel == "L2")
+        #expect(closeStep.requiresConfirmationLevel == "L3")
         #expect(steps.map(\.command) == ["open", "bounce", "close"])
     }
 
@@ -110,6 +145,7 @@ struct ProjectExportPlannerTests {
         await router.register(keyCmd)
         await router.register(appleScript)
 
+        let before = Set(try FileManager.default.contentsOfDirectory(atPath: outputRoot.path))
         let result = await ProjectDispatcher.handle(
             command: "export_plan",
             params: [
@@ -119,6 +155,8 @@ struct ProjectExportPlannerTests {
             router: router,
             cache: StateCache()
         )
+        let after = Set(try FileManager.default.contentsOfDirectory(atPath: outputRoot.path))
+        #expect(before == after)
 
         #expect(result.isError != true)
         let data = try #require(sharedToolText(result).data(using: .utf8))
@@ -127,5 +165,328 @@ struct ProjectExportPlannerTests {
         #expect(plan.executionMode == "dry_run_only")
         #expect(await keyCmd.executedOps.isEmpty)
         #expect(await appleScript.executedOps.isEmpty)
+    }
+
+    // MARK: - PR99-T5: multi-project batch enumeration
+
+    @Test("plans every project in a batch with distinct per-project indices and namespaced step ids")
+    func multiProjectBatchPlan() throws {
+        let alpha = try makeExportPlannerProject(named: "Alpha Song")
+        let beta = try makeExportPlannerProject(named: "Beta Song")
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(alpha.path), .string(beta.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+        ])
+
+        #expect(plan.projectCount == 2)
+        #expect(plan.projects.count == 2)
+        let p0 = try #require(plan.projects.first)
+        let p1 = try #require(plan.projects.last)
+        #expect(p0.index == 0)
+        #expect(p1.index == 1)
+        #expect(p0.displayName == "Alpha Song")
+        #expect(p1.displayName == "Beta Song")
+        #expect(p0.projectPath == alpha.path)
+        #expect(p1.projectPath == beta.path)
+        #expect(p0.workflowSteps.map(\.id) == ["project_0_open", "project_0_export", "project_0_close"])
+        #expect(p1.workflowSteps.map(\.id) == ["project_1_open", "project_1_export", "project_1_close"])
+        let allIDs = (p0.workflowSteps + p1.workflowSteps).map(\.id)
+        #expect(Set(allIDs).count == allIDs.count)
+        #expect(try #require(p0.expectedArtifacts.first).path.hasSuffix("/Alpha-Song-bounce.wav"))
+        #expect(try #require(p1.expectedArtifacts.first).path.hasSuffix("/Beta-Song-bounce.wav"))
+        // distinct basenames -> no collision flag
+        #expect(!(try #require(p0.expectedArtifacts.first)).verification.issues.contains("artifact_path_collides_in_plan"))
+    }
+
+    // MARK: - PR99-C1 / edge-2 / edge-3: intra-plan artifact-path collisions
+
+    @Test("two projects with the same basename in different dirs collide and degrade the plan")
+    func sameBasenameCrossProjectCollision() throws {
+        let dirA = try makeExportPlannerDirectory()
+        let dirB = try makeExportPlannerDirectory()
+        let songA = dirA.appendingPathComponent("Song").appendingPathExtension("logicx")
+        let songB = dirB.appendingPathComponent("Song").appendingPathExtension("logicx")
+        try FileManager.default.createDirectory(at: songA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: songB, withIntermediateDirectories: true)
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(songA.path), .string(songB.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+        ])
+
+        #expect(plan.status == "degraded")
+        let a0 = try #require(plan.projects.first?.expectedArtifacts.first)
+        let a1 = try #require(plan.projects.last?.expectedArtifacts.first)
+        #expect(a0.verification.issues.contains("artifact_path_collides_in_plan"))
+        #expect(a1.verification.issues.contains("artifact_path_collides_in_plan"))
+    }
+
+    @Test("case-only-different basenames collide on the case-insensitive default volume")
+    func caseInsensitiveCrossProjectCollision() throws {
+        let dirA = try makeExportPlannerDirectory()
+        let dirB = try makeExportPlannerDirectory()
+        let songA = dirA.appendingPathComponent("Song").appendingPathExtension("logicx")
+        let songB = dirB.appendingPathComponent("song").appendingPathExtension("logicx")
+        try FileManager.default.createDirectory(at: songA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: songB, withIntermediateDirectories: true)
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(songA.path), .string(songB.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+        ])
+
+        #expect(plan.status == "degraded")
+        let a0 = try #require(plan.projects.first?.expectedArtifacts.first)
+        let a1 = try #require(plan.projects.last?.expectedArtifacts.first)
+        #expect(a0.verification.issues.contains("artifact_path_collides_in_plan"))
+        #expect(a1.verification.issues.contains("artifact_path_collides_in_plan"))
+    }
+
+    @Test("the same project listed twice collides with itself and degrades the plan")
+    func duplicateProjectEntryCollision() throws {
+        let project = try makeExportPlannerProject(named: "Dup Song")
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(project.path), .string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+        ])
+
+        #expect(plan.status == "degraded")
+        #expect(plan.projects.allSatisfy { project in
+            project.expectedArtifacts.allSatisfy {
+                $0.verification.issues.contains("artifact_path_collides_in_plan")
+            }
+        })
+    }
+
+    // MARK: - PR99-C3: zero-byte vs unreadable disambiguation
+
+    @Test("an existing artifact whose attributes are unreadable is flagged unreadable, not zero-byte")
+    func unreadableArtifactSizeIsNotZeroByte() throws {
+        let project = try makeExportPlannerProject(named: "Unreadable Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        // A real on-disk file the artifact resolves to. `fileExists` will see it,
+        // but the injected FileManager refuses to read its attributes — this is the
+        // TOCTOU / unreadable case PR99-C3 must distinguish from a genuine 0 bytes.
+        let existing = outputRoot.appendingPathComponent("Unreadable-Song-bounce.wav")
+        try Data("non-empty".utf8).write(to: existing)
+
+        let plan = try ProjectExportPlanner.plan(
+            params: [
+                "project": .string(project.path),
+                "output_root": .string(outputRoot.path),
+                "artifact": .string("bounce"),
+            ],
+            fileManager: UnreadableAttributesFileManager()
+        )
+
+        let artifact = try #require(plan.projects.first?.expectedArtifacts.first)
+        #expect(artifact.verification.exists)
+        #expect(artifact.verification.fileSizeBytes == nil)
+        #expect(artifact.verification.issues.contains("artifact_size_unreadable"))
+        #expect(!artifact.verification.issues.contains("artifact_zero_bytes"))
+    }
+
+    // MARK: - PR99-T1: skip_existing collision policy
+
+    @Test("skip_existing suppresses overwrite flagging for a pre-existing artifact")
+    func skipExistingCollisionPolicy() throws {
+        let project = try makeExportPlannerProject(named: "Skip Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let existing = outputRoot.appendingPathComponent("Skip-Song-bounce.wav")
+        try Data("non-empty".utf8).write(to: existing)
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "project": .string(project.path),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+            "collision_policy": .string("skip_existing"),
+        ])
+        let artifact = try #require(plan.projects.first?.expectedArtifacts.first)
+        #expect(artifact.verification.exists)
+        #expect(!artifact.verification.wouldOverwrite)
+        #expect(!artifact.verification.issues.contains("artifact_would_overwrite"))
+        #expect(plan.collisionPolicy == "skip_existing")
+        #expect(plan.status == "planned")
+    }
+
+    @Test("invalid collision_policy is rejected")
+    func invalidCollisionPolicyRejected() {
+        #expect(throws: ExportPlanError.self) {
+            _ = try ProjectExportPlanner.plan(params: [
+                "project": .string("/tmp/Nope.logicx"),
+                "output_root": .string("/tmp/out"),
+                "collision_policy": .string("overwrite"),
+            ])
+        }
+    }
+
+    // MARK: - PR99-T3: run_id contract
+
+    @Test("run_id is deterministic, prefixed, and input-sensitive")
+    func runIDContractIsStable() throws {
+        let project = try makeExportPlannerProject(named: "RunID Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let params: [String: Value] = [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("stem"), .string("bounce")]),
+        ]
+
+        let a = try ProjectExportPlanner.plan(params: params)
+        let b = try ProjectExportPlanner.plan(params: params)
+        #expect(a.runID.hasPrefix("export-"))
+        #expect(a.runID.count > "export-".count)
+        #expect(a.runID == b.runID)
+
+        let otherRoot = try makeExportPlannerDirectory()
+        let c = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(otherRoot.path),
+            "artifacts": .array([.string("stem"), .string("bounce")]),
+        ])
+        #expect(c.runID != a.runID)
+
+        let otherProject = try makeExportPlannerProject(named: "Other Song")
+        let d = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(otherProject.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("stem"), .string("bounce")]),
+        ])
+        #expect(d.runID != a.runID)
+    }
+
+    // MARK: - PR99-T4: valid-shaped but missing project
+
+    @Test("missing but well-formed project path degrades the plan without throwing")
+    func missingProjectDegradesPlan() throws {
+        let outputRoot = try makeExportPlannerDirectory()
+        let missing = outputRoot.appendingPathComponent("Missing-Song.logicx").path
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "project": .string(missing),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+        ])
+
+        #expect(plan.status == "degraded")
+        let project = try #require(plan.projects.first)
+        #expect(project.validationStatus == "invalid")
+        #expect(project.validationIssues.contains("project_path_not_found"))
+        #expect(!project.validationIssues.contains("project_path_must_be_absolute_logicx"))
+    }
+
+    // MARK: - PR99-T6: dispatcher fail-closed
+
+    @Test("dispatcher fails closed on invalid export_plan params")
+    func dispatcherFailsClosedOnInvalidParams() async throws {
+        let router = ChannelRouter()
+        let keyCmd = MockChannel(id: .midiKeyCommands)
+        await router.register(keyCmd)
+
+        let result = await ProjectDispatcher.handle(
+            command: "export_plan",
+            params: [
+                "projects": .array([.string("/tmp/Nope.logicx")]),
+                "output_root": .string("relative/out"),
+            ],
+            router: router,
+            cache: StateCache()
+        )
+
+        #expect(result.isError!)
+        #expect(sharedToolText(result).contains("invalid_params"))
+        #expect(await keyCmd.executedOps.isEmpty)
+    }
+
+    @Test("dispatcher fails closed on empty projects array")
+    func dispatcherFailsClosedOnEmptyProjects() async throws {
+        let router = ChannelRouter()
+        let keyCmd = MockChannel(id: .midiKeyCommands)
+        await router.register(keyCmd)
+
+        let result = await ProjectDispatcher.handle(
+            command: "export_plan",
+            params: [
+                "projects": .array([]),
+                "output_root": .string("/tmp/out"),
+            ],
+            router: router,
+            cache: StateCache()
+        )
+
+        #expect(result.isError!)
+        #expect(sharedToolText(result).contains("invalid_params"))
+        #expect(await keyCmd.executedOps.isEmpty)
+    }
+
+    // MARK: - PR99-T7: non-empty existing artifact (zero-byte vs would-overwrite)
+
+    @Test("non-empty existing artifact flags overwrite but not zero-byte and reports true size")
+    func nonEmptyExistingArtifactRisk() throws {
+        let project = try makeExportPlannerProject(named: "NonEmpty Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let existingArtifact = outputRoot.appendingPathComponent("NonEmpty-Song-bounce.wav")
+        try Data([0x01, 0x02]).write(to: existingArtifact)
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "project": .string(project.path),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+        ])
+
+        let artifact = try #require(plan.projects.first?.expectedArtifacts.first)
+        #expect(artifact.verification.exists)
+        #expect(artifact.verification.fileSizeBytes == 2)
+        #expect(artifact.verification.wouldOverwrite)
+        #expect(artifact.verification.issues.contains("artifact_would_overwrite"))
+        #expect(!artifact.verification.issues.contains("artifact_zero_bytes"))
+        #expect(!artifact.verification.issues.contains("artifact_size_unreadable"))
+    }
+
+    // MARK: - PR99-edge-1: single project param is trimmed like the array branch
+
+    @Test("single project param is trimmed so it matches the array branch normalization")
+    func singleProjectParamIsTrimmed() throws {
+        let project = try makeExportPlannerProject(named: "Trim Song")
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let trimmed = try ProjectExportPlanner.plan(params: [
+            "project": .string(project.path),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+        ])
+        let padded = try ProjectExportPlanner.plan(params: [
+            "project": .string("  \(project.path)  "),
+            "output_root": .string(outputRoot.path),
+            "artifact": .string("bounce"),
+        ])
+
+        #expect(trimmed.projects.first?.projectPath == project.path)
+        #expect(padded.projects.first?.projectPath == project.path)
+        // identical normalization -> identical deterministic run id
+        #expect(trimmed.runID == padded.runID)
+        #expect(padded.projects.first?.validationStatus == "valid")
+    }
+
+    // MARK: - PR99-edge-4: output_root system-location containment
+
+    @Test("output_root resolving to a system location via traversal is rejected")
+    func outputRootSystemTraversalRejected() {
+        #expect(throws: ExportPlanError.self) {
+            _ = try ProjectExportPlanner.plan(params: [
+                "project": .string("/tmp/Nope.logicx"),
+                "output_root": .string("/Users/x/../../etc/out"),
+            ])
+        }
     }
 }

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -322,6 +322,12 @@ struct WorkflowSkillCatalogTests {
         let readiness = snapshot.workflows.first { $0.id == "logic.workflow.readiness.project" }
         #expect(readiness?.dependenciesResolved == true)
         #expect(readiness?.unresolvedResources == nil)
+
+        let exportPlan = snapshot.workflows.first { $0.id == "logic.workflow.export.batch_plan" }
+        #expect(exportPlan?.mutationKind == .readOnly)
+        #expect(exportPlan?.productionReady == true)
+        #expect(exportPlan?.evidenceLevel == .deterministic)
+        #expect(exportPlan?.steps.contains { $0.tool == "logic_project" && $0.command == "export_plan" } == true)
     }
 
     @Test("default workflows declare required fields that match served top-level resource shapes")
@@ -352,6 +358,9 @@ struct WorkflowSkillCatalogTests {
         #expect(try! stepFields(guardedInsert, "read_gain_catalog") == ["entry", "validation"])
         #expect(try! stepFields(guardedInsert, "read_mixer_slots") == ["strips", "data_source"])
         #expect(try! stepFields(guardedInsert, "read_strip_after_insert") == ["strip"])
+
+        let exportPlan = try! workflow("logic.workflow.export.batch_plan")
+        #expect(try! stepFields(exportPlan, "plan_exports") == ["schema", "projects", "baseline_verification", "required_confirmations"])
     }
 
     @Test("dependencies resolve once the stock plugin surface exists")
@@ -490,6 +499,11 @@ struct WorkflowSkillResourceTests {
         } == true)
         #expect((search["workflows"] as? [[String: Any]])?.contains {
             $0["id"] as? String == "logic.workflow.plugins.stock_insert_gain_live_verified"
+        } == true)
+
+        let exportSearch = try await workflowResourceObject("logic://workflow-skills/search?query=export")
+        #expect((exportSearch["workflows"] as? [[String: Any]])?.contains {
+            $0["id"] as? String == "logic.workflow.export.batch_plan"
         } == true)
 
         let schema = try await workflowResourceObject("logic://workflow-skills/schema")

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -292,7 +292,7 @@ struct WorkflowSkillCatalogTests {
     }
 
     @Test("default workflow pack validates and stays honest about unresolved dependencies")
-    func defaultPackValidates() {
+    func defaultPackValidates() throws {
         let snapshot = WorkflowSkillCatalog.defaultSnapshot()
 
         #expect(snapshot.schemaVersion == 1)
@@ -323,11 +323,11 @@ struct WorkflowSkillCatalogTests {
         #expect(readiness?.dependenciesResolved == true)
         #expect(readiness?.unresolvedResources == nil)
 
-        let exportPlan = snapshot.workflows.first { $0.id == "logic.workflow.export.batch_plan" }
-        #expect(exportPlan?.mutationKind == .readOnly)
-        #expect(exportPlan?.productionReady == true)
-        #expect(exportPlan?.evidenceLevel == .deterministic)
-        #expect(exportPlan?.steps.contains { $0.tool == "logic_project" && $0.command == "export_plan" } == true)
+        let exportPlan = try #require(snapshot.workflows.first { $0.id == "logic.workflow.export.batch_plan" })
+        #expect(exportPlan.mutationKind == .readOnly)
+        #expect(exportPlan.productionReady)
+        #expect(exportPlan.evidenceLevel == .deterministic)
+        #expect(exportPlan.steps.contains { $0.tool == "logic_project" && $0.command == "export_plan" })
     }
 
     @Test("default workflows declare required fields that match served top-level resource shapes")
@@ -502,9 +502,10 @@ struct WorkflowSkillResourceTests {
         } == true)
 
         let exportSearch = try await workflowResourceObject("logic://workflow-skills/search?query=export")
-        #expect((exportSearch["workflows"] as? [[String: Any]])?.contains {
+        let exportWorkflows = try #require(exportSearch["workflows"] as? [[String: Any]])
+        #expect(exportWorkflows.contains {
             $0["id"] as? String == "logic.workflow.export.batch_plan"
-        } == true)
+        })
 
         let schema = try await workflowResourceObject("logic://workflow-skills/schema")
         #expect((schema["fields"] as? [String])?.contains("state_checks") == true)

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,7 +19,7 @@ Every tool call returns a `CallTool.Result` with `content: [{ type: "text", text
 | [`logic_midi`](#logic_midi) | Raw MIDI + MMC + step input | Write |
 | [`logic_edit`](#logic_edit) | Undo/redo/cut/copy/paste/quantize | Write |
 | [`logic_navigate`](#logic_navigate) | Bar navigation, markers, zoom, view toggles | Write |
-| [`logic_project`](#logic_project) | Open, save, close, bounce, quit | Write |
+| [`logic_project`](#logic_project) | Open, save, close, bounce, dry-run export plan, quit | Write |
 | [`logic_system`](#logic_system) | Health, permissions, help, cache refresh | Mixed |
 
 All tool invocations use:
@@ -725,6 +725,7 @@ On Logic Pro 12.x the new `AXRuler`-structural walker (v3.1.8) succeeds for typi
 | `bounce` | `{ confirmed?: bool }` | text | MIDIKeyCommands → CGEvent | L2 |
 | `is_running` | — | `"true"` or `"false"` | (direct) | L0 |
 | `get_regions` | — | JSON `RegionInfo[]` | Accessibility (read-only arrange area scan) | L0 |
+| `export_plan` | `{ projects?: string[], project?: string, output_root: string, artifacts?: string[], collision_policy?: "fail_if_exists"\|"skip_existing" }` | JSON `logic_pro_mcp_export_manifest.v1` dry-run plan | (direct, read-only filesystem checks) | L0 |
 | `launch` | — | text | AppleScript | L1 |
 | `quit` | `{ confirmed?: bool }` | text | AppleScript | L3 |
 

--- a/docs/prd/PRD-batch-export-manifest-plan.md
+++ b/docs/prd/PRD-batch-export-manifest-plan.md
@@ -1,0 +1,141 @@
+# PRD: Batch Export Manifest Plan
+
+**Version**: 0.1
+**Author**: Codex
+**Date**: 2026-06-20
+**Status**: Done
+**Size**: S
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Issue #27 asks for batch bounce/stem/export workflows, but live execution is blocked until the project can prove safe open/bounce/close boundaries and post-export verification. The first reviewable scope is a deterministic plan contract that clients can inspect before any Logic project mutation.
+
+### 1.2 Problem Definition
+Agents need a dry-run export manifest that names target projects, expected artifacts, collision risks, required confirmations, and unsupported execution steps without opening Logic Pro or writing files.
+
+### 1.3 Impact of Not Solving
+Without a plan contract, any future batch export implementation would either over-claim unsupported live behavior or duplicate path/collision/verification logic across clients.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [x] G1: Add `logic_project export_plan` returning JSON schema `logic_pro_mcp_export_manifest.v1`.
+- [x] G2: Keep the command read-only: no ChannelRouter call, no Logic open/bounce/close, no manifest/audio writes.
+- [x] G3: Report baseline verification gates and blocked future execution steps.
+
+### 2.2 Non-Goals
+- NG1: No live batch bounce, stem export, resume, or queue runner in this PR.
+- NG2: No cloud upload, email delivery, or external sharing.
+- NG3: No #29 audio analysis execution from the dry-run planner.
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Dry-run export planning
+**As a** client, **I want** a structured export plan, **so that** I can review paths and safety gates before any Logic mutation.
+
+**Acceptance Criteria:**
+- [x] AC-1.1: Given absolute `.logicx` project paths and an absolute output root, when `logic_project export_plan` is called, then JSON includes schema, run id, projects, expected artifacts, confirmations, and blocked steps.
+- [x] AC-1.2: Given existing artifact paths, when collision policy is `fail_if_exists`, then the response reports overwrite and zero-byte risks without modifying the file.
+- [x] AC-1.3: Given invalid parameter shapes, when the planner runs, then it returns `invalid_params` and routes no channels.
+
+### US-2: Workflow discovery
+**As a** workflow-skill consumer, **I want** a catalog entry for export planning, **so that** I can discover the safe first step without confusing it with live export execution.
+
+**Acceptance Criteria:**
+- [x] AC-2.1: The workflow catalog includes `logic.workflow.export.batch_plan`.
+- [x] AC-2.2: The workflow is `read_only`, deterministic, and production-ready only for planning.
+- [x] AC-2.3: Limitations explicitly say the workflow does not open Logic, bounce, resume, or write manifests.
+
+## 4. Technical Design
+
+### 4.1 Architecture Overview
+`ProjectExportPlanner` is a pure planning component used directly by `ProjectDispatcher` for the `export_plan` command. It reads only filesystem metadata for declared output artifacts and never calls `ChannelRouter`.
+
+### 4.2 Data Model Changes
+No persisted schema changes. The response model is a Codable JSON envelope:
+- `ProjectExportPlan`
+- `ProjectExportPlanProject`
+- `ProjectExportPlanArtifact`
+- `ProjectExportArtifactVerification`
+- `ProjectExportWorkflowStep`
+- `ProjectExportConfirmation`
+- `ProjectExportBlockedStep`
+
+### 4.3 API Design
+
+| Method | Endpoint | Description | Auth |
+|--------|----------|-------------|------|
+| MCP tool | `logic_project export_plan` | Build a dry-run batch export manifest plan | MCP client |
+
+Params:
+- `projects?: string[]`
+- `project?: string` or `path?: string`
+- `output_root: string`
+- `artifacts?: string[]` where values are `bounce`, `stem`, `preview`, `variant`
+- `collision_policy?: "fail_if_exists" | "skip_existing"`
+- `naming_policy?: string`
+
+### 4.4 Key Technical Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Execution boundary | Add live `export_run` now vs dry-run first | Dry-run first | Issue #27 remains blocked for live execution evidence; planning is safe and reviewable. |
+| Routing | Reuse `ChannelRouter` vs direct planner | Direct planner | The command must prove no Logic open/bounce/close can occur. |
+| Artifact checks | Ignore output state vs read metadata | Read metadata only | Collision and zero-byte evidence are useful and non-mutating. |
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | Missing project list/path | `invalid_params` before plan creation | P1 |
+| E2 | Relative output root | `invalid_params` before plan creation | P1 |
+| E3 | Unsupported artifact kind | `invalid_params` before plan creation | P1 |
+| E4 | Project path missing | Plan status `degraded`, project validation issue included | P2 |
+| E5 | Existing artifact under fail-if-exists | Plan status `degraded`, artifact overwrite issue included | P2 |
+
+## 6. Security & Permissions
+
+N/A for S scope. The command is read-only and does not request new OS permissions.
+
+## 7. Performance & Monitoring
+
+N/A for S scope. Runtime is proportional to declared project/artifact count and uses local filesystem metadata reads.
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+- `ProjectExportPlannerTests`: manifest shape, blocked steps, collision/zero-byte detection, invalid params.
+
+### 8.2 Integration Tests
+- `ProjectExportPlannerTests`: dispatcher response JSON and no channel routing.
+- `WorkflowSkillCatalogTests`: workflow catalog validation, command census, workflow search.
+- `EndToEndTests`: server tool call returns dry-run manifest.
+
+### 8.3 Edge Case Tests
+- Relative output root.
+- Unsupported artifact kind.
+- Empty projects array.
+- Existing zero-byte output artifact.
+
+## 9. Rollout Plan
+
+N/A for S scope. This is a new command and workflow entry with no migration.
+
+## 10. Dependencies & Risks
+
+### 10.1 Dependencies
+
+| Dependency | Owner | Status | Risk if Delayed |
+|------------|-------|--------|-----------------|
+| Issue #29 audio analysis | Project | PR #94 open | Live export verification remains incomplete. |
+| Live export evidence for #27 | Project | Blocked | `export_run` and `export_resume` must stay unavailable. |
+
+### 10.2 Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Clients treat plan as execution | Medium | High | Response uses `execution_mode: dry_run_only` and lists unsupported steps. |
+| Future live exporter diverges from plan schema | Medium | Medium | Schema and tests define the first manifest contract. |

--- a/docs/tickets/issue27-batch-export-manifest/STATUS.md
+++ b/docs/tickets/issue27-batch-export-manifest/STATUS.md
@@ -1,0 +1,48 @@
+# Pipeline Status: Issue 27 Batch Export Manifest Plan
+
+**PRD**: docs/prd/PRD-batch-export-manifest-plan.md
+**Size**: S
+**Current Phase**: 7
+
+## Ticket Status Definitions
+- **Todo**: Not started
+- **In Progress**: Implementation underway
+- **In Review**: Review underway
+- **Done**: Acceptance criteria met and tests passing
+- **Invalidated**: Superseded by revised plan
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | Export plan schema and parser | Done | Self-review PASS | Pure planner, no router calls. |
+| T2 | Dispatcher, workflow catalog, and docs | Done | Self-review PASS | Adds `export_plan` and `logic.workflow.export.batch_plan`. |
+| T3 | Tests and verification | Done | Self-review PASS | Targeted Swift filters passed. |
+
+## Review History
+
+| Phase | Round | Verdict | P0 | P1 | P2 | Notes |
+|-------|-------|---------|----|----|----|-------|
+| 2 | 1 | PASS | 0 | 0 | 0 | Scope constrained to dry-run planning because live #27 execution remains blocked. |
+| 4 | 1 | PASS | 0 | 0 | 0 | No Logic open/bounce/close, no manifest/audio writes, no ChannelRouter path. |
+| 6 | 1 | PASS | 0 | 0 | 0 | `ProjectExportPlanner`, workflow catalog, dispatcher, E2E, handler, transport, and version filters passed. |
+
+## Verification
+
+- `swift test --filter ProjectExportPlanner` - 4 passed
+- `swift test --filter WorkflowSkillCatalog` - 24 passed
+- `swift test --filter ProjectDispatcher` - 22 passed
+- `swift test --filter EndToEnd` - 104 passed
+- `swift test --filter LogicProServerHandler` - 10 passed
+- `swift test --filter LogicProServerTransport` - 18 passed
+- `swift test --filter VersionConsistency` - 7 passed
+- `git diff --check` - passed
+- `git diff --cached --check` - passed
+
+## Remaining Issue #27 Work
+
+This PR intentionally does not close full Issue #27. The remaining phases are:
+- Live guarded `export_run` after explicit Logic open/bounce/close evidence.
+- Durable manifest writes and resume reconciliation.
+- #29 post-bounce audio analysis integration.
+- Stem-specific export evidence and recovery behavior.

--- a/docs/tickets/issue27-batch-export-manifest/T1-export-plan-schema-parser.md
+++ b/docs/tickets/issue27-batch-export-manifest/T1-export-plan-schema-parser.md
@@ -1,0 +1,67 @@
+# T1: Export Plan Schema And Parser
+
+**PRD Ref**: PRD-batch-export-manifest-plan > US-1
+**Priority**: P1 (High)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: None
+
+---
+
+## 1. Objective
+Create a pure Swift planner that builds a deterministic dry-run export manifest without touching Logic Pro.
+
+## 2. Acceptance Criteria
+- [x] AC-1: Accept explicit project path(s), absolute output root, artifact kinds, collision policy, and naming policy.
+- [x] AC-2: Return schema `logic_pro_mcp_export_manifest.v1` with projects, artifacts, confirmations, baseline verification gates, and unsupported execution steps.
+- [x] AC-3: Report missing project paths, unsafe output roots, unsupported artifacts, collision risks, and zero-byte artifacts honestly.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `dryRunManifestPlan` | Unit | Valid project and output root produce a dry-run manifest | Planned manifest, no executed steps |
+| 2 | `collisionAndZeroByteRisks` | Unit | Existing zero-byte artifact is detected | Degraded plan with overwrite and zero-byte issues |
+| 3 | `rejectsInvalidParams` | Unit | Bad params fail before plan creation | `ExportPlanError` |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/ProjectExportPlannerTests.swift`
+
+### 3.3 Mock/Setup Required
+- Temporary `.logicx` directories.
+- Temporary output directory and zero-byte artifact.
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `Sources/LogicProMCP/Projects/ProjectExportPlanner.swift` | Create | Planner models and param validation. |
+| `Tests/LogicProMCPTests/ProjectExportPlannerTests.swift` | Create | Unit and dispatcher safety tests. |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Define Codable response models and snake_case coding keys.
+2. Parse project/output/artifact/collision params with fail-fast invalid shapes.
+3. Build artifact paths and read filesystem metadata only.
+4. Include blocked execution steps and baseline verification names.
+
+### 4.3 Refactor Phase
+- Keep live execution out of the planner so future `export_run` cannot accidentally share dry-run code paths that mutate state.
+
+## 5. Edge Cases
+- Missing projects.
+- Relative output root.
+- Unsupported artifact kind.
+- Existing output artifact.
+
+## 6. Review Checklist
+- [x] Red: Test cases defined before final implementation.
+- [x] Green: Tests passed.
+- [x] Refactor: Tests still passed.
+- [x] AC all met.
+- [x] Existing tests not broken.
+- [x] Code style followed.
+- [x] No unrelated changes.

--- a/docs/tickets/issue27-batch-export-manifest/T2-dispatcher-workflow-docs.md
+++ b/docs/tickets/issue27-batch-export-manifest/T2-dispatcher-workflow-docs.md
@@ -1,0 +1,70 @@
+# T2: Dispatcher, Workflow Catalog, And Docs
+
+**PRD Ref**: PRD-batch-export-manifest-plan > US-1, US-2
+**Priority**: P1 (High)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: T1
+
+---
+
+## 1. Objective
+Expose the planner through the public MCP surface and workflow catalog while documenting the dry-run-only boundary.
+
+## 2. Acceptance Criteria
+- [x] AC-1: `logic_project export_plan` returns compact JSON from `ProjectExportPlanner`.
+- [x] AC-2: The dispatcher does not route any channels for `export_plan`.
+- [x] AC-3: Workflow catalog includes `logic.workflow.export.batch_plan` as read-only deterministic planning.
+- [x] AC-4: README, API docs, and system help mention `export_plan`.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `dispatcherDoesNotRoute` | Integration | Dispatcher returns JSON and records no channel ops | No `MockChannel` operations |
+| 2 | `defaultPackValidates` | Unit | Workflow catalog validates after new workflow | Valid pack |
+| 3 | `workflowResources` | Integration | Workflow search finds export plan workflow | Search result includes workflow |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/ProjectExportPlannerTests.swift`
+- `Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift`
+
+### 3.3 Mock/Setup Required
+- `MockChannel` registered with `ChannelRouter` for no-route assertion.
+- Workflow resource reads via `ResourceHandlers`.
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift` | Modify | Add `export_plan` command case and metadata. |
+| `Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift` | Modify | Add command census and workflow skill. |
+| `Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift` | Modify | Add help text. |
+| `README.md` | Modify | Mention export plan in project lifecycle row. |
+| `docs/API.md` | Modify | Document command params/return/channel/level. |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Add dispatcher command case before mutating lifecycle commands.
+2. Add command census entry so linter can validate workflow steps.
+3. Add read-only workflow with explicit limitations.
+4. Update docs and help text.
+
+### 4.3 Refactor Phase
+- Keep the workflow step `mutates: false` and limitations explicit to avoid production mutation claims.
+
+## 5. Edge Cases
+- Unknown command list must include `export_plan`.
+- Workflow linter must not require confirmations for the read-only planner.
+
+## 6. Review Checklist
+- [x] Red: Test cases defined before final implementation.
+- [x] Green: Tests passed.
+- [x] Refactor: Tests still passed.
+- [x] AC all met.
+- [x] Existing tests not broken.
+- [x] Code style followed.
+- [x] No unrelated changes.

--- a/docs/tickets/issue27-batch-export-manifest/T3-tests-verification.md
+++ b/docs/tickets/issue27-batch-export-manifest/T3-tests-verification.md
@@ -1,0 +1,68 @@
+# T3: Tests And Verification
+
+**PRD Ref**: PRD-batch-export-manifest-plan > US-1, US-2
+**Priority**: P1 (High)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: T1, T2
+
+---
+
+## 1. Objective
+Verify the planner, dispatcher, workflow catalog, server E2E, and docs consistency for the new dry-run command.
+
+## 2. Acceptance Criteria
+- [x] AC-1: Planner tests cover manifest shape, invalid params, collision risk, and no-route dispatcher behavior.
+- [x] AC-2: Workflow catalog tests cover command census and workflow discoverability.
+- [x] AC-3: E2E server call returns `dry_run_only` manifest JSON.
+- [x] AC-4: Handler, transport, and version consistency filters continue passing.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `testE2EProjectExportPlanReturnsDryRunManifest` | E2E | Server handler dispatches command and returns manifest | `dry_run_only`, no executed workflow steps |
+| 2 | `defaultPackCommandsAreReal` | Unit | Catalog commands match dispatcher cases | `export_plan` has executable dispatcher case |
+| 3 | `testReadmeAndAPIDocsMatchPublicSurfaceAndRouting` | Docs regression | Public docs remain consistent | Pass |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/EndToEndTests.swift`
+- `Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift`
+- `Tests/LogicProMCPTests/VersionConsistencyTests.swift`
+
+### 3.3 Mock/Setup Required
+- Temporary project/output folders for E2E call.
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `Tests/LogicProMCPTests/EndToEndTests.swift` | Modify | Add dry-run manifest server test. |
+| `Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift` | Modify | Add workflow assertions/search coverage. |
+| `Tests/LogicProMCPTests/DispatcherTests.swift` | Modify | Assert tool metadata documents `export_plan`. |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Run planner-specific tests.
+2. Run workflow catalog and dispatcher filters.
+3. Run E2E, handler, transport, and version consistency filters.
+4. Run whitespace checks before commit.
+
+### 4.3 Refactor Phase
+- Keep tests focused on dry-run behavior and avoid introducing live Logic requirements.
+
+## 5. Edge Cases
+- Server E2E must not require Logic Pro to be running.
+- The workflow search result must be discoverable by export intent.
+
+## 6. Review Checklist
+- [x] Red: Test cases defined before final implementation.
+- [x] Green: Tests passed.
+- [x] Refactor: Tests still passed.
+- [x] AC all met.
+- [x] Existing tests not broken.
+- [x] Code style followed.
+- [x] No unrelated changes.


### PR DESCRIPTION
## Summary
- Add `logic_project export_plan` for a read-only batch export manifest plan (`logic_pro_mcp_export_manifest.v1`).
- Add `ProjectExportPlanner` with project validation, artifact path planning, collision/zero-byte checks, required confirmations, baseline verification gates, and blocked future execution steps.
- Add `logic.workflow.export.batch_plan` plus README/API/system-help docs and dev-pipeline PRD/tickets.

## Safety boundary
- Dry-run only: no `ChannelRouter` route, no Logic open/bounce/close, no manifest write, no audio write.
- This is the safe Phase 1 foundation for Issue #27. It intentionally does not implement live `export_run`, `export_resume`, stem execution, or cloud delivery.
- Post-export audio verification remains the Issue #29 integration path.

## Verification
- `swift test --filter ProjectExportPlanner` - 4 passed
- `swift test --filter WorkflowSkillCatalog` - 24 passed
- `swift test --filter ProjectDispatcher` - 22 passed
- `swift test --filter EndToEnd` - 104 passed
- `swift test --filter LogicProServerHandler` - 10 passed
- `swift test --filter LogicProServerTransport` - 18 passed
- `swift test --filter VersionConsistency` - 7 passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

Refs #27