### PR TITLE
fix: derive project track count from live tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
-No unreleased changes.
+### Fixed
+
+- **`logic://project/info.trackCount` now follows trusted live track cache** when `ProjectInfo` is name-only and saved project metadata has no positive count. This keeps `logic://project/info` consistent with `logic://tracks` for unsaved or freshly edited Logic projects, while still rejecting Inspector-contaminated or placeholder track rows and preserving the resource layer as read-only.
 
 ## [3.6.0] — 2026-06-19
 

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -784,8 +784,7 @@ extension ResourceHandlers {
         let axOccluded = await cache.getAXOccluded()
 
         // Inspector contamination guard.
-        if liveTracks.count >= 3,
-           liveTracks.allSatisfy({ $0.name.hasSuffix(":") }) {
+        if tracksAreInspectorContaminated(liveTracks) {
             liveTracks = []
         }
 
@@ -880,10 +879,13 @@ extension ResourceHandlers {
     ///   1. Cache (live AX poll) — preferred when `lastUpdated > .distantPast`
     ///      (poller has written real data). Source: "ax_live" if recent
     ///      (< 5s), else "cache".
-    ///   2. LogicProjectFileReader — reads MetaData.plist for tempo / tsig /
-    ///      trackCount when cache is at struct defaults. Source:
+    ///   2. Live track cache — fills `trackCount` from the same trusted
+    ///      cache used by `logic://tracks` when ProjectInfo itself is name-only
+    ///      and file metadata has no positive count.
+    ///   3. LogicProjectFileReader — reads MetaData.plist for tempo / tsig /
+    ///      trackCount when live cache is at struct defaults. Source:
     ///      "project_file" + last_saved_age_sec extra.
-    ///   3. Struct defaults (ProjectInfo()). Source: "default".
+    ///   4. Struct defaults (ProjectInfo()). Source: "default".
     ///
     /// **Critical**: this function is read-only — it MUST NOT call
     /// `cache.updateProject(...)`. The poller is the sole writer to cache
@@ -894,9 +896,12 @@ extension ResourceHandlers {
         uri: String,
         fileReader: LogicProjectFileReader.Runtime
     ) async throws -> ReadResource.Result {
-        let cached = await cache.getProject()
-        let projectFetchedAt = await cache.getProjectFetchedAt()
-        let cachedTransport = await cache.getTransport()
+        let snapshot = await cache.auditSnapshot()
+        let cached = snapshot.project
+        let projectFetchedAt = snapshot.projectFetchedAt
+        let cachedTransport = snapshot.transport
+        let cachedTracks = snapshot.tracks
+        let tracksFetchedAt = snapshot.tracksFetchedAt
         // Cache is "fresh" if either (a) the poller has timestamped a write,
         // or (b) ProjectInfo's own lastUpdated is non-default. Either signal
         // means downstream consumers wrote real data.
@@ -909,9 +914,11 @@ extension ResourceHandlers {
         // "cache fresh wins" rule would therefore mask the file's correct
         // values whenever the poller has run at least once. Instead, we:
         //   1. Start with cached values (preserves the AX-only `name`).
-        //   2. For each field, if cache is default AND file has a non-nil
-        //      value, the file fills it.
-        //   3. `source` is "ax_live"/"cache" if any non-default field came
+        //   2. Fill tempo/sample-rate from live transport when available.
+        //   3. Fill trackCount from the trusted live track cache when
+        //      ProjectInfo itself is still at its default count.
+        //   4. Fill any remaining defaults from file metadata.
+        //   5. `source` is "ax_live"/"cache" if any non-default field came
         //      from cache; otherwise "project_file"; otherwise "default".
         let metadata = await LogicProjectFileReader.read(runtime: fileReader)
 
@@ -919,13 +926,19 @@ extension ResourceHandlers {
 
         var fileContributed = false
         var cacheContributedLive = false
+        let cachedProjectReferenceDate = [cached.lastUpdated, projectFetchedAt]
+            .filter { $0 > .distantPast }
+            .max()
+        var cacheContributionDates: [Date] = []
 
         // tempo
         if cacheFresh && cached.tempo != 120.0 {
             cacheContributedLive = true
+            if let date = cachedProjectReferenceDate { cacheContributionDates.append(date) }
         } else if transportFresh {
             info.tempo = cachedTransport.tempo
             cacheContributedLive = true
+            cacheContributionDates.append(cachedTransport.lastUpdated)
         } else if let tempo = metadata?.tempo {
             info.tempo = tempo
             fileContributed = true
@@ -936,6 +949,7 @@ extension ResourceHandlers {
         // timeSignature
         if cacheFresh && cached.timeSignature != "4/4" {
             cacheContributedLive = true
+            if let date = cachedProjectReferenceDate { cacheContributionDates.append(date) }
         } else if let tsig = metadata?.timeSignatureString {
             info.timeSignature = tsig
             fileContributed = true
@@ -943,6 +957,11 @@ extension ResourceHandlers {
         // trackCount
         if cacheFresh && cached.trackCount != 0 {
             cacheContributedLive = true
+            if let date = cachedProjectReferenceDate { cacheContributionDates.append(date) }
+        } else if let trackCount = trustedLiveTrackCount(cachedTracks, fetchedAt: tracksFetchedAt) {
+            info.trackCount = trackCount
+            cacheContributedLive = true
+            cacheContributionDates.append(tracksFetchedAt)
         } else if let count = metadata?.trackCount, count > 0 {
             info.trackCount = count
             fileContributed = true
@@ -959,11 +978,9 @@ extension ResourceHandlers {
             source = "default"
         } else if cacheContributedLive {
             // Cache supplied at least one real value — promote to ax_live/cache.
-            let referenceDate = [
-                cached.lastUpdated,
-                projectFetchedAt,
-                cachedTransport.lastUpdated
-            ].filter { $0 > .distantPast }.max() ?? .distantPast
+            let referenceDate = cacheContributionDates.max()
+                ?? cachedProjectReferenceDate
+                ?? .distantPast
             let age = Date().timeIntervalSince(referenceDate)
             source = age < 5 ? "ax_live" : "cache"
         } else if fileContributed {
@@ -983,15 +1000,30 @@ extension ResourceHandlers {
         if let age = lastSavedAgeSec { extras["last_saved_age_sec"] = age }
 
         let body = encodeJSON(info)
+        let cacheReferenceDate = cacheContributionDates.max() ?? cachedProjectReferenceDate
         let envelope = wrapWithCacheEnvelope(
             bodyJSON: body,
-            fetchedAt: cacheFresh ? cached.lastUpdated : nil,
-            axOccluded: await cache.getAXOccluded(),
+            fetchedAt: (source == "ax_live" || source == "cache") ? cacheReferenceDate : nil,
+            axOccluded: snapshot.axOccluded,
             extras: extras
         )
         return ReadResource.Result(
             contents: [.text(envelope, uri: uri, mimeType: "application/json")]
         )
+    }
+
+    private static func tracksAreInspectorContaminated(_ tracks: [TrackState]) -> Bool {
+        tracks.count >= 3 && tracks.allSatisfy { $0.name.hasSuffix(":") }
+    }
+
+    private static func trustedLiveTrackCount(_ tracks: [TrackState], fetchedAt: Date) -> Int? {
+        guard fetchedAt > .distantPast,
+              !tracks.isEmpty,
+              !tracksAreInspectorContaminated(tracks),
+              tracks.allSatisfy({ $0.placeholder != true }) else {
+            return nil
+        }
+        return tracks.count
     }
 
     private static func readMIDIPorts(router: ChannelRouter, uri: String) async throws -> ReadResource.Result {

--- a/Tests/LogicProMCPTests/ResourceProjectInfoTierMergeTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProjectInfoTierMergeTests.swift
@@ -85,7 +85,7 @@ func cacheLive_filePresent_cachePreferred_sourceAxLive() async throws {
 }
 
 @Test
-func cacheProjectNameOnly_usesLiveTransportButDoesNotPromoteVisibleTrackRowsToProjectTrackCount() async throws {
+func cacheProjectNameOnly_usesLiveTransportAndLiveTrackCacheForProjectTrackCount() async throws {
     let cache = StateCache()
 
     var liveProject = ProjectInfo()
@@ -116,7 +116,7 @@ func cacheProjectNameOnly_usesLiveTransportButDoesNotPromoteVisibleTrackRowsToPr
     }
     #expect(data["tempo"] as? Double == 127)
     #expect(data["sampleRate"] as? Int == 48_000)
-    #expect(data["trackCount"] as? Int == 0)
+    #expect(data["trackCount"] as? Int == 11)
     #expect(envelope["source"] as? String == "ax_live")
     #expect(envelope["last_saved_age_sec"] == nil)
 }

--- a/Tests/LogicProMCPTests/ResourceProjectInfoTierMergeTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProjectInfoTierMergeTests.swift
@@ -5,8 +5,9 @@ import Testing
 
 // v3.1.8 (Issue #7) — readProjectInfo tier merge:
 // Tier 1: cache (live AX, source "ax_live" or "cache")
-// Tier 2: LogicProjectFileReader (source "project_file" + last_saved_age_sec)
-// Tier 3: defaults (source "default")
+// Tier 2: trusted live track cache for trackCount when ProjectInfo is name-only
+// Tier 3: LogicProjectFileReader (source "project_file" + last_saved_age_sec)
+// Tier 4: defaults (source "default")
 // Critical: live cache values win when present; project file values only fill
 // fields the live cache has not observed.
 
@@ -119,6 +120,62 @@ func cacheProjectNameOnly_usesLiveTransportAndLiveTrackCacheForProjectTrackCount
     #expect(data["trackCount"] as? Int == 11)
     #expect(envelope["source"] as? String == "ax_live")
     #expect(envelope["last_saved_age_sec"] == nil)
+}
+
+@Test
+func cacheProjectNameOnly_rejectsPlaceholderTrackCacheForProjectTrackCount() async throws {
+    let cache = StateCache()
+
+    var liveProject = ProjectInfo()
+    liveProject.name = "Untitled Live"
+    liveProject.lastUpdated = Date()
+    await cache.updateProject(liveProject)
+
+    await cache.updateTracks((0..<11).map {
+        TrackState(id: $0, name: "Track \($0 + 1)", type: .unknown, placeholder: true)
+    })
+
+    let bundle = ensureFixtureBundle(at: FileManager.default.temporaryDirectory
+        .appendingPathComponent("PlaceholderSiblingCacheBundle.logicx", isDirectory: true))
+    let runtime = makeFileReaderRuntime(tempo: 120, trackCount: 0, bundlePath: bundle)
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://project/info", cache: cache, router: ChannelRouter(), fileReader: runtime
+    )
+    let envelope = try parseEnvelope(result)
+    guard let data = envelope["data"] as? [String: Any] else {
+        Issue.record("data missing"); return
+    }
+    #expect(data["trackCount"] as? Int == 0)
+}
+
+@Test
+func cacheProjectNameOnly_rejectsInspectorContaminatedTrackCacheForProjectTrackCount() async throws {
+    let cache = StateCache()
+
+    var liveProject = ProjectInfo()
+    liveProject.name = "Untitled Live"
+    liveProject.lastUpdated = Date()
+    await cache.updateProject(liveProject)
+
+    await cache.updateTracks([
+        TrackState(id: 0, name: "Region:", type: .unknown),
+        TrackState(id: 1, name: "Track:", type: .unknown),
+        TrackState(id: 2, name: "Channel Strip:", type: .unknown)
+    ])
+
+    let bundle = ensureFixtureBundle(at: FileManager.default.temporaryDirectory
+        .appendingPathComponent("InspectorSiblingCacheBundle.logicx", isDirectory: true))
+    let runtime = makeFileReaderRuntime(tempo: 120, trackCount: 0, bundlePath: bundle)
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://project/info", cache: cache, router: ChannelRouter(), fileReader: runtime
+    )
+    let envelope = try parseEnvelope(result)
+    guard let data = envelope["data"] as? [String: Any] else {
+        Issue.record("data missing"); return
+    }
+    #expect(data["trackCount"] as? Int == 0)
 }
 
 @Test


### PR DESCRIPTION
## Summary

- Fixes `logic://project/info.trackCount` returning 0 when ProjectInfo is name-only and saved metadata has no positive count.
- Derives trackCount from the same trusted live track cache used by `logic://tracks`.
- Keeps the resource path read-only and rejects placeholder or Inspector-contaminated track rows.

## Linked issue

- Closes #4

## Risk

- Priority: P2
- Area: resources, tracks
- User-visible impact: `logic://project/info` now reports live track count for unsaved/fresh Logic sessions when trusted live tracks are available.
- Contract impact: resource behavior changed; no mutating State A-B-C behavior changed.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel`
- [x] `swift build -c release`
- [x] Targeted test: `swift test --filter ResourceProjectInfoTierMergeTests`
- [x] Targeted test: `swift test --filter ResourceTracksTierMergeTests`
- [x] Targeted test: `swift test --filter Issue7IntegrationTests`
- [x] Live Logic evidence: not required; this is a deterministic resource merge regression covered by cache/file fixtures.

Evidence:
```text
swift test --filter ResourceProjectInfoTierMergeTests -> 10 tests passed
swift test --filter ResourceTracksTierMergeTests -> 8 tests passed
swift test --filter Issue7IntegrationTests -> 5 tests passed
swift test --no-parallel -> 1697 tests passed
swift build -c release -> Build complete
```

## Release readiness

- [x] Public claims, API docs, troubleshooting, and changelog are updated if behavior changed.
- [x] Mutating or destructive behavior has explicit target validation, confirmation, and readback.
- [x] Known limitations are documented in the PR or docs.

## Reviewer focus

- Confirm `readProjectInfo` remains cache read-only.
- Confirm only trusted live track rows can supply project `trackCount`.
- Confirm placeholder and Inspector-contaminated rows cannot inflate `trackCount`.