### PR TITLE
Fix #144: block project lifecycle behind Logic dialogs

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -30,6 +30,7 @@ struct ProjectDispatcher {
             await executeAppleScript(script)
         },
         sleep: (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
+        dialogPresent: @escaping @Sendable () -> Bool = { false },
         // #27 Phase 2 — injectable export-execution seams (identity readback,
         // audio analysis, file polling). Defaults to the live wiring; tests
         // inject fakes so the guarded state machine is unit-testable headless.
@@ -99,6 +100,10 @@ struct ProjectDispatcher {
                 audit(command, phase: .rejected, reason: "invalid export plan")
                 return toolTextResult("\(command) invalid_params: \(error)", isError: true)
             }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.\(command)")
+            }
             // The destructive confirmation is enforced INSIDE the executor (it
             // must be checked per-run before any open/bounce). Audit the
             // execution intent here; the executor's confirmed:false path returns
@@ -131,6 +136,10 @@ struct ProjectDispatcher {
             }
 
         case "new":
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.new")
+            }
             audit(command, phase: .executed)
             let result = await router.route(operation: "project.new")
             // v3.1.2 (P0-3) — clear cache on lifecycle success so the next
@@ -161,6 +170,10 @@ struct ProjectDispatcher {
                 audit(command, phase: .confirmationRequired)
                 return toolTextResult(response)
             }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.open")
+            }
             audit(command, phase: .executed)
             let result = await router.route(
                 operation: "project.open",
@@ -171,6 +184,10 @@ struct ProjectDispatcher {
             return toolTextResult(result)
 
         case "save":
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.save")
+            }
             audit(command, phase: .executed)
             // #110: save is an export/bounce prerequisite. The read-back
             // verification lives in the AppleScript channel (the reliable
@@ -195,6 +212,10 @@ struct ProjectDispatcher {
                 audit(command, phase: .confirmationRequired)
                 return toolTextResult(response)
             }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.save_as")
+            }
             audit(command, phase: .executed)
             let result = await router.route(
                 operation: "project.save_as",
@@ -218,6 +239,10 @@ struct ProjectDispatcher {
                 audit(command, phase: .confirmationRequired)
                 return toolTextResult(response)
             }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.close")
+            }
             audit(command, phase: .executed)
             let result = await router.route(
                 operation: "project.close",
@@ -235,6 +260,10 @@ struct ProjectDispatcher {
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
                 return toolTextResult(response)
+            }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.bounce")
             }
             let preflight = await ProjectSessionAudit.buildAudit(cache: cache)
             if let block = bouncePreflightBlock(preflight) {
@@ -281,6 +310,10 @@ struct ProjectDispatcher {
             }
 
         case "cleanup_apply":
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.cleanup_apply")
+            }
             return await handleCleanupApply(params: params, router: router, cache: cache)
 
         case "launch":
@@ -310,6 +343,10 @@ struct ProjectDispatcher {
                 audit(command, phase: .rejected, reason: "not running")
                 return toolTextResult("Logic Pro is not running")
             }
