### PR TITLE
fix(#200): indexed resource templates return a typed empty-state body, not a raw -32602

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -2275,10 +2275,15 @@ def main():
 
     # Template resource
     r = read_resource(client, "logic://tracks/0")
-    T("resource template tracks/0 responds", r, lambda _: True)  # may return track or error, both valid
+    T("resource template tracks/0 responds", r, lambda _: True)  # may return track or typed out-of-range, both valid
 
+    # #200: an out-of-range indexed-template read returns a typed, classifiable
+    # index_out_of_range body (never a raw JSON-RPC -32602 / no response).
     r = read_resource(client, "logic://tracks/-1")
-    T("resource template tracks/-1 throws", r, lambda _: "error" in r or is_error(r))
+    _oob = safe_json(resource_text(r)) or {}
+    T("resource template tracks/-1 returns typed index_out_of_range (#200)", r,
+      lambda _: _oob.get("error") == "index_out_of_range" and _oob.get("success") is False
+      and _oob.get("requested_index") == -1)
 
     # Unknown URI
     r = read_resource(client, "logic://nonexistent")

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -826,6 +826,37 @@ extension ResourceHandlers {
         )
     }
 
+    /// #200: an out-of-range / empty-state indexed-template read returns a typed,
+    /// classifiable resource body (State C `index_out_of_range`) instead of a raw
+    /// JSON-RPC `-32602`. `availableIndices` is the EXACT set of valid indices for
+    /// the collection — `0..<count` for the positionally-indexed track list, but
+    /// the actual `trackIndex` values for the mixer (whose strips are keyed by
+    /// `trackIndex`, NOT array position, so a strip set can be non-contiguous,
+    /// e.g. {0, 2, 4}). The hint therefore never asserts a contiguous `0..<N`
+    /// range (which would mislead a client past a gap); it points at the parent
+    /// collection and the body carries `available_indices` as the machine truth.
+    static func indexOutOfRangeResult(
+        uri: String,
+        requestedIndex: Int,
+        availableIndices: [Int],
+        collection: String
+    ) -> ReadResource.Result {
+        let body = HonestContract.encodeStateC(
+            error: .indexOutOfRange,
+            hint: "No \(collection) at index \(requestedIndex); \(availableIndices.count) \(collection)(s) available. Read the parent collection resource for the current valid indices.",
+            extras: [
+                "uri": uri,
+                "requested_index": requestedIndex,
+                "available_count": availableIndices.count,
+                "available_indices": availableIndices,
+                "collection": collection,
+            ]
+        )
+        return ReadResource.Result(
+            contents: [.text(body, uri: uri, mimeType: "application/json")]
+        )
+    }
+
     private static func readTrack(at index: Int, cache: StateCache, uri: String) async throws -> ReadResource.Result {
         if let track = await cache.getTrack(at: index) {
             let json = encodeJSON(track)
@@ -833,7 +864,14 @@ extension ResourceHandlers {
                 contents: [.text(json, uri: uri, mimeType: "application/json")]
             )
         }
-        throw MCPError.invalidParams("No track at index \(index)")
+        // Tracks are positionally indexed (`getTrack(at:)` uses `tracks.indices`),
+        // so the valid set is 0..<count.
+        return indexOutOfRangeResult(
+            uri: uri,
+            requestedIndex: index,
+            availableIndices: Array(0..<(await cache.getTracks().count)),
+            collection: "track"
+        )
     }
 
     /// B1 (#11) — `data_source` for `logic://mixer` strips. Strip volume/pan
