### PR TITLE
docs: surface the official Discord community across help entry points (#178)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,4 +173,6 @@ Do **not** open a public issue for vulnerabilities. See [SECURITY.md](SECURITY.m
 
 ## Questions
 
-Open a GitHub Discussion or Issue with the `question` label.
+For real-time help, coordination, and contributor chat, join the official Logic Pro MCP Discord: [https://discord.gg/4M3s79DBzz](https://discord.gg/4M3s79DBzz).
+
+For anything that should stay searchable, open a GitHub Discussion or Issue with the `question` label.

--- a/Tests/LogicProMCPTests/InstallScriptContractTests.swift
+++ b/Tests/LogicProMCPTests/InstallScriptContractTests.swift
@@ -162,6 +162,16 @@ import Testing
     )
 }
 
+@Test func testCommunityDiscordLinkIsDiscoverableAcrossDocs() throws {
+    // #178: the official Discord community must be discoverable from every help
+    // entry point — not just the README badge — so users land on real-time
+    // support from setup, troubleshooting, and contributor docs alike.
+    let discord = "https://discord.gg/4M3s79DBzz"
+    for path in ["README.md", "docs/SETUP.md", "docs/TROUBLESHOOTING.md", "CONTRIBUTING.md"] {
+        #expect(try scriptContents(path).contains(discord), "\(path) must link the official Discord (\(discord))")
+    }
+}
+
 @Test func testCoverageWorkflowFailsClosedAndUsesWritableProfilePath() throws {
     let workflow = try scriptContents(".github/workflows/ci.yml")
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -220,3 +220,7 @@ Unload and remove the launch agent plist, then verify no stale process remains.
 <a id="lifecycle-approvalsremove"></a>
 ### `approvals.remove`
 Delete the manual-validation approval store and its `.lock` sidecar only when you intentionally want to re-approve channels.
+
+## Community
+
+Stuck on setup? Join the official Logic Pro MCP Discord for real-time help: [https://discord.gg/4M3s79DBzz](https://discord.gg/4M3s79DBzz). For reproducible bugs, open a [GitHub Issue](https://github.com/MongLong0214/logic-pro-mcp/issues).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -164,3 +164,9 @@ LogicProMCP doctor
 ```
 
 If permissions look wrong after reinstalling, remove stale TCC entries in System Settings and grant them again to the actual launcher app.
+
+## Still stuck?
+
+Join the official Logic Pro MCP Discord for real-time setup help and triage: [https://discord.gg/4M3s79DBzz](https://discord.gg/4M3s79DBzz).
+
+For a reproducible bug, open a [GitHub Issue](https://github.com/MongLong0214/logic-pro-mcp/issues) with `LogicProMCP doctor` output and `LOG_LEVEL=debug` logs — that stays searchable and is the canonical tracker.


### PR DESCRIPTION
Closes #178.

## Context
The official Logic Pro MCP Discord is live and already linked in the README badge + header. This makes it discoverable from the **other** places users land when they need help, so the community resource isn't README-only.

## Changes
- **docs/SETUP.md** — adds a `## Community` section (Discord for real-time setup help; GitHub Issues for reproducible bugs).
- **docs/TROUBLESHOOTING.md** — adds a `## Still stuck?` section (Discord + GitHub Issues with `doctor`/debug-log guidance).
- **CONTRIBUTING.md** — the `## Questions` section now points to the Discord for real-time chat alongside GitHub Discussions/Issues.
- Contract test `testCommunityDiscordLinkIsDiscoverableAcrossDocs` pins `https://discord.gg/4M3s79DBzz` in README + SETUP + TROUBLESHOOTING + CONTRIBUTING.

## Verification
- `swift test` — **1848 passed / 0 failed** (adds the doc-link contract test, runs in PR CI).
- Discord invite present in all four help surfaces.

Docs-only; no runtime/tool/resource surface change.