### PR TITLE
fix: preflight Automation→System Events before MIDI import (#188)

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -918,6 +918,10 @@ def main():
         permissions = health.get("permissions", {})
         accessibility_ready = permissions.get("accessibility") is True
         automation_ready = permissions.get("automation_granted") is True
+        # #188: System Events automation is a distinct TCC target the MIDI import
+        # path requires. The strict live harness itself drives System Events, so a
+        # green run must report it granted.
+        system_events_ready = permissions.get("automation_system_events") is True
         core_midi = channels_by_name.get("CoreMIDI", {})
         core_midi_ready = core_midi.get("available") is True and core_midi.get("ready") is True
         live_logic_ready = logic_running and accessibility_ready
@@ -931,6 +935,14 @@ def main():
         T_LIVE("health.permissions.accessibility granted", r, lambda _: accessibility_ready, accessibility_ready, "Accessibility is not granted to this binary/session")
         T_LIVE("health.permissions.automation granted", r, lambda _: automation_ready, automation_ready, "Automation is not verifiable/granted without a running Logic session")
         T("health.permissions.post_event_access present", r, lambda _: "post_event_access" in permissions)
+        T("health.permissions.automation_system_events present (#188)", r, lambda _: "automation_system_events" in permissions)
+        T_LIVE(
+            "health.permissions.automation_system_events granted (#188)",
+            r,
+            lambda _: system_events_ready,
+            system_events_ready,
+            "Automation → System Events is required by the MIDI import path",
+        )
         T("health.process.memory_mb positive", r, lambda _: health["process"]["memory_mb"] > 0)
         T("health.process.uptime_sec non-negative", r, lambda _: health["process"]["uptime_sec"] >= 0)
 
@@ -939,6 +951,11 @@ def main():
         "system.permissions mentions accessibility and automation",
         r,
         lambda _: "Accessibility:" in tool_text(r) and "Automation (Logic Pro):" in tool_text(r),
+    )
+    T(
+        "system.permissions mentions System Events automation (#188)",
+        r,
+        lambda _: "Automation (System Events):" in tool_text(r),
     )
 
     r = call_tool(client, "logic_system", "refresh_cache")

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -4396,6 +4396,7 @@ actor AccessibilityChannel: Channel {
     /// hint, because such lanes route to a General MIDI device and may bounce
     /// silent — a count delta alone must never be claimed audible-verified.
     static func defaultImportMIDIFile(
+        systemEventsAuthorized: @Sendable () -> Bool = { PermissionChecker.checkSystemEventsAutomation() },
         path: String,
         runtime: AXLogicProElements.Runtime = .production,
         executeScript: @escaping @Sendable (String) async -> ChannelResult = { await AppleScriptChannel.executeAppleScript($0) },
@@ -4409,6 +4410,24 @@ actor AccessibilityChannel: Channel {
                 error: .invalidParams,
                 hint: "midi.import_file: file not found",
                 extras: ["requested": path]
+            ))
+        }
+        // #188: the import below drives `tell application "System Events"`, a
+        // distinct Automation TCC target from Logic Pro. If it is not authorized,
+        // fail closed with a typed permission error BEFORE the mutation instead of
+        // aborting mid-import with a bare Apple Events denial (health/permissions
+        // could otherwise look green on the Logic-Pro automation line alone).
+        guard systemEventsAuthorized() else {
+            return .error(HonestContract.encodeStateC(
+                error: .permissionDenied,
+                hint: "midi.import_file requires Automation access to System Events. Grant it in System Settings > Privacy & Security > Automation → allow your launcher app to control System Events, then retry.",
+                extras: [
+                    "permission": "automation_system_events",
+                    "failure_stage": "preflight_system_events_permission",
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                    "remediation": "System Settings > Privacy & Security > Automation → allow control of System Events",
+                ]
             ))
         }
         let readTrackCount = trackCount ?? { AXLogicProElements.allTrackHeaders(runtime: runtime).count }

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -59,6 +59,11 @@ struct SystemDispatcher {
             let accessibilityStatus: String
             let automationStatus: String
             let automationVerifiable: Bool
+            // #188: Automation → System Events is a distinct TCC target that the
+            // MIDI import / tempo-dialog paths require; surfacing it stops a green
+            // Logic-Pro automation line from hiding a denied System Events target.
+            let automationSystemEvents: Bool
+            let automationSystemEventsStatus: String
             let postEventAccess: Bool   // T5: CGPreflightPostEventAccess() — required for CGEvent.post
 
             enum CodingKeys: String, CodingKey {
@@ -68,6 +73,8 @@ struct SystemDispatcher {
                 case accessibilityStatus = "accessibility_status"
                 case automationStatus = "automation_status"
                 case automationVerifiable = "automation_verifiable"
+                case automationSystemEvents = "automation_system_events"
+                case automationSystemEventsStatus = "automation_system_events_status"
                 case postEventAccess = "post_event_access"
             }
         }
@@ -200,6 +207,8 @@ struct SystemDispatcher {
                     accessibilityStatus: permissions.accessibilityState.rawValue,
                     automationStatus: permissions.automationState.rawValue,
                     automationVerifiable: permissions.automationVerifiable,
+                    automationSystemEvents: permissions.automationSystemEvents,
+                    automationSystemEventsStatus: permissions.systemEventsAutomationState.rawValue,
                     postEventAccess: CGPreflightPostEventAccess()
                 ),
                 process: .init(

--- a/Sources/LogicProMCP/Utilities/PermissionChecker.swift
+++ b/Sources/LogicProMCP/Utilities/PermissionChecker.swift
@@ -29,6 +29,13 @@ enum PermissionChecker {
         let checkAccessibility: @Sendable (Bool) -> Bool
         let isLogicProRunning: @Sendable () -> Bool
         let runAutomationProbe: @Sendable () -> Bool
+        // Automation → System Events is a SEPARATE TCC target from Automation →
+        // Logic Pro. Multi-step paths (MIDI import, tempo dialog, project-state
+        // probes) drive `tell application "System Events"`, so a host that has
+        // Logic Pro automation granted can still have System Events denied —
+        // which is exactly the #188 gap where health looked green but
+        // record_sequence failed mid-import with an Apple Events denial.
+        let runSystemEventsAutomationProbe: @Sendable () -> Bool
 
         static let production = Runtime(
             checkAccessibility: { prompt in
@@ -38,6 +45,9 @@ enum PermissionChecker {
             isLogicProRunning: { ProcessUtils.isLogicProRunning },
             runAutomationProbe: {
                 runAutomationProbeViaShell()
+            },
+            runSystemEventsAutomationProbe: {
+                runSystemEventsAutomationProbeViaShell()
             }
         )
     }
@@ -45,20 +55,28 @@ enum PermissionChecker {
     struct PermissionStatus: Sendable {
         let accessibilityState: CheckState
         let automationState: CheckState
+        let systemEventsAutomationState: CheckState
 
-        init(accessibility: Bool, automationLogicPro: Bool) {
+        init(accessibility: Bool, automationLogicPro: Bool, systemEventsAutomation: CheckState = .notVerifiable) {
             self.accessibilityState = accessibility ? .granted : .notGranted
             self.automationState = automationLogicPro ? .granted : .notGranted
+            self.systemEventsAutomationState = systemEventsAutomation
         }
 
-        init(accessibilityState: CheckState, automationState: CheckState) {
+        init(
+            accessibilityState: CheckState,
+            automationState: CheckState,
+            systemEventsAutomationState: CheckState = .notVerifiable
+        ) {
             self.accessibilityState = accessibilityState
             self.automationState = automationState
+            self.systemEventsAutomationState = systemEventsAutomationState
         }
 
         var accessibility: Bool { accessibilityState.isGranted }
         var automationLogicPro: Bool { automationState.isGranted }
         var automationVerifiable: Bool { automationState != .notVerifiable }
+        var automationSystemEvents: Bool { systemEventsAutomationState.isGranted }
 
         var allGranted: Bool { accessibility && automationLogicPro }
 
@@ -71,6 +89,7 @@ enum PermissionChecker {
             case .notVerifiable:
                 lines.append("Automation (Logic Pro): NOT VERIFIABLE (Logic Pro not running)")
             }
+            lines.append("Automation (System Events): \(systemEventsAutomationState.summaryLabel)")
             if accessibilityState == .notGranted {
                 lines.append("  → System Settings > Privacy & Security > Accessibility → add your terminal app")
             }
@@ -81,6 +100,12 @@ enum PermissionChecker {
                 lines.append("  → Launch Logic Pro once, then rerun --check-permissions to verify Automation access")
             case .granted:
                 break
+            }
+            // System Events automation is required by MIDI import / tempo-dialog
+            // paths; surface its own remediation so a green Logic-Pro automation
+            // line never hides a denied System Events target (#188).
+            if systemEventsAutomationState == .notGranted {
+                lines.append("  → System Settings > Privacy & Security > Automation → allow control of System Events")
             }
             return lines.joined(separator: "\n")
         }
@@ -117,6 +142,23 @@ enum PermissionChecker {
         return runtime.runAutomationProbe() ? .granted : .notGranted
     }
 
+    /// Check if Automation permission for System Events is granted. Required by
+    /// the MIDI import / tempo-dialog / project-state paths that drive
+    /// `tell application "System Events"`. System Events is always running, so
+    /// (unlike Logic Pro) the probe is unconditional; a denied or undetermined
+    /// target returns `notGranted`.
+    static func checkSystemEventsAutomation() -> Bool {
+        checkSystemEventsAutomation(runtime: .production)
+    }
+
+    static func checkSystemEventsAutomation(runtime: Runtime) -> Bool {
+        checkSystemEventsAutomationState(runtime: runtime).isGranted
+    }
+
+    static func checkSystemEventsAutomationState(runtime: Runtime = .production) -> CheckState {
+        runtime.runSystemEventsAutomationProbe() ? .granted : .notGranted
+    }
+
     /// Full permission check.
     static func check() -> PermissionStatus {
         check(runtime: .production)
@@ -125,7 +167,8 @@ enum PermissionChecker {
     static func check(runtime: Runtime) -> PermissionStatus {
         PermissionStatus(
             accessibilityState: checkAccessibilityState(runtime: runtime),
-            automationState: checkAutomationState(runtime: runtime)
+            automationState: checkAutomationState(runtime: runtime),
+            systemEventsAutomationState: checkSystemEventsAutomationState(runtime: runtime)
         )
     }
 
@@ -145,5 +188,24 @@ enum PermissionChecker {
 
         let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed == ServerConfig.logicProProcessName
+    }
+
+    private static func runSystemEventsAutomationProbeViaShell() -> Bool {
+        // A no-op read against System Events. If the launcher lacks Automation →
+        // System Events, osascript exits non-zero (e.g. errAEEventNotPermitted
+        // -1743) and the probe reports notGranted instead of letting a later
+        // MIDI import fail mid-mutation with the same denial.
+        let script = "tell application \"System Events\" to return name"
+        guard case let .completed(output) = BoundedProcessRunner.run(
+            executable: "/usr/bin/osascript",
+            arguments: ["-e", script],
+            timeout: 1.0,
+            outputLimitBytes: 4 * 1024
+        ), output.exitCode == 0 else {
+            return false
+        }
+
+        let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed == "System Events"
     }
 }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1214,6 +1214,38 @@ private func makeSetInstrumentFixture() -> (
     #expect(result.message.contains("\"control_bar_slider_descriptions\":[\"Bar\"]"))
 }
 
+@Test func testImportMIDIFileFailsClosedWhenSystemEventsAutomationDenied() async throws {
+    // #188: when Automation → System Events is not authorized, the import must
+    // fail closed with a typed permission error BEFORE the mutation — it must
+    // NOT run the import script and abort mid-flight with a bare Apple Events
+    // denial.
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent("LogicProMCP-se-denied-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { false },
+        path: tempFile.path,
+        executeScript: { _ in
+            Issue.record("import script must not run when System Events automation is denied")
+            return .error("should not run")
+        },
+        trackCount: { 1 },
+        regionInfos: { .success([]) },
+        deltaPoll: {}
+    )
+
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect((obj["success"] as? Bool) == false)
+    #expect(obj["error"] as? String == "permission_denied")
+    #expect(obj["permission"] as? String == "automation_system_events")
+    #expect(obj["failure_stage"] as? String == "preflight_system_events_permission")
+    #expect((obj["write_attempted"] as? Bool) == false)
+    #expect((obj["safe_to_retry"] as? Bool)!)
+}
+
 @Test func testAccessibilityChannelImportMIDIFileReturnsErrorWhenTrackCountDoesNotIncrease() async throws {
     let tempFile = FileManager.default.temporaryDirectory
         .appendingPathComponent("LogicProMCP-import-mismatch-\(UUID().uuidString).mid")
@@ -1221,6 +1253,7 @@ private func makeSetInstrumentFixture() -> (
     defer { try? FileManager.default.removeItem(at: tempFile) }
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { 3 },
@@ -1253,6 +1286,7 @@ private func makeSetInstrumentFixture() -> (
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
@@ -1317,6 +1351,7 @@ private func makeSetInstrumentFixture() -> (
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: tempFile.path,
         executeScript: { _ in .success("OK TEMPO_SEEN") },
         trackCount: { counter.next() },
@@ -1364,6 +1399,7 @@ private func makeSetInstrumentFixture() -> (
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },
@@ -1396,6 +1432,7 @@ private func makeSetInstrumentFixture() -> (
     let spy = CountSpy()
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: tempFile.path,
         executeScript: { _ in .success(#"{"result":"DIALOG_NOT_FOUND: file-open sheet did not appear"}"#) },
         trackCount: { spy.read() },
@@ -1420,6 +1457,7 @@ private func makeSetInstrumentFixture() -> (
 
 @Test func testAccessibilityChannelImportMIDIFileMissingFileShortCircuits() async throws {
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: "/tmp/LogicProMCP/does-not-exist-\(UUID().uuidString).mid",
         executeScript: { _ in .success("OK") },
         trackCount: { 0 },

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -131,6 +131,7 @@ struct Issue108Tests {
         let counter = CallCounter([1, 2]) // before=1, after=2
         let regions = RegionSnapshotBox([.success([]), .success([importedRegion()])])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
@@ -151,6 +152,7 @@ struct Issue108Tests {
         let counter = CallCounter([1, 2])
         let regions = RegionSnapshotBox([.success([]), .success([])])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
@@ -171,6 +173,7 @@ struct Issue108Tests {
         let counter = CallCounter([3, 3]) // before==after → no import landed
         let regions = RegionSnapshotBox([.success([]), .success([])])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
             path: path,
             executeScript: { _ in .success("OK") },
             trackCount: { counter.next() },
@@ -189,6 +192,7 @@ struct Issue108Tests {
     func importMenuClickError() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
             path: path,
             executeScript: { _ in .success(#"{"result":"MENU_ERROR: not found"}"#) },
             trackCount: { 1 },
@@ -203,6 +207,7 @@ struct Issue108Tests {
     @Test("import_file rejects a nonexistent file with a typed error")
     func importMissingFile() async {
         let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
             path: "/tmp/LogicProMCP/does-not-exist-\(UUID().uuidString).mid",
             executeScript: { _ in .success("OK") },
             trackCount: { 1 },

--- a/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
@@ -98,6 +98,7 @@ func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async th
     let spy = ImportCountSpy(value: 9)
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: fixture.fileURL.path,
         executeScript: { _ in .success(sentinel) },
         trackCount: { spy.read() },
@@ -156,6 +157,7 @@ func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async th
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
         path: fixture.fileURL.path,
         executeScript: { _ in .success("OK") },
         trackCount: { counter.next() },

--- a/Tests/LogicProMCPTests/PermissionCheckerTests.swift
+++ b/Tests/LogicProMCPTests/PermissionCheckerTests.swift
@@ -7,6 +7,8 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     var accessibility = true
     var running = true
     var probeResult = true
+    var systemEventsProbeCalls = 0
+    var systemEventsProbeResult = true
 
     func runtime() -> PermissionChecker.Runtime {
         PermissionChecker.Runtime(
@@ -18,9 +20,38 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
             runAutomationProbe: {
                 self.probeCalls += 1
                 return self.probeResult
+            },
+            runSystemEventsAutomationProbe: {
+                self.systemEventsProbeCalls += 1
+                return self.systemEventsProbeResult
             }
         )
     }
+}
+
+@Test func testPermissionCheckerSystemEventsAutomationProbeReflectsGrant() {
+    let harness = PermissionRuntimeHarness()
+    harness.systemEventsProbeResult = true
+
+    let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
+
+    #expect(state == .granted)
+    #expect(PermissionChecker.checkSystemEventsAutomation(runtime: harness.runtime()))
+    #expect(harness.systemEventsProbeCalls == 2)
+}
+
+@Test func testPermissionCheckerSystemEventsAutomationProbeRunsEvenWhenLogicProNotRunning() {
+    // System Events is always running; its probe is NOT gated on Logic Pro
+    // (unlike the Logic Pro automation probe), so a denied System Events target
+    // is reported as not_granted, not not_verifiable.
+    let harness = PermissionRuntimeHarness()
+    harness.running = false
+    harness.systemEventsProbeResult = false
+
+    let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
+
+    #expect(state == .notGranted)
+    #expect(harness.systemEventsProbeCalls == 1)
 }
 
 @Test func testPermissionCheckerCheckAccessibilityUsesInjectedRuntimeAndPrompt() {

--- a/Tests/LogicProMCPTests/ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/ProductionReadinessTests.swift
@@ -292,10 +292,14 @@ import Testing
     let status = PermissionChecker.check(runtime: .init(
         checkAccessibility: { _ in true },
         isLogicProRunning: { false },
-        runAutomationProbe: { false }
+        runAutomationProbe: { false },
+        runSystemEventsAutomationProbe: { false }
     ))
     #expect(status.accessibility == true)
     #expect(status.automationState == .notVerifiable)
+    // #188: System Events automation is probed unconditionally (System Events is
+    // always running), so a denied probe is reported as not_granted.
+    #expect(status.systemEventsAutomationState == .notGranted)
 }
 
 @Test func testPermissionStatusSummaryFormatsCorrectly() {


### PR DESCRIPTION
Closes #188.

## Problem
`record_sequence` / `midi.import_file` drive `tell application "System Events"` (osascript) to walk Logic's Import menu. **Automation → System Events is a separate TCC target from Automation → Logic Pro.** A host with Logic Pro automation granted (so `logic_system.health` reported `automation: true`, all channels ready) could still have System Events denied — the import then failed *mid-mutation* with a bare Apple Events denial (`import_error: ax_write_failed`), even though the health/permissions surface looked fully green.

## Fix
- **PermissionChecker**: adds a System Events automation probe (`checkSystemEventsAutomation`, an unconditional `tell application "System Events" to return name` — System Events is always running) + `systemEventsAutomationState`. Surfaced in:
  - `--check-permissions` summary → `Automation (System Events): granted|NOT GRANTED`
  - `logic_system.health` → `automation_system_events` + `automation_system_events_status`
- **`defaultImportMIDIFile`**: preflights System Events automation **before** the mutation. If unauthorized → fail closed with a typed State C `permission_denied` (`permission:"automation_system_events"`, `failure_stage:"preflight_system_events_permission"`, `write_attempted:false`, remediation), instead of aborting mid-import.

## Acceptance criteria (#188)
- [x] `--check-permissions` / `logic_system.health` verify the launcher can drive System Events.
- [x] If System Events is not authorized, `record_sequence`/`midi.import_file` fails **before** the mutation with a typed permission error naming the missing permission + the fix.
- [x] A host with green permission checks (incl. System Events) imports + verifies a MIDI region (live E2E).

## Verification
- `swift test` — **1850 passed / 0 failed** (adds System Events probe tests + `testImportMIDIFileFailsClosedWhenSystemEventsAutomationDenied`, which proves the import script never runs when denied).
- Strict fresh live Logic Pro 12.2 E2E — **348 passed / 0 skipped / 0 failed**, including new assertions that health exposes `automation_system_events` (present + granted) and the permissions text lists `Automation (System Events):`.