### PR TITLE
fix(#106): track mute/solo/arm via AX checkbox locator + read-back-polled write

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -1198,18 +1198,58 @@ enum AXLogicProElements {
 
     // MARK: - Track Controls
 
+    /// Find a track-header toggle control (Mute / Solo / Record-enable).
+    ///
+    /// #106: Logic Pro 12.x renders all three as `AXCheckBox` elements
+    /// (live-confirmed on 12.2: `desc="Mute"/"Solo"/"Record Enable"`,
+    /// `settable=false`, only `AXPress`) — NOT `AXButton`. The prior Mute/Solo
+    /// locators searched only `kAXButtonRole` and therefore returned nil on
+    /// 12.x, so `track.set_mute`/`set_solo` never reached an executable AX
+    /// write and the whole channel chain fell through to `channels_exhausted`.
+    /// Only the arm locator searched checkboxes (which is why arm at least
+    /// found its element). This unifies all three on the checkbox-first match
+    /// using the centralized `AXLocalePolicy` label sets, keeping the legacy
+    /// `AXButton` description/title fallback for build drift.
+    static func findTrackToggleControl(
+        in header: AXUIElement,
+        labels: [String],
+        legacyTitle: String,
+        runtime: Runtime = .production
+    ) -> AXUIElement? {
+        let checkboxes = AXHelpers.findAllDescendants(
+            of: header, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime.ax
+        )
+        if let match = checkboxes.first(where: { cb in
+            guard let desc = AXHelpers.getDescription(cb, runtime: runtime.ax) else { return false }
+            // Exact match preserves the historical arm locator semantics;
+            // prefix match tolerates trailing state suffixes some builds append.
+            return labels.contains(desc) || labels.contains { !$0.isEmpty && desc.hasPrefix($0) }
+        }) {
+            return match
+        }
+        // Legacy fallback: AXButton with description prefix / single-letter title.
+        for label in labels {
+            if let button = findButtonByDescriptionPrefix(in: header, prefix: label, runtime: runtime.ax) {
+                return button
+            }
+        }
+        return AXHelpers.findDescendant(of: header, role: kAXButtonRole, title: legacyTitle, runtime: runtime.ax)
+    }
+
     /// Find the mute button on a track header.
     static func findTrackMuteButton(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }
-        return findButtonByDescriptionPrefix(in: header, prefix: "Mute", runtime: runtime.ax)
-            ?? AXHelpers.findDescendant(of: header, role: kAXButtonRole, title: "M", runtime: runtime.ax)
+        return findTrackToggleControl(
+            in: header, labels: AXLocalePolicy.trackMuteButton.labels, legacyTitle: "M", runtime: runtime
+        )
     }
 
     /// Find the solo button on a track header.
     static func findTrackSoloButton(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }
-        return findButtonByDescriptionPrefix(in: header, prefix: "Solo", runtime: runtime.ax)
-            ?? AXHelpers.findDescendant(of: header, role: kAXButtonRole, title: "S", runtime: runtime.ax)
+        return findTrackToggleControl(
+            in: header, labels: AXLocalePolicy.trackSoloButton.labels, legacyTitle: "S", runtime: runtime
+        )
     }
 
     /// Find the record-arm button on a track header.
@@ -1217,22 +1257,9 @@ enum AXLogicProElements {
     /// `Record Enable` (EN) inside each track header.
     static func findTrackArmButton(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }
-        // Logic 12: per-track record-enable is an AXCheckBox
-        let checkboxes = AXHelpers.findAllDescendants(
-            of: header, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime.ax
+        return findTrackToggleControl(
+            in: header, labels: AXLocalePolicy.trackRecordEnableCheckbox.labels, legacyTitle: "R", runtime: runtime
         )
-        // Verbatim (case-sensitive) equality preserves the historical locator
-        // exactly; only the EN/KO label tokens move into AXLocalePolicy.
-        let armLabels = AXLocalePolicy.trackRecordEnableCheckbox.labels
-        for cb in checkboxes {
-            let desc = AXHelpers.getDescription(cb, runtime: runtime.ax) ?? ""
-            if armLabels.contains(desc) {
-                return cb
-            }
-        }
-        // Legacy fallback: AXButton with description / title
-        return findButtonByDescriptionPrefix(in: header, prefix: "Record", runtime: runtime.ax)
-            ?? AXHelpers.findDescendant(of: header, role: kAXButtonRole, title: "R", runtime: runtime.ax)
     }
 
     /// Find the track name text field on a header.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -1404,34 +1404,50 @@ actor AccessibilityChannel: Channel {
             return nil
         }
 
