### PR TITLE
fix: identify the blocking dialog in transport/preflight refusals (#190)

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -1297,6 +1297,18 @@ def main():
         disarm_after_transport = call_tool(client, "logic_tracks", "arm", {"index": 0, "enabled": False})
         disarm_track = wait_for_track_arm(client, 0, False)
 
+        # #190: if a transport op IS refused for a blocking dialog, the refusal
+        # must be IDENTIFIED (dialog role + a safe recovery action), never a bare
+        # blocking_dialog_present. Passes vacuously when no dialog is present.
+        for _label, _env in (("play", play_env), ("play_unchanged", play_unchanged_env), ("stop", final_stop_env)):
+            T(
+                f"transport.{_label} blocking-dialog refusal is identified (#190)",
+                play_resp,
+                lambda _, e=_env: (not isinstance(e, dict))
+                or (e.get("blocking_dialog_present") is not True)
+                or (e.get("recovery_action") is not None and e.get("dialog_role") is not None),
+            )
+
     T_LIVE(
         "fresh transport bootstrap detected",
         fresh_transport_payload,

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -84,6 +84,62 @@ enum AXLogicProElements {
         return windows.contains { isBlockingDialogWindow($0, runtime: runtime.ax) }
     }
 
+    /// Identity of a blocking dialog/sheet, for #190 diagnostics: callers refuse
+    /// mutations while one is present, and an actionable identity (title, role,
+    /// owning window, buttons, recovery action) lets the operator/agent recover
+    /// deterministically instead of guessing at a generic `blocking_dialog_present`.
+    struct BlockingDialogInfo: Sendable, Equatable {
+        let title: String
+        let role: String
+        let owningWindow: String
+        let buttonTitles: [String]
+        let recoveryAction: String
+    }
+
+    static func blockingDialogInfo(runtime: Runtime = .production) -> BlockingDialogInfo? {
+        guard let app = appRoot(runtime: runtime) else { return nil }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app, kAXWindowsAttribute, runtime: runtime.ax
+        ) ?? []
+        guard let dialog = windows.first(where: { isBlockingDialogWindow($0, runtime: runtime.ax) }) else {
+            return nil
+        }
+        let title = (AXHelpers.getAttribute(dialog, kAXTitleAttribute, runtime: runtime.ax) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let role = (AXHelpers.getAttribute(dialog, kAXSubroleAttribute, runtime: runtime.ax) ?? (kAXDialogSubrole as String))
+        let owningWindow = (mainWindow(runtime: runtime).flatMap {
+            AXHelpers.getTitle($0, runtime: runtime.ax)
+        } ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let buttons = AXHelpers.getChildren(dialog, runtime: runtime.ax)
+            .filter { AXHelpers.getRole($0, runtime: runtime.ax) == (kAXButtonRole as String) }
+            .compactMap { AXHelpers.getTitle($0, runtime: runtime.ax) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return BlockingDialogInfo(
+            title: title,
+            role: role,
+            owningWindow: owningWindow,
+            buttonTitles: buttons,
+            recoveryAction: blockingDialogRecoveryAction(title: title, buttons: buttons)
+        )
+    }
+
+    /// A safe, non-destructive recovery action for a blocking dialog. Prefers a
+    /// Cancel-style button (which never saves or discards), then Escape; only
+    /// names a different button when no cancel/escape path is exposed.
+    private static func blockingDialogRecoveryAction(title: String, buttons: [String]) -> String {
+        let cancelMarkers = ["cancel", "취소"]
+        if let cancel = buttons.first(where: { name in
+            cancelMarkers.contains { name.lowercased().contains($0) }
+        }) {
+            return "Press \"\(cancel)\" to dismiss this dialog, then retry."
+        }
+        if !title.isEmpty {
+            return "Dismiss the \"\(title)\" dialog (press Escape or its Cancel/close control), then retry."
+        }
+        return "Dismiss the blocking dialog (press Escape), then retry. Check logic_system.health for the current dialog state."
+    }
+
     /// True when `window` carries an AXSubrole indicating a modal dialog/sheet.
     /// Logic 12 commonly tags Bounce/Save/Open/tempo-alert windows with one of:
     ///   AXDialog, AXSystemDialog, AXFloatingWindow (rare).

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -156,19 +156,31 @@ func toolTextResultTreatingUnverifiedAsError(_ result: ChannelResult) -> CallToo
     return toolTextResult(result)
 }
 
-func blockingLogicDialogResult(operation: String) -> CallTool.Result {
-    toolTextResult(
-        HonestContract.encodeStateC(
-            error: .unsupportedState,
-            hint: "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry.",
-            extras: [
-                "operation": operation,
-                "failure_stage": "preflight_blocking_dialog",
-                "blocking_dialog_present": true,
-                "write_attempted": false,
-                "safe_to_retry": true,
-            ]
-        ),
+func blockingLogicDialogResult(
+    operation: String,
+    info: AXLogicProElements.BlockingDialogInfo? = AXLogicProElements.blockingDialogInfo()
+) -> CallTool.Result {
+    var extras: [String: Any] = [
+        "operation": operation,
+        "failure_stage": "preflight_blocking_dialog",
+        "blocking_dialog_present": true,
+        "write_attempted": false,
+        "safe_to_retry": true,
+    ]
+    var hint = "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry."
+    // #190: identify the dialog so the demo/product workflow can recover
+    // deterministically instead of guessing at a generic blocking-dialog refusal.
+    if let info {
+        extras["dialog_title"] = info.title
+        extras["dialog_role"] = info.role
+        extras["owning_window"] = info.owningWindow
+        extras["dialog_buttons"] = info.buttonTitles
+        extras["recovery_action"] = info.recoveryAction
+        let label = info.title.isEmpty ? info.role : info.title
+        hint = "Refusing \(operation): a blocking Logic dialog/sheet is present (\(label)). \(info.recoveryAction)"
+    }
+    return toolTextResult(
+        HonestContract.encodeStateC(error: .unsupportedState, hint: hint, extras: extras),
         isError: true
     )
 }

--- a/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
@@ -140,6 +140,49 @@ import Testing
     #expect(AXLogicProElements.dialogPresent(runtime: runtime) == true)
 }
 
+@Test func testBlockingDialogInfoReportsIdentityAndCancelRecovery() {
+    // #190: a blocking dialog must be identified — title, role, owning window,
+    // buttons, and a safe (Cancel-first) recovery action.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let dialog = builder.element(2)
+    let arrange = builder.element(3)
+    let cancelButton = builder.element(4)
+    let saveButton = builder.element(5)
+
+    builder.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(dialog, kAXTitleAttribute as String, "Save")
+    builder.setChildren(dialog, [cancelButton, saveButton])
+    builder.setAttribute(cancelButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(cancelButton, kAXTitleAttribute as String, "Cancel")
+    builder.setAttribute(saveButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(saveButton, kAXTitleAttribute as String, "Save")
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Demo - Tracks")
+    builder.setAttribute(app, kAXWindowsAttribute as String, [dialog, arrange])
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    let info = AXLogicProElements.blockingDialogInfo(runtime: runtime)
+
+    let resolved = try! #require(info)
+    #expect(resolved.title == "Save")
+    #expect(resolved.role == (kAXDialogSubrole as String))
+    #expect(resolved.owningWindow == "Demo - Tracks")
+    #expect(resolved.buttonTitles.contains("Cancel"))
+    #expect(resolved.buttonTitles.contains("Save"))
+    #expect(resolved.recoveryAction.contains("Cancel"))
+}
+
+@Test func testBlockingDialogInfoReturnsNilWhenNoDialog() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.blockingDialogInfo(runtime: runtime) == nil)
+}
+
 @Test func testDialogPresentReturnsFalseWhenNoDialogs() {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(1)

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -525,6 +525,48 @@ private func liveTransportJSON(
     #expect(executed.isEmpty)
 }
 
+@Test func testBlockingLogicDialogResultEnrichesDiagnosticWithDialogIdentity() throws {
+    // #190: when a blocking dialog is identified, the refusal envelope must carry
+    // its title, role, owning window, buttons, and a safe recovery action — not
+    // just a generic blocking_dialog_present.
+    let info = AXLogicProElements.BlockingDialogInfo(
+        title: "Save",
+        role: "AXDialog",
+        owningWindow: "Demo - Tracks",
+        buttonTitles: ["Cancel", "Save"],
+        recoveryAction: "Press \"Cancel\" to dismiss this dialog, then retry."
+    )
+
+    let result = blockingLogicDialogResult(operation: "transport.play", info: info)
+
+    #expect(result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["error"] as? String == "unsupported_state")
+    #expect(object["operation"] as? String == "transport.play")
+    #expect(object["failure_stage"] as? String == "preflight_blocking_dialog")
+    #expect((object["blocking_dialog_present"] as? Bool)!)
+    #expect(object["dialog_title"] as? String == "Save")
+    #expect(object["dialog_role"] as? String == "AXDialog")
+    #expect(object["owning_window"] as? String == "Demo - Tracks")
+    #expect((object["dialog_buttons"] as? [String])!.contains("Cancel"))
+    #expect(object["recovery_action"] as? String == info.recoveryAction)
+    #expect((object["hint"] as? String)!.contains("Cancel"))
+}
+
+@Test func testBlockingLogicDialogResultWithoutInfoStaysGenericButHonest() throws {
+    // No identifiable dialog (probe returned nil): keep the base fail-closed
+    // envelope without fabricating identity fields.
+    let result = blockingLogicDialogResult(operation: "transport.play", info: nil)
+
+    #expect(result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["error"] as? String == "unsupported_state")
+    #expect((object["blocking_dialog_present"] as? Bool)!)
+    #expect(object["dialog_title"] == nil)
+    #expect(object["dialog_role"] == nil)
+    #expect(object["recovery_action"] == nil)
+}
+
 @Test func testTransportDispatcherToggleMetronomeVerifiesViaTransportStateReadback() async throws {
     let router = ChannelRouter()
     let ax = SequencedTransportReadbackChannel(


### PR DESCRIPTION
Closes #190.

## Problem
After a MIDI import (or any modal), transport ops correctly fail closed — but the diagnostic was a bare `blocking_dialog_present: true` / `failure_stage: preflight_blocking_dialog`. The demo/product workflow couldn't tell **which** dialog blocked it or **how to recover**, forcing manual screen-level cleanup.

## Fix
- **`AXLogicProElements.blockingDialogInfo()`** reads the blocking dialog's identity: `title`, `role` (AXSubrole), owning window, button titles, and a **safe recovery action** (prefers a Cancel-style button → never saves/discards; falls back to Escape). Returns `nil` when no blocking dialog is present.
- **`blockingLogicDialogResult`** enriches the State C refusal with `dialog_title`, `dialog_role`, `owning_window`, `dialog_buttons`, and `recovery_action` (defaults to the real AX probe; injectable for tests). With no identifiable dialog it stays the honest generic envelope.

## Acceptance criteria (#190)
- [x] `blocking_dialog_present` diagnostics include dialog title, role, owning window, and at least one safe recovery action.
- [x] A blocking-dialog refusal is identified, not generic (live-e2e guard).
- [x] A fresh import→playback path executes `goto_position`/`play`/`stop` after region readback (live E2E).
- Note: clearing import/save/tempo sheets at import completion is addressed by the bootstrap Escape-recovery work (#187); this PR makes the *remaining* blocking dialog deterministically identifiable + recoverable.

## Verification
- `swift test` — **1851 passed / 0 failed** (adds `blockingDialogInfo` identity/recovery tests + `blockingLogicDialogResult` enrichment tests).
- Strict fresh live Logic Pro 12.2 E2E — **348 passed / 0 skipped / 0 failed** (regression + the new "blocking-dialog refusal is identified" guard).
- **LIVE, definitive**: with a real blocking dialog injected, `logic_transport.play` returned `blocking_dialog_present:true`, `dialog_role:"AXDialog"`, `owning_window:"Untitled 54 - Tracks"`, and `recovery_action:"Press \"Cancel\" to dismiss this dialog, then retry."` — identified, not generic.