### PR TITLE
Fix #141: block library UI commands behind Logic dialogs

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -17,7 +17,8 @@ struct TrackDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
         switch command {
         case "select":
@@ -365,6 +366,9 @@ struct TrackDispatcher {
             if !path.isEmpty { routeParams["path"] = path }
             if !category.isEmpty { routeParams["category"] = category }
             if !preset.isEmpty { routeParams["preset"] = preset }
+            if dialogPresent() {
+                return blockingDialogResult(operation: "track.set_instrument")
+            }
             let result = await router.route(
                 operation: "track.set_instrument",
                 params: routeParams
@@ -383,6 +387,9 @@ struct TrackDispatcher {
             return toolTextResult(result)
 
         case "list_library", "library":
+            if dialogPresent() {
+                return blockingDialogResult(operation: "library.list")
+            }
             let result = await router.route(operation: "library.list")
             return toolTextResult(result)
 
@@ -398,6 +405,9 @@ struct TrackDispatcher {
                     )
                 }
                 scanParams["mode"] = mode
+            }
+            if dialogPresent(), mode != "disk" {
+                return blockingDialogResult(operation: "library.scan_all")
             }
             let result = await router.route(
                 operation: "library.scan_all",
@@ -419,6 +429,9 @@ struct TrackDispatcher {
             } else {
                 settleMs = 250
             }
+            if dialogPresent() {
+                return blockingDialogResult(operation: "plugin.scan_presets")
+            }
             let result = await router.route(
                 operation: "plugin.scan_presets",
                 params: ["submenuOpenDelayMs": String(settleMs)]
@@ -431,6 +444,23 @@ struct TrackDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func blockingDialogResult(operation: String) -> CallTool.Result {
+        toolTextResult(
+            HonestContract.encodeStateC(
+                error: .unsupportedState,
+                hint: "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry.",
+                extras: [
+                    "operation": operation,
+                    "failure_stage": "preflight_blocking_dialog",
+                    "blocking_dialog_present": true,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ),
+            isError: true
+        )
     }
 
     private static func trackToggleResultIsVerified(_ result: ChannelResult) -> Bool {

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -216,7 +216,7 @@ actor LogicProServer {
 
     // MARK: - Tool Registration (10 dispatchers)
 
-    func makeHandlers() -> LogicProServerHandlers {
+    func makeHandlers(dialogPresent: @escaping @Sendable () -> Bool = { false }) -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
         let poller = self.poller
@@ -247,7 +247,13 @@ actor LogicProServer {
                     case "logic_transport":
                         return await TransportDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_tracks":
-                        return await TrackDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await TrackDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            dialogPresent: dialogPresent
+                        )
                     case "logic_mixer":
                         return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_midi":
@@ -359,7 +365,7 @@ actor LogicProServer {
     }
 
     private func registerTools() async {
-        let handlers = makeHandlers()
+        let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }

--- a/Tests/LogicProMCPTests/Issue141LibraryModalPreconditionTests.swift
+++ b/Tests/LogicProMCPTests/Issue141LibraryModalPreconditionTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Suite("Issue141 library modal preconditions")
+struct Issue141LibraryModalPreconditionTests {
+    private actor TrackingChannel: Channel {
+        nonisolated let id: ChannelID = .accessibility
+        private var executedOps: [(String, [String: String])] = []
+
+        func start() async throws {}
+        func stop() async {}
+
+        func execute(operation: String, params: [String: String]) async -> ChannelResult {
+            executedOps.append((operation, params))
+            return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+        }
+
+        func healthCheck() async -> ChannelHealth {
+            .healthy(detail: "tracking channel")
+        }
+
+        func operations() -> [(String, [String: String])] {
+            executedOps
+        }
+    }
+
+    private func call(
+        command: String,
+        params: [String: Value],
+        dialogPresent: @escaping @Sendable () -> Bool = { true }
+    ) async -> (CallTool.Result, TrackingChannel) {
+        let router = ChannelRouter()
+        let channel = TrackingChannel()
+        await router.register(channel)
+        let result = await TrackDispatcher.handle(
+            command: command,
+            params: params,
+            router: router,
+            cache: StateCache(),
+            dialogPresent: dialogPresent
+        )
+        return (result, channel)
+    }
+
+    @Test("set_instrument refuses before routing while a blocking dialog is present")
+    func setInstrumentRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(
+            command: "set_instrument",
+            params: ["index": .int(1), "path": .string("Bass/Sub Bass")]
+        )
+
+        let isError = try #require(result.isError)
+        #expect(isError)
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(json["error"] as? String == "unsupported_state")
+        #expect(json["operation"] as? String == "track.set_instrument")
+        #expect(json["failure_stage"] as? String == "preflight_blocking_dialog")
+        #expect(json["blocking_dialog_present"] as? Bool == true)
+        #expect(json["write_attempted"] as? Bool == false)
+        #expect(await channel.operations().isEmpty)
+    }
+
+    @Test("list_library refuses before routing while a blocking dialog is present")
+    func listLibraryRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(command: "list_library", params: [:])
+
+        let isError = try #require(result.isError)
+        #expect(isError)
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(json["error"] as? String == "unsupported_state")
+        #expect(json["operation"] as? String == "library.list")
+        #expect(json["failure_stage"] as? String == "preflight_blocking_dialog")
+        #expect(await channel.operations().isEmpty)
+    }
+
+    @Test("scan_plugin_presets refuses before routing while a blocking dialog is present")
+    func scanPluginPresetsRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(command: "scan_plugin_presets", params: [:])
+
+        let isError = try #require(result.isError)
+        #expect(isError)
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(json["error"] as? String == "unsupported_state")
+        #expect(json["operation"] as? String == "plugin.scan_presets")
+        #expect(json["failure_stage"] as? String == "preflight_blocking_dialog")
+        #expect(await channel.operations().isEmpty)
+    }
+
+    @Test("disk-only scan_library remains available while a blocking dialog is present")
+    func diskOnlyScanLibraryBypassesBlockingDialogGuard() async throws {
+        let (result, channel) = await call(
+            command: "scan_library",
+            params: ["mode": .string("disk")]
+        )
+
+        let isError = try #require(result.isError)
+        #expect(!isError)
+        #expect(await channel.operations().map(\.0) == ["library.scan_all"])
+    }
+}


### PR DESCRIPTION
Fixes #141

## Summary
- Add a dialog preflight for UI-facing library operations: set_instrument, list_library, non-disk scan_library, and scan_plugin_presets.
- Return a typed State C unsupported_state envelope with operation, failure_stage, blocking_dialog_present, write_attempted=false, and safe_to_retry metadata before any routed UI write/read occurs.
- Preserve disk-only scan_library while a dialog is present because it does not depend on the live Library UI.

## Verification
- swift test --filter Issue141 --no-parallel
- swift test --filter TrackDispatcher --no-parallel
- swift test --filter SetInstrument --no-parallel
- swift test --no-parallel
- swift build -c release