### PR TITLE
fix: set_tempo fails closed on readback mismatch (#189)

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -1457,7 +1457,7 @@ def main():
     transport_after_128 = safe_get_transport_state(client) if live_logic_ready else None
     T("transport.set_tempo(128) dispatches", r, lambda _: len(set_tempo_128_text) > 0)
     T_LIVE(
-        "transport.set_tempo(128) verifies exact readback or fails closed with landmarks",
+        "transport.set_tempo(128) verifies exact readback or fails closed (never success on mismatch)",
         r,
         lambda _: (
             isinstance(set_tempo_128_json, dict)
@@ -1476,9 +1476,31 @@ def main():
             and set_tempo_128_json.get("success") is False
             and set_tempo_128_json.get("error") in ("element_not_found", "readback_unavailable")
             and has_tempo_landmarks(set_tempo_128_json)
+        ) or (
+            # #189: the slider-increment fallback fails closed (State C) when it
+            # cannot land the requested tempo — it must NEVER report success on a
+            # readback mismatch. Honest evidence: observed tempo + fallback method.
+            isinstance(set_tempo_128_json, dict)
+            and set_tempo_128_json.get("success") is False
+            and set_tempo_128_json.get("error") == "readback_mismatch"
+            and set_tempo_128_json.get("via") == "slider-increment"
+            and approx_equal(set_tempo_128_json.get("requested"), 128.0)
+            and isinstance(set_tempo_128_json.get("observed"), (int, float))
         ),
         live_logic_ready,
         "Logic Pro + Accessibility are required",
+    )
+    # #189 guard: regardless of which path runs, a tempo write must never claim
+    # success while reporting a tempo that differs from the request.
+    T(
+        "transport.set_tempo(128) never reports success on a readback mismatch (#189)",
+        r,
+        lambda _: not (
+            isinstance(set_tempo_128_json, dict)
+            and set_tempo_128_json.get("success") is True
+            and isinstance(set_tempo_128_json.get("observed"), (int, float))
+            and not approx_equal(set_tempo_128_json.get("observed"), 128.0)
+        ),
     )
 
     r = call_tool(client, "logic_transport", "set_tempo", {"tempo": 90.5})

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -179,7 +179,14 @@ actor AccessibilityChannel: Channel {
                         mouseRuntime: controlBarMouseRuntime
                     )
                 },
-                setTempo: { AccessibilityChannel.defaultSetTempo(params: $0, runtime: logicRuntime, runFallback: runTempoFallback) },
+                setTempo: {
+                    AccessibilityChannel.defaultSetTempo(
+                        params: $0,
+                        runtime: logicRuntime,
+                        mouseRuntime: controlBarMouseRuntime,
+                        runFallback: runTempoFallback
+                    )
+                },
                 setCycleRange: { AccessibilityChannel.defaultSetCycleRange(params: $0, runtime: logicRuntime) },
                 tracks: { AccessibilityChannel.defaultGetTracks(runtime: logicRuntime) },
                 selectedTrack: { AccessibilityChannel.defaultGetSelectedTrack(runtime: logicRuntime) },
