### PR TITLE
test(#123): lock midi.import_file dialog_not_found on occluded session

### DIFF
--- a/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #123 — file-open MIDI import occlusion → typed dialog_not_found
+//
+// #123 ("file-open MIDI import leaves Logic in a stale state") is ENVIRONMENTAL:
+// when the File → Import → MIDI File open sheet never materialises (an occluded
+// or otherwise unhealthy Logic session), `midi.import_file`
+// (AccessibilityChannel.defaultImportMIDIFile) must FAIL CLOSED with a typed
+// State C `dialog_not_found` — surfacing `file_open_dialog_seen:false` and
+// naming the occluded/stale-session cause — rather than racing ahead, typing a
+// path into the wrong field, and reporting a vacuous success against a leftover
+// session.
+//
+// This suite LOCKS that contract. The honest path landed in the merged #140
+// work; the assertions below guard against a future regression that silently
+// re-introduces the stale-session false success.
+//
+// swift-testing footgun: Optional<Bool> assertions only hold under force-unwrap
+// (`try #require(...)`), so every boolean flag is required-then-asserted; a
+// `?? false` / `== .some(true)` style would be a DEAD assertion that always
+// passes.
+
+private func decodeIssue123JSON(_ s: String) -> [String: Any] {
+    (try? JSONSerialization.jsonObject(with: Data(s.utf8))) as? [String: Any] ?? [:]
+}
+
+/// Write a minimal Standard MIDI File header into the managed import directory
+/// (`/private/tmp/LogicProMCP`) so the path mirrors a real, validator-eligible
+/// import target. `defaultImportMIDIFile` requires the file to EXIST before it
+/// runs the AX flow, so the file must be on disk.
+private func makeManagedMIDIFixture() throws -> URL {
+    let managed = URL(fileURLWithPath: "/private/tmp/LogicProMCP", isDirectory: true)
+    try FileManager.default.createDirectory(at: managed, withIntermediateDirectories: true)
+    let file = managed.appendingPathComponent("issue123-occlusion-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: file)
+    return file
+}
+
+/// Spy that records how many times the track-count read-back fires. On the
+/// occlusion path ONLY the before-count read must occur — once the dialog is
+/// known absent there is nothing imported to verify.
+private final class ImportCountSpy: @unchecked Sendable {
+    private(set) var reads = 0
+    let value: Int
+    init(value: Int) { self.value = value }
+    func read() -> Int {
+        reads += 1
+        return value
+    }
+}
+
+// Both sentinels the production script can emit when the open panel never
+// becomes usable map to the same fail-closed contract: the sheet never
+// appearing, and the go-to-folder field never accepting the path. #123 must
+// hold for either occlusion shape.
+@Test(arguments: [
+    "DIALOG_NOT_FOUND: file-open sheet did not appear",
+    "DIALOG_NOT_FOUND: go-to-folder field did not accept the path",
+])
+func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async throws {
+    let fixture = try makeManagedMIDIFixture()
+    defer { try? FileManager.default.removeItem(at: fixture) }
+
+    // Pre-condition: the fixture really lives under the managed import dir, so
+    // this is a faithful #123 scenario (a valid target, occluded session) and
+    // not a missing-file short-circuit.
+    let validated = AccessibilityChannel.validatedMIDIImportPath(fixture.path)
+    #expect(validated != nil, "fixture must be a managed, validator-eligible import target")
+
+    let spy = ImportCountSpy(value: 9)
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: fixture.path,
+        executeScript: { _ in .success(sentinel) },
+        trackCount: { spy.read() },
+        trackNames: { [] },
+        deltaPoll: {}
+    )
+
+    // Must be a hard failure — NOT a false success against the leftover session.
+    #expect(!result.isSuccess, "occluded session must fail closed, never report a vacuous success")
+
+    let obj = decodeIssue123JSON(result.message)
+
+    // Typed State C dialog_not_found.
+    #expect(obj["error"] as? String == "dialog_not_found")
+    #expect(obj["missing_element"] as? String == "file_open_sheet")
+
+    // The open sheet was never seen — the load-bearing #123 flag (force-unwrap;
+    // an Optional<Bool> compare would be a dead assertion).
+    let fileOpenSeen = try #require(obj["file_open_dialog_seen"] as? Bool)
+    #expect(!fileOpenSeen)
+    let tempoSeen = try #require(obj["tempo_dialog_seen"] as? Bool)
+    #expect(!tempoSeen)
+
+    // Hint must name the occluded / stale-session cause so the caller knows the
+    // failure is environmental (the heart of #123), not a server defect.
+    let hint = try #require(obj["hint"] as? String)
+    #expect(hint.contains("occluded") || hint.contains("unhealthy"))
+    #expect(hint.contains("never appeared"))
+
+    // dialog_not_found is terminal: the router must surface it verbatim and not
+    // fall through to a next-channel success that would re-create the stale
+    // success #123 reported.
+    #expect(HonestContract.terminalErrorCodes.contains("dialog_not_found"))
+
+    // No import happened, so only the before-count read should fire; a delta
+    // read here would mean we proceeded past a known-absent dialog.
+    #expect(spy.reads == 1, "only the before-count read should occur on the occlusion path")
+}
+
+// Positive contrast: a CLEAN session (sheet appeared, track created) is a
+// verified State A success. This proves the gate above is not trivially
+// always-failing — the occlusion fail-closed is specific to the missing sheet.
+@Test func testCleanSessionVerifiesImportStateAAndSeesDialog() async throws {
+    let fixture = try makeManagedMIDIFixture()
+    defer { try? FileManager.default.removeItem(at: fixture) }
+
+    final class Counter: @unchecked Sendable {
+        var values = [4, 5]
+        func next() -> Int { values.removeFirst() }
+    }
+    let counter = Counter()
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        path: fixture.path,
+        executeScript: { _ in .success("OK") },
+        trackCount: { counter.next() },
+        trackNames: { ["Studio Grand", "01 Felt Keys", "02 Bass", "03 Drums", "04 Imported Lead"] },
+        deltaPoll: {}
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeIssue123JSON(result.message)
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(verified)
+    let fileOpenSeen = try #require(obj["file_open_dialog_seen"] as? Bool)
+    #expect(fileOpenSeen)
+    #expect(obj["observed_delta"] as? Int == 1)
+    #expect(obj["error"] == nil)
+}


### PR DESCRIPTION
Closes #123. Environmental (server correct; honest path from merged #140). Regression test: defaultImportMIDIFile with the DIALOG_NOT_FOUND sentinel (occluded/stale session) returns typed State C dialog_not_found (file_open_dialog_seen:false), with a CountSpy proving no false import verification; plus a clean-session State-A contrast. Covers both occlusion sentinels. Build clean, tests pass.