### PR TITLE
release: sync v3.7.1 formula sha

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "61a13ef9c59e95c2ac39803acc48019259abeba7e45a0e475ce24b9678b6be79"
+    sha256 "a5833040ca47c928fa04a8e334e50af166640523b1067e5a52ae3a4804aa77b8"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
## Summary
- Sync the Homebrew Formula sha256 to the published v3.7.1 universal release tarball.

## Verification
- `curl -fsSL https://github.com/MongLong0214/logic-pro-mcp/releases/download/v3.7.1/SHA256SUMS.txt` confirms `LogicProMCP-macOS-universal.tar.gz` sha256 `a5833040ca47c928fa04a8e334e50af166640523b1067e5a52ae3a4804aa77b8`
- `ruby -c Formula/logic-pro-mcp.rb`
- `swift test --filter VersionConsistencyTests --no-parallel`
- `git diff --check`