### PR TITLE
feat(#60): centralize mixer/plugin + region classifier token bags (Phase 4)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -336,6 +336,167 @@ enum AXLocalePolicy {
         rationale: "Classifies tempo/position sliders inside the transport container; read-only."
     )
 
+    // MARK: - Read-only classifier token bags (Phase 4, issue #60)
+    //
+    // Mixer / inspector / channel-strip / plugin-slot classifiers (surface #3)
+    // and region / track-content / track-type classifiers (surface #5). All back
+    // read-only predicates/locators — they decide "what kind of element/region is
+    // this", never gate a State-A success. Each preserves its call site's EXACT
+    // token list, source order, and match semantics (`.containsAny` for the
+    // `text.contains(token)` || chains over an already-lowercased aggregate;
+    // `.labels.contains(normalized)` for the normalized `==` predicates). Write
+    // paths, AppleScript menu literals, and the region-bar regex are deliberately
+    // NOT centralized here (separate, behavior-changing migrations).
+
+    /// Inspector-context marker — prunes inspector ancestors from mixer scans.
+    static let mixerInspectorContext = LabelSet(
+        canonical: "inspector",
+        variants: ["인스펙터"],
+        rationale: "Marks an inspector ancestor so mixer-area detection skips it; read-only classifier."
+    )
+
+    /// Mixer container id/desc/title exact match (normalized lowercase equality).
+    static let mixerNamedElement = LabelSet(
+        canonical: "mixer",
+        variants: ["믹서"],
+        rationale: "Identifies the mixer container by exact normalized name; read-only classifier."
+    )
+
+    /// Slider type hints (mutually exclusive groups in `sliderText`).
+    static let sliderSendHint = LabelSet(
+        canonical: "send",
+        variants: ["센드"],
+        rationale: "Classifies a slider as a send control; read-only."
+    )
+    static let sliderZoomHint = LabelSet(
+        canonical: "zoom",
+        variants: ["확대"],
+        rationale: "Classifies a slider as a zoom control; read-only."
+    )
+    static let sliderVolumeHint = LabelSet(
+        canonical: "volume",
+        variants: ["fader", "볼륨"],
+        rationale: "Classifies a slider as a volume fader; read-only."
+    )
+    static let sliderPanHint = LabelSet(
+        canonical: "pan",
+        variants: ["panning", "패닝", "밸런스"],
+        rationale: "Classifies a slider as a pan control; read-only."
+    )
+
+    /// Plugin-slot child control locators.
+    static let pluginBypassControl = LabelSet(
+        canonical: "bypass",
+        variants: ["바이패스"],
+        rationale: "Locates a plugin-slot bypass control by label; read-only locator (structural fallback exists)."
+    )
+    static let pluginOpenOrListControl = LabelSet(
+        canonical: "open",
+        variants: ["열기", "list", "목록"],
+        rationale: "Locates a plugin-slot open/list control by label; read-only locator (structural fallback exists)."
+    )
+
+    /// Automation-mode labels that must NOT be read as a plugin display name.
+    static let pluginAutomationLabelExact = LabelSet(
+        canonical: "읽기, 오토메이션이 활성화됨",
+        variants: ["read"],
+        rationale: "Rejects automation-mode slot labels (exact) when extracting a plugin display name; read-only filter."
+    )
+    static let pluginAutomationLabelSubstring = LabelSet(
+        canonical: "automation",
+        variants: ["오토메이션"],
+        rationale: "Rejects automation-mode slot labels (substring) when extracting a plugin display name; read-only filter."
+    )
+
+    /// Empty audio-plugin insert-slot button classification.
+    static let audioPluginSlotLabel = LabelSet(
+        canonical: "audio plugin",
+        variants: ["audio effect", "오디오 플러그인", "오디오 이펙트"],
+        rationale: "Classifies an empty audio-plugin insert-slot button; read-only (structural fallback exists)."
+    )
+    static let sendOrIOControlLabel = LabelSet(
+        canonical: "send",
+        variants: ["센드", "input", "output", "입력", "출력"],
+        rationale: "Excludes send/IO buttons from empty audio-plugin slot detection; read-only."
+    )
+
+    /// Negative-case table: button labels that are NOT empty insert slots.
+    static let nonInsertButtonText = LabelSet(
+        canonical: "send",
+        variants: [
+            "센드", "input", "입력", "output", "출력", "group", "그룹",
+            "channel mode", "채널 모드", "eq", "setting", "설정",
+            "gain reduction", "게인 축소", "mute", "음소거", "solo", "record", "녹음",
+            "monitor", "모니터링", "volume", "볼륨", "fader", "페이더",
+            "pan", "패닝", "밸런스",
+        ],
+        rationale: "Negative-case table excluding non-insert channel-strip buttons from empty-slot enumeration; read-only."
+    )
+
+    /// Track-header pan slider locator (header-level).
+    static let headerPanHint = LabelSet(
+        canonical: "pan",
+        variants: ["팬", "밸런스"],
+        rationale: "Locates the track-header pan slider by child description; read-only locator (structural fallback exists)."
+    )
+
+    /// Track-header rail description (normalized exact match).
+    static let trackHeadersDescription = LabelSet(
+        canonical: "track headers",
+        variants: ["track header", "tracks header", "tracks headers", "트랙 헤더"],
+        rationale: "Identifies the track-header rail by normalized description; read-only classifier (structural detection preferred)."
+    )
+
+    /// Choose-Project picker window title markers.
+    static let projectPickerWindow = LabelSet(
+        canonical: "프로젝트 선택",
+        variants: ["choose a project", "choose project", "new from template"],
+        rationale: "Distinguishes the Choose-Project picker window from a real project; read-only classifier."
+    )
+
+    /// Transport text-field description hints (tempo/position fields).
+    static let transportTextFieldHint = LabelSet(
+        canonical: "tempo",
+        variants: ["bpm", "position", "템포", "재생헤드 위치"],
+        rationale: "Classifies transport tempo/position text fields inside the control bar; read-only."
+    )
+
+    /// Region container "Track Content" group (normalized exact match).
+    static let trackContentExplicit = LabelSet(
+        canonical: "트랙 콘텐츠",
+        variants: ["track content", "track contents", "tracks content", "tracks contents"],
+        rationale: "Identifies the arrange Track-Content group by normalized description; read-only classifier."
+    )
+    static let trackContentGeneric = LabelSet(
+        canonical: "콘텐츠",
+        variants: ["content", "contents"],
+        rationale: "Generic content-group fallback by normalized description; read-only classifier."
+    )
+
+    /// Region-kind classification by name+help substring.
+    static let regionKindDrummer = LabelSet(
+        canonical: "drummer",
+        variants: ["session player", "드러머", "세션 플레이어"],
+        rationale: "Classifies a region as drummer/session-player content; read-only."
+    )
+    static let regionKindMidi = LabelSet(
+        canonical: "midi",
+        variants: [],
+        rationale: "Classifies a region as MIDI content; read-only."
+    )
+    static let regionKindAudio = LabelSet(
+        canonical: "audio",
+        variants: ["오디오"],
+        rationale: "Classifies a region as audio content; read-only."
+    )
+
+    /// Region detection by AXHelp keyword.
+    static let regionHelpKeyword = LabelSet(
+        canonical: "region",
+        variants: ["리전"],
+        rationale: "Detects an arrange region by its AXHelp string; read-only classifier."
+    )
+
     static let showMixerMenuPath = MenuPath(bar: viewMenuBar, item: showMixerMenuItem)
     static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)
     static let editUndoMenuPath = MenuPath(bar: editMenuBar, item: undoMenuItemPrefix, itemMode: .prefix)

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -77,14 +77,21 @@ enum AXLocalePolicy {
             }
         }
 
