### PR TITLE
fix(#107): mixer set_volume/set_pan actually write (track-header AXIncrement/AXDecrement nudge)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -570,6 +570,41 @@ enum AXLogicProElements {
             .element
     }
 
+    /// #107: the per-track volume fader inside the track HEADER (an AXSlider
+    /// whose value-indicator reads "Volume"). Same channel parameter as the
+    /// mixer-strip fader, but identity-safe — it belongs to exactly track
+    /// `index` — and always present without the Mixer being visible. Logic
+    /// ignores AXValue writes on it, so callers drive it with
+    /// AXIncrement/AXDecrement detents.
+    static func findTrackHeaderVolumeFader(at index: Int, runtime: Runtime = .production) -> AXUIElement? {
+        guard let header = findTrackHeader(at: index, runtime: runtime) else { return nil }
+        return findVolumeFader(in: header, runtime: runtime.ax)
+    }
+
+    /// #107: the per-track pan slider inside the track HEADER. Its own
+    /// description is empty; the "Pan"/"팬" label lives on its
+    /// `AXValueIndicator` child. Falls back to the non-volume slider.
+    static func findTrackHeaderPanControl(at index: Int, runtime: Runtime = .production) -> AXUIElement? {
+        guard let header = findTrackHeader(at: index, runtime: runtime) else { return nil }
+        return findPanControlInHeader(header, runtime: runtime.ax)
+    }
+
+    /// Header-level pan-slider selection (split out for deterministic testing).
+    static func findPanControlInHeader(_ header: AXUIElement, runtime: AXHelpers.Runtime = .production) -> AXUIElement? {
+        let sliders = AXHelpers.findAllDescendants(of: header, role: kAXSliderRole, maxDepth: 4, runtime: runtime)
+        if let pan = sliders.first(where: { slider in
+            AXHelpers.getChildren(slider, runtime: runtime).contains { child in
+                let desc = (AXHelpers.getDescription(child, runtime: runtime) ?? "").lowercased()
+                return desc.contains("pan") || desc.contains("팬") || desc.contains("밸런스")
+            }
+        }) {
+            return pan
+        }
+        // Fallback: the slider that is NOT the volume fader.
+        let volume = findVolumeFader(in: header, runtime: runtime)
+        return sliders.first { volume == nil || !CFEqual($0, volume!) }
+    }
+
     /// Find a volume fader for a specific track index within the mixer.
     static func findFader(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let mixer = getMixerArea(runtime: runtime) else { return nil }

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -208,25 +208,28 @@ enum AXValueExtractors {
         return 1.0
     }
 
-    /// Set a Logic mixer fader using the public 0.0...1.0 contract value. When
-    /// Logic exposes the raw 0...233 AX range, interpolate through the observed
-    /// taper first so write and readback use the same contract space.
-    @discardableResult
-    static func setLogicMixerFaderValue(
-        _ element: AXUIElement,
-        _ value: Double,
-        runtime: AXHelpers.Runtime = .production
-    ) -> Bool {
-        let clamped = min(max(value, 0.0), 1.0)
-        guard let range = extractSliderRange(element, runtime: runtime),
-              range.max > range.min else {
-            return setSliderValue(element, clamped, runtime: runtime)
-        }
+    /// #107: target raw AX value for a desired public mixer volume contract,
+    /// for the `AXIncrement`/`AXDecrement` nudge writer (Logic ignores `AXValue`
+    /// writes on its faders). Mirrors `setLogicMixerFaderValue`'s contract→raw
+    /// math without performing the (ineffective) write.
+    static func logicMixerFaderContractToRaw(_ contract: Double, range: SliderRange) -> Double {
+        let clamped = min(max(contract, 0.0), 1.0)
         let position = isLogicMixerRawFaderRange(range)
             ? logicMixerFaderContractToPosition(clamped)
             : clamped
-        let raw = range.min + position * (range.max - range.min)
-        return setSliderValue(element, raw, runtime: runtime)
+        return range.min + position * (range.max - range.min)
+    }
+
+    /// #107: read a unipolar Logic track-header pan slider (live range 0...127,
+    /// electrical center at the midpoint) as the public -1.0...1.0 pan contract.
+    /// The header pan slider's `AXMinValue` is 0 (not negative), so the bipolar
+    /// `extractCenteredSliderValue` can't be used here.
+    static func headerPanContract(_ element: AXUIElement, range: SliderRange, runtime: AXHelpers.Runtime = .production) -> Double? {
+        guard let raw = extractSliderValue(element, runtime: runtime) else { return nil }
+        let center = (range.min + range.max) / 2.0
+        let half = (range.max - range.min) / 2.0
+        guard half > 0 else { return nil }
+        return min(max((raw - center) / half, -1.0), 1.0)
     }
 
     /// Normalize a bipolar Logic AX slider to -1.0...1.0. Pan knobs in Logic
@@ -249,31 +252,6 @@ enum AXValueExtractors {
         return min(value / range.max, 1.0)
     }
 
-    /// Set a centered slider using the public -1.0...1.0 contract. Logic 12.2
-    /// pan knobs expose an asymmetric integer AX range (-64...63), so map the
-    /// negative and positive sides independently to preserve true center.
-    @discardableResult
-    static func setCenteredSliderValue(
-        _ element: AXUIElement,
-        _ value: Double,
-        runtime: AXHelpers.Runtime = .production
-    ) -> Bool {
-        let clamped = min(max(value, -1.0), 1.0)
-        guard let range = extractSliderRange(element, runtime: runtime),
-              range.min < 0.0,
-              range.max > 0.0 else {
-            return setSliderValue(element, clamped, runtime: runtime)
-        }
-        let raw: Double
-        if clamped < 0.0 {
-            raw = clamped * abs(range.min)
-        } else if clamped > 0.0 {
-            raw = clamped * range.max
-        } else {
-            raw = 0.0
-        }
-        return setSliderValue(element, raw, runtime: runtime)
-    }
 
     /// Read a track header and extract its basic state.
     static func extractTrackState(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3744,19 +3744,6 @@ actor AccessibilityChannel: Channel {
         ))
     }
 
-    private static func mixerControlValue(
-        from slider: AXUIElement,
-        target: MixerTarget,
-        runtime: AXHelpers.Runtime
-    ) -> Double? {
-        switch target {
-        case .volume:
-            return AXValueExtractors.extractLogicMixerFaderValue(slider, runtime: runtime)
-        case .pan:
-            return AXValueExtractors.extractCenteredSliderValue(slider, runtime: runtime)
-        }
-    }
-
     // MARK: - Regions
 
     /// Read all regions (MIDI/audio clips) currently shown in the arrange area.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3625,116 +3625,118 @@ actor AccessibilityChannel: Channel {
             "track_index": index,
             "control": label,
         ]
