### PR TITLE
Fix #138: block transport writes behind Logic dialogs

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -13,8 +13,13 @@ struct TransportDispatcher {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
-        sleep: @escaping (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) }
+        sleep: @escaping (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
+        dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
+        if let operation = modalGuardedTransportOperation(for: command), dialogPresent() {
+            return blockingDialogResult(operation: operation)
+        }
+
         switch command {
         case "play":
             return await handleVerifiedTransportCommand(
@@ -185,6 +190,41 @@ struct TransportDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func modalGuardedTransportOperation(for command: String) -> String? {
+        switch command {
+        case "play": return "transport.play"
+        case "stop": return "transport.stop"
+        case "record": return "transport.record"
+        case "pause": return "transport.pause"
+        case "rewind": return "transport.rewind"
+        case "fast_forward": return "transport.fast_forward"
+        case "toggle_cycle": return "transport.toggle_cycle"
+        case "toggle_metronome": return "transport.toggle_metronome"
+        case "set_tempo": return "transport.set_tempo"
+        case "goto_position": return "transport.goto_position"
+        case "set_cycle_range": return "transport.set_cycle_range"
+        case "toggle_count_in": return "transport.toggle_count_in"
+        default: return nil
+        }
+    }
+
+    private static func blockingDialogResult(operation: String) -> CallTool.Result {
+        toolTextResult(
+            HonestContract.encodeStateC(
+                error: .unsupportedState,
+                hint: "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry.",
+                extras: [
+                    "operation": operation,
+                    "failure_stage": "preflight_blocking_dialog",
+                    "blocking_dialog_present": true,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ),
+            isError: true
+        )
     }
 
     private static func verifiedStopResult(

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -216,7 +216,7 @@ actor LogicProServer {
 
     // MARK: - Tool Registration (10 dispatchers)
 
-    func makeHandlers() -> LogicProServerHandlers {
+    func makeHandlers(dialogPresent: @escaping @Sendable () -> Bool = { false }) -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
         let poller = self.poller
@@ -245,7 +245,13 @@ actor LogicProServer {
                 return await Self.runWithDeadline(tool: name, command: command) {
                     switch name {
                     case "logic_transport":
-                        return await TransportDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await TransportDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            dialogPresent: dialogPresent
+                        )
                     case "logic_tracks":
                         return await TrackDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_mixer":
@@ -359,7 +365,7 @@ actor LogicProServer {
     }
 
     private func registerTools() async {
-        let handlers = makeHandlers()
+        let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -444,6 +444,31 @@ private func liveTransportJSON(
     ])
 }
 
+@Test func testTransportDispatcherRefusesWritesWhenBlockingDialogPresent() async throws {
+    let router = ChannelRouter()
+    let ax = FixedResultChannel(id: .accessibility, result: .success("should not execute"))
+    await router.register(ax)
+
+    let result = await TransportDispatcher.handle(
+        command: "set_tempo",
+        params: ["tempo": .double(78)],
+        router: router,
+        cache: StateCache(),
+        dialogPresent: { true }
+    )
+
+    #expect(result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["error"] as? String == "unsupported_state")
+    #expect(object["operation"] as? String == "transport.set_tempo")
+    #expect(object["failure_stage"] as? String == "preflight_blocking_dialog")
+    #expect(object["blocking_dialog_present"] as? Bool == true)
+    #expect(object["write_attempted"] as? Bool == false)
+
+    let executed = await ax.executedOps
+    #expect(executed.isEmpty)
+}
+
 @Test func testTransportDispatcherToggleMetronomeVerifiesViaTransportStateReadback() async throws {
     let router = ChannelRouter()
     let ax = SequencedTransportReadbackChannel(


### PR DESCRIPTION
Fixes #138

## Summary
- Add a transport dispatcher preflight that refuses mutating transport writes while a blocking Logic dialog or sheet is present.
- Return a typed State C unsupported_state envelope with operation, failure_stage, blocking_dialog_present, write_attempted=false, and safe_to_retry metadata.
- Keep test-created handlers isolated from the live app state while production tool registration injects the live dialog detector.

## Verification
- swift test --filter TransportDispatcher --no-parallel
- swift test --filter testE2ETransportSetTempoRequiresParams --no-parallel
- swift test --no-parallel
- swift build -c release