+            if dialogPresent() {
+                audit(command, phase: .rejected, reason: "blocking dialog")
+                return blockingDialogResult(operation: "project.quit")
+            }
             audit(command, phase: .executed)
             return await runLifecycleScript(
                 script: "tell application \"Logic Pro\" to quit",
@@ -327,6 +364,23 @@ struct ProjectDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func blockingDialogResult(operation: String) -> CallTool.Result {
+        toolTextResult(
+            HonestContract.encodeStateC(
+                error: .unsupportedState,
+                hint: "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry.",
+                extras: [
+                    "operation": operation,
+                    "failure_stage": "preflight_blocking_dialog",
+                    "blocking_dialog_present": true,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ),
+            isError: true
+        )
     }
 
     // MARK: - cleanup_apply (#28) — guarded execution of a cleanup-plan step

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -216,7 +216,7 @@ actor LogicProServer {
 
     // MARK: - Tool Registration (10 dispatchers)
 
-    func makeHandlers() -> LogicProServerHandlers {
+    func makeHandlers(dialogPresent: @escaping @Sendable () -> Bool = { false }) -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
         let poller = self.poller
@@ -257,7 +257,13 @@ actor LogicProServer {
                     case "logic_navigate":
                         return await NavigateDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_project":
-                        return await ProjectDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await ProjectDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            dialogPresent: dialogPresent
+                        )
                     case "logic_audio":
                         return AudioDispatcher.handle(command: command, params: cmdParams)
                     case "logic_system":
@@ -359,7 +365,7 @@ actor LogicProServer {
     }
 
     private func registerTools() async {
-        let handlers = makeHandlers()
+        let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }

--- a/Tests/LogicProMCPTests/Issue144ProjectModalPreconditionTests.swift
+++ b/Tests/LogicProMCPTests/Issue144ProjectModalPreconditionTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Suite("Issue144 project modal preconditions")
+struct Issue144ProjectModalPreconditionTests {
+    private actor TrackingProjectChannel: Channel {
+        nonisolated let id: ChannelID = .appleScript
+        private var executedOps: [(String, [String: String])] = []
+
+        func start() async throws {}
+        func stop() async {}
+
+        func execute(operation: String, params: [String: String]) async -> ChannelResult {
+            executedOps.append((operation, params))
+            return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+        }
+
+        func healthCheck() async -> ChannelHealth {
+            .healthy(detail: "tracking project channel")
+        }
+
+        func operations() -> [(String, [String: String])] {
+            executedOps
+        }
+    }
+
+    private func call(
+        command: String,
+        params: [String: Value] = [:]
+    ) async -> (CallTool.Result, TrackingProjectChannel) {
+        let router = ChannelRouter()
+        let channel = TrackingProjectChannel()
+        await router.register(channel)
+        let result = await ProjectDispatcher.handle(
+            command: command,
+            params: params,
+            router: router,
+            cache: StateCache(),
+            dialogPresent: { true }
+        )
+        return (result, channel)
+    }
+
+    @Test("project.new refuses before routing while a blocking dialog is present")
+    func projectNewRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(command: "new")
+
+        try assertBlockingDialog(result, operation: "project.new")
+        #expect(await channel.operations().isEmpty)
+    }
+
+    @Test("project.save refuses before routing while a blocking dialog is present")
+    func projectSaveRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(command: "save")
+
+        try assertBlockingDialog(result, operation: "project.save")
+        #expect(await channel.operations().isEmpty)
+    }
+
+    @Test("project.bounce refuses before routing while a blocking dialog is present")
+    func projectBounceRefusesBlockingDialog() async throws {
+        let (result, channel) = await call(
+            command: "bounce",
+            params: ["confirmed": .bool(true)]
+        )
+
+        try assertBlockingDialog(result, operation: "project.bounce")
+        #expect(await channel.operations().isEmpty)
+    }
+
+    private func assertBlockingDialog(_ result: CallTool.Result, operation: String) throws {
+        let isError = try #require(result.isError)
+        #expect(isError)
+        let json = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(json["error"] as? String == "unsupported_state")
+        #expect(json["operation"] as? String == operation)
+        #expect(json["failure_stage"] as? String == "preflight_blocking_dialog")
+        #expect(json["blocking_dialog_present"] as? Bool == true)
+        #expect(json["write_attempted"] as? Bool == false)
+    }
+}


### PR DESCRIPTION
Fixes #144

## Summary
- Add a dialog preflight for project lifecycle/export mutations including new, open, save, save_as, close, bounce, export_run/export_resume, cleanup_apply, and quit.
- Return a typed State C unsupported_state envelope with operation, failure_stage, blocking_dialog_present, write_attempted=false, and safe_to_retry metadata before route/executor work starts.
- Keep read-only project commands unchanged while ensuring a Save/Bounce sheet cannot lead to blind waits for missing artifacts.

## Verification
- swift test --filter Issue144 --no-parallel
- swift test --filter ProjectDispatcher --no-parallel
- swift test --no-parallel
- swift build -c release