### PR TITLE
feat(demo): timeout-resilient press_any policy + tests (#126)

### DIFF
--- a/docs/media/demo_press_any.py
+++ b/docs/media/demo_press_any.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Timeout-resilient candidate-press policy for the public Logic Pro demo run.
+
+This owns the correctness behaviour that previously lived inline in the
+untracked workspace capture scripts (``~/.openclaw/workspace/scripts``):
+
+* ``press_any`` -- try a list of candidate AX button titles in order, pressing
+  each via an injected ``press_fn``. A press that times out is caught per
+  candidate and the policy continues to the next candidate; only a successful
+  press short-circuits and is returned. If every candidate fails or times out,
+  ``None`` is returned -- the timeout is never allowed to escape (issue #126).
+
+The original bug (issue #126): a single AX button press in ``press_any`` raised
+``subprocess.TimeoutExpired``, which escaped the helper and aborted the entire
+demo render run instead of falling through to the next candidate button. The
+real workspace press is a ``subprocess.run(..., timeout=...)`` call that raises
+``subprocess.TimeoutExpired`` on timeout. Note ``subprocess.TimeoutExpired`` is
+NOT a subclass of the builtin ``TimeoutError`` (it derives from
+``subprocess.SubprocessError``), so the policy catches BOTH explicitly: the
+real subprocess path and a pure, subprocess-free ``TimeoutError`` test double.
+
+Keeping the logic here (a tracked, unit-tested module) lets CI guard it; the
+workspace pipeline imports and calls ``press_any`` with its real ``press_fn``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Callable, Sequence
+
+# The timeout exceptions a candidate press may raise. ``subprocess.TimeoutExpired``
+# is the real workspace path (subprocess.run timeout); ``TimeoutError`` is the
+# builtin a pure test double / non-subprocess press_fn can raise. They are
+# unrelated in the class hierarchy, so both must be named explicitly.
+_TIMEOUT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    subprocess.TimeoutExpired,
+    TimeoutError,
+)
+
+
+def press_any(
+    candidates: Sequence[str],
+    press_fn: Callable[[str], object],
+) -> str | None:
+    """Press the first candidate that succeeds, surviving per-candidate timeouts.
+
+    ``press_fn(title)`` is called for each candidate title in order. If it
+    raises ``subprocess.TimeoutExpired`` (the real subprocess press path) or the
+    builtin ``TimeoutError`` (a subprocess-free test double), the timeout is
+    swallowed and the policy advances to the next candidate.
+
+    Returns the title of the first candidate whose ``press_fn`` call returned
+    without raising, or ``None`` when every candidate timed out. A timeout from
+    any single candidate never escapes this function, so one slow AX button
+    press can no longer abort the whole demo run (issue #126).
+    """
+    for title in candidates:
+        try:
+            press_fn(title)
+        except _TIMEOUT_EXCEPTIONS:
+            continue
+        return title
+    return None

--- a/docs/media/test_demo_press_any.py
+++ b/docs/media/test_demo_press_any.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for the timeout-resilient press_any policy (issue #126)."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+
+from demo_press_any import press_any
+
+
+class PressAnyTests(unittest.TestCase):
+    """#126: a per-candidate press timeout must never escape press_any."""
+
+    def test_first_candidate_pressing_returns_its_title(self) -> None:
+        pressed: list[str] = []
+
+        def press_fn(title: str) -> None:
+            pressed.append(title)
+
+        self.assertEqual(press_any(["Play", "Bounce"], press_fn), "Play")
+        # Short-circuits on the first success; later candidates are not tried.
+        self.assertEqual(pressed, ["Play"])
+
+    def test_first_candidate_timeout_falls_through_to_next(self) -> None:
+        attempted: list[str] = []
+
+        def press_fn(title: str) -> None:
+            attempted.append(title)
+            if title == "Play":
+                raise TimeoutError("AX press timed out")
+
+        self.assertEqual(press_any(["Play", "Bounce"], press_fn), "Bounce")
+        self.assertEqual(attempted, ["Play", "Bounce"])
+
+    def test_all_candidates_timeout_returns_none_no_escape(self) -> None:
+        def press_fn(title: str) -> None:
+            raise TimeoutError("AX press timed out")
+
+        # The original bug: this would have escaped and aborted the run.
+        self.assertIsNone(press_any(["Play", "Bounce", "Record"], press_fn))
+
+    def test_subprocess_timeout_expired_is_caught(self) -> None:
+        # subprocess.TimeoutExpired is NOT a TimeoutError subclass (it derives
+        # from subprocess.SubprocessError); press_any must still catch it -- this
+        # is the exact escape that aborted the run in #126.
+        self.assertFalse(issubclass(subprocess.TimeoutExpired, TimeoutError))
+
+        def press_fn(title: str) -> None:
+            if title == "Play":
+                raise subprocess.TimeoutExpired(cmd=["osascript"], timeout=5.0)
+
+        self.assertEqual(press_any(["Play", "Bounce"], press_fn), "Bounce")
+
+    def test_candidate_order_is_preserved(self) -> None:
+        attempted: list[str] = []
+
+        def press_fn(title: str) -> None:
+            attempted.append(title)
+            raise TimeoutError("AX press timed out")
+
+        self.assertIsNone(press_any(["a", "b", "c", "d"], press_fn))
+        self.assertEqual(attempted, ["a", "b", "c", "d"])
+
+    def test_empty_candidates_returns_none(self) -> None:
+        def press_fn(title: str) -> None:  # pragma: no cover - never called
+            raise AssertionError("press_fn must not be called for no candidates")
+
+        self.assertIsNone(press_any([], press_fn))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #126. Re-homes the press_any timeout-escape fix into a tested helper. `press_any(candidates, press_fn)` catches a per-candidate timeout and continues, returning the first success or None — the exception never escapes to abort the run. Catches BOTH `subprocess.TimeoutExpired` AND `TimeoutError` (the former is NOT a subclass of the latter — catching only TimeoutError would reproduce the bug). 6 tests pass.