-        // Escalating strategy: each step verified by read-back. Stops on success.
-        // Logic Pro's custom AX checkboxes differ in what triggers them — some
-        // respond to AXPress, some only to direct value writes, some need a
-        // real mouse click at the button's screen position. The mouse-click
-        // last-resort fallback is intentional (see CHANGELOG v3.1.1 §retain-policy)
-        // — checkbox AX responds inconsistently across Logic 12 minor versions.
-        let strategies: [(String, () -> Void)] = [
-            ("press", { _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax) }),
-            ("confirm", { _ = AXHelpers.performAction(button, kAXConfirmAction, runtime: runtime.ax) }),
-            ("value-nsnumber", {
+        // #106: Logic 12.x track-header M/S/R checkboxes are `settable=false`
+        // and ignore `AXPress`/`AXConfirm`/value writes entirely — only a real
+        // mouse click at the control toggles Logic's internal state
+        // (live-confirmed: AXPress leaves the value at 0 indefinitely; a HID
+        // click flips it to 1 within ~350 ms). The earlier fixed 50 ms
+        // read-back was also too fast for Logic to publish the new AX value
+        // after a successful click, so even the arm path (whose locator did
+        // find the checkbox) reported a false `ax_write_failed` *after*
+        // physically toggling the control — a silent malfunction. The write
+        // now polls the read-back up to a per-strategy deadline, and the
+        // mouse-click last resort brings Logic frontmost first so the synthetic
+        // click lands on the (un-occluded) track header.
+        func pollMatched(deadlineMs: Int) -> Bool {
+            let deadline = Date().addingTimeInterval(Double(deadlineMs) / 1000.0)
+            repeat {
+                if let after = readCurrent(), after == desired { return true }
+                usleep(40_000)
+            } while Date() < deadline
+            return false
+        }
+
+        let strategies: [(name: String, pollMs: Int, action: () -> Void)] = [
+            ("press", 160, { _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax) }),
+            ("confirm", 160, { _ = AXHelpers.performAction(button, kAXConfirmAction, runtime: runtime.ax) }),
+            ("value-nsnumber", 160, {
                 let n: NSNumber = desired ? 1 : 0
                 AXHelpers.setAttribute(button, kAXValueAttribute, n as CFTypeRef, runtime: runtime.ax)
             }),
-            ("value-cfbool", {
+            ("value-cfbool", 160, {
                 let b: CFBoolean = desired ? kCFBooleanTrue : kCFBooleanFalse
                 AXHelpers.setAttribute(button, kAXValueAttribute, b, runtime: runtime.ax)
             }),
-            ("mouse-click", {
+            ("mouse-click", 1_000, {
+                _ = ProcessUtils.Runtime.production.activateLogicPro()
+                usleep(120_000)
                 Self.postMouseClickAt(element: button, runtime: runtime.ax)
             }),
         ]
-        for (name, action) in strategies {
-            action()
-            usleep(50_000)
-            if let after = readCurrent(), after == desired {
+        for strategy in strategies {
+            strategy.action()
+            if pollMatched(deadlineMs: strategy.pollMs) {
                 return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
                     "observed": desired,
-                    "action": name
+                    "action": strategy.name
                 ]) { _, new in new }))
             }
         }

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -191,6 +191,12 @@ struct TrackDispatcher {
                 operation: "track.set_mute",
                 params: ["index": String(index), "enabled": String(enabled)]
             )
+            // #106: never surface an unverified channel success — a State B
+            // "success without read-back" is reported as an error so callers
+            // can't mistake a fired-but-unconfirmed toggle for a verified one.
+            if result.isSuccess, !trackToggleResultIsVerified(result) {
+                return toolTextResult(result.message, isError: true)
+            }
             return toolTextResult(result)
 
         case "solo":
@@ -212,6 +218,10 @@ struct TrackDispatcher {
                 operation: "track.set_solo",
                 params: ["index": String(index), "enabled": String(enabled)]
             )
+            // #106: same verified-only gate as mute/arm.
+            if result.isSuccess, !trackToggleResultIsVerified(result) {
+                return toolTextResult(result.message, isError: true)
+            }
             return toolTextResult(result)
 
         case "arm":
@@ -233,7 +243,7 @@ struct TrackDispatcher {
                 operation: "track.set_arm",
                 params: ["index": String(index), "enabled": String(enabled)]
             )
-            if result.isSuccess, !trackArmResultIsVerified(result) {
+            if result.isSuccess, !trackToggleResultIsVerified(result) {
                 return toolTextResult(result.message, isError: true)
             }
             return toolTextResult(result)
@@ -256,7 +266,7 @@ struct TrackDispatcher {
                 )
                 if !r.isSuccess {
                     failedDisarm.append(t.id)
-                } else if trackArmResultIsVerified(r) {
+                } else if trackToggleResultIsVerified(r) {
                     disarmed.append(t.id)
                 } else {
                     unverifiedDisarm.append(t.id)
@@ -275,7 +285,7 @@ struct TrackDispatcher {
                     isError: true
                 )
             }
-            if !trackArmResultIsVerified(armResult) {
+            if !trackToggleResultIsVerified(armResult) {
                 return toolTextResult(
                     armOnlyResponse(
                         targetIndex: index,
@@ -423,7 +433,7 @@ struct TrackDispatcher {
         }
     }
 
-    private static func trackArmResultIsVerified(_ result: ChannelResult) -> Bool {
+    private static func trackToggleResultIsVerified(_ result: ChannelResult) -> Bool {
         guard result.isSuccess else { return false }
         guard let json = trackArmEnvelope(result),
               json["success"] != nil else {

--- a/Tests/LogicProMCPTests/Issue106TrackToggleLocatorTests.swift
+++ b/Tests/LogicProMCPTests/Issue106TrackToggleLocatorTests.swift
@@ -1,0 +1,115 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #106 regression: Logic 12.x track-header Mute/Solo/Record-enable controls
+/// are `AXCheckBox` elements, not `AXButton`. The pre-fix Mute/Solo locators
+/// searched only `kAXButtonRole`, returned nil, and the whole channel chain
+/// fell through to `channels_exhausted`. `findTrackToggleControl` must match
+/// the checkbox by its (localized) description.
+@Suite("Issue106 track-toggle locator")
+struct Issue106TrackToggleLocatorTests {
+    private struct Header {
+        let builder: FakeAXRuntimeBuilder
+        let header: AXUIElement
+        let runtime: AXLogicProElements.Runtime
+        let mute: AXUIElement
+        let solo: AXUIElement
+        let arm: AXUIElement
+    }
+
+    /// Build a fake track header whose children are the four Logic 12.x
+    /// checkboxes (Mute / Solo / Record Enable / Input Monitoring), localized
+    /// per `descriptions`.
+    private func makeHeader(_ descriptions: (mute: String, solo: String, arm: String)) -> Header {
+        let b = FakeAXRuntimeBuilder()
+        let header = b.element(1)
+        b.setAttribute(header, kAXRoleAttribute, "AXLayoutItem")
+        func checkbox(_ id: Int, _ desc: String) -> AXUIElement {
+            let e = b.element(id)
+            b.setAttribute(e, kAXRoleAttribute, "AXCheckBox")
+            b.setAttribute(e, kAXDescriptionAttribute, desc)
+            b.setAttribute(e, kAXValueAttribute, 0)
+            return e
+        }
+        let mute = checkbox(2, descriptions.mute)
+        let solo = checkbox(3, descriptions.solo)
+        let arm = checkbox(4, descriptions.arm)
+        let input = checkbox(5, "Input Monitoring")
+        b.setChildren(header, [mute, solo, arm, input])
+        return Header(builder: b, header: header, runtime: b.makeLogicRuntime(), mute: mute, solo: solo, arm: arm)
+    }
+
+    private func sameElement(_ a: AXUIElement?, _ b: AXUIElement) -> Bool {
+        guard let a else { return false }
+        return CFEqual(a, b)
+    }
+
+    @Test("English checkboxes: Mute/Solo/Record Enable are located")
+    func englishCheckboxes() {
+        let h = makeHeader((mute: "Mute", solo: "Solo", arm: "Record Enable"))
+        let mute = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackMuteButton.labels, legacyTitle: "M", runtime: h.runtime)
+        let solo = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackSoloButton.labels, legacyTitle: "S", runtime: h.runtime)
+        let arm = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackRecordEnableCheckbox.labels, legacyTitle: "R", runtime: h.runtime)
+        #expect(sameElement(mute, h.mute))
+        #expect(sameElement(solo, h.solo))
+        #expect(sameElement(arm, h.arm))
+    }
+
+    @Test("Korean checkboxes: 음소거/솔로/녹음 활성화 are located")
+    func koreanCheckboxes() {
+        let h = makeHeader((mute: "음소거", solo: "솔로", arm: "녹음 활성화"))
+        let mute = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackMuteButton.labels, legacyTitle: "M", runtime: h.runtime)
+        let solo = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackSoloButton.labels, legacyTitle: "S", runtime: h.runtime)
+        let arm = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackRecordEnableCheckbox.labels, legacyTitle: "R", runtime: h.runtime)
+        #expect(sameElement(mute, h.mute))
+        #expect(sameElement(solo, h.solo))
+        #expect(sameElement(arm, h.arm))
+    }
+
+    @Test("does not mismatch the Input Monitoring checkbox")
+    func inputMonitoringNotMistaken() {
+        let h = makeHeader((mute: "Mute", solo: "Solo", arm: "Record Enable"))
+        // The arm matcher's "Record" prefix must not bind to Input Monitoring.
+        let arm = AXLogicProElements.findTrackToggleControl(
+            in: h.header, labels: AXLocalePolicy.trackRecordEnableCheckbox.labels, legacyTitle: "R", runtime: h.runtime)
+        #expect(sameElement(arm, h.arm))
+        #expect(!sameElement(arm, h.builder.element(5)))
+    }
+
+    @Test("returns nil when no matching control exists (fail-closed)")
+    func noMatchReturnsNil() {
+        let b = FakeAXRuntimeBuilder()
+        let header = b.element(1)
+        b.setAttribute(header, kAXRoleAttribute, "AXLayoutItem")
+        let unrelated = b.element(2)
+        b.setAttribute(unrelated, kAXRoleAttribute, "AXCheckBox")
+        b.setAttribute(unrelated, kAXDescriptionAttribute, "Input Monitoring")
+        b.setChildren(header, [unrelated])
+        let mute = AXLogicProElements.findTrackToggleControl(
+            in: header, labels: AXLocalePolicy.trackMuteButton.labels, legacyTitle: "M", runtime: b.makeLogicRuntime())
+        #expect(mute == nil)
+    }
+
+    @Test("legacy AXButton fallback still works for older builds")
+    func legacyButtonFallback() {
+        // No checkboxes; a legacy AXButton with a "Mute" description.
+        let b = FakeAXRuntimeBuilder()
+        let header = b.element(1)
+        b.setAttribute(header, kAXRoleAttribute, "AXLayoutItem")
+        let muteButton = b.element(2)
+        b.setAttribute(muteButton, kAXRoleAttribute, "AXButton")
+        b.setAttribute(muteButton, kAXDescriptionAttribute, "Mute")
+        b.setChildren(header, [muteButton])
+        let mute = AXLogicProElements.findTrackToggleControl(
+            in: header, labels: AXLocalePolicy.trackMuteButton.labels, legacyTitle: "M", runtime: b.makeLogicRuntime())
+        #expect(sameElement(mute, muteButton))
+    }
+}


### PR DESCRIPTION
Closes #106.

## Problem (reproduced live, not environmental)

`logic_tracks.mute/solo/arm` (enable) returned `channels_exhausted` — `"No keyboard shortcut mapped for: track.set_mute"`. The routing chain is `[.accessibility, .mcu, .cgEvent]`; the user hasn't mapped Logic key commands and the MCU control surface isn't registered, so failures cascaded to CGEvent and exhausted. The *primary* Accessibility channel was failing for two distinct reasons:

1. **Locator role mismatch.** Logic 12.x track-header Mute/Solo/Record-enable are **`AXCheckBox`** (live AX dump: `desc="Mute"/"Solo"/"Record Enable"`, `settable=false`, only `AXPress`) — not `AXButton`. `findTrackMuteButton`/`findTrackSoloButton` searched only `kAXButtonRole`, returned **nil**, and the AX channel errored before doing anything. Only `findTrackArmButton` searched checkboxes (so arm at least found its element).

2. **Write never landed + false negatives.** These checkboxes ignore `AXPress`/`AXConfirm`/value writes; **only a real HID mouse click toggles Logic's internal state** (~350 ms to publish the new AX value). The old fixed **50 ms** read-back was too fast — even arm (whose locator worked) reported `ax_write_failed` *after physically toggling the control*, a silent malfunction.

## Fix

- **`AXLogicProElements.findTrackToggleControl`** — unified checkbox-first locator for all three, keyed on the centralized `AXLocalePolicy` label sets (EN `Mute`/`Solo`/`Record Enable` + KO `음소거`/`솔로`/`녹음 활성화`), with the legacy `AXButton` description/title fallback retained for build drift.
- **`defaultSetTrackToggle`** — replaced the fixed 50 ms read-back with a per-strategy **read-back poll**; the mouse-click last resort now brings Logic frontmost first so the synthetic click lands on the un-occluded header.
- **`TrackDispatcher`** — applied the verified-only gate (previously arm-only) to mute/solo too (`trackArmResultIsVerified` → generic `trackToggleResultIsVerified`); an unverified channel success can never surface as a confirmed toggle.

## Verification

**Live (fresh `.build/release` vs real Logic 12.2):**
```
mute  isMuted ->True : cmd_verified=True observed=True action=mouse-click isErr=False | readback isMuted=True  => PASS
mute  isMuted ->False: ...                                                            | readback isMuted=False => PASS
solo  isSoloed->True/False  => PASS / PASS  (readback-confirmed)
arm   isArmed ->True/False  => PASS / PASS  (readback-confirmed)
RESULT: 6/6 steps PASS — original state restored
```
Every write reaches verified State A via `mouse-click`, `isError=false`, and an independent `logic://tracks` read-back confirms the state.

**Unit:** `Issue106TrackToggleLocatorTests` — EN + KO checkbox location, Input-Monitoring not mismatched, fail-closed nil when absent, legacy AXButton fallback.

**Suite:** `swift test --no-parallel` → 0 issues. (Pre-existing `LoggerTests` global-state parallel flake is unrelated; passes in isolation/serialized.)

## Note
mute/solo/arm depend on the mouse-click path because Logic exposes no settable AX value and the user has neither mapped key commands nor registered the MCU surface. The fix makes the deterministic AX path reliable; it is fail-closed (typed `ax_write_failed` State C) if even the click can't be confirmed.