### PR TITLE
test: make EN/KO live close gate System Events-free

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 import uuid
+from pathlib import Path
 
 from logic_session_bootstrap import bootstrap_fresh_logic_session
 from logic_free_tempo_modal import DEFAULT_FREE_TEMPO_POLICY, detect_free_tempo_modal, resolve_free_tempo_modal
@@ -496,6 +497,17 @@ def wait_for_transport_state(client, predicate, timeout=6.0, interval=0.2):
 
 
 def ui_stop_logic_transport():
+    native_key_script = Path(__file__).with_name("logic_key_event.swift")
+    if native_key_script.exists():
+        native = subprocess.run(
+            ["/usr/bin/swift", str(native_key_script), "space"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if native.returncode == 0:
+            return True
+
     script = """
     tell application "Logic Pro" to activate
     delay 0.1

--- a/Scripts/logic_key_event.swift
+++ b/Scripts/logic_key_event.swift
@@ -1,0 +1,37 @@
+#!/usr/bin/env swift
+import AppKit
+import CoreGraphics
+import Foundation
+
+let keyName = CommandLine.arguments.dropFirst().first ?? ""
+let keyCodeByName: [String: CGKeyCode] = [
+    "space": 49,
+    "return": 36,
+]
+
+guard let keyCode = keyCodeByName[keyName] else {
+    FileHandle.standardError.write(Data("unknown_key\n".utf8))
+    exit(64)
+}
+
+guard CGPreflightPostEventAccess() else {
+    FileHandle.standardError.write(Data("post_event_access_denied\n".utf8))
+    exit(2)
+}
+
+if let app = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.logic10").first {
+    app.activate()
+    usleep(120_000)
+}
+
+let source = CGEventSource(stateID: .hidSystemState)
+guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+      let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else {
+    FileHandle.standardError.write(Data("event_create_failed\n".utf8))
+    exit(1)
+}
+
+keyDown.post(tap: .cghidEventTap)
+usleep(30_000)
+keyUp.post(tap: .cghidEventTap)
+print("ok")

--- a/Scripts/logic_session_bootstrap.py
+++ b/Scripts/logic_session_bootstrap.py
@@ -112,6 +112,7 @@ class UISnapshot:
     logic_window_names: list[str]
     logic_menu_items: list[str]
     detected_language: str | None
+    system_events_error: str | None
     project_picker_visible: bool
     new_track_dialog_visible: bool
 
@@ -230,6 +231,12 @@ def evaluate_fresh_session(
             "logic_window_not_visible",
             "Bring a Logic Pro document window on-screen before continuing.",
         )
+    if ui.system_events_error:
+        return FreshSessionAssessment(
+            False,
+            "system_events_unavailable",
+            f"System Events UI probe failed; grant Automation access to this harness runner. {ui.system_events_error}",
+        )
     if ui.frontmost_app != LOGIC_APP_NAME:
         return FreshSessionAssessment(
             False,
@@ -327,7 +334,13 @@ def evaluate_fresh_session(
     )
 
 
-def _run_osascript(lines: Sequence[str], timeout_sec: float = 3.0) -> str | None:
+@dataclass(frozen=True)
+class AppleScriptProbe:
+    output: str | None
+    error: str | None
+
+
+def _run_osascript_probe(lines: Sequence[str], timeout_sec: float = 3.0) -> AppleScriptProbe:
     args = ["/usr/bin/osascript"]
     for line in lines:
         args.extend(["-e", line])
@@ -339,11 +352,21 @@ def _run_osascript(lines: Sequence[str], timeout_sec: float = 3.0) -> str | None
             timeout=timeout_sec,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return None
+    except FileNotFoundError:
+        return AppleScriptProbe(None, "osascript_not_found")
+    except subprocess.TimeoutExpired:
+        return AppleScriptProbe(None, "osascript_timeout")
     if result.returncode != 0:
-        return None
-    return result.stdout.strip()
+        detail = (result.stderr or result.stdout or "").strip()
+        if len(detail) > 240:
+            detail = detail[:237] + "..."
+        suffix = f": {detail}" if detail else ""
+        return AppleScriptProbe(None, f"osascript_exit_{result.returncode}{suffix}")
+    return AppleScriptProbe(result.stdout.strip(), None)
+
+
+def _run_osascript(lines: Sequence[str], timeout_sec: float = 3.0) -> str | None:
+    return _run_osascript_probe(lines, timeout_sec=timeout_sec).output
 
 
 def _split_lines(output: str | None) -> list[str]:
@@ -380,15 +403,16 @@ def _send_return_key() -> bool:
     return output is not None
 
 
-def _frontmost_application() -> str | None:
-    return _run_osascript(
+def _frontmost_application_probe() -> tuple[str | None, str | None]:
+    result = _run_osascript_probe(
         ['tell application "System Events" to get name of first application process whose frontmost is true'],
         timeout_sec=2.0,
     )
+    return result.output, result.error
 
 
-def _logic_window_names() -> list[str]:
-    output = _run_osascript(
+def _logic_window_names_probe() -> tuple[list[str], str | None]:
+    result = _run_osascript_probe(
         [
             'tell application "System Events"',
             f'if not (exists application process "{LOGIC_APP_NAME}") then return ""',
@@ -400,11 +424,11 @@ def _logic_window_names() -> list[str]:
         ],
         timeout_sec=2.0,
     )
-    return _split_lines(output)
+    return _split_lines(result.output), result.error
 
 
-def _logic_menu_items() -> list[str]:
-    output = _run_osascript(
+def _logic_menu_items_probe() -> tuple[list[str], str | None]:
+    result = _run_osascript_probe(
         [
             'tell application "System Events"',
             f'tell application process "{LOGIC_APP_NAME}"',
@@ -415,17 +439,20 @@ def _logic_menu_items() -> list[str]:
         ],
         timeout_sec=2.0,
     )
-    return _split_lines(output)
+    return _split_lines(result.output), result.error
 
 
 def collect_ui_snapshot() -> UISnapshot:
-    window_names = _logic_window_names()
-    menu_items = _logic_menu_items()
+    window_names, window_error = _logic_window_names_probe()
+    menu_items, menu_error = _logic_menu_items_probe()
+    frontmost_app, frontmost_error = _frontmost_application_probe()
+    probe_errors = [error for error in (window_error, menu_error, frontmost_error) if error]
     return UISnapshot(
-        frontmost_app=_frontmost_application(),
+        frontmost_app=frontmost_app,
         logic_window_names=window_names,
         logic_menu_items=menu_items,
         detected_language=detect_language(menu_items),
+        system_events_error="; ".join(probe_errors) if probe_errors else None,
         project_picker_visible=_contains_marker(window_names, PROJECT_PICKER_MARKERS),
         new_track_dialog_visible=_contains_marker(window_names, NEW_TRACK_DIALOG_MARKERS),
     )

--- a/Scripts/logic_session_bootstrap.py
+++ b/Scripts/logic_session_bootstrap.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Reusable fresh-session bootstrap helper for Logic Pro live/demo runs.
 
-This helper uses MCP-visible truth for project/document state and System Events
-only for UI readiness signals such as frontmost app, window titles, and menu
-language. It never relies on coordinate clicks.
+This helper uses MCP-visible truth for project/document state and a native
+AX/NSWorkspace probe for UI readiness signals such as frontmost app, window
+titles, and menu language. It never relies on coordinate clicks.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ import os
 import subprocess
 import time
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 LOGIC_APP_NAME = "Logic Pro"
@@ -396,6 +397,21 @@ def _hide_application(name: str) -> bool:
 
 
 def _send_return_key() -> bool:
+    native_key_script = Path(__file__).with_name("logic_key_event.swift")
+    if native_key_script.exists():
+        try:
+            result = subprocess.run(
+                ["/usr/bin/swift", str(native_key_script), "return"],
+                capture_output=True,
+                text=True,
+                timeout=5.0,
+                check=False,
+            )
+            if result.returncode == 0:
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
     output = _run_osascript(
         ['tell application "System Events" to key code 36'],
         timeout_sec=2.0,
@@ -442,11 +458,76 @@ def _logic_menu_items_probe() -> tuple[list[str], str | None]:
     return _split_lines(result.output), result.error
 
 
+def _ui_snapshot_from_native_payload(payload: Any) -> UISnapshot | None:
+    if not isinstance(payload, dict):
+        return None
+    frontmost_app = payload.get("frontmost_app")
+    frontmost_bundle_id = payload.get("frontmost_bundle_id")
+    window_names = payload.get("logic_window_names")
+    menu_items = payload.get("logic_menu_items")
+    if frontmost_app is not None and not isinstance(frontmost_app, str):
+        return None
+    if frontmost_bundle_id is not None and not isinstance(frontmost_bundle_id, str):
+        return None
+    if frontmost_bundle_id == "com.apple.logic10":
+        frontmost_app = LOGIC_APP_NAME
+    if not isinstance(window_names, list) or not all(isinstance(item, str) for item in window_names):
+        return None
+    if not isinstance(menu_items, list) or not all(isinstance(item, str) for item in menu_items):
+        return None
+    error = payload.get("error")
+    if error is not None and not isinstance(error, str):
+        return None
+    return UISnapshot(
+        frontmost_app=frontmost_app,
+        logic_window_names=window_names,
+        logic_menu_items=menu_items,
+        detected_language=detect_language(menu_items),
+        system_events_error=error,
+        project_picker_visible=_contains_marker(window_names, PROJECT_PICKER_MARKERS),
+        new_track_dialog_visible=_contains_marker(window_names, NEW_TRACK_DIALOG_MARKERS),
+    )
+
+
+def _native_ui_snapshot() -> tuple[UISnapshot | None, str | None]:
+    script = Path(__file__).with_name("logic_ui_snapshot.swift")
+    if not script.exists():
+        return None, "native_snapshot_script_missing"
+    try:
+        result = subprocess.run(
+            ["/usr/bin/swift", str(script)],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None, "swift_not_found"
+    except subprocess.TimeoutExpired:
+        return None, "native_snapshot_timeout"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        if len(detail) > 240:
+            detail = detail[:237] + "..."
+        if detail:
+            return None, f"native_snapshot_exit_{result.returncode}: {detail}"
+        return None, f"native_snapshot_exit_{result.returncode}"
+    payload = _safe_json(result.stdout.strip())
+    snapshot = _ui_snapshot_from_native_payload(payload)
+    if snapshot is None:
+        return None, "native_snapshot_invalid_json"
+    return snapshot, None
+
+
 def collect_ui_snapshot() -> UISnapshot:
+    native_snapshot, native_error = _native_ui_snapshot()
+    if native_snapshot is not None:
+        return native_snapshot
+
     window_names, window_error = _logic_window_names_probe()
     menu_items, menu_error = _logic_menu_items_probe()
     frontmost_app, frontmost_error = _frontmost_application_probe()
-    probe_errors = [error for error in (window_error, menu_error, frontmost_error) if error]
+    probe_errors = [error for error in (native_error, window_error, menu_error, frontmost_error) if error]
     return UISnapshot(
         frontmost_app=frontmost_app,
         logic_window_names=window_names,
@@ -581,11 +662,17 @@ def bootstrap_fresh_logic_session(
         wait_for(lambda: (_activate_logic() or True) and collect_ui_snapshot().frontmost_app == LOGIC_APP_NAME, 2.0)
         ui = collect_ui_snapshot()
 
-    if health.get("logic_pro_has_document") is not True:
+    if health.get("logic_pro_has_document") is not True or ui.project_picker_visible:
         if not config.allow_new_project:
+            reason = "project_picker_visible" if ui.project_picker_visible else "no_document_open"
+            hint = (
+                "The Choose Project picker is visible and auto-new-project is disabled."
+                if ui.project_picker_visible
+                else "No Logic document is open and auto-new-project is disabled."
+            )
             return blocked(
-                "no_document_open",
-                "No Logic document is open and auto-new-project is disabled.",
+                reason,
+                hint,
                 health=health,
                 ui=ui,
             )
@@ -603,7 +690,8 @@ def bootstrap_fresh_logic_session(
         actions.append("logic_system.refresh_cache")
 
         deadline = time.time() + config.timeout_sec
-        sent_return = False
+        sent_project_picker_return = False
+        sent_new_track_return = False
         while time.time() < deadline:
             time.sleep(config.poll_interval_sec)
             _activate_logic()
@@ -612,9 +700,29 @@ def bootstrap_fresh_logic_session(
                 continue
             ui = collect_ui_snapshot()
             if (
+                ui.project_picker_visible
+                and config.confirm_new_track_dialog
+                and not sent_project_picker_return
+            ):
+                permissions = health.get("permissions", {})
+                if permissions.get("post_event_access") is not True:
+                    return blocked(
+                        "post_event_access_denied",
+                        "Need CGEvent post-event access to confirm Logic's project picker.",
+                        health=health,
+                        ui=ui,
+                    )
+                if _send_return_key():
+                    actions.append("confirm_project_picker:return")
+                    sent_project_picker_return = True
+                    call_tool("logic_system", "refresh_cache", None, 5.0)
+                    actions.append("logic_system.refresh_cache")
+                    continue
+
+            if (
                 ui.new_track_dialog_visible
                 and config.confirm_new_track_dialog
-                and not sent_return
+                and not sent_new_track_return
             ):
                 permissions = health.get("permissions", {})
                 if permissions.get("post_event_access") is not True:
@@ -626,7 +734,7 @@ def bootstrap_fresh_logic_session(
                     )
                 if _send_return_key():
                     actions.append("confirm_new_track_dialog:return")
-                    sent_return = True
+                    sent_new_track_return = True
                     call_tool("logic_system", "refresh_cache", None, 5.0)
                     actions.append("logic_system.refresh_cache")
                     continue
@@ -690,6 +798,45 @@ def bootstrap_fresh_logic_session(
             project=project_payload,
             ui=ui,
         )
+
+    if not _track_rows(tracks_payload) and config.allow_new_project:
+        log("  [bootstrap] creating one fresh software-instrument track")
+        response = call_tool("logic_tracks", "create_instrument", None, 10.0)
+        actions.append("logic_tracks.create_instrument")
+        if _response_is_error(response):
+            return blocked(
+                "fresh_track_create_failed",
+                tool_text(response) or "logic_tracks.create_instrument failed",
+                health=health,
+                project=project_payload,
+                tracks=tracks_payload,
+                ui=ui,
+            )
+        deadline = time.time() + config.timeout_sec
+        while time.time() < deadline:
+            call_tool("logic_system", "refresh_cache", None, 5.0)
+            actions.append("logic_system.refresh_cache")
+            time.sleep(config.poll_interval_sec)
+            _, health_latest = fetch_health()
+            if health_latest is not None:
+                health = health_latest
+            _, _, project_latest = _resource_json(read_resource, resource_text, "logic://project/info")
+            if isinstance(project_latest, dict):
+                project_payload = project_latest
+            _, _, tracks_latest = _resource_json(read_resource, resource_text, "logic://tracks")
+            if isinstance(tracks_latest, dict):
+                tracks_payload = tracks_latest
+                if _track_rows(tracks_payload):
+                    break
+        else:
+            return blocked(
+                "fresh_track_unavailable",
+                "The fresh project did not expose a live track after track creation.",
+                health=health,
+                project=project_payload,
+                tracks=tracks_payload,
+                ui=ui,
+            )
 
     region_count = 0
     if _track_rows(tracks_payload):

--- a/Scripts/logic_session_bootstrap_test.py
+++ b/Scripts/logic_session_bootstrap_test.py
@@ -29,6 +29,7 @@ def make_ui(**overrides):
         logic_window_names=["Untitled 1 - Tracks"],
         logic_menu_items=["File", "Edit", "Track", "Navigate", "Record", "Mix", "View", "Window", "Help"],
         detected_language="en",
+        system_events_error=None,
         project_picker_visible=False,
         new_track_dialog_visible=False,
     )
@@ -172,6 +173,24 @@ class EvaluateFreshSessionTests(unittest.TestCase):
             config=make_config(),
         )
         self.assert_reason(assessment, "existing_regions_present")
+
+    def test_blocks_system_events_probe_failure_before_frontmost(self):
+        assessment = evaluate_fresh_session(
+            ui=make_ui(
+                frontmost_app=None,
+                logic_window_names=[],
+                logic_menu_items=[],
+                detected_language=None,
+                system_events_error="osascript_exit_1: Not authorized to send Apple events to System Events. (-1743)",
+            ),
+            health=make_health(),
+            project_payload=make_project(track_count=1),
+            tracks_payload=make_tracks(count=1),
+            region_count=0,
+            config=make_config(),
+        )
+        self.assert_reason(assessment, "system_events_unavailable")
+        self.assertIn("System Events", assessment.hint or "")
 
 
 if __name__ == "__main__":

--- a/Scripts/logic_session_bootstrap_test.py
+++ b/Scripts/logic_session_bootstrap_test.py
@@ -7,6 +7,7 @@ from logic_session_bootstrap import (
     UISnapshot,
     detect_language,
     evaluate_fresh_session,
+    _ui_snapshot_from_native_payload,
 )
 
 
@@ -191,6 +192,52 @@ class EvaluateFreshSessionTests(unittest.TestCase):
         )
         self.assert_reason(assessment, "system_events_unavailable")
         self.assertIn("System Events", assessment.hint or "")
+
+    def test_native_ui_snapshot_payload_maps_language_and_modal_markers(self):
+        snapshot = _ui_snapshot_from_native_payload(
+            {
+                "frontmost_app": "Logic Pro",
+                "frontmost_bundle_id": "com.apple.logic10",
+                "logic_window_names": ["Untitled 1 - Tracks", "New Tracks"],
+                "logic_menu_items": ["Apple", "Logic Pro", "File", "Edit", "Track", "Navigate"],
+                "error": None,
+            }
+        )
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.detected_language, "en")
+        self.assertTrue(snapshot.new_track_dialog_visible)
+        self.assertFalse(snapshot.project_picker_visible)
+        self.assertIsNone(snapshot.system_events_error)
+
+    def test_native_ui_snapshot_payload_surfaces_ax_error(self):
+        snapshot = _ui_snapshot_from_native_payload(
+            {
+                "frontmost_app": "Logic Pro",
+                "frontmost_bundle_id": "com.apple.logic10",
+                "logic_window_names": [],
+                "logic_menu_items": [],
+                "error": "accessibility_not_trusted",
+            }
+        )
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.system_events_error, "accessibility_not_trusted")
+
+    def test_native_ui_snapshot_payload_normalizes_logic_bundle_frontmost_name(self):
+        snapshot = _ui_snapshot_from_native_payload(
+            {
+                "frontmost_app": "Logic\u00a0Pro",
+                "frontmost_bundle_id": "com.apple.logic10",
+                "logic_window_names": ["프로젝트 선택"],
+                "logic_menu_items": ["Apple", "Logic\u00a0Pro", "파일", "편집", "트랙"],
+                "error": None,
+            }
+        )
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.frontmost_app, "Logic Pro")
+        self.assertEqual(snapshot.detected_language, "ko")
 
 
 if __name__ == "__main__":

--- a/Scripts/logic_ui_snapshot.swift
+++ b/Scripts/logic_ui_snapshot.swift
@@ -1,0 +1,68 @@
+#!/usr/bin/env swift
+import AppKit
+import ApplicationServices
+import Foundation
+
+struct Snapshot: Encodable {
+    let frontmost_app: String?
+    let frontmost_bundle_id: String?
+    let logic_window_names: [String]
+    let logic_menu_items: [String]
+    let error: String?
+}
+
+func axAttribute<T>(_ element: AXUIElement, _ attribute: String) -> T? {
+    var value: AnyObject?
+    let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    guard result == .success else { return nil }
+    return value as? T
+}
+
+func title(of element: AXUIElement) -> String? {
+    let raw: String? = axAttribute(element, kAXTitleAttribute as String)
+    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+func children(of element: AXUIElement) -> [AXUIElement] {
+    let raw: [AXUIElement]? = axAttribute(element, kAXChildrenAttribute as String)
+    return raw ?? []
+}
+
+let frontmost = NSWorkspace.shared.frontmostApplication
+let logicApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.logic10").first
+
+var error: String?
+var windowNames: [String] = []
+var menuItems: [String] = []
+
+if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": false] as CFDictionary) {
+    error = "accessibility_not_trusted"
+} else if let logicApp {
+    let appElement = AXUIElementCreateApplication(logicApp.processIdentifier)
+    AXUIElementSetMessagingTimeout(appElement, 2.5)
+
+    if let windows: [AXUIElement] = axAttribute(appElement, kAXWindowsAttribute as String) {
+        windowNames = windows.compactMap(title)
+    }
+
+    if let menuBar: AXUIElement = axAttribute(appElement, kAXMenuBarAttribute as String) {
+        menuItems = children(of: menuBar).compactMap(title)
+    } else {
+        error = "logic_menu_bar_unavailable"
+    }
+} else {
+    error = "logic_not_running"
+}
+
+let snapshot = Snapshot(
+    frontmost_app: frontmost?.localizedName,
+    frontmost_bundle_id: frontmost?.bundleIdentifier,
+    logic_window_names: windowNames,
+    logic_menu_items: menuItems,
+    error: error
+)
+
+let data = try JSONEncoder().encode(snapshot)
+FileHandle.standardOutput.write(data)
+FileHandle.standardOutput.write(Data([0x0A]))


### PR DESCRIPTION
## Summary
- Replaces the live bootstrap UI readiness probe with a native AX/NSWorkspace Swift helper, avoiding the System Events AppleEvent path that produced -1743 on the runner.
- Adds a CGEvent key helper for confirming Logic project/new-track UI and stopping transport before falling back to System Events.
- Teaches fresh bootstrap to confirm the project picker, create one software-instrument track when a fresh project exposes zero tracks, and keep EN/KO UI detection strict.

## Verification
- python3 Scripts/logic_session_bootstrap_test.py -> 14 passed
- python3 -m py_compile Scripts/logic_session_bootstrap.py Scripts/live-e2e-test.py
- swift build -c release
- swift test --filter Issue60LocalePhase --no-parallel -> 19 passed
- swift test --filter AXLocalePolicy --no-parallel -> 25 passed
- swift test --filter AXLogicProElements --no-parallel -> 24 passed
- swift test --no-parallel -> 1743 passed
- LOGIC_PRO_MCP_STRICT_LIVE=1 LOGIC_PRO_MCP_BOOTSTRAP_FRESH=1 LOGIC_PRO_MCP_BOOTSTRAP_LANGUAGE=en python3 Scripts/live-e2e-test.py -> 341 passed, 0 skipped
- LOGIC_PRO_MCP_STRICT_LIVE=1 LOGIC_PRO_MCP_BOOTSTRAP_FRESH=1 LOGIC_PRO_MCP_BOOTSTRAP_LANGUAGE=ko python3 Scripts/live-e2e-test.py -> 341 passed, 0 skipped

Issue #60 live close-gate is pass-ready on this PR head. Mainline closure still depends on merging this PR into main.