-        /// True if `haystack` contains ANY label as a case-insensitive substring.
-        /// Preserves the existing `combined.contains(token)` control flow where a
-        /// pre-built, already-lowercased aggregate string is scanned for any of a
-        /// set of localized tokens. The caller keeps its own AX traversal and
-        /// structural ordering; only the token list moves into policy.
+        /// True if `haystack` contains ANY label as a substring.
+        ///
+        /// Faithfully mirrors the inline `combined.contains(token)` control flow
+        /// it replaced: Swift's `String.contains` is case-sensitive,
+        /// **diacritic-sensitive**, and canonical-equivalence aware. We use
+        /// `.caseInsensitive` (inert on the already-lowercased aggregates the
+        /// callers pass, and required for the one raw-string site) but
+        /// deliberately do NOT add `.diacriticInsensitive` — folding accents
+        /// (e.g. "ínspector" → "inspector") would WIDEN matching beyond the
+        /// original and risk misclassifying accented-Latin AX text in non-EN/KO
+        /// locales. Omitting `.literal` keeps Hangul NFC/NFD canonical matching,
+        /// matching `String.contains`.
         func containsAny(in haystack: String) -> Bool {
             labels.contains { label in
-                haystack.range(of: label, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+                haystack.range(of: label, options: [.caseInsensitive]) != nil
             }
         }
     }

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -160,11 +160,7 @@ enum AXLogicProElements {
             .lowercased()
             .split { $0.isWhitespace }
             .joined(separator: " ")
-        return normalized == "track headers"
-            || normalized == "track header"
-            || normalized == "tracks header"
-            || normalized == "tracks headers"
-            || normalized == "트랙 헤더"
+        return AXLocalePolicy.trackHeadersDescription.labels.contains(normalized)
     }
 
     // MARK: - Transport
@@ -343,8 +339,7 @@ enum AXLogicProElements {
     /// bogus resource payloads and rename/mute ops that silently fail.
     static func isProjectPickerWindow(_ window: AXUIElement, runtime: Runtime) -> Bool {
         let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "").lowercased()
-        let pickerMarkers = ["프로젝트 선택", "choose a project", "choose project", "new from template"]
-        return pickerMarkers.contains { title.contains($0) }
+        return AXLocalePolicy.projectPickerWindow.containsAny(in: title)
     }
 
     /// Find the track header area containing individual track rows.