@@ -1071,6 +1109,12 @@ extension ResourceHandlers {
         router: ChannelRouter,
         uri: String
     ) async throws -> ReadResource.Result {
+        // The regions read returns an empty array for an index with no regions —
+        // already a classifiable empty-state — and its live-route "no JSON-RPC
+        // response" hang is bounded by the resource-read deadline (#199), NOT by a
+        // track-count short-circuit: the cache can hold regions for a track whose
+        // header isn't in the track array, so track_count is not a reliable
+        // existence proxy here.
         if case .success(let payload) = await router.route(operation: "region.get_regions"),
            let liveRegions = try? RegionInfo.decodeToolPayload(payload) {
             await cache.updateRegions(liveRegions.map { $0.asRegionState() })
@@ -1084,7 +1128,14 @@ extension ResourceHandlers {
 
     private static func readMixerStrip(at index: Int, cache: StateCache, uri: String) async throws -> ReadResource.Result {
         guard let strip = await cache.getChannelStrip(at: index) else {
-            throw MCPError.invalidParams("No channel strip at index \(index)")
+            // Mixer strips are keyed by `trackIndex` (not array position), so the
+            // valid set is the actual trackIndex values — possibly non-contiguous.
+            return indexOutOfRangeResult(
+                uri: uri,
+                requestedIndex: index,
+                availableIndices: await cache.getChannelStrips().map(\.trackIndex).sorted(),
+                collection: "channel strip"
+            )
         }
         // B2 (#11): give the single-strip read the same envelope + provenance as
         // logic://mixer, so a harness reading an individual strip gets the same

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -158,6 +158,7 @@ enum HonestContract {
         /// other channel can save an untitled document without a path; the
         /// caller must supply one via `project.save_as`. #144 (P3 hardening).
         case unsupportedState
+        case indexOutOfRange
 
         var rawValue: String {
             switch self {
@@ -199,6 +200,7 @@ enum HonestContract {
             case .unsupportedTrackType: return "unsupported_track_type"
             case .pathNotInLibrary: return "path_not_in_library"
             case .unsupportedState: return "unsupported_state"
+            case .indexOutOfRange: return "index_out_of_range"
             }
         }
     }
@@ -367,6 +369,10 @@ enum HonestContract {
         // State C `unsupported_state` — no fallback channel can save a document
         // that has no on-disk path; the caller must use `project.save_as`.
         FailureError.unsupportedState.rawValue,
+        // #200: an out-of-range/empty indexed resource template read is terminal
+        // — retrying the same index against the same project state can't succeed;
+        // the client must read the parent collection for valid indices.
+        FailureError.indexOutOfRange.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -866,18 +866,29 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     }
 }
 
-@Test func testE2EResourceTrackIndexWithNoTracksThrows() async throws {
+@Test func testE2EResourceTrackIndexWithNoTracksReturnsTypedOutOfRange() async throws {
+    // #200: an indexed-template read on empty/out-of-range project state must
+    // return a typed, classifiable body (State C index_out_of_range with the
+    // requested index + available count), NOT a raw JSON-RPC -32602 the client
+    // can only treat as a protocol error.
     let h = await makeE2EHandlers()
-    await #expect(throws: MCPError.self) {
-        try await h.readResource(.init(uri: "logic://tracks/0"))
-    }
+    let result = try await h.readResource(.init(uri: "logic://tracks/0"))
+    let obj = sharedJSONObject(sharedResourceText(result))
+    #expect((obj?["success"] as? Bool)! == false)
+    #expect(obj?["error"] as? String == "index_out_of_range")
+    #expect(obj?["requested_index"] as? Int == 0)
+    #expect(obj?["available_count"] as? Int == 0)
 }
 
-@Test func testE2EResourceTrackIndexNegativeThrows() async throws {
+@Test func testE2EResourceTrackIndexNegativeReturnsTypedOutOfRange() async throws {
+    // A malformed negative index is out of range too — still a typed body, never
+    // a raw -32602, so the indexed-template surface is internally consistent.
     let h = await makeE2EHandlers()
-    await #expect(throws: MCPError.self) {
-        try await h.readResource(.init(uri: "logic://tracks/-1"))
-    }
+    let result = try await h.readResource(.init(uri: "logic://tracks/-1"))
+    let obj = sharedJSONObject(sharedResourceText(result))
+    #expect((obj?["success"] as? Bool)! == false)
+    #expect(obj?["error"] as? String == "index_out_of_range")
+    #expect(obj?["requested_index"] as? Int == -1)
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/Tests/LogicProMCPTests/Issue200IndexedTemplateEmptyStateTests.swift
+++ b/Tests/LogicProMCPTests/Issue200IndexedTemplateEmptyStateTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #200: concrete indexed resource templates (`logic://tracks/{i}`,
+/// `logic://mixer/{i}`, `logic://tracks/{i}/regions`) used to fail on empty /
+/// out-of-range project state with a raw JSON-RPC `-32602` (or, for regions, a
+/// live-route hang). They now return a typed, classifiable `index_out_of_range`
+/// resource body the client can recover from.
+@Suite("Issue200 indexed template empty-state")
+struct Issue200IndexedTemplateEmptyStateTests {
+    private func obj(_ r: ReadResource.Result) -> [String: Any]? {
+        sharedJSONObject(sharedResourceText(r))
+    }
+
+    @Test("logic://tracks/{i} out of range returns a typed index_out_of_range body, not -32602")
+    func trackOutOfRangeTyped() async throws {
+        let result = try await ResourceHandlers.read(
+            uri: "logic://tracks/0", cache: StateCache(), router: ChannelRouter()
+        )
+        let o = obj(result)
+        #expect((o?["success"] as? Bool)! == false)
+        #expect(o?["error"] as? String == "index_out_of_range")
+        #expect(o?["requested_index"] as? Int == 0)
+        #expect(o?["available_count"] as? Int == 0)
+        #expect(o?["collection"] as? String == "track")
+        #expect((o?["hint"] as? String)?.contains("parent collection") == true)
+    }
+
+    @Test("logic://mixer/{i} out of range returns a typed index_out_of_range body")
+    func mixerOutOfRangeTyped() async throws {
+        let result = try await ResourceHandlers.read(
+            uri: "logic://mixer/0", cache: StateCache(), router: ChannelRouter()
+        )
+        let o = obj(result)
+        #expect((o?["success"] as? Bool)! == false)
+        #expect(o?["error"] as? String == "index_out_of_range")
+        #expect(o?["requested_index"] as? Int == 0)
+        #expect(o?["collection"] as? String == "channel strip")
+    }
+
+    @Test("a negative index is also a typed body, never a raw -32602")
+    func negativeIndexTyped() async throws {
+        let result = try await ResourceHandlers.read(
+            uri: "logic://tracks/-1", cache: StateCache(), router: ChannelRouter()
+        )
+        let o = obj(result)
+        #expect(o?["error"] as? String == "index_out_of_range")
+        #expect(o?["requested_index"] as? Int == -1)
+    }
+
+    @Test("mixer out-of-range reports the ACTUAL trackIndex set, not a misleading 0..<N range")
+    func mixerReportsActualAvailableIndices() async throws {
+        // Mixer strips are keyed by trackIndex, which can be non-contiguous. A
+        // gap index (1) between real strips {0, 2, 4} must report the true valid
+        // set so a client doesn't infer "0..<3" and skip strip 4.
+        let cache = StateCache()
+        await cache.updateChannelStrips([
+            ChannelStripState(trackIndex: 0),
+            ChannelStripState(trackIndex: 2),
+            ChannelStripState(trackIndex: 4),
+        ])
+        let result = try await ResourceHandlers.read(
+            uri: "logic://mixer/1", cache: cache, router: ChannelRouter()
+        )
+        let o = obj(result)
+        #expect(o?["error"] as? String == "index_out_of_range")
+        #expect(o?["requested_index"] as? Int == 1)
+        #expect(o?["available_count"] as? Int == 3)
+        let available = o?["available_indices"] as? [Int]
+        #expect(available == [0, 2, 4], "must report the actual trackIndex set, got: \(String(describing: available))")
+    }
+
+    @Test("index_out_of_range is a terminal, classifiable error code")
+    func indexOutOfRangeTerminal() {
+        #expect(HonestContract.FailureError.indexOutOfRange.rawValue == "index_out_of_range")
+        #expect(HonestContract.terminalErrorCodes.contains("index_out_of_range"))
+    }
+}

--- a/Tests/LogicProMCPTests/MixerProvenanceTests.swift
+++ b/Tests/LogicProMCPTests/MixerProvenanceTests.swift
@@ -112,11 +112,16 @@ import Testing
         #expect(stripJSON?["trackIndex"] as? Int == 2)
     }
 
-    @Test func testMixerStripMissingThrows() async {
+    @Test func testMixerStripMissingReturnsTypedOutOfRange() async throws {
+        // #200: a missing channel strip returns a typed index_out_of_range body
+        // (classifiable + recoverable), not a thrown JSON-RPC error.
         let cache = StateCache()
         let router = ChannelRouter()
-        await #expect(throws: (any Error).self) {
-            _ = try await ResourceHandlers.read(uri: "logic://mixer/9", cache: cache, router: router)
-        }
+        let result = try await ResourceHandlers.read(uri: "logic://mixer/9", cache: cache, router: router)
+        let obj = sharedJSONObject(sharedResourceText(result))
+        #expect((obj?["success"] as? Bool)! == false)
+        #expect(obj?["error"] as? String == "index_out_of_range")
+        #expect(obj?["requested_index"] as? Int == 9)
+        #expect(obj?["collection"] as? String == "channel strip")
     }
 }

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -275,14 +275,20 @@ private func normalizedHealthJSON(_ text: String) throws -> [String: Any] {
     #expect(json["type"] as? String == "software_instrument")
 }
 
-@Test func testTrackResourceRejectsMissingIndex() async {
+@Test func testTrackResourceRejectsMissingIndex() async throws {
     let cache = StateCache()
     await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
     let router = ChannelRouter()
 
-    await #expect(throws: MCPError.self) {
-        try await ResourceHandlers.read(uri: "logic://tracks/99", cache: cache, router: router)
-    }
+    // #200: out-of-range indexed-template reads return a typed, classifiable
+    // index_out_of_range body (with the requested index + available count) rather
+    // than a raw JSON-RPC -32602.
+    let result = try await ResourceHandlers.read(uri: "logic://tracks/99", cache: cache, router: router)
+    let obj = sharedJSONObject(sharedResourceText(result))
+    #expect((obj?["success"] as? Bool)! == false)
+    #expect(obj?["error"] as? String == "index_out_of_range")
+    #expect(obj?["requested_index"] as? Int == 99)
+    #expect(obj?["available_count"] as? Int == 1)
 }
 
 @Test func testTracksAndProjectResourcesReturnEmptyDataWhenNoDocumentOpen() async throws {


### PR DESCRIPTION
Fixes #200.

## Problem
`logic://tracks/{i}` and `logic://mixer/{i}` threw `MCPError.invalidParams` (JSON-RPC **-32602**) for an out-of-range / empty-project index, so a client could only treat an empty-state read as a protocol error.

## Fix
Both handlers now return a typed, classifiable `index_out_of_range` resource body (`success:false`, `error:"index_out_of_range"`, `requested_index`, `available_count`, `available_indices`, `collection`, hint) for any out-of-range index — including negative — so the indexed-template surface never emits a raw -32602. Adds the terminal `indexOutOfRange` Honest Contract code.

`available_indices` reports the **exact** valid set: `0..<count` for the positionally-indexed track list, but the actual `trackIndex` values for the mixer (whose strips are keyed by `trackIndex`, not array position, so the set can be non-contiguous e.g. `{0,2,4}`). The hint never asserts a contiguous `0..<N` range that would mislead a client past a gap — it points at the parent collection, and the body carries `available_indices` as the machine truth. *(This `trackIndex`-vs-position correction came out of the adversarial review.)*

## Scope
The `logic://tracks/{i}/regions` "no response" hang reported in #200 is a live-route concern fixed by the sibling resource-read deadline PR (#199); the regions read already returns an empty array for a track with no regions, and was deliberately **not** track-count short-circuited (the cache can hold regions for a track whose header isn't in the track array, so track_count is not a reliable existence proxy). Catalog lookups (`stock-plugins/{id}` etc.) correctly keep throwing for unknown IDs — those are static enumerable sets, not live project indices.

## Verification
- New tests: out-of-range track/mixer/negative reads return the typed body; mixer reports the actual non-contiguous `trackIndex` set; `index_out_of_range` is terminal. Throw-pinning tests (EndToEnd, ResourceSchema, MixerProvenance) updated.
- `swift test --no-parallel`: **1864 passed / 0 failed**.
- Strict live E2E (real Logic Pro 12.2): **352/352**, including a new check that `logic://tracks/-1` returns the typed `index_out_of_range` body live.
- Adversarial review: MCP body-vs-throw shape correct; failure-code addition safe; regions path unchanged; catalog paths legitimately different. The HIGH finding (mixer `available_count` was misleading for non-contiguous strips) is fixed by `available_indices`.