### PR TITLE
fix: block unverified external MIDI bounce paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
-No unreleased changes.
+### Fixed
+
+- `record_sequence` no longer re-promotes a lower-level `midi.import_file` State B GM Device / External MIDI audibility downgrade into verified success; it now fails closed with `audibility_unverified` before a silent Bounce can be claimed.
+- `logic://project/audit` now reports `external_midi_regions_bounce_risk` as an export blocker when MIDI regions sit on GM Device / External MIDI tracks, preventing track/region readback from being mistaken for audible-routing evidence.
+- `logic_project.bounce` now runs the audit preflight and refuses `export_readiness_blocked` before opening the Bounce dialog when export blockers are present.
 
 ## [3.7.1] — 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Live E2E defaults to the release binary. Protocol/security assertions run on any
 - **Exact-slot plugin insertion** — `logic_plugins.insert_verified` targets the physical insert index returned by `get_inventory`, verifies the popup is anchored to that slot, and confirms success only by post-write inventory diff.
 - **Target-faithful navigation** — `goto_marker` returns `element_not_found` on a cold cache instead of advancing to the next marker.
 - **1-based MIDI channel** — `send_note`, `send_cc`, and `record_sequence` `ch` values accept 1..16 to match Logic's UI.
+- **Audible-bounce guardrails** — `record_sequence` refuses unverified GM Device / External MIDI imports, `logic://project/audit` marks External MIDI tracks with MIDI regions as export blockers, and `logic_project.bounce` refuses those blockers before opening the Bounce dialog.
 - **Audit phase split** — audit logs distinguish rejected calls, confirmation prompts, and executed route invocations.
 - **Verified project saves** — `project.save_as` verifies the target `.logicx` package exists and that existing packages advance modification time.
 - **Live project metadata** — `logic://project/info` promotes live transport tempo/sample-rate when available and falls back per-field to saved project metadata.
@@ -260,6 +261,7 @@ The repository ships `server.json` for the official MCP Registry metadata path. 
 
 - **Tempo typing**: `transport.set_tempo` falls back to slider increments when Logic's tempo display cannot accept text input; sub-10-BPM precision may require setting tempo manually once in Logic.
 - **MIDI region padding**: `record_sequence` regions start at bar 1 and extend to the target bar using inaudible padding; note timing inside the region is exact, but the region can look longer than the phrase.
