### PR TITLE
test: deterministic MCU echo delivery (eliminate parallel-load flake)

### DIFF
--- a/Tests/LogicProMCPTests/MCUChannelEchoTests.swift
+++ b/Tests/LogicProMCPTests/MCUChannelEchoTests.swift
@@ -22,15 +22,26 @@ private func decodeJSON(_ s: String) -> [String: Any] {
     let lsb = UInt8(raw & 0x7F)
     let msb = UInt8((raw >> 7) & 0x7F)
 
-    Task.detached {
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        await channel.handleFeedback(.pitchBend(channel: 0, value: (UInt16(msb) << 7) | UInt16(lsb)))
+    // Deliver the matching fader echo CONCURRENTLY with execute. The echo must
+    // land *after* the internal sendAt stamp (pollFaderEcho rejects stale
+    // values), so it can't be pre-seeded. A single timed delivery is starvable
+    // under parallel test load (a delayed background task can miss the poll
+    // window entirely → false State B). Instead deliver repeatedly at high
+    // priority until execute returns, so at least one fresh echo always lands
+    // inside the poll window regardless of scheduler pressure.
+    let echoTask = Task.detached(priority: .high) {
+        while !Task.isCancelled {
+            await channel.handleFeedback(.pitchBend(channel: 0, value: (UInt16(msb) << 7) | UInt16(lsb)))
+            try? await Task.sleep(nanoseconds: 8_000_000)
+        }
     }
+    defer { echoTask.cancel() }
 
     let result = await channel.execute(
         operation: "mixer.set_volume",
         params: ["index": "0", "volume": "\(target)"]
     )
+    echoTask.cancel()
     #expect(result.isSuccess)
     let obj = decodeJSON(result.message)
     #expect((obj["success"] as? Bool)!)

--- a/Tests/LogicProMCPTests/MCUVPotTests.swift
+++ b/Tests/LogicProMCPTests/MCUVPotTests.swift
@@ -137,15 +137,24 @@ private func decodeJSON(_ s: String) -> [String: Any] {
     let channel = MCUChannel(transport: transport, cache: cache)
 
     // Target pan 0.5 → LED ring position 8 → CC 0x30 (strip 0), value 0x08.
-    Task.detached {
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        await channel.handleFeedback(.controlChange(channel: 0, controller: 0x30, value: 0x08))
+    // Deliver the echo repeatedly at high priority until execute returns: the
+    // V-Pot echo must be fresh (after the internal sendAt stamp), so a single
+    // timed delivery is starvable under parallel load and can miss the poll
+    // window → false State B. Repeated high-priority delivery guarantees a
+    // fresh echo lands inside the window regardless of scheduler pressure.
+    let echoTask = Task.detached(priority: .high) {
+        while !Task.isCancelled {
+            await channel.handleFeedback(.controlChange(channel: 0, controller: 0x30, value: 0x08))
+            try? await Task.sleep(nanoseconds: 8_000_000)
+        }
     }
+    defer { echoTask.cancel() }
 
     let result = await channel.execute(
         operation: "mixer.set_pan",
         params: ["index": "0", "pan": "0.4"]
     )
+    echoTask.cancel()
     #expect(result.isSuccess)
     let obj = decodeJSON(result.message)
     #expect((obj["success"] as? Bool)!)


### PR DESCRIPTION
## Problem
`testMCUSetVolumeReturnsStateAWhenEchoMatches` (MCUChannelEchoTests) and `testMixerSetPanReturnsStateAOnEcho` (MCUVPotTests) each delivered their matching MCU echo via a single `Task.detached { sleep(50ms); handleFeedback() }`. The echo must be **fresh** — `pollFaderEcho`/`pollPanEcho` reject any cache value older than the internal `sendAt` stamp — so it cannot be pre-seeded before `execute`. Under full **parallel** test load that one delayed background task could be starved past the 500ms poll window, so both tests failed ~100% of the time in a local parallel `swift test`. CI was green only because it runs `swift test --no-parallel`.

## Fix
Replace the single timed delivery with a **high-priority loop** that re-delivers the echo every 8ms until `execute` returns (cancelled immediately after). At least one fresh echo always lands inside the poll window regardless of scheduler pressure. Test-only change; no product code touched.

## Verification
- **5/5 full-parallel `swift test` runs pass** (1697 tests, 0 failures) — previously these two tests failed on essentially every parallel run.
- Serial (`--no-parallel`, CI mode) still green.