### PR TITLE
Fix #139: block track mutations behind Logic dialogs

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -17,8 +17,13 @@ struct TrackDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
+        if let operation = modalGuardedTrackOperation(for: command), dialogPresent() {
+            return blockingDialogResult(operation: operation)
+        }
+
         switch command {
         case "select":
             // Prefer index (accepts int/double/string), else match by name. If
@@ -431,6 +436,43 @@ struct TrackDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func modalGuardedTrackOperation(for command: String) -> String? {
+        switch command {
+        case "select": return "track.select"
+        case "create_audio": return "track.create_audio"
+        case "create_instrument": return "track.create_instrument"
+        case "create_drummer": return "track.create_drummer"
+        case "create_external_midi": return "track.create_external_midi"
+        case "delete": return "track.delete"
+        case "duplicate": return "track.duplicate"
+        case "rename": return "track.rename"
+        case "mute": return "track.set_mute"
+        case "solo": return "track.set_solo"
+        case "arm": return "track.set_arm"
+        case "arm_only": return "track.arm_only"
+        case "record_sequence": return "track.record_sequence"
+        case "set_automation": return "track.set_automation"
+        default: return nil
+        }
+    }
+
+    private static func blockingDialogResult(operation: String) -> CallTool.Result {
+        toolTextResult(
+            HonestContract.encodeStateC(
+                error: .unsupportedState,
+                hint: "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry.",
+                extras: [
+                    "operation": operation,
+                    "failure_stage": "preflight_blocking_dialog",
+                    "blocking_dialog_present": true,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ),
+            isError: true
+        )
     }
 
     private static func trackToggleResultIsVerified(_ result: ChannelResult) -> Bool {

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -216,7 +216,7 @@ actor LogicProServer {
 
     // MARK: - Tool Registration (10 dispatchers)
 
-    func makeHandlers() -> LogicProServerHandlers {
+    func makeHandlers(dialogPresent: @escaping @Sendable () -> Bool = { false }) -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
         let poller = self.poller
@@ -247,7 +247,13 @@ actor LogicProServer {
                     case "logic_transport":
                         return await TransportDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_tracks":
-                        return await TrackDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await TrackDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            dialogPresent: dialogPresent
+                        )
                     case "logic_mixer":
                         return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_midi":
@@ -359,7 +365,7 @@ actor LogicProServer {
     }
 
     private func registerTools() async {
-        let handlers = makeHandlers()
+        let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }

--- a/Tests/LogicProMCPTests/Issue139TrackMutationOcclusionHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue139TrackMutationOcclusionHonestTests.swift
@@ -47,6 +47,10 @@ struct Issue139TrackMutationOcclusionHonestTests {
             return results[operation] ?? .error("unexpected operation: \(operation)")
         }
 
+        func operations() -> [(String, [String: String])] {
+            executedOps
+        }
+
         func healthCheck() async -> ChannelHealth {
             // The channel itself is reachable — occlusion shows up in the
             // *result* (read-back unavailable / dialog never appeared), not in
@@ -73,6 +77,34 @@ struct Issue139TrackMutationOcclusionHonestTests {
     }
 
     // MARK: - State B (occluded read-back) must NOT become a false State A
+
+    @Test("create_instrument refuses while a blocking Logic dialog is present")
+    func createInstrumentRefusesBlockingDialogBeforeRouting() async throws {
+        let router = ChannelRouter()
+        let ax = OccludedToggleChannel(
+            id: .accessibility,
+            results: ["track.create_instrument": .success("should not execute")]
+        )
+        await router.register(ax)
+
+        let result = await TrackDispatcher.handle(
+            command: "create_instrument",
+            params: [:],
+            router: router,
+            cache: StateCache(),
+            dialogPresent: { true }
+        )
+
+        let isError = try #require(result.isError)
+        #expect(isError)
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(json["error"] as? String == "unsupported_state")
+        #expect(json["operation"] as? String == "track.create_instrument")
+        #expect(json["failure_stage"] as? String == "preflight_blocking_dialog")
+        #expect(json["blocking_dialog_present"] as? Bool == true)
+        #expect(json["write_attempted"] as? Bool == false)
+        #expect(await ax.operations().isEmpty)
+    }
 
     @Test("mute under occluded read-back fails closed to State B, not a false State A")
     func muteOccludedStateB() async throws {


### PR DESCRIPTION
Fixes #139

## Summary
- Add a track dispatcher preflight that refuses mutating track operations while a blocking Logic dialog or sheet is present.
- Return a typed State C unsupported_state envelope with operation, failure_stage, blocking_dialog_present, write_attempted=false, and safe_to_retry metadata.
- Keep direct test handlers isolated from live app modal state while production tool registration injects the live dialog detector.

## Verification
- swift test --filter createInstrumentRefusesBlockingDialogBeforeRouting --no-parallel
- swift test --filter Issue139 --no-parallel
- swift test --filter TrackDispatcher --no-parallel
- swift test --no-parallel
- swift build -c release