+- **External MIDI bounce readiness**: MIDI regions on GM Device / External MIDI tracks are not accepted as audible-bounce evidence by project audit or `logic_project.bounce`. Move or recreate the material on Software Instrument tracks before claiming a verified Logic Bounce.
 - **MIDI Key Commands**: Logic 12.2 does not accept the legacy `.plist` Key Commands import; manual MIDI Learn remains required for keycmd-only operations.
 - **Markers**: `logic://markers` returns `[]` honestly when the Marker List window is closed on Logic 12.2; auto-opening that window is not shipped because it changes focus.
 - **Plugin parameter readback**: `logic_plugins.set_param_verified` live-verifies Compressor `threshold` through the open plugin window; arbitrary plugin parameters remain future work and fail closed with `unsupported_param_readback`.

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -11,7 +11,7 @@ struct ProjectDispatcher {
 
     static let tool = commandTool(
         name: "logic_project",
-        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan, cleanup_apply. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; export_run -> { ...same as export_plan, confirmed: Bool } GUARDED execution (re-plans, opens, verifies project identity by readback, bounces, verifies each artifact on disk via logic_audio, records logic_pro_mcp_export_run.v1 with HC State A/B/C; never overwrites under fail_if_exists); export_resume -> { ...same as export_run } idempotent resume (skips already-present+verified artifacts, produces the rest); audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; cleanup_apply -> { step_id: String, confirmed: Bool, names?: \"newA,newB\" (CSV aligned to the step's target track indices) | new_name?: String (single target) } executes ONE supported mutating cleanup-plan step (currently rename_* only) through the existing track.rename path so it inherits AX readback + Honest Contract State A/B/C. Fails closed (State C) when confirmed!=true, the step is unknown/unsupported/non-mutating, the audit shows stale/occluded inventory or a track readback gap, or rename names are missing/mismatched. Deletion steps are unsupported by construction and are always refused; others -> {}.",
+        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan, cleanup_apply. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; bounce requires confirmation and runs a pre-bounce project audit, returning `export_readiness_blocked` before opening the Bounce dialog if blockers such as `external_midi_regions_bounce_risk` are present; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; export_run -> { ...same as export_plan, confirmed: Bool } GUARDED execution (re-plans, opens, verifies project identity by readback, bounces, verifies each artifact on disk via logic_audio, records logic_pro_mcp_export_run.v1 with HC State A/B/C; never overwrites under fail_if_exists); export_resume -> { ...same as export_run } idempotent resume (skips already-present+verified artifacts, produces the rest); audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; cleanup_apply -> { step_id: String, confirmed: Bool, names?: \"newA,newB\" (CSV aligned to the step's target track indices) | new_name?: String (single target) } executes ONE supported mutating cleanup-plan step (currently rename_* only) through the existing track.rename path so it inherits AX readback + Honest Contract State A/B/C. Fails closed (State C) when confirmed!=true, the step is unknown/unsupported/non-mutating, the audit shows stale/occluded inventory or a track readback gap, or rename names are missing/mismatched. Deletion steps are unsupported by construction and are always refused; others -> {}.",
         commandDescription: "Project command to execute"
     )
 
@@ -235,6 +235,11 @@ struct ProjectDispatcher {
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
                 return toolTextResult(response)
+            }
+            let preflight = await ProjectSessionAudit.buildAudit(cache: cache)
+            if let block = bouncePreflightBlock(preflight) {
+                audit(command, phase: .rejected, reason: "export readiness blocked")
+                return block
             }
             audit(command, phase: .executed)
             let result = await router.route(operation: "project.bounce")
@@ -589,6 +594,42 @@ struct ProjectDispatcher {
         let command = (step.command ?? "").lowercased()
         if command.contains("delete") || command.contains("remove") { return true }
         return step.proposedOperation.lowercased().contains("delete ")
+    }
+
+    private static func bouncePreflightBlock(
+        _ report: ProjectSessionAudit.AuditReport
+    ) -> CallTool.Result? {
+        let blockers = report.evidence.exportReadiness.blockers
+        guard !blockers.isEmpty else { return nil }
+        let blockerFindings = report.findings
+            .filter { $0.severity == .blocker }
+            .map {
+                [
+                    "id": $0.id,
+                    "category": $0.category,
+                    "summary": $0.summary,
+                    "resource": $0.evidence.resource,
+                    "target": $0.evidence.target ?? "",
+                ]
+            }
+        let payload: [String: Any] = [
+            "success": false,
+            "verified": false,
+            "error": "export_readiness_blocked",
+            "failure_stage": "pre_bounce_audit",
+            "status": report.evidence.exportReadiness.status,
+            "blockers": blockers,
+            "blocker_findings": blockerFindings,
+            "hint": "logic_project.bounce refused before opening the Bounce dialog because project audit export readiness is blocked. Resolve blockers, then re-run logic_project.audit and bounce.",
+        ]
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return toolTextResult(
+                "{\"success\":false,\"verified\":false,\"error\":\"export_readiness_blocked\",\"failure_stage\":\"pre_bounce_audit\"}",
+                isError: true
+            )
+        }
+        return toolTextResult(String(decoding: data, as: UTF8.self), isError: true)
     }
 
     /// Parse `tracks:0,1,2` (the plan's `target_identifier` form) into sorted,

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -270,10 +270,11 @@ struct SystemDispatcher {
                   arm_only          -> { index: Int } — disarms others, arms target; returns error on partial disarm failure
                   record_sequence   -> { bar?: Int, notes: "pitch,offsetMs,durMs[,vel[,ch]];...", tempo?: Float }
                                        v3.0.8 SMF-import: generates a MIDI file, forces playhead to bar 1, imports via AX menu.
-                                       Creates a new track per call with Logic's default Software Instrument.
+                                       Creates a new track per call; if Logic imports GM Device / External MIDI lanes,
+                                       returns audibility_unverified instead of claiming audible success.
                                        Response: { created_track, recorded_to_track, instrument }. `instrument` is always
                                        `"not-attempted"` (or `"ignored:<legacy instrument_path>"` for clients still sending the
-                                       removed param). Callers that want a specific patch call set_instrument separately — see
+                                       removed param). Callers that want a specific patch call set_instrument separately on a Software Instrument track — see
                                        CHANGELOG v3.0.8 for the selectTrackViaAX limitation on fresh SMF-created tracks.
                   set_automation    -> { index: Int, mode: String } (read/write/touch/latch/trim/off)
                   set_instrument    -> { index: Int, path: String } OR { index: Int, category: String, preset: String }
@@ -360,7 +361,8 @@ struct SystemDispatcher {
                   save              -> {} — Save current project
                   save_as           -> { path: String } — Save to new path
                   close             -> {} — Close project
-                  bounce            -> {} — Open bounce dialog
+                  bounce            -> {} — Open bounce dialog after audit preflight;
+                                       export blockers return export_readiness_blocked
                   get_regions       -> {} — Read arrange regions
                   export_plan       -> { projects, output_root, artifacts? } — Dry-run export manifest plan
                   launch            -> {} — Launch Logic Pro

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -4,7 +4,7 @@ import MCP
 struct TrackDispatcher {
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename/mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } v3.0.8 SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`. The new track keeps Logic's default Software Instrument (Studio Grand piano on a fresh project); callers that want a specific patch must follow up with an explicit `set_instrument` AFTER ensuring the intended track is selected. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default ax — live Library Panel; disk reads ~/Music/Logic Pro Library.bundle for 5,400+ leaves with Panel-taxonomy remap; both returns diff summary); resolve_path -> { path: String } cache-backed read-only; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename/mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default ax — live Library Panel; disk reads ~/Music/Logic Pro Library.bundle for 5,400+ leaves with Panel-taxonomy remap; both returns diff summary); resolve_path -> { path: String } cache-backed read-only; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -722,6 +722,39 @@ struct TrackDispatcher {
                 if let innerError = inner["error"] as? String {
                     failure["import_error"] = innerError
                 }
+            }
+            return jsonToolTextResult(failure, isError: true)
+        }
+
+        if let inner = importMessageJSON(importResult.message),
+           (inner["verified"] as? Bool) == false {
+            let reason = (inner["reason"] as? String) ?? "import_unverified"
+            let audibilityDowngrade = reason == HonestContract.UncertainReason.importedAsGMDevice.rawValue
+            var failure: [String: Any] = [
+                "success": false,
+                "verified": false,
+                "error": audibilityDowngrade ? "audibility_unverified" : "import_unverified",
+                "failure_stage": "midi.import_file",
+                "import_reason": reason,
+                "bar": bar,
+                "note_count": events.count,
+                "method": "smf_import",
+                "detail": importResult.message,
+                "hint": audibilityDowngrade
+                    ? "record_sequence imported GM Device / external-MIDI lane(s); region readback cannot prove audible routing, so the take is blocked before a silent Logic Bounce can be claimed."
+                    : "record_sequence import returned an unverified State B result; refusing to promote it to a verified take.",
+            ]
+            for key in [
+                "audible",
+                "gm_device_lanes",
+                "imported_lanes",
+                "track_count_before",
+                "track_count_after",
+                "observed_delta",
+                "file_open_dialog_seen",
+                "tempo_dialog_seen",
+            ] {
+                if let value = inner[key] { failure[key] = value }
             }
             return jsonToolTextResult(failure, isError: true)
         }

--- a/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
+++ b/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
@@ -580,6 +580,22 @@ enum ProjectSessionAudit {
             ))
         }
 
+        let externalMIDIRisks = externalMIDIRegionRisks(snapshot)
+        if !externalMIDIRisks.isEmpty {
+            findings.append(finding(
+                "external_midi_regions_bounce_risk",
+                .blocker,
+                "export",
+                "MIDI regions are placed on GM Device / External MIDI tracks; track and region readback do not prove audible Logic Bounce routing.",
+                "logic://tracks",
+                externalMIDIRisks.map { String($0.track.id) }.joined(separator: ","),
+                externalMIDIRisks.map {
+                    "track=\($0.track.id),name=\($0.track.name),regions=\($0.regionCount)"
+                } + ["risk=silent_logic_bounce"],
+                "ax_live"
+            ))
+        }
+
         if !tracks.soloedIndices.isEmpty {
             findings.append(finding(
                 "soloed_tracks_present",
@@ -891,6 +907,28 @@ enum ProjectSessionAudit {
             .filter { !tracksWithRegions.contains($0.id) }
             .map(\.id)
             .sorted()
+    }
+
+    private static func externalMIDIRegionRisks(
+        _ snapshot: Snapshot
+    ) -> [(track: TrackState, regionCount: Int)] {
+        guard snapshot.regionsFetchedAt > .distantPast else { return [] }
+        let regionCounts = Dictionary(grouping: snapshot.regions, by: \.trackIndex).mapValues(\.count)
+        return snapshot.tracks
+            .filter { track in
+                let hasRegions = (regionCounts[track.id] ?? 0) > 0
+                return hasRegions && isExternalMIDIAudibilityRisk(track)
+            }
+            .sorted { $0.id < $1.id }
+            .map { ($0, regionCounts[$0.id] ?? 0) }
+    }
+
+    private static func isExternalMIDIAudibilityRisk(_ track: TrackState) -> Bool {
+        if track.type == .externalMIDI { return true }
+        let lowerName = track.name.lowercased()
+        return ["gm device", "general midi", "external midi", "external instrument"].contains {
+            lowerName.contains($0)
+        }
     }
 
     private static func occupiedPluginSlots(_ strips: [ChannelStripState]) -> [PluginSlotEvidence] {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -2257,6 +2257,45 @@ private actor SelectiveFailChannel: Channel {
     ])
 }
 
+@Test func testProjectDispatcherBounceBlocksExternalMIDIBeforeRouting() async throws {
+    let router = ChannelRouter()
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(keyCmd)
+
+    let cache = StateCache()
+    await cache.updateTracks([
+        TrackState(id: 0, name: "GM Device 1", type: .externalMIDI),
+    ])
+    await cache.updateRegions([
+        RegionState(
+            id: "0:1:5:Lead",
+            name: "Lead",
+            trackIndex: 0,
+            startPosition: "1 1 1 1",
+            endPosition: "5 1 1 1",
+            length: "4 0 0 0"
+        ),
+    ])
+
+    let result = await ProjectDispatcher.handle(
+        command: "bounce",
+        params: ["confirmed": .bool(true)],
+        router: router,
+        cache: cache
+    )
+
+    let isError = try #require(result.isError)
+    #expect(isError)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["success"] as? Bool == false)
+    #expect(object["error"] as? String == "export_readiness_blocked")
+    #expect(object["failure_stage"] as? String == "pre_bounce_audit")
+    #expect((object["blockers"] as? [String])?.contains("external_midi_regions_bounce_risk") == true)
+
+    let routedOps = await keyCmd.executedOps
+    #expect(routedOps.isEmpty)
+}
+
 @Test func testProjectDispatcherCloseHonoursSavingParameter() async {
     let router = ChannelRouter()
     let appleScript = MockChannel(id: .appleScript)

--- a/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
+++ b/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
@@ -230,6 +230,37 @@ private func messySnapshot(
     #expect(!report.findings.contains { $0.id == "track_readback_gap" })
 }
 
+@Test func testProjectAuditBlocksExternalMIDIRegionsBeforeExportClaim() throws {
+    // #128 regression: a score opened from MIDI can look healthy in
+    // logic://tracks + project.get_regions while every lane is a GM Device /
+    // external-MIDI strip. That state is not audible-bounce verified, so audit
+    // must flag it before a workflow treats track/region counts as export-ready.
+    let tracks = [
+        TrackState(id: 0, name: "GM Device 1", type: .externalMIDI),
+        TrackState(id: 1, name: "Felt Keys", type: .softwareInstrument),
+    ]
+    let regions = [
+        RegionState(
+            id: "0:1:33:Imported",
+            name: "Imported",
+            trackIndex: 0,
+            startPosition: "1 1 1 1",
+            endPosition: "33 1 1 1",
+            length: "32 0 0 0"
+        ),
+    ]
+    let report = ProjectSessionAudit.buildAudit(snapshot: makeAuditSnapshot(tracks: tracks, regions: regions))
+
+    let finding = try #require(report.findings.first { $0.id == "external_midi_regions_bounce_risk" })
+    #expect(finding.severity == .blocker)
+    #expect(finding.category == "export")
+    #expect(finding.evidence.target == "0")
+    #expect(finding.evidence.values.contains("track=0,name=GM Device 1,regions=1"))
+    #expect(report.status == .failed)
+    #expect(report.evidence.exportReadiness.status == "blocked")
+    #expect(report.evidence.exportReadiness.blockers.contains("external_midi_regions_bounce_risk"))
+}
+
 @Test func testProjectAuditAndCleanupPlanResourcesAndCommandsReturnJSON() async throws {
     let cache = StateCache()
     var project = ProjectInfo()

--- a/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
+++ b/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
@@ -218,6 +218,70 @@ private func recordSequenceJSONObject(_ result: CallTool.Result) -> [String: Any
     #expect(!tempoSeen)
 }
 
+@Test func testRecordSequenceFailsClosedOnGMDeviceImportDowngrade() async throws {
+    // #128 regression: PR #150 correctly downgraded the lower-level
+    // `midi.import_file` result to State B when Logic created GM Device lanes,
+    // but `record_sequence` only checked `importResult.isSuccess`. It then
+    // verified region readback and re-promoted the take to success, allowing a
+    // visually valid but external-MIDI arrangement to reach a silent Bounce.
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let importEnvelope = HonestContract.encodeStateB(
+        reason: .importedAsGMDevice,
+        extras: [
+            "requested": "/tmp/LogicProMCP/seq.mid",
+            "track_count_before": 1,
+            "track_count_after": 2,
+            "observed_delta": 1,
+            "audible": false,
+            "gm_device_lanes": ["GM Device 1"],
+            "imported_lanes": ["GM Device 1"],
+            "file_open_dialog_seen": true,
+            "tempo_dialog_seen": true,
+        ]
+    )
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .success(importEnvelope))
+    await router.register(ax)
+
+    let trackCounts = SequentialIntBox([1, 2])
+    let regionReads = SequentialRegionReadBox([
+        .success([]),
+        .success([makeRegion(trackIndex: 1, startBar: 1, endBar: 2)]),
+    ])
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: ["notes": minimalNoteSpec(), "bar": .int(1)],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { trackCounts.next() },
+        trackNameAt: { $0 == 1 ? "GM Device 1" : nil },
+        readRegions: { regionReads.next() },
+        settleReadback: {}
+    )
+
+    let isError = try #require(result.isError)
+    #expect(isError)
+
+    let object = recordSequenceJSONObject(result)
+    let success = try #require(object["success"] as? Bool)
+    #expect(!success)
+    let verified = try #require(object["verified"] as? Bool)
+    #expect(!verified)
+    #expect(object["error"] as? String == "audibility_unverified")
+    #expect(object["failure_stage"] as? String == "midi.import_file")
+    #expect(object["import_reason"] as? String == "imported_as_gm_device")
+    #expect(object["audible"] as? Bool == false)
+    #expect(object["gm_device_lanes"] as? [String] == ["GM Device 1"])
+    // No success-provenance leakage: region readback cannot override the
+    // lower-level audible-routing downgrade.
+    #expect(object["created_track"] == nil)
+    #expect(object["verify_source"] == nil)
+    #expect(object["recorded_to_track"] == nil)
+}
+
 @Test func testRecordSequenceReturnsVerifiedRegionReadbackPayload() async {
     let cache = StateCache()
     await cache.updateDocumentState(true)

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,7 +74,7 @@ Use explicit indices or names. Track mutation fails closed when the target canno
 
 Common commands: `create_audio`, `create_instrument`, `create_drummer`, `create_external_midi`, `select`, `rename`, `delete`, `duplicate`, `mute`, `solo`, `arm`, `set_instrument`, `record_sequence`, `get_regions`.
 
-`record_sequence` writes a server-generated MIDI file under `/tmp/LogicProMCP/`, imports it into Logic, and verifies that a region or track appeared.
+`record_sequence` writes a server-generated MIDI file under `/tmp/LogicProMCP/`, imports it into Logic, and verifies the created region. If the import returns an unverified State B result, including GM Device / External MIDI lanes that can bounce silent, `record_sequence` fails closed with `audibility_unverified` or `import_unverified` instead of promoting region readback to audible success.
 
 ### `logic_mixer`
 
@@ -129,7 +129,7 @@ Common commands: `goto_bar`, `goto_marker`, `create_marker`, `delete_marker`, `r
 
 Common commands: `new`, `open`, `save`, `save_as`, `close`, `bounce`, `launch`, `quit`, `get_regions`, `export_plan`, `export_run`, `export_resume`, `audit`, `cleanup_plan`, `cleanup_apply`.
 
-Destructive or file-writing paths require confirmation. `save_as` verifies the resulting `.logicx` package. `export_plan` is read-only; `export_run` and `export_resume` re-plan, open, verify project identity, bounce, and verify artifacts via `logic_audio`.
+Destructive or file-writing paths require confirmation. `save_as` verifies the resulting `.logicx` package. `audit` marks GM Device / External MIDI tracks with MIDI regions as `external_midi_regions_bounce_risk` export blockers. `bounce` runs that preflight and returns `export_readiness_blocked` before opening the Bounce dialog when blockers are present. `export_plan` is read-only; `export_run` and `export_resume` re-plan, open, verify project identity, bounce, and verify artifacts via `logic_audio`.
 
 ### `logic_audio`
 


### PR DESCRIPTION
## Summary

Fixes #128.

- fail closed when `record_sequence` receives a lower-level `midi.import_file` State B GM Device / External MIDI audibility downgrade
- make `logic://project/audit` report `external_midi_regions_bounce_risk` as an export blocker when MIDI regions sit on GM Device / External MIDI tracks
- make `logic_project.bounce` run audit preflight and refuse `export_readiness_blocked` before opening the Bounce dialog when export blockers exist
- update public README/API/help/CHANGELOG wording so MIDI import is no longer described as automatically producing an audible Software Instrument path

## Verification

- `git diff --check`
- `swift test --filter RecordSequence --no-parallel` — 20 passed
- `swift test --filter ProjectSessionAudit --no-parallel` — 10 passed
- `swift test --filter ProjectDispatcher --no-parallel` — 23 passed
- `swift test --filter VersionConsistency --no-parallel` — 7 passed
- `swift test --filter SystemDispatcher --no-parallel` — 5 passed
- `swift build -c release`
- `swift test --no-parallel` — 1746 passed

## Notes

This PR does not merge to `main`. It only opens the reviewed branch for CI and review.