### PR TITLE
fix: stabilize health CPU sampling

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -76,11 +76,17 @@ struct SystemDispatcher {
             let memoryMb: Double
             let cpuPercent: Double
             let uptimeSec: Int
+            let cpuPercentStatus: String
+            let cpuPercentUnits: String
+            let cpuSampleWindowSec: Double
 
             enum CodingKeys: String, CodingKey {
                 case memoryMb = "memory_mb"
                 case cpuPercent = "cpu_percent"
                 case uptimeSec = "uptime_sec"
+                case cpuPercentStatus = "cpu_percent_status"
+                case cpuPercentUnits = "cpu_percent_units"
+                case cpuSampleWindowSec = "cpu_sample_window_sec"
             }
         }
 
@@ -199,7 +205,11 @@ struct SystemDispatcher {
                 process: .init(
                     memoryMb: Double(String(format: "%.1f", process.memoryMB)) ?? process.memoryMB,
                     cpuPercent: Double(String(format: "%.1f", process.cpuPercent)) ?? process.cpuPercent,
-                    uptimeSec: process.uptimeSec
+                    uptimeSec: process.uptimeSec,
+                    cpuPercentStatus: process.cpuPercentStatus,
+                    cpuPercentUnits: process.cpuPercentUnits,
+                    cpuSampleWindowSec: Double(String(format: "%.3f", process.cpuSampleWindowSec))
+                        ?? process.cpuSampleWindowSec
                 )
             )
             let json = encodeJSON(health)

--- a/Sources/LogicProMCP/Utilities/ProcessUtils.swift
+++ b/Sources/LogicProMCP/Utilities/ProcessUtils.swift
@@ -45,6 +45,9 @@ enum ProcessUtils {
         let memoryMB: Double
         let cpuPercent: Double
         let uptimeSec: Int
+        let cpuPercentStatus: String
+        let cpuPercentUnits: String
+        let cpuSampleWindowSec: Double
     }
 
     private struct TimedPIDCache {
@@ -53,6 +56,7 @@ enum ProcessUtils {
     }
 
     private static let processStartDate = Date()
+    private static let minimumCPUSampleUptimeSec: TimeInterval = 1.0
     private static let subprocessTimeout: TimeInterval = 1.0
     private static let pidCacheTTL: TimeInterval = 0.5
     private static let pidCacheLock = NSLock()
@@ -358,13 +362,12 @@ enum ProcessUtils {
 
     /// Lightweight server-process metrics for diagnostics.
     static func currentProcessMetrics() -> ProcessMetrics {
-        let uptime = max(Date().timeIntervalSince(processStartDate), 0.001)
+        let uptime = max(Date().timeIntervalSince(processStartDate), 0)
 
         var usage = rusage()
         let usageResult = getrusage(RUSAGE_SELF, &usage)
         let userTime = Double(usage.ru_utime.tv_sec) + Double(usage.ru_utime.tv_usec) / 1_000_000
         let systemTime = Double(usage.ru_stime.tv_sec) + Double(usage.ru_stime.tv_usec) / 1_000_000
-        let cpuPercent = usageResult == 0 ? ((userTime + systemTime) / uptime) * 100.0 : 0.0
 
         var taskInfo = mach_task_basic_info()
         var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info_data_t>.stride / MemoryLayout<natural_t>.stride)
@@ -373,12 +376,43 @@ enum ProcessUtils {
                 task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), reboundPointer, &count)
             }
         }
-        let memoryMB = taskInfoResult == KERN_SUCCESS ? Double(taskInfo.resident_size) / 1_048_576 : 0.0
+        let residentMemoryBytes = taskInfoResult == KERN_SUCCESS ? UInt64(taskInfo.resident_size) : 0
+        let cpuTimeSec = usageResult == 0 ? userTime + systemTime : 0
 
