### PR TITLE
feat(project): batch export Phase 2 guarded execution — export_run/export_resume (#27)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -11,7 +11,7 @@ struct ProjectDispatcher {
 
     static let tool = commandTool(
         name: "logic_project",
-        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, audit, cleanup_plan. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; others -> {}.",
+        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; export_run -> { ...same as export_plan, confirmed: Bool } GUARDED execution (re-plans, opens, verifies project identity by readback, bounces, verifies each artifact on disk via logic_audio, records logic_pro_mcp_export_run.v1 with HC State A/B/C; never overwrites under fail_if_exists); export_resume -> { ...same as export_run } idempotent resume (skips already-present+verified artifacts, produces the rest); audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; others -> {}.",
         commandDescription: "Project command to execute"
     )
 
@@ -29,7 +29,11 @@ struct ProjectDispatcher {
         executeLifecycleScript: (String) async -> LifecycleExecution = { script in
             await executeAppleScript(script)
         },
-        sleep: (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) }
+        sleep: (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
+        // #27 Phase 2 — injectable export-execution seams (identity readback,
+        // audio analysis, file polling). Defaults to the live wiring; tests
+        // inject fakes so the guarded state machine is unit-testable headless.
+        exportOptions: ProjectExportExecutor.Options = .live()
     ) async -> CallTool.Result {
         func destructiveConfirmation(for command: String) -> (confirmed: Bool, error: CallTool.Result?) {
             switch strictBoolParam(params, "confirmed") {
@@ -80,6 +84,50 @@ struct ProjectDispatcher {
             } catch {
                 audit(command, phase: .rejected, reason: "invalid export plan")
                 return toolTextResult("export_plan invalid_params: \(error)", isError: true)
+            }
+
+        case "export_run", "export_resume":
+            // #27 Phase 2 — GUARDED EXECUTION. Validate the plan inputs first so
+            // a malformed request fails closed with `invalid_params` (rejected,
+            // no mutation) exactly like export_plan, instead of reaching the
+            // executor. The executor then re-runs the planner itself for the
+            // authoritative manifest — the dispatcher's call is purely the
+            // caller-input gate.
+            do {
+                _ = try ProjectExportPlanner.plan(params: params)
+            } catch {
+                audit(command, phase: .rejected, reason: "invalid export plan")
+                return toolTextResult("\(command) invalid_params: \(error)", isError: true)
+            }
+            // The destructive confirmation is enforced INSIDE the executor (it
+            // must be checked per-run before any open/bounce). Audit the
+            // execution intent here; the executor's confirmed:false path returns
+            // a State-C-shaped `confirmation_required` run with no side effects.
+            audit(command, phase: .executed)
+            let run = await ProjectExportExecutor.run(
+                params: params,
+                router: router,
+                resume: command == "export_resume",
+                options: exportOptions
+            )
+            // Lifecycle cache invalidation: a guarded run opens projects, so the
+            // cache may now reflect the LAST opened project. Clear it on any run
+            // that actually opened something, matching open/close semantics.
+            if run.projects.contains(where: { $0.opened }) {
+                await cache.clearProjectState()
+            }
+            do {
+                // HC truthfulness: a run that produced ZERO verified artifacts and
+                // had failures (or the confirmation gate) is isError=true on the
+                // wire so a client never reads a failed/blocked run as success.
+                let body = try encodeJSONStrict(run, compact: true)
+                let isError = run.status == "failed" || run.status == "confirmation_required"
+                return toolTextResult(body, isError: isError)
+            } catch {
+                return toolTextResult(
+                    "{\"success\":false,\"error\":\"\(command) encode failed: \(jsonStringEscape(error.localizedDescription))\"}",
+                    isError: true
+                )
             }
 
         case "new":
@@ -263,7 +311,7 @@ struct ProjectDispatcher {
 
         default:
             return toolTextResult(
-                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan, audit, cleanup_plan",
+                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan",
                 isError: true
             )
         }

--- a/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
@@ -1,0 +1,716 @@
+import Foundation
+import MCP
+
+/// Issue #27 Phase 2 — GUARDED EXECUTION of the export plan that Phase 1
+/// (#99, `export_plan`) only described as a dry run.
+///
+/// The executor re-runs `ProjectExportPlanner` to obtain the authoritative
+/// manifest (so the contract a caller reviewed in `export_plan` is the contract
+/// that executes), then walks each project artifact through a fail-closed state
+/// machine:
+///
+///   1. `confirmed == true` is mandatory — otherwise NOTHING is opened, bounced,
+///      or written, and the run reports `confirmation_required` (State-C-shaped:
+///      `success:false`).
+///   2. Artifacts the plan reported as already present + verifiable on disk are
+///      SKIPPED (idempotent — this is what makes `export_resume` resumable).
+///   3. For every artifact that still needs producing: open the project,
+///      read back the OBSERVED front-document identity and require it to match
+///      the planned project path (fail closed on mismatch — never bounce the
+///      wrong project), trigger the bounce, poll (bounded) for the artifact file
+///      to appear, then verify it with `AudioAnalyzer` (exists + non-zero +
+///      non-silent + sane duration).
+///   4. Honest Contract per artifact:
+///        State A — bounce fired AND on-disk verification PASSED.
+///        State B — bounce fired but the artifact could not be verified
+///                  (never appeared / analyzer warn/fail) — success uncertain.
+///        State C — a hard failure (open/identity/bounce route error, or the
+///                  plan itself was degraded for this artifact).
+///   5. The collision policy from the plan is honoured: under `fail_if_exists`
+///      an artifact the plan flagged `would_overwrite` is NEVER overwritten —
+///      it fails closed (State C) instead of bouncing over an existing file.
+///
+/// Every live side effect (open / bounce / close) and every readback
+/// (front-document identity, audio analysis, file polling) goes through an
+/// injectable seam, so the state machine, the resume/idempotency logic, and the
+/// fail-closed gates are fully unit-testable with fake channels, an injected
+/// `FileManager`, fixture WAV files, and a stub identity provider — no live
+/// Logic required to test the logic.
+enum ProjectExportExecutor {
+    static let schema = "logic_pro_mcp_export_run.v1"
+
+    /// Bounded poll budget for an artifact file to appear after a bounce fires.
+    /// Injectable via `Options` so tests don't actually sleep.
+    static let defaultPollAttempts = 60
+    static let defaultPollIntervalNanos: UInt64 = 500_000_000
+
+    // MARK: - Injectable seams
+
+    /// Reads the OBSERVED front-document project path from live Logic. Mirrors
+    /// the verified-plugin identity gate seam (`FrontDocumentPathProvider`) so
+    /// the readback authority is the same one the open/save lifecycle relies on.
+    /// Returns nil when no front document can be read.
+    typealias IdentityReadback = @Sendable () async -> String?
+
+    /// Analyze an on-disk artifact. Defaults to `AudioAnalyzer.analyzeFile`; the
+    /// `policy` carries the output-root containment + non-silence/duration gates.
+    typealias ArtifactAnalyzer = @Sendable (_ path: String, _ policy: AudioAnalyzer.AnalysisPolicy) -> AudioAnalyzer.Result
+
+    /// `@unchecked Sendable` mirrors `AudioAnalyzer.Runtime`: the only
+    /// non-Sendable member is `FileManager`, which Apple documents as safe to
+    /// share across threads for the read-only `fileExists` use here.
+    struct Options: @unchecked Sendable {
+        var identityReadback: IdentityReadback
+        var analyze: ArtifactAnalyzer
+        var fileManager: FileManager
+        var pollAttempts: Int
+        var pollIntervalNanos: UInt64
+        var sleep: @Sendable (UInt64) async -> Void
+        /// Minimum sane duration (seconds) for a produced artifact. A bounce that
+        /// yields a sub-tick file is treated as not-verified (State B).
+        var minimumDurationSeconds: Double
+
+        static func live() -> Options {
+            Options(
+                identityReadback: { await AppleScriptChannel.currentDocumentPath() },
+                analyze: { path, policy in AudioAnalyzer.analyzeFile(path: path, policy: policy) },
+                fileManager: .default,
+                pollAttempts: defaultPollAttempts,
+                pollIntervalNanos: defaultPollIntervalNanos,
+                sleep: { try? await Task.sleep(nanoseconds: $0) },
+                minimumDurationSeconds: 0.05
+            )
+        }
+    }
+
+    // MARK: - Result model (logic_pro_mcp_export_run.v1)
+
+    struct RunResult: Codable, Sendable, Equatable {
+        let schema: String
+        let runID: String
+        let mode: String
+        let confirmed: Bool
+        let status: String
+        let outputRoot: String
+        let collisionPolicy: String
+        let projectCount: Int
+        let artifactsTotal: Int
+        let artifactsVerified: Int
+        let artifactsSkipped: Int
+        let artifactsUncertain: Int
+        let artifactsFailed: Int
+        let projects: [RunProject]
+        let nextSafeAction: String
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case runID = "run_id"
+            case mode
+            case confirmed
+            case status
+            case outputRoot = "output_root"
+            case collisionPolicy = "collision_policy"
+            case projectCount = "project_count"
+            case artifactsTotal = "artifacts_total"
+            case artifactsVerified = "artifacts_verified"
+            case artifactsSkipped = "artifacts_skipped"
+            case artifactsUncertain = "artifacts_uncertain"
+            case artifactsFailed = "artifacts_failed"
+            case projects
+            case nextSafeAction = "next_safe_action"
+        }
+    }
+
+    struct RunProject: Codable, Sendable, Equatable {
+        let index: Int
+        let projectPath: String
+        let displayName: String
+        let observedProjectPath: String?
+        let identityVerified: Bool
+        let opened: Bool
+        let artifacts: [RunArtifact]
+
+        enum CodingKeys: String, CodingKey {
+            case index
+            case projectPath = "project_path"
+            case displayName = "display_name"
+            case observedProjectPath = "observed_project_path"
+            case identityVerified = "identity_verified"
+            case opened
+            case artifacts
+        }
+    }
+
+    /// Per-artifact Honest Contract outcome. `state` is "A"|"B"|"C"; `verified`
+    /// is true ONLY for State A (on-disk verification passed). `error` is present
+    /// for State C, `reason` for State B.
+    struct RunArtifact: Codable, Sendable, Equatable {
+        let kind: String
+        let path: String
+        let state: String
+        let verified: Bool
+        let bounceFired: Bool
+        let error: String?
+        let reason: String?
+        let evidence: ArtifactEvidence?
+
+        enum CodingKeys: String, CodingKey {
+            case kind
+            case path
+            case state
+            case verified
+            case bounceFired = "bounce_fired"
+            case error
+            case reason
+            case evidence
+        }
+    }
+
+    /// On-disk verification evidence captured at State A (and recorded for State
+    /// B so a caller can see HOW close the artifact was to verifiable). Mirrors
+    /// the analyzer fields a future resume keys off.
+    struct ArtifactEvidence: Codable, Sendable, Equatable {
+        let exists: Bool
+        let fileSizeBytes: Int64
+        let durationSeconds: Double
+        let sampleRate: Int
+        let channelCount: Int
+        let silenceRatio: Double
+        let peakDbfs: Double
+        let verificationStatus: String
+        let verificationReasons: [String]
+        let source: String
+
+        enum CodingKeys: String, CodingKey {
+            case exists
+            case fileSizeBytes = "file_size_bytes"
+            case durationSeconds = "duration_seconds"
+            case sampleRate = "sample_rate"
+            case channelCount = "channel_count"
+            case silenceRatio = "silence_ratio"
+            case peakDbfs = "peak_dbfs"
+            case verificationStatus = "verification_status"
+            case verificationReasons = "verification_reasons"
+            case source
+        }
+
+        init(from analysis: AudioAnalyzer.Result, source: String) {
+            self.exists = analysis.exists
+            self.fileSizeBytes = analysis.fileSizeBytes
+            self.durationSeconds = analysis.durationSeconds
+            self.sampleRate = analysis.sampleRate
+            self.channelCount = analysis.channelCount
+            self.silenceRatio = analysis.silenceRatio
+            self.peakDbfs = analysis.peakDbfs
+            self.verificationStatus = analysis.verification.status.rawValue
+            self.verificationReasons = analysis.verification.reasons
+            self.source = source
+        }
+    }
+
+    // MARK: - Entry point
+
+    /// Execute (or resume) the guarded export. `resume` only changes the
+    /// surfaced `mode` string and `next_safe_action` wording — the artifact
+    /// state machine is identical: both skip already-present+verified artifacts
+    /// and produce the rest. That shared path is what makes `export_run`
+    /// re-entrant and `export_resume` idempotent.
+    static func run(
+        params: [String: Value],
+        router: ChannelRouter,
+        resume: Bool,
+        options: Options
+    ) async -> RunResult {
+        // (1) Re-run the planner. Caller-facing param errors are surfaced by the
+        // dispatcher's planner call BEFORE this executor is reached, so a throw
+        // here is unexpected — fail closed with an empty, failed run rather than
+        // crash.
+        let plan: ProjectExportPlan
+        do {
+            plan = try ProjectExportPlanner.plan(params: params, fileManager: options.fileManager)
+        } catch {
+            return failedRun(
+                runID: "export-unplanned",
+                mode: resume ? "resume" : "run",
+                confirmed: false,
+                outputRoot: stringParam(params, "output_root", "outputRoot"),
+                collisionPolicy: stringParam(params, "collision_policy", default: "fail_if_exists"),
+                reason: "plan_failed: \(error)"
+            )
+        }
+
+        // (2) confirmed gate — fail closed before ANY mutation.
+        let confirmed: Bool
+        switch strictBoolParam(params, "confirmed") {
+        case .value(let value):
+            confirmed = value
+        case .missing, .invalid:
+            confirmed = false
+        }
+        guard confirmed else {
+            return confirmationRequiredRun(plan: plan, resume: resume)
+        }
+
+        var runProjects: [RunProject] = []
+        for project in plan.projects {
+            let runProject = await execute(
+                project: project,
+                plan: plan,
+                router: router,
+                options: options
+            )
+            runProjects.append(runProject)
+        }
+
+        return aggregate(plan: plan, resume: resume, projects: runProjects)
+    }
+
+    // MARK: - Per-project execution
+
+    private static func execute(
+        project: ProjectExportPlanProject,
+        plan: ProjectExportPlan,
+        router: ChannelRouter,
+        options: Options
+    ) async -> RunProject {
+        // Partition: artifacts already present+verified are skipped without any
+        // mutation (resume idempotency). Everything else needs the project open.
+        var pendingExists = false
+        for artifact in project.expectedArtifacts where artifactNeedsProduction(artifact, plan: plan) {
+            pendingExists = true
+            break
+        }
+
+        // A degraded/invalid project (bad path, intra-plan collision, would-
+        // overwrite under fail_if_exists) never gets opened — every artifact
+        // fails closed with the plan's own reason.
+        guard project.validationStatus == "valid" else {
+            let arts = project.expectedArtifacts.map { artifact in
+                failedArtifact(artifact, error: "project_invalid: \(project.validationIssues.joined(separator: ","))")
+            }
+            return RunProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                observedProjectPath: nil,
+                identityVerified: false,
+                opened: false,
+                artifacts: arts
+            )
+        }
+
+        // If nothing needs producing, skip the open entirely and record skips.
+        guard pendingExists else {
+            let arts = project.expectedArtifacts.map { artifact in
+                skippedArtifact(artifact, options: options, outputRoot: plan.outputRoot)
+            }
+            return RunProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                observedProjectPath: nil,
+                identityVerified: false,
+                opened: false,
+                artifacts: arts
+            )
+        }
+
+        // (3a) Open the project (existing open path through the router).
+        let openResult = await router.route(
+            operation: "project.open",
+            params: ["path": project.projectPath]
+        )
+        guard openResult.isSuccess else {
+            let arts = project.expectedArtifacts.map { artifact -> RunArtifact in
+                artifactNeedsProduction(artifact, plan: plan)
+                    ? failedArtifact(artifact, error: "open_failed: \(openResult.message)")
+                    : skippedArtifact(artifact, options: options, outputRoot: plan.outputRoot)
+            }
+            return RunProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                observedProjectPath: nil,
+                identityVerified: false,
+                opened: false,
+                artifacts: arts
+            )
+        }
+
+        // (3b) Identity readback — the OBSERVED front document MUST match the
+        // planned project path or we fail closed for every pending artifact
+        // (never bounce the wrong project).
+        let observedPath = await options.identityReadback()
+        let identityVerified = observedPath.map {
+            AppleScriptChannel.projectPathsMatch(project.projectPath, $0)
+        } ?? false
+        guard identityVerified else {
+            let arts = project.expectedArtifacts.map { artifact -> RunArtifact in
+                artifactNeedsProduction(artifact, plan: plan)
+                    ? failedArtifact(
+                        artifact,
+                        error: observedPath == nil
+                            ? "project_identity_mismatch: no front document path could be read"
+                            : "project_identity_mismatch: observed=\(observedPath ?? "")"
+                    )
+                    : skippedArtifact(artifact, options: options, outputRoot: plan.outputRoot)
+            }
+            return RunProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                observedProjectPath: observedPath,
+                identityVerified: false,
+                opened: true,
+                artifacts: arts
+            )
+        }
+
+        // (3c) Per-artifact production.
+        var arts: [RunArtifact] = []
+        for artifact in project.expectedArtifacts {
+            if !artifactNeedsProduction(artifact, plan: plan) {
+                arts.append(skippedArtifact(artifact, options: options, outputRoot: plan.outputRoot))
+                continue
+            }
+            let produced = await produce(
+                artifact: artifact,
+                plan: plan,
+                router: router,
+                options: options
+            )
+            arts.append(produced)
+        }
+
+        return RunProject(
+            index: project.index,
+            projectPath: project.projectPath,
+            displayName: project.displayName,
+            observedProjectPath: observedPath,
+            identityVerified: true,
+            opened: true,
+            artifacts: arts
+        )
+    }
+
+    // MARK: - Per-artifact production
+
+    private static func produce(
+        artifact: ProjectExportPlanArtifact,
+        plan: ProjectExportPlan,
+        router: ChannelRouter,
+        options: Options
+    ) async -> RunArtifact {
+        // (5) Collision policy — under fail_if_exists an artifact the plan
+        // flagged would_overwrite is NEVER overwritten. Fail closed.
+        if artifact.verification.wouldOverwrite {
+            return failedArtifact(
+                artifact,
+                error: "overwrite_blocked: collision_policy=\(plan.collisionPolicy) and artifact already exists"
+            )
+        }
+        // Any other plan-level issue for this artifact (outside-root, zero-byte,
+        // unreadable, intra-plan collision) is terminal — do not bounce.
+        if !artifact.verification.issues.isEmpty {
+            return failedArtifact(
+                artifact,
+                error: "artifact_blocked: \(artifact.verification.issues.joined(separator: ","))"
+            )
+        }
+
+        // (3d) Trigger the bounce (existing bounce path through the router).
+        let bounceResult = await router.route(operation: "project.bounce")
+        guard bounceResult.isSuccess else {
+            return RunArtifact(
+                kind: artifact.kind,
+                path: artifact.path,
+                state: "C",
+                verified: false,
+                bounceFired: false,
+                error: "bounce_failed: \(bounceResult.message)",
+                reason: nil,
+                evidence: nil
+            )
+        }
+
+        // (3e) Bounded poll for the artifact file to appear on disk.
+        let appeared = await waitForArtifact(path: artifact.path, options: options)
+        guard appeared else {
+            // State B — the bounce fired but the artifact never materialized in
+            // the poll window. We canNOT claim success; we also did not hard-fail
+            // the mutation, so this is honestly uncertain.
+            return RunArtifact(
+                kind: artifact.kind,
+                path: artifact.path,
+                state: "B",
+                verified: false,
+                bounceFired: true,
+                error: nil,
+                reason: "artifact_not_observed_within_poll_window",
+                evidence: nil
+            )
+        }
+
+        // (3f) Verify with AudioAnalyzer (exists + non-zero + non-silent + sane
+        // duration). State A ONLY when verification passes.
+        let analysis = options.analyze(artifact.path, analysisPolicy(plan: plan, options: options))
+        let evidence = ArtifactEvidence(from: analysis, source: "audio_analyzer")
+        if analysis.verification.status == .pass {
+            return RunArtifact(
+                kind: artifact.kind,
+                path: artifact.path,
+                state: "A",
+                verified: true,
+                bounceFired: true,
+                error: nil,
+                reason: nil,
+                evidence: evidence
+            )
+        }
+        // Bounce fired, file present, but analysis did not pass (silent / short /
+        // unreadable). State B — success uncertain, NOT verified.
+        return RunArtifact(
+            kind: artifact.kind,
+            path: artifact.path,
+            state: "B",
+            verified: false,
+            bounceFired: true,
+            error: nil,
+            reason: "artifact_unverified: \(analysis.verification.reasons.joined(separator: ","))",
+            evidence: evidence
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// An artifact needs producing unless it is already present on disk AND
+    /// passes verification (resume idempotency). Under any collision policy an
+    /// existing+verified artifact is left untouched.
+    private static func artifactNeedsProduction(
+        _ artifact: ProjectExportPlanArtifact,
+        plan: ProjectExportPlan
+    ) -> Bool {
+        // A plan-level issue other than would_overwrite (outside-root, zero-byte,
+        // collision) still needs handling — surface it via produce()'s
+        // fail-closed path, so treat it as "needs production" here.
+        guard artifact.verification.exists else { return true }
+        if artifact.verification.wouldOverwrite { return true }
+        // Existing file under skip_existing (or otherwise non-overwriting) — only
+        // skip when we can independently verify it. The verification itself is
+        // re-checked in skippedArtifact(); here we use the plan's existence +
+        // absence-of-issues as the cheap gate, and skippedArtifact downgrades to
+        // State B if the on-disk verification fails.
+        return false
+    }
+
+    /// Build the analyzer policy from the plan — pins output-root containment and
+    /// the non-silence / minimum-duration gates that define a "sane" artifact.
+    private static func analysisPolicy(plan: ProjectExportPlan, options: Options) -> AudioAnalyzer.AnalysisPolicy {
+        var policy = AudioAnalyzer.AnalysisPolicy.default
+        policy.outputRoot = plan.outputRoot
+        policy.minimumDurationSeconds = options.minimumDurationSeconds
+        policy.minimumFileSizeBytes = 1
+        return policy
+    }
+
+    private static func waitForArtifact(path: String, options: Options) async -> Bool {
+        var attempt = 0
+        while attempt < max(1, options.pollAttempts) {
+            var isDir: ObjCBool = false
+            if options.fileManager.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue {
+                return true
+            }
+            attempt += 1
+            if attempt < options.pollAttempts {
+                await options.sleep(options.pollIntervalNanos)
+            }
+        }
+        // Final check after the last sleep.
+        var isDir: ObjCBool = false
+        return options.fileManager.fileExists(atPath: path, isDirectory: &isDir) && !isDir.boolValue
+    }
+
+    /// Record an artifact the plan reported as already present. We do NOT trust
+    /// the plan's existence flag alone — re-verify on disk so a corrupt/zero/
+    /// silent leftover is downgraded to State B instead of being skipped as a
+    /// false State A.
+    private static func skippedArtifact(
+        _ artifact: ProjectExportPlanArtifact,
+        options: Options,
+        outputRoot: String
+    ) -> RunArtifact {
+        guard artifact.verification.exists, artifact.verification.issues.isEmpty else {
+            // Should not reach here for a true skip, but stay honest if it does.
+            return RunArtifact(
+                kind: artifact.kind,
+                path: artifact.path,
+                state: "C",
+                verified: false,
+                bounceFired: false,
+                error: "skip_precondition_failed",
+                reason: nil,
+                evidence: nil
+            )
+        }
+        var policy = AudioAnalyzer.AnalysisPolicy.default
+        policy.outputRoot = outputRoot
+        policy.minimumDurationSeconds = options.minimumDurationSeconds
+        policy.minimumFileSizeBytes = 1
+        let analysis = options.analyze(artifact.path, policy)
+        let evidence = ArtifactEvidence(from: analysis, source: "skip_reverify")
+        guard analysis.verification.status == .pass else {
+            return RunArtifact(
+                kind: artifact.kind,
+                path: artifact.path,
+                state: "B",
+                verified: false,
+                bounceFired: false,
+                error: nil,
+                reason: "existing_artifact_unverified: \(analysis.verification.reasons.joined(separator: ","))",
+                evidence: evidence
+            )
+        }
+        return RunArtifact(
+            kind: artifact.kind,
+            path: artifact.path,
+            state: "A",
+            verified: true,
+            bounceFired: false,
+            error: nil,
+            reason: "skipped_already_verified",
+            evidence: evidence
+        )
+    }
+
+    private static func failedArtifact(_ artifact: ProjectExportPlanArtifact, error: String) -> RunArtifact {
+        RunArtifact(
+            kind: artifact.kind,
+            path: artifact.path,
+            state: "C",
+            verified: false,
+            bounceFired: false,
+            error: error,
+            reason: nil,
+            evidence: nil
+        )
+    }
+
+    // MARK: - Aggregation
+
+    private static func aggregate(
+        plan: ProjectExportPlan,
+        resume: Bool,
+        projects: [RunProject]
+    ) -> RunResult {
+        let allArtifacts = projects.flatMap(\.artifacts)
+        let verified = allArtifacts.filter { $0.state == "A" && $0.bounceFired }.count
+        let skipped = allArtifacts.filter { $0.state == "A" && !$0.bounceFired }.count
+        let uncertain = allArtifacts.filter { $0.state == "B" }.count
+        let failed = allArtifacts.filter { $0.state == "C" }.count
+
+        // Overall status: "completed" only when nothing failed and nothing is
+        // uncertain; "partial" when some succeeded but others are uncertain/
+        // failed; "failed" when nothing reached State A.
+        let succeededCount = verified + skipped
+        let status: String
+        if failed == 0 && uncertain == 0 {
+            status = "completed"
+        } else if succeededCount > 0 {
+            status = "partial"
+        } else {
+            status = "failed"
+        }
+
+        let nextSafeAction = status == "completed"
+            ? "verify_artifacts_with_logic_audio"
+            : "review_then_export_resume"
+
+        return RunResult(
+            schema: schema,
+            runID: plan.runID,
+            mode: resume ? "resume" : "run",
+            confirmed: true,
+            status: status,
+            outputRoot: plan.outputRoot,
+            collisionPolicy: plan.collisionPolicy,
+            projectCount: projects.count,
+            artifactsTotal: allArtifacts.count,
+            artifactsVerified: verified,
+            artifactsSkipped: skipped,
+            artifactsUncertain: uncertain,
+            artifactsFailed: failed,
+            projects: projects,
+            nextSafeAction: nextSafeAction
+        )
+    }
+
+    private static func confirmationRequiredRun(plan: ProjectExportPlan, resume: Bool) -> RunResult {
+        let arts = plan.projects.map { project in
+            RunProject(
+                index: project.index,
+                projectPath: project.projectPath,
+                displayName: project.displayName,
+                observedProjectPath: nil,
+                identityVerified: false,
+                opened: false,
+                artifacts: project.expectedArtifacts.map { artifact in
+                    RunArtifact(
+                        kind: artifact.kind,
+                        path: artifact.path,
+                        state: "C",
+                        verified: false,
+                        bounceFired: false,
+                        error: "confirmation_required",
+                        reason: nil,
+                        evidence: nil
+                    )
+                }
+            )
+        }
+        let total = arts.flatMap(\.artifacts).count
+        return RunResult(
+            schema: schema,
+            runID: plan.runID,
+            mode: resume ? "resume" : "run",
+            confirmed: false,
+            status: "confirmation_required",
+            outputRoot: plan.outputRoot,
+            collisionPolicy: plan.collisionPolicy,
+            projectCount: plan.projects.count,
+            artifactsTotal: total,
+            artifactsVerified: 0,
+            artifactsSkipped: 0,
+            artifactsUncertain: 0,
+            artifactsFailed: total,
+            projects: arts,
+            nextSafeAction: "retry_with_confirmed_true"
+        )
+    }
+
+    private static func failedRun(
+        runID: String,
+        mode: String,
+        confirmed: Bool,
+        outputRoot: String,
+        collisionPolicy: String,
+        reason: String
+    ) -> RunResult {
+        RunResult(
+            schema: schema,
+            runID: runID,
+            mode: mode,
+            confirmed: confirmed,
+            status: "failed",
+            outputRoot: outputRoot,
+            collisionPolicy: collisionPolicy,
+            projectCount: 0,
+            artifactsTotal: 0,
+            artifactsVerified: 0,
+            artifactsSkipped: 0,
+            artifactsUncertain: 0,
+            artifactsFailed: 0,
+            projects: [],
+            nextSafeAction: "fix_inputs_then_retry: \(reason)"
+        )
+    }
+}

--- a/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
+++ b/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
@@ -17,7 +17,13 @@ enum DestructivePolicy {
         switch command {
         case "quit", "close":
             return .l3
-        case "save_as", "bounce", "open":
+        case "save_as", "bounce", "open", "export_run", "export_resume":
+            // #27 Phase 2 — guarded export execution opens projects and fires
+            // bounces, so it carries the same L2 destructive weight as the
+            // individual open/bounce ops it composes. (The per-run `confirmed`
+            // gate is enforced inside ProjectExportExecutor, not via the
+            // dispatcher confirmation prompt, so a confirmed:false run returns a
+            // State-C `confirmation_required` envelope rather than the L2 prompt.)
             return .l2
         case "save", "new", "launch":
             return .l1

--- a/Tests/LogicProMCPTests/ProjectExportExecutionTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportExecutionTests.swift
@@ -1,0 +1,577 @@
+import AVFoundation
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Fixture helpers
+
+/// Write a real, non-silent stereo WAV at `url` so AudioAnalyzer verification
+/// can PASS (exists + non-zero + non-silent + sane duration). Uses the same
+/// AVAudioFile path AudioAnalyzerTests relies on so the executor is exercised
+/// against the real analyzer, not a stub.
+@discardableResult
+private func writeToneWav(at url: URL, durationSeconds: Double = 0.2) throws -> URL {
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    let sampleRate = 44_100.0
+    let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2)!
+    let frameCount = AVAudioFrameCount(sampleRate * durationSeconds)
+    let file = try AVAudioFile(forWriting: url, settings: format.settings)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+    buffer.frameLength = frameCount
+    let channelData = buffer.floatChannelData!
+    for channel in 0..<2 {
+        for frame in 0..<Int(frameCount) {
+            channelData[channel][frame] = Float(sin(2.0 * Double.pi * 440.0 * Double(frame) / sampleRate) * 0.5)
+        }
+    }
+    try file.write(from: buffer)
+    return url
+}
+
+/// Write a fully-silent WAV (all zeros) so AudioAnalyzer flags `near_silent_output`.
+@discardableResult
+private func writeSilentWav(at url: URL, durationSeconds: Double = 0.2) throws -> URL {
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    let sampleRate = 44_100.0
+    let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2)!
+    let frameCount = AVAudioFrameCount(sampleRate * durationSeconds)
+    let file = try AVAudioFile(forWriting: url, settings: format.settings)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+    buffer.frameLength = frameCount
+    try file.write(from: buffer) // floatChannelData defaults to 0.0
+    return url
+}
+
+/// Thread-safe boolean flag so a `@Sendable` bounce side-effect closure can
+/// record whether it fired without a data race on a captured `var`.
+private final class BoolFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+    func set() { lock.lock(); value = true; lock.unlock() }
+    var isSet: Bool { lock.lock(); defer { lock.unlock() }; return value }
+}
+
+private func makeExecTempDir() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logicpromcp-export-exec-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func makeLogicxProject(in dir: URL, named name: String) throws -> URL {
+    let url = dir.appendingPathComponent(name).appendingPathExtension("logicx")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+/// Deterministic artifact path the planner resolves for a project display name +
+/// kind under an output root. Sanitization replaces spaces/illegal chars with '-'.
+private func plannedArtifactPath(outputRoot: URL, displayName: String, kind: String) -> String {
+    let sanitized = displayName.unicodeScalars.map { scalar -> Character in
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        return allowed.contains(scalar) ? Character(scalar) : Character("-")
+    }
+    let safe = String(sanitized).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    return outputRoot.appendingPathComponent("\(safe.isEmpty ? "project" : safe)-\(kind).wav")
+        .standardizedFileURL.path
+}
+
+// MARK: - Configurable fake channel
+
+/// A router channel that records ops and (a) reports success/failure per op and
+/// (b) runs a side-effect closure on success (used to simulate a bounce writing
+/// the artifact file). Lets the export state machine be driven headless.
+private actor FakeExportChannel: Channel {
+    nonisolated let id: ChannelID
+    private let onExecute: @Sendable (String, [String: String]) async -> ChannelResult
+    private(set) var ops: [String] = []
+
+    init(id: ChannelID, onExecute: @escaping @Sendable (String, [String: String]) async -> ChannelResult) {
+        self.id = id
+        self.onExecute = onExecute
+    }
+
+    func start() async throws {}
+    func stop() async {}
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        ops.append(operation)
+        return await onExecute(operation, params)
+    }
+    func healthCheck() async -> ChannelHealth { .healthy(detail: "fake") }
+}
+
+/// Router wired so `project.open` (AppleScript) and `project.bounce`
+/// (MIDIKeyCommands) resolve to fakes. `bounceSideEffect` runs on each
+/// successful bounce — production-equivalent of Logic writing the file.
+private func makeExportRouter(
+    openSucceeds: Bool = true,
+    bounceSucceeds: Bool = true,
+    bounceSideEffect: @escaping @Sendable () -> Void = {}
+) async -> ChannelRouter {
+    let router = ChannelRouter()
+    let appleScript = FakeExportChannel(id: .appleScript) { op, _ in
+        openSucceeds ? .success("opened via \(op)") : .error("open boom")
+    }
+    let keyCmd = FakeExportChannel(id: .midiKeyCommands) { op, _ in
+        if op == "project.bounce" {
+            guard bounceSucceeds else { return .error("bounce boom") }
+            bounceSideEffect()
+            return .success("bounced")
+        }
+        return .success("ok")
+    }
+    await router.register(appleScript)
+    await router.register(keyCmd)
+    return router
+}
+
+/// Options that never sleep, poll quickly, and analyze with the real analyzer.
+private func fastOptions(
+    identity: @escaping @Sendable () async -> String?
+) -> ProjectExportExecutor.Options {
+    ProjectExportExecutor.Options(
+        identityReadback: identity,
+        analyze: { path, policy in AudioAnalyzer.analyzeFile(path: path, policy: policy) },
+        fileManager: .default,
+        pollAttempts: 5,
+        pollIntervalNanos: 1_000,
+        sleep: { _ in },
+        minimumDurationSeconds: 0.05
+    )
+}
+
+// MARK: - Tests
+
+@Suite("Project export guarded execution")
+struct ProjectExportExecutionTests {
+
+    @Test("full run opens, verifies identity, bounces, and records each artifact as State A")
+    func fullRunVerifiesAndRecords() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Run Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Run Song", kind: "bounce")
+
+        let router = await makeExportRouter(bounceSideEffect: {
+            try? writeToneWav(at: URL(fileURLWithPath: bouncePath))
+        })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.schema == "logic_pro_mcp_export_run.v1")
+        #expect(run.confirmed)
+        #expect(run.status == "completed")
+        #expect(run.artifactsTotal == 1)
+        #expect(run.artifactsVerified == 1)
+        #expect(run.artifactsFailed == 0)
+        #expect(run.artifactsUncertain == 0)
+
+        let runProject = try #require(run.projects.first)
+        #expect(runProject.opened)
+        #expect(runProject.identityVerified)
+        #expect(runProject.observedProjectPath == project.path)
+
+        let artifact = try #require(runProject.artifacts.first)
+        #expect(artifact.state == "A")
+        #expect(artifact.verified)
+        #expect(artifact.bounceFired)
+        #expect(artifact.error == nil)
+        let evidence = try #require(artifact.evidence)
+        #expect(evidence.exists)
+        #expect(evidence.fileSizeBytes > 0)
+        #expect(evidence.durationSeconds > 0.1)
+        #expect(evidence.verificationStatus == "pass")
+        #expect(evidence.source == "audio_analyzer")
+        // The artifact file actually exists on disk — State A is not fabricated.
+        #expect(FileManager.default.fileExists(atPath: bouncePath))
+    }
+
+    @Test("resume skips already-present+verified artifacts and produces only the rest")
+    func resumeSkipsVerifiedAndCompletesRest() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Resume Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Resume Song", kind: "bounce")
+        let stemPath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Resume Song", kind: "stem")
+
+        // Pre-stage the bounce artifact as a verifiable file — it must be SKIPPED.
+        try writeToneWav(at: URL(fileURLWithPath: bouncePath))
+
+        // The bounce route writes whichever artifact is still missing (the stem).
+        let router = await makeExportRouter(bounceSideEffect: {
+            try? writeToneWav(at: URL(fileURLWithPath: stemPath))
+        })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                // skip_existing so the already-present bounce is not a fail_if_exists collision.
+                "collision_policy": .string("skip_existing"),
+                "artifacts": .array([.string("bounce"), .string("stem")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: true,
+            options: options
+        )
+
+        #expect(run.mode == "resume")
+        #expect(run.status == "completed")
+        #expect(run.artifactsTotal == 2)
+        #expect(run.artifactsSkipped == 1)
+        #expect(run.artifactsVerified == 1)
+
+        let artifacts = try #require(run.projects.first?.artifacts)
+        let bounce = try #require(artifacts.first { $0.kind == "bounce" })
+        let stem = try #require(artifacts.first { $0.kind == "stem" })
+        // The already-present bounce was skipped (State A, no bounce fired).
+        #expect(bounce.state == "A")
+        #expect(bounce.verified)
+        #expect(!bounce.bounceFired)
+        #expect(bounce.reason == "skipped_already_verified")
+        // The missing stem was produced (State A, bounce fired).
+        #expect(stem.state == "A")
+        #expect(stem.verified)
+        #expect(stem.bounceFired)
+    }
+
+    @Test("identity mismatch fails closed and never bounces the wrong project")
+    func identityMismatchFailsClosed() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Identity Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Identity Song", kind: "bounce")
+
+        let bounceFired = BoolFlag()
+        let router = await makeExportRouter(bounceSideEffect: {
+            bounceFired.set()
+            try? writeToneWav(at: URL(fileURLWithPath: bouncePath))
+        })
+        // Front document reports a DIFFERENT project than the one we planned.
+        let options = fastOptions(identity: { "/Users/someone/OtherProject.logicx" })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.status == "failed")
+        #expect(run.artifactsFailed == 1)
+        #expect(run.artifactsVerified == 0)
+
+        let runProject = try #require(run.projects.first)
+        #expect(runProject.opened)
+        #expect(!runProject.identityVerified)
+
+        let artifact = try #require(runProject.artifacts.first)
+        #expect(artifact.state == "C")
+        #expect(!artifact.verified)
+        #expect(!artifact.bounceFired)
+        let error = try #require(artifact.error)
+        #expect(error.contains("project_identity_mismatch"))
+        // Critically: no bounce was triggered and no file was written.
+        #expect(!bounceFired.isSet)
+        #expect(!FileManager.default.fileExists(atPath: bouncePath))
+    }
+
+    @Test("missing artifact after bounce gives State B (uncertain), not State A")
+    func missingArtifactGivesStateB() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Missing Song")
+
+        // Bounce SUCCEEDS at the channel level but writes NOTHING — the artifact
+        // never appears. Must NOT be reported as verified.
+        let router = await makeExportRouter(bounceSideEffect: { /* intentionally empty */ })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.status == "failed") // nothing reached State A
+        #expect(run.artifactsUncertain == 1)
+        #expect(run.artifactsVerified == 0)
+        let artifact = try #require(run.projects.first?.artifacts.first)
+        #expect(artifact.state == "B")
+        #expect(!artifact.verified)
+        #expect(artifact.bounceFired)
+        #expect(artifact.reason == "artifact_not_observed_within_poll_window")
+    }
+
+    @Test("silent artifact after bounce gives State B (uncertain), not State A")
+    func silentArtifactGivesStateB() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Silent Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Silent Song", kind: "bounce")
+
+        // Bounce writes a fully-silent WAV — present + non-zero but analysis fails.
+        let router = await makeExportRouter(bounceSideEffect: {
+            try? writeSilentWav(at: URL(fileURLWithPath: bouncePath))
+        })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.artifactsUncertain == 1)
+        #expect(run.artifactsVerified == 0)
+        let artifact = try #require(run.projects.first?.artifacts.first)
+        #expect(artifact.state == "B")
+        #expect(!artifact.verified)
+        #expect(artifact.bounceFired)
+        let reason = try #require(artifact.reason)
+        #expect(reason.contains("artifact_unverified"))
+        #expect(reason.contains("near_silent_output"))
+        let evidence = try #require(artifact.evidence)
+        #expect(evidence.silenceRatio >= 0.98)
+    }
+
+    @Test("fail_if_exists never overwrites an existing artifact (fails closed)")
+    func failIfExistsNeverOverwrites() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Collide Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Collide Song", kind: "bounce")
+
+        // Pre-existing artifact + default fail_if_exists policy => would_overwrite.
+        try writeToneWav(at: URL(fileURLWithPath: bouncePath))
+        let originalSize = (try FileManager.default.attributesOfItem(atPath: bouncePath)[.size] as? NSNumber)?.int64Value ?? 0
+
+        let bounceFired = BoolFlag()
+        let router = await makeExportRouter(bounceSideEffect: {
+            bounceFired.set()
+            // If this ran it would overwrite with a longer file — prove it doesn't.
+            try? writeToneWav(at: URL(fileURLWithPath: bouncePath), durationSeconds: 1.0)
+        })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                // fail_if_exists is the default, set explicitly for clarity.
+                "collision_policy": .string("fail_if_exists"),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.status == "failed")
+        #expect(run.artifactsFailed == 1)
+        #expect(run.artifactsVerified == 0)
+        let artifact = try #require(run.projects.first?.artifacts.first)
+        #expect(artifact.state == "C")
+        #expect(!artifact.verified)
+        let error = try #require(artifact.error)
+        #expect(error.contains("overwrite_blocked"))
+        // No bounce fired and the original file is byte-for-byte untouched.
+        #expect(!bounceFired.isSet)
+        let afterSize = (try FileManager.default.attributesOfItem(atPath: bouncePath)[.size] as? NSNumber)?.int64Value ?? -1
+        #expect(afterSize == originalSize)
+    }
+
+    @Test("confirmed:false fails closed with confirmation_required and no side effects")
+    func confirmedFalseFailsClosed() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Unconfirmed Song")
+        let bouncePath = plannedArtifactPath(outputRoot: outputRoot, displayName: "Unconfirmed Song", kind: "bounce")
+
+        let anyChannelOp = BoolFlag()
+        let router = await makeExportRouter(bounceSideEffect: {
+            anyChannelOp.set()
+            try? writeToneWav(at: URL(fileURLWithPath: bouncePath))
+        })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                // confirmed omitted entirely => treated as false.
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.status == "confirmation_required")
+        #expect(!run.confirmed)
+        #expect(run.artifactsFailed == 1)
+        #expect(run.artifactsVerified == 0)
+        #expect(run.nextSafeAction == "retry_with_confirmed_true")
+        let artifact = try #require(run.projects.first?.artifacts.first)
+        #expect(artifact.state == "C")
+        #expect(artifact.error == "confirmation_required")
+        // No bounce ran and no artifact was written.
+        #expect(!anyChannelOp.isSet)
+        #expect(!FileManager.default.fileExists(atPath: bouncePath))
+    }
+
+    @Test("open failure fails closed and never bounces")
+    func openFailureFailsClosed() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Unopenable Song")
+
+        let bounceFired = BoolFlag()
+        let router = await makeExportRouter(openSucceeds: false, bounceSideEffect: { bounceFired.set() })
+        let options = fastOptions(identity: { project.path })
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            resume: false,
+            options: options
+        )
+
+        #expect(run.status == "failed")
+        let runProject = try #require(run.projects.first)
+        #expect(!runProject.opened)
+        #expect(!runProject.identityVerified)
+        let artifact = try #require(runProject.artifacts.first)
+        #expect(artifact.state == "C")
+        let error = try #require(artifact.error)
+        #expect(error.contains("open_failed"))
+        #expect(!bounceFired.isSet)
+    }
+
+    // MARK: - Dispatcher integration
+
+    @Test("dispatcher export_run returns HC-truthful isError on a failed run")
+    func dispatcherExportRunIsErrorOnFailure() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Dispatch Song")
+
+        // Identity mismatch => failed run => isError must be true on the wire.
+        let router = await makeExportRouter()
+        let options = fastOptions(identity: { "/Users/elsewhere/Wrong.logicx" })
+        let cache = StateCache()
+
+        let result = await ProjectDispatcher.handle(
+            command: "export_run",
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            cache: cache,
+            exportOptions: options
+        )
+
+        // isError is Bool?; force-unwrap so a nil/false would FAIL (the
+        // `== true` form is a swift-testing dead assertion, issue #92).
+        #expect(try #require(result.isError))
+        let text = sharedToolText(result)
+        #expect(text.contains("\"schema\":\"logic_pro_mcp_export_run.v1\""))
+        #expect(text.contains("\"status\":\"failed\""))
+    }
+
+    @Test("dispatcher export_run rejects invalid params before any execution")
+    func dispatcherExportRunRejectsInvalidParams() async throws {
+        let router = await makeExportRouter()
+        let cache = StateCache()
+        let options = fastOptions(identity: { nil })
+
+        // Missing output_root => planner throws => rejected invalid_params.
+        let result = await ProjectDispatcher.handle(
+            command: "export_run",
+            params: [
+                "projects": .array([.string("/tmp/nope.logicx")]),
+                "confirmed": .bool(true),
+            ],
+            router: router,
+            cache: cache,
+            exportOptions: options
+        )
+
+        #expect(try #require(result.isError))
+        #expect(sharedToolText(result).contains("invalid_params"))
+    }
+
+    @Test("dispatcher export_run returns confirmation_required HC envelope when confirmed omitted")
+    func dispatcherExportRunConfirmationRequired() async throws {
+        let projDir = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projDir, named: "Gate Song")
+
+        let router = await makeExportRouter()
+        let options = fastOptions(identity: { project.path })
+        let cache = StateCache()
+
+        let result = await ProjectDispatcher.handle(
+            command: "export_run",
+            params: [
+                "projects": .array([.string(project.path)]),
+                "output_root": .string(outputRoot.path),
+                "artifacts": .array([.string("bounce")]),
+            ],
+            router: router,
+            cache: cache,
+            exportOptions: options
+        )
+
+        #expect(try #require(result.isError))
+        let text = sharedToolText(result)
+        #expect(text.contains("\"status\":\"confirmation_required\""))
+        #expect(text.contains("\"confirmed\":false"))
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -802,6 +802,8 @@ Example:
 | `is_running` | — | `"true"` or `"false"` | (direct) | L0 |
 | `get_regions` | — | JSON `RegionInfo[]` | Accessibility (read-only arrange area scan) | L0 |
 | `export_plan` | `{ projects?: string[], project?: string, output_root: string, artifacts?: string[], collision_policy?: "fail_if_exists"\|"skip_existing" }` | JSON `logic_pro_mcp_export_manifest.v1` dry-run plan | (direct, read-only filesystem checks) | L0 |
