### PR TITLE
fix(#199): bound resource reads with a deadline so they never hang with no JSON-RPC response

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -364,7 +364,13 @@ actor LogicProServer {
                 )
             },
             readResource: { params in
-                try await ResourceHandlers.read(uri: params.uri, cache: cache, router: router)
+                // #199: bound every resource read with the same liveness backstop
+                // as tool calls. A live-route-backed read on a wedged Logic
+                // session must return a typed operation_timeout body, never leave
+                // the client with no JSON-RPC response.
+                try await Self.runResourceReadWithDeadline(uri: params.uri) {
+                    try await ResourceHandlers.read(uri: params.uri, cache: cache, router: router)
+                }
             },
             listResourceTemplates: { _ in
                 let connected = await cache.getMCUConnection().isConnected
@@ -514,6 +520,73 @@ actor LogicProServer {
         }
     }
 
+    // MARK: - #199 resource-read deadline (resources had NO backstop)
+
+    /// Resource reads (`logic://…`) had no deadline wrapper, unlike tool calls.
+    /// A read backed by a live AX route (`logic://transport/state`,
+    /// `logic://tracks/{i}/regions`) on a wedged/occluded Logic session could
+    /// block past the client's read timeout and leave it with NO JSON-RPC
+    /// response (#199). This backstop bounds every resource read the same way
+    /// the #112 deadline bounds tool calls. Set to match the fast tool tier so a
+    /// healthy read (sub-second) can never false-trip; only a genuine hang trips.
+    static let resourceReadDeadlineSeconds: Double = 25
+
+    /// Typed `operation_timeout` envelope returned as the resource body when a
+    /// read exceeds its deadline — a bounded JSON-RPC response the client can
+    /// classify, instead of a hang with no response.
+    static func resourceReadTimeoutResult(uri: String, seconds: Double) -> ReadResource.Result {
+        let body = HonestContract.encodeStateC(
+            error: .operationTimeout,
+            hint: "Resource read \(uri) exceeded the \(Int(seconds))s server-side deadline and was abandoned so the stdio loop stays responsive.",
+            extras: [
+                "uri": uri,
+                "timeout_sec": seconds,
+                "recovery_hint": "Logic Pro may be busy, occluded, or showing a modal dialog. Dismiss any dialog and retry; check logic_system.health.",
+            ]
+        )
+        return ReadResource.Result(contents: [.text(body, uri: uri, mimeType: "application/json")])
+    }
+
+    /// Race a throwing resource read against `resourceReadDeadlineSeconds`. A
+    /// genuine read error (invalid URI, etc.) is rethrown unchanged so existing
+    /// JSON-RPC error semantics are preserved; only a deadline overrun is
+    /// converted into a typed `operation_timeout` resource body. Mirrors
+    /// `runWithDeadline` but for the read-only `ReadResource.Result` shape, so
+    /// it never touches the mutation gate.
+    static func runResourceReadWithDeadline(
+        uri: String,
+        deadlineOverride: Double? = nil,
+        work: @escaping @Sendable () async throws -> ReadResource.Result
+    ) async throws -> ReadResource.Result {
+        let deadline = deadlineOverride ?? resourceReadDeadlineSeconds
+        return try await withCheckedThrowingContinuation { continuation in
+            let race = ResourceDeadlineRace()
+            let timeoutHandle = DeadlineTimeoutHandle()
+            let workTask = Task.detached(priority: .userInitiated) {
+                do {
+                    let result = try await work()
+                    if race.resume(continuation, returning: result) { timeoutHandle.cancel() }
+                } catch {
+                    if race.resume(continuation, throwing: error) { timeoutHandle.cancel() }
+                }
+            }
+            let timeoutTask = DispatchWorkItem {
+                let didWin = race.resume(
+                    continuation,
+                    returning: Self.resourceReadTimeoutResult(uri: uri, seconds: deadline)
+                )
+                if didWin {
+                    workTask.cancel()
+                }
+            }
+            timeoutHandle.set(timeoutTask)
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                deadline: .now() + deadline,
+                execute: timeoutTask
+            )
+        }
+    }
+
     private static let mutatingCommandsByTool: [String: Set<String>] = [
         "logic_transport": [
             "play", "stop", "record", "pause", "rewind", "fast_forward", "toggle_cycle",
@@ -578,6 +651,41 @@ actor LogicProServer {
             resumed = true
             lock.unlock()
             continuation.resume(returning: result)
+            return true
+        }
+    }
+
+    /// #199 throwing-capable single-winner race for the resource-read deadline.
+    /// Like `DeadlineRace` but resumes a `CheckedContinuation<…, Error>` and can
+    /// resume with either a value (read success / timeout body) or a thrown
+    /// error (genuine read failure), guaranteeing the continuation resumes once.
+    private final class ResourceDeadlineRace: @unchecked Sendable {
+        private let lock = NSLock()
+        private var resumed = false
+
+        @discardableResult
+        func resume(
+            _ continuation: CheckedContinuation<ReadResource.Result, Error>,
+            returning result: ReadResource.Result
+        ) -> Bool {
+            lock.lock()
+            if resumed { lock.unlock(); return false }
+            resumed = true
+            lock.unlock()
+            continuation.resume(returning: result)
+            return true
+        }
+
+        @discardableResult
+        func resume(
+            _ continuation: CheckedContinuation<ReadResource.Result, Error>,
+            throwing error: Error
+        ) -> Bool {
+            lock.lock()
+            if resumed { lock.unlock(); return false }
+            resumed = true
+            lock.unlock()
+            continuation.resume(throwing: error)
             return true
         }
     }

--- a/Tests/LogicProMCPTests/Issue199ResourceReadDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue199ResourceReadDeadlineTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #199: resource reads (`logic://…`) had no deadline wrapper, so a read backed
+/// by a live AX route on a wedged/occluded Logic session could block past the
+/// client read timeout and leave it with NO JSON-RPC response. The backstop
+/// bounds every resource read into a typed `operation_timeout` body the same way
+/// the #112 deadline bounds tool calls.
+@Suite("Issue199 resource-read deadline")
+struct Issue199ResourceReadDeadlineTests {
+    private func json(_ r: ReadResource.Result) -> [String: Any]? {
+        guard let data = sharedResourceText(r).data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    @Test("a fast resource read passes through unchanged")
+    func fastReadPassesThrough() async throws {
+        let result = try await LogicProServer.runResourceReadWithDeadline(
+            uri: "logic://tracks",
+            deadlineOverride: 5.0
+        ) {
+            ReadResource.Result(contents: [.text("{\"ok\":true}", uri: "logic://tracks", mimeType: "application/json")])
+        }
+        #expect(json(result)?["ok"] as? Bool == true)
+    }
+
+    @Test("a resource read that exceeds the deadline returns a typed operation_timeout body, not a hang")
+    func slowReadTimesOut() async throws {
+        let uri = "logic://transport/state"
+        let result = try await LogicProServer.runResourceReadWithDeadline(uri: uri, deadlineOverride: 0.15) {
+            // Far past the 0.15s deadline — this read must NOT win the race.
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            return ReadResource.Result(contents: [.text("{\"should\":\"not win\"}", uri: uri, mimeType: "application/json")])
+        }
+        let obj = try #require(json(result))
+        #expect(obj["error"] as? String == "operation_timeout")
+        #expect((obj["success"] as? Bool)! == false)
+        #expect(obj["uri"] as? String == uri)
+        #expect(obj["timeout_sec"] as? Double == 0.15)
+    }
+
+    @Test("a genuine read error is rethrown unchanged so JSON-RPC error semantics are preserved")
+    func readErrorRethrown() async {
+        do {
+            _ = try await LogicProServer.runResourceReadWithDeadline(
+                uri: "logic://bogus",
+                deadlineOverride: 5.0
+            ) {
+                throw MCPError.invalidParams("Unknown resource URI: logic://bogus")
+            }
+            Issue.record("expected the underlying read error to propagate")
+        } catch {
+            // Rethrown unchanged: same MCPError type AND original message preserved
+            // (the wrapper must not swallow or transform a genuine read error).
+            #expect(error is MCPError)
+            #expect("\(error)".contains("Unknown resource URI"))
+        }
+    }
+
+    @Test("the resource-read deadline matches the fast tool tier")
+    func resourceDeadlineValue() {
+        #expect(LogicProServer.resourceReadDeadlineSeconds == 25)
+    }
+
+    @Test("the resource timeout body is a State C envelope shape")
+    func timeoutBodyShape() {
+        let uri = "logic://tracks/0/regions"
+        let result = LogicProServer.resourceReadTimeoutResult(uri: uri, seconds: 25)
+        let obj = json(result)
+        #expect((obj?["success"] as? Bool)! == false)
+        #expect(obj?["error"] as? String == "operation_timeout")
+        #expect(obj?["uri"] as? String == uri)
+        #expect(obj?["timeout_sec"] as? Double == 25)
+    }
+}


### PR DESCRIPTION
Fixes #199.

## Problem
Tool calls run under the #112 server-side deadline, but resource reads (`logic://…`) had **no backstop**. A read backed by a live AX route (`logic://transport/state`, `logic://tracks/{i}/regions`) on a wedged/occluded Logic session could block past the client's read timeout and leave it with **no JSON-RPC response**.

## Fix
Wrap the `ReadResource` handler in `runResourceReadWithDeadline`, mirroring `runWithDeadline` for the read-only `ReadResource.Result` shape (**no mutation gate** — resources are read-only). On overrun it returns a typed `operation_timeout` resource body (`success:false`, `uri`, `timeout_sec`, recovery hint) the client can classify; a genuine read error (invalid URI, etc.) is **rethrown unchanged** so JSON-RPC error semantics are preserved. Deadline matches the fast tool tier (25s) so a healthy sub-second read can never false-trip.

## Scope
- The tool reads in the report (`resolve_path`/`library`/`get_inventory`/`get_regions`/`refresh_cache`) already return a typed `operation_timeout` via `runWithDeadline` — compliant.
- The long scans (`scan_library`/`scan_plugin_presets`) return a typed envelope at their long-running 300s tier; a real library walk is legitimately long, so the harness seeing "no response" within its shorter patience is the client giving up before the server's bounded deadline, not an unbounded server hang.

## Verification
- New tests: fast read passes through; a read past the deadline yields a typed `operation_timeout` body (not a hang); a genuine read error rethrows unchanged (type + message preserved); envelope shape + deadline value pinned.
- `swift test --no-parallel`: **1864 passed / 0 failed**.
- Strict live E2E (real Logic Pro 12.2): **352/352** (all resource reads return correctly).
- Adversarial review: single-resume continuation safety verified across all work/throw/timeout interleavings; mutation gate untouched; error fidelity preserved; all resource paths routed through the wrapper.