### PR TITLE
feat(project): guarded execution of cleanup-plan steps — cleanup_apply (#28)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -11,7 +11,7 @@ struct ProjectDispatcher {
 
     static let tool = commandTool(
         name: "logic_project",
-        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, audit, cleanup_plan. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; others -> {}.",
+        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, audit, cleanup_plan, cleanup_apply. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; cleanup_apply -> { step_id: String, confirmed: Bool, names?: \"newA,newB\" (CSV aligned to the step's target track indices) | new_name?: String (single target) } executes ONE supported mutating cleanup-plan step (currently rename_* only) through the existing track.rename path so it inherits AX readback + Honest Contract State A/B/C. Fails closed (State C) when confirmed!=true, the step is unknown/unsupported/non-mutating, the audit shows stale/occluded inventory or a track readback gap, or rename names are missing/mismatched. Deletion steps are unsupported by construction and are always refused; others -> {}.",
         commandDescription: "Project command to execute"
     )
 
@@ -223,6 +223,9 @@ struct ProjectDispatcher {
                 )
             }
 
+        case "cleanup_apply":
+            return await handleCleanupApply(params: params, router: router, cache: cache)
+
         case "launch":
             if isLogicProRunning() {
                 audit(command, phase: .rejected, reason: "already running")
@@ -263,10 +266,340 @@ struct ProjectDispatcher {
 
         default:
             return toolTextResult(
-                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan, audit, cleanup_plan",
+                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan, audit, cleanup_plan, cleanup_apply",
                 isError: true
             )
         }
+    }
+
+    // MARK: - cleanup_apply (#28) — guarded execution of a cleanup-plan step
+
+    /// Guarded execution of exactly ONE cleanup-plan step (#28). The read-only
+    /// `audit` + `cleanup_plan` surfaces (shipped in #95) propose steps but never
+    /// mutate; this command turns a single supported, mutating step into a real
+    /// Logic mutation while inheriting every Honest Contract guarantee of the
+    /// underlying tool path.
+    ///
+    /// Contract:
+    ///   1. Re-derive the audit + cleanup plan deterministically from the cache
+    ///      (the caller cannot smuggle a stale plan — the step is matched against
+    ///      a freshly-built plan).
+    ///   2. Find the step by `step_id`.
+    ///   3. Fail CLOSED (State C, isError) when any of:
+    ///        - `confirmed` is not literally `true`
+    ///        - the step id is unknown
+    ///        - `supported_by_current_tools == false`
+    ///        - `mutates_project == false` (nothing to execute)
+    ///        - the audit shows stale/occluded inventory or a track readback gap
+    ///   4. For a supported mutating step, dispatch through the EXISTING tool
+    ///      path (currently only `track.rename`) so it inherits AX readback +
+    ///      HC State A/B/C. The dispatcher does NOT re-implement the readback.
+    ///   5. NEVER delete. Deletion steps are `supported_by_current_tools:false`
+    ///      by construction (see `ProjectSessionAudit.cleanupPlanSteps`), so the
+    ///      unsupported gate already refuses them; a redundant explicit refusal
+    ///      guards against any future plan that mislabels a delete as supported.
+    static func handleCleanupApply(
+        command: String = "cleanup_apply",
+        params: [String: Value],
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        let stepID = stringParam(params, "step_id", "stepId")
+        guard !stepID.isEmpty else {
+            audit(command, phase: .rejected, reason: "missing step_id")
+            return MIDIDispatcher.invalidParamsResult(
+                hint: "cleanup_apply requires 'step_id' (an id from logic_project cleanup_plan)"
+            )
+        }
+
+        // Gate 1 — explicit confirmation. A missing or non-literal-boolean
+        // `confirmed` must NOT be coerced; this is a mutating op, so an
+        // ambiguous confirmation fails closed rather than executing.
+        switch strictBoolParam(params, "confirmed") {
+        case .invalid(let hint):
+            audit(command, phase: .rejected, reason: "invalid confirmed")
+            return MIDIDispatcher.invalidParamsResult(hint: "cleanup_apply \(hint)")
+        case .missing:
+            audit(command, phase: .confirmationRequired, reason: stepID)
+            return cleanupApplyStateC(
+                .invalidParams,
+                stepID: stepID,
+                hint: "cleanup_apply requires 'confirmed:true' to execute a mutating cleanup step; re-run logic_project cleanup_plan, confirm the step, then retry with confirmed:true."
+            )
+        case .value(let confirmed):
+            guard confirmed else {
+                audit(command, phase: .confirmationRequired, reason: stepID)
+                return cleanupApplyStateC(
+                    .invalidParams,
+                    stepID: stepID,
+                    hint: "cleanup_apply 'confirmed' was false; the step was not executed. Retry with confirmed:true once the caller has approved it."
+                )
+            }
+        }
+
+        // Gate 2 — re-derive the plan deterministically and locate the step.
+        // The caller cannot pass a step body in; only its id. This guarantees
+        // execution is gated on the CURRENT audit, not a snapshot the caller
+        // may have cached before the project changed underneath them.
+        let auditReport = await ProjectSessionAudit.buildAudit(cache: cache)
+        guard let step = auditReport.cleanupPlan.first(where: { $0.id == stepID }) else {
+            audit(command, phase: .rejected, reason: "unknown step")
+            return cleanupApplyStateC(
+                .elementNotFound,
+                stepID: stepID,
+                hint: "cleanup_apply: no cleanup-plan step with id '\(stepID)' in the current audit. The plan is re-derived on every call; re-run logic_project cleanup_plan and use a current step id."
+            )
+        }
+
+        // Gate 3 — the audit itself must be safe to act on. Stale, occluded, or
+        // gap-bearing inventory means the plan's targets may not correspond to
+        // the live session, so any rename could hit the wrong track.
+        if let blockingHint = cleanupApplyInventoryBlocker(auditReport) {
+            audit(command, phase: .rejected, reason: "stale inventory")
+            return cleanupApplyStateC(
+                .staleSnapshot,
+                stepID: stepID,
+                hint: blockingHint
+            )
+        }
+
+        // Gate 4 — non-mutating / unsupported steps are refused. A
+        // non-mutating step has nothing to execute; an unsupported step
+        // (e.g. delete, marker planning gaps) is not safely executable via
+        // the current tool surface.
+        guard step.mutatesProject else {
+            audit(command, phase: .rejected, reason: "non-mutating step")
+            return cleanupApplyStateC(
+                .invalidParams,
+                stepID: stepID,
+                hint: "cleanup_apply: step '\(stepID)' does not mutate the project (\(step.proposedOperation)); there is nothing to execute."
+            )
+        }
+        guard step.supportedByCurrentTools else {
+            audit(command, phase: .rejected, reason: "unsupported step")
+            return cleanupApplyStateC(
+                .notImplemented,
+                stepID: stepID,
+                hint: "cleanup_apply: step '\(stepID)' is not supported by the current tool surface (supported_by_current_tools=false). Resolve its stop condition (\(step.stopCondition)) and re-derive the plan."
+            )
+        }
+
+        // Gate 5 — deletion is NEVER executed. By construction no plan step
+        // proposes a supported delete, but this explicit refusal makes the
+        // invariant impossible to regress: even a future mislabelled delete
+        // step fails closed here.
+        if cleanupApplyIsDeletion(step) {
+            audit(command, phase: .rejected, reason: "deletion refused")
+            return cleanupApplyStateC(
+                .notImplemented,
+                stepID: stepID,
+                hint: "cleanup_apply refuses deletion: step '\(stepID)' (tool=\(step.tool ?? "nil") command=\(step.command ?? "nil")) is a destructive delete and is never executed by cleanup_apply."
+            )
+        }
+
+        // Dispatch — currently only the rename family is executable. Every
+        // supported mutating step in the plan is `tool:"logic_tracks"`; the
+        // rename command renames duplicate/unnamed tracks. solo/arm toggle
+        // steps are deferred (see deferred[] / docs): they need an explicit
+        // per-track enabled vector that the read-only plan does not yet carry.
+        switch (step.tool, step.command) {
+        case ("logic_tracks", "rename"):
+            return await applyRenameStep(
+                step,
+                params: params,
+                router: router,
+                cache: cache
+            )
+        default:
+            audit(command, phase: .rejected, reason: "no executable path")
+            return cleanupApplyStateC(
+                .notImplemented,
+                stepID: stepID,
+                hint: "cleanup_apply: step '\(stepID)' (tool=\(step.tool ?? "nil") command=\(step.command ?? "nil")) has no executable cleanup path yet. Currently only rename_* steps are executable; perform other steps through their named tool directly."
+            )
+        }
+    }
+
+    /// Execute a rename cleanup step through the existing `track.rename` path so
+    /// it inherits AX readback + HC State A/B/C. The step's `targetIdentifier`
+    /// is `tracks:<i0,i1,...>`; the caller supplies one new name per target via
+    /// `names` (CSV) or, for a single target, `new_name`. Mismatched counts fail
+    /// closed before any write so a partial rename can't corrupt the session.
+    private static func applyRenameStep(
+        _ step: ProjectSessionAudit.CleanupPlanStep,
+        params: [String: Value],
+        router: ChannelRouter,
+        cache: StateCache
+    ) async -> CallTool.Result {
+        let targets = cleanupApplyTargetIndices(step.targetIdentifier)
+        guard !targets.isEmpty else {
+            return cleanupApplyStateC(
+                .invalidParams,
+                stepID: step.id,
+                hint: "cleanup_apply: rename step '\(step.id)' has no parseable target track indices in '\(step.targetIdentifier)'."
+            )
+        }
+
+        let names = cleanupApplyRenameNames(params, targetCount: targets.count)
+        guard names.count == targets.count else {
+            return cleanupApplyStateC(
+                .invalidParams,
+                stepID: step.id,
+                hint: "cleanup_apply: rename step '\(step.id)' targets \(targets.count) track(s) \(targets); supply exactly that many names via 'names' (CSV) — or 'new_name' for a single target. Got \(names.count)."
+            )
+        }
+        // Reject blank names up-front: track.rename refuses an empty name, but
+        // catching it here keeps a multi-target rename all-or-nothing instead of
+        // failing partway after some tracks were already renamed.
+        if let blankIdx = names.firstIndex(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+            return cleanupApplyStateC(
+                .invalidParams,
+                stepID: step.id,
+                hint: "cleanup_apply: rename name #\(blankIdx + 1) for step '\(step.id)' is blank; every target needs a non-empty name."
+            )
+        }
+
+        var renamed: [[String: Any]] = []
+        for (target, newName) in zip(targets, names) {
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: ["index": .int(target), "name": .string(newName)],
+                router: router,
+                cache: cache
+            )
+            let body = cleanupApplyResultText(result)
+            renamed.append([
+                "track_index": target,
+                "new_name": newName,
+                "result": body,
+            ])
+            // TrackDispatcher.rename already maps State B/C to isError. If any
+            // target failed (or came back unverified), stop and surface the
+            // underlying HC envelope as State C — do NOT report State A for a
+            // batch where a later track could not be confirmed.
+            if result.isError == true {
+                return cleanupApplyStateC(
+                    .readbackMismatch,
+                    stepID: step.id,
+                    hint: "cleanup_apply: rename step '\(step.id)' stopped at track \(target) — the track.rename path did not confirm a verified rename (State B/C). Re-read logic://tracks and retry.",
+                    extras: [
+                        "tool": "logic_tracks",
+                        "command": "rename",
+                        "failed_track_index": target,
+                        "applied": renamed,
+                        "underlying": body,
+                    ]
+                )
+            }
+        }
+
+        // Every target reached verified State A from the underlying rename path.
+        return toolTextResult(
+            HonestContract.encodeStateA(extras: [
+                "op": "project.cleanup_apply",
+                "step_id": step.id,
+                "tool": "logic_tracks",
+                "command": "rename",
+                "target_track_indices": targets,
+                "applied": renamed,
+                "verify_source": "track.rename ax_readback",
+            ])
+        )
+    }
+
+    // MARK: - cleanup_apply helpers
+
+    /// Returns a blocking hint when the audit's inventory is unsafe to act on
+    /// (no document, AX occluded, stale track inventory, or a file-vs-AX track
+    /// readback gap), else nil. Keeps the stale/occluded/gap gate in one place.
+    private static func cleanupApplyInventoryBlocker(_ report: ProjectSessionAudit.AuditReport) -> String? {
+        if !report.evidence.hasDocument {
+            return "cleanup_apply: no open Logic document is confirmed; refusing to mutate."
+        }
+        if report.evidence.axOccluded {
+            return "cleanup_apply: Accessibility readback is occluded (modal/floating window); the plan's targets cannot be trusted. Dismiss the dialog, re-run the audit, and retry."
+        }
+        let tracksFreshness = report.evidence.tracks.freshness
+        if !tracksFreshness.available || tracksFreshness.stale {
+            return "cleanup_apply: track inventory is unread or stale (available=\(tracksFreshness.available), stale=\(tracksFreshness.stale)); re-read logic://tracks before applying a step."
+        }
+        if report.findings.contains(where: { $0.id == "track_readback_gap" }) {
+            return "cleanup_apply: the project file reports more tracks than Accessibility surfaced (track_readback_gap); plan target indices may not match the live arrange. Bring the arrange window forward, re-run the audit, and retry."
+        }
+        return nil
+    }
+
+    /// True when the step is a destructive delete, regardless of how it is
+    /// labelled. Belt-and-braces against a future plan that mislabels a delete.
+    /// Internal (not private) so the deletion-refusal invariant can be asserted
+    /// directly in tests against a synthetic mislabelled delete step.
+    static func cleanupApplyIsDeletion(_ step: ProjectSessionAudit.CleanupPlanStep) -> Bool {
+        let command = (step.command ?? "").lowercased()
+        if command.contains("delete") || command.contains("remove") { return true }
+        return step.proposedOperation.lowercased().contains("delete ")
+    }
+
+    /// Parse `tracks:0,1,2` (the plan's `target_identifier` form) into sorted,
+    /// de-duplicated non-negative indices. Returns [] for any unparseable shape
+    /// so the caller fails closed instead of guessing a target.
+    static func cleanupApplyTargetIndices(_ identifier: String) -> [Int] {
+        let parts = identifier.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2, parts[0] == "tracks" else { return [] }
+        let csv = parts[1]
+        var indices: [Int] = []
+        for token in csv.split(separator: ",") {
+            guard let value = Int(token.trimmingCharacters(in: .whitespaces)), value >= 0 else {
+                return []
+            }
+            indices.append(value)
+        }
+        return Array(Set(indices)).sorted()
+    }
+
+    /// Resolve the new names for a rename step. `names` (CSV) takes precedence;
+    /// `new_name` is a single-target convenience. Returns the parsed list as-is
+    /// (count is validated against the target count by the caller).
+    private static func cleanupApplyRenameNames(_ params: [String: Value], targetCount: Int) -> [String] {
+        if let array = params["names"]?.arrayValue {
+            return array.compactMap { $0.stringValue }
+        }
+        let csv = stringParam(params, "names")
+        if !csv.isEmpty {
+            return csv.split(separator: ",", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+        let single = stringParam(params, "new_name", "name")
+        if !single.isEmpty {
+            return [single]
+        }
+        return []
+    }
+
+    /// Extract the text body from a CallTool.Result so cleanup_apply can fold
+    /// the underlying `track.rename` HC envelope into its own response.
+    private static func cleanupApplyResultText(_ result: CallTool.Result) -> String {
+        guard let first = result.content.first else { return "" }
+        if case .text(let text, _, _) = first { return text }
+        return ""
+    }
+
+    /// Build a State C (hard-failure) Honest Contract envelope for cleanup_apply
+    /// with the step id always attached for diagnosis.
+    private static func cleanupApplyStateC(
+        _ error: HonestContract.FailureError,
+        stepID: String,
+        hint: String,
+        extras: [String: Any] = [:]
+    ) -> CallTool.Result {
+        var merged: [String: Any] = [
+            "op": "project.cleanup_apply",
+            "step_id": stepID,
+        ]
+        for (k, v) in extras { merged[k] = v }
+        return toolTextResult(
+            HonestContract.encodeStateC(error: error, hint: hint, extras: merged),
+            isError: true
+        )
     }
 
     /// v3.1.2 (P0-3) — invalidate cache on successful project lifecycle

--- a/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
+++ b/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
@@ -19,7 +19,11 @@ enum DestructivePolicy {
             return .l3
         case "save_as", "bounce", "open":
             return .l2
-        case "save", "new", "launch":
+        case "save", "new", "launch", "cleanup_apply":
+            // cleanup_apply mutates the project (executes a confirmed cleanup
+            // step through track.rename). It carries its own confirmed:true
+            // gate (#28), so it does NOT use the L2/L3 confirmation-prompt
+            // flow — L1 here just turns on the SIEM audit trail.
             return .l1
         default:
             return .l0

--- a/Tests/LogicProMCPTests/CleanupExecutionTests.swift
+++ b/Tests/LogicProMCPTests/CleanupExecutionTests.swift
@@ -1,0 +1,407 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+// Issue #28 — guarded execution of cleanup-plan steps via
+// `logic_project cleanup_apply`. These tests drive the dispatcher with an
+// injected/fake Accessibility channel so the rename path's Honest Contract
+// State A/B/C is exercised headlessly, with no real Logic Pro.
+//
+// Every #expect here is force-unwrap / boolean-expression / nil-compare so it
+// can genuinely FAIL (issue #92 dead-assertion footgun avoided).
+
+// MARK: - Fake Accessibility channel
+
+/// Returns a caller-supplied Honest Contract envelope for `track.rename`
+/// (the only op cleanup_apply currently dispatches), and records what it saw
+/// so a test can assert the dispatcher actually routed — or DIDN'T route — a
+/// rename. Any other op returns a hard error so an unexpected route surfaces.
+private actor FakeRenameChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    /// Maps requested rename name -> HC envelope JSON to return.
+    private let envelopeForName: @Sendable (String) -> ChannelResult
+    private(set) var renameCalls: [(index: String, name: String)] = []
+
+    init(envelopeForName: @escaping @Sendable (String) -> ChannelResult) {
+        self.envelopeForName = envelopeForName
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        guard operation == "track.rename" else {
+            return .error("FakeRenameChannel: unexpected op \(operation)")
+        }
+        let name = params["name"] ?? ""
+        renameCalls.append((index: params["index"] ?? "", name: name))
+        return envelopeForName(name)
+    }
+
+    func healthCheck() async -> ChannelHealth { .healthy(detail: "fake") }
+
+    func calls() -> [(index: String, name: String)] { renameCalls }
+}
+
+private func stateARename(name: String) -> ChannelResult {
+    .success(HonestContract.encodeStateA(extras: [
+        "op": "track.rename",
+        "observed": name,
+        "requested": name,
+    ]))
+}
+
+private func stateBRename(name: String) -> ChannelResult {
+    .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: [
+        "op": "track.rename",
+        "requested": name,
+    ]))
+}
+
+// MARK: - Cache fixtures
+
+/// Seed a cache with two duplicate-named tracks so the deterministic audit
+/// produces a `rename_duplicate_<name>_<i0>_<i1>` cleanup step that
+/// `cleanup_apply` can target. Returns the expected step id.
+@discardableResult
+private func seedDuplicateTracks(_ cache: StateCache) async -> String {
+    await cache.updateDocumentState(true)
+    await cache.updateTracks([
+        TrackState(id: 0, name: "Kick", type: .audio),
+        TrackState(id: 1, name: "Kick", type: .audio),
+        TrackState(id: 2, name: "Bass", type: .audio),
+    ])
+    return "rename_duplicate_kick_0_1"
+}
+
+private func routerWith(_ channel: any Channel) async -> ChannelRouter {
+    let router = ChannelRouter()
+    await router.register(channel)
+    return router
+}
+
+// MARK: - Tests
+
+@Test func testCleanupApplyRenameReachesStateAOnVerifiedReadback() async throws {
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    // Sanity: the plan really does contain the step we are about to execute.
+    let plan = await ProjectSessionAudit.buildCleanupPlan(cache: cache)
+    let planned = plan.steps.first { $0.id == stepID }
+    let step = try #require(planned, "expected duplicate-rename step in the plan")
+    #expect(step.supportedByCurrentTools)
+    #expect(step.mutatesProject)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "confirmed": .bool(true),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError != true)
+    let body = sharedToolText(result)
+    let json = try #require(sharedJSONObject(body), "response must be a JSON object")
+    #expect(try #require(json["success"] as? Bool))
+    #expect(try #require(json["verified"] as? Bool))
+    #expect(json["step_id"] as? String == stepID)
+    #expect(json["command"] as? String == "rename")
+
+    // The dispatcher must have routed exactly one rename per target track,
+    // with the supplied names — proving it went through the real track path.
+    let calls = await channel.calls()
+    #expect(calls.count == 2)
+    #expect(calls.map(\.index).sorted() == ["0", "1"])
+    #expect(Set(calls.map(\.name)) == ["Kick L", "Kick R"])
+}
+
+@Test func testCleanupApplyRefusesWhenNotConfirmed() async throws {
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "confirmed": .bool(false),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    // Fail-closed: NO rename was attempted.
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyRefusesWhenConfirmedMissing() async throws {
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyRefusesUnknownStep() async throws {
+    let cache = StateCache()
+    await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string("rename_duplicate_does_not_exist_9_99"),
+            "confirmed": .bool(true),
+            "names": .string("x,y"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    #expect(json["error"] as? String == "element_not_found")
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyRefusesUnsupportedStep() async throws {
+    // The `review_empty_tracks_no_delete` step is `supported_by_current_tools:
+    // false` and `mutates_project:false` by construction — exactly the kind of
+    // step cleanup_apply must refuse. Seed a project with an empty track to
+    // produce it.
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+    await cache.updateTracks([
+        TrackState(id: 0, name: "Has Region", type: .audio),
+        TrackState(id: 1, name: "Empty One", type: .audio),
+    ])
+    await cache.updateRegions([
+        RegionState(
+            id: "0:1:5:Has Region",
+            name: "Has Region",
+            trackIndex: 0,
+            startPosition: "1 1 1 1",
+            endPosition: "5 1 1 1",
+            length: "4 0 0 0"
+        )
+    ])
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    // Confirm the unsupported step exists before asserting it's refused.
+    let plan = await ProjectSessionAudit.buildCleanupPlan(cache: cache)
+    let emptyStep = try #require(
+        plan.steps.first { $0.id == "review_empty_tracks_no_delete" },
+        "expected empty-track review step"
+    )
+    #expect(emptyStep.supportedByCurrentTools == false)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string("review_empty_tracks_no_delete"),
+            "confirmed": .bool(true),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    // A non-mutating step is caught by the mutates_project gate first.
+    #expect(json["error"] as? String == "invalid_params")
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyNeverExecutesDeletion() async throws {
+    // No real plan step proposes a supported delete, so we verify the
+    // deletion refusal directly against a synthetic delete step that lies
+    // about being supported + mutating. This proves the belt-and-braces guard
+    // refuses a delete even if a future plan mislabels it.
+    let deleteStep = ProjectSessionAudit.CleanupPlanStep(
+        id: "delete_empty_tracks",
+        targetIdentifier: "tracks:3,4",
+        proposedOperation: "Delete empty tracks.",
+        rationale: "synthetic",
+        riskLevel: .high,
+        requiredConfirmation: "L2",
+        expectedReadback: "tracks gone",
+        rollbackOrRecovery: "undo",
+        stopCondition: "—",
+        supportedByCurrentTools: true,
+        mutatesProject: true,
+        tool: "logic_tracks",
+        command: "delete"
+    )
+    #expect(ProjectDispatcher.cleanupApplyIsDeletion(deleteStep))
+
+    // Also: a delete COMMAND on the track tool must not be parseable into the
+    // rename dispatch path. There is no ("logic_tracks","delete") executable
+    // arm, so even bypassing the deletion guard it would hit notImplemented —
+    // but the deletion guard fires first.
+    #expect(ProjectDispatcher.cleanupApplyTargetIndices(deleteStep.targetIdentifier) == [3, 4])
+}
+
+@Test func testCleanupApplyRefusesStaleInventory() async throws {
+    // hasDocument=true but the track inventory was never read (tracksFetchedAt
+    // stays at .distantPast), so the audit reports the track evidence as
+    // unavailable/stale. cleanup_apply must refuse before any rename.
+    //
+    // We seed the duplicate-rename step body by hand-deriving the SAME step id
+    // the plan uses, but the audit (built from this stale cache) will instead
+    // refuse on the stale-inventory gate. To make the step actually present we
+    // would need fresh tracks — but a stale cache yields no rename step at all,
+    // which is itself fail-closed. So here we assert: with stale inventory, the
+    // duplicate-rename step is NOT in the plan, and applying it is refused.
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+    // Deliberately do NOT call updateTracks — tracksFetchedAt stays distantPast.
+
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    let plan = await ProjectSessionAudit.buildCleanupPlan(cache: cache)
+    #expect(plan.steps.first { $0.id == "rename_duplicate_kick_0_1" } == nil)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string("rename_duplicate_kick_0_1"),
+            "confirmed": .bool(true),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyRefusesOccludedInventory() async throws {
+    // Fresh duplicate tracks (so the step exists) but AX is occluded — the
+    // plan's targets cannot be trusted, so the stale/occluded gate must refuse
+    // even though the step is present and supported.
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    await cache.updateAXOccluded(true)
+
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    // The step is still in the plan...
+    let plan = await ProjectSessionAudit.buildCleanupPlan(cache: cache)
+    #expect(plan.steps.first { $0.id == stepID } != nil)
+
+    // ...but cleanup_apply refuses on the occlusion gate.
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "confirmed": .bool(true),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    #expect(json["error"] as? String == "stale_snapshot")
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}
+
+@Test func testCleanupApplyStateBStopsBeforeClaimingSuccess() async throws {
+    // The first rename comes back State A, the second State B (unverified).
+    // cleanup_apply must NOT report an overall State A; it must fail closed at
+    // the unverified track and surface State C with the underlying envelope.
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { name in
+        name == "Kick R" ? stateBRename(name: name) : stateARename(name: name)
+    }
+    let router = await routerWith(channel)
+
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "confirmed": .bool(true),
+            "names": .string("Kick L,Kick R"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    // Some rename(s) were attempted; the failure surfaces the failed track.
+    let calls = await channel.calls()
+    #expect(calls.isEmpty == false)
+}
+
+@Test func testCleanupApplyRefusesNameCountMismatch() async throws {
+    let cache = StateCache()
+    let stepID = await seedDuplicateTracks(cache)
+    let channel = FakeRenameChannel { stateARename(name: $0) }
+    let router = await routerWith(channel)
+
+    // Two targets, one name supplied -> fail closed before any write.
+    let result = await ProjectDispatcher.handle(
+        command: "cleanup_apply",
+        params: [
+            "step_id": .string(stepID),
+            "confirmed": .bool(true),
+            "names": .string("OnlyOne"),
+        ],
+        router: router,
+        cache: cache
+    )
+
+    #expect(result.isError == true)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(json["success"] as? Bool) == false)
+    #expect(json["error"] as? String == "invalid_params")
+    let calls = await channel.calls()
+    #expect(calls.isEmpty)
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -804,6 +804,7 @@ Example:
 | `export_plan` | `{ projects?: string[], project?: string, output_root: string, artifacts?: string[], collision_policy?: "fail_if_exists"\|"skip_existing" }` | JSON `logic_pro_mcp_export_manifest.v1` dry-run plan | (direct, read-only filesystem checks) | L0 |
 | `audit` | — | `logic_pro_mcp_project_audit.v1` JSON | Cache/resource provenance synthesis | L0 |
 | `cleanup_plan` | — | `logic_pro_mcp_project_cleanup_plan.v1` JSON | Derived from audit; no mutation | L0 |
+| `cleanup_apply` | `{ step_id: string, confirmed: bool, names?: "newA,newB" \| new_name?: string }` | HC JSON; State A only after the underlying `track.rename` AX readback confirms | Re-derives audit → routes one supported mutating step through `track.rename` | L1 |
 | `launch` | — | text | AppleScript | L1 |
 | `quit` | `{ confirmed?: bool }` | text | AppleScript | L3 |
 
@@ -834,6 +835,18 @@ Use `logic://project/audit` or `logic_project audit` to inspect a messy session 
 Use `logic://project/cleanup-plan` or `logic_project cleanup_plan` when a client only needs the serializable plan. Each step includes `target_identifier`, `proposed_operation`, `risk_level`, `required_confirmation`, `expected_readback`, `rollback_or_recovery`, `stop_condition`, `supported_by_current_tools`, and `mutates_project`.
 
 The first milestone is intentionally read-only: it can propose rename, mute/solo/arm reset, marker planning, or mixer-refresh steps, but it never executes them. Unsupported or unsafe cleanup actions are labelled `supported_by_current_tools:false`; deletion is never proposed by default.
+
+#### Guarded execution: `cleanup_apply`
+
+`logic_project cleanup_apply` (#28) executes exactly **one** supported, mutating cleanup-plan step. It re-derives the audit + cleanup plan deterministically on every call (the caller passes only a `step_id`, never a step body), matches the step by id, then runs a fail-closed gate chain before any write:
+
+- `confirmed` must be a literal `true`. A missing or non-boolean value is **not** coerced — the op refuses (State C) without touching the project.
+- The `step_id` must exist in the freshly-derived plan (`element_not_found` otherwise).
+- The audit's inventory must be safe to act on: refuses (`stale_snapshot`) when there is no open document, when Accessibility is occluded, when the track inventory is unread/stale, or when a `track_readback_gap` finding is present (the file reports more tracks than AX surfaced).
+- The step must be mutating (`invalid_params` for a no-op step) and `supported_by_current_tools:true` (`not_implemented` otherwise).
+- **Deletion is never executed.** Deletion steps are `supported_by_current_tools:false` by construction, and `cleanup_apply` additionally refuses any step whose command/operation looks like a delete (`not_implemented`).
+
+Currently only the rename family (`rename_duplicate_*`, `rename_unnamed_or_placeholder_tracks`) is executable. Supply one new name per target track via `names` (CSV aligned to the step's target indices) or `new_name` for a single target; a count mismatch or a blank name fails closed before any write so a multi-target rename is all-or-nothing. Each rename is dispatched through the existing `track.rename` path, inheriting its AX readback and Honest Contract State A/B/C — `cleanup_apply` reports an overall **State A only when every target reached verified State A**, and surfaces **State C** (with the underlying envelope and the failed track index) the moment any rename comes back State B/C. solo/arm-clear steps are not yet executable here (the read-only plan does not carry a per-track enabled vector); perform them through `logic_tracks` directly for now.
 
 #### Tempo semantics: `project/info` vs `transport/state`
 


### PR DESCRIPTION
## Summary
Completes the execution half of the audit→cleanup workflow (read-only audit + plan shipped in #95).

- New `logic_project cleanup_apply { step_id, confirmed, names?|new_name? }`: re-derives the deterministic audit+plan, finds the step, and executes ONLY supported mutating steps (e.g. `rename_duplicate`) via the existing TrackDispatcher rename path so it inherits AX readback + HC State A/B/C.
- Fail-closed: refuses unconfirmed, unknown step, unsupported step, non-mutating step, stale/occluded inventory or readback gap. **Never deletes** (deletion steps are unsupported by construction).
- New `CleanupExecutionTests` (10 tests). Full suite green.

## Live gate
Genuine State A requires real Logic (rename + readback). The full guard logic + HC truthfulness are unit-tested with injected runtime; live rename verification is the close gate.

Refs #28