+| `export_run` | `{ ...same as export_plan, confirmed: bool }` | JSON `logic_pro_mcp_export_run.v1` guarded-execution result; per-artifact HC State A/B/C | AppleScript (open) + MIDIKeyCommands (bounce) + AudioAnalyzer (on-disk verify) | L2 |
+| `export_resume` | `{ ...same as export_run }` | JSON `logic_pro_mcp_export_run.v1` (`mode:"resume"`); idempotent — skips already present+verified artifacts | AppleScript + MIDIKeyCommands + AudioAnalyzer | L2 |
 | `audit` | — | `logic_pro_mcp_project_audit.v1` JSON | Cache/resource provenance synthesis | L0 |
 | `cleanup_plan` | — | `logic_pro_mcp_project_cleanup_plan.v1` JSON | Derived from audit; no mutation | L0 |
 | `launch` | — | text | AppleScript | L1 |
@@ -832,6 +834,21 @@ Example:
 Use `logic://project/audit` or `logic_project audit` to inspect a messy session without mutation. The audit reports `schema: "logic_pro_mcp_project_audit.v1"`, `status`, `read_only: true`, evidence/provenance sections, deterministic findings, and an embedded `cleanup_plan`.
 
 Use `logic://project/cleanup-plan` or `logic_project cleanup_plan` when a client only needs the serializable plan. Each step includes `target_identifier`, `proposed_operation`, `risk_level`, `required_confirmation`, `expected_readback`, `rollback_or_recovery`, `stop_condition`, `supported_by_current_tools`, and `mutates_project`.