-        guard let mixer = AXLogicProElements.getMixerArea(runtime: runtime) else {
-            return .error(HonestContract.encodeStateC(
-                error: .elementNotFound,
-                hint: "Cannot locate visible mixer for \(operation)",
-                extras: [
-                    "operation": operation,
-                    "track": index,
-                    "requested": value,
-                    "target_identity": targetIdentity,
-                    "recovery_hint": "Open View > Show Mixer in Logic Pro and retry the mixer write.",
-                ]
-            ))
-        }
-        let strips = AXLogicProElements.mixerChannelStrips(in: mixer, runtime: runtime.ax)
-        guard index >= 0 && index < strips.count else {
-            return .error(HonestContract.encodeStateC(
-                error: .elementNotFound,
-                hint: "track index \(index) is not present in the visible mixer",
-                extras: [
-                    "operation": operation,
-                    "track": index,
-                    "requested": value,
-                    "target_identity": targetIdentity,
-                    "visible_strips": strips.count,
-                ]
-            ))
-        }
-        let strip = strips[index]
+
+        // #107: target the per-track fader/pan slider in the track HEADER. It is
+        // the same channel parameter as the mixer-strip control but identity-safe
+        // (it belongs to exactly track `index`, so we can never write the wrong
+        // strip the way positional indexing into a 2-strip Inspector mixer could)
+        // and is available without the Mixer being visible. Logic ignores AXValue
+        // writes on these sliders entirely (live-confirmed: `set 0.5` leaves a
+        // 0.76 fader unmoved) — only AXIncrement/AXDecrement detents move them,
+        // in deterministic ~10-raw-unit steps. We converge to the nearest
+        // representable detent and read back every step.
         let slider: AXUIElement?
         switch target {
-        case .volume:
-            slider = AXLogicProElements.findVolumeFader(in: strip, runtime: runtime.ax)
-        case .pan:
-            slider = AXLogicProElements.findPanControl(in: strip, runtime: runtime.ax)
+        case .volume: slider = AXLogicProElements.findTrackHeaderVolumeFader(at: index, runtime: runtime)
+        case .pan:    slider = AXLogicProElements.findTrackHeaderPanControl(at: index, runtime: runtime)
         }
         guard let slider else {
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "Cannot locate \(label) control for visible mixer track \(index)",
+                hint: "Cannot locate \(label) control for track \(index)",
                 extras: [
                     "operation": operation,
                     "track": index,
                     "requested": value,
                     "target_identity": targetIdentity,
-                    "visible_strips": strips.count,
+                    "recovery_hint": "Ensure track \(index) exists and the Tracks area is shown.",
+                ]
+            ))
+        }
+        guard let range = AXValueExtractors.extractSliderRange(slider, runtime: runtime.ax),
+              range.max > range.min else {
+            return .error(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "\(label) slider for track \(index) exposes no AX range",
+                extras: [
+                    "operation": operation, "track": index, "requested": value,
+                    "target_identity": targetIdentity, "verify_source": "ax_slider",
                 ]
             ))
         }
 
