### PR TITLE
refactor(ax): centralize remaining locale-sensitive AX matchers into AXLocalePolicy (#60)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -12,6 +12,12 @@ enum AXLocalePolicy {
         case exact
         case prefix
         case contains
+        /// Whole-string equality WITHOUT whitespace trimming, case-insensitive.
+        /// Preserves the raw `desc == label` / `desc.lowercased() == label`
+        /// semantics used by structural control-bar / track-header locators that
+        /// historically compared the AX description verbatim. Distinct from
+        /// `.exact`, which trims surrounding whitespace.
+        case exactStrict
     }
 
     struct LabelSet: Sendable, Equatable {
@@ -38,6 +44,16 @@ enum AXLocalePolicy {
 
         func matches(_ text: String?, mode: MatchMode = .exact) -> Bool {
             guard let text else { return false }
+
+            // `.exactStrict` compares the verbatim string (no trim) so it
+            // preserves the historical `desc == label` semantics exactly. All
+            // other modes trim surrounding whitespace, matching the existing
+            // migrated policy behavior.
+            if mode == .exactStrict {
+                guard !text.isEmpty else { return false }
+                return labels.contains { text.caseInsensitiveCompare($0) == .orderedSame }
+            }
+
             let candidate = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !candidate.isEmpty else { return false }
 
@@ -55,7 +71,20 @@ enum AXLocalePolicy {
                         of: label,
                         options: [.caseInsensitive, .diacriticInsensitive]
                     ) != nil
+                case .exactStrict:
+                    candidate.caseInsensitiveCompare(label) == .orderedSame
                 }
+            }
+        }
+
+        /// True if `haystack` contains ANY label as a case-insensitive substring.
+        /// Preserves the existing `combined.contains(token)` control flow where a
+        /// pre-built, already-lowercased aggregate string is scanned for any of a
+        /// set of localized tokens. The caller keeps its own AX traversal and
+        /// structural ordering; only the token list moves into policy.
+        func containsAny(in haystack: String) -> Bool {
+            labels.contains { label in
+                haystack.range(of: label, options: [.caseInsensitive, .diacriticInsensitive]) != nil
             }
         }
     }
@@ -132,6 +161,134 @@ enum AXLocalePolicy {
         LabelSet(canonical: "Mono->Stereo", variants: ["모노->스테레오"], rationale: "Plugin format leaf after exact plugin selection."),
         LabelSet(canonical: "Dual Mono", variants: ["듀얼 모노"], rationale: "Plugin format leaf after exact plugin selection."),
     ]
