### PR TITLE
fix: require MIDI import region readback

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -4366,6 +4366,71 @@ actor AccessibilityChannel: Channel {
         }
     }
 
+    enum MIDIImportRegionReadback {
+        case success([RegionInfo])
+        case failure(String)
+    }
+
+    private static func defaultMIDIImportRegionInfos(
+        runtime: AXLogicProElements.Runtime
+    ) -> MIDIImportRegionReadback {
+        switch enumerateRegionItems(runtime: runtime) {
+        case .success(let result):
+            return .success(result.regions.map { $0.info })
+        case .failure(let error):
+            return .failure(error.message)
+        }
+    }
+
+    private static func midiImportRegionKey(_ region: RegionInfo) -> String {
+        [
+            region.name,
+            String(region.trackIndex),
+            String(region.startBar),
+            String(region.endBar),
+            region.kind,
+        ].joined(separator: "|")
+    }
+
+    private static func midiImportRegionFields(_ region: RegionInfo) -> [String: Any] {
+        var fields: [String: Any] = [
+            "name": region.name,
+            "track_index": region.trackIndex,
+            "start_bar": region.startBar,
+            "end_bar": region.endBar,
+            "kind": region.kind,
+        ]
+        if let rawHelp = region.rawHelp, !rawHelp.isEmpty {
+            fields["raw_help"] = rawHelp
+        }
+        return fields
+    }
+
+    private static func newMIDIRegionsForImport(
+        afterRegions: [RegionInfo],
+        beforeRegionKeys: Set<String>?,
+        beforeCount: Int,
+        afterCount: Int
+    ) -> [RegionInfo] {
+        afterRegions.filter { region in
+            region.kind.lowercased() == "midi"
+                && region.trackIndex >= beforeCount
+                && region.trackIndex < afterCount
+                && beforeRegionKeys?.contains(midiImportRegionKey(region)) != true
+        }
+    }
+
+    private static func addedMIDIRegionsForImport(
+        afterRegions: [RegionInfo],
+        beforeRegionKeys: Set<String>?
+    ) -> [RegionInfo] {
+        guard let beforeRegionKeys else { return [] }
+        return afterRegions.filter { region in
+            region.kind.lowercased() == "midi"
+                && !beforeRegionKeys.contains(midiImportRegionKey(region))
+        }
+    }
+
     /// Import a .mid file via Logic Pro's File → Import → MIDI File menu.
     /// Always creates a new MIDI track (Logic Pro's built-in behavior, OQ-3 confirmed).
     /// Uses osascript to coordinate the menu click, path-entry keystroke, and dialog dismissals.
