### PR TITLE
fix(#138): verified transport.pause (State A/C) + working pause routing + set_cycle_range doc-demote

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -270,6 +270,10 @@ actor AccessibilityChannel: Channel {
             return runtime.toggleTransportButton("Play")
         case "transport.stop":
             return runtime.toggleTransportButton("Stop")
+        case "transport.pause":
+            // Logic has no distinct pause control; the Stop button halts the
+            // playhead in place, which is exactly the verified pause target.
+            return runtime.toggleTransportButton("Stop")
         case "transport.record":
             return runtime.toggleTransportButton("Record")
 

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -45,7 +45,12 @@ actor ChannelRouter {
         // let the dispatcher's live readback gate decide success.
         "transport.stop":             [.accessibility, .cgEvent, .mcu, .coreMIDI, .appleScript],
         "transport.record":           [.accessibility, .mcu, .coreMIDI, .cgEvent, .appleScript],
-        "transport.pause":            [.coreMIDI, .cgEvent],
+        // Logic 12.x has no distinct "pause" — the playhead stops in place via
+        // the Stop button / spacebar. MMC "pause" (the old primary) is silently
+        // ignored by Logic, so a verified pause always failed closed. Mirror the
+        // proven transport.stop order: AX Stop-button first (frontmost-independent),
+        // spacebar next, MMC last as a best-effort fallback.
+        "transport.pause":            [.accessibility, .cgEvent, .coreMIDI],
         "transport.rewind":           [.mcu, .coreMIDI, .cgEvent],
         "transport.fast_forward":     [.mcu, .coreMIDI, .cgEvent],
         "transport.toggle_cycle":     [.accessibility, .midiKeyCommands, .cgEvent, .mcu],

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -248,7 +248,7 @@ struct SystemDispatcher {
                   toggle_count_in   -> {} — Toggle count-in
                   set_tempo         -> { tempo: Float } — Set BPM (5-999)
                   goto_position     -> { bar: Int (1..9999) } or { position: String } — bar.beat.sub.tick or HH:MM:SS:FF SMPTE
-                  set_cycle_range   -> { start: Int, end: Int } — Bar numbers
+                  set_cycle_range   -> { start: Int, end: Int } — Bar numbers (UNSUPPORTED/best-effort: Logic 12.x exposes no numeric cycle-locator fields; fails closed with State C not_implemented, cannot verify a write)
 
                 Read state via resource: logic://transport/state
                 """

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -4,7 +4,7 @@ import MCP
 struct TransportDispatcher {
     static let tool = Tool(
         name: "logic_transport",
-        description: "Control Logic Pro transport. Commands: play, stop, record, pause, rewind, fast_forward, toggle_cycle, toggle_metronome, set_tempo, goto_position, set_cycle_range, toggle_count_in. Params: set_tempo -> { tempo: Float } (5.0-999.0); goto_position -> { bar: Int (1..9999) } or { position: String } where String is bar.beat.sub.tick (e.g. \"9.1.1.1\") or HH:MM:SS:FF SMPTE (e.g. \"00:00:08:12\"); set_cycle_range -> { start: Int, end: Int }; others -> {}.",
+        description: "Control Logic Pro transport. Commands: play, stop, record, pause, rewind, fast_forward, toggle_cycle, toggle_metronome, set_tempo, goto_position, set_cycle_range, toggle_count_in. Params: set_tempo -> { tempo: Float } (5.0-999.0); goto_position -> { bar: Int (1..9999) } or { position: String } where String is bar.beat.sub.tick (e.g. \"9.1.1.1\") or HH:MM:SS:FF SMPTE (e.g. \"00:00:08:12\"); set_cycle_range -> { start: Int, end: Int } (UNSUPPORTED/best-effort: Logic 12.x exposes no numeric cycle-locator fields, so this fails closed with State C not_implemented and CANNOT verify a write); others -> {}.",
         inputSchema: commandParamsToolSchema(commandDescription: "Transport command to execute")
     )
 
@@ -34,8 +34,7 @@ struct TransportDispatcher {
             )
 
         case "pause":
-            let result = await router.route(operation: "transport.pause")
-            return toolTextResult(result)
+            return await verifiedPauseResult(router: router, cache: cache, sleep: sleep)
 
         case "rewind":
             let result = await router.route(operation: "transport.rewind")
@@ -246,6 +245,92 @@ struct TransportDispatcher {
         }
 
         return toolTextResult(HonestContract.encodeStateA(extras: observedExtras))
+    }
+
+    /// Verified `pause` mirroring `verifiedStopResult`: a pause that does not
+    /// actually halt the playhead must NEVER report bare success. Logic's pause
+    /// stops the running transport, so the verified target is the same as stop —
+    /// `isPlaying == false`. Read state first, send pause, then poll
+    /// `readTransportState` up to 12x for the playhead to settle; State A only on
+    /// a verified stop, State C `readback_mismatch` if it keeps playing.
+    private static func verifiedPauseResult(
+        router: ChannelRouter,
+        cache: StateCache,
+        sleep: @escaping (UInt64) async -> Void
+    ) async -> CallTool.Result {
+        if let beforeState = await readTransportState(router: router),
+           beforeState.isPlaying == false {
+            return toolTextResult(.success(HonestContract.encodeStateA(
+                extras: [
+                    "operation": "transport.pause",
+                    "requested_state": "paused",
+                    "verify_source": "transport_state",
+                    "write_attempted": false,
+                    "unchanged": true,
+                    "observed_before": transportStateSummary(beforeState),
+                    "observed_after": transportStateSummary(beforeState)
+                ]
+            )))
+        }
+
+        let writeResult = await router.route(operation: "transport.pause")
+        let writePayload = jsonValue(from: writeResult.message)
+
+        var attempts = 0
+        var afterState: TransportState?
+        for _ in 0..<12 {
+            attempts += 1
+            if let observed = await readTransportState(router: router) {
+                afterState = observed
+                await cache.updateTransport(observed)
+                if observed.isPlaying == false {
+                    return toolTextResult(.success(HonestContract.encodeStateA(extras: [
+                        "operation": "transport.pause",
+                        "requested_state": "paused",
+                        "verify_source": "transport_state",
+                        "write_attempted": true,
+                        "poll_attempts": attempts,
+                        "observed_isPlaying": observed.isPlaying,
+                        "observed_isRecording": observed.isRecording,
+                        "observed_position": observed.position,
+                        "observed_time_position": observed.timePosition,
+                        "write_result": writePayload
+                    ])))
+                }
+            }
+            await sleep(100_000_000)
+        }
+
+        guard writeResult.isSuccess else {
+            return toolTextResult(writeResult)
+        }
+
+        var extras: [String: Any] = [
+            "operation": "transport.pause",
+            "requested_state": "paused",
+            "verify_source": "transport_state",
+            "write_attempted": true,
+            "poll_attempts": attempts,
+            "write_result": writePayload
+        ]
+        guard let afterState else {
+            return toolTextResult(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "transport.pause executed, but live transport state could not be refreshed. Focus Logic's Tracks window, dismiss modal or plugin dialogs, then retry or run logic_system refresh_cache.",
+                extras: extras
+            ), isError: true)
+        }
+
+        extras["observed_isPlaying"] = afterState.isPlaying
+        extras["observed_isRecording"] = afterState.isRecording
+        extras["observed_position"] = afterState.position
+        extras["observed_time_position"] = afterState.timePosition
+        extras["safe_to_retry"] = true
+        return toolTextResult(HonestContract.encodeStateC(
+            error: .readbackMismatch,
+            hint: "transport.pause executed, but live transport state still reports playback",
+            extras: extras
+        ), isError: true)
     }
 
     private static func stopReadbackUnavailableExtras(

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -344,10 +344,13 @@ private func liveTransportJSON(
 // MARK: - TransportDispatcher
 
 @Test func testTransportDispatcherRoutesPrimaryCommands() async {
+    // NOTE: `pause` is intentionally absent here — it is now a verified
+    // Honest-Contract command (see verifiedPauseResult / the dedicated
+    // pause tests below) and can no longer succeed against a plain
+    // MockChannel that does not answer transport.get_state.
     let cases: [(command: String, operation: String)] = [
         ("play", "transport.play"),
         ("record", "transport.record"),
-        ("pause", "transport.pause"),
         ("rewind", "transport.rewind"),
         ("fast_forward", "transport.fast_forward"),
         ("toggle_cycle", "transport.toggle_cycle"),
@@ -358,7 +361,6 @@ private func liveTransportJSON(
     for testCase in cases {
         let router = ChannelRouter()
         let channelID: ChannelID = switch testCase.operation {
-        case "transport.pause": .coreMIDI
         case "transport.toggle_metronome", "transport.toggle_count_in": .midiKeyCommands
         default: .mcu
         }
@@ -523,6 +525,165 @@ private func liveTransportJSON(
     #expect(object["verification_source"] as? String == "transport_state")
     #expect(object["requested"] as? String == "9.1.1.1")
     #expect(object["observed"] as? String == "8.1.1.1")
+}
+
+@Test func testTransportDispatcherPauseReturnsStateAWhenPlaybackStops() async throws {
+    // #138: pause must verify via transport readback like stop, not report
+    // bare success. Routing: transport.pause -> .coreMIDI; transport.get_state
+    // -> .accessibility, so the write and the readback live on separate fakes.
+    let router = ChannelRouter()
+    let pauseWrite = FixedResultChannel(id: .coreMIDI, result: .success("MMC pause sent"))
+    let readback = SequencedTransportReadbackChannel(
+        id: .accessibility,
+        transportStates: [
+            // before: playing -> first poll: stopped
+            TransportState(isPlaying: true, position: "1.2.1.1", timePosition: "00:00:02.000", lastUpdated: Date()),
+            TransportState(isPlaying: false, position: "1.2.1.1", timePosition: "00:00:02.000", lastUpdated: Date()),
+        ]
+    )
+    await router.register(pauseWrite)
+    await router.register(readback)
+
+    let result = await TransportDispatcher.handle(
+        command: "pause",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect((object["verified"] as? Bool)!)
+    #expect(object["operation"] as? String == "transport.pause")
+    let observedPlaying = try #require(object["observed_isPlaying"] as? Bool)
+    #expect(!observedPlaying)
+}
+
+@Test func testTransportDispatcherPauseReturnsStateCWhenPlaybackContinues() async throws {
+    // #138: if the playhead keeps running after the pause send, pause must
+    // fail closed with State C readback_mismatch — never bare success.
+    let router = ChannelRouter()
+    let pauseWrite = FixedResultChannel(id: .coreMIDI, result: .success("MMC pause sent"))
+    // 13 states: 1 "before" read + 12 polls, all still playing.
+    let stillPlaying = Array(
+        repeating: TransportState(
+            isPlaying: true,
+            position: "1.3.1.1",
+            timePosition: "00:00:03.000",
+            lastUpdated: Date()
+        ),
+        count: 13
+    )
+    let readback = SequencedTransportReadbackChannel(
+        id: .accessibility,
+        transportStates: stillPlaying
+    )
+    await router.register(pauseWrite)
+    await router.register(readback)
+
+    let result = await TransportDispatcher.handle(
+        command: "pause",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    #expect(result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    // State C carries success:false + error (no `verified`/`reason` keys).
+    let success = try #require(object["success"] as? Bool)
+    #expect(!success)
+    #expect(object["error"] as? String == "readback_mismatch")
+    #expect(object["operation"] as? String == "transport.pause")
+    let observedPlaying = try #require(object["observed_isPlaying"] as? Bool)
+    #expect(observedPlaying)
+    let safeToRetry = try #require(object["safe_to_retry"] as? Bool)
+    #expect(safeToRetry)
+}
+
+@Test func testTransportDispatcherPauseReturnsStateAUnchangedWhenAlreadyStopped() async throws {
+    // Idempotent early-return: already stopped means no write is attempted.
+    let router = ChannelRouter()
+    let pauseWrite = FixedResultChannel(id: .coreMIDI, result: .success("MMC pause sent"))
+    let readback = SequencedTransportReadbackChannel(
+        id: .accessibility,
+        transportStates: [
+            TransportState(isPlaying: false, position: "1.1.1.1", timePosition: "00:00:00.000", lastUpdated: Date())
+        ]
+    )
+    await router.register(pauseWrite)
+    await router.register(readback)
+
+    let result = await TransportDispatcher.handle(
+        command: "pause",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect((object["verified"] as? Bool)!)
+    let writeAttempted = try #require(object["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    let unchanged = try #require(object["unchanged"] as? Bool)
+    #expect(unchanged)
+    // No write should have been routed to the coreMIDI pause channel.
+    let writeOps = await pauseWrite.executedOps
+    #expect(writeOps.isEmpty)
+}
+
+@Test func testTransportDispatcherPauseReturnsStateCWhenReadbackUnavailable() async throws {
+    // If no transport readback is ever available, pause must fail closed with
+    // State C readback_unavailable, never bare success.
+    let router = ChannelRouter()
+    let pauseWrite = FixedResultChannel(id: .coreMIDI, result: .success("MMC pause sent"))
+    // SequencedTransportReadbackChannel returns .error when its queue is empty,
+    // so an empty queue models a transport whose state can never be read.
+    let readback = SequencedTransportReadbackChannel(
+        id: .accessibility,
+        transportStates: []
+    )
+    await router.register(pauseWrite)
+    await router.register(readback)
+
+    let result = await TransportDispatcher.handle(
+        command: "pause",
+        params: [:],
+        router: router,
+        cache: StateCache(),
+        sleep: { _ in }
+    )
+
+    #expect(result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    // State C carries success:false + error (no `verified`/`reason` keys).
+    let success = try #require(object["success"] as? Bool)
+    #expect(!success)
+    #expect(object["error"] as? String == "readback_unavailable")
+    #expect(object["operation"] as? String == "transport.pause")
+}
+
+@Test func testTransportDispatcherSetCycleRangeDocumentedUnsupported() async {
+    // #138 (2): set_cycle_range stays honest fail-closed but is demoted to a
+    // documented unsupported/best-effort surface in the tool description and
+    // the SystemDispatcher transport help.
+    let toolDescription = TransportDispatcher.tool.description ?? ""
+    #expect(toolDescription.contains("set_cycle_range"))
+    #expect(toolDescription.lowercased().contains("unsupported"))
+
+    let helpResult = await SystemDispatcher.handle(
+        command: "help",
+        params: ["category": .string("transport")],
+        router: ChannelRouter(),
+        cache: StateCache()
+    )
+    let help = dispatcherText(helpResult)
+    #expect(help.contains("set_cycle_range"))
+    #expect(help.lowercased().contains("unsupported"))
 }
 
 @Test func testTransportDispatcherRejectsMissingSemanticPayloads() async {

--- a/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
+++ b/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
@@ -122,4 +122,20 @@ struct RoutingAuditInvariantTests {
         let bytes = detail.utf8.count
         #expect(bytes < 1024, "manualValidationDetailSuffix is \(bytes) UTF-8 bytes; the surrounding comment claims < 1 KB.")
     }
+
+    /// #138 regression: Logic 12.x silently ignores MMC "pause", so a verified
+    /// transport.pause that routed CoreMIDI first always failed closed. The
+    /// pause chain must prefer a channel that actually halts the playhead
+    /// (AX Stop button / spacebar) BEFORE the no-op MMC fallback.
+    @Test("transport.pause routes a working stop channel before MMC")
+    func pausePrefersWorkingChannelOverMMC() throws {
+        let chain = try #require(ChannelRouter.routingTable["transport.pause"])
+        let mmcIndex = try #require(chain.firstIndex(of: .coreMIDI))
+        let axIndex = chain.firstIndex(of: .accessibility)
+        let cgIndex = chain.firstIndex(of: .cgEvent)
+        let firstWorking = [axIndex, cgIndex].compactMap { $0 }.min()
+        let working = try #require(firstWorking)
+        #expect(working < mmcIndex,
+                "transport.pause chain \(chain) must try AX/cgEvent before MMC; MMC pause is ignored by Logic 12.x")
+    }
 }


### PR DESCRIPTION
Closes #138.

## Problem
`transport.pause` returned bare success while playback continued (no readback). It also routed `[.coreMIDI, .cgEvent]` — MMC-pause first — and Logic 12.x silently IGNORES MMC pause, so even after wrapping it in a verified envelope it could only ever fail closed.

## Fix
- Wrap `transport.pause` in a verified Honest-Contract envelope mirroring `verifiedStopResult`: read state, send pause, poll `readTransportState` 12× for `isPlaying==false` → State A, else State C `readback_mismatch`.
- **Make pause actually work:** Logic has no distinct pause — the Stop button / spacebar halts the playhead in place. Reorder routing to `[.accessibility, .cgEvent, .coreMIDI]` (mirrors proven `transport.stop`) and add an `AccessibilityChannel` `transport.pause` handler (clicks Stop). MMC kept only as last-resort fallback.
- `set_cycle_range`: kept honest State C `not_implemented`, demoted to UNSUPPORTED/best-effort in the tool description + system help.

## Verification
- Unit: `swift test --filter TransportDispatcher --filter ChannelRouter --filter CoreMIDIChannel --filter AppleScriptChannel` → 98 passed; added a routingTable regression guard (pause prefers a working stop channel before MMC).
- **Live (real Logic 12.2, fresh binary, stdio):** `play` → State A `isPlaying:true`; `pause` → **State A `verified:true observed_isPlaying:false`**; `transport/state` confirms stopped; `set_cycle_range` → State C `not_implemented`; tool description shows UNSUPPORTED. ✓