### PR TITLE
fix(#105): goto_position/goto_bar drop the self-contradictory read-back note

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3362,12 +3362,21 @@ actor AccessibilityChannel: Channel {
             if output.contains("DIALOG_NOT_READY") {
                 return .error("goto-position dialog did not appear within timeout")
             }
+            // #105: this State B reports only that the Go-To-Position dialog
+            // keystroke was sent; the playhead is verified independently by
+            // `TransportDispatcher.finalizeGotoPositionResult` via a transport-
+            // state read-back. Earlier this carried a `note` claiming the
+            // playhead was "not read back" — which the finalize step then
+            // contradicted by reading it back and gating `verified` on it, so a
+            // verified State A shipped a self-contradictory note. The provenance
+            // (`via:"dialog"`) plus finalize's `verification_source` /
+            // `observed` / `verified` fields describe the outcome honestly
+            // without it.
             return .success(HonestContract.encodeStateB(
                 reason: .readbackUnavailable,
                 extras: [
                     "requested": "\(bar).1.1.1",
-                    "via": "dialog",
-                    "note": "AppleScript dialog OK confirms keystroke send; resulting playhead not read back"
+                    "via": "dialog"
                 ]
             ))
         case .error(let msg):

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -327,6 +327,10 @@ struct TransportDispatcher {
         }
 
         var extras = honestContractExtras(from: result.message)
+        // #105: drop any channel-level "keystroke sent; not read back" note —
+        // this finalize step IS the authoritative read-back, so carrying that
+        // note forward would contradict the verified verdict below.
+        extras.removeValue(forKey: "note")
         extras["verification_source"] = "transport_state"
         extras["requested"] = requestedPosition
         extras["observed"] = observedTransport.position

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #105: a verified goto_position/goto_bar must not ship the stale
+/// "resulting playhead not read back" note — `finalizeGotoPositionResult`
+/// performs an authoritative transport-state read-back and gates `verified`
+/// on it, so the note (from the dialog keystroke channel) would contradict the
+/// verdict. Also locks the faithful verified-vs-mismatch behavior.
+@Suite("Issue105 goto note + verification")
+struct Issue105GotoNoteTests {
+    private actor StubTransportChannel: Channel {
+        nonisolated let id: ChannelID = .accessibility
+        let gotoResult: ChannelResult
+        let readbackPosition: String
+        init(gotoResult: ChannelResult, readbackPosition: String) {
+            self.gotoResult = gotoResult
+            self.readbackPosition = readbackPosition
+        }
+        func start() async throws {}
+        func stop() async {}
+        func healthCheck() async -> ChannelHealth { .healthy(detail: "stub") }
+        func execute(operation: String, params: [String: String]) async -> ChannelResult {
+            switch operation {
+            case "transport.goto_position": return gotoResult
+            case "transport.get_state":
+                return .success("""
+                {"isPlaying":false,"isRecording":false,"isPaused":false,"tempo":120.0,\
+                "position":"\(readbackPosition)","timePosition":"00:00:00.000","sampleRate":44100,\
+                "isCycleEnabled":false,"isMetronomeEnabled":false,"lastUpdated":"2026-06-21T00:00:00.000Z"}
+                """)
+            default: return .error("unexpected: \(operation)")
+            }
+        }
+    }
+
+    private func text(_ r: CallTool.Result) -> String {
+        if case .text(let t, _, _) = r.content.first { return t }
+        return ""
+    }
+    private func obj(_ r: CallTool.Result) -> [String: Any]? {
+        (try? JSONSerialization.jsonObject(with: Data(text(r).utf8))) as? [String: Any]
+    }
+
+    /// The dialog channel's real State B output, including the historical note.
+    private func notedDialogStateB(bar: Int) -> ChannelResult {
+        .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "requested": "\(bar).1.1.1",
+                "via": "dialog",
+                "note": "AppleScript dialog OK confirms keystroke send; resulting playhead not read back",
+            ]
+        ))
+    }
+
+    @Test("verified goto_position drops the contradictory readback note")
+    func verifiedHasNoStaleNote() async throws {
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 1), readbackPosition: "1.1.1.1"))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position", params: ["bar": .int(1)], router: router, cache: StateCache()
+        )
+        #expect(result.isError != true)
+        let o = try #require(obj(result))
+        #expect((o["verified"] as? Bool) == true)
+        #expect(o["verification_source"] as? String == "transport_state")
+        #expect(o["observed"] as? String == "1.1.1.1")
+        #expect(o["note"] == nil, "verified envelope must not carry a 'not read back' note")
+        #expect(!text(result).contains("not read back"))
+    }
+
+    @Test("goto_bar shares the same verified, note-free contract")
+    func gotoBarNoteFree() async throws {
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 17), readbackPosition: "17.1.1.1"))
+        let result = await NavigateDispatcher.handle(
+            command: "goto_bar", params: ["bar": .int(17)], router: router, cache: StateCache()
+        )
+        #expect(result.isError != true)
+        let o = try #require(obj(result))
+        #expect((o["verified"] as? Bool) == true)
+        #expect(!text(result).contains("not read back"))
+    }
+
+    @Test("mismatched readback fails closed as unverified State B")
+    func mismatchFailsClosed() async throws {
+        let router = ChannelRouter()
+        // Requested bar 1 but the playhead landed at 1.2.1.1 (the #105 symptom).
+        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 1), readbackPosition: "1.2.1.1"))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position", params: ["bar": .int(1)], router: router, cache: StateCache()
+        )
+        let o = try #require(obj(result))
+        #expect((o["verified"] as? Bool) != true)
+        #expect(o["observed"] as? String == "1.2.1.1")
+        #expect(result.isError == true)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -25,11 +25,17 @@ struct Issue105GotoNoteTests {
             switch operation {
             case "transport.goto_position": return gotoResult
             case "transport.get_state":
-                return .success("""
-                {"isPlaying":false,"isRecording":false,"isPaused":false,"tempo":120.0,\
-                "position":"\(readbackPosition)","timePosition":"00:00:00.000","sampleRate":44100,\
-                "isCycleEnabled":false,"isMetronomeEnabled":false,"lastUpdated":"2026-06-21T00:00:00.000Z"}
-                """)
+                // Encode a real TransportState with the SAME .iso8601 strategy
+                // the dispatcher decodes with. A hand-written date carrying
+                // fractional seconds (".000Z") fails strict .iso8601 decoding on
+                // the CI Foundation, which made `liveTransportState` return nil
+                // and the verdict fall back to the un-stripped State B.
+                var state = TransportState()
+                state.position = readbackPosition
+                state.lastUpdated = Date(timeIntervalSince1970: 0)
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                return .success(String(decoding: (try? encoder.encode(state)) ?? Data(), as: UTF8.self))
             default: return .error("unexpected: \(operation)")
             }
         }