+        return processMetricsForSample(
+            cpuTimeSec: cpuTimeSec,
+            uptimeSec: uptime,
+            residentMemoryBytes: residentMemoryBytes
+        )
+    }
+
+    static func processMetricsForSample(
+        cpuTimeSec: Double,
+        uptimeSec: TimeInterval,
+        residentMemoryBytes: UInt64
+    ) -> ProcessMetrics {
+        let memoryMB = Double(residentMemoryBytes) / 1_048_576
+        let uptime = max(uptimeSec, 0)
+        guard uptime >= minimumCPUSampleUptimeSec,
+              cpuTimeSec.isFinite,
+              cpuTimeSec >= 0 else {
+            return ProcessMetrics(
+                memoryMB: memoryMB,
+                cpuPercent: 0,
+                uptimeSec: Int(uptime.rounded()),
+                cpuPercentStatus: "warming_up",
+                cpuPercentUnits: "single_core_lifetime_average",
+                cpuSampleWindowSec: 0
+            )
+        }
+        let cpuPercent = (cpuTimeSec / uptime) * 100.0
         return ProcessMetrics(
             memoryMB: memoryMB,
-            cpuPercent: cpuPercent,
-            uptimeSec: Int(uptime.rounded())
+            cpuPercent: max(0, cpuPercent),
+            uptimeSec: Int(uptime.rounded()),
+            cpuPercentStatus: "sampled",
+            cpuPercentUnits: "single_core_lifetime_average",
+            cpuSampleWindowSec: uptime
         )
     }
 }

--- a/Tests/LogicProMCPTests/ProcessUtilsTests.swift
+++ b/Tests/LogicProMCPTests/ProcessUtilsTests.swift
@@ -68,6 +68,32 @@ private func makeBundleURL(version: String) throws -> URL {
     #expect(metrics.uptimeSec >= 0)
 }
 
+@Test func testProcessUtilsMarksZeroUptimeCPUAsWarmingUp() {
+    let metrics = ProcessUtils.processMetricsForSample(
+        cpuTimeSec: 0.144807,
+        uptimeSec: 0.001,
+        residentMemoryBytes: 18_559_795
+    )
+
+    #expect(metrics.memoryMB > 17)
+    #expect(metrics.cpuPercent == 0)
+    #expect(metrics.cpuPercentStatus == "warming_up")
+    #expect(metrics.cpuSampleWindowSec == 0)
+}
+
+@Test func testProcessUtilsReportsSampledCPUWithExplicitUnits() {
+    let metrics = ProcessUtils.processMetricsForSample(
+        cpuTimeSec: 1.5,
+        uptimeSec: 3.0,
+        residentMemoryBytes: 0
+    )
+
+    #expect(metrics.cpuPercent == 50)
+    #expect(metrics.cpuPercentStatus == "sampled")
+    #expect(metrics.cpuPercentUnits == "single_core_lifetime_average")
+    #expect(metrics.cpuSampleWindowSec == 3)
+}
+
 @Test func testProcessUtilsRuntimeControlsPIDAndRunningState() {
     let harness = ProcessRuntimeHarness()
 

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -336,9 +336,15 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     let process = (json["process"] as? [String: Any]) ?? [:]
     let memoryMB = process["memory_mb"] as? Double
     let cpuPercent = process["cpu_percent"] as? Double
+    let cpuPercentStatus = process["cpu_percent_status"] as? String
+    let cpuPercentUnits = process["cpu_percent_units"] as? String
+    let cpuSampleWindowSec = process["cpu_sample_window_sec"] as? Double
     let uptimeSec = process["uptime_sec"] as? Int
     #expect((memoryMB ?? -1) >= 0)
     #expect((cpuPercent ?? -1) >= 0)
+    #expect(["warming_up", "sampled"].contains(cpuPercentStatus ?? ""))
+    #expect(cpuPercentUnits == "single_core_lifetime_average")
+    #expect((cpuSampleWindowSec ?? -1) >= 0)
     #expect((uptimeSec ?? -1) >= 0)
 }
 


### PR DESCRIPTION
## Summary

- mark process CPU telemetry as `warming_up` until a stable sampling window exists
- expose CPU status, units, and sample window in `logic_system.health`
- add regression coverage for zero-uptime startup samples and health schema output

## Verification

- `git diff --check`
- `swift test --filter "ProcessUtilsTests|ResourceSchemaTests" --no-parallel` (39 passed)
- `swift build -c release`

Closes #180