@@ -733,6 +740,7 @@ actor AccessibilityChannel: Channel {
     private static func defaultSetTempo(
         params: [String: String],
         runtime: AXLogicProElements.Runtime = .production,
+        mouseRuntime: AXMouseHelper.Runtime = .production,
         runFallback: @escaping @Sendable (String) -> Bool = runTempoFallbackScript
     ) -> ChannelResult {
         guard let tempoStr = params["bpm"] ?? params["tempo"], let tempoValue = Double(tempoStr) else {
@@ -765,11 +773,11 @@ actor AccessibilityChannel: Channel {
                 x: position.x + size.width / 2,
                 y: position.y + size.height / 2
             )
-            AXMouseHelper.doubleClick(at: center)
+            AXMouseHelper.doubleClick(at: center, runtime: mouseRuntime)
             Thread.sleep(forTimeInterval: 0.12)
-            AXMouseHelper.typeNumericString(tempoStr)
+            AXMouseHelper.typeNumericString(tempoStr, runtime: mouseRuntime)
             Thread.sleep(forTimeInterval: 0.05)
-            AXMouseHelper.pressReturn()
+            AXMouseHelper.pressReturn(runtime: mouseRuntime)
             Thread.sleep(forTimeInterval: 0.15)
 
             if let finalValue = AXHelpers.getValue(slider, runtime: runtime.ax) as? Double,
@@ -779,7 +787,7 @@ actor AccessibilityChannel: Channel {
                 ))
             }
 
-            AXMouseHelper.pressEscape()
+            AXMouseHelper.pressEscape(runtime: mouseRuntime)
             Thread.sleep(forTimeInterval: 0.05)
             let current = (AXHelpers.getValue(slider, runtime: runtime.ax) as? Double) ?? 0
             let delta = tempoValue - current
@@ -791,14 +799,29 @@ actor AccessibilityChannel: Channel {
                 }
             }
             if let afterIncrement = AXHelpers.getValue(slider, runtime: runtime.ax) as? Double {
-                let extras = baseExtras.merging([
-                    "observed": afterIncrement,
-                    "via": "slider-increment",
-                    "note": "fell back to 10 BPM step — typed entry didn't commit"
-                ]) { _, new in new }
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackMismatch,
-                    extras: extras
+                // Honest Contract (#189): the slider-increment fallback steps in
+                // 10-BPM granularity, so it only reaches the requested tempo by
+                // coincidence. Report success ONLY when the observed value matches
+                // the request within tolerance; ANY readback mismatch fails closed
+                // with State C — a write path must never report success when the
+                // observed tempo differs from the requested tempo.
+                if abs(afterIncrement - tempoValue) < 1.0 {
+                    return .success(HonestContract.encodeStateA(
+                        extras: baseExtras.merging([
+                            "observed": afterIncrement,
+                            "via": "slider-increment"
+                        ]) { _, new in new }
+                    ))
+                }
+                return .error(HonestContract.encodeStateC(
+                    error: .readbackMismatch,
+                    hint: "tempo write fell back to a 10-BPM increment step that did not land on the requested value (typed entry didn't commit); the slider cannot represent this exact tempo via increment",
+                    extras: baseExtras.merging([
+                        "observed": afterIncrement,
+                        "via": "slider-increment",
+                        "write_attempted": true,
+                        "safe_to_retry": true
+                    ]) { _, new in new }
                 ))
             }
         }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -926,18 +926,16 @@ private func makeSetInstrumentFixture() -> (
     #expect(toggleResult.isSuccess)
     #expect(builder.actionCalls.contains { $0.elementID == builder.elementID(cycle) && $0.action == kAXPressAction as String })
 
-    // v3.0.2: set_tempo uses CGEvent double-click + typed entry on the tempo
-    // slider. CGEvent is real mouse input that our fake AX runtime can't
-    // observe, so after the typed entry fails to stick, the implementation
-    // falls back to AXIncrement/AXDecrement with 10-BPM granularity — that
-    // DOES go through the AX runtime and is observable. Verify at least the
-    // slider was located (no "could not locate" error) and the operation
-    // returned success. Pinning the exact fallback payload is brittle because
-    // it changes with Logic's actual slider min/max ranges.
+    // set_tempo locates the tempo AXSlider. In this fixture the slider has no
+    // AX position/size, so defaultSetTempo takes the geometry-free "slider-direct"
+    // branch (blind setAttribute + confirm, readback unavailable) → State B. The
+    // slider-increment mismatch path (#189) is exercised hermetically in
+    // testSetTempoSliderIncrementMismatchFailsClosed below.
     let tempoResult = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "132.0"])
     #expect(tempoResult.isSuccess)
     #expect(!tempoResult.message.contains("element_not_found"))
     #expect(tempoResult.message.contains("\"requested\":132"))
+    #expect(tempoResult.message.contains("\"via\":\"slider-direct\""))
 
     let cycleMissing = await channel.execute(operation: "transport.set_cycle_range", params: [:])
     #expect(!cycleMissing.isSuccess)
