### PR TITLE
feat(demo): curly Don't Save (U+2019) candidate expansion + tests (#132)

### DIFF
--- a/docs/media/demo_dont_save.py
+++ b/docs/media/demo_dont_save.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Tracked, tested candidate-expansion policy for Logic's "Don't Save" modal (#132).
+
+Issue #132: a blank-start run failed to dismiss Logic Pro's unsaved-changes
+sheet because the candidate button-title list only contained the
+straight-apostrophe ``"Don't Save"`` (U+0027 APOSTROPHE). Logic actually renders
+the button with a curly typographic apostrophe -- ``"Don’t Save"`` (U+2019 RIGHT
+SINGLE QUOTATION MARK) -- so the literal compare never matched and the sheet was
+never clicked, stalling the harness.
+
+The fix (already live in the ``~/.openclaw`` harness) is re-homed here as a pure,
+unit-tested helper so CI can guard the byte-exact behaviour: whenever the
+straight ``"Don't Save"`` (U+0027) is a candidate, also try the curly
+``"Don’t Save"`` (U+2019) and ``"Delete"`` (Logic's alternate localized
+discard-on-blank-start label), without ever dropping or reordering the originals.
+
+Keeping the U+2019-vs-U+0027 distinction in a tracked module -- rather than inline
+in the untracked workspace capture scripts -- lets a test assert the literal
+codepoint, which is exactly the assumption that broke in #132.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+# The straight-apostrophe spelling the candidate list historically contained
+# (U+0027 APOSTROPHE). This is what failed to match Logic's rendered button.
+STRAIGHT_DONT_SAVE = "Don't Save"
+
+# The curly-apostrophe spelling Logic actually renders (U+2019 RIGHT SINGLE
+# QUOTATION MARK). The character between "Don" and "t" below is U+2019, NOT a
+# plain ASCII apostrophe -- this is the load-bearing distinction from #132.
+CURLY_DONT_SAVE = "Don’t Save"
+
+# Logic's alternate discard label on a blank-start / never-saved project.
+DELETE_LABEL = "Delete"
+
+
+def expand_dont_save_candidates(titles: Iterable[str]) -> list[str]:
+    """Return ``titles`` with the curly ``"Don’t Save"`` + ``"Delete"`` ensured.
+
+    Policy (issue #132): when the straight-apostrophe ``"Don't Save"`` (U+0027)
+    is present in ``titles`` and the curly-apostrophe ``"Don’t Save"`` (U+2019)
+    is *absent*, append the curly spelling so the dismiss step matches the button
+    Logic actually renders. Likewise append ``"Delete"`` when it is absent.
+
+    Originals are preserved verbatim and in order; only the genuinely missing
+    fallbacks are appended (so the function is idempotent). Lists that do not
+    contain the straight ``"Don't Save"`` are returned unchanged.
+    """
+    result = list(titles)
+    if STRAIGHT_DONT_SAVE not in result:
+        return result
+    if CURLY_DONT_SAVE not in result:
+        result.append(CURLY_DONT_SAVE)
+    if DELETE_LABEL not in result:
+        result.append(DELETE_LABEL)
+    return result

--- a/docs/media/test_demo_dont_save.py
+++ b/docs/media/test_demo_dont_save.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for the "Don't Save" candidate-expansion policy (issue #132).
+
+These tests pin the byte-exact behaviour that broke in #132: the candidate list
+must gain the *curly* "Don’t Save" (U+2019) that Logic actually renders, not just
+the straight "Don't Save" (U+0027).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from demo_dont_save import (
+    CURLY_DONT_SAVE,
+    DELETE_LABEL,
+    STRAIGHT_DONT_SAVE,
+    expand_dont_save_candidates,
+)
+
+
+class ExpandDontSaveCandidatesTests(unittest.TestCase):
+    def test_appends_curly_dont_save_and_delete(self) -> None:
+        result = expand_dont_save_candidates(["저장 안 함", "Don't Save", "생성"])
+        # The curly U+2019 spelling Logic actually renders must be present.
+        self.assertIn(CURLY_DONT_SAVE, result)
+        self.assertIn("Delete", result)
+        # Originals preserved verbatim and in order, fallbacks appended after.
+        self.assertEqual(result[:3], ["저장 안 함", "Don't Save", "생성"])
+        self.assertEqual(result[3:], [CURLY_DONT_SAVE, DELETE_LABEL])
+
+    def test_appended_apostrophe_is_byte_level_u2019(self) -> None:
+        result = expand_dont_save_candidates(["저장 안 함", "Don't Save", "생성"])
+        result_joined = "".join(result)
+        # Byte-level: the curly RIGHT SINGLE QUOTATION MARK must literally appear.
+        self.assertIn("’", result_joined)
+        self.assertIn("’", result_joined)
+        # And the appended spelling carries U+2019, not the U+0027 it started with.
+        appended_curly = result[3]
+        self.assertIn("’", appended_curly)
+        self.assertNotIn("'", appended_curly)
+
+    def test_straight_input_has_only_u0027(self) -> None:
+        # Guards the premise of #132: the seed straight title carries U+0027 only.
+        self.assertIn("'", STRAIGHT_DONT_SAVE)
+        self.assertNotIn("’", STRAIGHT_DONT_SAVE)
+
+    def test_idempotent_when_curly_already_present(self) -> None:
+        already = ["저장 안 함", "Don't Save", CURLY_DONT_SAVE, "Delete"]
+        result = expand_dont_save_candidates(already)
+        # No double-append: already-present curly + Delete are not duplicated.
+        self.assertEqual(result, already)
+        self.assertEqual(result.count(CURLY_DONT_SAVE), 1)
+        self.assertEqual(result.count(DELETE_LABEL), 1)
+
+    def test_idempotent_on_repeated_application(self) -> None:
+        once = expand_dont_save_candidates(["Don't Save"])
+        twice = expand_dont_save_candidates(once)
+        self.assertEqual(once, twice)
+
+    def test_unrelated_list_unchanged(self) -> None:
+        unrelated = ["저장 안 함", "생성", "Cancel"]
+        result = expand_dont_save_candidates(unrelated)
+        self.assertEqual(result, unrelated)
+        self.assertNotIn(CURLY_DONT_SAVE, result)
+        self.assertNotIn(DELETE_LABEL, result)
+
+    def test_delete_appended_even_if_already_curly_present_but_no_delete(self) -> None:
+        # Straight present, curly present, Delete absent -> only Delete appended.
+        result = expand_dont_save_candidates(["Don't Save", CURLY_DONT_SAVE])
+        self.assertEqual(result, ["Don't Save", CURLY_DONT_SAVE, DELETE_LABEL])
+
+    def test_input_iterable_not_mutated(self) -> None:
+        source = ["Don't Save"]
+        expand_dont_save_candidates(source)
+        self.assertEqual(source, ["Don't Save"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #132. Re-homes the curly-apostrophe fix. `expand_dont_save_candidates` appends the curly "Don’t Save" (U+2019, what Logic actually renders) and "Delete" when the straight "Don't Save" (U+0027) is present. Idempotent, order-preserving; the literal U+2019 codepoint is byte-asserted. 8 tests pass.