### PR TITLE
fix(#140,#128): reliable MIDI file-open automation + GM-device audibility downgrade

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -4184,6 +4184,18 @@ actor AccessibilityChannel: Channel {
             tell application "Logic Pro" to activate
             delay 0.3
             tell application "System Events"
+                -- Self-heal: dismiss a stale Import open-panel left by a prior
+                -- failed run so repeated imports never stack file-open dialogs.
+                tell process "Logic Pro"
+                    repeat 4 times
+                        if (exists (first window whose name is "Import")) or (exists (first window whose name is "가져오기")) then
+                            key code 53
+                            delay 0.25
+                        else
+                            exit repeat
+                        end if
+                    end repeat
+                end tell
                 tell process "Logic Pro"
                     try
                         click menu item "MIDI 파일…" of menu 1 of menu item "가져오기" of menu 1 of menu bar item "파일" of menu bar 1
@@ -4221,32 +4233,109 @@ actor AccessibilityChannel: Channel {
                 if fileOpenSeen is false then
                     return "DIALOG_NOT_FOUND: file-open sheet did not appear"
                 end if
+                delay 0.2
+                -- Open the "Go to the folder" field, then SET its value directly.
+                -- Typing the path char-by-char proved unreliable (the field kept
+                -- only the leading "/" because the second keystroke did not land
+                -- in the freshly-opened sheet), which left the open panel stuck
+                -- and stacked dialogs on the next call. Poll the field into
+                -- existence across both window topologies Logic exposes
+                -- (sheet-on-window-1 vs standalone AXDialog) and assign AXValue.
+                tell process "Logic Pro" to set frontmost to true
+                delay 0.15
                 keystroke "/"
-                delay 0.5
-                keystroke "\(typedPath)"
-                delay 0.3
-                keystroke return
-                delay 1.5
-                tell process "Logic Pro"
-                    try
-                        set importDlg to first window whose name is "가져오기"
-                        click button "가져오기" of UI element 1 of importDlg
-                    on error
+                delay 0.4
+                set goToSet to false
+                repeat 20 times
+                    tell process "Logic Pro"
+                        -- Only accept the assignment once the field actually
+                        -- READS BACK our path, so a race that targets the wrong
+                        -- early text field cannot exit the loop prematurely.
                         try
-                            set importDlg to first window whose name is "Import"
-                            click button "Import" of UI element 1 of importDlg
-                        on error errMsg
-                            return "IMPORT_BTN_ERROR: " & errMsg
+                            set goDlg to first window whose subrole is "AXDialog"
+                            set value of text field 1 of sheet 1 of goDlg to "\(escapedPath)"
+                            if (value of text field 1 of sheet 1 of goDlg) is "\(escapedPath)" then
+                                set goToSet to true
+                            end if
                         end try
-                    end try
-                end tell
+                        if goToSet is false then
+                            try
+                                set value of text field 1 of sheet 1 of window 1 to "\(escapedPath)"
+                                if (value of text field 1 of sheet 1 of window 1) is "\(escapedPath)" then
+                                    set goToSet to true
+                                end if
+                            end try
+                        end if
+                    end tell
+                    if goToSet then exit repeat
+                    delay 0.15
+                end repeat
+                if goToSet is false then
+                    -- self-clean so we never leave a stuck panel for the next call
+                    tell process "Logic Pro"
+                        try
+                            key code 53
+                            delay 0.2
+                            key code 53
+                        end try
+                    end tell
+                    return "DIALOG_NOT_FOUND: go-to-folder field did not accept the path"
+                end if
+                delay 0.3
+                tell process "Logic Pro" to set frontmost to true
+                delay 0.15
+                keystroke return
+                -- Navigating to + selecting the file can take >1s, so poll the
+                -- Import button into an ENABLED state before clicking rather than
+                -- racing a fixed delay (clicking too early imports nothing and
+                -- leaves the panel open). ~4s (20 x 200ms).
+                set importClicked to false
+                repeat 20 times
+                    tell process "Logic Pro"
+                        try
+                            set importDlg to first window whose name is "가져오기"
+                            set ib to button "가져오기" of UI element 1 of importDlg
+                            if (enabled of ib) then
+                                click ib
+                                set importClicked to true
+                            end if
+                        end try
+                        if importClicked is false then
+                            try
+                                set importDlg to first window whose name is "Import"
+                                set ib to button "Import" of UI element 1 of importDlg
+                                if (enabled of ib) then
+                                    click ib
+                                    set importClicked to true
+                                end if
+                            end try
+                        end if
+                    end tell
+                    if importClicked then exit repeat
+                    delay 0.2
+                end repeat
+                if importClicked is false then
+                    tell process "Logic Pro"
+                        repeat 3 times
+                            if (exists (first window whose name is "Import")) or (exists (first window whose name is "가져오기")) then
+                                key code 53
+                                delay 0.2
+                            else
+                                exit repeat
+                            end if
+                        end repeat
+                    end tell
+                    return "IMPORT_BTN_ERROR: Import button never became enabled (file not selected)"
+                end if
                 -- Poll for the tempo dialog (subrole AXDialog) before dismissing
                 -- rather than a fixed delay. ~3s (15 x 200ms).
+                -- A lingering Import open-panel also has subrole AXDialog, so
+                -- exclude it by name; only a genuine tempo alert counts.
                 set tempoSeen to false
                 repeat 15 times
                     tell process "Logic Pro"
                         try
-                            if (exists (first window whose subrole is "AXDialog")) then
+                            if (exists (first window whose subrole is "AXDialog" and name is not "Import" and name is not "가져오기")) then
                                 set tempoSeen to true
                             end if
                         end try
@@ -4257,7 +4346,7 @@ actor AccessibilityChannel: Channel {
                 if tempoSeen then
                     tell process "Logic Pro"
                         try
-                            set tempoDlg to first window whose subrole is "AXDialog"
+                            set tempoDlg to first window whose subrole is "AXDialog" and name is not "Import" and name is not "가져오기"
                             try
                                 click button "아니요" of tempoDlg
                             on error
@@ -4268,6 +4357,18 @@ actor AccessibilityChannel: Channel {
                         end try
                     end tell
                 end if
+                -- Final self-heal: if an Import open-panel is somehow still up
+                -- (failed mid-flow), dismiss it so the next call starts clean.
+                tell process "Logic Pro"
+                    repeat 3 times
+                        if (exists (first window whose name is "Import")) or (exists (first window whose name is "가져오기")) then
+                            key code 53
+                            delay 0.2
+                        else
+                            exit repeat
+                        end if
+                    end repeat
+                end tell
                 if tempoSeen then
                     return "OK TEMPO_SEEN"
                 end if

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -4103,15 +4103,58 @@ actor AccessibilityChannel: Channel {
 
     // MARK: - MIDI file import
 
+    /// Tokens that mark a track header as a GM Device / external-MIDI synth
+    /// lane rather than an audible Software Instrument track. Logic's multi-track
+    /// SMF open creates these "GM Device N" / External MIDI lanes, which route to
+    /// a General MIDI device and bounce silent (#128). Matching is
+    /// case-insensitive substring. Kept narrow on purpose: a Software Instrument
+    /// track named "MIDI Bass" must NOT trip this — only the literal Logic lane
+    /// names ("GM Device", "External MIDI", "External Instrument") do.
+    static let gmDeviceLaneTokens: [String] = [
+        "gm device", "general midi", "external midi", "external instrument"
+    ]
+
+    /// Pure classifier: given the track-header names observed AFTER an import and
+    /// the count BEFORE, return the newly-created lane names that are GM Device /
+    /// external-MIDI (i.e. silent-on-bounce) lanes. Deterministic + unit-testable
+    /// without live AX. Only the *new* lanes (suffix beyond `beforeCount`) are
+    /// inspected so a pre-existing GM Device track never poisons a clean import.
+    static func gmDeviceLanesAmongNewTracks(
+        names: [String],
+        beforeCount: Int
+    ) -> [String] {
+        guard beforeCount >= 0, names.count > beforeCount else { return [] }
+        let newLanes = names.suffix(from: min(beforeCount, names.count))
+        return newLanes.filter { name in
+            let lower = name.lowercased()
+            return gmDeviceLaneTokens.contains { lower.contains($0) }
+        }
+    }
+
     /// Import a .mid file via Logic Pro's File → Import → MIDI File menu.
     /// Always creates a new MIDI track (Logic Pro's built-in behavior, OQ-3 confirmed).
     /// Uses osascript to coordinate the menu click, path-entry keystroke, and dialog dismissals.
+    ///
+    /// v3.6.x hardening (#140): the AppleScript no longer relies on a fixed
+    /// `delay 1.5` to assume the file-open sheet appeared. It POLLS (up to ~5s)
+    /// for the sheet to exist before issuing the path keystroke, and reports
+    /// `FILEOPEN_SEEN` / `TEMPO_SEEN` flags plus a `DIALOG_NOT_FOUND` sentinel so
+    /// an occluded-session miss (no sheet ever appeared) is distinguishable from
+    /// a real import that created no track. The track-count delta is read with a
+    /// bounded poll on the Swift side, not a single settle.
+    ///
+    /// v3.6.x audibility (#128): on the otherwise-State-A path, the created lane
+    /// names are read back; if any new lane is a GM Device / external-MIDI synth
+    /// lane the result is DOWNGRADED to State B `imported_as_gm_device` with a
+    /// hint, because such lanes route to a General MIDI device and may bounce
+    /// silent — a count delta alone must never be claimed audible-verified.
     static func defaultImportMIDIFile(
         path: String,
         runtime: AXLogicProElements.Runtime = .production,
         executeScript: @escaping @Sendable (String) async -> ChannelResult = { await AppleScriptChannel.executeAppleScript($0) },
         trackCount: (@Sendable () -> Int)? = nil,
-        settle: @escaping @Sendable () async -> Void = { try? await Task.sleep(nanoseconds: 500_000_000) }
+        trackNames: (@Sendable () -> [String])? = nil,
+        deltaPoll: @escaping @Sendable () async -> Void = { try? await Task.sleep(nanoseconds: 100_000_000) }
     ) async -> ChannelResult {
         guard FileManager.default.fileExists(atPath: path) else {
             return .error(HonestContract.encodeStateC(
@@ -4121,10 +4164,21 @@ actor AccessibilityChannel: Channel {
             ))
         }
         let readTrackCount = trackCount ?? { AXLogicProElements.allTrackHeaders(runtime: runtime).count }
+        let readTrackNames = trackNames ?? {
+            AXLogicProElements.allTrackHeaders(runtime: runtime).enumerated().map { index, header in
+                AXValueExtractors.extractTrackState(from: header, index: index, runtime: runtime.ax).name
+            }
+        }
         let beforeCount = readTrackCount()
         let escapedPath = path.replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         let typedPath = escapedPath.hasPrefix("/") ? String(escapedPath.dropFirst()) : escapedPath
+        // Poll the file-open sheet into existence (mirrors the
+        // `waitForControlBarCheckboxValue` / goto_position "first window whose
+        // name is" pattern) instead of blindly sleeping 1.5s. ~5s budget at
+        // 250ms granularity = 20 attempts. A sheet on a Logic process is a
+        // `window whose subrole is "AXSheet"` (file chooser) — fall back to the
+        // standard window if no sheet subrole is exposed on this build.
         let script = """
         on importMIDI()
             tell application "Logic Pro" to activate
@@ -4141,7 +4195,32 @@ actor AccessibilityChannel: Channel {
                         end try
                     end try
                 end tell
-                delay 1.5
+                -- Poll for the file-open sheet to actually exist before typing
+                -- the path. Up to ~5s (20 x 250ms). The Open panel attaches as a
+                -- sheet (AXSheet) on the front window; some builds expose it as a
+                -- standalone window with a chooser-style name instead.
+                set fileOpenSeen to false
+                repeat 20 times
+                    tell process "Logic Pro"
+                        try
+                            if (exists sheet 1 of window 1) then
+                                set fileOpenSeen to true
+                            end if
+                        end try
+                        if fileOpenSeen is false then
+                            try
+                                if (exists (first window whose subrole is "AXDialog")) then
+                                    set fileOpenSeen to true
+                                end if
+                            end try
+                        end if
+                    end tell
+                    if fileOpenSeen then exit repeat
+                    delay 0.25
+                end repeat
+                if fileOpenSeen is false then
+                    return "DIALOG_NOT_FOUND: file-open sheet did not appear"
+                end if
                 keystroke "/"
                 delay 0.5
                 keystroke "\(typedPath)"
@@ -4161,20 +4240,37 @@ actor AccessibilityChannel: Channel {
                         end try
                     end try
                 end tell
-                delay 2.0
-                -- Dismiss tempo dialog if it appears
-                tell process "Logic Pro"
-                    try
-                        set tempoDlg to first window whose subrole is "AXDialog"
+                -- Poll for the tempo dialog (subrole AXDialog) before dismissing
+                -- rather than a fixed delay. ~3s (15 x 200ms).
+                set tempoSeen to false
+                repeat 15 times
+                    tell process "Logic Pro"
                         try
-                            click button "아니요" of tempoDlg
-                        on error
+                            if (exists (first window whose subrole is "AXDialog")) then
+                                set tempoSeen to true
+                            end if
+                        end try
+                    end tell
+                    if tempoSeen then exit repeat
+                    delay 0.2
+                end repeat
+                if tempoSeen then
+                    tell process "Logic Pro"
+                        try
+                            set tempoDlg to first window whose subrole is "AXDialog"
                             try
-                                click button "No" of tempoDlg
+                                click button "아니요" of tempoDlg
+                            on error
+                                try
+                                    click button "No" of tempoDlg
+                                end try
                             end try
                         end try
-                    end try
-                end tell
+                    end tell
+                end if
+                if tempoSeen then
+                    return "OK TEMPO_SEEN"
+                end if
             end tell
             return "OK"
         end importMIDI
@@ -4187,34 +4283,81 @@ actor AccessibilityChannel: Channel {
                 return .error(HonestContract.encodeStateC(
                     error: .axWriteFailed,
                     hint: "midi.import_file menu/button click failed: \(output)",
-                    extras: ["requested": path, "track_count_before": beforeCount]
+                    extras: [
+                        "requested": path,
+                        "track_count_before": beforeCount,
+                        "file_open_dialog_seen": false,
+                        "tempo_dialog_seen": false,
+                    ]
                 ))
             }
-            // Read-back via track count delta. Logic always creates a new track
-            // for MIDI import (OQ-3 confirmed). Allow a short settle window
-            // for the AX tree to reflect the new track header.
-            await settle()
-            let afterCount = readTrackCount()
-            let extras: [String: Any] = [
+            if output.hasPrefix("DIALOG_NOT_FOUND") {
+                return .error(HonestContract.encodeStateC(
+                    error: .dialogNotFound,
+                    hint: "midi.import_file: \(output). The File → Import → MIDI File open sheet never appeared (likely an occluded or unhealthy Logic session). No path keystroke was issued.",
+                    extras: [
+                        "requested": path,
+                        "track_count_before": beforeCount,
+                        "missing_element": "file_open_sheet",
+                        "file_open_dialog_seen": false,
+                        "tempo_dialog_seen": false,
+                    ]
+                ))
+            }
+            let fileOpenSeen = true
+            let tempoSeen = output.contains("TEMPO_SEEN")
+            // Read-back via track-count delta. Logic always creates a new track
+            // for MIDI import (OQ-3 confirmed). Bounded poll (5 x 100ms) for the
+            // AX tree to reflect the new header, rather than a single settle.
+            var afterCount = readTrackCount()
+            for _ in 0..<5 {
+                if afterCount > beforeCount { break }
+                await deltaPoll()
+                afterCount = readTrackCount()
+            }
+            var extras: [String: Any] = [
                 "requested": path,
                 "track_count_before": beforeCount,
                 "track_count_after": afterCount,
                 "observed_delta": afterCount - beforeCount,
-                "via": "ax_menu_import"
+                "via": "ax_menu_import",
+                "file_open_dialog_seen": fileOpenSeen,
+                "tempo_dialog_seen": tempoSeen,
             ]
-            if afterCount > beforeCount {
-                return .success(HonestContract.encodeStateA(extras: extras))
+            guard afterCount > beforeCount else {
+                return .error(HonestContract.encodeStateC(
+                    error: .readbackMismatch,
+                    hint: "midi.import_file did not create a new track",
+                    extras: extras
+                ))
             }
-            return .error(HonestContract.encodeStateC(
-                error: .readbackMismatch,
-                hint: "midi.import_file did not create a new track",
-                extras: extras
-            ))
+            // #128 — audibility downgrade. A count delta proves a track was
+            // created, NOT that it is audible. If any NEW lane is a GM Device /
+            // external-MIDI synth lane, downgrade State A → State B so a caller
+            // never treats it as a verified audible arrangement.
+            let names = readTrackNames()
+            let gmLanes = gmDeviceLanesAmongNewTracks(names: names, beforeCount: beforeCount)
+            if !gmLanes.isEmpty {
+                extras["imported_lanes"] = Array(names.suffix(from: min(beforeCount, names.count)))
+                extras["gm_device_lanes"] = gmLanes
+                extras["audible"] = false
+                extras["hint"] = "Imported SMF lanes \(gmLanes) are GM Device / external-MIDI synth lanes that route to a General MIDI device and may bounce SILENT. Assign an audible Software Instrument (e.g. create a Software Instrument track and copy the regions, or re-import onto a Software Instrument track) before relying on the bounce."
+                return .success(HonestContract.encodeStateB(
+                    reason: .importedAsGMDevice,
+                    extras: extras
+                ))
+            }
+            return .success(HonestContract.encodeStateA(extras: extras))
         case .error(let msg):
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "midi.import_file osascript failed: \(msg)",
-                extras: ["requested": path, "track_count_before": beforeCount]
+                extras: [
+                    "requested": path,
+                    "track_count_before": beforeCount,
+                    "file_open_dialog_seen": false,
+                    "tempo_dialog_seen": false,
+                ]
             ))
         }
     }

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -699,7 +699,12 @@ struct TrackDispatcher {
             params: ["path": path]
         )
         guard importResult.isSuccess else {
-            return jsonToolTextResult([
+            // #140 — surface the import handler's dialog-seen flags at the top
+            // level (not only buried in `detail`) so callers can distinguish an
+            // occluded session (no file-open sheet ever appeared) from a real
+            // import miss. The flags originate in
+            // `AccessibilityChannel.defaultImportMIDIFile`.
+            var failure: [String: Any] = [
                 "success": false,
                 "verified": false,
                 "error": "import_failure",
@@ -709,7 +714,16 @@ struct TrackDispatcher {
                 "method": "smf_import",
                 "detail": importResult.message,
                 "hint": "record_sequence failed at midi.import_file: \(importResult.message)",
-            ], isError: true)
+            ]
+            if let inner = importMessageJSON(importResult.message) {
+                for key in ["file_open_dialog_seen", "tempo_dialog_seen", "missing_element"] {
+                    if let value = inner[key] { failure[key] = value }
+                }
+                if let innerError = inner["error"] as? String {
+                    failure["import_error"] = innerError
+                }
+            }
+            return jsonToolTextResult(failure, isError: true)
         }
 
         // Re-read live AX to confirm the new track index. Import handler has
@@ -803,6 +817,18 @@ struct TrackDispatcher {
         case verified([String: Any])
         case failed([String: Any])
         case pending
+    }
+
+    /// Parse the `midi.import_file` envelope (a JSON string carried in
+    /// `ChannelResult.message`) so record_sequence can lift specific fields
+    /// (e.g. #140 dialog-seen flags) to its own top-level envelope. Returns nil
+    /// for non-JSON/free-form messages.
+    private static func importMessageJSON(_ message: String) -> [String: Any]? {
+        guard let data = message.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
     }
 
     private static func jsonToolTextResult(_ object: [String: Any], isError: Bool = false) -> CallTool.Result {

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -24,6 +24,13 @@ enum HonestContract {
         /// Retry budget exhausted without either a confirmed read-back or a
         /// hard error.
         case retryExhausted
+        /// `midi.import_file` created a new track, but the imported lane(s) are
+        /// GM Device / external-MIDI synth lanes (NOT audible software-instrument
+        /// tracks). The write landed and a region exists, but the import cannot be
+        /// claimed audible-verified: such lanes route to a General MIDI device and
+        /// may bounce silent. Downgrades State A → State B so a caller never treats
+        /// a count-delta success as an audible arrangement. v3.6.x (#128).
+        case importedAsGMDevice
 
         var rawValue: String {
             switch self {
@@ -31,6 +38,7 @@ enum HonestContract {
             case .readbackUnavailable: return "readback_unavailable"
             case .readbackMismatch: return "readback_mismatch"
             case .retryExhausted: return "retry_exhausted"
+            case .importedAsGMDevice: return "imported_as_gm_device"
             }
         }
     }
@@ -64,6 +72,14 @@ enum HonestContract {
         /// every router fallthrough was being mis-classified as
         /// `port_unavailable` regardless of root cause).
         case channelsExhausted
+        /// `midi.import_file` clicked File → Import → MIDI File but the
+        /// file-open sheet never appeared inside the bounded poll window, so the
+        /// path keystroke was never issued (no side effect). Distinct from
+        /// `.axWriteFailed` (menu click rejected) and `.readbackMismatch` (import
+        /// ran but created no track): the dialog itself was never observed, which
+        /// is the textbook occluded/unhealthy-session signature. Terminal — a
+        /// different channel cannot conjure the missing sheet. v3.6.x (#140).
+        case dialogNotFound
 
         // HC v2 (logic_plugins.* verified plugin path) — §4 error table.
         // These codes only originate from the verified-plugin surface; the
@@ -124,6 +140,7 @@ enum HonestContract {
             case .notImplemented: return "not_implemented"
             case .portUnavailable: return "port_unavailable"
             case .channelsExhausted: return "channels_exhausted"
+            case .dialogNotFound: return "dialog_not_found"
             case .unsupportedMode: return "unsupported_mode"
             case .projectPathRequired: return "project_path_required"
             case .projectIdentityMismatch: return "project_identity_mismatch"
@@ -275,6 +292,10 @@ enum HonestContract {
         FailureError.portUnavailable.rawValue,
         FailureError.readbackUnavailable.rawValue,
         FailureError.channelsExhausted.rawValue,
+        // #140 — the file-open sheet never appeared; the menu route was driven
+        // but no dialog surfaced, so no other channel can recover the missing
+        // element. Terminal, mirroring `.elementNotFound`.
+        FailureError.dialogNotFound.rawValue,
         // HC v2 verified-plugin path: every failure is terminal. The verified
         // surface routes through `[.accessibility]` alone (no fallback chain),
         // and falling back to Scripter/MCU would fabricate a false verified

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1057,7 +1057,7 @@ private func makeSetInstrumentFixture() -> (
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { 3 },
-        settle: {}
+        deltaPoll: {}
     )
 
     #expect(!result.isSuccess)
@@ -1084,12 +1084,167 @@ private func makeSetInstrumentFixture() -> (
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
-        settle: {}
+        trackNames: { ["Studio Grand", "01 Felt Keys"] },
+        deltaPoll: {}
     )
 
     #expect(result.isSuccess)
     #expect(result.message.contains("\"verified\":true"))
     #expect(result.message.contains("\"observed_delta\":1"))
+}
+
+// MARK: - #128 GM Device audibility downgrade
+
+@Test func testGMDeviceLanesAmongNewTracksClassifiesOnlyNewExternalMIDILanes() {
+    // Pre-existing GM Device track must NOT trip the gate; only the newly
+    // appended lanes are inspected.
+    let preExistingGM = AccessibilityChannel.gmDeviceLanesAmongNewTracks(
+        names: ["GM Device 1", "01 Felt Keys"],
+        beforeCount: 1
+    )
+    #expect(preExistingGM.isEmpty)
+
+    // A newly appended GM Device lane IS flagged.
+    let newGM = AccessibilityChannel.gmDeviceLanesAmongNewTracks(
+        names: ["Studio Grand", "GM Device 1", "GM Device 2"],
+        beforeCount: 1
+    )
+    #expect(newGM == ["GM Device 1", "GM Device 2"])
+
+    // A Software Instrument track whose user name happens to contain "midi"
+    // (but not the literal lane tokens) must NOT be flagged.
+    let benignName = AccessibilityChannel.gmDeviceLanesAmongNewTracks(
+        names: ["Studio Grand", "MIDI Bass Lead"],
+        beforeCount: 1
+    )
+    #expect(benignName.isEmpty)
+
+    // External MIDI / External Instrument tokens are flagged too.
+    let external = AccessibilityChannel.gmDeviceLanesAmongNewTracks(
+        names: ["Studio Grand", "External MIDI 3"],
+        beforeCount: 1
+    )
+    #expect(external == ["External MIDI 3"])
+}
+
+@Test func testAccessibilityChannelImportMIDIFileDowngradesToStateBOnGMDeviceLanes() async throws {
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent("LogicProMCP-import-gmdevice-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    final class Counter: @unchecked Sendable {
+        var values = [1, 7]
+        func next() -> Int { values.removeFirst() }
+    }
+    let counter = Counter()
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: tempFile.path,
+        executeScript: { _ in .success("OK TEMPO_SEEN") },
+        trackCount: { counter.next() },
+        trackNames: {
+            ["Studio Grand", "GM Device 1", "GM Device 2", "GM Device 3",
+             "GM Device 4", "GM Device 5", "GM Device 6"]
+        },
+        deltaPoll: {}
+    )
+
+    // State B: success but NOT verified — count delta alone is not audible.
+    #expect(result.isSuccess, "GM-Device import is a soft success (State B), not a hard failure")
+    let obj = decodeAccessibilityJSON(result.message)
+    let success = try #require(obj["success"] as? Bool)
+    #expect(success)
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(!verified)
+    #expect(obj["reason"] as? String == "imported_as_gm_device")
+    let audible = try #require(obj["audible"] as? Bool)
+    #expect(!audible)
+    let gmLanes = try #require(obj["gm_device_lanes"] as? [String])
+    #expect(gmLanes.count == 6)
+    let hint = try #require(obj["hint"] as? String)
+    #expect(hint.contains("GM Device"))
+    // Dialog-seen flags are surfaced even on the downgrade path.
+    let tempoSeen = try #require(obj["tempo_dialog_seen"] as? Bool)
+    #expect(tempoSeen)
+}
+
+@Test func testAccessibilityChannelImportMIDIFileStateAWhenLanesAreSoftwareInstruments() async throws {
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent("LogicProMCP-import-si-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    final class Counter: @unchecked Sendable {
+        var values = [1, 2]
+        func next() -> Int { values.removeFirst() }
+    }
+    let counter = Counter()
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: tempFile.path,
+        executeScript: { _ in .success("OK") },
+        trackCount: { counter.next() },
+        trackNames: { ["Studio Grand", "01 Felt Keys"] },
+        deltaPoll: {}
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(verified)
+    #expect(obj["reason"] == nil)
+    let fileOpenSeen = try #require(obj["file_open_dialog_seen"] as? Bool)
+    #expect(fileOpenSeen)
+}
+
+// MARK: - #140 file-open dialog poll / dialog_not_found
+
+@Test func testAccessibilityChannelImportMIDIFileReturnsDialogNotFoundWhenSheetNeverAppears() async throws {
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent("LogicProMCP-import-nodialog-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    final class CountSpy: @unchecked Sendable {
+        var reads = 0
+        func read() -> Int { reads += 1; return 5 }
+    }
+    let spy = CountSpy()
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: tempFile.path,
+        executeScript: { _ in .success("DIALOG_NOT_FOUND: file-open sheet did not appear") },
+        trackCount: { spy.read() },
+        trackNames: { [] },
+        deltaPoll: {}
+    )
+
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["error"] as? String == "dialog_not_found")
+    #expect(obj["missing_element"] as? String == "file_open_sheet")
+    let fileOpenSeen = try #require(obj["file_open_dialog_seen"] as? Bool)
+    #expect(!fileOpenSeen)
+    // dialog_not_found is terminal — the router must not fall through to a
+    // vacuous next-channel success.
+    #expect(HonestContract.terminalErrorCodes.contains("dialog_not_found"))
+    // No track-count delta should be read once we know the dialog never opened:
+    // the path keystroke was never issued so there is no import to verify.
+    #expect(spy.reads == 1, "only the before-count read should occur on the dialog_not_found path")
+}
+
+@Test func testAccessibilityChannelImportMIDIFileMissingFileShortCircuits() async throws {
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: "/tmp/LogicProMCP/does-not-exist-\(UUID().uuidString).mid",
+        executeScript: { _ in .success("OK") },
+        trackCount: { 0 },
+        trackNames: { [] },
+        deltaPoll: {}
+    )
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["error"] as? String == "invalid_params")
 }
 
 @Test func testAccessibilityChannelValidatedMIDIImportPathAcceptsManagedTempMID() throws {

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -105,7 +105,8 @@ struct Issue108Tests {
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
-            settle: {}
+            trackNames: { ["Studio Grand", "Imported"] },
+            deltaPoll: {}
         )
         #expect(result.isSuccess)
         let o = (try? JSONSerialization.jsonObject(with: Data(result.message.utf8))) as? [String: Any]
@@ -121,7 +122,8 @@ struct Issue108Tests {
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
-            settle: {}
+            trackNames: { [] },
+            deltaPoll: {}
         )
         #expect(!result.isSuccess)
         #expect(result.message.contains("readback_mismatch"))
@@ -135,7 +137,8 @@ struct Issue108Tests {
             path: path,
             executeScript: { _ in .success("MENU_ERROR: not found") },
             trackCount: { 1 },
-            settle: {}
+            trackNames: { [] },
+            deltaPoll: {}
         )
         #expect(!result.isSuccess)
         #expect(result.message.contains("ax_write_failed"))
@@ -147,7 +150,8 @@ struct Issue108Tests {
             path: "/tmp/LogicProMCP/does-not-exist-\(UUID().uuidString).mid",
             executeScript: { _ in .success("OK") },
             trackCount: { 1 },
-            settle: {}
+            trackNames: { [] },
+            deltaPoll: {}
         )
         #expect(!result.isSuccess)
         #expect(result.message.contains("invalid_params"))

--- a/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
+++ b/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
@@ -179,6 +179,45 @@ private func recordSequenceJSONObject(_ result: CallTool.Result) -> [String: Any
     )
 }
 
+@Test func testRecordSequenceSurfacesImportDialogSeenFlags() async throws {
+    // #140 — when import_file fails with the new dialog_not_found envelope, the
+    // record_sequence import_failure result must lift the dialog-seen flags to
+    // its own top level so callers can tell an occluded session (no sheet ever
+    // appeared) from a real import miss, rather than only burying them in
+    // `detail`.
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let importEnvelope = HonestContract.encodeStateC(
+        error: .dialogNotFound,
+        hint: "midi.import_file: file-open sheet did not appear",
+        extras: [
+            "requested": "/tmp/LogicProMCP/x.mid",
+            "missing_element": "file_open_sheet",
+            "file_open_dialog_seen": false,
+            "tempo_dialog_seen": false,
+        ]
+    )
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .error(importEnvelope))
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: ["notes": minimalNoteSpec(), "bar": .int(1)],
+        router: router,
+        cache: cache
+    )
+    let obj = recordSequenceJSONObject(result)
+    #expect(obj["error"] as? String == "import_failure")
+    #expect(obj["import_error"] as? String == "dialog_not_found")
+    #expect(obj["missing_element"] as? String == "file_open_sheet")
+    let fileOpenSeen = try #require(obj["file_open_dialog_seen"] as? Bool)
+    #expect(!fileOpenSeen)
+    let tempoSeen = try #require(obj["tempo_dialog_seen"] as? Bool)
+    #expect(!tempoSeen)
+}
+
 @Test func testRecordSequenceReturnsVerifiedRegionReadbackPayload() async {
     let cache = StateCache()
     await cache.updateDocumentState(true)


### PR DESCRIPTION
Closes #140. Closes #128.

## Problem (#140)
`midi.import_file`'s AX file-open navigation only worked from a terminal, never from the background server: keystrokes did not land (the go-to-folder sheet kept just the leading `/`), so the import silently selected nothing and **stacked open-panels** on repeated calls. Root cause: keystrokes route to the *frontmost* app, and the background server had not raised Logic.

## Fix
- **Force Logic frontmost (AX `set frontmost`) immediately before each keystroke** — the key fix that makes panel navigation land from the server process.
- Set the go-to-folder path via AXValue + poll-confirm the readback; bounded poll for the Import button to become **enabled** before clicking (was a fixed delay racing file selection).
- **Self-heal:** dismiss any stale Import open-panel at start AND end → repeated imports never stack.
- Poll-wait the file-open + tempo dialogs (no fixed delays); enrich State C with `file_open_dialog_seen` / `tempo_dialog_seen`; typed `dialog_not_found` when the sheet never appears.
- **#128 audibility:** after import, read back created lane names/types; GM-Device / external-MIDI lanes downgrade State A → State B `imported_as_gm_device` (a count delta proves a track exists, not that it's audible).

## Verification
- Unit: `swift test --filter AccessibilityChannel --filter TrackDispatcherRecordSequence --filter MIDIDispatcher --filter Issue108 --filter HonestContract` → 189 passed.
- **Live (real Logic 12.2, fresh binary, stdio):**
  - **5/5 sequential single-track imports → State A `verified:true observed_delta:1`, zero leftover dialogs** (pre-fix: 0/5 + 4 stacked panels). ✓
  - Multi-track SMF import → State A `observed_delta:3` (audible software-instrument lanes correctly NOT downgraded). ✓
  - `file_open_dialog_seen` / `tempo_dialog_seen` flags present. ✓

Note: the GM-Device → State B downgrade path is unit-verified (synthetic SMFs import as audible SI lanes; reproducing Logic's GM-Device lane creation requires a specific multichannel file).