@@ -4389,6 +4454,7 @@ actor AccessibilityChannel: Channel {
         executeScript: @escaping @Sendable (String) async -> ChannelResult = { await AppleScriptChannel.executeAppleScript($0) },
         trackCount: (@Sendable () -> Int)? = nil,
         trackNames: (@Sendable () -> [String])? = nil,
+        regionInfos: (@Sendable () -> MIDIImportRegionReadback)? = nil,
         deltaPoll: @escaping @Sendable () async -> Void = { try? await Task.sleep(nanoseconds: 100_000_000) }
     ) async -> ChannelResult {
         guard FileManager.default.fileExists(atPath: path) else {
@@ -4404,7 +4470,22 @@ actor AccessibilityChannel: Channel {
                 AXValueExtractors.extractTrackState(from: header, index: index, runtime: runtime.ax).name
             }
         }
+        let readRegionInfos = regionInfos ?? {
+            defaultMIDIImportRegionInfos(runtime: runtime)
+        }
         let beforeCount = readTrackCount()
+        let beforeRegionRead = readRegionInfos()
+        let beforeRegions: [RegionInfo]?
+        let beforeRegionError: String?
+        switch beforeRegionRead {
+        case .success(let regions):
+            beforeRegions = regions
+            beforeRegionError = nil
+        case .failure(let error):
+            beforeRegions = nil
+            beforeRegionError = error
+        }
+        let beforeRegionKeys = beforeRegions.map { Set($0.map(midiImportRegionKey)) }
         let escapedPath = path.replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         // Poll the file-open sheet into existence (mirrors the
@@ -4659,6 +4740,49 @@ actor AccessibilityChannel: Channel {
                 "file_open_dialog_seen": fileOpenSeen,
                 "tempo_dialog_seen": tempoSeen,
             ]
+            if let beforeRegions {
+                extras["region_count_before"] = beforeRegions.count
+            }
+            if let beforeRegionError {
+                extras["region_readback_before_error"] = beforeRegionError
+            }
+            var afterRegions: [RegionInfo]?
+            var afterRegionError: String?
+            var addedRegions: [RegionInfo] = []
+            var importedRegions: [RegionInfo] = []
+            for attempt in 0..<10 {
+                switch readRegionInfos() {
+                case .success(let regions):
+                    afterRegions = regions
+                    afterRegionError = nil
+                    addedRegions = addedMIDIRegionsForImport(
+                        afterRegions: regions,
+                        beforeRegionKeys: beforeRegionKeys
+                    )
+                    importedRegions = newMIDIRegionsForImport(
+                        afterRegions: regions,
+                        beforeRegionKeys: beforeRegionKeys,
+                        beforeCount: beforeCount,
+                        afterCount: afterCount
+                    )
+                    if !importedRegions.isEmpty { break }
+                case .failure(let error):
+                    afterRegionError = error
+                }
+                if attempt < 9 {
+                    await deltaPoll()
+                }
+            }
+            if let afterRegions {
+                extras["region_count_after"] = afterRegions.count
+                extras["new_midi_region_count"] = addedRegions.count
+                extras["new_midi_regions"] = addedRegions.map(midiImportRegionFields)
+                extras["imported_region_count"] = importedRegions.count
+                extras["imported_regions"] = importedRegions.map(midiImportRegionFields)
+            }
+            if let afterRegionError {
+                extras["region_readback_after_error"] = afterRegionError
+            }
             guard afterCount > beforeCount else {
                 return .error(HonestContract.encodeStateC(
                     error: .readbackMismatch,
@@ -4679,6 +4803,20 @@ actor AccessibilityChannel: Channel {
                 extras["hint"] = "Imported SMF lanes \(gmLanes) are GM Device / external-MIDI synth lanes that route to a General MIDI device and may bounce SILENT. Assign an audible Software Instrument (e.g. create a Software Instrument track and copy the regions, or re-import onto a Software Instrument track) before relying on the bounce."
                 return .success(HonestContract.encodeStateB(
                     reason: .importedAsGMDevice,
+                    extras: extras
+                ))
+            }
+            if let afterRegionError {
+                return .error(HonestContract.encodeStateC(
+                    error: .readbackUnavailable,
+                    hint: "midi.import_file created a new track, but AX region readback was unavailable: \(afterRegionError)",
+                    extras: extras
+                ))
+            }
+            guard !importedRegions.isEmpty else {
+                return .error(HonestContract.encodeStateC(
+                    error: .readbackMismatch,
+                    hint: "midi.import_file created a new track but did not create a verifiable MIDI region",
                     extras: extras
                 ))
             }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -7,6 +7,34 @@ private func decodeAccessibilityJSON(_ s: String) -> [String: Any] {
     (try? JSONSerialization.jsonObject(with: Data(s.utf8))) as? [String: Any] ?? [:]
 }
 
+private final class MIDIRegionReadbackSequence: @unchecked Sendable {
+    private var values: [AccessibilityChannel.MIDIImportRegionReadback]
+    private let lock = NSLock()
+
+    init(_ values: [AccessibilityChannel.MIDIImportRegionReadback]) {
+        self.values = values
+    }
+
+    func next() -> AccessibilityChannel.MIDIImportRegionReadback {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !values.isEmpty else { return .success([]) }
+        if values.count == 1 { return values[0] }
+        return values.removeFirst()
+    }
+}
+
+private func midiRegionForImport(trackIndex: Int) -> RegionInfo {
+    RegionInfo(
+        name: "Imported MIDI",
+        trackIndex: trackIndex,
+        startBar: 1,
+        endBar: 2,
+        kind: "midi",
+        rawHelp: nil
+    )
+}
+
 private func axPoint(_ x: CGFloat, _ y: CGFloat) -> AXValue {
     var point = CGPoint(x: x, y: y)
     return AXValueCreate(.cgPoint, &point)!
@@ -1113,12 +1141,17 @@ private func makeSetInstrumentFixture() -> (
         }
     }
     let counter = Counter()
+    let regions = MIDIRegionReadbackSequence([
+        .success([]),
+        .success([midiRegionForImport(trackIndex: 2)]),
+    ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
         trackNames: { ["Studio Grand", "01 Felt Keys"] },
+        regionInfos: { regions.next() },
         deltaPoll: {}
     )
 
@@ -1214,12 +1247,17 @@ private func makeSetInstrumentFixture() -> (
         func next() -> Int { values.removeFirst() }
     }
     let counter = Counter()
+    let regions = MIDIRegionReadbackSequence([
+        .success([]),
+        .success([midiRegionForImport(trackIndex: 1)]),
+    ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
         trackNames: { ["Studio Grand", "01 Felt Keys"] },
+        regionInfos: { regions.next() },
         deltaPoll: {}
     )
 

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -97,37 +97,92 @@ struct Issue108Tests {
         return path
     }
 
-    @Test("import_file returns verified State A when a new track appears")
-    func importVerifiedOnTrackDelta() async {
+    private final class RegionSnapshotBox: @unchecked Sendable {
+        private var values: [AccessibilityChannel.MIDIImportRegionReadback]
+        private let lock = NSLock()
+
+        init(_ values: [AccessibilityChannel.MIDIImportRegionReadback]) {
+            self.values = values
+        }
+
+        func next() -> AccessibilityChannel.MIDIImportRegionReadback {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !values.isEmpty else { return .success([]) }
+            if values.count == 1 { return values[0] }
+            return values.removeFirst()
+        }
+    }
+
+    private func importedRegion(trackIndex: Int = 1) -> RegionInfo {
+        RegionInfo(
+            name: "Imported MIDI",
+            trackIndex: trackIndex,
+            startBar: 1,
+            endBar: 2,
+            kind: "midi",
+            rawHelp: nil
+        )
+    }
+
+    @Test("import_file returns verified State A when a new track and MIDI region appear")
+    func importVerifiedOnTrackAndRegionDelta() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let counter = CallCounter([1, 2]) // before=1, after=2
+        let regions = RegionSnapshotBox([.success([]), .success([importedRegion()])])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
             trackNames: { ["Studio Grand", "Imported"] },
+            regionInfos: { regions.next() },
             deltaPoll: {}
         )
         #expect(result.isSuccess)
         let o = (try? JSONSerialization.jsonObject(with: Data(result.message.utf8))) as? [String: Any]
         #expect(o?["observed_delta"] as? Int == 1)
         #expect(o?["track_count_after"] as? Int == 2)
+        #expect(o?["imported_region_count"] as? Int == 1)
+    }
+
+    @Test("import_file fails closed when a new track appears without a MIDI region")
+    func importFailsClosedOnTrackDeltaWithoutRegion() async {
+        let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
+        let counter = CallCounter([1, 2])
+        let regions = RegionSnapshotBox([.success([]), .success([])])
+        let result = await AccessibilityChannel.defaultImportMIDIFile(
+            path: path,
+            executeScript: { _ in .success("OK") },
+            trackCount: { counter.next() },
+            trackNames: { ["Studio Grand", "Imported"] },
+            regionInfos: { regions.next() },
+            deltaPoll: {}
+        )
+        #expect(!result.isSuccess)
+        #expect(result.message.contains("readback_mismatch"))
+        #expect(result.message.contains("did not create a verifiable MIDI region"))
+        #expect(result.message.contains("\"track_count_after\":2"))
+        #expect(result.message.contains("\"region_count_after\":0"))
     }
 
     @Test("import_file fails closed when no track is created")
     func importFailsClosedOnNoDelta() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let counter = CallCounter([3, 3]) // before==after → no import landed
+        let regions = RegionSnapshotBox([.success([]), .success([])])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
             trackNames: { [] },
+            regionInfos: { regions.next() },
             deltaPoll: {}
         )
         #expect(!result.isSuccess)
         #expect(result.message.contains("readback_mismatch"))
         #expect(result.message.contains("did not create a new track"))
+        #expect(result.message.contains("\"region_count_after\":0"))
+        #expect(result.message.contains("\"new_midi_region_count\":0"))
     }
 
     @Test("import_file surfaces a typed error when the import menu click fails")

--- a/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
@@ -26,6 +26,34 @@ private func decodeIssue123JSON(_ s: String) -> [String: Any] {
     (try? JSONSerialization.jsonObject(with: Data(s.utf8))) as? [String: Any] ?? [:]
 }
 
+private final class Issue123MIDIRegionReadbackSequence: @unchecked Sendable {
+    private var values: [AccessibilityChannel.MIDIImportRegionReadback]
+    private let lock = NSLock()
+
+    init(_ values: [AccessibilityChannel.MIDIImportRegionReadback]) {
+        self.values = values
+    }
+
+    func next() -> AccessibilityChannel.MIDIImportRegionReadback {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !values.isEmpty else { return .success([]) }
+        if values.count == 1 { return values[0] }
+        return values.removeFirst()
+    }
+}
+
+private func issue123MIDIRegion(trackIndex: Int) -> RegionInfo {
+    RegionInfo(
+        name: "Imported MIDI",
+        trackIndex: trackIndex,
+        startBar: 1,
+        endBar: 2,
+        kind: "midi",
+        rawHelp: nil
+    )
+}
+
 /// Write a minimal Standard MIDI File header into the managed import directory
 /// (`/private/tmp/LogicProMCP`) so the path mirrors a real, validator-eligible
 /// import target. `defaultImportMIDIFile` requires the file to EXIST before it
@@ -123,12 +151,17 @@ func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async th
         func next() -> Int { values.removeFirst() }
     }
     let counter = Counter()
+    let regions = Issue123MIDIRegionReadbackSequence([
+        .success([]),
+        .success([issue123MIDIRegion(trackIndex: 4)]),
+    ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
         path: fixture.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
         trackNames: { ["Studio Grand", "01 Felt Keys", "02 Bass", "03 Drums", "04 Imported Lead"] },
+        regionInfos: { regions.next() },
         deltaPoll: {}
     )
 


### PR DESCRIPTION
## Summary

- capture before/after MIDI region snapshots during `logic_midi.import_file`
- require a verifiable imported MIDI region before returning State A
- include region readback counts and imported-region metadata in failure envelopes

## Verification

- `git diff --check`
- `swift test --filter "AccessibilityChannelTests|Issue108Tests|Issue123ImportOcclusionHonestTests" --no-parallel` (64 passed)
- `swift build -c release`

Closes #140
