### PR TITLE
fix(#109): set_zoom verifies via the writable Horizontal-Zoom AXSlider

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -254,6 +254,14 @@ enum AXLocalePolicy {
         rationale: "Identifies the tempo slider in TransportState extraction; substring match without bpm; read-only."
     )
 
+    /// #109: arrange Horizontal-Zoom slider (writable AXValue). EN canonical +
+    /// KO variant; matched by description substring.
+    static let horizontalZoomSlider = LabelSet(
+        canonical: "Horizontal Zoom",
+        variants: ["가로 확대/축소", "가로 확대"],
+        rationale: "Locates the arrange horizontal-zoom AXSlider for verified set_zoom writes; description substring match."
+    )
+
     // --- Track-header read-only locators ---
 
     static let trackMuteButton = LabelSet(

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -1235,6 +1235,19 @@ enum AXLogicProElements {
             ?? AXHelpers.findDescendant(of: header, role: kAXButtonRole, title: "R", runtime: runtime.ax)
     }
 
+    /// #109: the arrange Horizontal-Zoom AXSlider (range 0...1, settable).
+    /// Logic honours AXValue writes here, so `set_zoom` can drive it directly
+    /// with a verifiable read-back instead of an unmappable key command.
+    static func findHorizontalZoomSlider(runtime: Runtime = .production) -> AXUIElement? {
+        guard let window = mainWindow(runtime: runtime) else { return nil }
+        let labels = AXLocalePolicy.horizontalZoomSlider.labels
+        return AXHelpers.findAllDescendants(of: window, role: kAXSliderRole, maxDepth: 16, runtime: runtime.ax)
+            .first { slider in
+                let desc = AXHelpers.getDescription(slider, runtime: runtime.ax) ?? ""
+                return labels.contains { !$0.isEmpty && desc.contains($0) }
+            }
+    }
+
     /// Find the track name text field on a header.
     static func findTrackNameField(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -283,6 +283,12 @@ actor AccessibilityChannel: Channel {
                 params: params, runtime: runtime.logicRuntime
             )
 
+        case "nav.set_zoom_level":
+            // #109: verified zoom via the writable Horizontal-Zoom AXSlider.
+            return AccessibilityChannel.defaultSetZoomLevel(
+                params: params, runtime: runtime.logicRuntime
+            )
+
         // MARK: - Track reads
         case "track.get_tracks":
             // v3.1.8 (Issue #7) — AX-only at the channel layer. The v3.1.5
@@ -3225,6 +3231,46 @@ actor AccessibilityChannel: Channel {
     /// 2) Control-bar 마디 slider (clamps to project length; silently stops at
     ///    end when requested bar exceeds length)
     /// Accepts `{"bar": Int}` or `{"position": "B.B.S.S"}`.
+    /// #109: set the arrange horizontal zoom to `level` (1...10) by writing the
+    /// Horizontal-Zoom AXSlider (range 0...1, level 1 = fully out, 10 = fully
+    /// in) and reading it back. Returns verified State A on a confirmed write,
+    /// State B if the read-back can't confirm it. If the slider can't be found,
+    /// returns a plain (non-terminal) error so the router falls back to the
+    /// key-command channel.
+    static func defaultSetZoomLevel(
+        params: [String: String],
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ChannelResult {
+        guard let levelStr = params["level"], let level = Int(levelStr), (1...10).contains(level) else {
+            return .error("nav.set_zoom_level requires 'level' (Int 1..10)")
+        }
+        guard let slider = AXLogicProElements.findHorizontalZoomSlider(runtime: runtime) else {
+            return .error("Horizontal Zoom slider not found — falling back to key command")
+        }
+        let target = Double(level - 1) / 9.0
+        let before = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        _ = AXValueExtractors.setSliderValue(slider, target, runtime: runtime.ax)
+        usleep(120_000)
+        let after = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        let extras: [String: Any] = [
+            "operation": "nav.set_zoom",
+            "axis": "horizontal",
+            "level": level,
+            "requested": target,
+            "observed_before": before ?? NSNull(),
+            "observed": after ?? NSNull(),
+            "observed_after": after ?? NSNull(),
+            "verify_source": "ax_zoom_slider",
+        ]
+        if let after, abs(after - target) < 0.02 {
+            return .success(HonestContract.encodeStateA(extras: extras))
+        }
+        return .success(HonestContract.encodeStateB(
+            reason: after == nil ? .readbackUnavailable : .readbackMismatch,
+            extras: extras
+        ))
+    }
+
     private static func gotoPositionViaBarSlider(
         params: [String: String],
         runtime: AXLogicProElements.Runtime = .production

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3241,9 +3241,18 @@ actor AccessibilityChannel: Channel {
         params: [String: String],
         runtime: AXLogicProElements.Runtime = .production
     ) -> ChannelResult {
+        // Malformed input fails closed as terminal State C: a bad level must NOT
+        // fall through to the key-command channel (which doesn't validate and
+        // would fire a generic zoom). Mirrors gotoPositionViaBarSlider's guard.
         guard let levelStr = params["level"], let level = Int(levelStr), (1...10).contains(level) else {
-            return .error("nav.set_zoom_level requires 'level' (Int 1..10)")
+            return .error(HonestContract.encodeStateC(
+                error: .invalidParams,
+                hint: "nav.set_zoom_level requires 'level' (Int 1..10)",
+                extras: ["operation": "nav.set_zoom"]
+            ))
         }
+        // Slider absent is NOT terminal: plain error lets the router fall back to
+        // the key-command / CGEvent channels.
         guard let slider = AXLogicProElements.findHorizontalZoomSlider(runtime: runtime) else {
             return .error("Horizontal Zoom slider not found — falling back to key command")
         }

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -186,7 +186,11 @@ actor ChannelRouter {
         "nav.rename_marker":          [.accessibility],
         "nav.get_markers":            [.accessibility],
         "nav.zoom_to_fit":            [.midiKeyCommands, .cgEvent],
-        "nav.set_zoom_level":         [.midiKeyCommands, .cgEvent],
+        // #109: AX-first — the arrange Horizontal-Zoom AXSlider honours AXValue
+        // writes (unlike faders/playhead), so set_zoom now lands a verified
+        // zoom level instead of an unmappable, unverifiable key command. Keeps
+        // the key-command + CGEvent fallbacks for when the slider isn't found.
+        "nav.set_zoom_level":         [.accessibility, .midiKeyCommands, .cgEvent],
 
         // Editing — MIDIKeyCommands primary, CGEvent fallback
         "edit.undo":                  [.midiKeyCommands, .cgEvent],

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -2682,6 +2682,11 @@ private actor SelectiveFailChannel: Channel {
         ("transport.goto_position", ["position": "17.1.1.1"]),
         ("transport.goto_position", ["position": "17.1.1.1"]),
         ("nav.rename_marker", ["index": "2", "name": "Big Chorus"]),
+        // #109 — set_zoom is now AX-first (writable Horizontal-Zoom slider);
+        // zoom_to_fit stays on the key-command path (no slider equivalent).
+        ("nav.set_zoom_level", ["level": "8"]),
+        ("nav.set_zoom_level", ["level": "2"]),
+        ("nav.set_zoom_level", ["level": "5"]),
     ])
     expectExecutedOps(keyCmdOps, equals: [
         // v3.1.10 — `nav.goto_marker` keycmd path is reserved for the
@@ -2690,9 +2695,6 @@ private actor SelectiveFailChannel: Channel {
         ("nav.create_marker", ["name": "Bridge"]),
         ("nav.delete_marker", ["index": "1"]),
         ("nav.zoom_to_fit", [:]),
-        ("nav.set_zoom_level", ["level": "8"]),
-        ("nav.set_zoom_level", ["level": "2"]),
-        ("nav.set_zoom_level", ["level": "5"]),
     ])
 }
 

--- a/Tests/LogicProMCPTests/Issue109ZoomTests.swift
+++ b/Tests/LogicProMCPTests/Issue109ZoomTests.swift
@@ -1,0 +1,82 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #109: set_zoom now drives the writable Horizontal-Zoom AXSlider with a
+/// read-back instead of an unmappable, unverifiable key command. The other
+/// edit/nav key-command surfaces (undo/copy/… honest State B; select_all/
+/// quantize/zoom_to_fit fail-loud) are unchanged and remain covered by
+/// existing dispatcher tests.
+@Suite("Issue109 zoom readback")
+struct Issue109ZoomTests {
+    private func zoomFixture(start: Double) -> (builder: FakeAXRuntimeBuilder, app: AXUIElement, slider: AXUIElement) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(7700)
+        let window = b.element(7701)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        let slider = b.element(7702)
+        b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+        b.setAttribute(slider, kAXDescriptionAttribute as String, "Horizontal Zoom")
+        b.setAttribute(slider, kAXValueAttribute as String, start)
+        b.setAttribute(slider, kAXMinValueAttribute as String, 0.0)
+        b.setAttribute(slider, kAXMaxValueAttribute as String, 1.0)
+        b.setChildren(window, [slider])
+        return (b, app, slider)
+    }
+
+    private func obj(_ r: ChannelResult) -> [String: Any]? {
+        (try? JSONSerialization.jsonObject(with: Data(r.message.utf8))) as? [String: Any]
+    }
+
+    @Test("set_zoom_level writes the horizontal zoom slider and verifies (State A)")
+    func zoomVerifies() {
+        let f = zoomFixture(start: 0.18)
+        let result = AccessibilityChannel.defaultSetZoomLevel(
+            params: ["level": "8"], runtime: f.builder.makeLogicRuntime(appElement: f.app)
+        )
+        #expect(result.isSuccess)
+        let o = obj(result)
+        #expect(o?["verified"] as? Bool == true)
+        #expect(o?["verify_source"] as? String == "ax_zoom_slider")
+        // level 8 → (8-1)/9 = 0.777…
+        #expect(abs((o?["observed"] as? Double ?? -9) - (7.0 / 9.0)) < 0.02)
+        // The slider's stored AX value actually moved.
+        let stored = (f.builder.attributeValue(f.slider, kAXValueAttribute as String) as? NSNumber)?.doubleValue
+            ?? (f.builder.attributeValue(f.slider, kAXValueAttribute as String) as? Double)
+        #expect(abs((stored ?? -9) - (7.0 / 9.0)) < 0.001)
+    }
+
+    @Test("set_zoom_level maps level 1 to fully out and 10 to fully in")
+    func zoomLevelMapping() {
+        for (level, expected) in [(1, 0.0), (10, 1.0), (5, 4.0 / 9.0)] {
+            let f = zoomFixture(start: 0.5)
+            let result = AccessibilityChannel.defaultSetZoomLevel(
+                params: ["level": String(level)], runtime: f.builder.makeLogicRuntime(appElement: f.app)
+            )
+            #expect(abs((obj(result)?["observed"] as? Double ?? -9) - expected) < 0.02, "level \(level) → \(expected)")
+        }
+    }
+
+    @Test("set_zoom_level falls back (non-terminal plain error) when no slider exists")
+    func zoomFallsBackWhenNoSlider() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(7800)
+        let window = b.element(7801)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        b.setChildren(window, []) // no zoom slider
+        let result = AccessibilityChannel.defaultSetZoomLevel(
+            params: ["level": "8"], runtime: b.makeLogicRuntime(appElement: app)
+        )
+        #expect(!result.isSuccess)
+        // Plain (non-HC) error → non-terminal → the router falls back to keycmd.
+        #expect(!HonestContract.isTerminalStateC(result.message))
+    }
+
+    @Test("set_zoom is AX-first with key-command fallback in the router")
+    func routingIsAXFirst() {
+        let chain = ChannelRouter.routingTable["nav.set_zoom_level"]
+        #expect(chain?.first == .accessibility)
+        #expect(chain?.contains(.midiKeyCommands) == true)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue109ZoomTests.swift
+++ b/Tests/LogicProMCPTests/Issue109ZoomTests.swift
@@ -79,4 +79,33 @@ struct Issue109ZoomTests {
         #expect(chain?.first == .accessibility)
         #expect(chain?.contains(.midiKeyCommands) == true)
     }
+
+    @Test(
+        "set_zoom_level rejects malformed level with TERMINAL State C invalid_params",
+        arguments: [
+            ["level": "0"],     // below range
+            ["level": "11"],    // above range
+            ["level": "-1"],    // negative
+            ["level": "abc"],   // non-numeric
+            ["level": ""],      // empty
+            [:],                // missing entirely
+        ]
+    )
+    func zoomInvalidParamsAreTerminal(params: [String: String]) throws {
+        let f = zoomFixture(start: 0.5)
+        let result = AccessibilityChannel.defaultSetZoomLevel(
+            params: params, runtime: f.builder.makeLogicRuntime(appElement: f.app)
+        )
+        #expect(!result.isSuccess)
+        let o = try #require(obj(result))
+        #expect(!((o["success"] as? Bool)!))
+        #expect(o["error"] as? String == "invalid_params")
+        // Terminal → the router MUST suppress fallback to the key-command
+        // channel (which doesn't validate and would fire a generic zoom).
+        #expect(HonestContract.isTerminalStateC(result.message))
+        // Guard must fire before any slider write: the fixture slider is untouched.
+        let stored = (f.builder.attributeValue(f.slider, kAXValueAttribute as String) as? NSNumber)?.doubleValue
+            ?? (f.builder.attributeValue(f.slider, kAXValueAttribute as String) as? Double)
+        #expect(abs((stored ?? -9) - 0.5) < 0.001)
+    }
 }


### PR DESCRIPTION
Closes #109.

## Triage (live)

- **Edit key commands** (undo/redo/copy/paste/cut/delete/split/join/bounce_in_place/normalize/duplicate/toggle_step_input) are key-command-backed with no AX read-back. Honest **State B** (`verified:false`, non-error) is the correct contract and is unchanged.
- **select_all / quantize / zoom_to_fit** keep their deliberate **fail-loud** contract (existing tests `testEditDispatcherTreatsUnverifiedStateBAsError` / `testNavigateDispatcherZoomCommandsTreatUnverifiedStateBAsError` pin `isError` on unverified).
- **create_marker** verifies via marker read-back; the probe `timeout` was environmental and no command can hang anymore (#112's command deadline).
- **`set_zoom`** was the real defect: it routed only to an **unmappable key command** and was a live-confirmed **no-op** — firing `set_zoom in` left the arrange Horizontal-Zoom AXSlider unchanged (0.185 → 0.185). That slider **is** writable (unlike the faders/playhead slider Logic ignores), so the command had an observable postcondition it wasn't using.

## Fix

Route `nav.set_zoom_level` **AX-first** (keeping the key-command + CGEvent fallbacks). The Accessibility channel writes the Horizontal-Zoom slider to a level-mapped value (level 1 = fully out … 10 = fully in) and reads it back: **verified State A** on a confirmed write, State B otherwise; a missing slider returns a plain (non-terminal) error so the router still falls back to the key command. `zoom_to_fit` stays on the key-command path (no slider equivalent).

## Verification

- **Live** (fresh `.build/release` vs Logic 12.2): `set_zoom in/out/level` all return `verified=true` via `ax_zoom_slider`, observed matching the level mapping (in→0.778, out→0.111, level 5→0.444) — the slider actually moves.
- **Unit** (`Issue109ZoomTests`): write+verify, level 1↔10 mapping, non-terminal fallback when no slider, AX-first routing. Existing fail-loud edit/nav contracts unchanged; the marker/zoom routing test updated for AX-first `set_zoom`.
- **Suite**: `swift test --no-parallel` → 0 issues.

## Scope note
The other edit/nav key-command surfaces are honestly unverifiable (key commands have no AX read-back) and keep their existing contracts — clear non-error State B for the edit ops, deliberate fail-loud for select_all/quantize/zoom_to_fit. This PR adds the one readback probe where an observable postcondition (the zoom slider) actually exists.