### PR TITLE
fix(#201): bound mutation gate's post-timeout hold so one hung op can't pin the session

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6e07dc4da9ac4deea92962bd900f9f9c2e9142c00e7d40339c271704612cdb36",
+  "originHash" : "62fe1af023a6940785857caee9fd5350e94f6ea47c129225487b640c5e50dcee",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
-        "version" : "0.12.0"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -138,6 +138,11 @@ final class LogicMutationGate: @unchecked Sendable {
     private let lock = NSLock()
     private var activeOperation: String?
     private var acquiredAt: Date?
+    /// Set when the command deadline abandons the current holder (#201). A
+    /// timed-out holder is reclaimable after the much shorter `timedOutReclaimGrace`
+    /// rather than the blanket `staleHolderTTL`, so one hung transport/track op
+    /// cannot pin the entire write surface for minutes.
+    private var timedOutAt: Date?
     private var epoch: UInt64 = 0
 
     /// Staleness safety valve. The #112 deadline frees the stdio loop on a hang,
@@ -150,24 +155,54 @@ final class LogicMutationGate: @unchecked Sendable {
     /// longest command deadline so a healthy long-running op never trips it.
     private let staleHolderTTL: TimeInterval
 
-    init(staleHolderTTL: TimeInterval = 360) {
+    /// #201: once the command deadline has ABANDONED a mutating op, the server
+    /// already gave up on it — holding the gate for the full `staleHolderTTL`
+    /// (minutes) needlessly locks out every other mutation. After the deadline
+    /// marks the holder timed-out, the gate is reclaimable after this short
+    /// grace, set comfortably above the worst-case single blocked AX call
+    /// (≈2.5s) so the abandoned work has unwound before a successor proceeds.
+    private let timedOutReclaimGrace: TimeInterval
+
+    init(staleHolderTTL: TimeInterval = 360, timedOutReclaimGrace: TimeInterval = 15) {
         self.staleHolderTTL = staleHolderTTL
+        self.timedOutReclaimGrace = timedOutReclaimGrace
     }
 
     func tryAcquire(operation: String, now: Date = Date()) -> Claim? {
         lock.lock()
         defer { lock.unlock() }
         if let active = activeOperation, let since = acquiredAt {
-            guard now.timeIntervalSince(since) >= staleHolderTTL else { return nil }
-            Log.warn(
-                "Reclaiming stale mutation gate from \(active) held \(Int(now.timeIntervalSince(since)))s (TTL \(Int(staleHolderTTL))s) — prior op may still be wedged",
-                subsystem: "server"
-            )
+            if let timedOutAt, now.timeIntervalSince(timedOutAt) >= timedOutReclaimGrace {
+                Log.warn(
+                    "Reclaiming timed-out mutation gate from \(active) (grace \(Int(timedOutReclaimGrace))s elapsed) — prior op was abandoned by the command deadline",
+                    subsystem: "server"
+                )
+            } else if now.timeIntervalSince(since) >= staleHolderTTL {
+                Log.warn(
+                    "Reclaiming stale mutation gate from \(active) held \(Int(now.timeIntervalSince(since)))s (TTL \(Int(staleHolderTTL))s) — prior op may still be wedged",
+                    subsystem: "server"
+                )
+            } else {
+                return nil
+            }
         }
         epoch &+= 1
         activeOperation = operation
         acquiredAt = now
+        timedOutAt = nil
         return Claim(epoch: epoch, operation: operation)
+    }
+
+    /// Mark the current holder (if `claim` still owns the gate) as abandoned by
+    /// the command deadline, starting the short `timedOutReclaimGrace` window.
+    /// Epoch-guarded so a late mark from an abandoned op cannot affect a
+    /// successor that already reclaimed the gate.
+    func markTimedOut(_ claim: Claim, now: Date = Date()) {
+        lock.lock()
+        if epoch == claim.epoch {
+            timedOutAt = now
+        }
+        lock.unlock()
     }
 
     func release(_ claim: Claim) {
@@ -175,6 +210,7 @@ final class LogicMutationGate: @unchecked Sendable {
         if epoch == claim.epoch {
             activeOperation = nil
             acquiredAt = nil
+            timedOutAt = nil
         }
         lock.unlock()
     }
@@ -206,7 +242,12 @@ actor LogicProServer {
     private let cgEventChannel: CGEventChannel
     private let appleScriptChannel: AppleScriptChannel
     private let runtimeOverrides: LogicProServerRuntimeOverrides?
-    private let mutationGate = LogicMutationGate()
+    /// #201: after the command deadline abandons a mutating op, the gate is
+    /// reclaimable this many seconds later so one hung op cannot pin the whole
+    /// write surface for the full stale-holder TTL. Single source of truth for
+    /// the gate's grace and the timeout envelope's `gate_reclaim_after_sec`.
+    static let mutationGateReclaimGraceSeconds: Double = 15
+    private let mutationGate = LogicMutationGate(timedOutReclaimGrace: LogicProServer.mutationGateReclaimGraceSeconds)
 
     init(
         runtimeOverrides: LogicProServerRuntimeOverrides? = nil,
@@ -415,9 +456,15 @@ actor LogicProServer {
             "recovery_hint": "Logic Pro may be busy, occluded, or showing a modal dialog. Dismiss any dialog and retry; check logic_system.health.",
         ]
         if mutationMayStillBeRunning {
+            // #201: the abandoned op's effect is unknown, so this result is not
+            // itself safe to retry — but the gate no longer pins the session
+            // indefinitely. It auto-reclaims `gate_reclaim_after_sec` after this
+            // timeout, so unrelated mutating commands recover on their own
+            // (their `mutating_operation_in_progress` refusal is `safe_to_retry`).
             extras["safe_to_retry"] = false
             extras["underlying_operation_stopped"] = false
-            extras["mutation_gate"] = "held_until_underlying_operation_returns"
+            extras["mutation_gate"] = "reclaimable_after_grace"
+            extras["gate_reclaim_after_sec"] = Self.mutationGateReclaimGraceSeconds
         }
         let body = HonestContract.encodeStateC(
             error: .operationTimeout,
@@ -504,6 +551,14 @@ actor LogicProServer {
                 )
                 if didWin {
                     workTask.cancel()
+                    // #201: the deadline has abandoned this op. Start the gate's
+                    // bounded reclaim grace so a successor mutation recovers
+                    // without waiting for the (possibly wedged) work to return or
+                    // for the multi-minute stale-holder TTL. Epoch-guarded: if the
+                    // work later returns and releases, that wins harmlessly first.
+                    if let heldMutationGate, let heldClaim {
+                        heldMutationGate.markTimedOut(heldClaim)
+                    }
                 }
             }
             timeoutHandle.set(timeoutTask)

--- a/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
@@ -252,4 +252,131 @@ struct Issue112CommandDeadlineTests {
         #expect(obj?["error"] as? String == "operation_timeout")
         #expect(obj?["operation"] as? String == "logic_navigate.create_marker")
     }
+
+    // MARK: - #201 bounded post-timeout gate reclaim
+
+    @Test("a timed-out holder is reclaimed after the short grace, not the full stale TTL")
+    func timedOutHolderReclaimsAfterGrace() {
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+        let t0 = Date()
+        let first = gate.tryAcquire(operation: "logic_transport.play", now: t0)
+        #expect(first != nil)
+        // The command deadline abandons logic_transport.play at its 25s deadline.
+        gate.markTimedOut(first!, now: t0.addingTimeInterval(25))
+        // Within the grace after the timeout, the gate is still genuinely held —
+        // a successor mutation is refused (the abandoned work may still be unwinding).
+        #expect(gate.tryAcquire(operation: "logic_transport.stop", now: t0.addingTimeInterval(25 + 14)) == nil)
+        // Past the grace, a successor reclaims it — recovery happens ~40s after the
+        // op started, NOT after the 360s blanket stale-holder TTL (#201).
+        let second = gate.tryAcquire(operation: "logic_transport.stop", now: t0.addingTimeInterval(25 + 16))
+        #expect(second != nil)
+        #expect(gate.currentOperation() == "logic_transport.stop")
+        // The abandoned op's late release must NOT free the reclaimed gate (epoch).
+        gate.release(first!)
+        #expect(gate.currentOperation() == "logic_transport.stop")
+        gate.release(second!)
+        #expect(gate.currentOperation() == nil)
+    }
+
+    @Test("markTimedOut is epoch-guarded against an already-reclaimed successor")
+    func markTimedOutIsEpochGuarded() {
+        let gate = LogicMutationGate(staleHolderTTL: 5, timedOutReclaimGrace: 15)
+        let t0 = Date()
+        let first = gate.tryAcquire(operation: "logic_tracks.rename", now: t0)
+        #expect(first != nil)
+        // A successor reclaims via the stale TTL before any timeout mark.
+        let second = gate.tryAcquire(operation: "logic_tracks.mute", now: t0.addingTimeInterval(6))
+        #expect(second != nil)
+        // A late timeout mark from the abandoned first op must not mark the
+        // successor — the successor is healthy and still owns the gate.
+        gate.markTimedOut(first!, now: t0.addingTimeInterval(7))
+        // Within the successor's own grace/TTL a third op is still refused.
+        #expect(gate.tryAcquire(operation: "logic_tracks.solo", now: t0.addingTimeInterval(8)) == nil)
+        gate.release(second!)
+        #expect(gate.currentOperation() == nil)
+    }
+
+    @Test("a healthy (non-timed-out) holder still requires the full stale TTL")
+    func nonTimedOutHolderUsesStaleTTL() {
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+        let t0 = Date()
+        let first = gate.tryAcquire(operation: "logic_project.bounce", now: t0)
+        #expect(first != nil)
+        // No timeout mark → the short grace must NOT apply to a healthy long-running
+        // op; it is still held well past the grace window.
+        #expect(gate.tryAcquire(operation: "logic_tracks.mute", now: t0.addingTimeInterval(16)) == nil)
+        // Only the full stale TTL reclaims a healthy long-running holder.
+        #expect(gate.tryAcquire(operation: "logic_tracks.mute", now: t0.addingTimeInterval(361)) != nil)
+    }
+
+    @Test("a timed-out mutating deadline result advertises bounded gate reclaim")
+    func timeoutResultAdvertisesBoundedReclaim() {
+        let result = LogicProServer.deadlineTimeoutResult(
+            tool: "logic_transport", command: "play", seconds: 25, mutationMayStillBeRunning: true
+        )
+        #expect(result.isError!)
+        let obj = json(result)
+        #expect(obj?["error"] as? String == "operation_timeout")
+        #expect(obj?["mutation_gate"] as? String == "reclaimable_after_grace")
+        #expect((obj?["gate_reclaim_after_sec"] as? Double) == LogicProServer.mutationGateReclaimGraceSeconds)
+        // The abandoned op's own effect is unknown → still not safe to retry, and
+        // it was not stopped (only abandoned).
+        #expect(!((obj?["safe_to_retry"] as? Bool)!))
+        #expect(!((obj?["underlying_operation_stopped"] as? Bool)!))
+    }
+
+    @Test("a timed-out mutating op frees the gate after the reclaim grace, end-to-end")
+    func timedOutMutationRecoversGateEndToEnd() async throws {
+        // The wedged op never returns (held by the semaphore for the whole test),
+        // so recovery can ONLY come from the #201 bounded reclaim, not from the
+        // work's own release. Grace is injected short so the test stays fast.
+        let blocker = BlockingWorkProbe()
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 0.3)
+        let resultProbe = ResultProbe()
+
+        let runner = Task {
+            let result = await LogicProServer.runWithDeadline(
+                tool: "logic_transport",
+                command: "play",
+                deadlineOverride: 0.05,
+                mutationGate: gate
+            ) {
+                blocker.run()
+            }
+            await resultProbe.store(result)
+        }
+
+        #expect(try await waitUntil(timeoutNanoseconds: 5_000_000_000) { blocker.hasEntered() })
+        #expect(try await waitUntil(timeoutNanoseconds: 10_000_000_000) { await resultProbe.hasResult() })
+        #expect(json(await resultProbe.load()!)?["error"] as? String == "operation_timeout")
+
+        // Immediately after the timeout (within the grace) a follow-up is refused —
+        // the wedged play may still be unwinding.
+        let refused = await LogicProServer.runWithDeadline(
+            tool: "logic_transport",
+            command: "stop",
+            deadlineOverride: 1,
+            mutationGate: gate
+        ) {
+            toolTextResult("{\"unexpected\":true}")
+        }
+        #expect(json(refused)?["error"] as? String == "mutating_operation_in_progress")
+
+        // Once the reclaim grace elapses, the gate auto-recovers WITHOUT the wedged
+        // play ever returning, so a follow-up mutation proceeds (#201).
+        try await Task.sleep(nanoseconds: 500_000_000) // > the 0.3s injected grace
+        let recovered = await LogicProServer.runWithDeadline(
+            tool: "logic_transport",
+            command: "stop",
+            deadlineOverride: 1,
+            mutationGate: gate
+        ) {
+            toolTextResult("{\"verified\":true}")
+        }
+        #expect(recovered.isError != true)
+        #expect((json(recovered)?["verified"] as? Bool)!)
+
+        blocker.unblock()
+        await runner.value
+    }
 }


### PR DESCRIPTION
Fixes #201.

## Problem
When the #112 command deadline abandons a hung mutating op to free the stdio loop, the `LogicMutationGate` was released only when the (possibly wedged) detached work finally returned, or after the **360s** blanket stale-holder TTL. So one timed-out `logic_transport.play` left **every** subsequent mutating command returning `mutating_operation_in_progress` for up to 6 minutes — the entire write surface dead.

## Fix
The deadline now marks the abandoned holder timed-out (`markTimedOut`), and the gate becomes reclaimable after a short bounded grace (`LogicProServer.mutationGateReclaimGraceSeconds = 15s`, comfortably above the worst-case single blocked AX call ≈2.5s and the ≈0.7s `BoundedProcessRunner` SIGKILL window) instead of the full stale TTL. A successor mutation recovers on its own ~grace seconds after the timeout. **Epoch-guarded throughout**: a late `release`/`markTimedOut` from the abandoned work cannot affect a successor that already reclaimed the gate.

The timed-out envelope advertises this honestly: `mutation_gate:"reclaimable_after_grace"` + `gate_reclaim_after_sec`. The op's own result stays `safe_to_retry:false` / `underlying_operation_stopped:false` (its effect is unknown), but the session is no longer pinned.

## Verification
- New `LogicMutationGate` state-machine tests (timed-out reclaim after grace; still held within grace; epoch-guard vs reclaimed successor; healthy holder still needs the full stale TTL), bounded-reclaim envelope shape, and an **end-to-end** `runWithDeadline` test proving a wedged op that NEVER returns still frees the gate after the grace. Existing gate/deadline contract tests unchanged.
- `swift test --no-parallel`: **1864 passed / 0 failed**.
- Strict live E2E (real Logic Pro 12.2): **352/352** — mutating ops still acquire/release correctly on the happy path.
- Adversarial concurrency review: race-free state machine; 15s grace verified safe for every mutating command path; no regressions.