### PR TITLE
feat(#60): centralize read-only transport/marker classifier token bags (Phase 3)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -290,6 +290,44 @@ enum AXLocalePolicy {
         rationale: "Identifies the plugin Setting AXPopUpButton by its value substring; read-only locator."
     )
 
+    // MARK: - Read-only heuristic token bags (Phase 3, issue #60)
+    //
+    // These back read-only *classifiers* (which AX container is the marker
+    // ruler / the transport-control bar). They are scanned with `.contains`
+    // semantics over an already-lowercased aggregate string and never gate a
+    // State-A success — purely "which region of the tree is this". Centralized
+    // here as compatibility-hint token bags so the EN/KO pairs live in one
+    // audited place; each preserves its call site's exact token list + order.
+
+    /// Marker ruler keyword fallback (oldest locator path).
+    static let markerContainerKeywords = LabelSet(
+        canonical: "marker",
+        variants: ["마커"],
+        rationale: "Last-resort marker-ruler container classifier; read-only keyword scan."
+    )
+
+    /// Control-bar / transport container metadata tokens (id/title/desc scan).
+    static let transportContainerMetadata = LabelSet(
+        canonical: "transport",
+        variants: ["control bar", "컨트롤 막대"],
+        rationale: "Classifies the transport/control-bar container by metadata substring; read-only."
+    )
+
+    /// Transport control-button label tokens (≥2 distinct hits ⇒ transport bar).
+    static let transportContainerControlKeywords = LabelSet(
+        canonical: "play",
+        variants: ["stop", "record", "cycle", "loop", "metronome", "rewind", "forward",
+                   "재생", "녹음", "사이클", "메트로놈", "클릭"],
+        rationale: "Counts distinct transport-control labels to classify the control bar; read-only."
+    )
+
+    /// Tempo/position slider description tokens inside the transport container.
+    static let transportSliderHints = LabelSet(
+        canonical: "tempo",
+        variants: ["bpm", "position", "템포", "재생헤드 위치", "마디", "비트"],
+        rationale: "Classifies tempo/position sliders inside the transport container; read-only."
+    )
+
     static let showMixerMenuPath = MenuPath(bar: viewMenuBar, item: showMixerMenuItem)
     static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)
     static let editUndoMenuPath = MenuPath(bar: editMenuBar, item: undoMenuItemPrefix, itemMode: .prefix)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -1299,7 +1299,8 @@ enum AXLogicProElements {
 
         // Strategy 3 — keyword fallback (oldest path).
         if rulerElement == nil {
-            let markerKeywords = ["marker", "마커"]
+            // #60: centralized marker-container keyword bag (read-only classifier).
+            let markerKeywords = AXLocalePolicy.markerContainerKeywords.labels
             let groups = AXHelpers.findAllDescendants(
                 of: arrangementArea, role: kAXGroupRole, maxDepth: 6, runtime: runtime.ax
             )
@@ -1308,7 +1309,7 @@ enum AXLogicProElements {
                 let desc = AXHelpers.getDescription(group, runtime: runtime.ax)?.lowercased() ?? ""
                 let title = AXHelpers.getTitle(group, runtime: runtime.ax)?.lowercased() ?? ""
                 let combined = "\(id) \(desc) \(title)"
-                if markerKeywords.contains(where: { combined.contains($0) }) {
+                if markerKeywords.contains(where: { combined.contains($0.lowercased()) }) {
                     rulerElement = group
                     break
                 }
@@ -1561,11 +1562,13 @@ enum AXLogicProElements {
             .compactMap { $0?.lowercased() }
             .joined(separator: " ")
 
-        if metadata.contains("transport") || metadata.contains("control bar") || metadata.contains("컨트롤 막대") {
+        // #60: centralized control-bar metadata + control-keyword token bags
+        // (read-only classifiers). Same lowercased `.contains` semantics.
+        if AXLocalePolicy.transportContainerMetadata.labels.contains(where: { metadata.contains($0.lowercased()) }) {
             return true
         }
 
-        let transportKeywords = ["play", "stop", "record", "cycle", "loop", "metronome", "rewind", "forward", "재생", "녹음", "사이클", "메트로놈", "클릭"]
+        let transportKeywords = AXLocalePolicy.transportContainerControlKeywords.labels.map { $0.lowercased() }
         let controls = AXHelpers.findAllDescendants(of: element, role: kAXButtonRole, maxDepth: 4, runtime: runtime)
             + AXHelpers.findAllDescendants(of: element, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime)
         let controlHits = controls.reduce(into: Set<String>()) { hits, control in
@@ -1584,15 +1587,11 @@ enum AXLogicProElements {
             return true
         }
 
+        // #60: centralized tempo/position slider hint token bag (read-only).
+        let sliderHintTokens = AXLocalePolicy.transportSliderHints.labels.map { $0.lowercased() }
         let sliderHits = AXHelpers.findAllDescendants(of: element, role: kAXSliderRole, maxDepth: 4, runtime: runtime).contains { slider in
             let description = AXHelpers.getDescription(slider, runtime: runtime)?.lowercased() ?? ""
-            return description.contains("tempo")
-                || description.contains("bpm")
-                || description.contains("position")
-                || description.contains("템포")
-                || description.contains("재생헤드 위치")
-                || description.contains("마디")
-                || description.contains("비트")
+            return sliderHintTokens.contains { description.contains($0) }
         }
 
         let textRoles = [kAXStaticTextRole, kAXTextFieldRole]

--- a/Tests/LogicProMCPTests/Issue60LocalePhase3Tests.swift
+++ b/Tests/LogicProMCPTests/Issue60LocalePhase3Tests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #60 (Phase 3): the read-only heuristic token bags that classify which AX
+/// container is the marker ruler / the transport-control bar are now centralized
+/// in `AXLocalePolicy` instead of inline literals. These deterministic EN+KO
+/// tests pin the token coverage so a future edit can't silently drop a locale.
+/// They are read-only classifiers — no State-A success is gated on them.
+@Suite("Issue60 locale phase 3 token bags")
+struct Issue60LocalePhase3Tests {
+    @Test("marker container keywords cover EN + KO")
+    func markerKeywords() {
+        let labels = AXLocalePolicy.markerContainerKeywords.labels
+        #expect(labels.contains("marker"))
+        #expect(labels.contains("마커"))
+    }
+
+    @Test("transport container metadata covers EN + KO")
+    func transportMetadata() {
+        let labels = AXLocalePolicy.transportContainerMetadata.labels
+        #expect(labels.contains("transport"))
+        #expect(labels.contains("control bar"))
+        #expect(labels.contains("컨트롤 막대"))
+    }
+
+    @Test("transport control keywords preserve the full EN + KO token set")
+    func transportControlKeywords() {
+        let labels = Set(AXLocalePolicy.transportContainerControlKeywords.labels)
+        // The exact set the inline literal carried (order-independent).
+        let expected: Set<String> = [
+            "play", "stop", "record", "cycle", "loop", "metronome", "rewind", "forward",
+            "재생", "녹음", "사이클", "메트로놈", "클릭",
+        ]
+        #expect(labels == expected, "token set drifted: \(labels.symmetricDifference(expected))")
+    }
+
+    @Test("transport slider hint tokens cover EN + KO")
+    func transportSliderHints() {
+        let labels = Set(AXLocalePolicy.transportSliderHints.labels)
+        let expected: Set<String> = ["tempo", "bpm", "position", "템포", "재생헤드 위치", "마디", "비트"]
+        #expect(labels == expected, "token set drifted: \(labels.symmetricDifference(expected))")
+    }
+
+    @Test("containsAny matches both EN and KO control-bar metadata (classifier semantics)")
+    func containsAnyEnKo() {
+        // The classifier scans an already-lowercased aggregate string.
+        #expect(AXLocalePolicy.transportContainerMetadata.containsAny(in: "group transport bar"))
+        #expect(AXLocalePolicy.transportContainerMetadata.containsAny(in: "그룹 컨트롤 막대"))
+        #expect(!AXLocalePolicy.transportContainerMetadata.containsAny(in: "mixer strip"))
+    }
+
+    @Test("every Phase 3 token bag carries at least one Korean variant")
+    func everyBagHasKorean() {
+        let bags: [(String, AXLocalePolicy.LabelSet)] = [
+            ("markerContainerKeywords", AXLocalePolicy.markerContainerKeywords),
+            ("transportContainerMetadata", AXLocalePolicy.transportContainerMetadata),
+            ("transportContainerControlKeywords", AXLocalePolicy.transportContainerControlKeywords),
+            ("transportSliderHints", AXLocalePolicy.transportSliderHints),
+        ]
+        for (name, bag) in bags {
+            let hasKorean = bag.labels.contains { $0.unicodeScalars.contains { (0xAC00...0xD7A3).contains($0.value) } }
+            #expect(hasKorean, "\(name) must carry a Korean variant for KO-locale coverage")
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/Issue60LocalePhase3Tests.swift
+++ b/Tests/LogicProMCPTests/Issue60LocalePhase3Tests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Foundation
 import Testing
 @testable import LogicProMCP
@@ -62,5 +63,87 @@ struct Issue60LocalePhase3Tests {
             let hasKorean = bag.labels.contains { $0.unicodeScalars.contains { (0xAC00...0xD7A3).contains($0.value) } }
             #expect(hasKorean, "\(name) must carry a Korean variant for KO-locale coverage")
         }
+    }
+
+    // MARK: - Functional classifier coverage (drives the real AX entry points)
+    //
+    // The token-coverage tests above pin the bag contents; these prove the bag
+    // is actually *consumed* by the read-only classifier it backs, end-to-end,
+    // through a fake AX tree — in both English and Korean.
+
+    /// `enumerateMarkers` Strategy 3 (keyword fallback) must classify a marker
+    /// container by the `markerContainerKeywords` bag when no Marker-List window
+    /// and no AXRuler exist. Exercises EN + KO.
+    @Test("enumerateMarkers keyword-fallback classifies the marker container (EN + KO)",
+          arguments: ["Marker", "마커"])
+    func markerKeywordFallbackIsWired(containerLabel: String) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(8000)
+        let arrange = b.element(8001)
+        b.setAttribute(app, kAXWindowsAttribute as String, [arrange])
+        b.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+        b.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+        // Title without any Marker-List suffix → Strategy 1 skipped.
+        b.setAttribute(arrange, kAXTitleAttribute as String, "Proj - Tracks")
+        // No AXRuler anywhere → Strategy 2 skipped, forcing the keyword fallback.
+        let markerGroup = b.element(8010)
+        b.setAttribute(markerGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(markerGroup, kAXDescriptionAttribute as String, containerLabel)
+        let t1 = b.element(8020)
+        let t2 = b.element(8021)
+        b.setAttribute(t1, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setAttribute(t1, kAXTitleAttribute as String, "Intro")
+        b.setAttribute(t2, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setAttribute(t2, kAXTitleAttribute as String, "Chorus")
+        b.setChildren(markerGroup, [t1, t2])
+        b.setChildren(arrange, [markerGroup])
+
+        let markers = AXLogicProElements.enumerateMarkers(in: arrange, runtime: b.makeLogicRuntime(appElement: app))
+        #expect(markers.map { $0.name } == ["Intro", "Chorus"], "locale \(containerLabel)")
+    }
+
+    /// A group with no marker keyword must NOT be classified as the marker
+    /// container — proves the bag discriminates rather than matching anything.
+    @Test("enumerateMarkers keyword-fallback ignores a non-marker group")
+    func markerKeywordFallbackDiscriminates() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(8030)
+        let arrange = b.element(8031)
+        b.setAttribute(app, kAXWindowsAttribute as String, [arrange])
+        b.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+        b.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(arrange, kAXTitleAttribute as String, "Proj - Tracks")
+        let mixerGroup = b.element(8040)
+        b.setAttribute(mixerGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(mixerGroup, kAXDescriptionAttribute as String, "Mixer")
+        let t1 = b.element(8041)
+        b.setAttribute(t1, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setAttribute(t1, kAXTitleAttribute as String, "Volume")
+        b.setChildren(mixerGroup, [t1])
+        b.setChildren(arrange, [mixerGroup])
+
+        let markers = AXLogicProElements.enumerateMarkers(in: arrange, runtime: b.makeLogicRuntime(appElement: app))
+        #expect(markers.isEmpty)
+    }
+
+    /// `getTransportBar` falls through to the `looksLikeTransportContainer`
+    /// classifier (no toolbar / no id="Transport" group), which must recognize
+    /// the control-bar group by the `transportContainerMetadata` bag. EN + KO.
+    @Test("getTransportBar classifies the control bar by metadata (EN + KO)",
+          arguments: ["transport", "컨트롤 막대"])
+    func transportContainerMetadataIsWired(metadataLabel: String) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(8100)
+        let window = b.element(8101)
+        b.setAttribute(app, kAXWindowsAttribute as String, [window])
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+        let group = b.element(8110)
+        b.setAttribute(group, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(group, kAXDescriptionAttribute as String, metadataLabel)
+        b.setChildren(window, [group])
+
+        let bar = AXLogicProElements.getTransportBar(runtime: b.makeLogicRuntime(appElement: app))
+        #expect(bar == group, "locale \(metadataLabel)")
     }
 }

--- a/docs/locale-agnostic-ax-policy.md
+++ b/docs/locale-agnostic-ax-policy.md
@@ -49,11 +49,29 @@ These labels are allowed because each use is either best-effort cleanup/reveal, 
 - Do not infer State A from the click itself.
 - Include a failure mode that returns State B/C when readback is unavailable or ambiguous.
 
+## Phase 3 (issue #60) — read-only heuristic token bags centralized
+
+The transport/marker container *classifier* token bags moved from inline
+literals in `AXLogicProElements` into `AXLocalePolicy` compatibility-hint sets,
+behavior-preserving (same lowercased `.contains` scan + token order), with
+deterministic EN+KO tests (`Issue60LocalePhase3Tests`):
+
+- `markerContainerKeywords` (`marker` / `마커`) — marker-ruler fallback locator.
+- `transportContainerMetadata` (`transport` / `control bar` / `컨트롤 막대`).
+- `transportContainerControlKeywords` (play/stop/record/… + 재생/녹음/사이클/메트로놈/클릭).
+- `transportSliderHints` (tempo/bpm/position/… + 템포/재생헤드 위치/마디/비트).
+
+These are read-only classifiers (which AX container is which); none gate a
+State-A success. This closes the previously-listed `looksLikeTransportContainer`
+keyword aggregate and the marker-ruler keyword fallback below.
+
 ## Known Remaining Surfaces
 
-The locale-agnostic epic (#60) is **not closed**. The following localized text
-surfaces are still pending and require live EN+KO E2E against real Logic Pro to
-confirm State A on their respective paths:
+The locale-agnostic epic (#60) is **not closed** (its acceptance criterion 5
+keeps it open until a live EN **and** KO Logic UI E2E pass — the Korean-locale
+run remains environmentally blocked; see the epic thread). The following
+localized text surfaces are still pending and require live EN+KO E2E against real
+Logic Pro to confirm State A on their respective paths:
 
 1. **AppleScript / System Events menu literals** — `AccessibilityChannel`
    contains many menu-addressing strings (e.g. `트랙 → 트랙 삭제`,
@@ -63,18 +81,19 @@ confirm State A on their respective paths:
    `osascript` source and addressed by System Events text, so they cannot move to
    a Swift `LabelSet` without rewriting the menu-click mechanism — a behavior
    change, deferred. They must remain guarded by post-action readback.
-2. **`looksLikeTransportContainer` keyword aggregate** (`AXLogicProElements`) —
-   a transport-detection heuristic scanning a multi-token keyword list. It is a
-   classifier, not a State-A gate; centralizing its overlapping token bag without
-   widening needs a dedicated audit and is deferred.
+2. ~~**`looksLikeTransportContainer` keyword aggregate** (`AXLogicProElements`)~~
+   — **centralized in Phase 3** (`transportContainerMetadata`,
+   `transportContainerControlKeywords`, `transportSliderHints`). Behavior
+   preserved; EN+KO tested. Still pending live KO confirmation.
 3. **Mixer / inspector / channel-strip metadata keyword scans**
    (`AXLogicProElements`: send/입력/출력/그룹/채널 모드/볼륨/패닝/바이패스/오토메이션
    etc.) — large heuristic token bags used for classification and disambiguation.
    These are read-only but interdependent; a careful, separately-tested pass is
    required to avoid changing which strips/controls are recognized.
 4. **Marker-list / cell placeholder keywords** (`AXLogicProElements`:
-   `마커`/`marker`, `셀`/`Cell`, marker-list window-title suffixes) — read-only
-   scraping fallbacks for old Logic versions; pending.
+   `셀`/`Cell`, marker-list window-title suffixes) — read-only scraping fallbacks
+   for old Logic versions; pending. (The marker-*ruler* keyword fallback
+   `마커`/`marker` was centralized in Phase 3 as `markerContainerKeywords`.)
 5. **Region / track-content / track-type description keywords**
    (`AccessibilityChannel`: `리전`/region, `트랙 콘텐츠`/Track Content,
    드러머/세션 플레이어/오디오 etc.) — read-only classification, pending.


### PR DESCRIPTION
Advances #60 (epic — **stays open**, see Scope below).

## What

Moves the last inline heuristic token bags in `AXLogicProElements` into `AXLocalePolicy` compatibility-hint sets — the read-only container *classifiers* the epic's remaining-surfaces list named (item #2 `looksLikeTransportContainer` keyword aggregate + the marker-ruler keyword fallback):

- `markerContainerKeywords` — `marker` / `마커`
- `transportContainerMetadata` — `transport` / `control bar` / `컨트롤 막대`
- `transportContainerControlKeywords` — play/stop/record/… + 재생/녹음/사이클/메트로놈/클릭
- `transportSliderHints` — tempo/bpm/position/… + 템포/재생헤드 위치/마디/비트

**Behavior-preserving:** the call sites keep the identical lowercased `.contains` scan and the distinct-hit count logic; only the EN/KO token lists move into the audited policy. None of these gate a State-A success — they classify *which AX container is which* (read-only). `docs/locale-agnostic-ax-policy.md` gets a Phase 3 section and the remaining list is narrowed accordingly.

## Verification

- **Unit** (`Issue60LocalePhase3Tests`): EN+KO coverage per bag, **exact token-set pinning** (a dropped/added token fails the test), `containsAny` EN/KO classifier semantics, and a guard that every bag carries a Korean variant.
- **Suite**: `swift test --no-parallel` → **1644 tests, 0 issues** — proving the existing transport-container / marker-ruler detection is unchanged.
- The token sets are byte-identical to those PR #101 already live-verified against real Logic 12.2, so the live behavior is unchanged.

## Scope — epic stays open

This is **advancement, not a close**. Per the epic's **acceptance criterion 5**, #60 remains open until a live EN **and** KO Logic UI E2E pass — the **Korean-locale run is environmentally blocked** (relaunch instability; documented in the epic thread). Remaining un-centralized surfaces are explicitly listed in `docs/locale-agnostic-ax-policy.md`:
- AppleScript/System-Events menu literals (behavior-changing migration, per-path live-gated);
- mixer/inspector/channel-strip + region/track-type heuristic bags (a separate, individually-tested pass).

Criteria satisfied by the cumulative epic + this PR: #1 (single policy ✓), #2 (these surfaces centralized/justified ✓ for this slice), #3 (fail-closed on write paths ✓), #4 (deterministic EN+KO tests ✓ for the centralized surfaces). #5 (KO-live) remains the open gate.