+
+    // MARK: - Read-only locator labels (Phase 2, issue #60)
+    //
+    // The label sets below back read-only AX locators / state extractors. None
+    // of them gate a State-A success: they identify which control to read, or
+    // classify a description string. Mutating callers still verify via
+    // independent readback. They are centralized here so the EN/KO token pairs
+    // live in one audited place; each preserves the EXACT match mode and token
+    // order of its original call site.
+
+    // --- Transport control identification (read-only, `.contains` semantics) ---
+
+    static let transportPlayControl = LabelSet(
+        canonical: "play",
+        variants: ["재생"],
+        rationale: "Identifies the Play transport control when reading TransportState; read-only."
+    )
+
+    static let transportRecordControl = LabelSet(
+        canonical: "record",
+        variants: ["녹음"],
+        rationale: "Identifies the Record transport control; excluded by arm-tokens at the call site; read-only."
+    )
+
+    static let transportCycleControl = LabelSet(
+        canonical: "cycle",
+        variants: ["loop", "사이클"],
+        rationale: "Identifies the Cycle/Loop transport control; read-only."
+    )
+
+    static let transportMetronomeControl = LabelSet(
+        canonical: "metronome",
+        variants: ["click", "메트로놈", "클릭"],
+        rationale: "Identifies the Metronome/Click transport control; read-only."
+    )
+
+    /// Record-arm disambiguation tokens. Their PRESENCE on a Record control
+    /// EXCLUDES it from being treated as the transport Record button.
+    static let transportRecordArmExclusion = LabelSet(
+        canonical: "arm",
+        variants: ["활성화"],
+        rationale: "Negative guard: distinguishes per-track record-arm from transport Record; read-only."
+    )
+
+    static let tempoFieldLabel = LabelSet(
+        canonical: "tempo",
+        variants: ["bpm", "템포"],
+        rationale: "Identifies a tempo text field/slider description; read-only."
+    )
+
+    static let playheadPositionFieldLabel = LabelSet(
+        canonical: "position",
+        variants: ["재생헤드 위치"],
+        rationale: "Identifies the playhead position text field description; read-only."
+    )
+
+    // --- Control-bar slider locators (read-only, verbatim `.exactStrict`) ---
+
+    static let controlBarGroupLabel = LabelSet(
+        canonical: "control bar",
+        variants: ["컨트롤 막대"],
+        rationale: "Identifies the control-bar AXGroup by description; read-only locator."
+    )
+
+    static let barSliderLabel = LabelSet(
+        canonical: "bar",
+        variants: ["마디"],
+        rationale: "Identifies the bar slider in the control bar; verbatim description match; read-only."
+    )
+
+    static let beatSliderLabel = LabelSet(
+        canonical: "beat",
+        variants: ["비트"],
+        rationale: "Identifies the beat slider in the control bar; verbatim description match; read-only."
+    )
+
+    /// Tempo slider description for `findTempoSlider` (verbatim `.exactStrict`).
+    /// Includes `bpm` because that locator explicitly accepts `desc == "bpm"`.
+    static let tempoSliderLabel = LabelSet(
+        canonical: "tempo",
+        variants: ["bpm", "템포"],
+        rationale: "Identifies the tempo slider; verbatim (lowercased) description match; read-only."
+    )
+
+    /// Tempo slider description for the read-only `extractTransportState` slider
+    /// loop, which historically matched ONLY `tempo`/`템포` via `.contains`
+    /// (NOT `bpm`). Kept distinct from `tempoSliderLabel` to preserve behavior.
+    static let tempoSliderContainsLabel = LabelSet(
+        canonical: "tempo",
+        variants: ["템포"],
+        rationale: "Identifies the tempo slider in TransportState extraction; substring match without bpm; read-only."
+    )
+
+    // --- Track-header read-only locators ---
+
+    static let trackMuteButton = LabelSet(
+        canonical: "Mute",
+        variants: ["음소거"],
+        rationale: "Identifies the track Mute button by description substring; read-only state extraction."
+    )
+
+    static let trackSoloButton = LabelSet(
+        canonical: "Solo",
+        variants: ["솔로"],
+        rationale: "Identifies the track Solo button by description substring; read-only state extraction."
+    )
+
+    static let trackRecordButton = LabelSet(
+        canonical: "Record",
+        variants: ["Rec", "녹음 활성화", "레코드 활성화"],
+        rationale: "Identifies the track Record/arm button by description substring; read-only state extraction."
+    )
+
+    /// Per-track record-enable AXCheckBox description. Verbatim match preserves
+    /// the original `desc == "녹음 활성화" || ...` locator semantics.
+    static let trackRecordEnableCheckbox = LabelSet(
+        canonical: "녹음 활성화",
+        variants: ["Record Enable", "Record"],
+        rationale: "Locates the per-track record-enable AXCheckBox; verbatim description match; read-only locator."
+    )
+
+    // --- Plugin Setting popup locator (read-only, `.contains`) ---
+
+    static let settingPopupValue = LabelSet(
+        canonical: "Preset",
+        variants: ["프리셋", "Default", "기본"],
+        rationale: "Identifies the plugin Setting AXPopUpButton by its value substring; read-only locator."
+    )
 
     static let showMixerMenuPath = MenuPath(bar: viewMenuBar, item: showMixerMenuItem)
     static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -220,7 +220,7 @@ enum AXLogicProElements {
         let groups = AXHelpers.findAllDescendants(of: window, role: kAXGroupRole, maxDepth: 8, runtime: runtime.ax)
         for group in groups {
             let desc = AXHelpers.getDescription(group, runtime: runtime.ax) ?? ""
-            if desc == "컨트롤 막대" || desc.lowercased() == "control bar" {
+            if AXLocalePolicy.controlBarGroupLabel.matches(desc, mode: .exactStrict) {
                 return group
             }
         }
@@ -264,7 +264,7 @@ enum AXLogicProElements {
         )
         for s in sliders {
             let desc = AXHelpers.getDescription(s, runtime: runtime.ax) ?? ""
-            if desc == "마디" || desc.lowercased() == "bar" {
+            if AXLocalePolicy.barSliderLabel.matches(desc, mode: .exactStrict) {
                 return s
             }
         }
@@ -293,7 +293,7 @@ enum AXLogicProElements {
             )
             for s in sliders {
                 let desc = (AXHelpers.getDescription(s, runtime: runtime.ax) ?? "").lowercased()
-                if desc == "템포" || desc == "tempo" || desc == "bpm" {
+                if AXLocalePolicy.tempoSliderLabel.matches(desc, mode: .exactStrict) {
                     return s
                 }
             }
@@ -309,7 +309,7 @@ enum AXLogicProElements {
         )
         for s in sliders {
             let desc = AXHelpers.getDescription(s, runtime: runtime.ax) ?? ""
-            if desc == "비트" || desc.lowercased() == "beat" {
+            if AXLocalePolicy.beatSliderLabel.matches(desc, mode: .exactStrict) {
                 return s
             }
         }
@@ -1221,9 +1221,12 @@ enum AXLogicProElements {
         let checkboxes = AXHelpers.findAllDescendants(
             of: header, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime.ax
         )
+        // Verbatim (case-sensitive) equality preserves the historical locator
+        // exactly; only the EN/KO label tokens move into AXLocalePolicy.
+        let armLabels = AXLocalePolicy.trackRecordEnableCheckbox.labels
         for cb in checkboxes {
             let desc = AXHelpers.getDescription(cb, runtime: runtime.ax) ?? ""
-            if desc == "녹음 활성화" || desc == "Record Enable" || desc == "Record" {
+            if armLabels.contains(desc) {
                 return cb
             }
         }

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -320,13 +320,14 @@ enum AXValueExtractors {
             let pressed = extractButtonState(control, runtime: runtime) ?? false
             let descLower = desc.lowercased()
 
-            if descLower.contains("play") || descLower.contains("재생") {
+            if AXLocalePolicy.transportPlayControl.containsAny(in: descLower) {
                 state.isPlaying = pressed
-            } else if (descLower.contains("record") || descLower.contains("녹음")) && !descLower.contains("arm") && !descLower.contains("활성화") {
+            } else if AXLocalePolicy.transportRecordControl.containsAny(in: descLower)
+                && !AXLocalePolicy.transportRecordArmExclusion.containsAny(in: descLower) {
                 state.isRecording = pressed
-            } else if descLower.contains("cycle") || descLower.contains("loop") || descLower.contains("사이클") {
+            } else if AXLocalePolicy.transportCycleControl.containsAny(in: descLower) {
                 state.isCycleEnabled = pressed
-            } else if descLower.contains("metronome") || descLower.contains("click") || descLower.contains("메트로놈") || descLower.contains("클릭") {
+            } else if AXLocalePolicy.transportMetronomeControl.containsAny(in: descLower) {
                 state.isMetronomeEnabled = pressed
             }
         }
@@ -339,11 +340,11 @@ enum AXValueExtractors {
             let desc = AXHelpers.getDescription(text, runtime: runtime) ?? ""
             let descLower = desc.lowercased()
 
-            if descLower.contains("tempo") || descLower.contains("bpm") || descLower.contains("템포") {
+            if AXLocalePolicy.tempoFieldLabel.containsAny(in: descLower) {
                 if let tempo = Double(value.replacingOccurrences(of: " BPM", with: "")) {
                     state.tempo = tempo
                 }
-            } else if descLower.contains("position") || descLower.contains("재생헤드 위치") || value.contains(".") && value.contains(":") == false {
+            } else if AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: descLower) || value.contains(".") && value.contains(":") == false {
                 // Bar.Beat.Division.Tick format
                 if value.filter({ $0 == "." }).count >= 2 {
                     state.position = value
@@ -359,11 +360,11 @@ enum AXValueExtractors {
         var beatValue: Int?
         for slider in sliders {
             let desc = (AXHelpers.getDescription(slider, runtime: runtime) ?? "").lowercased()
-            if (desc.contains("tempo") || desc.contains("템포")), let tempo = extractSliderValue(slider, runtime: runtime) {
+            if AXLocalePolicy.tempoSliderContainsLabel.containsAny(in: desc), let tempo = extractSliderValue(slider, runtime: runtime) {
                 state.tempo = tempo
-            } else if desc.contains("마디") || desc.contains("bar") {
+            } else if AXLocalePolicy.barSliderLabel.containsAny(in: desc) {
                 barValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)
-            } else if desc.contains("비트") || desc.contains("beat") {
+            } else if AXLocalePolicy.beatSliderLabel.containsAny(in: desc) {
                 beatValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)
             }
         }
@@ -424,12 +425,12 @@ enum AXValueExtractors {
         prefix: String,
         runtime: AXHelpers.Runtime
     ) -> Bool? {
-        let localizedKeywords: [String: [String]] = [
-            "Mute": ["Mute", "음소거"],
-            "Solo": ["Solo", "솔로"],
-            "Record": ["Record", "Rec", "녹음 활성화", "레코드 활성화"]
+        let localizedKeywords: [String: AXLocalePolicy.LabelSet] = [
+            "Mute": AXLocalePolicy.trackMuteButton,
+            "Solo": AXLocalePolicy.trackSoloButton,
+            "Record": AXLocalePolicy.trackRecordButton
         ]
-        let keywords = localizedKeywords[prefix] ?? [prefix]
+        let labels = localizedKeywords[prefix]
         let controls = AXHelpers.findAllDescendants(of: header, role: kAXButtonRole, maxDepth: 4, runtime: runtime)
             + AXHelpers.findAllDescendants(of: header, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime)
         for control in controls {
@@ -438,7 +439,8 @@ enum AXValueExtractors {
                     ?? AXHelpers.getTitle(control, runtime: runtime)
                     ?? ""
             ).lowercased()
-            if keywords.contains(where: { desc.contains($0.lowercased()) }) {
+            let matched = labels?.containsAny(in: desc) ?? desc.contains(prefix.lowercased())
+            if matched {
                 return extractButtonState(control, runtime: runtime)
             }
         }

--- a/Sources/LogicProMCP/Accessibility/PluginInspector.swift
+++ b/Sources/LogicProMCP/Accessibility/PluginInspector.swift
@@ -520,7 +520,9 @@ public enum PluginInspector {
             var valRaw: AnyObject?
             AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valRaw)
             let v = (valRaw as? String) ?? ""
-            if v.contains("Preset") || v.contains("프리셋") || v.contains("Default") || v.contains("기본") {
+            // Verbatim (case-sensitive) substring match preserves the historical
+            // locator; only the EN/KO Setting-dropdown tokens move into policy.
+            if AXLocalePolicy.settingPopupValue.labels.contains(where: { v.contains($0) }) {
                 return element
             }
         }

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -429,6 +429,161 @@ struct AXLocalePolicyTests {
         )
         #expect(shallow == nil)
     }
+
+    // MARK: - Phase 2 (#60) read-only locator label sets
+
+    /// `.exactStrict` mode preserves verbatim (no-trim) equality used by the
+    /// control-bar / track-header structural locators. A title with surrounding
+    /// whitespace must NOT match under `.exactStrict` (whereas `.exact` would).
+    @Test("exactStrict matches verbatim and does not trim whitespace")
+    func exactStrictNoTrim() {
+        #expect(AXLocalePolicy.barSliderLabel.matches("bar", mode: .exactStrict))
+        #expect(AXLocalePolicy.barSliderLabel.matches("마디", mode: .exactStrict))
+        // Case-insensitive (the EN locator lowercased before comparing).
+        #expect(AXLocalePolicy.barSliderLabel.matches("BAR", mode: .exactStrict))
+        // No trimming: padded titles are rejected, preserving raw `==` behavior.
+        #expect(!AXLocalePolicy.barSliderLabel.matches(" bar ", mode: .exactStrict))
+        #expect(!AXLocalePolicy.barSliderLabel.matches("마디 ", mode: .exactStrict))
+        // Empty / nil fail closed.
+        #expect(!AXLocalePolicy.barSliderLabel.matches("", mode: .exactStrict))
+        #expect(!AXLocalePolicy.barSliderLabel.matches(nil, mode: .exactStrict))
+        // Unrelated token rejected.
+        #expect(!AXLocalePolicy.barSliderLabel.matches("beat", mode: .exactStrict))
+    }
+
+    /// Transport control identification label sets (read-only) resolve EN+KO and
+    /// reject unrelated descriptions. `containsAny` mirrors the original
+    /// lowercased-substring control flow.
+    @Test("transport control labels resolve English and Korean via containsAny")
+    func transportControlLabels() {
+        #expect(AXLocalePolicy.transportPlayControl.containsAny(in: "play"))
+        #expect(AXLocalePolicy.transportPlayControl.containsAny(in: "재생"))
+        #expect(!AXLocalePolicy.transportPlayControl.containsAny(in: "record"))
+
+        #expect(AXLocalePolicy.transportRecordControl.containsAny(in: "record"))
+        #expect(AXLocalePolicy.transportRecordControl.containsAny(in: "녹음"))
+        #expect(!AXLocalePolicy.transportRecordControl.containsAny(in: "play"))
+
+        #expect(AXLocalePolicy.transportCycleControl.containsAny(in: "cycle"))
+        #expect(AXLocalePolicy.transportCycleControl.containsAny(in: "loop"))
+        #expect(AXLocalePolicy.transportCycleControl.containsAny(in: "사이클"))
+        #expect(!AXLocalePolicy.transportCycleControl.containsAny(in: "metronome"))
+
+        #expect(AXLocalePolicy.transportMetronomeControl.containsAny(in: "metronome"))
+        #expect(AXLocalePolicy.transportMetronomeControl.containsAny(in: "click"))
+        #expect(AXLocalePolicy.transportMetronomeControl.containsAny(in: "메트로놈"))
+        #expect(AXLocalePolicy.transportMetronomeControl.containsAny(in: "클릭"))
+        #expect(!AXLocalePolicy.transportMetronomeControl.containsAny(in: "cycle"))
+    }
+
+    /// The record-arm exclusion tokens distinguish a per-track record-arm control
+    /// from the transport Record button. Their presence must be detectable in
+    /// both EN and KO so the negative guard fires.
+    @Test("record-arm exclusion tokens resolve English and Korean")
+    func recordArmExclusionLabels() {
+        #expect(AXLocalePolicy.transportRecordArmExclusion.containsAny(in: "record arm"))
+        #expect(AXLocalePolicy.transportRecordArmExclusion.containsAny(in: "녹음 활성화"))
+        // A plain transport Record description does not trip the exclusion.
+        #expect(!AXLocalePolicy.transportRecordArmExclusion.containsAny(in: "record"))
+        #expect(!AXLocalePolicy.transportRecordArmExclusion.containsAny(in: "녹음"))
+    }
+
+    /// Tempo/position field labels (read-only text fields). The tempo FIELD set
+    /// includes `bpm`; pin EN+KO resolution and a clean rejection.
+    @Test("tempo and position field labels resolve English and Korean")
+    func tempoAndPositionFieldLabels() {
+        #expect(AXLocalePolicy.tempoFieldLabel.containsAny(in: "tempo"))
+        #expect(AXLocalePolicy.tempoFieldLabel.containsAny(in: "bpm"))
+        #expect(AXLocalePolicy.tempoFieldLabel.containsAny(in: "템포"))
+        #expect(!AXLocalePolicy.tempoFieldLabel.containsAny(in: "position"))
+
+        #expect(AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: "position"))
+        #expect(AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: "재생헤드 위치"))
+        #expect(!AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: "tempo"))
+    }
+
+    /// The transport-extraction tempo SLIDER set must NOT include `bpm` (the
+    /// historical `.contains` loop matched only tempo/템포). This pins the
+    /// deliberate distinction from `tempoSliderLabel` (the exact slider locator,
+    /// which DOES accept bpm). Mixing them up would widen the extraction loop.
+    @Test("tempo slider contains-label excludes bpm but exact slider label keeps it")
+    func tempoSliderLabelSplit() {
+        // Read-only extraction loop: tempo/템포 only.
+        #expect(AXLocalePolicy.tempoSliderContainsLabel.containsAny(in: "tempo"))
+        #expect(AXLocalePolicy.tempoSliderContainsLabel.containsAny(in: "템포"))
+        #expect(!AXLocalePolicy.tempoSliderContainsLabel.containsAny(in: "bpm"))
+
+        // Exact locator (findTempoSlider): tempo/템포/bpm all match verbatim.
+        #expect(AXLocalePolicy.tempoSliderLabel.matches("tempo", mode: .exactStrict))
+        #expect(AXLocalePolicy.tempoSliderLabel.matches("템포", mode: .exactStrict))
+        #expect(AXLocalePolicy.tempoSliderLabel.matches("bpm", mode: .exactStrict))
+        #expect(!AXLocalePolicy.tempoSliderLabel.matches("position", mode: .exactStrict))
+    }
+
+    /// Control-bar / bar / beat slider locators resolve EN+KO verbatim and
+    /// reject unrelated descriptions.
+    @Test("control-bar and bar/beat slider labels resolve English and Korean")
+    func controlBarAndSliderLabels() {
+        #expect(AXLocalePolicy.controlBarGroupLabel.matches("control bar", mode: .exactStrict))
+        #expect(AXLocalePolicy.controlBarGroupLabel.matches("컨트롤 막대", mode: .exactStrict))
+        #expect(!AXLocalePolicy.controlBarGroupLabel.matches("transport", mode: .exactStrict))
+
+        #expect(AXLocalePolicy.barSliderLabel.matches("bar", mode: .exactStrict))
+        #expect(AXLocalePolicy.barSliderLabel.matches("마디", mode: .exactStrict))
+
+        #expect(AXLocalePolicy.beatSliderLabel.matches("beat", mode: .exactStrict))
+        #expect(AXLocalePolicy.beatSliderLabel.matches("비트", mode: .exactStrict))
+        #expect(!AXLocalePolicy.beatSliderLabel.matches("bar", mode: .exactStrict))
+    }
+
+    /// Track-header Mute/Solo/Record button labels (read-only state extraction)
+    /// resolve EN+KO via substring and reject the wrong control.
+    @Test("track mute/solo/record button labels resolve English and Korean")
+    func trackButtonLabels() {
+        #expect(AXLocalePolicy.trackMuteButton.containsAny(in: "mute channel strip"))
+        #expect(AXLocalePolicy.trackMuteButton.containsAny(in: "음소거"))
+        #expect(!AXLocalePolicy.trackMuteButton.containsAny(in: "solo"))
+
+        #expect(AXLocalePolicy.trackSoloButton.containsAny(in: "solo"))
+        #expect(AXLocalePolicy.trackSoloButton.containsAny(in: "솔로"))
+        #expect(!AXLocalePolicy.trackSoloButton.containsAny(in: "mute"))
+
+        #expect(AXLocalePolicy.trackRecordButton.containsAny(in: "record"))
+        #expect(AXLocalePolicy.trackRecordButton.containsAny(in: "rec"))
+        #expect(AXLocalePolicy.trackRecordButton.containsAny(in: "녹음 활성화"))
+        #expect(AXLocalePolicy.trackRecordButton.containsAny(in: "레코드 활성화"))
+        #expect(!AXLocalePolicy.trackRecordButton.containsAny(in: "mute"))
+    }
+
+    /// The per-track record-enable AXCheckBox label set is matched VERBATIM
+    /// (case-sensitive) at the call site via `labels.contains(desc)`. Pin the
+    /// exact label tokens and ordering so the locator can never silently drift.
+    @Test("record-enable checkbox labels are verbatim and ordered")
+    func recordEnableCheckboxLabels() {
+        let labels = AXLocalePolicy.trackRecordEnableCheckbox.labels
+        #expect(labels == ["녹음 활성화", "Record Enable", "Record"])
+        // Verbatim contains (the production call site uses `labels.contains(desc)`).
+        #expect(labels.contains("녹음 활성화"))
+        #expect(labels.contains("Record Enable"))
+        #expect(labels.contains("Record"))
+        // Case-sensitive: a lowercased English variant is NOT in the set.
+        #expect(!labels.contains("record"))
+        #expect(!labels.contains("record enable"))
+    }
+
+    /// The plugin Setting popup value label set is matched VERBATIM
+    /// (case-sensitive substring) at the call site. Pin EN+KO tokens and order.
+    @Test("setting popup value labels are verbatim and ordered")
+    func settingPopupValueLabels() {
+        let labels = AXLocalePolicy.settingPopupValue.labels
+        #expect(labels == ["Preset", "프리셋", "Default", "기본"])
+        #expect(labels.contains(where: { "#0 Preset 1".contains($0) }))
+        #expect(labels.contains(where: { "프리셋 없음".contains($0) }))
+        #expect(labels.contains(where: { "Default Setting".contains($0) }))
+        #expect(labels.contains(where: { "기본 설정".contains($0) }))
+        // Case-sensitive substring: lowercased English must not match.
+        #expect(!labels.contains(where: { "preset".contains($0) }))
+    }
 }
 
 /// Replicates the first-match priority loop from

--- a/docs/locale-agnostic-ax-policy.md
+++ b/docs/locale-agnostic-ax-policy.md
@@ -15,6 +15,8 @@ Logic Pro MCP must not treat localized UI text as proof that a UI mutation succe
 
 `AXLocalePolicy` currently owns English/Korean labels for:
 
+Menu / dialog / confirmation surfaces (PR #98):
+
 - View > Show Mixer
 - Window > Hide All Plug-in Windows
 - Edit > Undo prefix
@@ -23,7 +25,21 @@ Logic Pro MCP must not treat localized UI text as proof that a UI mutation succe
 - Save/OK confirmation buttons
 - Plugin format leaves: Stereo, Mono, Mono->Stereo, Dual Mono
 
-These labels are allowed because each use is either best-effort cleanup/reveal or followed by independent file, project, track, plugin, or inventory readback.
+Read-only locator / state-extraction surfaces (issue #60 Phase 2):
+
+- Transport control identification (read-only `TransportState` extraction): Play, Record (with a separate record-arm exclusion guard), Cycle/Loop, Metronome/Click.
+- Transport text-field labels: Tempo (incl. `bpm`), playhead Position.
+- Control-bar AXGroup description: Control Bar / 컨트롤 막대.
+- Control-bar slider descriptions: bar (마디), beat (비트), tempo (템포/bpm for the exact `findTempoSlider` locator; tempo/템포 only for the read-only extraction loop — two deliberately distinct label sets).
+- Track-header read-only state extraction buttons: Mute (음소거), Solo (솔로), Record (Rec / 녹음 활성화 / 레코드 활성화).
+- Per-track record-enable AXCheckBox description: 녹음 활성화 / Record Enable / Record (matched verbatim/case-sensitive at the call site).
+- Plugin Setting AXPopUpButton value tokens: Preset / 프리셋 / Default / 기본 (matched verbatim/case-sensitive substring at the call site).
+
+These labels are allowed because each use is either best-effort cleanup/reveal, a read-only locator/state read, or followed by independent file, project, track, plugin, or inventory readback. The issue #60 additions are all read-only identification helpers and introduce no new State-A success path: they preserve the EXACT label tokens, token order, and match semantics (`.contains` vs verbatim equality vs whitespace-free `.exactStrict`) of the call sites they replaced.
+
+### Match-mode note
+
+`AXLocalePolicy.MatchMode.exactStrict` was added in Phase 2 to model the structural control-bar / track-header locators that historically compared the AX description verbatim (`desc == "마디"`), i.e. without the whitespace trimming that `.exact` applies. Centralizing those onto `.exact` would have widened behavior, so `.exactStrict` preserves it exactly. Two call sites (the record-enable checkbox and the plugin Setting popup) require case-sensitive matching and therefore iterate over `LabelSet.labels` with verbatim `==` / `contains` rather than a policy match mode.
 
 ## Adding New Labels
 
@@ -35,4 +51,41 @@ These labels are allowed because each use is either best-effort cleanup/reveal o
 
 ## Known Remaining Surfaces
 
-Some AppleScript fallback snippets still contain explicit menu labels because System Events menu addressing is text-based. Those fallbacks must remain guarded by post-action readback and should be migrated to policy-owned helpers when the AX path can replace the script path.
+The locale-agnostic epic (#60) is **not closed**. The following localized text
+surfaces are still pending and require live EN+KO E2E against real Logic Pro to
+confirm State A on their respective paths:
+
+1. **AppleScript / System Events menu literals** — `AccessibilityChannel`
+   contains many menu-addressing strings (e.g. `트랙 → 트랙 삭제`,
+   `다른 이름으로 저장…`, `탐색 → 이동 → 위치…`, `파일 → 가져오기 → MIDI 파일…`,
+   `편집 → 이동 → 재생헤드로`, `로케이터 설정…`, the track-creation menu map, the
+   plugin-insert menu chains, and rename-track menu names). These are embedded in
+   `osascript` source and addressed by System Events text, so they cannot move to
+   a Swift `LabelSet` without rewriting the menu-click mechanism — a behavior
+   change, deferred. They must remain guarded by post-action readback.
+2. **`looksLikeTransportContainer` keyword aggregate** (`AXLogicProElements`) —
+   a transport-detection heuristic scanning a multi-token keyword list. It is a
+   classifier, not a State-A gate; centralizing its overlapping token bag without
+   widening needs a dedicated audit and is deferred.
+3. **Mixer / inspector / channel-strip metadata keyword scans**
+   (`AXLogicProElements`: send/입력/출력/그룹/채널 모드/볼륨/패닝/바이패스/오토메이션
+   etc.) — large heuristic token bags used for classification and disambiguation.
+   These are read-only but interdependent; a careful, separately-tested pass is
+   required to avoid changing which strips/controls are recognized.
+4. **Marker-list / cell placeholder keywords** (`AXLogicProElements`:
+   `마커`/`marker`, `셀`/`Cell`, marker-list window-title suffixes) — read-only
+   scraping fallbacks for old Logic versions; pending.
+5. **Region / track-content / track-type description keywords**
+   (`AccessibilityChannel`: `리전`/region, `트랙 콘텐츠`/Track Content,
+   드러머/세션 플레이어/오디오 etc.) — read-only classification, pending.
+
+**Live verification still required** for the surfaces centralized in this pass:
+each read-only locator/extractor was verified headless with injected fake
+runtimes, but the actual EN vs KO AX descriptions Logic emits at runtime (control
+bar group/sliders, transport controls, track Mute/Solo/Record buttons, the
+record-enable checkbox, and the plugin Setting popup value) must be confirmed
+against a live Logic Pro in both locales to prove the token sets still match the
+real UI.
+
+When the AX path can replace a script path, the corresponding AppleScript literal
+should be migrated to a policy-owned helper.


### PR DESCRIPTION
## Summary
Advances the locale-agnostic epic (#60; #98 centralized the first slice). Centralizes 17 more read-only AX locator/extractor label sets (transport play/record/cycle/metronome, tempo/playhead fields, control-bar group, bar/beat/tempo sliders, track mute/solo/record, setting popups) into `AXLocalePolicy` as compatibility-hint LabelSets.

- Behavior-preserving: same labels, order, and match mode — no widening/narrowing; structural AX + readback stay preferred; no State-A path created from labels.
- New deterministic EN+KO tests for every centralized matcher (13 new; AXLocalePolicy 24 total).
- Regression-critical suites green: AccessibilityChannel 70, PluginInsertVerified 32, PluginGetInventory 12. Full suite green.

## Remaining (epic stays open)
- AppleScript/System-Events menu literals (would require rewriting the menu-click mechanism = behavior change) and several read-only heuristic token bags — documented in `docs/locale-agnostic-ax-policy.md`.
- Live EN+KO E2E remains the epic close gate.

Refs #60