### PR TITLE
fix: block silent MIDI-import bounce readiness

### DIFF
--- a/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
+++ b/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
@@ -596,6 +596,25 @@ enum ProjectSessionAudit {
             ))
         }
 
+        let softwareInstrumentAudibilityRisks = softwareInstrumentAudibilityRisks(snapshot)
+        if !softwareInstrumentAudibilityRisks.isEmpty {
+            findings.append(finding(
+                "software_instrument_regions_without_audible_plugin",
+                .blocker,
+                "export",
+                "Software Instrument tracks contain regions but have no readable instrument/plugin evidence; track and region readback alone do not prove audible Logic Bounce routing.",
+                "logic://mixer",
+                softwareInstrumentAudibilityRisks.map { String($0.track.id) }.joined(separator: ","),
+                softwareInstrumentAudibilityRisks.flatMap {
+                    [
+                        "track=\($0.track.id),name=\($0.track.name),regions=\($0.regionCount),plugins=\($0.pluginCount)",
+                        "track=\($0.track.id),plugins_source=\($0.pluginsSource),plugins_read_error=\($0.pluginsReadError)",
+                    ]
+                } + ["risk=silent_logic_bounce"],
+                "ax_live"
+            ))
+        }
+
         if !tracks.soloedIndices.isEmpty {
             findings.append(finding(
                 "soloed_tracks_present",
@@ -921,6 +940,49 @@ enum ProjectSessionAudit {
             }
             .sorted { $0.id < $1.id }
             .map { ($0, regionCounts[$0.id] ?? 0) }
+    }
+
+    private struct SoftwareInstrumentAudibilityRisk {
+        let track: TrackState
+        let regionCount: Int
+        let pluginCount: Int
+        let pluginsSource: String
+        let pluginsReadError: String
+    }
+
+    private static func softwareInstrumentAudibilityRisks(
+        _ snapshot: Snapshot
+    ) -> [SoftwareInstrumentAudibilityRisk] {
+        guard snapshot.regionsFetchedAt > .distantPast else { return [] }
+        let regionCounts = Dictionary(grouping: snapshot.regions, by: \.trackIndex).mapValues(\.count)
+        let stripsByTrack = Dictionary(grouping: snapshot.channelStrips, by: \.trackIndex).mapValues { strips in
+            strips.sorted { $0.trackIndex < $1.trackIndex }.first
+        }
+        return snapshot.tracks
+            .filter { track in
+                track.type == .softwareInstrument && (regionCounts[track.id] ?? 0) > 0
+            }
+            .compactMap { track in
+                let strip = stripsByTrack[track.id] ?? nil
+                if let strip, hasAudiblePluginEvidence(strip) {
+                    return nil
+                }
+                return SoftwareInstrumentAudibilityRisk(
+                    track: track,
+                    regionCount: regionCounts[track.id] ?? 0,
+                    pluginCount: strip?.plugins.count ?? 0,
+                    pluginsSource: strip?.pluginsSource ?? "<nil>",
+                    pluginsReadError: strip?.pluginsReadError ?? "<nil>"
+                )
+            }
+            .sorted { $0.track.id < $1.track.id }
+    }
+
+    private static func hasAudiblePluginEvidence(_ strip: ChannelStripState) -> Bool {
+        guard strip.pluginsSource == "ax", strip.pluginsReadError == nil else { return false }
+        return strip.plugins.contains { plugin in
+            !plugin.isBypassed && !plugin.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 
     private static func isExternalMIDIAudibilityRisk(_ track: TrackState) -> Bool {

--- a/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
+++ b/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
@@ -261,6 +261,70 @@ private func messySnapshot(
     #expect(report.evidence.exportReadiness.blockers.contains("external_midi_regions_bounce_risk"))
 }
 
+@Test func testProjectAuditBlocksSoftwareInstrumentRegionsWithoutPluginEvidenceBeforeExportClaim() throws {
+    // #174 regression: a MIDI-import demo can show software-instrument tracks
+    // plus visible regions but still render a silent Logic Bounce when no
+    // instrument/plugin evidence is readable. Track/region readback alone is
+    // not export-ready audibility evidence.
+    let tracks = [
+        TrackState(id: 0, name: "Imported Keys", type: .softwareInstrument),
+    ]
+    let regions = [
+        RegionState(
+            id: "0:1:33:Imported Keys",
+            name: "Imported Keys",
+            trackIndex: 0,
+            startPosition: "1 1 1 1",
+            endPosition: "33 1 1 1",
+            length: "32 0 0 0"
+        ),
+    ]
+    var strip = ChannelStripState(trackIndex: 0)
+    strip.plugins = []
+    strip.pluginsSource = "ax"
+    let report = ProjectSessionAudit.buildAudit(
+        snapshot: makeAuditSnapshot(tracks: tracks, regions: regions, channelStrips: [strip])
+    )
+
+    let finding = try #require(report.findings.first {
+        $0.id == "software_instrument_regions_without_audible_plugin"
+    })
+    #expect(finding.severity == .blocker)
+    #expect(finding.category == "export")
+    #expect(finding.evidence.target == "0")
+    #expect(finding.evidence.values.contains("track=0,name=Imported Keys,regions=1,plugins=0"))
+    #expect(report.status == .failed)
+    #expect(report.evidence.exportReadiness.status == "blocked")
+    #expect(report.evidence.exportReadiness.blockers.contains("software_instrument_regions_without_audible_plugin"))
+}
+
+@Test func testProjectAuditAllowsSoftwareInstrumentRegionsWithPluginEvidence() throws {
+    let tracks = [
+        TrackState(id: 0, name: "Imported Keys", type: .softwareInstrument),
+    ]
+    let regions = [
+        RegionState(
+            id: "0:1:9:Imported Keys",
+            name: "Imported Keys",
+            trackIndex: 0,
+            startPosition: "1 1 1 1",
+            endPosition: "9 1 1 1",
+            length: "8 0 0 0"
+        ),
+    ]
+    var strip = ChannelStripState(trackIndex: 0)
+    strip.plugins = [PluginSlotState(index: 0, name: "Studio Grand", isBypassed: false)]
+    strip.pluginsSource = "ax"
+    let report = ProjectSessionAudit.buildAudit(
+        snapshot: makeAuditSnapshot(tracks: tracks, regions: regions, channelStrips: [strip])
+    )
+
+    #expect(!report.findings.contains {
+        $0.id == "software_instrument_regions_without_audible_plugin"
+    })
+    #expect(!report.evidence.exportReadiness.blockers.contains("software_instrument_regions_without_audible_plugin"))
+}
+
 @Test func testProjectAuditAndCleanupPlanResourcesAndCommandsReturnJSON() async throws {
     let cache = StateCache()
     var project = ProjectInfo()

--- a/docs/prd/PRD-issue-174-midi-import-bounce-audibility.md
+++ b/docs/prd/PRD-issue-174-midi-import-bounce-audibility.md
@@ -1,0 +1,56 @@
+# PRD: Issue 174 MIDI Import Bounce Audibility Guard
+
+**Version**: 0.1
+**Author**: Codex
+**Date**: 2026-06-23
+**Status**: Done
+**Size**: S
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Issue #174 reports a fresh demo where imported MIDI regions were visible and MCP readback showed 5 tracks / 5 regions, but the same-run Logic Bounce artifact was silent and rejected by audio analysis.
+
+### 1.2 Problem Definition
+Track and region readback alone must not be treated as export readiness for MIDI-backed software instrument content unless the session also has readable audible plugin/instrument evidence.
+
+### 1.3 Impact of Not Solving
+Demo/export tooling can spend time rendering a final artifact that is predictably silent, leaving the failure to a late audio guard rather than blocking before the Bounce dialog.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [x] G1: Project audit marks software-instrument tracks with regions but no readable plugin evidence as export blockers.
+- [x] G2: `logic_project.bounce` preflight inherits the blocker through existing export readiness handling.
+- [x] G3: Existing audio/external-MIDI bounce readiness behavior remains unchanged.
+
+### 2.2 Non-Goals
+- NG1: Automatically load or mutate instruments during bounce.
+- NG2: Replace post-bounce audio analysis.
+- NG3: Infer audibility from track/region counts alone.
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Fail Before Silent Bounce
+**As a** demo/export runner, **I want** MIDI-backed software-instrument regions without readable audible plugin evidence to block export readiness, **so that** a likely silent bounce is refused before rendering.
+
+**Acceptance Criteria:**
+- [x] AC-1.1: Given a software-instrument track with regions and no plugin evidence, when project audit runs, then it emits a blocker finding.
+- [x] AC-1.2: Given the blocker, when export readiness is computed, then status is `blocked` and blockers include the new finding id.
+- [x] AC-1.3: Given software-instrument regions with readable plugin evidence, when audit runs, then the new blocker is not emitted.
+
+## 4. Technical Design
+
+### 4.3 API Design
+No public API shape change. Existing `logic://project/audit` and `logic_project.bounce` preflight surface the new finding through existing `findings` and `export_readiness.blockers`.
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | External MIDI / GM Device regions | Existing `external_midi_regions_bounce_risk` blocker remains authoritative | P0 |
+| E2 | Audio tracks with audio regions | New software-instrument audibility blocker does not apply | P1 |
+| E3 | Software instrument regions with readable plugin evidence | Export readiness is not blocked by the new guard | P1 |
+| E4 | Software instrument regions with stale/unreadable mixer evidence | Block before bounce | P0 |

--- a/docs/tickets/issue-174-midi-import-bounce-audibility/STATUS.md
+++ b/docs/tickets/issue-174-midi-import-bounce-audibility/STATUS.md
@@ -1,0 +1,17 @@
+# Pipeline Status: Issue 174 MIDI Import Bounce Audibility Guard
+
+**PRD**: docs/prd/PRD-issue-174-midi-import-bounce-audibility.md
+**Size**: S
+**Current Phase**: 8
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | Add audit blocker for MIDI-backed software instrument tracks without audible plugin evidence | Done | Pass | S fast-track |
+
+## Review History
+
+| Phase | Round | Verdict | P0 | P1 | P2 | Notes |
+|-------|-------|---------|----|----|----|-------|
+| 6 | 1 | Pass | 0 | 0 | 0 | Red/Green targeted tests passed; diff scoped to audit guard, regression tests, and pipeline docs |

--- a/docs/tickets/issue-174-midi-import-bounce-audibility/T1-audit-audible-plugin-evidence.md
+++ b/docs/tickets/issue-174-midi-import-bounce-audibility/T1-audit-audible-plugin-evidence.md
@@ -1,0 +1,60 @@
+# T1: Add Audit Blocker For Software Instrument Regions Without Audible Plugin Evidence
+
+**PRD Ref**: PRD-issue-174-midi-import-bounce-audibility > US-1
+**Priority**: P0 (Blocker)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: None
+
+---
+
+## 1. Objective
+Prevent MIDI-import demo/export sessions from claiming bounce readiness when software-instrument tracks have regions but no readable instrument/plugin evidence.
+
+## 2. Acceptance Criteria
+- [x] AC-1: Audit emits `software_instrument_regions_without_audible_plugin` as a blocker when software-instrument tracks with regions lack plugin evidence.
+- [x] AC-2: Export readiness status becomes `blocked` and includes the blocker.
+- [x] AC-3: The blocker is absent when readable plugin evidence exists for the same track.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `testProjectAuditBlocksSoftwareInstrumentRegionsWithoutPluginEvidenceBeforeExportClaim` | Unit | Software-instrument track with region and no plugin evidence | Blocker finding + export readiness blocked |
+| 2 | `testProjectAuditAllowsSoftwareInstrumentRegionsWithPluginEvidence` | Unit | Same region plus readable plugin evidence | No new blocker |
+
+### 3.2 Test File Location
+- `Tests/LogicProMCPTests/ProjectSessionAuditTests.swift`
+
+### 3.3 Mock/Setup Required
+- Synthetic `ProjectSessionAudit.Snapshot`
+- Synthetic `ChannelStripState`
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+| File | Change Type | Description |
+|------|------------|-------------|
+| `Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift` | Modify | Add deterministic blocker over snapshot tracks/regions/mixer evidence |
+| `Tests/LogicProMCPTests/ProjectSessionAuditTests.swift` | Modify | Add regression coverage |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Add failing unit tests for missing/present plugin evidence.
+2. Add pure helper to find software-instrument tracks with regions and no readable plugin evidence.
+3. Emit blocker finding and let existing export readiness aggregation include it.
+
+## 5. Edge Cases
+- Software-instrument track with regions and stale mixer readback blocks.
+- External MIDI tracks remain covered by the existing blocker.
+- Audio tracks are not affected.
+
+## 6. Review Checklist
+- [x] Red: 테스트 실행 → FAILED 확인됨
+- [x] Green: 테스트 실행 → PASSED 확인됨
+- [x] Refactor: 테스트 실행 → PASSED 유지 확인됨
+- [x] AC 전부 충족
+- [x] 기존 테스트 깨지지 않음
+- [x] 코드 스타일 준수
+- [x] 불필요한 변경 없음


### PR DESCRIPTION
## Summary
- add an export-readiness blocker when software-instrument tracks have regions but no readable AX plugin/instrument evidence
- keep existing external MIDI bounce-risk behavior unchanged
- add dev-pipeline PRD/ticket artifacts for issue #174

## Tests
- swift test --filter testProjectAuditBlocksSoftwareInstrumentRegionsWithoutPluginEvidenceBeforeExportClaim
- swift test --skip-build --filter testProjectAuditAllowsSoftwareInstrumentRegionsWithPluginEvidence
- swift test --skip-build --filter testProjectAuditBlocksExternalMIDIRegionsBeforeExportClaim
- swift test --skip-build --filter testProjectAudit
- git diff --check

Closes #174