### PR TITLE
fix(#112): server-side command deadline → typed operation_timeout (stdio-loop liveness)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -219,6 +219,7 @@ actor LogicProServer {
     func makeHandlers() -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
+        let poller = self.poller
 
         return LogicProServerHandlers(
             listTools: { _ in
@@ -231,29 +232,41 @@ actor LogicProServer {
 
                 await cache.recordToolAccess()
 
-                switch name {
-                case "logic_transport":
-                    return await TransportDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_tracks":
-                    return await TrackDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_mixer":
-                    return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_midi":
-                    return await MIDIDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_edit":
-                    return await EditDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_navigate":
-                    return await NavigateDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_project":
-                    return await ProjectDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                case "logic_audio":
-                    return AudioDispatcher.handle(command: command, params: cmdParams)
-                case "logic_system":
-                    return await SystemDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, poller: self.poller)
-                case "logic_plugins":
-                    return await PluginsDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                default:
-                    return toolTextResult("Unknown tool: \(name)", isError: true)
+                // #112: every tool dispatch runs under a server-side deadline.
+                // A wedged/occluded Logic session (modal dialog up, AX server
+                // unresponsive) makes multi-message AX operations block far past
+                // the client's tools/call timeout, surfacing as a bare "timeout"
+                // and — worse — stalling the stdio read loop so every subsequent
+                // command also hangs. The deadline converts that into a typed
+                // `operation_timeout` State C and frees the loop. Deadlines are
+                // set well above each command's healthy completion time, so a
+                // normal op can never false-trip (verified across the full live
+                // surface); only a genuine hang is bounded.
+                return await Self.runWithDeadline(tool: name, command: command) {
+                    switch name {
+                    case "logic_transport":
+                        return await TransportDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_tracks":
+                        return await TrackDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_mixer":
+                        return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_midi":
+                        return await MIDIDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_edit":
+                        return await EditDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_navigate":
+                        return await NavigateDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_project":
+                        return await ProjectDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    case "logic_audio":
+                        return AudioDispatcher.handle(command: command, params: cmdParams)
+                    case "logic_system":
+                        return await SystemDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, poller: poller)
+                    case "logic_plugins":
+                        return await PluginsDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                    default:
+                        return toolTextResult("Unknown tool: \(name)", isError: true)
+                    }
                 }
             },
             listResources: { _ in
@@ -275,6 +288,74 @@ actor LogicProServer {
                 )
             }
         )
+    }
+
+    // MARK: - #112 command deadline (stdio-loop liveness backstop)
+
+    /// Commands that legitimately take many seconds against live AX: full
+    /// Library / preset tree walks, SMF import, and the guarded bounce/export
+    /// state machines. They get a much longer deadline so the backstop never
+    /// false-trips them, while still bounding a genuine hang.
+    private static let longRunningCommands: Set<String> = [
+        "scan_library", "scan_plugin_presets", "list_library", "record_sequence",
+        "import_file", "bounce", "export_run", "export_resume", "open", "save_as",
+    ]
+
+    /// Medium-cost commands that drive multi-step AX menu/library navigation.
+    private static let mediumRunningCommands: Set<String> = [
+        "set_instrument", "insert_verified", "set_param_verified",
+        "cleanup_apply", "new", "save", "close", "quit",
+    ]
+
+    /// Per-command server-side deadline in seconds. Set far above each
+    /// command's healthy completion time (sub-second for the fast tier) so a
+    /// normal op can never false-trip; only a wedged/occluded Logic session
+    /// that would otherwise hang the stdio loop is bounded.
+    static func commandDeadlineSeconds(tool: String, command: String) -> Double {
+        if longRunningCommands.contains(command) { return 300 }
+        if mediumRunningCommands.contains(command) { return 90 }
+        return 25
+    }
+
+    static func deadlineTimeoutResult(tool: String, command: String, seconds: Double) -> CallTool.Result {
+        let operation = command.isEmpty ? tool : "\(tool).\(command)"
+        let body = HonestContract.encodeStateC(
+            error: .operationTimeout,
+            hint: "\(operation) exceeded the \(Int(seconds))s server-side deadline and was abandoned so the stdio loop stays responsive.",
+            extras: [
+                "operation": operation,
+                "timeout_sec": seconds,
+                "recovery_hint": "Logic Pro may be busy, occluded, or showing a modal dialog. Dismiss any dialog and retry; check logic_system.health.",
+            ]
+        )
+        return toolTextResult(body, isError: true)
+    }
+
+    /// Race the dispatch `work` against a per-command deadline. Whichever
+    /// finishes first wins; on timeout we return a typed `operation_timeout`
+    /// State C. The orphaned synchronous AX work (if any) is left to finish and
+    /// is discarded — the point is to free the stdio loop, not to cancel a
+    /// blocking AX call (which cooperative cancellation cannot interrupt).
+    static func runWithDeadline(
+        tool: String,
+        command: String,
+        deadlineOverride: Double? = nil,
+        work: @escaping @Sendable () async -> CallTool.Result
+    ) async -> CallTool.Result {
+        let deadline = deadlineOverride ?? commandDeadlineSeconds(tool: tool, command: command)
+        return await withTaskGroup(of: CallTool.Result?.self) { group in
+            group.addTask { await work() }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+                return nil // sentinel: the deadline fired before `work` finished
+            }
+            defer { group.cancelAll() }
+            if let first = await group.next() {
+                if let result = first { return result }
+                return Self.deadlineTimeoutResult(tool: tool, command: command, seconds: deadline)
+            }
+            return Self.deadlineTimeoutResult(tool: tool, command: command, seconds: deadline)
+        }
     }
 
     private func registerTools() async {

--- a/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #112: the server-side command deadline turns a wedged/occluded Logic session
+/// (AX ops blocking past the client tools/call timeout, stalling the stdio loop)
+/// into a typed `operation_timeout` State C instead of a bare hang.
+@Suite("Issue112 command deadline")
+struct Issue112CommandDeadlineTests {
+    private func text(_ result: CallTool.Result) -> String {
+        if case .text(let t, _, _) = result.content.first { return t }
+        return ""
+    }
+
+    private func json(_ result: CallTool.Result) -> [String: Any]? {
+        guard let data = text(result).data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    @Test("fast work passes through unchanged")
+    func fastWorkPassesThrough() async {
+        let result = await LogicProServer.runWithDeadline(tool: "logic_transport", command: "stop", deadlineOverride: 5.0) {
+            toolTextResult("{\"verified\":true,\"operation\":\"transport.stop\"}")
+        }
+        #expect(result.isError != true)
+        #expect(json(result)?["verified"] as? Bool == true)
+    }
+
+    @Test("work that exceeds the deadline returns typed operation_timeout")
+    func slowWorkTimesOut() async {
+        let result = await LogicProServer.runWithDeadline(tool: "logic_tracks", command: "rename", deadlineOverride: 0.15) {
+            try? await Task.sleep(nanoseconds: 3_000_000_000) // 3s — far past the 0.15s deadline
+            return toolTextResult("{\"verified\":true}") // must NOT win
+        }
+        #expect(result.isError == true)
+        let obj = json(result)
+        #expect(obj?["error"] as? String == "operation_timeout")
+        #expect(obj?["operation"] as? String == "logic_tracks.rename")
+        #expect(obj?["timeout_sec"] as? Double == 0.15)
+        #expect((obj?["hint"] as? String)?.isEmpty == false)
+    }
+
+    @Test("operation_timeout is a terminal error code")
+    func timeoutIsTerminal() {
+        #expect(HonestContract.terminalErrorCodes.contains(HonestContract.FailureError.operationTimeout.rawValue))
+        #expect(HonestContract.FailureError.operationTimeout.rawValue == "operation_timeout")
+    }
+
+    @Test("deadline tiers: fast commands short, long/medium commands generous")
+    func deadlineTiers() {
+        // Fast tier — far above the sub-second healthy completion time.
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_transport", command: "stop") == 25)
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_mixer", command: "set_volume") == 25)
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_tracks", command: "mute") == 25)
+        // Long tier — full Library walks / SMF import / guarded export.
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_tracks", command: "scan_library") == 300)
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: "import_file") == 300)
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: "bounce") == 300)
+        // Medium tier — multi-step menu/library navigation.
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_tracks", command: "set_instrument") == 90)
+        #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_plugins", command: "insert_verified") == 90)
+    }
+
+    @Test("the deadline timeout result is shaped like a State C envelope")
+    func timeoutResultShape() {
+        let result = LogicProServer.deadlineTimeoutResult(tool: "logic_navigate", command: "create_marker", seconds: 25)
+        #expect(result.isError == true)
+        let obj = json(result)
+        #expect(obj?["success"] as? Bool == false)
+        #expect(obj?["error"] as? String == "operation_timeout")
+        #expect(obj?["operation"] as? String == "logic_navigate.create_marker")
+    }
+}


