### PR TITLE
fix(#60): diacritic-sensitive AXLocalePolicy.matches(.contains/.prefix)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -62,14 +62,22 @@ enum AXLocalePolicy {
                 case .exact:
                     candidate.caseInsensitiveCompare(label) == .orderedSame
                 case .prefix:
+                    // #60 — diacritic-SENSITIVE, matching `containsAny` (made
+                    // sensitive in #122). Folding accents (e.g. "ínspector" →
+                    // "inspector") WIDENS matching beyond the stored label and
+                    // risks misclassifying accented-Latin AX text in non-EN/KO
+                    // locales — the exact locale collision #60 guards against.
+                    // The EN/KO LabelSets carry their real diacritics, so
+                    // sensitive matching is both safer and correct.
                     candidate.range(
                         of: label,
-                        options: [.anchored, .caseInsensitive, .diacriticInsensitive]
+                        options: [.anchored, .caseInsensitive]
                     ) != nil
                 case .contains:
+                    // #60 — diacritic-SENSITIVE (same rationale as `.prefix`).
                     candidate.range(
                         of: label,
-                        options: [.caseInsensitive, .diacriticInsensitive]
+                        options: [.caseInsensitive]
                     ) != nil
                 case .exactStrict:
                     candidate.caseInsensitiveCompare(label) == .orderedSame

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -49,6 +49,28 @@ struct AXLocalePolicyTests {
         #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Redo Insert Plug-in", mode: .prefix))
     }
 
+    @Test("#60 — matches(.contains/.prefix) is diacritic-SENSITIVE (no accent-folding widening)")
+    func matchesIsDiacriticSensitive() {
+        let set = AXLocalePolicy.LabelSet(
+            canonical: "Inspector",
+            variants: ["Inspector", "인스펙터"],
+            rationale: "diacritic-sensitivity regression guard"
+        )
+        // Plain forms match — the real strings Logic emits.
+        #expect(set.matches("Inspector", mode: .contains))
+        #expect(set.matches("track inspector area", mode: .contains))
+        #expect(set.matches("Inspector — Track", mode: .prefix))
+        #expect(set.matches("인스펙터", mode: .contains))
+        // Accented-Latin forms must NOT match. Pre-#60 the `.diacriticInsensitive`
+        // option folded "ínspector" → "inspector" and matched, widening across
+        // accented-Latin locales (French/Spanish/Portuguese Logic UIs) — the
+        // exact locale collision #60 guards against. Aligns with containsAny (#122).
+        #expect(!set.matches("ínspector", mode: .contains))
+        #expect(!set.matches("Ínspector — Track", mode: .prefix))
+        // Case-insensitivity is retained.
+        #expect(set.matches("INSPECTOR", mode: .contains))
+    }
+
     @Test("menu path lookup resolves English and Korean titles through one policy")
     func menuPathLookup() {
         let builder = FakeAXRuntimeBuilder()
@@ -175,10 +197,12 @@ struct AXLocalePolicyTests {
         #expect(!AXLocalePolicy.saveConfirmationButton.matches("   "))
     }
 
-    /// Pin the `.prefix` mode's case- and diacritic-insensitive matching used
-    /// by the Undo rollback path. The anchored option means the label must be
-    /// a true prefix; case/diacritics are folded.
-    @Test("prefix mode is anchored, case- and diacritic-insensitive")
+    /// Pin the `.prefix` mode's anchored, case-insensitive, **diacritic-SENSITIVE**
+    /// matching used by the Undo rollback path. The anchored option means the
+    /// label must be a true prefix; case is folded but accents are NOT (#60 —
+    /// aligned with `containsAny`'s #122 sensitivity so accent-folding can't
+    /// widen matching across accented-Latin locales).
+    @Test("prefix mode is anchored, case-insensitive, diacritic-SENSITIVE")
     func prefixModeWidening() {
         // Real prefixes match (operation name follows the localized prefix).
         #expect(AXLocalePolicy.undoMenuItemPrefix.matches("Undo Insert Plug-in", mode: .prefix))
@@ -187,12 +211,14 @@ struct AXLocalePolicyTests {
         // Case-insensitive prefix.
         #expect(AXLocalePolicy.undoMenuItemPrefix.matches("UNDO Insert Plug-in", mode: .prefix))
 
-        // Diacritic-insensitive prefix (an accented homograph still matches).
-        #expect(AXLocalePolicy.undoMenuItemPrefix.matches("Ündo Insert Plug-in", mode: .prefix))
+        // #60 — diacritic-SENSITIVE: an accented homograph must NOT match
+        // (pre-#60 the folded "Ü" → "U" widened this).
+        #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Ündo Insert Plug-in", mode: .prefix))
 
-        // NFD vs NFC variant of an accented prefix still matches.
+        // NFD vs NFC: the decomposed accented prefix likewise must NOT match
+        // (canonical equivalence keeps NFC/NFD together, but "Ü" ≠ "U").
         let undoNFD = "U\u{0308}ndo Insert Plug-in" // U + combining diaeresis
-        #expect(AXLocalePolicy.undoMenuItemPrefix.matches(undoNFD, mode: .prefix))
+        #expect(!AXLocalePolicy.undoMenuItemPrefix.matches(undoNFD, mode: .prefix))
 
         // Anchored: a label that appears mid-string is NOT a prefix match.
         #expect(!AXLocalePolicy.undoMenuItemPrefix.matches("Redo then Undo", mode: .prefix))


### PR DESCRIPTION
Advances #60 (locale-agnostic UI automation). The epic stays open — this is one concrete increment.

## Problem
`containsAny` was made **diacritic-sensitive** in #122 (folding accents widens matching and risks misclassifying accented-Latin AX text in French/Spanish/Portuguese Logic UIs). But `matches(.contains)` and `matches(.prefix)` still passed `.diacriticInsensitive` — an unfixed parallel that left the same locale-collision hole on the menu/dialog match paths (e.g. the Undo-rollback prefix lookup). Token-coverage tests didn't catch the divergence.

## Fix
Drop `.diacriticInsensitive` from both `.prefix` and `.contains` so all three match modes (`containsAny`, `.contains`, `.prefix`) are consistently diacritic-sensitive. The EN/KO `LabelSet`s carry no accents, so genuine matching is unaffected; only accented homographs (`"Ündo"` → `"Undo"`) stop false-matching.

## Verification
- New guard `matchesIsDiacriticSensitive` (plain forms match; `"ínspector"`/`"Ínspector"` do not; case-insensitivity retained).
- Updated `prefixModeWidening` (which pinned the old insensitive behavior) to assert sensitivity, incl. the NFC/NFD decomposed case.
- **Full serial suite (CI mode, `swift test --no-parallel`): 1698 passed, 0 regressions.**