### PR TITLE
fix: key-event primitive accepts --return + adds a no-post preflight (#186)

### DIFF
--- a/Scripts/logic_key_event.swift
+++ b/Scripts/logic_key_event.swift
@@ -3,21 +3,78 @@ import AppKit
 import CoreGraphics
 import Foundation
 
-let keyName = CommandLine.arguments.dropFirst().first ?? ""
 struct KeyEventSpec {
     let keyCode: CGKeyCode
     let flags: CGEventFlags
 }
 
+// Canonical key names plus aliases. `enter` is accepted as a synonym for
+// `return` and `esc` for `escape`. `normalize()` also strips a leading `--`, so
+// a caller that passes a flag-style argument (e.g. `--return`) still resolves to
+// the verified Return primitive instead of aborting with an "unknown option"
+// error. This is the #186 fix: capture tooling that scripted `--return` now
+// drives a real Return/Enter key press.
 let keyEventByName: [String: KeyEventSpec] = [
     "space": KeyEventSpec(keyCode: 49, flags: []),
     "return": KeyEventSpec(keyCode: 36, flags: []),
+    "enter": KeyEventSpec(keyCode: 36, flags: []),
     "escape": KeyEventSpec(keyCode: 53, flags: []),
+    "esc": KeyEventSpec(keyCode: 53, flags: []),
 ]
 
+// Canonical name per key code, so `--check enter`/`--check esc` confirm the
+// resolved primitive ("return"/"escape") rather than echoing the alias.
+let canonicalNameByKeyCode: [CGKeyCode: String] = [
+    49: "space",
+    36: "return",
+    53: "escape",
+]
+
+func supportedKeysLine() -> String {
+    keyEventByName.keys.sorted().joined(separator: ", ")
+}
+
+func normalize(_ raw: String) -> String {
+    var value = raw.lowercased()
+    while value.hasPrefix("-") { value.removeFirst() }
+    return value
+}
+
+let rawArgs = Array(CommandLine.arguments.dropFirst())
+let helpTokens: Set<String> = ["-h", "--help", "--list", "help"]
+
+// Discovery / preflight surface — lists supported keys WITHOUT posting an event,
+// so a capture harness can verify the required input primitive is available
+// before it starts recording.
+if rawArgs.isEmpty || rawArgs.contains(where: { helpTokens.contains($0.lowercased()) }) {
+    print("usage: logic_key_event [--check] <key>")
+    print("keys: \(supportedKeysLine())")
+    print("notes: a leading -- is accepted (e.g. --return); --check <key> validates a key without posting it")
+    // No argument at all is a usage error; an explicit --help/--list is success.
+    exit(rawArgs.isEmpty ? 64 : 0)
+}
+
+// `--check <key>` (a.k.a. --dry-run / -n) resolves and validates the key without
+// posting a CGEvent. Capture tooling uses this to fail closed BEFORE recording
+// when a required input flag is unsupported, instead of aborting mid-capture.
+let checkTokens: Set<String> = ["--check", "--dry-run", "-n"]
+let checkMode = rawArgs.first.map { checkTokens.contains($0.lowercased()) } ?? false
+let keyArgs = checkMode ? Array(rawArgs.dropFirst()) : rawArgs
+let requestedKey = keyArgs.first ?? ""
+let keyName = normalize(requestedKey)
+
 guard let keyEvent = keyEventByName[keyName] else {
-    FileHandle.standardError.write(Data("unknown_key\n".utf8))
+    FileHandle.standardError.write(
+        Data("unknown_key: \(requestedKey) (supported: \(supportedKeysLine()))\n".utf8)
+    )
     exit(64)
+}
+
+let canonicalName = canonicalNameByKeyCode[keyEvent.keyCode] ?? keyName
+
+if checkMode {
+    print("ok:\(canonicalName)")
+    exit(0)
 }
 
 guard CGPreflightPostEventAccess() else {

--- a/Scripts/logic_key_event_test.py
+++ b/Scripts/logic_key_event_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Behavioral tests for Scripts/logic_key_event.swift (#186).
+
+The demo capture harness aborted on `--return` ("Unknown option --return").
+These tests pin the verified Return/Enter input primitive contract:
+
+- A flag-style `--return` (and `--enter`) resolves to the Return key.
+- `--check <key>` is a preflight that validates a key WITHOUT posting an event,
+  so a capture harness can fail before recording if a flag is unsupported.
+- Unknown keys fail closed (exit 64) and name the supported keys, so a local
+  harness failure is distinguishable from a Logic Pro product failure.
+- `--help` / `--list` lists the supported keys.
+
+The post-event paths are not exercised here (they require Accessibility/CGEvent
+permission and would inject real key presses); `--check` covers the resolution
+contract deterministically.
+"""
+
+import os
+import subprocess
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logic_key_event.swift")
+
+
+def run_key_event(*args):
+    return subprocess.run(
+        ["swift", SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+class LogicKeyEventContractTests(unittest.TestCase):
+    def test_help_lists_supported_keys(self):
+        result = run_key_event("--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for key in ("return", "enter", "escape", "space"):
+            self.assertIn(key, result.stdout)
+
+    def test_check_flag_return_resolves(self):
+        # #186: a flag-style --return must resolve to the verified Return key.
+        result = run_key_event("--check", "--return")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ok:return")
+
+    def test_check_enter_aliases_return(self):
+        result = run_key_event("--check", "enter")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ok:return")
+
+    def test_check_bare_return_resolves(self):
+        result = run_key_event("--check", "return")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ok:return")
+
+    def test_check_escape_aliases(self):
+        for token in ("escape", "esc", "--escape"):
+            result = run_key_event("--check", token)
+            self.assertEqual(result.returncode, 0, f"{token}: {result.stderr}")
+            self.assertEqual(result.stdout.strip(), "ok:escape")
+
+    def test_unknown_key_fails_closed_with_supported_list(self):
+        result = run_key_event("--check", "--bogus")
+        self.assertEqual(result.returncode, 64)
+        self.assertIn("unknown_key", result.stderr)
+        # Names the supported keys so a harness failure is self-explanatory.
+        self.assertIn("return", result.stderr)
+
+    def test_no_argument_is_usage_error(self):
+        result = run_key_event()
+        self.assertEqual(result.returncode, 64)
+        self.assertIn("usage", result.stdout.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/release-stable.sh
+++ b/Scripts/release-stable.sh
@@ -91,13 +91,14 @@ if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
     exit 1
 fi
 
-run python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_bounce.py Scripts/logic_bounce_test.py Scripts/logic_bounce_main_test.py Scripts/logic_bounce_support_test.py Scripts/logic_bounce_ui.py Scripts/logic_bounce_ui_test.py Scripts/logic_input_source.py Scripts/logic_session_bootstrap.py Scripts/logic_session_bootstrap_test.py Scripts/logic_session_bootstrap_action_test.py Scripts/logic_ui_jxa.py Scripts/logic_ui_jxa_test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/logic_controller_learn_mode.py Scripts/logic_controller_learn_mode_test.py
+run python3 -m py_compile Scripts/live-e2e-test.py Scripts/logic_bounce.py Scripts/logic_bounce_test.py Scripts/logic_bounce_main_test.py Scripts/logic_bounce_support_test.py Scripts/logic_bounce_ui.py Scripts/logic_bounce_ui_test.py Scripts/logic_input_source.py Scripts/logic_session_bootstrap.py Scripts/logic_session_bootstrap_test.py Scripts/logic_session_bootstrap_action_test.py Scripts/logic_ui_jxa.py Scripts/logic_ui_jxa_test.py Scripts/logic_free_tempo_modal.py Scripts/logic_free_tempo_modal_test.py Scripts/logic_controller_learn_mode.py Scripts/logic_controller_learn_mode_test.py Scripts/logic_key_event_test.py
 run python3 Scripts/logic_bounce_test.py
 run python3 Scripts/logic_session_bootstrap_test.py
 run python3 Scripts/logic_session_bootstrap_action_test.py
 run python3 Scripts/logic_ui_jxa_test.py
 run python3 Scripts/logic_free_tempo_modal_test.py
 run python3 Scripts/logic_controller_learn_mode_test.py
+run python3 Scripts/logic_key_event_test.py
 run swiftc -typecheck Scripts/logic_key_event.swift
 run swiftc -typecheck Scripts/logic_ui_snapshot.swift
 run swift test --no-parallel

--- a/Tests/LogicProMCPTests/InstallScriptContractTests.swift
+++ b/Tests/LogicProMCPTests/InstallScriptContractTests.swift
@@ -278,3 +278,24 @@ import Testing
     #expect(script.contains("Removed operator approvals"))
     #expect(script.contains("APPROVAL_LOCK"))
 }
+
+@Test func testKeyEventHelperSupportsReturnEnterAliasesAndPreflight() throws {
+    // #186: the demo capture harness aborted on `--return` ("Unknown option").
+    // The key-event input primitive must accept a flag-style --return (leading
+    // dashes stripped), alias `enter` -> Return, expose a no-post `--check`
+    // preflight, and fail closed naming the supported keys.
+    let script = try scriptContents("Scripts/logic_key_event.swift")
+
+    #expect(script.contains("\"return\": KeyEventSpec(keyCode: 36"))
+    #expect(script.contains("\"enter\": KeyEventSpec(keyCode: 36"))
+    #expect(script.contains("\"esc\": KeyEventSpec(keyCode: 53"))
+    // A leading `--` is stripped so `--return` resolves to the Return key.
+    #expect(script.contains("while value.hasPrefix(\"-\")"))
+    // Preflight that validates a key without posting a CGEvent.
+    #expect(script.contains("--check"))
+    #expect(script.contains("checkMode"))
+    #expect(script.contains("canonicalNameByKeyCode"))
+    // Fail-closed unknown key names the supported set.
+    #expect(script.contains("unknown_key:"))
+    #expect(script.contains("supportedKeysLine()"))
+}


### PR DESCRIPTION
Closes #186.

## Problem
The demo MIDI-import capture harness aborted with `Error: Unknown option --return`. The repo's Return/Enter input primitive `Scripts/logic_key_event.swift` only accepted a bare positional key name, so a flag-style `--return` was rejected — wasting the capture pass on harness/tooling drift rather than a product result.

## Fix (`Scripts/logic_key_event.swift`)
- **Accept flag-style keys**: a leading `--` is stripped on resolution, so `--return` / `--enter` / `--escape` drive the verified Return/Escape key. `enter` aliases Return; `esc` aliases Escape.
- **Preflight without side effects**: `--check <key>` (a.k.a. `--dry-run`) resolves+validates a key **without posting a CGEvent**, so capture tooling can verify a required input flag is supported *before* it starts recording (reports the canonical key, e.g. `enter` → `ok:return`).
- **Self-documenting + fail-closed**: `--help`/`--list` prints the supported keys; an unknown key exits 64 and names the supported set, making a local harness failure clearly distinguishable from a Logic Pro product failure.

## Acceptance criteria (#186)
- [x] The unsupported `--return` path now resolves to a verified Return/Enter input primitive.
- [x] Preflight check for a required input flag before capture (`--check`).
- [x] Logs/exit codes distinguish a harness failure (`unknown_key`, exit 64) from a product failure.

## Verification
- `Scripts/logic_key_event_test.py` — **7/7**, runs the actual script (compiles + executes `--return`/`enter`/`esc` resolution, `--check` preflight, unknown-key fail-closed, `--help`). Wired into `release-stable.sh`.
- `swift test` — **1848 passed / 0 failed** (adds `testKeyEventHelperSupportsReturnEnterAliasesAndPreflight`, runs in PR CI).
- `swiftc -typecheck` + `bash -n` clean.

The CGEvent post path is byte-unchanged (only argument parsing was hardened), so no new real-key-injection behavior. The primitive is not part of the live-E2E bootstrap flow, so verification is via the behavioral script-execution test above.