### PR TITLE
ci: install cliclick in the release install-validation job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,12 @@ jobs:
           echo "Using LOGIC_PRO_MCP_SHA256=$LOGIC_PRO_MCP_SHA256"
           echo "Using LOGIC_PRO_MCP_TEAM_ID=$LOGIC_PRO_MCP_TEAM_ID"
 
+          # install.sh hard-requires `cliclick` (require_command, core install
+          # path). GitHub's macOS runners don't ship it, so install it before
+          # exercising the installer end-to-end — otherwise install.sh exits 1
+          # with "required dependency missing: cliclick".
+          brew list cliclick >/dev/null 2>&1 || brew install cliclick
+
           bash Scripts/install.sh | tee install.log
           test -x "$LOGIC_PRO_MCP_INSTALL_DIR/LogicProMCP"
           test -f "$LOGIC_PRO_MCP_SHARE_DIR/logic_bounce.py"

--- a/Tests/LogicProMCPTests/InstallScriptContractTests.swift
+++ b/Tests/LogicProMCPTests/InstallScriptContractTests.swift
@@ -107,6 +107,11 @@ import Testing
     #expect(workflow.contains("LOGIC_PRO_MCP_SHARE_DIR"))
     #expect(workflow.contains("LogicProMCP-macOS-universal.tar.gz"))
     #expect(workflow.contains("test -f \"$LOGIC_PRO_MCP_SHARE_DIR/logic_ui_jxa.py\""))
+    // The install-validation job MUST install cliclick before running install.sh:
+    // install.sh hard-requires it (require_command "cliclick"), and GitHub's macOS
+    // runners don't ship it, so without this the job fails "required dependency
+    // missing: cliclick" on every tagged release.
+    #expect(workflow.contains("brew install cliclick"))
     #expect(packageScript.contains("RELEASE-METADATA.json"))
     #expect(packageScript.contains("Scripts/logic_bounce.py"))
     #expect(packageScript.contains("Scripts/logic_bounce_ui.py"))


### PR DESCRIPTION
## Summary
The v3.7.2 release published successfully but its `validate-install` job failed on both `macos-14` and `macos-15` with `Error: required dependency missing: cliclick`.

Root cause: `Scripts/install.sh` hard-requires `cliclick` (`require_command "cliclick"`, core install path — covered by `testInstallScriptFailsClosedWhenCliclickIsMissing`), but the GitHub macOS runners don't ship it and the `validate-install` job never installed it. v3.7.2 is the first release whose `install.sh` carries the cliclick requirement; the earlier share-dir path bug (fixed in #183) short-circuited `install.sh` *before* this check, masking it until now.

## Fix
- `release.yml`: `brew list cliclick || brew install cliclick` before `bash Scripts/install.sh` in the validate-install job.
- New contract assertion pins `brew install cliclick` in the workflow so the installer dependency set and the CI job cannot drift again.

## Verification
- Mirrored the **entire** validate-install job locally against the **published v3.7.2** artifact (cliclick present): `install.sh` completes, binary executable, all share files present, `uninstall.sh` clean, share dir removed.
- `swift test --filter InstallScriptContract` — 29/29 pass.

Targeted hotfix for the release pipeline; enables a clean green re-release of v3.7.2.