-        let tolerance = 0.01
-        let observedBefore = mixerControlValue(from: slider, target: target, runtime: runtime.ax)
-        var observedAfter = observedBefore
-        var writeAttempts = 0
-        var stagnantSteps = 0
-        let maxWriteAttempts = 128
-        while writeAttempts < maxWriteAttempts {
-            guard setMixerControlValue(slider, target: target, requested: value, runtime: runtime.ax) else {
-                if writeAttempts == 0 {
-                    return .error(HonestContract.encodeStateC(
-                        error: .axWriteFailed,
-                        hint: "AX write failed for \(label) on visible mixer track \(index)",
-                        extras: [
-                            "operation": operation,
-                            "track": index,
-                            "requested": value,
-                            "target_identity": targetIdentity,
-                            "observed_before": observedBefore ?? NSNull(),
-                            "verify_source": "ax_slider",
-                        ]
-                    ))
-                }
-                break
+        func readContract() -> Double? {
+            switch target {
+            case .volume: return AXValueExtractors.extractLogicMixerFaderValue(slider, runtime: runtime.ax)
+            case .pan:    return AXValueExtractors.headerPanContract(slider, range: range, runtime: runtime.ax)
             }
-            writeAttempts += 1
-            usleep(10_000)
-            let nextObserved = mixerControlValue(from: slider, target: target, runtime: runtime.ax)
-            if let nextObserved, abs(nextObserved - value) < tolerance {
-                observedAfter = nextObserved
-                break
-            }
-            if nextObserved == observedAfter {
-                stagnantSteps += 1
-                if stagnantSteps >= 5 {
-                    observedAfter = nextObserved
-                    break
-                }
-            } else {
-                stagnantSteps = 0
-            }
-            observedAfter = nextObserved
+        }
+        let observedBefore = readContract()
+
+        // Desired raw AX value for the requested contract value.
+        let targetRaw: Double
+        switch target {
+        case .volume:
+            targetRaw = AXValueExtractors.logicMixerFaderContractToRaw(value, range: range)
+        case .pan:
+            let center = (range.min + range.max) / 2.0
+            let half = (range.max - range.min) / 2.0
+            targetRaw = center + min(max(value, -1.0), 1.0) * half
         }
 
-        let baseExtras: [String: Any] = [
+        // Closed-loop AXIncrement/AXDecrement nudge toward `targetRaw`. Stops on
+        // reaching/crossing the target (landing on the nearer detent) or when no
+        // detent moves the value (rail / unresponsive).
+        var current = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        var steps = 0
+        var stagnant = 0
+        let maxSteps = 64
+        while let cur = current, steps < maxSteps {
+            if abs(cur - targetRaw) < 0.5 { break }
+            let goingUp = cur < targetRaw
+            _ = AXHelpers.performAction(slider, goingUp ? kAXIncrementAction : kAXDecrementAction, runtime: runtime.ax)
+            steps += 1
+            usleep(25_000)
+            guard let next = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else { break }
+            let crossed = (cur < targetRaw && next >= targetRaw) || (cur > targetRaw && next <= targetRaw)
+            if crossed {
+                // Land on whichever of cur/next is closer to the target.
+                if abs(cur - targetRaw) < abs(next - targetRaw) {
+                    _ = AXHelpers.performAction(slider, goingUp ? kAXDecrementAction : kAXIncrementAction, runtime: runtime.ax)
+                    usleep(25_000)
+                }
+                break
+            }
+            if next == cur { stagnant += 1; if stagnant >= 2 { break } } else { stagnant = 0 }
+            current = next
+        }
+
+        let observedRaw = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        let observedAfter = readContract()
+        // One detent is ~10 raw units; "verified" means we converged to the
+        // nearest AX-representable detent (within ~half a detent of target).
+        let convergedToNearestDetent = observedRaw.map { abs($0 - targetRaw) <= 6.0 } ?? false
+
+        var baseExtras: [String: Any] = [
             "operation": operation,
             "track": index,
             "control": label,
             "requested": value,
             "target_identity": targetIdentity,
-            "visible_strips": strips.count,
             "observed_before": observedBefore ?? NSNull(),
             "observed_after": observedAfter ?? NSNull(),
             "observed": observedAfter ?? NSNull(),
+            "observed_raw": observedRaw ?? NSNull(),
+            "target_raw": targetRaw,
+            "detent_raw_step": 10,
             "verify_source": "ax_slider",
-            "write_attempted": true,
-            "write_attempts": writeAttempts,
+            "write_method": "ax_increment_decrement",
+            "nudge_steps": steps,
+            "quantization_note": "Logic exposes this fader to AX in ~10-raw-unit detents; observed is the nearest representable level to requested.",
         ]
-        if let actual = observedAfter, abs(actual - value) < tolerance {
-            return .success(HonestContract.encodeStateA(
-                extras: baseExtras.merging(["observed": actual]) { _, new in new }
-            ))
+        if convergedToNearestDetent, let actual = observedAfter {
+            baseExtras["observed"] = actual
+            return .success(HonestContract.encodeStateA(extras: baseExtras))
         }
         return .success(HonestContract.encodeStateB(
             reason: observedAfter == nil ? .readbackUnavailable : .readbackMismatch,
@@ -3752,20 +3754,6 @@ actor AccessibilityChannel: Channel {
             return AXValueExtractors.extractLogicMixerFaderValue(slider, runtime: runtime)
         case .pan:
             return AXValueExtractors.extractCenteredSliderValue(slider, runtime: runtime)
-        }
-    }
-
-    private static func setMixerControlValue(
-        _ slider: AXUIElement,
-        target: MixerTarget,
-        requested: Double,
-        runtime: AXHelpers.Runtime
-    ) -> Bool {
-        switch target {
-        case .volume:
-            return AXValueExtractors.setLogicMixerFaderValue(slider, requested, runtime: runtime)
-        case .pan:
-            return AXValueExtractors.setCenteredSliderValue(slider, requested, runtime: runtime)
         }
     }
 

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -167,6 +167,68 @@ private func makeAXBackedAccessibilityChannel(
     return AccessibilityChannel(runtime: runtime)
 }
 
+/// #107: a logic runtime whose AXIncrement/AXDecrement move a slider by one
+/// ~10-raw-unit detent (clamped to AXMin/AXMax), so the closed-loop nudge
+/// writer (`mixer.set_volume`/`set_pan`) converges against a fake AX tree.
+private func nudgeResponsiveLogicRuntime(_ builder: FakeAXRuntimeBuilder, app: AXUIElement) -> AXLogicProElements.Runtime {
+    builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            let number: @Sendable (String) -> Double? = { attr in
+                if let n = builder.attributeValue(element, attr) as? NSNumber { return n.doubleValue }
+                return builder.attributeValue(element, attr) as? Double
+            }
+            let delta: Double = (action == (kAXIncrementAction as String)) ? 10
+                : ((action == (kAXDecrementAction as String)) ? -10 : 0)
+            guard delta != 0, let cur = number(kAXValueAttribute as String) else { return true }
+            let lo = number(kAXMinValueAttribute as String) ?? -1e9
+            let hi = number(kAXMaxValueAttribute as String) ?? 1e9
+            builder.setAttribute(element, kAXValueAttribute as String, Swift.min(Swift.max(cur + delta, lo), hi))
+            return true
+        }
+    )
+}
+
+/// #107: build a Logic-12-style track-header rail (AXList id="Track Headers")
+/// with one header carrying a "Volume" fader (range/value) and a pan slider
+/// (empty desc, "0 Pan" value-indicator child). Returns the fader + pan.
+@discardableResult
+private func attachTrackHeaderRail(
+    _ builder: FakeAXRuntimeBuilder,
+    window: AXUIElement,
+    siblings: [AXUIElement],
+    baseID: Int,
+    volume: (value: Double, min: Double, max: Double),
+    pan: (value: Double, min: Double, max: Double)
+) -> (volume: AXUIElement, pan: AXUIElement) {
+    let rail = builder.element(baseID)
+    builder.setAttribute(rail, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(rail, kAXIdentifierAttribute as String, "Track Headers")
+    let header = builder.element(baseID + 1)
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    let volumeSlider = builder.element(baseID + 2)
+    builder.setAttribute(volumeSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(volumeSlider, kAXDescriptionAttribute as String, "Volume")
+    builder.setAttribute(volumeSlider, kAXValueAttribute as String, volume.value)
+    builder.setAttribute(volumeSlider, kAXMinValueAttribute as String, volume.min)
+    builder.setAttribute(volumeSlider, kAXMaxValueAttribute as String, volume.max)
+    let panSlider = builder.element(baseID + 3)
+    builder.setAttribute(panSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(panSlider, kAXDescriptionAttribute as String, "")
+    builder.setAttribute(panSlider, kAXValueAttribute as String, pan.value)
+    builder.setAttribute(panSlider, kAXMinValueAttribute as String, pan.min)
+    builder.setAttribute(panSlider, kAXMaxValueAttribute as String, pan.max)
+    let panIndicator = builder.element(baseID + 4)
+    builder.setAttribute(panIndicator, kAXRoleAttribute as String, "AXValueIndicator")
+    builder.setAttribute(panIndicator, kAXDescriptionAttribute as String, "0 Pan")
+    builder.setChildren(panSlider, [panIndicator])
+    builder.setChildren(header, [volumeSlider, panSlider])
+    builder.setChildren(rail, [header])
+    builder.setChildren(window, siblings + [rail])
+    return (volumeSlider, panSlider)
+}
+
 private func makeSetInstrumentFixture() -> (
     builder: FakeAXRuntimeBuilder,
     app: AXUIElement,
@@ -1736,7 +1798,6 @@ private func makeSetInstrumentFixture() -> (
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
     builder.setAttribute(window, kAXTitleAttribute as String, "Song.logicx")
-    builder.setChildren(window, [mixer])
     builder.setAttribute(mixer, kAXRoleAttribute as String, kAXGroupRole as String)
     builder.setAttribute(mixer, kAXIdentifierAttribute as String, "Mixer")
     builder.setChildren(mixer, [strip])
@@ -1745,8 +1806,16 @@ private func makeSetInstrumentFixture() -> (
     builder.setAttribute(fader, kAXValueAttribute as String, 0.8)
     builder.setAttribute(pan, kAXRoleAttribute as String, kAXSliderRole as String)
     builder.setAttribute(pan, kAXValueAttribute as String, -0.25)
+    // #107: writes target the per-track header fader/pan, not the mixer strip.
+    let headerControls = attachTrackHeaderRail(
+        builder, window: window, siblings: [mixer], baseID: 3_040,
+        volume: (value: 173, min: 0, max: 233),
+        pan: (value: 64, min: 0, max: 127)
+    )
 
-    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, logicRuntime: nudgeResponsiveLogicRuntime(builder, app: app)
+    )
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
 
@@ -1769,22 +1838,20 @@ private func makeSetInstrumentFixture() -> (
     #expect((volumeObj["verified"] as? Bool)!)
     #expect(volumeObj["operation"] as? String == "mixer.set_volume")
     #expect(volumeObj["verify_source"] as? String == "ax_slider")
-    #expect(volumeObj["observed_before"] as? Double == 0.8)
-    #expect(volumeObj["observed_after"] as? Double == 0.5)
+    // Nudge converges to the nearest ~10-raw-unit detent → observed within a detent of 0.5.
+    #expect(abs((volumeObj["observed_after"] as? Double ?? -9) - 0.5) < 0.07)
     #expect((volumeObj["target_identity"] as? [String: Any])?["track_index"] as? Int == 0)
-    #expect((builder.attributeValue(fader, kAXValueAttribute as String) as? NSNumber)?.doubleValue == 0.5)
 
-    let panResult = await channel.execute(operation: "mixer.set_pan", params: ["index": "0", "value": "-0.1"])
+    let panResult = await channel.execute(operation: "mixer.set_pan", params: ["index": "0", "value": "-0.5"])
     #expect(panResult.isSuccess)
     let panObj = decodeAccessibilityJSON(panResult.message)
     #expect((panObj["success"] as? Bool)!)
     #expect((panObj["verified"] as? Bool)!)
     #expect(panObj["operation"] as? String == "mixer.set_pan")
     #expect(panObj["verify_source"] as? String == "ax_slider")
-    #expect(panObj["observed_before"] as? Double == -0.25)
-    #expect(panObj["observed_after"] as? Double == -0.1)
+    #expect(abs((panObj["observed_after"] as? Double ?? -9) - (-0.5)) < 0.07)
     #expect((panObj["target_identity"] as? [String: Any])?["control"] as? String == "pan")
-    #expect((builder.attributeValue(pan, kAXValueAttribute as String) as? NSNumber)?.doubleValue == -0.1)
+    _ = headerControls
 
     let projectResult = await channel.execute(operation: "project.get_info", params: [:])
     #expect(projectResult.isSuccess)
@@ -1840,51 +1907,40 @@ private func makeSetInstrumentFixture() -> (
 }
 
 @Test func testAccessibilityChannelMixerWritesUseLogic12RawSliderRanges() async {
+    // #107: writes are driven via the per-track header fader/pan with an
+    // AXIncrement/AXDecrement nudge (Logic ignores AXValue writes on its
+    // faders). The fake rail starts the volume fader at raw 173 (0...233) and
+    // pan at the electrical center (64 of 0...127); the responsive runtime
+    // moves each by ~10-raw-unit detents so the writer converges.
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(396)
     let window = builder.element(397)
-    let mixer = builder.element(398)
-    let strip = builder.element(399)
-    let fader = builder.element(400)
-    let pan = builder.element(401)
-
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
-    builder.setChildren(window, [mixer])
-    builder.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
-    builder.setAttribute(mixer, kAXDescriptionAttribute as String, "Mixer")
-    builder.setChildren(mixer, [strip])
-    builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
-    builder.setChildren(strip, [fader, pan])
-
-    builder.setAttribute(fader, kAXRoleAttribute as String, kAXSliderRole as String)
-    builder.setAttribute(fader, kAXDescriptionAttribute as String, "Volume Fader")
-    builder.setAttribute(fader, kAXValueAttribute as String, 70)
-    builder.setAttribute(fader, kAXMinValueAttribute as String, 0)
-    builder.setAttribute(fader, kAXMaxValueAttribute as String, 233)
-
-    builder.setAttribute(pan, kAXRoleAttribute as String, kAXSliderRole as String)
-    builder.setAttribute(pan, kAXDescriptionAttribute as String, "Pan")
-    builder.setAttribute(pan, kAXValueAttribute as String, 0)
-    builder.setAttribute(pan, kAXMinValueAttribute as String, -64)
-    builder.setAttribute(pan, kAXMaxValueAttribute as String, 63)
-
-    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    let controls = attachTrackHeaderRail(
+        builder, window: window, siblings: [], baseID: 3_960,
+        volume: (value: 173, min: 0, max: 233),
+        pan: (value: 64, min: 0, max: 127)
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, logicRuntime: nudgeResponsiveLogicRuntime(builder, app: app)
+    )
 
     let volumeResult = await channel.execute(operation: "mixer.set_volume", params: ["index": "0", "value": "0.5"])
     #expect(volumeResult.isSuccess)
     let volumeObj = decodeAccessibilityJSON(volumeResult.message)
     #expect((volumeObj["verified"] as? Bool)!)
-    #expect(abs((volumeObj["observed_before"] as? Double ?? 0.0) - 0.4) < 0.01)
-    #expect(abs((volumeObj["observed_after"] as? Double ?? 0.0) - 0.5) < 0.01)
-    #expect(abs(((builder.attributeValue(fader, kAXValueAttribute as String) as? NSNumber)?.doubleValue ?? 0.0) - 98.0) < 0.01)
+    #expect(volumeObj["write_method"] as? String == "ax_increment_decrement")
+    #expect(abs((volumeObj["observed_after"] as? Double ?? -9) - 0.5) < 0.07)
+    // The raw fader actually moved toward the 0.5 target detent (~raw 98).
+    let faderRaw = (builder.attributeValue(controls.volume, kAXValueAttribute as String) as? NSNumber)?.doubleValue
+        ?? (builder.attributeValue(controls.volume, kAXValueAttribute as String) as? Double) ?? -1
+    #expect(faderRaw >= 90 && faderRaw <= 110, "fader raw should land near 98, got \(faderRaw)")
 
     let panResult = await channel.execute(operation: "mixer.set_pan", params: ["index": "0", "value": "-0.5"])
     #expect(panResult.isSuccess)
     let panObj = decodeAccessibilityJSON(panResult.message)
     #expect((panObj["verified"] as? Bool)!)
-    #expect(panObj["observed_before"] as? Double == 0.0)
-    #expect(abs((panObj["observed_after"] as? Double ?? 0.0) - (-0.5)) < 0.01)
-    #expect(abs(((builder.attributeValue(pan, kAXValueAttribute as String) as? NSNumber)?.doubleValue ?? 0.0) - (-32.0)) < 0.01)
+    #expect(abs((panObj["observed_after"] as? Double ?? -9) - (-0.5)) < 0.07)
 }
 
 @Test func testAccessibilityChannelMixerPopulatesAXPluginSlotsAndSource() async throws {

--- a/Tests/LogicProMCPTests/Issue107MixerWriteTests.swift
+++ b/Tests/LogicProMCPTests/Issue107MixerWriteTests.swift
@@ -1,0 +1,87 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #107 deterministic coverage for the mixer-write value mapping + the
+/// track-header fader/pan locators. The AXIncrement/AXDecrement nudge loop
+/// itself runs against live Logic (covered by the live E2E probe); these tests
+/// pin the pure math + locator selection that the nudge relies on.
+@Suite("Issue107 mixer write")
+struct Issue107MixerWriteTests {
+    @Test("volume contract↔raw round-trips through the fader taper")
+    func volumeContractRawRoundTrip() {
+        let range = AXValueExtractors.SliderRange(min: 0, max: 233)
+        for contract in [0.0, 0.2, 0.4, 0.5, 0.6, 0.8, 1.0] {
+            let raw = AXValueExtractors.logicMixerFaderContractToRaw(contract, range: range)
+            #expect(raw >= 0 && raw <= 233)
+            let position = (raw - range.min) / (range.max - range.min)
+            let back = AXValueExtractors.logicMixerFaderPositionToContract(position)
+            #expect(abs(back - contract) < 0.0001,
+                    "contract \(contract) -> raw \(raw) -> contract \(back)")
+        }
+    }
+
+    @Test("volume contract→raw is monotonic increasing")
+    func volumeMonotonic() {
+        let range = AXValueExtractors.SliderRange(min: 0, max: 233)
+        var last = -1.0
+        for contract in stride(from: 0.0, through: 1.0, by: 0.05) {
+            let raw = AXValueExtractors.logicMixerFaderContractToRaw(contract, range: range)
+            #expect(raw >= last - 0.0001, "raw must not decrease as contract rises (\(contract) -> \(raw))")
+            last = raw
+        }
+    }
+
+    @Test("header pan: raw center→0, rails→±1")
+    func headerPanMapping() {
+        let b = FakeAXRuntimeBuilder()
+        let range = AXValueExtractors.SliderRange(min: 0, max: 127)
+        func panContract(_ raw: Int) -> Double? {
+            let e = b.element(raw + 1)
+            b.setAttribute(e, kAXValueAttribute, raw)
+            return AXValueExtractors.headerPanContract(e, range: range, runtime: b.makeAXRuntime())
+        }
+        #expect(abs((panContract(64) ?? -9) - 0.0079) < 0.01) // midpoint ≈ center
+        #expect(abs((panContract(0) ?? 9) - (-1.0)) < 0.0001)
+        #expect(abs((panContract(127) ?? -9) - 1.0) < 0.0001)
+        #expect((panContract(96) ?? 0) > 0)  // right of center
+        #expect((panContract(32) ?? 0) < 0)  // left of center
+    }
+
+    /// Build a fake track header: a "Volume"-described AXSlider plus a
+    /// description-less pan AXSlider whose AXValueIndicator child reads "0 Pan".
+    private func makeHeader() -> (b: FakeAXRuntimeBuilder, header: AXUIElement, vol: AXUIElement, pan: AXUIElement) {
+        let b = FakeAXRuntimeBuilder()
+        let header = b.element(1)
+        b.setAttribute(header, kAXRoleAttribute, "AXLayoutItem")
+        let pan = b.element(2)
+        b.setAttribute(pan, kAXRoleAttribute, "AXSlider")
+        b.setAttribute(pan, kAXDescriptionAttribute, "")
+        let panIndicator = b.element(3)
+        b.setAttribute(panIndicator, kAXRoleAttribute, "AXValueIndicator")
+        b.setAttribute(panIndicator, kAXDescriptionAttribute, "0 Pan")
+        b.setChildren(pan, [panIndicator])
+        let vol = b.element(4)
+        b.setAttribute(vol, kAXRoleAttribute, "AXSlider")
+        b.setAttribute(vol, kAXDescriptionAttribute, "Volume")
+        b.setChildren(header, [pan, vol])
+        return (b, header, vol, pan)
+    }
+
+    @Test("findVolumeFader picks the Volume-described slider in a header")
+    func volumeFaderLocator() {
+        let h = makeHeader()
+        let found = AXLogicProElements.findVolumeFader(in: h.header, runtime: h.b.makeAXRuntime())
+        #expect(found != nil && CFEqual(found!, h.vol))
+    }
+
+    @Test("findPanControlInHeader picks the pan slider, not the volume fader")
+    func panLocator() {
+        let h = makeHeader()
+        let found = AXLogicProElements.findPanControlInHeader(h.header, runtime: h.b.makeAXRuntime())
+        #expect(found != nil && CFEqual(found!, h.pan))
+        let vol = AXLogicProElements.findVolumeFader(in: h.header, runtime: h.b.makeAXRuntime())
+        #expect(found != nil && vol != nil && !CFEqual(found!, vol!))
+    }
+}


### PR DESCRIPTION
Closes #107.

## Problem (reproduced live)

`logic_mixer.set_volume`/`set_pan {track:0}` returned `element_not_found` — "Cannot locate volume control for visible mixer track 0" — even with 8 visible strips. Live AX reverse-engineering found two root causes:

1. **`getMixerArea` mis-detection.** `mixerChannelStrips`' "fall back to all children" let a mixer **toolbar** (`AXButton "Leave Folder"` + misc controls, **zero faders**) masquerade as 8 channel strips and win the `stripCount` sort, so `findVolumeFader` searched a fader-less container.
2. **Logic ignores AXValue writes on its faders.** Live-confirmed: `set 0.5` left a 0.76 fader unmoved. This is *why* the codebase historically required the MCU control surface for the mixer.

## Fix — write the identity-safe track-header control via nudge

The per-track **header** Volume `AXSlider` (and the pan slider, whose `AXValueIndicator` child reads "Pan") is the **same channel parameter** as the mixer-strip fader, but:
- **identity-safe** — it belongs to exactly track `index`, so we can never write the wrong strip the way positional indexing into a 2-strip Inspector mixer could;
- **always available** — no Mixer window, `toggle_view`, or MCU surface needed.

Logic honours **`AXIncrement`/`AXDecrement`** on these sliders in deterministic ~10-raw-unit detents (live-measured, fully reversible). `defaultSetMixerValue` now computes the target raw value (volume through the fader taper; pan through the range midpoint) and **nudges toward it, reading back every step**, landing on the nearest representable detent. Honest **State A only on convergence**, with `observed`, `observed_raw`, `target_raw`, and a `quantization_note`.

New helpers: `AXValueExtractors.logicMixerFaderContractToRaw` / `headerPanContract`; `AXLogicProElements.findTrackHeaderVolumeFader` / `findPanControlInHeader`. Removed the now-dead AXValue-set mixer writers.

## Verification

**Live (fresh `.build/release` vs real Logic 12.2):**
```
set_volume(0.3) → observed 0.307 (9 steps)   set_pan(-0.5) → -0.465 (4 steps)
set_volume(0.8) → observed 0.800 (14 steps)  set_pan( 0.5) →  0.480 (7 steps)
set_volume(0.5) → observed 0.507 (10 steps)  set_pan( 0.0) →  0.008 (4 steps)
RESULT: 6/6 PASS — verified via ax_slider, isError=false, original restored
```

**Unit:** `Issue107MixerWriteTests` (taper contract↔raw round-trip + monotonicity, pan center/rails, header fader/pan locators) + the rewritten `AccessibilityChannel` mixer tests now drive the responsive `AXIncrement`/`AXDecrement` nudge path against a fake AX tree.

**Suite:** `swift test --no-parallel` → 0 issues, no crash.

## Scope note
Writes converge to the AX-exposed fader resolution (~10 raw detents → typically <0.02 contract error near mid-scale; reported in `observed`). `set_master_volume`/`set_automation` remain MCU-dependent (registered control surface) and continue to fail-closed with an actionable hint; `set_plugin_param` is unchanged. The `logic://mixer` *read* path (separate from these writes) is untouched here.