### PR TITLE
feat(setup): install/update/uninstall dry-run lifecycle commands (#26)

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -21,6 +21,7 @@ enum MainEntrypoint {
         serverFactory: () -> any ServerStarting = { LogicProServer() },
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
         doctorRuntime: SetupDoctor.Runtime = .production,
+        lifecycleRuntime: SetupLifecycle.Runtime = .production,
         writeStdout: (String) -> Void = { message in
             FileHandle.standardOutput.write(Data(message.utf8))
         },
@@ -42,6 +43,29 @@ enum MainEntrypoint {
                 : SetupDoctor.renderHuman(report)
             writeStdout(output + "\n")
             return SetupDoctor.shouldExitWithFailure(report) ? 1 : 0
+        }
+
+        if let command = lifecycleCommand(arguments) {
+            // Live execution is intentionally NOT performed here — it is delegated
+            // to Scripts/install.sh / uninstall.sh. Without --dry-run we refuse
+            // honestly and exit non-zero rather than faking execution.
+            guard arguments.contains("--dry-run") else {
+                let script = command == .uninstall
+                    ? "Scripts/uninstall.sh"
+                    : "Scripts/install.sh"
+                writeStderr(
+                    "Live \(command.rawValue) is not performed by this binary. "
+                        + "Re-run with --dry-run to preview the plan, or run \(script) "
+                        + "to execute (see docs/SETUP.md).\n"
+                )
+                return 1
+            }
+            let plan = SetupLifecycle.plan(command: command, runtime: lifecycleRuntime)
+            let output = arguments.contains("--json")
+                ? encodeJSON(plan)
+                : SetupLifecycle.renderHuman(plan)
+            writeStdout(output + "\n")
+            return 0
         }
 
         if arguments.contains("--list-approvals") {
@@ -144,5 +168,10 @@ enum MainEntrypoint {
 
     private static func isDoctorCommand(_ arguments: [String]) -> Bool {
         Array(arguments.dropFirst()).first == "doctor"
+    }
+
+    private static func lifecycleCommand(_ arguments: [String]) -> SetupLifecycle.Command? {
+        guard let first = Array(arguments.dropFirst()).first else { return nil }
+        return SetupLifecycle.Command(rawValue: first)
     }
 }

--- a/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
+++ b/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
@@ -1,0 +1,590 @@
+import Foundation
+
+/// Read-only PLANNER for the install / update / uninstall lifecycle.
+///
+/// Mirrors `SetupDoctor`'s Runtime-injection seam so it is fully testable
+/// without touching the real filesystem, the real Claude config, or the real
+/// install location. A plan DESCRIBES the ordered steps a live execution would
+/// take — it NEVER mutates anything. The `Runtime` exposes only read accessors;
+/// there is deliberately no write/delete/register hook on it, so a dry-run plan
+/// is structurally incapable of changing state (the test asserts this by handing
+/// in a runtime that records any unexpected access).
+///
+/// Honest Contract: a plan is not a claim of success. It reports the CURRENT
+/// observed state and the PLANNED state for each artifact, plus whether the step
+/// is reversible and whether it needs sudo. Live execution is delegated to
+/// `Scripts/install.sh` / `Scripts/uninstall.sh`; the planner does not pretend
+/// to perform it.
+enum SetupLifecycle {
+    enum Command: String, Codable, Sendable, CaseIterable {
+        case install
+        case update
+        case uninstall
+    }
+
+    enum Action: String, Codable, Sendable {
+        case create
+        case update
+        case delete
+        case register
+        case unregister
+        case skip
+    }
+
+    /// Mirrors `SetupDoctor.RemediationType` so a step's remediation reads with
+    /// the same vocabulary and anchor scheme operators already know from doctor.
+    enum RemediationType: String, Codable, Sendable {
+        case command
+        case docs
+        case manual
+        case none
+    }
+
+    struct Remediation: Codable, Equatable, Sendable {
+        let type: RemediationType
+        let value: String
+    }
+
+    struct Step: Codable, Equatable, Sendable {
+        let id: String
+        let action: Action
+        let target: String
+        let currentState: String
+        let plannedState: String
+        let reversible: Bool
+        let requiresSudo: Bool
+        let remediation: Remediation
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case action
+            case target
+            case currentState = "current_state"
+            case plannedState = "planned_state"
+            case reversible
+            case requiresSudo = "requires_sudo"
+            case remediation
+        }
+    }
+
+    struct Plan: Codable, Equatable, Sendable {
+        let schema: String
+        let command: Command
+        let executionMode: String
+        let installedVersion: String?
+        let targetVersion: String
+        let installDir: String
+        let steps: [Step]
+        let nextSafeAction: String
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case command
+            case executionMode = "execution_mode"
+            case installedVersion = "installed_version"
+            case targetVersion = "target_version"
+            case installDir = "install_dir"
+            case steps
+            case nextSafeAction = "next_safe_action"
+        }
+    }
+
+    /// Read-only inspection seam. Every closure READS observed state; there is no
+    /// mutation hook by construction, so a dry-run plan cannot change anything.
+    /// Production wires these to the same primitives `Scripts/install.sh` and
+    /// `Scripts/uninstall.sh` touch.
+    struct Runtime: @unchecked Sendable {
+        /// Default install directory (`/usr/local/bin` unless overridden by env).
+        let installDir: () -> String
+        /// Does a file/package exist at the absolute path?
+        let fileExists: (String) -> Bool
+        /// Is the directory at `path` writable without elevation? Used to decide
+        /// `requires_sudo` for binary placement/removal under `INSTALL_DIR`.
+        let directoryWritable: (String) -> Bool
+        /// Claude Code MCP registration state (reuses the doctor's read-only reader).
+        let claudeRegistration: () -> SetupDoctor.ClaudeRegistration
+        /// Is the `claude` CLI resolvable on PATH? Drives whether registration is a
+        /// command step or a manual one.
+        let claudeCLIAvailable: () -> Bool
+        /// Version string of the binary already installed at `INSTALL_DIR`, if it
+        /// can be read; nil when nothing is installed or the version cannot be read.
+        let installedBinaryVersion: () -> String?
+        /// Home directory for resolving per-user artifacts (Key Commands, plist,
+        /// approval store). Injected so tests never read the real home dir.
+        let homeDirectory: () -> URL
+
+        static let production = Runtime(
+            installDir: {
+                ProcessInfo.processInfo.environment["LOGIC_PRO_MCP_INSTALL_DIR"] ?? "/usr/local/bin"
+            },
+            fileExists: { path in
+                FileManager.default.fileExists(atPath: path)
+            },
+            directoryWritable: { path in
+                FileManager.default.isWritableFile(atPath: path)
+            },
+            claudeRegistration: {
+                SetupDoctor.readProductionClaudeRegistration()
+            },
+            claudeCLIAvailable: {
+                productionClaudeCLIAvailable()
+            },
+            installedBinaryVersion: {
+                productionInstalledBinaryVersion()
+            },
+            homeDirectory: {
+                FileManager.default.homeDirectoryForCurrentUser
+            }
+        )
+    }
+
+    static let schema = "logic_pro_mcp_lifecycle_plan.v1"
+
+    /// Stable doc anchors, sharing `docs/SETUP.md` with the doctor so remediation
+    /// language and links stay consistent across both surfaces.
+    static let remediationAnchorsByStepID: [String: String] = [
+        "binary.install": "docs/SETUP.md#lifecycle-binaryinstall",
+        "binary.update": "docs/SETUP.md#lifecycle-binaryupdate",
+        "binary.remove": "docs/SETUP.md#lifecycle-binaryremove",
+        "mcp.register": "docs/SETUP.md#lifecycle-mcpregister",
+        "mcp.unregister": "docs/SETUP.md#lifecycle-mcpunregister",
+        "keycmds.stage": "docs/SETUP.md#lifecycle-keycmdsstage",
+        "keycmds.remove": "docs/SETUP.md#lifecycle-keycmdsremove",
+        "scripter.insert": "docs/SETUP.md#lifecycle-scripterinsert",
+        "scripter.remove": "docs/SETUP.md#lifecycle-scripterremove",
+        "launch_agent.install": "docs/SETUP.md#lifecycle-launchagentinstall",
+        "launch_agent.remove": "docs/SETUP.md#lifecycle-launchagentremove",
+        "approvals.remove": "docs/SETUP.md#lifecycle-approvalsremove",
+    ]
+
+    /// Build a read-only plan for `command`. Never mutates; `execution_mode` is
+    /// always `dry_run_only` so the wire contract states the plan does nothing.
+    static func plan(command: Command, runtime: Runtime = .production) -> Plan {
+        let installDir = runtime.installDir()
+        let binaryPath = installDir + "/LogicProMCP"
+        let binaryInstalled = runtime.fileExists(binaryPath)
+        let installDirWritable = runtime.directoryWritable(installDir)
+        let installedVersion = binaryInstalled ? runtime.installedBinaryVersion() : nil
+        let targetVersion = ServerConfig.serverVersion
+
+        let steps: [Step]
+        switch command {
+        case .install:
+            steps = installSteps(
+                runtime: runtime,
+                binaryPath: binaryPath,
+                binaryInstalled: binaryInstalled,
+                installDirWritable: installDirWritable
+            )
+        case .update:
+            steps = updateSteps(
+                runtime: runtime,
+                binaryPath: binaryPath,
+                binaryInstalled: binaryInstalled,
+                installDirWritable: installDirWritable,
+                installedVersion: installedVersion,
+                targetVersion: targetVersion
+            )
+        case .uninstall:
+            steps = uninstallSteps(
+                runtime: runtime,
+                binaryPath: binaryPath,
+                binaryInstalled: binaryInstalled,
+                installDirWritable: installDirWritable
+            )
+        }
+
+        return Plan(
+            schema: schema,
+            command: command,
+            executionMode: "dry_run_only",
+            installedVersion: installedVersion,
+            targetVersion: targetVersion,
+            installDir: installDir,
+            steps: steps,
+            nextSafeAction: nextSafeAction(for: command)
+        )
+    }
+
+    static func renderHuman(_ plan: Plan) -> String {
+        var lines: [String] = [
+            "Logic Pro MCP lifecycle plan",
+            "schema: \(plan.schema)",
+            "command: \(plan.command.rawValue)",
+            "execution_mode: \(plan.executionMode)",
+            "install_dir: \(plan.installDir)",
+            "installed_version: \(plan.installedVersion ?? "<none>")",
+            "target_version: \(plan.targetVersion)",
+            "",
+        ]
+        for step in plan.steps {
+            lines.append("[\(step.action.rawValue)] \(step.id) -> \(step.target)")
+            lines.append("  current: \(step.currentState) | planned: \(step.plannedState)")
+            lines.append("  reversible: \(step.reversible) | requires_sudo: \(step.requiresSudo)")
+            if step.remediation.type != .none {
+                lines.append("  remediation: \(step.remediation.value)")
+            }
+        }
+        lines.append("")
+        lines.append("next_safe_action: \(plan.nextSafeAction)")
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Step builders
+
+    private static func installSteps(
+        runtime: Runtime,
+        binaryPath: String,
+        binaryInstalled: Bool,
+        installDirWritable: Bool
+    ) -> [Step] {
+        var steps: [Step] = []
+
+        steps.append(step(
+            id: "binary.install",
+            action: binaryInstalled ? .skip : .create,
+            target: binaryPath,
+            currentState: binaryInstalled ? "present" : "absent",
+            plannedState: "present",
+            // A create is reversible (uninstall removes it); a skip is a no-op so
+            // it leaves nothing to roll back.
+            reversible: true,
+            requiresSudo: !installDirWritable,
+            remediationType: .command,
+            remediationValueOverride: binaryInstalled
+                ? "Already installed at \(binaryPath); use the update command to refresh."
+                : "Run Scripts/install.sh (pins LOGIC_PRO_MCP_VERSION + provenance)."
+        ))
+
+        steps.append(registrationStep(runtime: runtime, binaryPath: binaryPath, removing: false))
+        steps.append(keyCommandsStep(runtime: runtime, removing: false))
+        steps.append(scripterStep(removing: false))
+
+        return steps
+    }
+
+    private static func updateSteps(
+        runtime: Runtime,
+        binaryPath: String,
+        binaryInstalled: Bool,
+        installDirWritable: Bool,
+        installedVersion: String?,
+        targetVersion: String
+    ) -> [Step] {
+        var steps: [Step] = []
+
+        // No binary installed -> update is really an install of the binary.
+        let action: Action
+        let plannedState: String
+        let current: String
+        if !binaryInstalled {
+            action = .create
+            current = "absent"
+            plannedState = "present (\(targetVersion))"
+        } else if let installedVersion, installedVersion == targetVersion {
+            action = .skip
+            current = "present (\(installedVersion))"
+            plannedState = "present (\(targetVersion))"
+        } else {
+            action = .update
+            current = "present (\(installedVersion ?? "unknown"))"
+            plannedState = "present (\(targetVersion))"
+        }
+
+        steps.append(step(
+            id: "binary.update",
+            action: action,
+            target: binaryPath,
+            currentState: current,
+            plannedState: plannedState,
+            reversible: true,
+            requiresSudo: !installDirWritable,
+            remediationType: .command,
+            remediationValueOverride: action == .skip
+                ? "Installed version already matches \(targetVersion); nothing to update."
+                : "Run Scripts/install.sh with LOGIC_PRO_MCP_VERSION=v\(targetVersion)."
+        ))
+
+        // Re-point the Claude registration at the (possibly refreshed) binary.
+        steps.append(registrationStep(runtime: runtime, binaryPath: binaryPath, removing: false))
+
+        return steps
+    }
+
+    private static func uninstallSteps(
+        runtime: Runtime,
+        binaryPath: String,
+        binaryInstalled: Bool,
+        installDirWritable: Bool
+    ) -> [Step] {
+        var steps: [Step] = []
+        let home = runtime.homeDirectory()
+
+        // Order mirrors Scripts/uninstall.sh: approvals, binary, key commands,
+        // registration, then manual Logic-side reminders.
+        let approvalStore = approvalStorePath(home: home)
+        let approvalsPresent = runtime.fileExists(approvalStore)
+        steps.append(step(
+            id: "approvals.remove",
+            action: approvalsPresent ? .delete : .skip,
+            target: approvalStore,
+            currentState: approvalsPresent ? "present" : "absent",
+            plannedState: "absent",
+            // Operator approvals are re-creatable via --approve-channel, so this
+            // delete is reversible by re-approving.
+            reversible: true,
+            requiresSudo: false,
+            remediationType: approvalsPresent ? .command : .none,
+            remediationValueOverride: approvalsPresent
+                ? "Scripts/uninstall.sh removes \(approvalStore); re-approve later with --approve-channel."
+                : nil
+        ))
+
+        steps.append(step(
+            id: "binary.remove",
+            action: binaryInstalled ? .delete : .skip,
+            target: binaryPath,
+            currentState: binaryInstalled ? "present" : "absent",
+            plannedState: "absent",
+            // The binary can be reinstalled, so removal is reversible.
+            reversible: true,
+            requiresSudo: binaryInstalled && !installDirWritable,
+            remediationType: binaryInstalled ? .command : .none,
+            remediationValueOverride: binaryInstalled
+                ? "Scripts/uninstall.sh removes \(binaryPath)."
+                : nil
+        ))
+
+        steps.append(keyCommandsStep(runtime: runtime, removing: true))
+        steps.append(registrationStep(runtime: runtime, binaryPath: binaryPath, removing: true))
+        steps.append(scripterStep(removing: true))
+
+        let launchAgent = launchAgentPath(home: home)
+        let launchAgentPresent = runtime.fileExists(launchAgent)
+        steps.append(step(
+            id: "launch_agent.remove",
+            action: launchAgentPresent ? .delete : .skip,
+            target: launchAgent,
+            currentState: launchAgentPresent ? "present" : "absent",
+            plannedState: "absent",
+            reversible: true,
+            requiresSudo: false,
+            remediationType: launchAgentPresent ? .manual : .none,
+            remediationValueOverride: launchAgentPresent
+                ? "launchctl unload \(launchAgent) && rm \(launchAgent)"
+                : nil
+        ))
+
+        return steps
+    }
+
+    // MARK: - Shared step constructors
+
+    private static func registrationStep(runtime: Runtime, binaryPath: String, removing: Bool) -> Step {
+        let registered: Bool
+        switch runtime.claudeRegistration() {
+        case .registered:
+            registered = true
+        case .notRegistered, .configUnavailable:
+            registered = false
+        }
+        let cliAvailable = runtime.claudeCLIAvailable()
+
+        if removing {
+            return step(
+                id: "mcp.unregister",
+                action: registered ? .unregister : .skip,
+                target: "claude://mcp/logic-pro",
+                currentState: registered ? "registered" : "not_registered",
+                plannedState: "not_registered",
+                reversible: true,
+                requiresSudo: false,
+                remediationType: registered ? (cliAvailable ? .command : .manual) : .none,
+                remediationValueOverride: registered
+                    ? "claude mcp remove logic-pro"
+                    : nil
+            )
+        }
+
+        return step(
+            id: "mcp.register",
+            action: registered ? .skip : .register,
+            target: "claude://mcp/logic-pro",
+            currentState: registered ? "registered" : "not_registered",
+            plannedState: "registered",
+            reversible: true,
+            requiresSudo: false,
+            remediationType: cliAvailable ? .command : .manual,
+            remediationValueOverride: registered
+                ? "Already registered with Claude Code."
+                : "claude mcp add --scope user logic-pro -- \(binaryPath)"
+        )
+    }
+
+    private static func keyCommandsStep(runtime: Runtime, removing: Bool) -> Step {
+        let home = runtime.homeDirectory()
+        let preset = keyCommandsPresetPath(home: home)
+        let present = runtime.fileExists(preset)
+
+        if removing {
+            return step(
+                id: "keycmds.remove",
+                action: present ? .delete : .skip,
+                target: preset,
+                currentState: present ? "present" : "absent",
+                plannedState: "absent",
+                // uninstall-keycmds.sh can restore a pre-install backup, so this
+                // delete is reversible.
+                reversible: true,
+                requiresSudo: false,
+                remediationType: present ? .command : .none,
+                remediationValueOverride: present
+                    ? "Scripts/uninstall-keycmds.sh (restores any pre-install backup)."
+                    : nil
+            )
+        }
+
+        // Staging the mapping reference only copies a reference plist; the live
+        // bindings still require manual MIDI Learn on Logic 12.2+, so the planned
+        // state is honest about that.
+        return step(
+            id: "keycmds.stage",
+            action: present ? .skip : .create,
+            target: preset,
+            currentState: present ? "present" : "absent",
+            plannedState: "staged (manual MIDI Learn still required on Logic 12.2+)",
+            reversible: true,
+            requiresSudo: false,
+            remediationType: .command,
+            remediationValueOverride: present
+                ? "Mapping reference already staged at \(preset)."
+                : "Scripts/install-keycmds.sh stages the CC->Command mapping reference."
+        )
+    }
+
+    private static func scripterStep(removing: Bool) -> Step {
+        // Scripter insertion is a manual Logic-side step (insert the MIDI FX +
+        // paste Scripts/LogicProMCP-Scripter.js); it leaves no filesystem artifact
+        // the planner can inspect, so current/planned state are reported as manual
+        // rather than fabricated.
+        if removing {
+            return step(
+                id: "scripter.remove",
+                action: .skip,
+                target: "logic://midi-fx/LogicProMCP-Scripter",
+                currentState: "manual",
+                plannedState: "manual",
+                reversible: true,
+                requiresSudo: false,
+                remediationType: .manual,
+                remediationValueOverride:
+                    "In Logic Pro, remove the LogicProMCP Scripter MIDI FX from each channel strip."
+            )
+        }
+        return step(
+            id: "scripter.insert",
+            action: .skip,
+            target: "logic://midi-fx/LogicProMCP-Scripter",
+            currentState: "manual",
+            plannedState: "manual",
+            reversible: true,
+            requiresSudo: false,
+            remediationType: .manual,
+            remediationValueOverride:
+                "Optional legacy path: insert Scripter and load Scripts/LogicProMCP-Scripter.js, then --approve-channel Scripter."
+        )
+    }
+
+    // MARK: - Artifact paths (injected home so tests stay off the real FS)
+
+    private static func keyCommandsPresetPath(home: URL) -> String {
+        home
+            .appendingPathComponent("Music/Audio Music Apps/Key Commands/LogicProMCP-KeyCommands.plist")
+            .path
+    }
+
+    private static func launchAgentPath(home: URL) -> String {
+        home
+            .appendingPathComponent("Library/LaunchAgents/com.logicpro.mcp.plist")
+            .path
+    }
+
+    private static func approvalStorePath(home: URL) -> String {
+        home
+            .appendingPathComponent("Library/Application Support/LogicProMCP/operator-approvals.json")
+            .path
+    }
+
+    private static func nextSafeAction(for command: Command) -> String {
+        switch command {
+        case .install:
+            return "review_install_plan"
+        case .update:
+            return "review_update_plan"
+        case .uninstall:
+            return "review_uninstall_plan"
+        }
+    }
+
+    private static func step(
+        id: String,
+        action: Action,
+        target: String,
+        currentState: String,
+        plannedState: String,
+        reversible: Bool,
+        requiresSudo: Bool,
+        remediationType: RemediationType,
+        remediationValueOverride: String? = nil
+    ) -> Step {
+        let value = remediationValueOverride ?? defaultRemediationValue(for: id, type: remediationType)
+        return Step(
+            id: id,
+            action: action,
+            target: target,
+            currentState: currentState,
+            plannedState: plannedState,
+            reversible: reversible,
+            requiresSudo: requiresSudo,
+            remediation: Remediation(type: remediationType, value: value)
+        )
+    }
+
+    private static func defaultRemediationValue(for id: String, type: RemediationType) -> String {
+        switch type {
+        case .none:
+            return ""
+        case .command, .docs, .manual:
+            return remediationAnchorsByStepID[id] ?? "docs/SETUP.md#lifecycle"
+        }
+    }
+
+    // MARK: - Production read helpers
+
+    private static func productionClaudeCLIAvailable() -> Bool {
+        guard let result = SetupDoctor.runProductionCommandForTesting(
+            executable: "/usr/bin/which",
+            arguments: ["claude"],
+            timeout: 1.0
+        ), let output = result.output else {
+            return false
+        }
+        return output.exitCode == 0
+            && !output.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func productionInstalledBinaryVersion() -> String? {
+        let installDir = ProcessInfo.processInfo.environment["LOGIC_PRO_MCP_INSTALL_DIR"] ?? "/usr/local/bin"
+        let binaryPath = installDir + "/LogicProMCP"
+        guard FileManager.default.isExecutableFile(atPath: binaryPath) else { return nil }
+        guard let result = SetupDoctor.runProductionCommandForTesting(
+            executable: binaryPath,
+            arguments: ["--version"],
+            timeout: 1.5
+        ), let output = result.output, output.exitCode == 0 else {
+            return nil
+        }
+        let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/LogicProMCP/main.swift
+++ b/Sources/LogicProMCP/main.swift
@@ -7,6 +7,7 @@ enum LogicProMCPMain {
         serverFactory: () -> any ServerStarting = { LogicProServer() },
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
         doctorRuntime: SetupDoctor.Runtime = .production,
+        lifecycleRuntime: SetupLifecycle.Runtime = .production,
         writeStdout: (String) -> Void = { message in
             FileHandle.standardOutput.write(Data(message.utf8))
         },
@@ -20,6 +21,7 @@ enum LogicProMCPMain {
             serverFactory: serverFactory,
             approvalStoreFactory: approvalStoreFactory,
             doctorRuntime: doctorRuntime,
+            lifecycleRuntime: lifecycleRuntime,
             writeStdout: writeStdout,
             writeStderr: writeStderr
         )

--- a/Tests/LogicProMCPTests/SetupLifecycleTests.swift
+++ b/Tests/LogicProMCPTests/SetupLifecycleTests.swift
@@ -1,0 +1,530 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private actor LifecycleMockMainServer: ServerStarting {
+    func start() async throws {}
+}
+
+/// Records every read the planner makes against the injected runtime AND records
+/// any path the planner would mutate. The lifecycle Runtime has no write hook by
+/// construction, so a non-empty `writes` array can only happen if a future change
+/// adds one — the dry-run zero-mutation test asserts it stays empty.
+private final class LifecycleRuntimeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var fileExistsQueries: [String] = []
+    private(set) var directoryWritableQueries: [String] = []
+    private(set) var writes: [String] = []
+
+    func recordFileExists(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        fileExistsQueries.append(path)
+    }
+
+    func recordDirectoryWritable(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        directoryWritableQueries.append(path)
+    }
+
+    func recordWrite(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        writes.append(path)
+    }
+
+    func snapshotWrites() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return writes
+    }
+}
+
+private let lifecycleTestHome = URL(fileURLWithPath: "/Users/tester")
+
+private func lifecycleRuntime(
+    installDir: String = "/usr/local/bin",
+    presentPaths: Set<String> = [],
+    installDirWritable: Bool = false,
+    registration: SetupDoctor.ClaudeRegistration = .notRegistered,
+    claudeCLIAvailable: Bool = true,
+    installedVersion: String? = nil,
+    home: URL = lifecycleTestHome,
+    recorder: LifecycleRuntimeRecorder? = nil
+) -> SetupLifecycle.Runtime {
+    SetupLifecycle.Runtime(
+        installDir: { installDir },
+        fileExists: { path in
+            recorder?.recordFileExists(path)
+            return presentPaths.contains(path)
+        },
+        directoryWritable: { path in
+            recorder?.recordDirectoryWritable(path)
+            return installDirWritable
+        },
+        claudeRegistration: { registration },
+        claudeCLIAvailable: { claudeCLIAvailable },
+        installedBinaryVersion: { installedVersion },
+        homeDirectory: { home }
+    )
+}
+
+private func step(_ plan: SetupLifecycle.Plan, _ id: String) -> SetupLifecycle.Step? {
+    plan.steps.first { $0.id == id }
+}
+
+private func binaryPath(_ installDir: String = "/usr/local/bin") -> String {
+    installDir + "/LogicProMCP"
+}
+
+private func keyCommandsPath(_ home: URL = lifecycleTestHome) -> String {
+    home.appendingPathComponent("Music/Audio Music Apps/Key Commands/LogicProMCP-KeyCommands.plist").path
+}
+
+private func approvalStorePath(_ home: URL = lifecycleTestHome) -> String {
+    home.appendingPathComponent("Library/Application Support/LogicProMCP/operator-approvals.json").path
+}
+
+private func launchAgentPath(_ home: URL = lifecycleTestHome) -> String {
+    home.appendingPathComponent("Library/LaunchAgents/com.logicpro.mcp.plist").path
+}
+
+// MARK: - Install plan (nothing installed)
+
+@Test func testInstallPlanWhenNothingInstalledIsAllCreateOrRegister() throws {
+    let plan = SetupLifecycle.plan(
+        command: .install,
+        runtime: lifecycleRuntime(registration: .notRegistered)
+    )
+
+    #expect(plan.schema == "logic_pro_mcp_lifecycle_plan.v1")
+    #expect(plan.command == .install)
+    #expect(plan.executionMode == "dry_run_only")
+    #expect(plan.targetVersion == ServerConfig.serverVersion)
+    #expect(plan.installedVersion == nil)
+
+    let binary = try #require(step(plan, "binary.install"))
+    #expect(binary.action == .create)
+    #expect(binary.currentState == "absent")
+    #expect(binary.plannedState == "present")
+    #expect(binary.target == binaryPath())
+    // /usr/local/bin not writable by the fake -> sudo required.
+    #expect(binary.requiresSudo)
+
+    let register = try #require(step(plan, "mcp.register"))
+    #expect(register.action == .register)
+    #expect(register.currentState == "not_registered")
+    #expect(!register.requiresSudo)
+
+    let keycmds = try #require(step(plan, "keycmds.stage"))
+    #expect(keycmds.action == .create)
+
+    // Scripter is a manual Logic-side step with no FS artifact -> always skip.
+    let scripter = try #require(step(plan, "scripter.insert"))
+    #expect(scripter.action == .skip)
+    #expect(scripter.remediation.type == .manual)
+
+    // No delete/unregister actions in a fresh install plan.
+    let actions = Set(plan.steps.map(\.action))
+    #expect(!actions.contains(.delete))
+    #expect(!actions.contains(.unregister))
+}
+
+@Test func testInstallPlanSkipsBinaryWhenAlreadyPresent() throws {
+    let plan = SetupLifecycle.plan(
+        command: .install,
+        runtime: lifecycleRuntime(
+            presentPaths: [binaryPath()],
+            installDirWritable: true,
+            registration: .registered(command: binaryPath())
+        )
+    )
+    let binary = try #require(step(plan, "binary.install"))
+    #expect(binary.action == .skip)
+    #expect(binary.currentState == "present")
+    // Already writable dir -> no sudo even though it's a skip.
+    #expect(!binary.requiresSudo)
+
+    let register = try #require(step(plan, "mcp.register"))
+    #expect(register.action == .skip)
+    #expect(register.currentState == "registered")
+}
+
+@Test func testInstallPlanRequiresSudoOnlyWhenInstallDirNotWritable() throws {
+    let writable = SetupLifecycle.plan(
+        command: .install,
+        runtime: lifecycleRuntime(installDirWritable: true)
+    )
+    let notWritable = SetupLifecycle.plan(
+        command: .install,
+        runtime: lifecycleRuntime(installDirWritable: false)
+    )
+    #expect(try #require(step(writable, "binary.install")).requiresSudo == false)
+    #expect(try #require(step(notWritable, "binary.install")).requiresSudo == true)
+}
+
+// MARK: - Uninstall plan (fully installed)
+
+@Test func testUninstallPlanWhenFullyInstalledIsAllDeleteOrUnregister() throws {
+    let present: Set<String> = [
+        binaryPath(),
+        keyCommandsPath(),
+        approvalStorePath(),
+        launchAgentPath(),
+    ]
+    let plan = SetupLifecycle.plan(
+        command: .uninstall,
+        runtime: lifecycleRuntime(
+            presentPaths: present,
+            installDirWritable: false,
+            registration: .registered(command: binaryPath()),
+            claudeCLIAvailable: true
+        )
+    )
+
+    #expect(plan.command == .uninstall)
+
+    let approvals = try #require(step(plan, "approvals.remove"))
+    #expect(approvals.action == .delete)
+    #expect(approvals.reversible)
+    #expect(!approvals.requiresSudo)
+
+    let binary = try #require(step(plan, "binary.remove"))
+    #expect(binary.action == .delete)
+    #expect(binary.reversible)
+    // Install dir not writable -> sudo required to remove the binary.
+    #expect(binary.requiresSudo)
+
+    let keycmds = try #require(step(plan, "keycmds.remove"))
+    #expect(keycmds.action == .delete)
+    #expect(keycmds.reversible)
+
+    let unregister = try #require(step(plan, "mcp.unregister"))
+    #expect(unregister.action == .unregister)
+    #expect(unregister.currentState == "registered")
+    #expect(unregister.remediation.type == .command)
+    #expect(unregister.remediation.value == "claude mcp remove logic-pro")
+
+    let launch = try #require(step(plan, "launch_agent.remove"))
+    #expect(launch.action == .delete)
+
+    // Every reachable artifact step is reversible (re-installable / re-approvable).
+    for s in plan.steps where s.action == .delete || s.action == .unregister {
+        #expect(s.reversible, "\(s.id) should be reversible")
+    }
+    // No create/register in an uninstall plan.
+    let actions = Set(plan.steps.map(\.action))
+    #expect(!actions.contains(.create))
+    #expect(!actions.contains(.register))
+}
+
+@Test func testUninstallPlanSkipsAbsentArtifacts() throws {
+    // Nothing present at all -> every removable step is skip, scripter stays manual.
+    let plan = SetupLifecycle.plan(
+        command: .uninstall,
+        runtime: lifecycleRuntime(presentPaths: [], registration: .notRegistered)
+    )
+    #expect(try #require(step(plan, "approvals.remove")).action == .skip)
+    #expect(try #require(step(plan, "binary.remove")).action == .skip)
+    #expect(try #require(step(plan, "keycmds.remove")).action == .skip)
+    #expect(try #require(step(plan, "mcp.unregister")).action == .skip)
+    #expect(try #require(step(plan, "launch_agent.remove")).action == .skip)
+
+    // A skipped binary removal needs no sudo regardless of dir writability.
+    #expect(try #require(step(plan, "binary.remove")).requiresSudo == false)
+}
+
+@Test func testUninstallUnregisterIsManualWhenClaudeCLIMissing() throws {
+    let plan = SetupLifecycle.plan(
+        command: .uninstall,
+        runtime: lifecycleRuntime(
+            registration: .registered(command: binaryPath()),
+            claudeCLIAvailable: false
+        )
+    )
+    let unregister = try #require(step(plan, "mcp.unregister"))
+    #expect(unregister.action == .unregister)
+    #expect(unregister.remediation.type == .manual)
+}
+
+// MARK: - Update plan (version delta)
+
+@Test func testUpdatePlanWithVersionDeltaIsUpdate() throws {
+    let plan = SetupLifecycle.plan(
+        command: .update,
+        runtime: lifecycleRuntime(
+            presentPaths: [binaryPath()],
+            installDirWritable: true,
+            registration: .registered(command: binaryPath()),
+            installedVersion: "3.0.0"
+        )
+    )
+
+    #expect(plan.command == .update)
+    #expect(plan.installedVersion == "3.0.0")
+    #expect(plan.targetVersion == ServerConfig.serverVersion)
+    #expect(plan.installedVersion != plan.targetVersion)
+
+    let binary = try #require(step(plan, "binary.update"))
+    #expect(binary.action == .update)
+    #expect(binary.currentState == "present (3.0.0)")
+    #expect(binary.plannedState == "present (\(ServerConfig.serverVersion))")
+    #expect(!binary.requiresSudo)
+}
+
+@Test func testUpdatePlanSkipsWhenAlreadyAtTargetVersion() throws {
+    let plan = SetupLifecycle.plan(
+        command: .update,
+        runtime: lifecycleRuntime(
+            presentPaths: [binaryPath()],
+            installDirWritable: true,
+            registration: .registered(command: binaryPath()),
+            installedVersion: ServerConfig.serverVersion
+        )
+    )
+    let binary = try #require(step(plan, "binary.update"))
+    #expect(binary.action == .skip)
+    #expect(binary.currentState == "present (\(ServerConfig.serverVersion))")
+}
+
+@Test func testUpdatePlanFallsBackToCreateWhenNothingInstalled() throws {
+    let plan = SetupLifecycle.plan(
+        command: .update,
+        runtime: lifecycleRuntime(presentPaths: [], installDirWritable: false)
+    )
+    #expect(plan.installedVersion == nil)
+    let binary = try #require(step(plan, "binary.update"))
+    #expect(binary.action == .create)
+    #expect(binary.currentState == "absent")
+    #expect(binary.requiresSudo)
+}
+
+// MARK: - JSON schema contract
+
+@Test func testLifecyclePlanJSONValidatesAgainstSchema() throws {
+    let plan = SetupLifecycle.plan(
+        command: .uninstall,
+        runtime: lifecycleRuntime(
+            presentPaths: [binaryPath(), keyCommandsPath(), approvalStorePath()],
+            registration: .registered(command: binaryPath())
+        )
+    )
+    let json = encodeJSON(plan)
+    let object = try #require(sharedJSONObject(json))
+
+    #expect(object["schema"] as? String == "logic_pro_mcp_lifecycle_plan.v1")
+    #expect(object["command"] as? String == "uninstall")
+    #expect(object["execution_mode"] as? String == "dry_run_only")
+    #expect(object["target_version"] as? String == ServerConfig.serverVersion)
+    #expect(object["install_dir"] as? String == "/usr/local/bin")
+    #expect(object["next_safe_action"] as? String == "review_uninstall_plan")
+
+    let steps = try #require(object["steps"] as? [[String: Any]])
+    #expect(steps.count == plan.steps.count)
+
+    // Lock the per-step wire shape with snake_case keys so a CodingKeys typo on a
+    // nested field cannot ship green. All force-unwrap / != nil — never dead forms.
+    let first = try #require(steps.first)
+    #expect(first["id"] as? String == "approvals.remove")
+    let action = try #require(first["action"] as? String)
+    #expect(action == "delete")
+    #expect(first["target"] as? String != nil)
+    #expect(first["current_state"] as? String != nil)
+    #expect(first["planned_state"] as? String != nil)
+    #expect(first["reversible"] as? Bool != nil)
+    #expect(first["requires_sudo"] as? Bool != nil)
+    let remediation = try #require(first["remediation"] as? [String: Any])
+    #expect(remediation["type"] as? String != nil)
+    #expect(remediation["value"] as? String != nil)
+}
+
+@Test func testLifecyclePlanActionVocabularyIsClosed() {
+    // Every emitted action must be one of the documented enum cases across all
+    // three commands and both present/absent states.
+    let allowed: Set<String> = ["create", "update", "delete", "register", "unregister", "skip"]
+    for command in SetupLifecycle.Command.allCases {
+        let installed = SetupLifecycle.plan(
+            command: command,
+            runtime: lifecycleRuntime(
+                presentPaths: [binaryPath(), keyCommandsPath(), approvalStorePath(), launchAgentPath()],
+                registration: .registered(command: binaryPath()),
+                installedVersion: "1.0.0"
+            )
+        )
+        let empty = SetupLifecycle.plan(
+            command: command,
+            runtime: lifecycleRuntime(presentPaths: [], registration: .notRegistered)
+        )
+        for s in installed.steps + empty.steps {
+            #expect(allowed.contains(s.action.rawValue), "unexpected action \(s.action.rawValue)")
+        }
+    }
+}
+
+// MARK: - Dry-run is read-only (zero mutations)
+
+@Test func testDryRunPlanPerformsZeroMutations() {
+    let recorder = LifecycleRuntimeRecorder()
+    for command in SetupLifecycle.Command.allCases {
+        _ = SetupLifecycle.plan(
+            command: command,
+            runtime: lifecycleRuntime(
+                presentPaths: [binaryPath(), keyCommandsPath(), approvalStorePath(), launchAgentPath()],
+                installDirWritable: false,
+                registration: .registered(command: binaryPath()),
+                installedVersion: "1.0.0",
+                recorder: recorder
+            )
+        )
+    }
+    // The runtime exposes only read accessors; no write was ever recorded.
+    #expect(recorder.snapshotWrites().isEmpty)
+    // And the planner DID inspect real artifact paths (proves it read, not guessed).
+    #expect(recorder.fileExistsQueries.contains(binaryPath()))
+    #expect(recorder.fileExistsQueries.contains(keyCommandsPath()))
+}
+
+@Test func testDryRunDoesNotTouchRealFilesystemArtifacts() {
+    // Drive the planner with the PRODUCTION fileExists against a path we control
+    // in a temp dir, then assert the path was never created by the read-only plan.
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("lifecycle-readonly-\(UUID().uuidString)", isDirectory: true)
+    let fakeBinary = tmp.appendingPathComponent("LogicProMCP").path
+
+    let runtime = SetupLifecycle.Runtime(
+        installDir: { tmp.path },
+        fileExists: { FileManager.default.fileExists(atPath: $0) },
+        directoryWritable: { FileManager.default.isWritableFile(atPath: $0) },
+        claudeRegistration: { .notRegistered },
+        claudeCLIAvailable: { false },
+        installedBinaryVersion: { nil },
+        homeDirectory: { tmp }
+    )
+
+    _ = SetupLifecycle.plan(command: .install, runtime: runtime)
+    _ = SetupLifecycle.plan(command: .uninstall, runtime: runtime)
+
+    #expect(!FileManager.default.fileExists(atPath: fakeBinary))
+    #expect(!FileManager.default.fileExists(atPath: tmp.path))
+}
+
+// MARK: - Entrypoint exit-code contract (mirrors doctor entrypoint tests)
+
+@Test func testMainEntrypointInstallDryRunJSONExitsZeroWithoutStartingServer() async throws {
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "install", "--dry-run", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle plan")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stderr.isEmpty)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["schema"] as? String == "logic_pro_mcp_lifecycle_plan.v1")
+    #expect(json["command"] as? String == "install")
+}
+
+@Test func testMainEntrypointUninstallDryRunHumanOutputIncludesStableIDs() async {
+    var stdout = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "uninstall", "--dry-run"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle plan")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(
+            presentPaths: [binaryPath()],
+            registration: .registered(command: binaryPath())
+        ),
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stdout.contains("Logic Pro MCP lifecycle plan"))
+    #expect(stdout.contains("binary.remove"))
+    #expect(stdout.contains("mcp.unregister"))
+}
+
+@Test func testMainEntrypointLifecycleWithoutDryRunRefusesAndExitsNonZero() async {
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "install"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a refused lifecycle command")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 1)
+    #expect(stdout.isEmpty)
+    #expect(stderr.contains("--dry-run"))
+    #expect(stderr.contains("Scripts/install.sh"))
+}
+
+@Test func testMainEntrypointUninstallWithoutDryRunPointsAtUninstallScript() async {
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "uninstall"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a refused lifecycle command")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 1)
+    #expect(stderr.contains("Scripts/uninstall.sh"))
+}
+
+@Test func testMainEntrypointUnknownFirstArgStillStartsServer() async {
+    // A non-lifecycle, non-doctor first arg must not be hijacked by the lifecycle
+    // router — the server still starts.
+    let server = LifecycleMockMainServer()
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP"],
+        permissionCheck: {
+            Issue.record("Permission check should not run on the server path")
+            return .init(accessibility: false, automationLogicPro: false)
+        },
+        serverFactory: { server },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStderr: { _ in }
+    )
+    #expect(exitCode == 0)
+}
+
+// MARK: - Docs anchor coverage (mirror doctor anchor doc-lint)
+
+@Test func testSetupDocsContainEveryLifecycleRemediationAnchor() throws {
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let setup = try String(
+        contentsOf: root.appendingPathComponent("docs/SETUP.md"),
+        encoding: .utf8
+    )
+    for anchor in SetupLifecycle.remediationAnchorsByStepID.values.sorted() {
+        let id = anchor.replacingOccurrences(of: "docs/SETUP.md#", with: "")
+        #expect(setup.contains("id=\"\(id)\""), "Missing lifecycle remediation anchor \(anchor)")
+    }
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -420,6 +420,129 @@ Inside Logic Pro, open **Control Surfaces → Setup…**, select the Mackie Cont
 
 ---
 
+## Lifecycle Plans (`install` / `update` / `uninstall` — read-only preview)
+
+Before running an install, update, or uninstall, you can preview exactly which artifacts the operation would touch with a **read-only plan**. Like `doctor`, these commands are strictly non-mutating and run before any server startup:
+
+```bash
+LogicProMCP install --dry-run
+LogicProMCP update --dry-run --json
+LogicProMCP uninstall --dry-run
+```
+
+`--dry-run` is currently **required**. Without it the binary refuses to run the command, prints an honest message, and exits non-zero — live execution is delegated to `Scripts/install.sh` and `Scripts/uninstall.sh`, which carry the pinned-version + provenance checks. The binary never fakes execution.
+
+`--json` emits the stable schema `logic_pro_mcp_lifecycle_plan.v1`. Each plan reports `command`, `execution_mode` (always `dry_run_only`), `installed_version`, `target_version`, `install_dir`, and an ordered list of `steps`. Every step carries a stable `id`, an `action` (`create` / `update` / `delete` / `register` / `unregister` / `skip`), the `target` (path or registration key), the observed `current_state`, the `planned_state`, plus `reversible` and `requires_sudo` flags and a `remediation` whose `type` and anchors match the doctor's vocabulary.
+
+The plan inspects current state through the same primitives the install/uninstall scripts touch: the binary at `INSTALL_DIR/LogicProMCP` (`INSTALL_DIR` defaults to `/usr/local/bin`, overridable via `LOGIC_PRO_MCP_INSTALL_DIR`), the Claude Code MCP registration in `~/.claude.json`, the Key Commands mapping reference, the optional launchd agent, and the operator-approval store. Scripter insertion has no filesystem artifact, so it is always reported as a `manual` Logic-side step. When `INSTALL_DIR` is not writable without elevation, the relevant binary step reports `requires_sudo: true`.
+
+### Lifecycle Remediation Anchors
+
+<a id="lifecycle-binaryinstall"></a>
+#### `binary.install`
+
+Place the `LogicProMCP` binary into `INSTALL_DIR`. Run the installer, which pins the release version and verifies provenance (SHA256 + Team ID / signature) before copying:
+
+```bash
+Scripts/install.sh
+```
+
+<a id="lifecycle-binaryupdate"></a>
+#### `binary.update`
+
+Refresh the installed binary to the version this build targets. Re-run the installer with a pinned version:
+
+```bash
+LOGIC_PRO_MCP_VERSION=v3.6.0 Scripts/install.sh
+```
+
+<a id="lifecycle-binaryremove"></a>
+#### `binary.remove`
+
+Remove the installed binary from `INSTALL_DIR`. The uninstaller handles sudo escalation when the install directory is not writable:
+
+```bash
+Scripts/uninstall.sh
+```
+
+<a id="lifecycle-mcpregister"></a>
+#### `mcp.register`
+
+Register the binary with Claude Code so the MCP server auto-starts when Claude connects:
+
+```bash
+claude mcp add --scope user logic-pro -- /usr/local/bin/LogicProMCP
+```
+
+<a id="lifecycle-mcpunregister"></a>
+#### `mcp.unregister`
+
+Remove the Claude Code MCP registration:
+
+```bash
+claude mcp remove logic-pro
+```
+
+<a id="lifecycle-keycmdsstage"></a>
+#### `keycmds.stage`
+
+Stage the CC→Command mapping reference. Note that on Logic Pro 12.2+ the live bindings still require manual MIDI Learn (see [§4 MIDIKeyCommands](#4-midikeycommands-optional--only-if-you-need-channel-only-ops)):
+
+```bash
+Scripts/install-keycmds.sh
+```
+
+<a id="lifecycle-keycmdsremove"></a>
+#### `keycmds.remove`
+
+Remove the staged mapping reference and restore any pre-install Key Commands backup:
+
+```bash
+Scripts/uninstall-keycmds.sh
+```
+
+<a id="lifecycle-scripterinsert"></a>
+#### `scripter.insert`
+
+Scripter is an optional, manual Logic-side step with no filesystem artifact to plan. Insert the Scripter MIDI FX, load `Scripts/LogicProMCP-Scripter.js`, then approve the channel (see [§6 Install Scripter Insert](#6-install-scripter-insert-optional--legacy-plugin-parameter-path)).
+
+<a id="lifecycle-scripterremove"></a>
+#### `scripter.remove`
+
+Remove the LogicProMCP Scripter MIDI FX from each channel strip manually inside Logic Pro (Channel Strip → MIDI FX → remove LogicProMCP-Scripter).
+
+<a id="lifecycle-launchagentinstall"></a>
+#### `launch_agent.install`
+
+The optional launchd agent runs the server detached from Claude Code so Logic always sees the virtual MIDI ports. Only install it if you need the ports outside Claude Code sessions:
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+cp Scripts/com.logicpro.mcp.plist.template ~/Library/LaunchAgents/com.logicpro.mcp.plist
+launchctl load ~/Library/LaunchAgents/com.logicpro.mcp.plist
+```
+
+<a id="lifecycle-launchagentremove"></a>
+#### `launch_agent.remove`
+
+Unload and remove the optional launchd agent:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.logicpro.mcp.plist
+rm ~/Library/LaunchAgents/com.logicpro.mcp.plist
+```
+
+<a id="lifecycle-approvalsremove"></a>
+#### `approvals.remove`
+
+Remove the operator-approval store. Approvals are re-creatable later with `--approve-channel`:
+
+```bash
+rm "$HOME/Library/Application Support/LogicProMCP/operator-approvals.json"
+```
+
+---
+
 ## What's Next
 
 - [API Reference](API.md) — full MCP tool surface


### PR DESCRIPTION
## Summary
Completes the install/update/uninstall half of the setup lifecycle (doctor shipped in #93).

- `LogicProMCP install|update|uninstall --dry-run [--json]` — read-only PLANNER emitting `logic_pro_mcp_lifecycle_plan.v1` (ordered steps: action/target/current_state/planned_state/reversible/requires_sudo/remediation).
- Registration detected by reading `~/.claude.json` directly (same read-only contract as doctor — never spawns `claude mcp list`).
- Without `--dry-run`, the binary refuses and points to `Scripts/install.sh`/`uninstall.sh` (no faked execution — Honest Contract).
- New: `Sources/LogicProMCP/Utilities/SetupLifecycle.swift` + `SetupLifecycleTests.swift` (19 tests). Full suite green.

## Scope / honesty
- Dry-run is read-only and fully headless-verifiable; the Runtime injection seam has no write hook, so a dry-run is structurally incapable of mutating (asserted by a zero-mutation recorder test).
- Live execution + a `--version` read seam are explicit follow-ups (documented).

Refs #26