### PR TITLE
fix(#144): project.save fail-fast on untitled docs + unwrap project.new observed_name

### DIFF
--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -83,8 +83,18 @@ actor AppleScriptChannel: Channel {
     func execute(operation: String, params: [String: String]) async -> ChannelResult {
         switch operation {
         case "project.new":
+            // #144 (B): `newProjectScript()` returns `name of newDocument`, so
+            // the raw script output IS the observed new-document name. Surface it
+            // as `observed_name` in the State-B envelope to make the unverified
+            // result actionable (e.g. "Untitled 17"). There is no reliable
+            // AppleScript readback for blank-active-project identity, so this
+            // stays verified:false — observed_name is evidence, not verification.
             let raw = await runScript(newProjectScript())
-            return Self.wrapMutatingResult(raw, operation: operation)
+            return Self.wrapMutatingResult(
+                raw,
+                operation: operation,
+                extras: Self.newProjectExtras(raw)
+            )
 
         case "project.open":
             guard let path = params["path"] else {
@@ -108,6 +118,16 @@ actor AppleScriptChannel: Channel {
             // package whose mtime did not advance stays an honest State B and
             // never claims a verified save an export/bounce step would trust.
             let documentPath = await runtime.currentDocumentPath()
+            // #144 fail-fast: resolving the front document's path FIRST means an
+            // UNTITLED document (no on-disk path) never reaches `save front
+            // document`, which would raise Logic's modal Save sheet and block the
+            // AppleEvent until the sheet is dismissed (observed live as a server
+            // hang to the command deadline / harness teardown). Short-circuit to a
+            // terminal State C `unsupported_state` so the caller gets an instant,
+            // honest failure with a recovery hint instead of a guaranteed hang.
+            if let failFast = Self.untitledSaveFailFast(documentPath: documentPath) {
+                return failFast
+            }
             let beforeMtime = documentPath.flatMap(runtime.fileModificationDate)
             let saveStartedAt = Date()
             let raw = await runScript(saveProjectScript())
@@ -203,6 +223,37 @@ actor AppleScriptChannel: Channel {
         for (k, v) in extras { merged[k] = v }
         return .success(HonestContract.encodeStateB(
             reason: .readbackUnavailable, extras: merged
+        ))
+    }
+
+    /// #144 (B): derive the `observed_name` extra for `project.new` from the
+    /// raw script output (`name of newDocument`). Returns an empty dictionary on
+    /// a script error or blank/whitespace name so the envelope is unchanged when
+    /// there is no usable name — the State-B verdict itself never changes.
+    static func newProjectExtras(_ result: ChannelResult) -> [String: Any] {
+        guard result.isSuccess else { return [:] }
+        let name = result.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return [:] }
+        return ["observed_name": name]
+    }
+
+    /// #144: fail-fast guard for `project.save`. Returns a terminal State C
+    /// `unsupported_state` envelope when the front document is untitled (no
+    /// on-disk path), so the blocking `save front document` script is never
+    /// fired against a document that would raise Logic's modal Save sheet and
+    /// hang the AppleEvent. Returns `nil` for a titled document (non-empty
+    /// path) so the healthy verified-save path proceeds unchanged. Deterministic
+    /// and side-effect-free — unit-testable without driving live Logic.
+    static func untitledSaveFailFast(documentPath: String?) -> ChannelResult? {
+        let hasPath = (documentPath?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+        guard !hasPath else { return nil }
+        return .error(HonestContract.encodeStateC(
+            error: .unsupportedState,
+            hint: "front document is untitled (no on-disk path); use project.save_as with an absolute .logicx path to write and verify it",
+            extras: [
+                "operation": "project.save",
+                "method": "applescript",
+            ]
         ))
     }
 

--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -232,7 +232,19 @@ actor AppleScriptChannel: Channel {
     /// there is no usable name — the State-B verdict itself never changes.
     static func newProjectExtras(_ result: ChannelResult) -> [String: Any] {
         guard result.isSuccess else { return [:] }
-        let name = result.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        // runScript wraps the AppleScript value as `{"result":"<name>"}`; unwrap
+        // it so observed_name is the bare document name ("Untitled"), not the
+        // raw JSON envelope. Fall back to the trimmed message if it is not the
+        // expected wrapper shape.
+        let trimmed = result.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name: String
+        if let data = trimmed.data(using: .utf8),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let unwrapped = obj["result"] as? String {
+            name = unwrapped.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            name = trimmed
+        }
         guard !name.isEmpty else { return [:] }
         return ["observed_name": name]
     }

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -111,6 +111,14 @@ enum HonestContract {
         case rollbackFailed
         case verifiedOpInProgress
         case operationTimeout
+        /// The requested operation cannot be performed in the front document's
+        /// current state — e.g. `project.save` on an UNTITLED document that has
+        /// no on-disk path. Firing `save front document` on such a document
+        /// raises Logic's modal Save sheet and the AppleEvent blocks until it is
+        /// dismissed, so the save path fails fast here instead. Terminal — no
+        /// other channel can save an untitled document without a path; the
+        /// caller must supply one via `project.save_as`. #144 (P3 hardening).
+        case unsupportedState
 
         var rawValue: String {
             switch self {
@@ -146,6 +154,7 @@ enum HonestContract {
             case .rollbackFailed: return "rollback_failed"
             case .verifiedOpInProgress: return "verified_op_in_progress"
             case .operationTimeout: return "operation_timeout"
+            case .unsupportedState: return "unsupported_state"
             }
         }
     }
@@ -305,6 +314,10 @@ enum HonestContract {
         FailureError.rollbackFailed.rawValue,
         FailureError.verifiedOpInProgress.rawValue,
         FailureError.operationTimeout.rawValue,
+        // #144: `project.save` on an untitled document fails fast as terminal
+        // State C `unsupported_state` — no fallback channel can save a document
+        // that has no on-disk path; the caller must use `project.save_as`.
+        FailureError.unsupportedState.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Tests/LogicProMCPTests/AppleScriptChannelHCWrapTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelHCWrapTests.swift
@@ -98,7 +98,15 @@ private func makeAppleScriptRuntime(
     // would break the existing terminal-state detector.
     let recorder = AppleScriptRecorder()
     await recorder.setResult(.error("AppleScript error: boom"))
-    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+    // #144: a titled (but non-existent on-disk) front document reaches the
+    // script — its error surfaces verbatim with no mtime evidence — instead of
+    // short-circuiting on the untitled fail-fast (which is its own typed State C).
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
 
     let result = await channel.execute(operation: "project.save", params: [:])
     #expect(!result.isSuccess)
@@ -113,7 +121,15 @@ private func makeAppleScriptRuntime(
     let alreadyEnveloped = HonestContract.encodeStateA(extras: ["custom": "ok"])
     let recorder = AppleScriptRecorder()
     await recorder.setResult(.success(alreadyEnveloped))
-    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+    // #144: titled front document so the save reaches the script whose body
+    // already produced an HC envelope; the untitled fail-fast must not preempt
+    // the no-double-wrap passthrough being asserted here.
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
 
     let result = await channel.execute(operation: "project.save", params: [:])
     #expect(result.isSuccess)

--- a/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
@@ -586,4 +586,8 @@ private func makeAppleScriptRuntime(
     #expect(AppleScriptChannel.newProjectExtras(.success("  Demo  "))["observed_name"] as? String == "Demo")
     #expect(AppleScriptChannel.newProjectExtras(.success("   "))["observed_name"] == nil)
     #expect(AppleScriptChannel.newProjectExtras(.error("boom"))["observed_name"] == nil)
+    // runScript wraps the value as {"result":"<name>"}; observed_name must be the
+    // bare unwrapped name, not the raw JSON envelope.
+    #expect(AppleScriptChannel.newProjectExtras(.success("{\"result\":\"Untitled\"}"))["observed_name"] as? String == "Untitled")
+    #expect(AppleScriptChannel.newProjectExtras(.success("{\"result\":\"\"}"))["observed_name"] == nil)
 }

--- a/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptChannelTests.swift
@@ -245,7 +245,15 @@ private func makeAppleScriptRuntime(
 
 @Test func testAppleScriptProjectCommandsGenerateExpectedScripts() async {
     let recorder = AppleScriptRecorder()
-    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+    // #144: a titled front document keeps `project.save` on the healthy path
+    // that fires `save front document` (the untitled fail-fast is covered
+    // separately in testAppleScriptSaveOnUntitledDocumentFailsFast).
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
 
     let newProject = await channel.execute(operation: "project.new", params: [:])
     let saveProject = await channel.execute(operation: "project.save", params: [:])
@@ -370,7 +378,15 @@ private func makeAppleScriptRuntime(
 @Test func testAppleScriptExecutePropagatesScriptErrors() async {
     let recorder = AppleScriptRecorder()
     await recorder.setResult(.error("AppleScript error: boom"))
-    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+    // #144: titled document so the save reaches the script (and propagates its
+    // error) rather than short-circuiting on the untitled fail-fast.
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            fileModificationDate: { _ in nil },
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
 
     let result = await channel.execute(operation: "project.save", params: [:])
     #expect(!result.isSuccess)
@@ -391,7 +407,18 @@ private func makeAppleScriptRuntime(
 @Test func testAppleScriptExecuteReturnsInjectedJSONResult() async {
     let recorder = AppleScriptRecorder()
     await recorder.setResult(.success("{\"result\":\"hello\"}"))
-    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+    // #144: titled document on the healthy save path, but with a stale mtime
+    // that does NOT advance past saveStartedAt — so the verdict stays the
+    // honest State B this test asserts (script fired-but-unconfirmed), not the
+    // untitled fail-fast (which would be State C and never fire the script).
+    let stale = Date(timeIntervalSince1970: 1_000)
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            fileModificationDate: { _ in stale },
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
 
     let result = await channel.execute(operation: "project.save", params: [:])
 
@@ -439,4 +466,124 @@ private func makeAppleScriptRuntime(
     let script = AppleScriptChannel.currentDocumentPathScript()
     #expect(script.contains("path of front document"))
     #expect(script.contains("count of documents"))
+}
+
+// MARK: - #144 — project.save fail-fast on untitled document
+
+/// The untitled fail-fast must return State C `unsupported_state` BEFORE the
+/// blocking `save front document` script is ever fired — proving the modal
+/// Save-sheet hang is impossible. We assert the recorder captured ZERO scripts.
+@Test func testAppleScriptSaveOnUntitledDocumentFailsFastWithoutFiringScript() async throws {
+    let recorder = AppleScriptRecorder()
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { nil } // untitled: no on-disk path
+        )
+    )
+
+    let result = await channel.execute(operation: "project.save", params: [:])
+
+    #expect(!result.isSuccess)
+    let obj = try JSONSerialization.jsonObject(
+        with: Data(result.message.utf8), options: []
+    ) as! [String: Any]
+    let success = try #require(obj["success"] as? Bool)
+    #expect(!success)
+    #expect(obj["error"] as? String == "unsupported_state")
+    let hint = try #require(obj["hint"] as? String)
+    #expect(hint.contains("untitled"))
+    #expect(hint.contains("save_as"))
+    #expect(obj["operation"] as? String == "project.save")
+
+    // The decisive assertion: NO save script was fired, so Logic's modal Save
+    // sheet can never appear and the AppleEvent can never block.
+    let scripts = await recorder.snapshot()
+    #expect(scripts.isEmpty)
+}
+
+/// An empty-string document path (the AppleScript `""`-untitled signal) is the
+/// same untitled case and must also fail fast without firing the script.
+@Test func testAppleScriptSaveOnEmptyPathDocumentFailsFast() async throws {
+    let recorder = AppleScriptRecorder()
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { "   " } // whitespace-only == untitled
+        )
+    )
+
+    let result = await channel.execute(operation: "project.save", params: [:])
+
+    #expect(!result.isSuccess)
+    #expect(result.message.contains("unsupported_state"))
+    let scripts = await recorder.snapshot()
+    #expect(scripts.isEmpty)
+}
+
+/// A titled document MUST proceed to fire `save front document` (the healthy
+/// verified-save path stays unchanged) — the fail-fast only fires when untitled.
+@Test func testAppleScriptSaveOnTitledDocumentFiresSaveScript() async throws {
+    let recorder = AppleScriptRecorder()
+    let channel = AppleScriptChannel(
+        runtime: makeAppleScriptRuntime(
+            scriptRecorder: recorder,
+            currentDocumentPath: { "/Users/x/Song.logicx" }
+        )
+    )
+
+    let result = await channel.execute(operation: "project.save", params: [:])
+
+    #expect(result.isSuccess)
+    let scripts = await recorder.snapshot()
+    let savedScript = try #require(scripts.first)
+    #expect(savedScript.contains("save front document"))
+}
+
+/// Deterministic, side-effect-free helper: nil / empty / whitespace → State C;
+/// any real path → nil (proceed). Each assertion can genuinely fail.
+@Test func testUntitledSaveFailFast_deterministicTriState() throws {
+    #expect(AppleScriptChannel.untitledSaveFailFast(documentPath: nil) != nil)
+    #expect(AppleScriptChannel.untitledSaveFailFast(documentPath: "") != nil)
+    #expect(AppleScriptChannel.untitledSaveFailFast(documentPath: "  \n ") != nil)
+    // Titled → no fail-fast (proceed to the verified-save path).
+    #expect(AppleScriptChannel.untitledSaveFailFast(documentPath: "/Users/x/A.logicx") == nil)
+
+    // The State C it builds is the typed, terminal envelope the router surfaces.
+    let failFast = try #require(AppleScriptChannel.untitledSaveFailFast(documentPath: nil))
+    #expect(!failFast.isSuccess)
+    #expect(HonestContract.isTerminalStateC(failFast.message))
+    #expect(HonestContract.stateCErrorCode(failFast.message) == "unsupported_state")
+}
+
+// MARK: - #144 (B) — project.new observed_name enrichment
+
+/// `project.new` carries the observed new-document name (the raw script output)
+/// into the State-B envelope, while staying verified:false (no real readback).
+@Test func testAppleScriptProjectNewAttachesObservedName() async throws {
+    let recorder = AppleScriptRecorder()
+    await recorder.setResult(.success("Untitled 17"))
+    let channel = AppleScriptChannel(runtime: makeAppleScriptRuntime(scriptRecorder: recorder))
+
+    let result = await channel.execute(operation: "project.new", params: [:])
+
+    #expect(result.isSuccess)
+    let obj = try JSONSerialization.jsonObject(
+        with: Data(result.message.utf8), options: []
+    ) as! [String: Any]
+    let success = try #require(obj["success"] as? Bool)
+    #expect(success)
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(!verified) // still unverified — observed_name is evidence, not proof
+    #expect(obj["reason"] as? String == "readback_unavailable")
+    #expect(obj["observed_name"] as? String == "Untitled 17")
+}
+
+/// newProjectExtras is the deterministic seam: a real name → observed_name; a
+/// script error or blank name → no observed_name (envelope unchanged).
+@Test func testNewProjectExtras_deterministic() {
+    #expect(AppleScriptChannel.newProjectExtras(.success("Untitled 4"))["observed_name"] as? String == "Untitled 4")
+    #expect(AppleScriptChannel.newProjectExtras(.success("  Demo  "))["observed_name"] as? String == "Demo")
+    #expect(AppleScriptChannel.newProjectExtras(.success("   "))["observed_name"] == nil)
+    #expect(AppleScriptChannel.newProjectExtras(.error("boom"))["observed_name"] == nil)
 }

--- a/Tests/LogicProMCPTests/Issue110SaveVerifyTests.swift
+++ b/Tests/LogicProMCPTests/Issue110SaveVerifyTests.swift
@@ -85,4 +85,75 @@ struct Issue110SaveVerifyTests {
         #expect(o?["verified"] as? Bool == false)
         #expect((o?["reason_detail"] as? String)?.contains("untitled") == true)
     }
+
+    // #144 — channel-level fail-fast: driving `project.save` end-to-end through
+    // the channel on an UNTITLED document must short-circuit to a terminal State
+    // C `unsupported_state` BEFORE the blocking `save front document` script is
+    // ever recorded. This is the contract that converts a guaranteed modal
+    // Save-sheet hang into an instant honest failure. The titled-doc case below
+    // proves the healthy verified-save path is unchanged.
+    @Test("project.save on an untitled document fails fast before any script fires")
+    func untitledSaveFailsFastBeforeScript() async throws {
+        let recorder = SaveScriptRecorder()
+        let channel = AppleScriptChannel(
+            runtime: makeRuntime(recorder: recorder, documentPath: nil)
+        )
+
+        let result = await channel.execute(operation: "project.save", params: [:])
+
+        #expect(!result.isSuccess)
+        let o = try #require(obj(result))
+        let success = try #require(o["success"] as? Bool)
+        #expect(!success)
+        #expect(o["error"] as? String == "unsupported_state")
+        let hint = try #require(o["hint"] as? String)
+        #expect(hint.contains("untitled"))
+        #expect(hint.contains("save_as"))
+        // Decisive: zero scripts recorded ⇒ no modal Save sheet, no AppleEvent block.
+        let scripts = await recorder.snapshot()
+        #expect(scripts.isEmpty)
+    }
+
+    @Test("project.save on a titled document still fires the save script")
+    func titledSaveFiresScript() async throws {
+        let recorder = SaveScriptRecorder()
+        let channel = AppleScriptChannel(
+            runtime: makeRuntime(recorder: recorder, documentPath: "/Users/x/Song.logicx")
+        )
+
+        let result = await channel.execute(operation: "project.save", params: [:])
+
+        #expect(result.isSuccess)
+        let scripts = await recorder.snapshot()
+        let fired = try #require(scripts.first)
+        #expect(fired.contains("save front document"))
+    }
+
+    // Local recorder + Runtime builder so this suite is self-contained (the
+    // helper in AppleScriptChannelTests is file-private to that file).
+    private actor SaveScriptRecorder {
+        private var scripts: [String] = []
+        func run(_ source: String) -> ChannelResult {
+            scripts.append(source)
+            return .success("{\"result\":\"\"}")
+        }
+        func snapshot() -> [String] { scripts }
+    }
+
+    private func makeRuntime(
+        recorder: SaveScriptRecorder,
+        documentPath: String?
+    ) -> AppleScriptChannel.Runtime {
+        AppleScriptChannel.Runtime(
+            isLogicProRunning: { true },
+            openFile: { _ in true },
+            runScript: { source in await recorder.run(source) },
+            executeTransportAction: { _ in .success("{\"result\":\"\"}") },
+            // distantFuture mtime ⇒ titled-doc save reads back as written (State A),
+            // keeping the healthy path's success verdict for the titled test.
+            fileExists: { _ in true },
+            fileModificationDate: { _ in Date.distantFuture },
+            currentDocumentPath: { documentPath }
+        )
+    }
 }


### PR DESCRIPTION
Closes #144.

## Problem
`project.save` on an **untitled** (never-saved, no on-disk path) document fired the blocking `save front document` AppleScript, which raised Logic's modal Save sheet and hung to the deadline / harness teardown. `project.new` also surfaced its name as a raw JSON wrapper.

## Fix
- **Fail-fast:** `project.save` calls `currentDocumentPath()` BEFORE the blocking script; if nil/empty → instant typed State C `error="unsupported_state"` with hint to use `project.save_as <absolute .logicx>`. Healthy titled-doc path (file-mtime State A) unchanged.
- `project.new` attaches `observed_name` (State B, `verified:false`), now unwrapped from the `{"result":"…"}` script envelope to the bare name.

## Verification
- Unit: `swift test --filter ProjectDispatcher --filter AppleScriptChannel --filter Issue110 --filter HonestContract` → 304 passed (incl. new fail-fast + unwrap tests).
- **Live (real Logic 12.2, fresh binary, stdio):**
  - Titled doc → `save` → State A `verified:true verify_source:file_mtime`, sub-second, no modal. ✓
  - `project.new` (untitled) → `save` → **State C `unsupported_state`**, 1.5s, **zero Save sheet** (sheets=0 dialogs=0). ✓
  - `project.new` → State B with `observed_name:"Untitled"` (unwrapped). ✓