@@ -1212,6 +1210,84 @@ private func makeSetInstrumentFixture() -> (
     #expect(result.message.contains("\"track_header_count\":1"))
     #expect(result.message.contains("\"control_bar_found\":true"))
     #expect(result.message.contains("\"control_bar_slider_descriptions\":[\"Bar\"]"))
+}
+
+// MARK: - #189 set_tempo slider-increment fail-closed
+
+/// Build a control-bar tempo slider that HAS AX geometry, so defaultSetTempo
+/// takes the doubleClick/type path (no-op under the fake mouse runtime), the
+/// typed entry "doesn't commit" (value unchanged), and it falls to the
+/// slider-increment fallback — the exact #189 path.
+private func makeTempoSliderFixture(
+    builder: FakeAXRuntimeBuilder,
+    tempoValue: Double
+) -> (app: AXUIElement, slider: AXUIElement) {
+    let app = builder.element(7100)
+    let window = builder.element(7101)
+    let controlBar = builder.element(7102)
+    let tempoSlider = builder.element(7103)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [tempoSlider])
+    builder.setAttribute(tempoSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(tempoSlider, kAXDescriptionAttribute as String, "Tempo")
+    builder.setAttribute(tempoSlider, kAXValueAttribute as String, NSNumber(value: tempoValue))
+    var point = CGPoint(x: 40, y: 12)
+    builder.setAttribute(tempoSlider, kAXPositionAttribute as String, AXValueCreate(.cgPoint, &point)!)
+    var size = CGSize(width: 60, height: 18)
+    builder.setAttribute(tempoSlider, kAXSizeAttribute as String, AXValueCreate(.cgSize, &size)!)
+    return (app, tempoSlider)
+}
+
+@Test func testSetTempoSliderIncrementMismatchFailsClosed() async {
+    // #189 regression: when typed entry doesn't commit and the 10-BPM increment
+    // fallback CANNOT land the requested tempo, set_tempo must fail closed with
+    // State C `readback_mismatch` — NEVER report success on a readback mismatch.
+    let builder = FakeAXRuntimeBuilder()
+    let fixture = makeTempoSliderFixture(builder: builder, tempoValue: 120.0)
+    // Default fake performAction is a no-op, so the increment never moves the
+    // slider; observed stays 120 while 96 was requested.
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: fixture.app)
+
+    let result = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "96"])
+
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect((obj["success"] as? Bool) == false)
+    #expect(obj["error"] as? String == "readback_mismatch")
+    #expect(obj["via"] as? String == "slider-increment")
+    #expect((obj["requested"] as? Double) == 96)
+    #expect((obj["observed"] as? Double) == 120)
+    #expect((obj["safe_to_retry"] as? Bool)!)
+    // The bug was a State B success envelope; assert it is gone.
+    #expect(obj["reason"] == nil)
+}
+
+@Test func testSetTempoSliderIncrementExactLandingIsStateA() async {
+    // The slider-increment fallback reports success ONLY when the observed value
+    // matches the request within tolerance. A nudge-responsive runtime moves the
+    // slider +10 per increment, so requesting 130 from 120 lands exactly → State A.
+    let builder = FakeAXRuntimeBuilder()
+    let fixture = makeTempoSliderFixture(builder: builder, tempoValue: 120.0)
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: fixture.app,
+        logicRuntime: nudgeResponsiveLogicRuntime(builder, app: fixture.app)
+    )
+
+    let result = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "130"])
+
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect((obj["success"] as? Bool)!)
+    #expect((obj["verified"] as? Bool)!)
+    #expect(obj["via"] as? String == "slider-increment")
+    #expect((obj["requested"] as? Double) == 130)
+    #expect((obj["observed"] as? Double) == 130)
+    #expect(obj["error"] == nil)
 }
 
 @Test func testAccessibilityChannelImportMIDIFileReturnsErrorWhenTrackCountDoesNotIncrease() async throws {


### PR DESCRIPTION
Closes #189.

## Problem
`logic_transport.set_tempo`'s slider-increment fallback returned `success:true` (State B `readback_mismatch`) even when the observed tempo differed from the requested tempo — a Honest Contract violation. v3.7.2 evidence (#189): requested 96, observed 100, `success:true, verified:false, reason:readback_mismatch`.

## Fix
`AccessibilityChannel.defaultSetTempo` slider-increment fallback:
- Reports success **only** when the observed value matches the request within tolerance (State A).
- **Any** readback mismatch now **fails closed** with State C `readback_mismatch` carrying `requested`, `observed`, `via:"slider-increment"`, `write_attempted`, and `safe_to_retry` — never a success envelope on a mismatch. The single-channel router guard surfaces this State C verbatim for the `[.accessibility]`-only `set_tempo` route.
- Threaded the typed-entry mouse input through the channel's injectable `controlBarMouseRuntime` so the increment path is hermetically testable without firing real CGEvents (no production behavior change — production already used the real CGEvent runtime).

## Acceptance criteria (#189)
- [x] `set_tempo` returns non-success for any requested/observed mismatch.
- [x] Fallback slider-increment writes are exact (State A) or fail closed (State C).
- [x] Tests cover `requested != observed` and assert no success wording / State A envelope.
- [x] Live demo QA treats this response as a failed operation (live-e2e guard added).

## Verification
- `swift test` — **1849 passed / 0 failed** (adds `testSetTempoSliderIncrementMismatchFailsClosed` + `…ExactLandingIsStateA`; the mismatch test provably traverses the increment path).
- Strict fresh live Logic Pro 12.2 E2E — **346 passed / 0 skipped / 0 failed**, including the new hard guard "set_tempo never reports success on a readback mismatch".
- `swift build -c release` clean; `py_compile` live-e2e clean.