### PR DESCRIPTION
Closes #105.

## Live triage

Driving a freshly-built binary against a healthy Logic 12.2 session:

- **`goto_position` / `goto_bar` work and verify.** The probe's "observed 1.2.1.1 for requested 1.1.1.1, verified=false" was the *honest* read-back of an environmentally off-position playhead — `verified=false` was correct, not a bug. But the **verified** envelope still carried a stale `note`: *"AppleScript dialog OK confirms keystroke send; resulting playhead not read back"* — which directly contradicts `finalizeGotoPositionResult`, the step that **does** read the live transport state back and gates `verified` on it. A verified State A shipping "not read back" is a self-contradiction.
- **`set_cycle_range` → `not_implemented` is genuinely correct.** Live AX dump of the control + transport bars shows only `bar`/`beat`/`Tempo` playhead sliders and a `Cycle` toggle checkbox — **no numeric cycle-locator AX fields exist** in Logic 12.2 to drive. The honest fast-fail (with scanned landmarks + recovery hint, never a false State A) is the right behavior and matches the issue's *"fail fast with a stable unsupported/error code, not hang"*. No-hang is additionally backstopped by #112.

## Fix

Remove the obsolete note at its source (`gotoPositionViaDialog`) and defensively strip any channel-level `note` in `finalizeGotoPositionResult`, so a verified goto envelope never lies about read-back. Provenance is fully conveyed by `via` + `verification_source` + `observed` + `verified`.

## Verification

- **Live** (fresh `.build/release` vs Logic 12.2): `goto_position(1)` / `goto_bar(1)` → `verified=true`, `observed=1.1.1.1`, **no `note`, no "not read back"**.
- **Unit** (`Issue105GotoNoteTests`): verified path is note-free; `goto_bar` shares the contract; a mismatched read-back (1.2.1.1 for bar 1) fails closed as unverified State B.
- **Suite**: `swift test --no-parallel` → 0 issues.

## Scope note
`set_cycle_range` stays an explicit unsupported surface (no AX cycle-locator path in Logic 12.2); it fails fast with a typed `not_implemented`/`readback_unavailable` State C and is exercised by the live E2E `cycle_range_result_ok` contract. The original `mmc_locate`/`goto_bar` *timeouts* were environmental (resolved on a healthy session; hang-class covered by #112).