+
+### Guarded export execution (`export_run` / `export_resume`)
+
+`export_plan` only describes a dry run. `export_run` performs the GUARDED execution of that same plan; `export_resume` is the idempotent re-entry of the identical state machine. Both return `schema: "logic_pro_mcp_export_run.v1"`.
+
+State machine, per project, per artifact:
+
+1. The planner is re-run so the contract you reviewed in `export_plan` is the contract that executes.
+2. `confirmed: true` is mandatory. Without it the run does nothing and returns `status: "confirmation_required"` (a State-C-shaped `confirmed:false` envelope, `isError:true`).
+3. Artifacts the plan reports as already present **and** independently re-verifiable on disk are **skipped** (this is what makes `export_resume` resumable). A leftover that is present but silent/zero/short is downgraded to State B, not skipped as a false success.
+4. For every artifact that still needs producing: the project is opened (existing open path), the **observed** front-document identity is read back and must match the planned project path (fail closed on mismatch — the wrong project is never bounced), the bounce is triggered (existing bounce path), the artifact file is polled for (bounded), then verified with `logic_audio` / `AudioAnalyzer` (exists + non-zero + non-silent + sane duration).
+5. Honest Contract per artifact: **State A** = bounce fired and on-disk verification passed (`verified:true`); **State B** = bounce fired but the artifact could not be verified (never appeared, or analysis warned/failed) — success uncertain; **State C** = a hard failure (confirmation gate, open/identity/bounce error, or collision-policy block).
+6. The plan's collision policy is honoured: under `fail_if_exists` an artifact that already exists is **never** overwritten — it fails closed (State C `overwrite_blocked`) instead of bouncing over the existing file.
+
+Run-level `status` is `completed` (all artifacts State A), `partial` (some State A, some uncertain/failed), `failed` (nothing reached State A), or `confirmation_required`. Each artifact carries `evidence` (size, duration, sample-rate, channels, silence-ratio, peak, verification status/reasons) so a client can audit exactly why State A was (or was not) granted.
 
 The first milestone is intentionally read-only: it can propose rename, mute/solo/arm reset, marker planning, or mixer-refresh steps, but it never executes them. Unsupported or unsafe cleanup actions are labelled `supported_by_current_tools:false`; deletion is never proposed by default.
 


### PR DESCRIPTION
## Summary
Implements Phase 2 of the batch export workflow (Phase-1 dry-run plan shipped in #99).

- New `logic_project export_run` / `export_resume { ...plan params, confirmed }` → result schema `logic_pro_mcp_export_run.v1`.
- Per-project state machine: open → confirm observed project identity (readback, fail-closed on mismatch) → bounce → bounded wait for artifact → verify via AudioAnalyzer (#94: exists/non-zero/non-silent/sane duration) → record evidence.
- HC: State A per artifact only after on-disk verification; State B if bounce fired but unverified; State C on failure. `export_resume` is idempotent (skips already-verified artifacts). No silent overwrite.
- Injectable `ProjectExportExecutor` seam → state machine/resume/fail-closed/HC unit-tested with fake router + injected FS + fixture wavs. New `ProjectExportExecutionTests` (11 tests). Full suite green.

## Live gate
Genuine State A requires a real bounce against live Logic. Logic + resume + fail-closed are fully unit-tested; live bounce verification is the close gate.

Refs #27