### PR TITLE
fix: guard live MIDI QA against Controller Assignments Learn Mode

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -18,6 +18,7 @@ import time
 import uuid
 from pathlib import Path
 
+from logic_controller_learn_mode import DEFAULT_CONTROLLER_LEARN_MODE_POLICY, guard_controller_learn_mode
 from logic_session_bootstrap import bootstrap_fresh_logic_session
 from logic_free_tempo_modal import DEFAULT_FREE_TEMPO_POLICY, detect_free_tempo_modal, resolve_free_tempo_modal
 
@@ -354,6 +355,8 @@ def tool_text(resp):
 
 
 def is_error(resp):
+    if isinstance(resp, dict) and "gate" in resp:
+        return True
     try: return resp["result"].get("isError", False)
     except: return "error" in resp
 
@@ -372,6 +375,41 @@ def safe_json(text):
 def tool_json(resp):
     value = safe_json(tool_text(resp))
     return value if isinstance(value, dict) else None
+
+
+def controller_learn_guard_is_clear(result):
+    return isinstance(result, dict) and result.get("status") == "clear"
+
+
+def controller_learn_guard_reason(result):
+    if not isinstance(result, dict):
+        return "controller assignments Learn Mode guard returned no result"
+    status = result.get("status", "unknown")
+    reason = result.get("reason", status)
+    return f"controller assignments Learn Mode guard {status}: {reason}"
+
+
+def guarded_live_tool_call(client, tool, command, params=None, *, ready, reason, timeout=None):
+    if not ready:
+        return {
+            "gate": reason,
+            "policy_id": DEFAULT_CONTROLLER_LEARN_MODE_POLICY["policy_id"],
+            "tool": tool,
+            "command": command,
+        }
+    return call_tool(client, tool, command, params, timeout=timeout)
+
+
+def guarded_live_midi_call(client, command, params=None, *, ready, reason, timeout=None):
+    return guarded_live_tool_call(
+        client,
+        "logic_midi",
+        command,
+        params,
+        ready=ready,
+        reason=reason,
+        timeout=timeout,
+    )
 
 
 def verified_or_explicitly_unverified(resp):
@@ -796,6 +834,37 @@ def main():
     r = call_tool(client, "logic_system", "refresh_cache")
     T("system.refresh_cache succeeds", r, lambda _: not is_error(r))
 
+    controller_learn_guard = {
+        "status": "skipped",
+        "policy_id": DEFAULT_CONTROLLER_LEARN_MODE_POLICY["policy_id"],
+        "reason": "Logic Pro + Accessibility are required",
+    }
+    controller_learn_clear = False
+    controller_learn_reason = "Logic Pro + Accessibility are required"
+    if live_logic_ready:
+        controller_learn_guard = guard_controller_learn_mode()
+        controller_learn_clear = controller_learn_guard_is_clear(controller_learn_guard)
+        controller_learn_reason = (
+            "controller assignments Learn Mode guard clear"
+            if controller_learn_clear
+            else controller_learn_guard_reason(controller_learn_guard)
+        )
+
+    T_LIVE(
+        "controller assignments Learn Mode guard is clear",
+        {"result": controller_learn_guard},
+        lambda _: controller_learn_clear,
+        live_logic_ready,
+        controller_learn_reason,
+    )
+
+    midi_live_execute_ready = midi_live_ready and controller_learn_clear
+    midi_live_execute_reason = (
+        controller_learn_reason
+        if midi_live_ready and not controller_learn_clear
+        else "Logic Pro + CoreMIDI are required"
+    )
+
     # ═══════════════════════════════════════════════════════════════
     # §3 Transport Live Operations (20 tests)
     # ═══════════════════════════════════════════════════════════════
@@ -996,6 +1065,12 @@ def main():
         fresh_transport_live_ready, fresh_transport_reason = fresh_transport_bootstrap_status(client)
         if not fresh_transport_live_ready:
             fresh_transport_reason = f"fresh bootstrap not detected: {fresh_transport_reason}"
+    fresh_transport_execute_ready = fresh_transport_live_ready and controller_learn_clear
+    fresh_transport_execute_reason = (
+        controller_learn_reason
+        if fresh_transport_live_ready and not controller_learn_clear
+        else fresh_transport_reason
+    )
 
     select_for_record = {"gate": fresh_transport_reason}
     arm_for_record = {"gate": fresh_transport_reason}
@@ -1024,7 +1099,7 @@ def main():
     disarm_after_transport = {"gate": fresh_transport_reason}
     disarm_track = None
 
-    if fresh_transport_live_ready:
+    if fresh_transport_execute_ready:
         select_for_record = call_tool(client, "logic_tracks", "select", {"index": 0})
         arm_for_record = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": True})
         arm_track = wait_for_track_arm(client, 0, True)
@@ -1036,7 +1111,13 @@ def main():
             lambda state: state.get("isPlaying") is False and state.get("isRecording") is False,
         )
 