### PR DESCRIPTION
Closes #112.

## Diagnosis

The 2026-06-21 fresh full-surface probe saw broad transport + AX-backed commands `timeout` (43 in the re-record vs 27 earlier — same v3.6.0 binary, 30 min apart). That non-determinism across an identical surface is the tell: **the timeouts were environmental** — a wedged/occluded Logic session (modal dialog up, AX server unresponsive). Driving a freshly-built binary against a *healthy* live session, every one of those commands returns **verified State A in <0.5s** (`transport.stop` 0.16s, `refresh_cache` 0.39s, `get_regions` 0.13s, …).

So this isn't a per-command logic bug. The real product gap (called out in the issue's "Expected": *"should fail fast with typed reasons instead of timing out"*) is that **one hung AX command had no server-side bound and stalled the stdio read loop**, so every subsequent command hung too (the exact failure `AXHelpers` already documents: *"exceeded the client's 15s tools/call timeout and stalled the stdio loop"*).

## Fix

Every tool dispatch now runs under a per-command deadline (`LogicProServer.runWithDeadline`). On expiry it returns a typed **`operation_timeout`** State C (already a terminal error code) and frees the stdio loop. The orphaned synchronous AX work is left to finish and discarded — cooperative cancellation can't interrupt a blocking AX call; the goal is loop liveness, not killing the call.

Deadlines are tiered **far above** each command's healthy completion time, so a normal op can never false-trip:
| tier | commands | deadline |
|---|---|---|
| fast | transport / tracks / mixer / edit / navigate / midi / reads | 25 s |
| medium | set_instrument, verified-plugin ops, lifecycle | 90 s |
| long | library/preset scans, SMF import, guarded bounce/export | 300 s |

## Verification

- **Unit** (`Issue112CommandDeadlineTests`): fast work passes through unchanged; work exceeding the deadline returns typed `operation_timeout` with `operation`/`timeout_sec`; `operation_timeout` is terminal; tier classification; State-C result shape.
- **Live** (fresh `.build/release` vs real Logic 12.2): the full read/transport/project surface returns real results in <0.4 s — **`operation_timeout` count = 0**, zero false-trips.
- **Suite**: `swift test --no-parallel` → 0 issues.

This is the umbrella hardening for the #105–#110 timeout cluster: a wedged session now yields an honest typed failure per command and a responsive loop, instead of a cascading bare hang.