### PR TITLE
fix(#110): read-back-verified project.save (file-evidence, AppleScript-first)

### DIFF
--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -14,6 +14,8 @@ actor AppleScriptChannel: Channel {
         let executeTransportAction: @Sendable (String) async -> ChannelResult
         let fileExists: @Sendable (String) -> Bool
         let fileModificationDate: @Sendable (String) -> Date?
+        // #110: front document's on-disk path, for read-back-verified save.
+        let currentDocumentPath: @Sendable () async -> String?
 
         init(
             isLogicProRunning: @escaping @Sendable () -> Bool,
@@ -23,6 +25,9 @@ actor AppleScriptChannel: Channel {
             fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
             fileModificationDate: @escaping @Sendable (String) -> Date? = {
                 (try? FileManager.default.attributesOfItem(atPath: $0)[.modificationDate]) as? Date
+            },
+            currentDocumentPath: @escaping @Sendable () async -> String? = {
+                await AppleScriptChannel.currentDocumentPath()
             }
         ) {
             self.isLogicProRunning = isLogicProRunning
@@ -31,6 +36,7 @@ actor AppleScriptChannel: Channel {
             self.executeTransportAction = executeTransportAction
             self.fileExists = fileExists
             self.fileModificationDate = fileModificationDate
+            self.currentDocumentPath = currentDocumentPath
         }
 
         static let production = Runtime(
@@ -93,8 +99,25 @@ actor AppleScriptChannel: Channel {
             return Self.wrapMutatingResult(raw, operation: operation, extras: ["saving": saving])
 
         case "project.save":
+            // #110: verify the front document's `.logicx` package was actually
+            // (re)written. The on-disk mtime is authoritative: `save front
+            // document` reliably persists even when the AppleEvent reply times
+            // out (-1712), so a successful write is confirmed by the file
+            // advancing past the save start — independent of the script's
+            // success/error verdict. An untitled document (no path) or a
+            // package whose mtime did not advance stays an honest State B and
+            // never claims a verified save an export/bounce step would trust.
+            let documentPath = await runtime.currentDocumentPath()
+            let beforeMtime = documentPath.flatMap(runtime.fileModificationDate)
+            let saveStartedAt = Date()
             let raw = await runScript(saveProjectScript())
-            return Self.wrapMutatingResult(raw, operation: operation)
+            return Self.verifiedSaveResult(
+                raw,
+                documentPath: documentPath,
+                beforeMtime: beforeMtime,
+                afterMtime: documentPath.flatMap(runtime.fileModificationDate),
+                saveStartedAt: saveStartedAt
+            )
 
         case "project.save_as":
             guard let path = params["path"] else {
@@ -181,6 +204,62 @@ actor AppleScriptChannel: Channel {
         return .success(HonestContract.encodeStateB(
             reason: .readbackUnavailable, extras: merged
         ))
+    }
+
+    /// #110: build the HC verdict for `project.save` from on-disk file
+    /// evidence. The `.logicx` package mtime is authoritative — `save front
+    /// document` persists even when the AppleEvent reply times out (-1712) —
+    /// so a write confirmed by the mtime advancing past `saveStartedAt` (or
+    /// beyond a pre-save snapshot) is verified State A regardless of `result`'s
+    /// success/error. No path (untitled) or an unchanged mtime → honest State B.
+    static func verifiedSaveResult(
+        _ result: ChannelResult,
+        documentPath: String?,
+        beforeMtime: Date?,
+        afterMtime: Date?,
+        saveStartedAt: Date
+    ) -> ChannelResult {
+        // A script body that already produced an HC envelope is passed through
+        // untouched (matches wrapMutatingResult's no-double-wrap contract).
+        if HonestContractEnvelopeDetector.isAlreadyEnvelope(result.message) {
+            return result
+        }
+
+        var extras: [String: Any] = [
+            "operation": "project.save",
+            "method": "applescript",
+            "verify_source": "file_mtime",
+            // Preserve the raw script payload verbatim, matching the prior
+            // wrapMutatingResult contract (callers/tests rely on `raw`).
+            "raw": result.message,
+        ]
+        if let documentPath { extras["document_path"] = documentPath }
+        if let afterMtime { extras["observed_mtime"] = iso8601String(afterMtime) }
+        if let beforeMtime { extras["previous_mtime"] = iso8601String(beforeMtime) }
+
+        // 1) File evidence is authoritative: a package written this save is
+        //    verified State A even if the AppleEvent reply timed out (-1712).
+        let documentExists = documentPath.map { !$0.isEmpty } ?? false
+        let wroteThisSave = documentExists && (afterMtime.map { after in
+            after >= saveStartedAt || beforeMtime.map { after > $0 } == true
+        } ?? false)
+        if wroteThisSave {
+            return .success(HonestContract.encodeStateA(extras: extras))
+        }
+        // 2) No write observed + the script itself errored → surface that error
+        //    verbatim (terminal); the router treats it as a real failure.
+        if !result.isSuccess {
+            return result
+        }
+        // 3) Script succeeded but no on-disk evidence: an untitled document has
+        //    no path to check (direct to save_as); a titled one whose mtime
+        //    didn't advance is an honest "fired but unconfirmed". Never State A.
+        guard documentExists else {
+            extras["reason_detail"] = "front document has no on-disk path (untitled); use save_as to verify"
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        extras["reason_detail"] = "save reported success but the .logicx package mtime did not advance"
+        return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
     }
 
     static func wrapSaveAsResult(

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -207,7 +207,11 @@ actor ChannelRouter {
         // Project — AppleScript primary for new/open/close lifecycle, KeyCmd for save/bounce
         "project.new":                [.appleScript, .cgEvent],
         "project.open":               [.appleScript],
-        "project.save":               [.midiKeyCommands, .cgEvent, .appleScript],
+        // #110: AppleScript-first — the direct `save front document` is the
+        // reliable writer and lets the channel verify the .logicx package was
+        // (re)written on disk (export/bounce prerequisite). KeyCmd/CGEvent
+        // remain as fallbacks (e.g. AppleScript automation denied).
+        "project.save":               [.appleScript, .midiKeyCommands, .cgEvent],
         "project.save_as":            [.accessibility, .appleScript],
         "project.close":              [.appleScript, .cgEvent],
         "project.get_info":           [.accessibility],

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -172,6 +172,10 @@ struct ProjectDispatcher {
 
         case "save":
             audit(command, phase: .executed)
+            // #110: save is an export/bounce prerequisite. The read-back
+            // verification lives in the AppleScript channel (the reliable
+            // writer, now tried first) so it stays DI-testable like save_as;
+            // the dispatcher just routes + surfaces the channel's HC verdict.
             let result = await router.route(operation: "project.save")
             return toolTextResult(result)
 

--- a/Tests/LogicProMCPTests/AppleScriptChannelHCWrapTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelHCWrapTests.swift
@@ -22,7 +22,8 @@ private func makeAppleScriptRuntime(
     isRunning: Bool = true,
     scriptRecorder: AppleScriptRecorder = AppleScriptRecorder(),
     openRecorder: OpenFileRecorder = OpenFileRecorder(),
-    transportRecorder: TransportActionRecorder = TransportActionRecorder()
+    transportRecorder: TransportActionRecorder = TransportActionRecorder(),
+    currentDocumentPath: @escaping @Sendable () async -> String? = { nil }
 ) -> AppleScriptChannel.Runtime {
     AppleScriptChannel.Runtime(
         isLogicProRunning: { isRunning },
@@ -35,7 +36,8 @@ private func makeAppleScriptRuntime(
         },
         executeTransportAction: { action in
             await transportRecorder.run(action)
-        }
+        },
+        currentDocumentPath: currentDocumentPath
     )
 }
 

--- a/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
@@ -63,7 +63,8 @@ private func makeAppleScriptRuntime(
     openRecorder: OpenFileRecorder = OpenFileRecorder(),
     transportRecorder: TransportActionRecorder = TransportActionRecorder(),
     fileExists: @escaping @Sendable (String) -> Bool = { _ in true },
-    fileModificationDate: @escaping @Sendable (String) -> Date? = { _ in Date.distantFuture }
+    fileModificationDate: @escaping @Sendable (String) -> Date? = { _ in Date.distantFuture },
+    currentDocumentPath: @escaping @Sendable () async -> String? = { nil }
 ) -> AppleScriptChannel.Runtime {
     AppleScriptChannel.Runtime(
         isLogicProRunning: { isRunning },
@@ -80,7 +81,8 @@ private func makeAppleScriptRuntime(
             await transportRecorder.run(action)
         },
         fileExists: fileExists,
-        fileModificationDate: fileModificationDate
+        fileModificationDate: fileModificationDate,
+        currentDocumentPath: currentDocumentPath
     )
 }
 

--- a/Tests/LogicProMCPTests/Issue110SaveVerifyTests.swift
+++ b/Tests/LogicProMCPTests/Issue110SaveVerifyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #110: project.save is an export/bounce prerequisite and must not report
+/// success without read-back. `AppleScriptChannel.verifiedSaveResult` decides
+/// the HC verdict from the front document's `.logicx` package mtime — the
+/// authoritative file evidence — so a confirmed write is verified State A even
+/// when `save front document` times out its AppleEvent reply (-1712).
+@Suite("Issue110 save verification")
+struct Issue110SaveVerifyTests {
+    private func obj(_ r: ChannelResult) -> [String: Any]? {
+        (try? JSONSerialization.jsonObject(with: Data(r.message.utf8))) as? [String: Any]
+    }
+
+    private let scriptOK = ChannelResult.success("{\"result\":\"\"}")
+    private let scriptTimeout = ChannelResult.error("AppleScript error: AppleEvent timed out (-1712)")
+
+    @Test("verified State A when the package mtime advances past the save start")
+    func verifiedWhenWritten() {
+        let started = Date()
+        let result = AppleScriptChannel.verifiedSaveResult(
+            scriptOK,
+            documentPath: "/Users/x/Song.logicx",
+            beforeMtime: started.addingTimeInterval(-60),
+            afterMtime: started.addingTimeInterval(0.4),
+            saveStartedAt: started
+        )
+        #expect(result.isSuccess)
+        let o = obj(result)
+        #expect(o?["verified"] as? Bool == true)
+        #expect(o?["verify_source"] as? String == "file_mtime")
+        #expect(o?["document_path"] as? String == "/Users/x/Song.logicx")
+    }
+
+    @Test("a -1712 reply timeout is still verified State A when the file was written")
+    func timeoutButWrittenIsVerified() {
+        let started = Date()
+        let result = AppleScriptChannel.verifiedSaveResult(
+            scriptTimeout, // save front document timed out its reply…
+            documentPath: "/Users/x/Song.logicx",
+            beforeMtime: started.addingTimeInterval(-60),
+            afterMtime: started.addingTimeInterval(0.6), // …but the package was written
+            saveStartedAt: started
+        )
+        #expect(result.isSuccess)
+        #expect(obj(result)?["verified"] as? Bool == true)
+    }
+
+    @Test("errored script + no write surfaces the error verbatim (terminal)")
+    func erroredAndNotWrittenFailsClosed() {
+        let started = Date()
+        let result = AppleScriptChannel.verifiedSaveResult(
+            scriptTimeout,
+            documentPath: "/Users/x/Song.logicx",
+            beforeMtime: started.addingTimeInterval(-60),
+            afterMtime: started.addingTimeInterval(-60), // unchanged
+            saveStartedAt: started
+        )
+        #expect(!result.isSuccess)
+        #expect(result.message.contains("1712"))
+    }
+
+    @Test("State B (no false success) when success but mtime did not advance")
+    func successButNotWrittenIsStateB() {
+        let started = Date()
+        let result = AppleScriptChannel.verifiedSaveResult(
+            scriptOK,
+            documentPath: "/Users/x/Song.logicx",
+            beforeMtime: started.addingTimeInterval(-60),
+            afterMtime: started.addingTimeInterval(-60),
+            saveStartedAt: started
+        )
+        #expect(result.isSuccess)
+        #expect(obj(result)?["verified"] as? Bool == false)
+    }
+
+    @Test("untitled document (no path) stays an honest State B")
+    func untitledStaysStateB() {
+        let result = AppleScriptChannel.verifiedSaveResult(
+            scriptOK, documentPath: nil, beforeMtime: nil, afterMtime: nil, saveStartedAt: Date()
+        )
+        #expect(result.isSuccess)
+        let o = obj(result)
+        #expect(o?["verified"] as? Bool == false)
+        #expect((o?["reason_detail"] as? String)?.contains("untitled") == true)
+    }
+}


### PR DESCRIPTION
Closes #110.

## Triage (live, healthy session)

- **`get_regions` / `system.health` / `system.refresh_cache` "timeouts" were environmental** (a wedged/modal Logic session during the probe). On a healthy session they return in <0.4s; a genuine hang now fails fast with a typed **`operation_timeout`** (#112's command deadline) instead of hanging the stdio loop — exactly #110's *"fail fast with typed UI/cache reasons instead of timing out."*
- **`project.audit` / `cleanup_plan` `status:degraded`** is an honest status (the audited project genuinely had findings), not a failure.
- **`project.save` reported `success=true verified=false`** — but save is an export/bounce prerequisite and must not claim success without read-back.

## Fix — file-evidence-verified save

The front document's **`.logicx` package mtime is authoritative**: `save front document` reliably persists even when its AppleEvent reply times out (`-1712` — live-confirmed: the package mtime advances). So the verdict is driven by the file, not the script's success/error:

- Route `project.save` **AppleScript-first** (the reliable direct writer; KeyCmd/CGEvent remain fallbacks — previously the no-op KeyCmd stopped the chain before any real save).
- `AppleScriptChannel.verifiedSaveResult` returns:
  - **verified State A** when the package was (re)written this save (even on a `-1712` reply timeout);
  - **honest State B** when an untitled document has no path, or a titled one's mtime didn't advance;
  - the **script error verbatim** when it errored and nothing was written.
  Never a verified save without file evidence an export step would trust.
- `currentDocumentPath` is now an injectable `Runtime` dependency, so save stays DI-testable like `save_as`.

## Verification

- **Unit** (`Issue110SaveVerifyTests`): written→State A; `-1712`-but-written→State A; errored+no-write→verbatim error; success+no-write→State B; untitled→State B. `AppleScriptChannel` + HC-wrap save tests updated for the injectable `currentDocumentPath`.
- **Live**: `save front document` writes the `.logicx` package (mtime advanced 17:01→19:05 on a real save); the verdict logic covers every branch above.
- **Suite**: `swift test --no-parallel` → **1647 tests, 0 issues**.

## Scope note
`get_regions`/`health`/`refresh_cache` need no code change (healthy sub-second + #112 backstop). `project.new` keeps its honest State B (a fresh untitled project has no readback-able postcondition / on-disk path); the verified **export/bounce** prerequisite is `project.save` (fixed here) and `export_run` (already file-verified). The MCP-driven export path needs no manual UI bounce.