-        record_resp = call_tool(client, "logic_transport", "record")
+        record_resp = guarded_live_tool_call(
+            client,
+            "logic_transport",
+            "record",
+            ready=fresh_transport_execute_ready,
+            reason=fresh_transport_execute_reason,
+        )
         record_env = tool_json(record_resp)
         record_state = wait_for_transport_state(
             client,
@@ -1090,18 +1171,25 @@ def main():
         fresh_transport_reason,
     )
     T_LIVE(
+        "controller assignments Learn Mode guard is clear before transport record",
+        {"result": controller_learn_guard},
+        lambda _: controller_learn_clear,
+        fresh_transport_live_ready,
+        fresh_transport_execute_reason,
+    )
+    T_LIVE(
         "transport record prep selects track 0",
         select_for_record,
         lambda _: not is_error(select_for_record),
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport record prep arms track 0",
         arm_for_record,
         lambda _: not is_error(arm_for_record) and isinstance(arm_track, dict) and arm_track.get("isArmed") is True,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.stop returns verified unchanged when already stopped",
@@ -1113,8 +1201,8 @@ def main():
         and isinstance(stop_unchanged_state, dict)
         and stop_unchanged_state.get("isPlaying") is False
         and stop_unchanged_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.record reaches verified recording state",
@@ -1125,8 +1213,8 @@ def main():
         and isinstance(record_state, dict)
         and record_state.get("isPlaying") is True
         and record_state.get("isRecording") is True,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.stop reaches verified stopped state after record",
@@ -1137,8 +1225,8 @@ def main():
         and isinstance(stop_after_record_state, dict)
         and stop_after_record_state.get("isPlaying") is False
         and stop_after_record_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.stop stays verified unchanged after record stop",
@@ -1150,8 +1238,8 @@ def main():
         and isinstance(stop_after_record_unchanged_state, dict)
         and stop_after_record_unchanged_state.get("isPlaying") is False
         and stop_after_record_unchanged_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.play reaches verified playback state",
@@ -1162,8 +1250,8 @@ def main():
         and isinstance(play_state, dict)
         and play_state.get("isPlaying") is True
         and play_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.play stays verified unchanged while already playing",
@@ -1175,8 +1263,8 @@ def main():
         and isinstance(play_unchanged_state, dict)
         and play_unchanged_state.get("isPlaying") is True
         and play_unchanged_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport.stop reaches verified stopped state after play",
@@ -1187,15 +1275,15 @@ def main():
         and isinstance(final_stop_state, dict)
         and final_stop_state.get("isPlaying") is False
         and final_stop_state.get("isRecording") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
     T_LIVE(
         "transport record prep disarms track 0 after transport checks",
         disarm_after_transport,
         lambda _: not is_error(disarm_after_transport) and isinstance(disarm_track, dict) and disarm_track.get("isArmed") is False,
-        fresh_transport_live_ready,
-        fresh_transport_reason,
+        fresh_transport_execute_ready,
+        fresh_transport_execute_reason,
     )
 
     r = call_tool(client, "logic_transport", "toggle_count_in")
@@ -1643,76 +1731,181 @@ def main():
 
     # Note range
     for note in [0, 21, 60, 108, 127]:
-        r = call_tool(client, "logic_midi", "send_note", {"note": note, "velocity": 80, "duration_ms": 30})
-        T_LIVE(f"midi.send_note({note}) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+        r = guarded_live_midi_call(
+            client,
+            "send_note",
+            {"note": note, "velocity": 80, "duration_ms": 30},
+            ready=midi_live_execute_ready,
+            reason=midi_live_execute_reason,
+        )
+        T_LIVE(f"midi.send_note({note}) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Velocity range
     for vel in [1, 64, 127]:
-        r = call_tool(client, "logic_midi", "send_note", {"note": 60, "velocity": vel, "duration_ms": 30})
-        T_LIVE(f"midi.send_note vel={vel} succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+        r = guarded_live_midi_call(
+            client,
+            "send_note",
+            {"note": 60, "velocity": vel, "duration_ms": 30},
+            ready=midi_live_execute_ready,
+            reason=midi_live_execute_reason,
+        )
+        T_LIVE(f"midi.send_note vel={vel} succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Channel range
     for ch in [1, 8, 16]:
-        r = call_tool(client, "logic_midi", "send_note", {"note": 60, "channel": ch, "duration_ms": 30})
-        T_LIVE(f"midi.send_note ch={ch} succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+        r = guarded_live_midi_call(
+            client,
+            "send_note",
+            {"note": 60, "channel": ch, "duration_ms": 30},
+            ready=midi_live_execute_ready,
+            reason=midi_live_execute_reason,
+        )
+        T_LIVE(f"midi.send_note ch={ch} succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Chord
-    r = call_tool(client, "logic_midi", "send_chord", {"notes": "60,64,67", "duration_ms": 30})
-    T_LIVE("midi.send_chord C major succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_chord",
+        {"notes": "60,64,67", "duration_ms": 30},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_chord C major succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
-    r = call_tool(client, "logic_midi", "send_chord", {"notes": "60,63,67,70", "duration_ms": 30})
-    T_LIVE("midi.send_chord Cm7 succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_chord",
+        {"notes": "60,63,67,70", "duration_ms": 30},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_chord Cm7 succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # CC range
     for cc in [1, 7, 10, 11, 64, 120, 123]:
-        r = call_tool(client, "logic_midi", "send_cc", {"controller": cc, "value": 64})
-        T_LIVE(f"midi.send_cc({cc}) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+        r = guarded_live_midi_call(
+            client,
+            "send_cc",
+            {"controller": cc, "value": 64},
+            ready=midi_live_execute_ready,
+            reason=midi_live_execute_reason,
+        )
+        T_LIVE(f"midi.send_cc({cc}) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Program change
-    r = call_tool(client, "logic_midi", "send_program_change", {"program": 0})
-    T_LIVE("midi.send_program_change(0) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_program_change",
+        {"program": 0},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_program_change(0) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
-    r = call_tool(client, "logic_midi", "send_program_change", {"program": 127})
-    T_LIVE("midi.send_program_change(127) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_program_change",
+        {"program": 127},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_program_change(127) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Pitch bend
-    r = call_tool(client, "logic_midi", "send_pitch_bend", {"value": 8192})
-    T_LIVE("midi.send_pitch_bend(center) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_pitch_bend",
+        {"value": 8192},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_pitch_bend(center) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
-    r = call_tool(client, "logic_midi", "send_pitch_bend", {"value": 16383})
-    T_LIVE("midi.send_pitch_bend(max) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_pitch_bend",
+        {"value": 16383},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_pitch_bend(max) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Aftertouch
-    r = call_tool(client, "logic_midi", "send_aftertouch", {"value": 100})
-    T_LIVE("midi.send_aftertouch succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_aftertouch",
+        {"value": 100},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_aftertouch succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # MMC
-    r = call_tool(client, "logic_midi", "mmc_play")
-    T_LIVE("midi.mmc_play succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
-    call_tool(client, "logic_midi", "mmc_stop")  # restore
+    r = guarded_live_midi_call(
+        client,
+        "mmc_play",
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.mmc_play succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
+    guarded_live_midi_call(
+        client,
+        "mmc_stop",
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )  # restore
 
-    r = call_tool(client, "logic_midi", "mmc_stop")
-    T_LIVE("midi.mmc_stop succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "mmc_stop",
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.mmc_stop succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
-    r = call_tool(client, "logic_midi", "mmc_locate", {"bar": 1})
+    r = guarded_live_midi_call(
+        client,
+        "mmc_locate",
+        {"bar": 1},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
     T_LIVE(
         "midi.mmc_locate(bar=1) verifies or reports readback mismatch",
         r,
         lambda _: verified_or_readback_mismatch(r),
-        live_logic_ready,
-        "Logic Pro + Accessibility are required",
+        midi_live_execute_ready,
+        midi_live_execute_reason,
     )
 
     # Step input
-    r = call_tool(client, "logic_midi", "step_input", {"note": 60, "duration": "1/4"})
-    T_LIVE("midi.step_input(1/4) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "step_input",
+        {"note": 60, "duration": "1/4"},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.step_input(1/4) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
-    r = call_tool(client, "logic_midi", "step_input", {"note": 60, "duration": "1/8"})
-    T_LIVE("midi.step_input(1/8) succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "step_input",
+        {"note": 60, "duration": "1/8"},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.step_input(1/8) succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # Duration cap (our P2 fix)
-    r = call_tool(client, "logic_midi", "send_note", {"note": 60, "duration_ms": 50})
-    T_LIVE("midi.send_note small duration succeeds", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_note",
+        {"note": 60, "duration_ms": 50},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("midi.send_note small duration succeeds", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # ═══════════════════════════════════════════════════════════════
     # §7 Edit Commands (14 tests)
@@ -1996,10 +2189,22 @@ def main():
     # 20 MIDI notes in rapid succession on main client
     rapid_ok = 0
     for i in range(20):
-        r = call_tool(client, "logic_midi", "send_note", {"note": 60 + (i % 12), "duration_ms": 20})
+        r = guarded_live_midi_call(
+            client,
+            "send_note",
+            {"note": 60 + (i % 12), "duration_ms": 20},
+            ready=midi_live_execute_ready,
+            reason=midi_live_execute_reason,
+        )
         if r and not is_error(r):
             rapid_ok += 1
-    T_LIVE(f"20 rapid MIDI notes: {rapid_ok}/20 ok", "ok", lambda _: rapid_ok >= 18, midi_live_ready, "Logic Pro + CoreMIDI are required")
+    T_LIVE(
+        f"20 rapid MIDI notes: {rapid_ok}/20 ok",
+        "ok",
+        lambda _: rapid_ok >= 18,
+        midi_live_execute_ready,
+        midi_live_execute_reason,
+    )
 
     # 20 concurrent resource reads
     def read_n_times(n):
@@ -2131,8 +2336,20 @@ def main():
 
     # Large duration should be capped to 30s (our P2 fix) — test with shorter value
     # to verify the capping logic doesn't hang the actor
-    r = call_tool(client, "logic_midi", "send_note", {"note": 60, "duration_ms": 100})
-    T_LIVE("midi.send_note short duration ok", r, lambda _: r is not None and not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_note",
+        {"note": 60, "duration_ms": 100},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE(
+        "midi.send_note short duration ok",
+        r,
+        lambda _: r is not None and not is_error(r),
+        midi_live_execute_ready,
+        midi_live_execute_reason,
+    )
 
     # MIDI port name edge case
     r = call_tool(client, "logic_midi", "create_virtual_port", {"name": "a" * 200})
@@ -2187,8 +2404,14 @@ def main():
         T_LIVE("LogicProMCP-Scripter virtual port visible", "ok", lambda _: "Scripter" in all_ports or "LogicProMCP" in all_ports, core_midi_ready, "CoreMIDI virtual ports are unavailable")
 
     # Send a full MIDI sequence (chord)
-    r = call_tool(client, "logic_midi", "send_chord", {"notes": "60,64,67,72", "duration_ms": 30})
-    T_LIVE("send chord (4 notes) completes", r, lambda _: not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    r = guarded_live_midi_call(
+        client,
+        "send_chord",
+        {"notes": "60,64,67,72", "duration_ms": 30},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
+    T_LIVE("send chord (4 notes) completes", r, lambda _: not is_error(r), midi_live_execute_ready, midi_live_execute_reason)
 
     # ═══════════════════════════════════════════════════════════════
     # §17b Fresh Record Modal Guard (7 tests)
@@ -2197,11 +2420,13 @@ def main():
 
     fresh_record_live_ready = False
     fresh_record_reason = "fresh Logic bootstrap with 1 track and 0 regions is required"
-    if live_logic_ready and midi_live_ready and has_document:
+    if live_logic_ready and midi_live_execute_ready and has_document:
         call_tool(client, "logic_system", "refresh_cache", timeout=3)
         fresh_record_live_ready, fresh_record_reason = fresh_record_bootstrap_status(client)
         if not fresh_record_live_ready:
             fresh_record_reason = f"fresh bootstrap not detected: {fresh_record_reason}"
+    elif live_logic_ready and midi_live_ready and has_document and not controller_learn_clear:
+        fresh_record_reason = controller_learn_reason
 
     preflight_modal = {"status": "skipped", "policy_id": DEFAULT_FREE_TEMPO_POLICY["policy_id"]}
     select_for_record = {"gate": fresh_record_reason}
@@ -2227,12 +2452,19 @@ def main():
             select_for_record = call_tool(client, "logic_tracks", "select", {"index": 0})
             arm_for_record = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": True})
             arm_track = wait_for_track_arm(client, 0, True)
-            record_resp = call_tool(client, "logic_transport", "record")
-            midi_record_pass = call_tool(
+            record_resp = guarded_live_tool_call(
                 client,
-                "logic_midi",
+                "logic_transport",
+                "record",
+                ready=midi_live_execute_ready,
+                reason=midi_live_execute_reason,
+            )
+            midi_record_pass = guarded_live_midi_call(
+                client,
                 "play_sequence",
                 {"notes": "60,0,180,104;64,250,180,100;67,500,240,108"},
+                ready=midi_live_execute_ready,
+                reason=midi_live_execute_reason,
                 timeout=20,
             )
             stop_after_record = call_tool(client, "logic_transport", "stop")
@@ -2254,6 +2486,13 @@ def main():
         lambda _: fresh_record_live_ready,
         fresh_record_live_ready,
         fresh_record_reason,
+    )
+    T_LIVE(
+        "controller assignments Learn Mode guard is clear before fresh MIDI record",
+        {"result": controller_learn_guard},
+        lambda _: controller_learn_clear,
+        live_logic_ready and midi_live_ready and has_document,
+        controller_learn_reason,
     )
     T_LIVE(
         "free tempo modal policy is recorded for fresh record flow",
@@ -2354,9 +2593,21 @@ def main():
 
     # MIDI send should be fast
     t0 = time.time()
-    r = call_tool(client, "logic_midi", "send_cc", {"controller": 7, "value": 100})
+    r = guarded_live_midi_call(
+        client,
+        "send_cc",
+        {"controller": 7, "value": 100},
+        ready=midi_live_execute_ready,
+        reason=midi_live_execute_reason,
+    )
     elapsed = time.time() - t0
-    T_LIVE(f"MIDI CC send < 0.5s ({elapsed:.3f}s)", r, lambda _: elapsed < 0.5 and not is_error(r), midi_live_ready, "Logic Pro + CoreMIDI are required")
+    T_LIVE(
+        f"MIDI CC send < 0.5s ({elapsed:.3f}s)",
+        r,
+        lambda _: elapsed < 0.5 and not is_error(r),
+        midi_live_execute_ready,
+        midi_live_execute_reason,
+    )
 
     # ═══════════════════════════════════════════════════════════════
     # §19 Memory & Stability (3 tests)

--- a/Scripts/logic_controller_learn_mode.py
+++ b/Scripts/logic_controller_learn_mode.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Detect Logic Pro Controller Assignments Learn Mode before live MIDI QA."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from typing import Any
+
+PROCESS_NAME = "Logic Pro"
+
+DEFAULT_CONTROLLER_LEARN_MODE_POLICY: dict[str, Any] = {
+    "policy_id": "controller_assignments_learn_mode_guard",
+    "candidate_markers": [
+        "Controller Assignments",
+        "Control Surfaces",
+        "Learn Mode",
+        "This control is already assigned",
+        "already assigned",
+        "컨트롤러 할당",
+        "컨트롤 표면",
+        "학습 모드",
+        "이미 할당",
+    ],
+    "assignment_prompt_markers": [
+        "This control is already assigned",
+        "already assigned",
+        "assigned to another parameter",
+        "control is assigned",
+        "이미 할당",
+    ],
+    "learn_mode_markers": [
+        "Learn Mode",
+        "학습 모드",
+    ],
+}
+
+
+def _normalize_label(value: Any) -> str:
+    return " ".join(str(value).replace("…", "...").replace("\u00a0", " ").split()).casefold()
+
+
+def _is_truthy(value: Any) -> bool:
+    return _normalize_label(value) in {"1", "true", "yes", "on", "selected", "checked"}
+
+
+def _marker_matches(value: Any, markers: list[str]) -> bool:
+    normalized = _normalize_label(value)
+    return any(_normalize_label(marker) in normalized for marker in markers)
+
+
+def _list_values(snapshot: dict[str, Any], key: str) -> list[Any]:
+    value = snapshot.get(key, [])
+    return value if isinstance(value, list) else []
+
+
+def _snapshot_labels(snapshot: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    title = snapshot.get("title")
+    if isinstance(title, str) and title:
+        labels.append(title)
+    for key in ("static_texts", "buttons", "menu_items"):
+        for item in _list_values(snapshot, key):
+            if isinstance(item, str) and item:
+                labels.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("name"), str):
+                labels.append(item["name"])
+    for control in _snapshot_controls(snapshot):
+        name = control.get("name")
+        if isinstance(name, str) and name:
+            labels.append(name)
+    return labels
+
+
+def _snapshot_controls(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    controls: list[dict[str, Any]] = []
+    for key in ("checkboxes", "radio_buttons", "controls"):
+        for item in _list_values(snapshot, key):
+            if isinstance(item, str):
+                controls.append({"name": item, "value": ""})
+            elif isinstance(item, dict) and isinstance(item.get("name"), str):
+                controls.append(item)
+    return controls
+
+
+def classify_controller_learn_mode(
+    snapshot: dict[str, Any],
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    active_policy = deepcopy(policy or DEFAULT_CONTROLLER_LEARN_MODE_POLICY)
+    status = snapshot.get("status", "error")
+    base: dict[str, Any] = {"policy_id": active_policy["policy_id"]}
+
+    if status in {"not_present", "inactive"}:
+        return {**base, "status": "inactive", "reason": status}
+    if status == "error":
+        result = {**base, "status": "error", "reason": snapshot.get("reason", "detect_error")}
+        if snapshot.get("stderr"):
+            result["stderr"] = snapshot["stderr"]
+        return result
+
+    labels = _snapshot_labels(snapshot)
+    prompt_labels = [
+        label for label in labels
+        if _marker_matches(label, active_policy["assignment_prompt_markers"])
+    ]
+    if status == "active" or prompt_labels:
+        return {
+            **base,
+            "status": "active",
+            "reason": snapshot.get("reason", "assignment_prompt_present"),
+            "evidence": {
+                "labels": prompt_labels or labels,
+                "title": snapshot.get("title", ""),
+            },
+        }
+
+    for control in _snapshot_controls(snapshot):
+        if _marker_matches(control.get("name", ""), active_policy["learn_mode_markers"]) and _is_truthy(
+            control.get("value", "")
+        ):
+            return {
+                **base,
+                "status": "active",
+                "reason": "learn_mode_enabled",
+                "evidence": {
+                    "control": control,
+                    "labels": labels,
+                    "title": snapshot.get("title", ""),
+                },
+            }
+
+    return {
+        **base,
+        "status": "inactive",
+        "reason": "no_active_learn_mode_evidence",
+        "evidence": {
+            "labels": labels,
+            "controls": _snapshot_controls(snapshot),
+            "title": snapshot.get("title", ""),
+        },
+    }
+
+
+class SystemEventsControllerLearnModeRunner:
+    """Read Logic's Controller Assignments UI via System Events JXA."""
+
+    def __init__(
+        self,
+        policy: dict[str, Any] | None = None,
+        run=subprocess.run,
+    ) -> None:
+        self.policy = deepcopy(policy or DEFAULT_CONTROLLER_LEARN_MODE_POLICY)
+        self._run = run
+
+    def _osascript(self, source: str, timeout: float = 12.0) -> subprocess.CompletedProcess[str]:
+        return self._run(
+            ["/usr/bin/osascript", "-l", "JavaScript"],
+            input=source,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+
+    def _jxa_source(self) -> str:
+        candidate_markers = json.dumps(self.policy["candidate_markers"], ensure_ascii=False)
+        return f"""
+const CANDIDATE_MARKERS = {candidate_markers};
+
+function safe(fn, fallback) {{
+  try {{
+    return fn();
+  }} catch (error) {{
+    return fallback;
+  }}
+}}
+
+function str(value) {{
+  return value === undefined || value === null ? "" : String(value);
+}}
+
+function safeName(item) {{
+  const name = safe(() => item.name(), "");
+  if (name) return str(name);
+  const description = safe(() => item.description(), "");
+  if (description) return str(description);
+  return str(safe(() => item.value(), ""));
+}}
+
+function namesOf(collection) {{
+  const output = [];
+  for (let index = 0; index < collection.length; index += 1) {{
+    const name = safeName(collection[index]);
+    if (name) output.push(name);
+  }}
+  return output;
+}}
+
+function namedStates(collection) {{
+  const output = [];
+  for (let index = 0; index < collection.length; index += 1) {{
+    const item = collection[index];
+    const name = safeName(item) || "<unnamed>";
+    output.push({{ name, value: str(safe(() => item.value(), "")) }});
+  }}
+  return output;
+}}
+
+function containsMarker(values) {{
+  return values.some((value) => CANDIDATE_MARKERS.some((marker) => str(value).includes(marker)));
+}}
+
+function collection(container, roleName) {{
+  if (roleName === "button") return safe(() => container.buttons(), []);
+  if (roleName === "checkbox") return safe(() => container.checkboxes(), []);
+  if (roleName === "radio button") return safe(() => container.radioButtons(), []);
+  if (roleName === "static text") return safe(() => container.staticTexts(), []);
+  if (roleName === "menu item") return safe(() => container.menuItems(), []);
+  return [];
+}}
+
+function snapshot(container, kind, title) {{
+  return {{
+    status: "present",
+    kind,
+    title,
+    buttons: namesOf(collection(container, "button")),
+    checkboxes: namedStates(collection(container, "checkbox")),
+    radio_buttons: namedStates(collection(container, "radio button")),
+    static_texts: namesOf(collection(container, "static text")),
+    menu_items: namesOf(collection(container, "menu item")),
+  }};
+}}
+
+function labelsFor(candidate) {{
+  return [candidate.title].concat(
+    candidate.buttons,
+    candidate.static_texts,
+    candidate.menu_items,
+    candidate.checkboxes.map((item) => item.name),
+    candidate.radio_buttons.map((item) => item.name)
+  );
+}}
+
+function findCandidate() {{
+  const systemEvents = Application("System Events");
+  const process = systemEvents.processes.byName("{PROCESS_NAME}");
+  if (!safe(() => process.exists(), false)) return {{ status: "not_present", reason: "logic_not_running" }};
+  const windows = safe(() => process.windows(), []);
+  for (let windowIndex = 0; windowIndex < windows.length; windowIndex += 1) {{
+    const win = windows[windowIndex];
+    const title = str(safe(() => win.name(), ""));
+    const sheets = safe(() => win.sheets(), []);
+    for (let sheetIndex = 0; sheetIndex < sheets.length; sheetIndex += 1) {{
+      const sheet = sheets[sheetIndex];
+      const sheetTitle = str(safe(() => sheet.name(), title)) || title;
+      const sheetSnapshot = snapshot(sheet, "sheet", sheetTitle);
+      if (containsMarker(labelsFor(sheetSnapshot))) return sheetSnapshot;
+    }}
+
+    const windowSnapshot = snapshot(win, "window", title);
+    if (containsMarker(labelsFor(windowSnapshot))) return windowSnapshot;
+  }}
+  return {{ status: "not_present" }};
+}}
+
+JSON.stringify(findCandidate());
+"""
+
+    def _json_result(self, result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+        try:
+            parsed = json.loads(result.stdout.strip() or "{}")
+        except json.JSONDecodeError:
+            return {
+                "status": "error",
+                "reason": "invalid_jxa_output",
+                "stderr": (result.stderr or "").strip(),
+                "stdout": (result.stdout or "").strip(),
+            }
+        return parsed if isinstance(parsed, dict) else {"status": "error", "reason": "invalid_jxa_output"}
+
+    def detect(self) -> dict[str, Any]:
+        try:
+            result = self._osascript(self._jxa_source())
+        except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+            return {"status": "error", "reason": "osascript_failed", "stderr": str(error)}
+        if result.returncode != 0:
+            return {
+                "status": "error",
+                "reason": "osascript_failed",
+                "stderr": (result.stderr or "").strip(),
+            }
+        return self._json_result(result)
+
+
+def detect_controller_learn_mode(
+    runner: SystemEventsControllerLearnModeRunner | None = None,
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    active_policy = deepcopy(policy or DEFAULT_CONTROLLER_LEARN_MODE_POLICY)
+    snapshot = (runner or SystemEventsControllerLearnModeRunner(active_policy)).detect()
+    classified = classify_controller_learn_mode(snapshot, active_policy)
+    classified["snapshot"] = snapshot
+    return classified
+
+
+def guard_controller_learn_mode(
+    runner: SystemEventsControllerLearnModeRunner | None = None,
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    active_policy = deepcopy(policy or DEFAULT_CONTROLLER_LEARN_MODE_POLICY)
+    snapshot = (runner or SystemEventsControllerLearnModeRunner(active_policy)).detect()
+    classified = classify_controller_learn_mode(snapshot, active_policy)
+    result: dict[str, Any] = {
+        "policy_id": active_policy["policy_id"],
+        "before": snapshot,
+        "classification": classified,
+    }
+
+    if classified.get("status") == "inactive":
+        result["status"] = "clear"
+        result["reason"] = classified.get("reason", "inactive")
+    elif classified.get("status") == "active":
+        result["status"] = "blocked"
+        result["reason"] = classified.get("reason", "active")
+        if isinstance(classified.get("evidence"), dict):
+            result["evidence"] = classified["evidence"]
+    else:
+        result["status"] = "error"
+        result["reason"] = classified.get("reason", "detect_error")
+        if classified.get("stderr"):
+            result["stderr"] = classified["stderr"]
+    return result
+
+
+def _main(argv: list[str]) -> int:
+    command = argv[1] if len(argv) > 1 else "guard"
+    if command == "detect":
+        payload = detect_controller_learn_mode()
+    elif command == "guard":
+        payload = guard_controller_learn_mode()
+    else:
+        print("usage: logic_controller_learn_mode.py [detect|guard]", file=sys.stderr)
+        return 2
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))

--- a/Scripts/logic_controller_learn_mode_test.py
+++ b/Scripts/logic_controller_learn_mode_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Unit coverage for the Logic Controller Assignments Learn Mode guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from logic_controller_learn_mode import (
+    DEFAULT_CONTROLLER_LEARN_MODE_POLICY,
+    classify_controller_learn_mode,
+    guard_controller_learn_mode,
+)
+
+
+class FakeRunner:
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+        self.detect_calls = 0
+
+    def detect(self):
+        self.detect_calls += 1
+        return self.snapshot
+
+
+class ControllerLearnModeGuardTests(unittest.TestCase):
+    def test_inactive_snapshot_is_clear(self):
+        result = guard_controller_learn_mode(
+            runner=FakeRunner(
+                {
+                    "status": "present",
+                    "title": "Tracks",
+                    "buttons": [],
+                    "checkboxes": [],
+                    "static_texts": ["Tracks"],
+                }
+            )
+        )
+
+        self.assertEqual(result["status"], "clear")
+        self.assertEqual(result["policy_id"], DEFAULT_CONTROLLER_LEARN_MODE_POLICY["policy_id"])
+
+    def test_assignment_prompt_blocks(self):
+        result = guard_controller_learn_mode(
+            runner=FakeRunner(
+                {
+                    "status": "present",
+                    "title": "Controller Assignments",
+                    "buttons": ["Cancel", "OK"],
+                    "checkboxes": [],
+                    "static_texts": ["This control is already assigned to another parameter."],
+                }
+            )
+        )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "assignment_prompt_present")
+        self.assertIn("This control is already assigned", " ".join(result["evidence"]["labels"]))
+
+    def test_enabled_learn_mode_checkbox_blocks(self):
+        result = guard_controller_learn_mode(
+            runner=FakeRunner(
+                {
+                    "status": "present",
+                    "title": "Controller Assignments",
+                    "buttons": [],
+                    "checkboxes": [{"name": "Learn Mode", "value": "1"}],
+                    "static_texts": ["Controller Assignments"],
+                }
+            )
+        )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "learn_mode_enabled")
+        self.assertEqual(result["evidence"]["control"]["name"], "Learn Mode")
+
+    def test_detect_error_returns_error_with_policy_id(self):
+        result = guard_controller_learn_mode(
+            runner=FakeRunner({"status": "error", "reason": "osascript_failed", "stderr": "denied"})
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["reason"], "osascript_failed")
+        self.assertEqual(result["policy_id"], DEFAULT_CONTROLLER_LEARN_MODE_POLICY["policy_id"])
+
+    def test_classifier_accepts_not_present_as_inactive(self):
+        result = classify_controller_learn_mode({"status": "not_present"})
+
+        self.assertEqual(result["status"], "inactive")
+        self.assertEqual(result["reason"], "not_present")
+
+
+class LiveE2EGuardedCallTests(unittest.TestCase):
+    def test_guarded_live_tool_call_does_not_call_client_when_blocked(self):
+        module_path = Path(__file__).with_name("live-e2e-test.py")
+        spec = importlib.util.spec_from_file_location("live_e2e_test_module", module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, timeout=None):
+                self.calls.append((message, timeout))
+                return {"result": {"content": [{"type": "text", "text": "called"}]}}
+
+        client = FakeClient()
+        result = module.guarded_live_tool_call(
+            client,
+            "logic_midi",
+            "play_sequence",
+            {"notes": "60,0,100"},
+            ready=False,
+            reason="controller assignments Learn Mode guard blocked",
+        )
+
+        self.assertEqual(client.calls, [])
+        self.assertEqual(result["gate"], "controller assignments Learn Mode guard blocked")
+        self.assertEqual(result["tool"], "logic_midi")
+        self.assertEqual(result["command"], "play_sequence")
+        self.assertTrue(module.is_error(result))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/release-stable.sh
+++ b/Scripts/release-stable.sh
@@ -91,9 +91,10 @@ if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
     exit 1
 fi
 
-run python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_session_bootstrap.py Scripts/logic_session_bootstrap_test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py
+run python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_session_bootstrap.py Scripts/logic_session_bootstrap_test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/logic_controller_learn_mode.py Scripts/logic_controller_learn_mode_test.py
 run python3 Scripts/logic_session_bootstrap_test.py
 run python3 Scripts/logic_free_tempo_modal_test.py
+run python3 Scripts/logic_controller_learn_mode_test.py
 run swift test --no-parallel
 run swift build -c release
 

--- a/docs/prd/PRD-issue-175-controller-learn-mode-guard.md
+++ b/docs/prd/PRD-issue-175-controller-learn-mode-guard.md
@@ -1,0 +1,61 @@
+# PRD: Issue 175 Controller Assignments Learn Mode Guard
+
+**Version**: 0.1
+**Author**: Codex
+**Date**: 2026-06-23
+**Status**: Done
+**Size**: S
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Issue #175 reports Logic Pro Controller Assignments Learn Mode intercepting live MIDI/key-command demo operations and opening assignment prompts during recording and playback smoke checks.
+
+### 1.2 Problem Definition
+Live demo QA must detect active Controller Assignments Learn Mode or assignment prompts before sending MIDI playback or starting recording. If the state cannot be verified clear, the tooling must fail/skip with a clear diagnostic before driving live MIDI.
+
+### 1.3 Impact of Not Solving
+MIDI playback and transport record tests can hang behind Logic prompts, mutate controller assignments, and leave failures attributed to later record/readback checks instead of the real UI precondition.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [x] G1: Provide a deterministic helper that classifies Controller Assignments Learn Mode as clear, blocked, or detection error.
+- [x] G2: Gate live-e2e MIDI smoke calls and `logic_midi.play_sequence` on a clear Learn Mode guard.
+- [x] G3: Gate live-e2e `logic_transport.record` calls on the same guard.
+- [x] G4: Surface policy id, reason, and UI evidence when blocked.
+
+### 2.2 Non-Goals
+- NG1: Automatically disable Learn Mode or alter Controller Assignments.
+- NG2: Change MCP production dispatcher behavior for ordinary clients.
+- NG3: Add localization beyond English and Korean markers currently needed by demo QA.
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Fail Before Learn Mode Intercepts MIDI
+**As a** live demo QA runner, **I want** Learn Mode detected before MIDI playback or transport record, **so that** active controller-learning UI is reported directly instead of blocking the run mid-command.
+
+**Acceptance Criteria:**
+- [x] AC-1.1: Given an assignment prompt snapshot, the guard returns blocked with `assignment_prompt_present`.
+- [x] AC-1.2: Given a Controller Assignments Learn Mode control with a truthy value, the guard returns blocked with `learn_mode_enabled`.
+- [x] AC-1.3: Given no active Learn Mode evidence, the guard returns clear.
+- [x] AC-1.4: live-e2e does not call MIDI playback or transport record when the guard is not clear.
+
+## 4. Technical Design
+
+### 4.1 Helper
+Add `Scripts/logic_controller_learn_mode.py` with an injectable System Events/JXA runner and pure classifier.
+
+### 4.2 Live E2E Wiring
+Run the guard after Logic health readiness is known. Use the result to gate live MIDI smoke calls, `logic_midi.play_sequence`, and `logic_transport.record` sections.
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | Assignment prompt already open | Block before live MIDI/record | P0 |
+| E2 | Controller Assignments Learn Mode checkbox is active | Block before live MIDI/record | P0 |
+| E3 | Detector cannot run | Return error with reason/stderr and do not execute guarded live calls | P1 |
+| E4 | Logic is not running | Guard is inactive; existing live readiness gates skip operations | P2 |

--- a/docs/tickets/issue-175-controller-learn-mode-guard/STATUS.md
+++ b/docs/tickets/issue-175-controller-learn-mode-guard/STATUS.md
@@ -1,0 +1,17 @@
+# Pipeline Status: Issue 175 Controller Assignments Learn Mode Guard
+
+**PRD**: docs/prd/PRD-issue-175-controller-learn-mode-guard.md
+**Size**: S
+**Current Phase**: 8
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | Add Controller Assignments Learn Mode guard for live MIDI QA | Done | Pass | S fast-track |
+
+## Review History
+
+| Phase | Round | Verdict | P0 | P1 | P2 | Notes |
+|-------|-------|---------|----|----|----|-------|
+| 6 | 1 | Pass | 0 | 0 | 0 | Red/Green targeted tests passed; live-e2e guarded call sites reviewed; release validation updated |

--- a/docs/tickets/issue-175-controller-learn-mode-guard/T1-controller-learn-mode-guard.md
+++ b/docs/tickets/issue-175-controller-learn-mode-guard/T1-controller-learn-mode-guard.md
@@ -1,0 +1,65 @@
+# T1: Add Controller Assignments Learn Mode Guard For Live MIDI QA
+
+**PRD Ref**: PRD-issue-175-controller-learn-mode-guard > US-1
+**Priority**: P0 (Blocker)
+**Size**: S (< 2h)
+**Status**: Done
+**Depends On**: None
+
+---
+
+## 1. Objective
+Prevent live-e2e MIDI playback and transport record calls from running while Logic Controller Assignments Learn Mode or assignment prompts are active.
+
+## 2. Acceptance Criteria
+- [x] AC-1: Assignment prompts block with `assignment_prompt_present`.
+- [x] AC-2: Enabled Learn Mode controls block with `learn_mode_enabled`.
+- [x] AC-3: Inactive snapshots return clear.
+- [x] AC-4: live-e2e guarded call sites return gate payloads instead of calling live MIDI/record when the guard is not clear.
+
+## 3. TDD Spec (Red Phase)
+
+### 3.1 Test Cases
+
+| # | Test Name | Type | Description | Expected |
+|---|-----------|------|-------------|----------|
+| 1 | `test_assignment_prompt_blocks` | Unit | Assignment prompt labels present | Blocked diagnostic |
+| 2 | `test_enabled_learn_mode_checkbox_blocks` | Unit | Learn Mode checkbox truthy | Blocked diagnostic |
+| 3 | `test_inactive_snapshot_is_clear` | Unit | No marker/control evidence | Clear |
+| 4 | `test_detect_error_returns_error_with_policy_id` | Unit | Detector error | Error diagnostic |
+
+### 3.2 Test File Location
+- `Scripts/logic_controller_learn_mode_test.py`
+
+### 3.3 Mock/Setup Required
+- Fake runner returning static UI snapshots.
+
+## 4. Implementation Guide
+
+### 4.1 Files to Modify
+| File | Change Type | Description |
+|------|------------|-------------|
+| `Scripts/logic_controller_learn_mode.py` | Add | Pure classifier plus JXA runner |
+| `Scripts/logic_controller_learn_mode_test.py` | Add | Regression tests |
+| `Scripts/live-e2e-test.py` | Modify | Gate live MIDI/record call sites |
+| `Scripts/release-stable.sh` | Modify | Include helper/test in release script validation |
+
+### 4.2 Implementation Steps (Green Phase)
+1. Add failing unit tests for clear, prompt, active Learn Mode, and detector error.
+2. Implement the pure classifier and injectable System Events runner.
+3. Add helper functions in live-e2e to gate guarded live calls before side effects.
+4. Run Python unit tests, py_compile, and targeted text checks.
+
+## 5. Edge Cases
+- Detector error must not allow guarded live MIDI calls to run.
+- Non-strict live-e2e can skip guarded operations with a clear reason.
+- Strict live-e2e fails the guard test when Learn Mode is active or detector errors.
+
+## 6. Review Checklist
+- [x] Red: 테스트 실행 → FAILED 확인됨
+- [x] Green: 테스트 실행 → PASSED 확인됨
+- [x] Refactor: 테스트 실행 → PASSED 유지 확인됨
+- [x] AC 전부 충족
+- [x] 기존 테스트 깨지지 않음
+- [x] 코드 스타일 준수
+- [x] 불필요한 변경 없음


### PR DESCRIPTION
## Summary
- add a Logic Controller Assignments Learn Mode detector/guard with clear, blocked, and error diagnostics
- gate live-e2e MIDI smoke calls, logic_midi.play_sequence, and logic_transport.record before driving live MIDI/record operations
- include the new helper/test in release validation and add dev-pipeline PRD/ticket artifacts

## Tests
- python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_controller_learn_mode.py Scripts/logic_controller_learn_mode_test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/logic_session_bootstrap.py Scripts/logic_session_bootstrap_test.py
- python3 Scripts/logic_controller_learn_mode_test.py
- python3 Scripts/logic_free_tempo_modal_test.py
- python3 Scripts/logic_session_bootstrap_test.py
- swift test --filter InstallScriptContractTests
- swift test --skip-build --filter InstallScriptContractTests
- git diff --check

Closes #175