### PR TITLE
fix: bootstrap escapes a stuck Save prompt instead of dead-ending (#187)

### DIFF
--- a/Scripts/logic_session_bootstrap.py
+++ b/Scripts/logic_session_bootstrap.py
@@ -1120,13 +1120,7 @@ def bootstrap_fresh_logic_session(
                 health=health_local,
                 ui=ui_local,
             )
-        if not _click_save_dialog_cancel_button():
-            return blocked(
-                "save_dialog_cancel_click_failed",
-                "Cancel button press failed while trying to dismiss Logic's Save dialog.",
-                health=health_local,
-                ui=ui_local,
-            )
+        _click_save_dialog_cancel_button()
         actions.append(action_label)
         call_tool("logic_system", "refresh_cache", None, 5.0)
         actions.append("logic_system.refresh_cache")
@@ -1135,10 +1129,27 @@ def bootstrap_fresh_logic_session(
         if latest_health is not None:
             health_local = latest_health
         ui_local = collect_ui_snapshot()
+        # #187: Logic's Save prompt can expose buttons with no AX name, so the
+        # Cancel marker match is a no-op and the prompt stays visible. Fall back
+        # to the Escape key — which cancels the save sheet without saving or
+        # discarding — but ONLY after attempting Cancel (Cancel-before-Escape).
+        if (
+            ui_local.blocking_dialog_present
+            and _contains_marker(ui_local.logic_window_names, SAVE_DIALOG_MARKERS)
+            and _send_escape_key()
+        ):
+            actions.append("dismiss_save_dialog:escape_fallback")
+            call_tool("logic_system", "refresh_cache", None, 5.0)
+            actions.append("logic_system.refresh_cache")
+            time.sleep(config.poll_interval_sec)
+            _, latest_health = fetch_health()
+            if latest_health is not None:
+                health_local = latest_health
+            ui_local = collect_ui_snapshot()
         if ui_local.blocking_dialog_present and _contains_marker(ui_local.logic_window_names, SAVE_DIALOG_MARKERS):
             return blocked(
                 "save_dialog_dismiss_failed",
-                "Logic's Save dialog remained visible after pressing Cancel.",
+                "Logic's Save dialog remained visible after pressing Cancel and Escape.",
                 health=health_local,
                 ui=ui_local,
             )

--- a/Scripts/logic_session_bootstrap.py
+++ b/Scripts/logic_session_bootstrap.py
@@ -1133,23 +1133,27 @@ def bootstrap_fresh_logic_session(
         # Cancel marker match is a no-op and the prompt stays visible. Fall back
         # to the Escape key — which cancels the save sheet without saving or
         # discarding — but ONLY after attempting Cancel (Cancel-before-Escape).
-        if (
-            ui_local.blocking_dialog_present
-            and _contains_marker(ui_local.logic_window_names, SAVE_DIALOG_MARKERS)
-            and _send_escape_key()
+        escape_attempted = False
+        if ui_local.blocking_dialog_present and _contains_marker(
+            ui_local.logic_window_names, SAVE_DIALOG_MARKERS
         ):
-            actions.append("dismiss_save_dialog:escape_fallback")
-            call_tool("logic_system", "refresh_cache", None, 5.0)
-            actions.append("logic_system.refresh_cache")
-            time.sleep(config.poll_interval_sec)
-            _, latest_health = fetch_health()
-            if latest_health is not None:
-                health_local = latest_health
-            ui_local = collect_ui_snapshot()
+            escape_attempted = _send_escape_key()
+            if escape_attempted:
+                actions.append("dismiss_save_dialog:escape_fallback")
+                call_tool("logic_system", "refresh_cache", None, 5.0)
+                actions.append("logic_system.refresh_cache")
+                time.sleep(config.poll_interval_sec)
+                _, latest_health = fetch_health()
+                if latest_health is not None:
+                    health_local = latest_health
+                ui_local = collect_ui_snapshot()
         if ui_local.blocking_dialog_present and _contains_marker(ui_local.logic_window_names, SAVE_DIALOG_MARKERS):
+            # Report only what was actually attempted (the Escape key is skipped
+            # when _send_escape_key() can't post, e.g. post-event access denied).
+            attempted = "Cancel and Escape" if escape_attempted else "Cancel"
             return blocked(
                 "save_dialog_dismiss_failed",
-                "Logic's Save dialog remained visible after pressing Cancel and Escape.",
+                f"Logic's Save dialog remained visible after pressing {attempted}.",
                 health=health_local,
                 ui=ui_local,
             )

--- a/Scripts/logic_session_bootstrap_action_test.py
+++ b/Scripts/logic_session_bootstrap_action_test.py
@@ -1049,6 +1049,130 @@ class BootstrapFreshSessionActionTests(unittest.TestCase):
         self.assertTrue(state["track_created"])
         self.assertIn("dismiss_save_dialog:cancel_button", result.actions)
 
+    def test_force_new_save_dialog_escape_fallback_when_cancel_button_unmatched(self):
+        # #187: Logic's Save prompt sometimes exposes buttons with no AX name, so
+        # the Cancel marker match is a no-op and the prompt stays visible. The
+        # bootstrap must fall back to Escape (Cancel-before-Escape) and recover,
+        # rather than dead-ending on save_dialog_dismiss_failed.
+        state = {
+            "closed": False,
+            "created": False,
+            "track_created": False,
+            "blocking_dialog_present": True,
+            "save_dialog_visible": False,
+            "send_return_calls": 0,
+            "cancel_button_clicks": 0,
+            "escape_calls": 0,
+        }
+
+        def make_ui_snapshot():
+            window_names = ["Untitled - Tracks"]
+            if state["save_dialog_visible"]:
+                window_names = ["Save", *window_names]
+            return bootstrap_module.UISnapshot(
+                frontmost_app="Logic Pro",
+                logic_window_names=window_names,
+                logic_menu_items=[
+                    "Apple", "Logic Pro", "File", "Edit", "Track", "Navigate",
+                    "Record", "Mix", "View", "Window", "Help",
+                ],
+                detected_language="en",
+                system_events_error=None,
+                project_picker_visible=False,
+                new_track_dialog_visible=False,
+                blocking_dialog_present=state["blocking_dialog_present"],
+            )
+
+        def call_tool(tool, command, params=None, timeout=None):
+            if tool == "logic_system" and command == "health":
+                return make_tool_response(json.dumps(make_health((not state["closed"]) or state["created"] or state["track_created"])))
+            if tool == "logic_project" and command == "close":
+                if state["blocking_dialog_present"]:
+                    return make_tool_response(
+                        '{"success":false,"error":"unsupported_state","failure_stage":"preflight_blocking_dialog","blocking_dialog_present":true}',
+                        is_error=True,
+                    )
+                state["closed"] = True
+                return make_tool_response('{"success":true,"verified":true}')
+            if tool == "logic_project" and command == "new":
+                state["created"] = True
+                return make_tool_response('{"success":true,"verified":true}')
+            if tool == "logic_system" and command == "refresh_cache":
+                return make_tool_response('{"ok":true}')
+            if tool == "logic_tracks" and command == "create_instrument":
+                state["track_created"] = True
+                return make_tool_response('{"success":true,"verified":true}')
+            return make_tool_response("{}")
+
+        def read_resource(uri):
+            if uri == "logic://project/info":
+                return make_resource_response(json.dumps({
+                    "source": "ax_live",
+                    "data": {
+                        "name": "Untitled - Tracks",
+                        "trackCount": 1 if state["track_created"] else 0,
+                        "source": "ax_live",
+                    },
+                }))
+            if uri == "logic://tracks":
+                return make_resource_response(json.dumps({
+                    "source": "ax_live",
+                    "ax_occluded": False,
+                    "data": (
+                        [{"id": 0, "name": "Track 1", "placeholder": False}]
+                        if state["track_created"] else []
+                    ),
+                }))
+            if uri == "logic://tracks/0/regions":
+                return make_resource_response("[]")
+            return make_resource_response("{}")
+
+        def send_return_key():
+            state["send_return_calls"] += 1
+            state["save_dialog_visible"] = True
+            state["blocking_dialog_present"] = True
+            return True
+
+        def click_save_dialog_cancel_button():
+            # Cancel "succeeds" (a button was pressed) but the prompt does NOT
+            # clear — the real-world missing-value-button no-op.
+            state["cancel_button_clicks"] += 1
+            return True
+
+        def send_escape_key():
+            state["escape_calls"] += 1
+            state["save_dialog_visible"] = False
+            state["blocking_dialog_present"] = False
+            return True
+
+        with (
+            mock.patch("logic_session_bootstrap._send_return_key", side_effect=send_return_key),
+            mock.patch(
+                "logic_session_bootstrap._click_save_dialog_cancel_button",
+                side_effect=click_save_dialog_cancel_button,
+            ),
+            mock.patch("logic_session_bootstrap._send_escape_key", side_effect=send_escape_key),
+        ):
+            result = run_force_new_bootstrap(
+                call_tool=call_tool,
+                document_probe=lambda timeout_sec: (
+                    (True, None)
+                    if (not state["closed"]) and (not state["created"]) and (not state["track_created"])
+                    else (False, None)
+                ),
+                ui_snapshot_factory=make_ui_snapshot,
+                read_resource=read_resource,
+            )
+
+        self.assertTrue(result.ok, result.as_dict())
+        self.assertEqual(state["cancel_button_clicks"], 1)
+        self.assertEqual(state["escape_calls"], 1)
+        self.assertTrue(state["closed"])
+        self.assertTrue(state["track_created"])
+        # Cancel was tried first, then Escape resolved it.
+        self.assertIn("dismiss_save_dialog:cancel_button", result.actions)
+        self.assertIn("dismiss_save_dialog:escape_fallback", result.actions)
+
     def test_force_new_closes_arrange_window_when_document_probe_reports_false(self):
         state = {
             "closed": False,


### PR DESCRIPTION
Closes #187.

## Problem
The fresh-demo bootstrap dismisses Logic's unsaved-project **Save** prompt by clicking a Cancel button matched by AX name. Logic sometimes exposes that prompt's buttons with **no AX name** (`missing value`), so the Cancel marker match is a no-op, the prompt stays, and the bootstrap dead-ends on `save_dialog_dismiss_failed` — needing manual screen-level cleanup. Reproduced live this session.

## Fix
`logic_session_bootstrap.dismiss_visible_save_dialog`: after attempting Cancel, if the Save prompt is still present, fall back to the **Escape** key (cancels the save sheet without saving or discarding) before declaring failure — **Cancel-before-Escape**, consistent with the existing safe-dialog path. The resolution method is recorded in the bootstrap actions (`dismiss_save_dialog:escape_fallback`); the run still stops with a precise dialog identity if both Cancel and Escape fail.

## Acceptance criteria (#187)
- [x] Deterministic preflight for unsaved-project prompts (detect + Cancel→Escape recovery).
- [x] Discard/close stays explicit and isolated (Escape cancels the sheet; the `close saving:no` is a separate, later step).
- [x] Records whether the prompt appeared and how it was resolved (bootstrap `actions`).
- [x] If the prompt can't be resolved, the run stops before MIDI import (`save_dialog_dismiss_failed`).

## Verification
- `logic_session_bootstrap_action_test.py` **36/36** (adds `test_force_new_save_dialog_escape_fallback_when_cancel_button_unmatched`) + `logic_session_bootstrap_test.py` **23/23**.
- Strict fresh live Logic Pro 12.2 E2E — **345 passed / 0 skipped / 0 failed** (bootstrap end-to-end, no regression).
- The Escape recovery was confirmed live this session against the exact missing-value Save prompt that previously blocked bootstrap.

Python-only change (no Swift/runtime surface change).