@@ -595,7 +590,7 @@ enum AXLogicProElements {
         if let pan = sliders.first(where: { slider in
             AXHelpers.getChildren(slider, runtime: runtime).contains { child in
                 let desc = (AXHelpers.getDescription(child, runtime: runtime) ?? "").lowercased()
-                return desc.contains("pan") || desc.contains("팬") || desc.contains("밸런스")
+                return AXLocalePolicy.headerPanHint.containsAny(in: desc)
             }
         }) {
             return pan
@@ -655,8 +650,7 @@ enum AXLogicProElements {
 
         let text = elementSearchText(element, runtime: runtime)
         let isInspector = ancestorIsInspector
-            || text.contains("inspector")
-            || text.contains("인스펙터")
+            || AXLocalePolicy.mixerInspectorContext.containsAny(in: text)
 
         if !isInspector,
            isMixerNamedElement(element, runtime: runtime),
@@ -698,7 +692,7 @@ enum AXLogicProElements {
             AXHelpers.getTitle(element, runtime: runtime)
         ]
         return candidates.compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-            .contains { $0 == "mixer" || $0 == "믹서" }
+            .contains { AXLocalePolicy.mixerNamedElement.labels.contains($0) }
     }
 
     private static func hasDirectChannelStripChildren(
@@ -837,12 +831,10 @@ enum AXLogicProElements {
         runtime: AXHelpers.Runtime
     ) -> (text: String, isVolumeFader: Bool, isPanControl: Bool) {
         let text = elementSearchText(slider, runtime: runtime)
-        let isSend = text.contains("send") || text.contains("센드")
-        let isZoom = text.contains("zoom") || text.contains("확대")
-        let isVolume = !isSend && !isZoom
-            && (text.contains("volume") || text.contains("fader") || text.contains("볼륨"))
-        let isPan = !isSend && !isZoom
-            && (text.contains("pan") || text.contains("panning") || text.contains("패닝") || text.contains("밸런스"))
+        let isSend = AXLocalePolicy.sliderSendHint.containsAny(in: text)
+        let isZoom = AXLocalePolicy.sliderZoomHint.containsAny(in: text)
+        let isVolume = !isSend && !isZoom && AXLocalePolicy.sliderVolumeHint.containsAny(in: text)
+        let isPan = !isSend && !isZoom && AXLocalePolicy.sliderPanHint.containsAny(in: text)
         return (text, isVolume, isPan)
     }
 
@@ -861,14 +853,11 @@ enum AXLogicProElements {
         let children = AXHelpers.getChildren(element, runtime: runtime)
         let hasBypass = children.contains { child in
             let text = elementSearchText(child, runtime: runtime)
-            return text.contains("bypass") || text.contains("바이패스")
+            return AXLocalePolicy.pluginBypassControl.containsAny(in: text)
         }
         let hasOpenOrMenu = children.contains { child in
             let text = elementSearchText(child, runtime: runtime)
-            return text.contains("open")
-                || text.contains("열기")
-                || text.contains("list")
-                || text.contains("목록")
+            return AXLocalePolicy.pluginOpenOrListControl.containsAny(in: text)
         }
         if hasBypass && hasOpenOrMenu {
             return true
@@ -894,10 +883,8 @@ enum AXLogicProElements {
             return nil
         }
         let lower = description.lowercased()
-        guard lower != "읽기, 오토메이션이 활성화됨",
-              lower != "read",
-              !lower.contains("automation"),
-              !lower.contains("오토메이션") else {
+        guard !AXLocalePolicy.pluginAutomationLabelExact.matches(lower, mode: .exactStrict),
+              !AXLocalePolicy.pluginAutomationLabelSubstring.containsAny(in: lower) else {
             return nil
         }
         return description
@@ -936,16 +923,8 @@ enum AXLogicProElements {
             return false
         }
         let text = elementSearchText(element, runtime: runtime)
-        let isAudioSlot = text.contains("audio plugin")
-            || text.contains("audio effect")
-            || text.contains("오디오 플러그인")
-            || text.contains("오디오 이펙트")
-        let isSendOrIO = text.contains("send")
-            || text.contains("센드")
-            || text.contains("input")
-            || text.contains("output")
-            || text.contains("입력")
-            || text.contains("출력")
+        let isAudioSlot = AXLocalePolicy.audioPluginSlotLabel.containsAny(in: text)
+        let isSendOrIO = AXLocalePolicy.sendOrIOControlLabel.containsAny(in: text)
         if isAudioSlot && !isSendOrIO {
             return true
         }
@@ -961,7 +940,7 @@ enum AXLogicProElements {
         let children = AXHelpers.getChildren(element, runtime: runtime)
         guard let bypass = children.first(where: { child in
             let text = elementSearchText(child, runtime: runtime)
-            return text.contains("bypass") || text.contains("바이패스")
+            return AXLocalePolicy.pluginBypassControl.containsAny(in: text)
         }) ?? children.first(where: { child in
             (AXHelpers.getRole(child, runtime: runtime) ?? "") == (kAXCheckBoxRole as String)
         }) else {
@@ -1077,22 +1056,7 @@ enum AXLogicProElements {
     }
 
     private static func isKnownNonInsertButtonText(_ text: String) -> Bool {
-        [
-            "send", "센드",
-            "input", "입력",
-            "output", "출력",
-            "group", "그룹",
-            "channel mode", "채널 모드",
-            "eq",
-            "setting", "설정",
-            "gain reduction", "게인 축소",
-            "mute", "음소거",
-            "solo", "record", "녹음",
-            "monitor", "모니터링",
-            "volume", "볼륨",
-            "fader", "페이더",
-            "pan", "패닝", "밸런스",
-        ].contains { text.contains($0) }
+        AXLocalePolicy.nonInsertButtonText.containsAny(in: text)
     }
 
     private static func elementSearchText(
@@ -1675,11 +1639,7 @@ enum AXLogicProElements {
         }.contains { text in
             let description = AXHelpers.getDescription(text, runtime: runtime)?.lowercased() ?? ""
             let value = (AXValueExtractors.extractTextValue(text, runtime: runtime) ?? "").lowercased()
-            return description.contains("tempo")
-                || description.contains("bpm")
-                || description.contains("position")
-                || description.contains("템포")
-                || description.contains("재생헤드 위치")
+            return AXLocalePolicy.transportTextFieldHint.containsAny(in: description)
                 || value.contains(" bpm")
                 || value.filter({ $0 == "." }).count >= 2
                 || value.contains(":")

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -3878,18 +3878,12 @@ actor AccessibilityChannel: Channel {
 
     private static func isExplicitTrackContentDescription(_ description: String) -> Bool {
         let normalized = normalizeRegionGroupDescription(description)
-        return normalized == "트랙 콘텐츠"
-            || normalized == "track content"
-            || normalized == "track contents"
-            || normalized == "tracks content"
-            || normalized == "tracks contents"
+        return AXLocalePolicy.trackContentExplicit.labels.contains(normalized)
     }
 
     private static func isGenericContentDescription(_ description: String) -> Bool {
         let normalized = normalizeRegionGroupDescription(description)
-        return normalized == "콘텐츠"
-            || normalized == "content"
-            || normalized == "contents"
+        return AXLocalePolicy.trackContentGeneric.labels.contains(normalized)
     }
 
     private static func frame(
@@ -3919,16 +3913,13 @@ actor AccessibilityChannel: Channel {
 
     private static func classifyRegionKind(name: String, help: String) -> String {
         let searchable = "\(name) \(help)".lowercased()
-        if searchable.contains("drummer")
-            || searchable.contains("session player")
-            || searchable.contains("드러머")
-            || searchable.contains("세션 플레이어") {
+        if AXLocalePolicy.regionKindDrummer.containsAny(in: searchable) {
             return "drummer"
         }
-        if searchable.contains("midi") {
+        if AXLocalePolicy.regionKindMidi.containsAny(in: searchable) {
             return "midi"
         }
-        if searchable.contains("audio") || searchable.contains("오디오") {
+        if AXLocalePolicy.regionKindAudio.containsAny(in: searchable) {
             return "audio"
         }
         return "unknown"
@@ -3988,7 +3979,7 @@ actor AccessibilityChannel: Channel {
         var nonRegionCount = 0
         for item in items {
             let help = AXHelpers.getHelp(item, runtime: runtime.ax) ?? ""
-            let isRegion = help.contains("리전") || help.lowercased().contains("region")
+            let isRegion = AXLocalePolicy.regionHelpKeyword.containsAny(in: help)
             guard isRegion else { nonRegionCount += 1; continue }
             guard isVisibleArrangeRegion(item, within: window, runtime: runtime.ax) else {
                 continue

--- a/Tests/LogicProMCPTests/Issue60LocalePhase4Tests.swift
+++ b/Tests/LogicProMCPTests/Issue60LocalePhase4Tests.swift
@@ -104,6 +104,25 @@ struct Issue60LocalePhase4Tests {
         #expect(!AXLocalePolicy.pluginBypassControl.containsAny(in: "open plugin window"))
     }
 
+    @Test("containsAny is diacritic-SENSITIVE, mirroring the inline String.contains it replaced")
+    func containsAnyIsDiacriticSensitive() {
+        // Plain forms match (the actual EN/KO strings Logic emits).
+        #expect(AXLocalePolicy.mixerInspectorContext.containsAny(in: "inspector"))
+        #expect(AXLocalePolicy.sliderSendHint.containsAny(in: "send level"))
+        #expect(AXLocalePolicy.transportTextFieldHint.containsAny(in: "tempo"))
+        // Accented-Latin forms must NOT match — folding them would widen matching
+        // beyond the original `text.contains(token)` and misclassify in accented
+        // locales (French/Spanish/Portuguese Logic UIs).
+        #expect(!AXLocalePolicy.mixerInspectorContext.containsAny(in: "ínspector"))
+        #expect(!AXLocalePolicy.sliderSendHint.containsAny(in: "sénd"))
+        #expect(!AXLocalePolicy.transportTextFieldHint.containsAny(in: "témpo"))
+        #expect(!AXLocalePolicy.pluginBypassControl.containsAny(in: "bypáss"))
+        // Case-insensitivity is retained (needed for the raw-help region site).
+        #expect(AXLocalePolicy.regionHelpKeyword.containsAny(in: "Audio Region at bar 5"))
+        // Korean canonical matching is preserved.
+        #expect(AXLocalePolicy.regionKindDrummer.containsAny(in: "세션 플레이어 리전"))
+    }
+
     @Test("mixerNamedElement exact-equality semantics (normalized lowercase)")
     func mixerNamedElementExact() {
         // Mirrors the call site: candidate is trimmed + lowercased, then == label.

--- a/Tests/LogicProMCPTests/Issue60LocalePhase4Tests.swift
+++ b/Tests/LogicProMCPTests/Issue60LocalePhase4Tests.swift
@@ -1,0 +1,197 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #60 (Phase 4): the remaining read-only classifier token bags — mixer /
+/// inspector / channel-strip / plugin-slot (surface #3) and region /
+/// track-content / track-type (surface #5) — are centralized into
+/// `AXLocalePolicy` instead of inline literals. These tests (1) pin each new
+/// LabelSet to the EXACT token set the inline code carried (the behavior-
+/// preservation guard — any dropped/changed token fails here), (2) check the
+/// EN+KO match semantics, and (3) drive the accessible classifiers end-to-end
+/// in both locales. None of these gate a State-A success.
+@Suite("Issue60 locale phase 4 classifier bags")
+struct Issue60LocalePhase4Tests {
+
+    // MARK: - Token-coverage guard (each bag == its original inline token list)
+
+    @Test("every Phase 4 LabelSet carries exactly its original inline tokens")
+    func bagsPreserveOriginalTokens() {
+        let cases: [(String, [String], Set<String>)] = [
+            ("mixerInspectorContext", AXLocalePolicy.mixerInspectorContext.labels, ["inspector", "인스펙터"]),
+            ("mixerNamedElement", AXLocalePolicy.mixerNamedElement.labels, ["mixer", "믹서"]),
+            ("sliderSendHint", AXLocalePolicy.sliderSendHint.labels, ["send", "센드"]),
+            ("sliderZoomHint", AXLocalePolicy.sliderZoomHint.labels, ["zoom", "확대"]),
+            ("sliderVolumeHint", AXLocalePolicy.sliderVolumeHint.labels, ["volume", "fader", "볼륨"]),
+            ("sliderPanHint", AXLocalePolicy.sliderPanHint.labels, ["pan", "panning", "패닝", "밸런스"]),
+            ("pluginBypassControl", AXLocalePolicy.pluginBypassControl.labels, ["bypass", "바이패스"]),
+            ("pluginOpenOrListControl", AXLocalePolicy.pluginOpenOrListControl.labels, ["open", "열기", "list", "목록"]),
+            ("pluginAutomationLabelExact", AXLocalePolicy.pluginAutomationLabelExact.labels, ["읽기, 오토메이션이 활성화됨", "read"]),
+            ("pluginAutomationLabelSubstring", AXLocalePolicy.pluginAutomationLabelSubstring.labels, ["automation", "오토메이션"]),
+            ("audioPluginSlotLabel", AXLocalePolicy.audioPluginSlotLabel.labels, ["audio plugin", "audio effect", "오디오 플러그인", "오디오 이펙트"]),
+            ("sendOrIOControlLabel", AXLocalePolicy.sendOrIOControlLabel.labels, ["send", "센드", "input", "output", "입력", "출력"]),
+            ("nonInsertButtonText", AXLocalePolicy.nonInsertButtonText.labels, [
+                "send", "센드", "input", "입력", "output", "출력", "group", "그룹",
+                "channel mode", "채널 모드", "eq", "setting", "설정",
+                "gain reduction", "게인 축소", "mute", "음소거", "solo", "record", "녹음",
+                "monitor", "모니터링", "volume", "볼륨", "fader", "페이더",
+                "pan", "패닝", "밸런스",
+            ]),
+            ("headerPanHint", AXLocalePolicy.headerPanHint.labels, ["pan", "팬", "밸런스"]),
+            ("trackHeadersDescription", AXLocalePolicy.trackHeadersDescription.labels, ["track headers", "track header", "tracks header", "tracks headers", "트랙 헤더"]),
+            ("projectPickerWindow", AXLocalePolicy.projectPickerWindow.labels, ["프로젝트 선택", "choose a project", "choose project", "new from template"]),
+            ("transportTextFieldHint", AXLocalePolicy.transportTextFieldHint.labels, ["tempo", "bpm", "position", "템포", "재생헤드 위치"]),
+            ("trackContentExplicit", AXLocalePolicy.trackContentExplicit.labels, ["트랙 콘텐츠", "track content", "track contents", "tracks content", "tracks contents"]),
+            ("trackContentGeneric", AXLocalePolicy.trackContentGeneric.labels, ["콘텐츠", "content", "contents"]),
+            ("regionKindDrummer", AXLocalePolicy.regionKindDrummer.labels, ["drummer", "session player", "드러머", "세션 플레이어"]),
+            ("regionKindMidi", AXLocalePolicy.regionKindMidi.labels, ["midi"]),
+            ("regionKindAudio", AXLocalePolicy.regionKindAudio.labels, ["audio", "오디오"]),
+            ("regionHelpKeyword", AXLocalePolicy.regionHelpKeyword.labels, ["region", "리전"]),
+        ]
+        for (name, labels, expected) in cases {
+            #expect(Set(labels) == expected, "\(name) token drift: \(Set(labels).symmetricDifference(expected))")
+        }
+    }
+
+    @Test("every Phase 4 classifier bag carries at least one Korean variant")
+    func everyBagHasKorean() {
+        let bags: [(String, AXLocalePolicy.LabelSet)] = [
+            ("mixerInspectorContext", AXLocalePolicy.mixerInspectorContext),
+            ("mixerNamedElement", AXLocalePolicy.mixerNamedElement),
+            ("sliderSendHint", AXLocalePolicy.sliderSendHint),
+            ("sliderZoomHint", AXLocalePolicy.sliderZoomHint),
+            ("sliderVolumeHint", AXLocalePolicy.sliderVolumeHint),
+            ("sliderPanHint", AXLocalePolicy.sliderPanHint),
+            ("pluginBypassControl", AXLocalePolicy.pluginBypassControl),
+            ("pluginOpenOrListControl", AXLocalePolicy.pluginOpenOrListControl),
+            ("audioPluginSlotLabel", AXLocalePolicy.audioPluginSlotLabel),
+            ("sendOrIOControlLabel", AXLocalePolicy.sendOrIOControlLabel),
+            ("headerPanHint", AXLocalePolicy.headerPanHint),
+            ("trackHeadersDescription", AXLocalePolicy.trackHeadersDescription),
+            ("projectPickerWindow", AXLocalePolicy.projectPickerWindow),
+            ("transportTextFieldHint", AXLocalePolicy.transportTextFieldHint),
+            ("trackContentExplicit", AXLocalePolicy.trackContentExplicit),
+            ("trackContentGeneric", AXLocalePolicy.trackContentGeneric),
+            ("regionKindDrummer", AXLocalePolicy.regionKindDrummer),
+            ("regionKindAudio", AXLocalePolicy.regionKindAudio),
+            ("regionHelpKeyword", AXLocalePolicy.regionHelpKeyword),
+        ]
+        for (name, bag) in bags {
+            let hasKorean = bag.labels.contains { $0.unicodeScalars.contains { (0xAC00...0xD7A3).contains($0.value) } }
+            #expect(hasKorean, "\(name) must carry a Korean variant")
+        }
+    }
+
+    // MARK: - Match semantics (EN + KO), mirroring the call-site usage
+
+    @Test("containsAny matches EN + KO and rejects unrelated text (classifier semantics)")
+    func containsAnySemantics() {
+        #expect(AXLocalePolicy.mixerInspectorContext.containsAny(in: "track inspector area"))
+        #expect(AXLocalePolicy.mixerInspectorContext.containsAny(in: "그룹 인스펙터"))
+        #expect(!AXLocalePolicy.mixerInspectorContext.containsAny(in: "mixer area"))
+
+        #expect(AXLocalePolicy.regionKindDrummer.containsAny(in: "drummer track 1"))
+        #expect(AXLocalePolicy.regionKindDrummer.containsAny(in: "세션 플레이어 리전"))
+        #expect(!AXLocalePolicy.regionKindDrummer.containsAny(in: "audio region"))
+
+        #expect(AXLocalePolicy.regionHelpKeyword.containsAny(in: "Audio Region starts at bar 5"))
+        #expect(AXLocalePolicy.regionHelpKeyword.containsAny(in: "리전은 5마디에서 시작"))
+        #expect(!AXLocalePolicy.regionHelpKeyword.containsAny(in: "marker at bar 5"))
+
+        #expect(AXLocalePolicy.pluginBypassControl.containsAny(in: "bypass"))
+        #expect(AXLocalePolicy.pluginBypassControl.containsAny(in: "바이패스 버튼"))
+        #expect(!AXLocalePolicy.pluginBypassControl.containsAny(in: "open plugin window"))
+    }
+
+    @Test("mixerNamedElement exact-equality semantics (normalized lowercase)")
+    func mixerNamedElementExact() {
+        // Mirrors the call site: candidate is trimmed + lowercased, then == label.
+        #expect(AXLocalePolicy.mixerNamedElement.labels.contains("mixer"))
+        #expect(AXLocalePolicy.mixerNamedElement.labels.contains("믹서"))
+        #expect(!AXLocalePolicy.mixerNamedElement.labels.contains("mixer area"))
+    }
+
+    @Test("trackContent normalized-exact bags: explicit vs generic do not overlap")
+    func trackContentExactness() {
+        #expect(AXLocalePolicy.trackContentExplicit.labels.contains("트랙 콘텐츠"))
+        #expect(AXLocalePolicy.trackContentExplicit.labels.contains("track content"))
+        #expect(AXLocalePolicy.trackContentGeneric.labels.contains("콘텐츠"))
+        #expect(AXLocalePolicy.trackContentGeneric.labels.contains("content"))
+        #expect(Set(AXLocalePolicy.trackContentExplicit.labels).isDisjoint(with: Set(AXLocalePolicy.trackContentGeneric.labels)))
+    }
+
+    // MARK: - Functional (drive the accessible classifiers, EN + KO)
+
+    @Test("isProjectPickerWindow classifies the picker by title (EN + KO), not a real project",
+          arguments: [
+            ("Choose a Project", true),
+            ("프로젝트 선택", true),
+            ("New from Template", true),
+            ("My Song - Tracks", false),
+            ("Untitled 6 - Tracks", false),
+          ])
+    func projectPickerClassifier(title: String, expected: Bool) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(9100)
+        let window = b.element(9101)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(window, kAXTitleAttribute as String, title)
+        let isPicker = AXLogicProElements.isProjectPickerWindow(window, runtime: b.makeLogicRuntime(appElement: app))
+        #expect(isPicker == expected, "title=\(title)")
+    }
+
+    @Test("findPanControlInHeader locates the pan slider by Korean child description")
+    func panLocatorKorean() {
+        let b = FakeAXRuntimeBuilder()
+        let header = b.element(9200)
+        let pan = b.element(9201)
+        b.setAttribute(pan, kAXRoleAttribute as String, kAXSliderRole as String)
+        b.setAttribute(pan, kAXDescriptionAttribute as String, "")
+        let panIndicator = b.element(9202)
+        b.setAttribute(panIndicator, kAXRoleAttribute as String, "AXValueIndicator")
+        b.setAttribute(panIndicator, kAXDescriptionAttribute as String, "0 팬")
+        b.setChildren(pan, [panIndicator])
+        let vol = b.element(9203)
+        b.setAttribute(vol, kAXRoleAttribute as String, kAXSliderRole as String)
+        b.setAttribute(vol, kAXDescriptionAttribute as String, "볼륨")
+        b.setChildren(header, [pan, vol])
+        let found = AXLogicProElements.findPanControlInHeader(header, runtime: b.makeAXRuntime())
+        #expect(found != nil && CFEqual(found!, pan))
+    }
+
+    @Test("isOccupiedPluginSlotElement recognizes the bypass+open label pair (EN + KO)",
+          arguments: [("Bypass", "Open"), ("바이패스", "열기"), ("Bypass", "List"), ("바이패스", "목록")])
+    func occupiedPluginSlotByLabel(bypassLabel: String, openLabel: String) {
+        let b = FakeAXRuntimeBuilder()
+        let slot = b.element(9300)
+        b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+        let bypass = b.element(9301)
+        b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        b.setAttribute(bypass, kAXDescriptionAttribute as String, bypassLabel)
+        let open = b.element(9302)
+        b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setAttribute(open, kAXDescriptionAttribute as String, openLabel)
+        b.setChildren(slot, [bypass, open])
+        #expect(AXLogicProElements.isOccupiedPluginSlotElement(slot, runtime: b.makeAXRuntime()))
+    }
+
+    @Test("pluginSlotDisplayName rejects automation-mode labels (EN + KO), accepts a real name",
+          arguments: [
+            ("읽기, 오토메이션이 활성화됨", nil as String?),
+            ("Read", nil as String?),
+            ("Volume Automation", nil as String?),
+            ("채널 EQ 오토메이션", nil as String?),
+            ("Channel EQ", "Channel EQ"),
+            ("컴프레서", "컴프레서"),
+          ])
+    func pluginDisplayNameRejectsAutomation(description: String, expected: String?) {
+        let b = FakeAXRuntimeBuilder()
+        let slot = b.element(9400)
+        b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(slot, kAXDescriptionAttribute as String, description)
+        let name = AXLogicProElements.pluginSlotDisplayName(slot, runtime: b.makeAXRuntime())
+        #expect(name == expected, "desc=\(description)")
+    }
+}

--- a/docs/locale-agnostic-ax-policy.md
+++ b/docs/locale-agnostic-ax-policy.md
@@ -65,6 +65,34 @@ These are read-only classifiers (which AX container is which); none gate a
 State-A success. This closes the previously-listed `looksLikeTransportContainer`
 keyword aggregate and the marker-ruler keyword fallback below.
 
+## Phase 4 (issue #60) — mixer/plugin + region classifier bags centralized
+
+The remaining read-only mixer/inspector/channel-strip/plugin-slot classifiers
+(surface #3) and region/track-content/track-type classifiers (surface #5) moved
+from inline literals into `AXLocalePolicy`, behavior-preserving (each LabelSet
+pins the EXACT prior token set, order, and match mode — `.containsAny` for the
+`text.contains(token)` `||` chains over an already-lowercased aggregate;
+`.labels.contains(normalized)` for the normalized `==` predicates; `.matches(_:
+mode: .exactStrict)` for the verbatim guards). Deterministic EN+KO coverage +
+functional tests in `Issue60LocalePhase4Tests` (the token-coverage guard fails
+on any drift). LabelSets added:
+
+- Mixer/plugin: `mixerInspectorContext`, `mixerNamedElement`, `sliderSendHint`,
+  `sliderZoomHint`, `sliderVolumeHint`, `sliderPanHint`, `pluginBypassControl`,
+  `pluginOpenOrListControl`, `pluginAutomationLabelExact`,
+  `pluginAutomationLabelSubstring`, `audioPluginSlotLabel`, `sendOrIOControlLabel`,
+  `nonInsertButtonText`, `headerPanHint`, `trackHeadersDescription`,
+  `projectPickerWindow`, `transportTextFieldHint`.
+- Region: `trackContentExplicit`, `trackContentGeneric`, `regionKindDrummer`,
+  `regionKindMidi`, `regionKindAudio`, `regionHelpKeyword`.
+
+None gate a State-A success. Not migrated (out of Phase-4 scope): the
+`parseRegionBars` regex literals (`리전은…마디…시작…끝` / `region…starts…at…bar`)
+are regex fragments, not token bags; AppleScript menu literals (surface #1) and
+write-path mutation gates (`pluginInsertSpec` switch-map, `findAudioPluginRootMenu`,
+`defaultSetCycleRange` locator, track-create/delete/save-as menu paths) are
+separate behavior-changing migrations.
+
 ## Known Remaining Surfaces
 
 The locale-agnostic epic (#60) is **not closed** (its acceptance criterion 5
@@ -85,18 +113,20 @@ Logic Pro to confirm State A on their respective paths:
    — **centralized in Phase 3** (`transportContainerMetadata`,
    `transportContainerControlKeywords`, `transportSliderHints`). Behavior
    preserved; EN+KO tested. Still pending live KO confirmation.
-3. **Mixer / inspector / channel-strip metadata keyword scans**
-   (`AXLogicProElements`: send/입력/출력/그룹/채널 모드/볼륨/패닝/바이패스/오토메이션
-   etc.) — large heuristic token bags used for classification and disambiguation.
-   These are read-only but interdependent; a careful, separately-tested pass is
-   required to avoid changing which strips/controls are recognized.
+3. ~~**Mixer / inspector / channel-strip metadata keyword scans**~~
+   — **centralized in Phase 4** (`sliderSendHint`/`sliderVolumeHint`/`sliderPanHint`,
+   `pluginBypassControl`, `audioPluginSlotLabel`, `sendOrIOControlLabel`,
+   `nonInsertButtonText`, `mixerNamedElement`, `mixerInspectorContext`, …).
+   Behavior preserved; EN+KO tested. Still pending live KO confirmation.
 4. **Marker-list / cell placeholder keywords** (`AXLogicProElements`:
    `셀`/`Cell`, marker-list window-title suffixes) — read-only scraping fallbacks
    for old Logic versions; pending. (The marker-*ruler* keyword fallback
    `마커`/`marker` was centralized in Phase 3 as `markerContainerKeywords`.)
-5. **Region / track-content / track-type description keywords**
-   (`AccessibilityChannel`: `리전`/region, `트랙 콘텐츠`/Track Content,
-   드러머/세션 플레이어/오디오 etc.) — read-only classification, pending.
+5. ~~**Region / track-content / track-type description keywords**~~
+   — **centralized in Phase 4** (`trackContentExplicit`/`trackContentGeneric`,
+   `regionKindDrummer`/`regionKindMidi`/`regionKindAudio`, `regionHelpKeyword`).
+   Behavior preserved; EN+KO tested. The `parseRegionBars` regex literals remain
+   inline (regex fragments, not a token bag). Still pending live KO confirmation.
 
 **Live verification still required** for the surfaces centralized in this pass:
 each read-only locator/extractor was verified headless with injected fake


### PR DESCRIPTION
## Issue #60 Phase 4 — read-only classifier centralization

Continues the locale-agnostic epic (#60). Moves the remaining **read-only** classifier literals out of `AXLogicProElements` + `AccessibilityChannel` into `AXLocalePolicy` LabelSets — the documented remaining **surface #3** (mixer/inspector/channel-strip/plugin-slot) and **surface #5** (region/track-content/track-type).

### Behavior-preserving by construction
Each LabelSet pins the **exact** prior token set, source order, and match mode:
- `.containsAny(in:)` replaces the `text.contains(token)` `||` chains over an already-lowercased aggregate.
- `.labels.contains(normalized)` replaces the normalized `==` predicates (track-headers, track-content).
- `.matches(_, mode: .exactStrict)` replaces the verbatim automation-label guard.

None of these gate a State-A success — they are pure classifiers/locators ("which element/region is this").

### Tests
`Issue60LocalePhase4Tests`:
- **Token-coverage guard** — pins every new LabelSet to its exact original inline token set (fails on any drift).
- EN+KO `containsAny`/exact semantics.
- Functional EN+KO tests for the accessible classifiers (`isProjectPickerWindow`, `findPanControlInHeader`, `isOccupiedPluginSlotElement`, `pluginSlotDisplayName`).

Full suite: **1694 tests pass**. Existing mixer/region/plugin/track functional tests unchanged → behavior preserved.

### Out of scope (still inline, documented)
- `parseRegionBars` regex literals (regex fragments, not a token bag).
- AppleScript/System-Events menu literals (surface #1 — behavior-changing migration).
- Write-path mutation gates (`pluginInsertSpec` switch-map, `findAudioPluginRootMenu`, `defaultSetCycleRange` locator, track create/delete/save-as menu paths).

Part of #60 — the epic stays **open** on its acceptance-criterion-5 close gate (a live EN+KO Logic UI E2E pass; the Korean-locale run remains environmentally blocked).