### PR TITLE
fix(#202): not-exposed command tokens return a distinct, classifiable command_not_exposed

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -1905,8 +1905,14 @@ def main():
     r = call_tool(client, "logic_mixer", "set_master_volume", {"volume": 0.8})
     T("mixer.set_master_volume dispatches", r, lambda _: len(tool_text(r)) > 0)
 
+    # #202: deliberately not-exposed command tokens return a single
+    # machine-classifiable command_not_exposed shape (not a generic
+    # not_implemented), so a complete-surface harness can mark them expected.
     r = call_tool(client, "logic_mixer", "set_send", {"index": 0, "send": 0, "value": 0.5})
-    T("mixer.set_send dispatches", r, lambda _: len(tool_text(r)) > 0)
+    _ne = safe_json(tool_text(r)) or {}
+    T("mixer.set_send returns typed command_not_exposed (#202)", r,
+      lambda _: _ne.get("error") == "command_not_exposed" and _ne.get("not_exposed") is True
+      and _ne.get("supported") is False)
 
     # ═══════════════════════════════════════════════════════════════
     # §6 MIDI Live Operations (25 tests)

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -63,26 +63,16 @@ struct MixerDispatcher {
             ])
 
         case "set_send":
-            return toolStateCResult(
-                .notImplemented,
-                hint:
-                "set_send is not exposed in the production MCP contract because targeted send/bus control is not yet deterministic",
-                extras: ["operation": "mixer.set_send"]
+            return notExposedCommandResult(
+                operation: "mixer.set_send",
+                reason: "targeted send/bus control is not yet deterministic"
             )
 
         case "set_output":
-            return toolStateCResult(
-                .notImplemented,
-                hint: "set_output is not exposed in the production MCP contract",
-                extras: ["operation": "mixer.set_output"]
-            )
+            return notExposedCommandResult(operation: "mixer.set_output")
 
         case "set_input":
-            return toolStateCResult(
-                .notImplemented,
-                hint: "set_input is not exposed in the production MCP contract",
-                extras: ["operation": "mixer.set_input"]
-            )
+            return notExposedCommandResult(operation: "mixer.set_input")
 
         case "set_master_volume":
             guard let volume = doubleParamOrNil(params, "value", "volume") else {
@@ -100,18 +90,10 @@ struct MixerDispatcher {
             ])
 
         case "toggle_eq":
-            return toolStateCResult(
-                .notImplemented,
-                hint: "toggle_eq is not exposed in the production MCP contract",
-                extras: ["operation": "mixer.toggle_eq"]
-            )
+            return notExposedCommandResult(operation: "mixer.toggle_eq")
 
         case "reset_strip":
-            return toolStateCResult(
-                .notImplemented,
-                hint: "reset_strip is not exposed in the production MCP contract",
-                extras: ["operation": "mixer.reset_strip"]
-            )
+            return notExposedCommandResult(operation: "mixer.reset_strip")
 
         case "insert_plugin":
             guard let track = intParamOrNil(params, "track", "track_index", "index"), track >= 0 else {
@@ -151,11 +133,9 @@ struct MixerDispatcher {
         case "bypass_plugin":
             // Still removed from the public surface: no verified AX/MCU
             // readback path exists for bypass writes yet.
-            return toolStateCResult(
-                .notImplemented,
-                hint:
-                "\(command) is not exposed in the production MCP contract; use set_plugin_param via Scripter on the selected track instead",
-                extras: ["operation": "mixer.\(command)"]
+            return notExposedCommandResult(
+                operation: "mixer.bypass_plugin",
+                reason: "no verified readback path for bypass writes yet; use set_plugin_param via Scripter on the selected track instead"
             )
 
         case "set_plugin_param":

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -392,11 +392,7 @@ struct TrackDispatcher {
             ))
 
         case "set_color":
-            return toolStateCResult(
-                .notImplemented,
-                hint: "set_color is not exposed in the production MCP contract",
-                extras: ["operation": "track.set_color"]
-            )
+            return notExposedCommandResult(operation: "track.set_color")
 
         case "set_automation":
             guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -158,6 +158,13 @@ enum HonestContract {
         /// other channel can save an untitled document without a path; the
         /// caller must supply one via `project.save_as`. #144 (P3 hardening).
         case unsupportedState
+        /// A command token the dispatcher recognises but that is deliberately
+        /// NOT part of the production MCP contract (no deterministic / verified
+        /// path exists yet). Distinct from `.notImplemented` (a surface that does
+        /// not exist at all): these are catalogued not-exposed stubs, excluded
+        /// from the workflow census, so a complete-surface harness can classify
+        /// the response as expected rather than a malfunction. Terminal. #202.
+        case commandNotExposed
 
         var rawValue: String {
             switch self {
@@ -199,6 +206,7 @@ enum HonestContract {
             case .unsupportedTrackType: return "unsupported_track_type"
             case .pathNotInLibrary: return "path_not_in_library"
             case .unsupportedState: return "unsupported_state"
+            case .commandNotExposed: return "command_not_exposed"
             }
         }
     }
@@ -367,6 +375,9 @@ enum HonestContract {
         // State C `unsupported_state` — no fallback channel can save a document
         // that has no on-disk path; the caller must use `project.save_as`.
         FailureError.unsupportedState.rawValue,
+        // #202: a deliberately not-exposed command token is terminal — no channel
+        // can expose a surface the production contract intentionally omits.
+        FailureError.commandNotExposed.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Sources/LogicProMCP/Utilities/MCPToolContent.swift
+++ b/Sources/LogicProMCP/Utilities/MCPToolContent.swift
@@ -27,6 +27,26 @@ func toolInvalidParamsResult(_ hint: String, extras: [String: Any] = [:]) -> Cal
     toolStateCResult(.invalidParams, hint: hint, extras: extras)
 }
 
+/// #202: a command token the dispatcher recognises but that is deliberately not
+/// part of the production MCP contract. Returns a single, machine-classifiable
+/// shape — `error:"command_not_exposed"` + `not_exposed:true` + `supported:false`
+/// — so a complete-surface harness can mark it expected rather than a
+/// malfunction. The hint keeps the canonical "not exposed in the production MCP
+/// contract" phrase (the workflow census uses it to detect stubs); `reason`
+/// carries any operation-specific detail.
+func notExposedCommandResult(operation: String, reason: String? = nil) -> CallTool.Result {
+    let detail = reason.map { " — \($0)" } ?? ""
+    return toolStateCResult(
+        .commandNotExposed,
+        hint: "\(operation) is not exposed in the production MCP contract\(detail)",
+        extras: [
+            "operation": operation,
+            "not_exposed": true,
+            "supported": false,
+        ]
+    )
+}
+
 func commandParamsToolSchema(commandDescription: String) -> Value {
     .object([
         "type": .string("object"),

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -101,7 +101,10 @@ private func parseDispatcherObject(_ raw: String) -> [String: Any]? {
         router: router,
         cache: cache
     )
-    expectStateC(unsupportedMixerCommand, error: "not_implemented", operation: "mixer.set_output")
+    // #202: deliberately not-exposed commands now report the distinct,
+    // machine-classifiable `command_not_exposed` code (not the generic
+    // `not_implemented`), so a complete-surface harness can mark them expected.
+    expectStateC(unsupportedMixerCommand, error: "command_not_exposed", operation: "mixer.set_output")
 }
 
 private final class ProjectLifecycleHarness {

--- a/Tests/LogicProMCPTests/Issue202SurfaceConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/Issue202SurfaceConsistencyTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #202: several command tokens are recognised by the dispatchers but are
+/// deliberately NOT part of the production MCP contract. They used to return a
+/// generic `not_implemented` State C, which a complete-surface harness could not
+/// tell apart from a real malfunction. They now return a single,
+/// machine-classifiable `command_not_exposed` shape (`not_exposed:true`,
+/// `supported:false`) the harness can mark as expected — while the workflow
+/// census continues to exclude them (catalog-level consistency).
+@Suite("Issue202 surface consistency — not-exposed commands")
+struct Issue202SurfaceConsistencyTests {
+    private func obj(_ r: CallTool.Result) -> [String: Any]? {
+        sharedJSONObject(sharedToolText(r))
+    }
+
+    private func mixer(_ command: String) async -> CallTool.Result {
+        await MixerDispatcher.handle(command: command, params: [:], router: ChannelRouter(), cache: StateCache())
+    }
+
+    private func track(_ command: String) async -> CallTool.Result {
+        await TrackDispatcher.handle(command: command, params: [:], router: ChannelRouter(), cache: StateCache())
+    }
+
+    @Test("every not-exposed command returns one machine-classifiable command_not_exposed shape")
+    func notExposedCommandsAreClassifiable() async {
+        let cases: [(operation: String, result: CallTool.Result)] = [
+            ("mixer.set_send", await mixer("set_send")),
+            ("mixer.set_output", await mixer("set_output")),
+            ("mixer.set_input", await mixer("set_input")),
+            ("mixer.toggle_eq", await mixer("toggle_eq")),
+            ("mixer.reset_strip", await mixer("reset_strip")),
+            ("mixer.bypass_plugin", await mixer("bypass_plugin")),
+            ("track.set_color", await track("set_color")),
+        ]
+        for (operation, result) in cases {
+            #expect(result.isError!, "\(operation) must be a State C error")
+            let o = obj(result)
+            #expect(o?["error"] as? String == "command_not_exposed", "\(operation) should report command_not_exposed")
+            #expect((o?["not_exposed"] as? Bool)!, "\(operation) must carry not_exposed:true")
+            #expect((o?["supported"] as? Bool)! == false, "\(operation) must carry supported:false")
+            #expect(o?["operation"] as? String == operation)
+            #expect((o?["success"] as? Bool)! == false)
+            // The census stub-detection phrase must be preserved in the hint.
+            let hint = (o?["hint"] as? String)!
+            #expect(hint.contains("not exposed in the production MCP contract"))
+        }
+    }
+
+    @Test("command_not_exposed is a distinct, terminal, classifiable code")
+    func commandNotExposedIsTerminal() {
+        #expect(HonestContract.FailureError.commandNotExposed.rawValue == "command_not_exposed")
+        #expect(HonestContract.terminalErrorCodes.contains("command_not_exposed"))
+        // Distinct from the generic `not_implemented` (surface-absent) code so a
+        // harness can tell "intentionally not exposed" from "genuinely missing".
+        #expect(HonestContract.FailureError.commandNotExposed.rawValue != HonestContract.FailureError.notImplemented.rawValue)
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,8 +142,15 @@ Destructive or file-writing paths require confirmation. `save_as` verifies the r
 
 Use `health` for channel readiness and `help` for command summaries.
 
+### Not-exposed commands
+
+A few command tokens are recognised by the dispatchers but are deliberately **not part of the production MCP contract** (no deterministic / verified path exists yet). They are excluded from the workflow command census and return a single machine-classifiable State C shape — `error: "command_not_exposed"`, `not_exposed: true`, `supported: false`, plus the `operation` — so a complete-surface demo/test harness can classify them as *expected*, not a malfunction:
+
+- `logic_tracks.set_color`
+- `logic_mixer.set_send`, `logic_mixer.set_output`, `logic_mixer.set_input`, `logic_mixer.toggle_eq`, `logic_mixer.reset_strip`, `logic_mixer.bypass_plugin`
+
 ## Error Format
 
-State C errors use stable machine-readable strings such as `invalid_params`, `not_implemented`, `element_not_found`, `readback_mismatch`, `port_unavailable`, `channels_exhausted`, `unsupported_param_readback`, and `confirmation_required`.
+State C errors use stable machine-readable strings such as `invalid_params`, `not_implemented`, `command_not_exposed`, `element_not_found`, `readback_mismatch`, `port_unavailable`, `channels_exhausted`, `unsupported_param_readback`, and `confirmation_required`.
 
 Clients should branch on `state`, `verified`, `error`, and `retry_safe`; do not parse human prose as the contract.


### PR DESCRIPTION
Fixes #202.

## Problem
Several command tokens (`tracks.set_color` + `mixer.set_send`/`set_output`/`set_input`/`toggle_eq`/`reset_strip`/`bypass_plugin`) are recognised by the dispatchers but are deliberately **not** part of the production MCP contract. They returned a generic `not_implemented` State C, which a complete-surface harness could not tell apart from a real malfunction.

## Fix
A shared `notExposedCommandResult` helper returns one machine-classifiable shape — `error:"command_not_exposed"` + `not_exposed:true` + `supported:false` + `operation` — via a new terminal `HonestContract.FailureError.commandNotExposed`. The canonical "not exposed in the production MCP contract" hint phrase is preserved (the workflow census uses it to detect stubs), and these tokens remain excluded from the census, so the advertised surface stays internally consistent at **both** the catalog level (census) and the runtime level (typed result). `docs/API.md` documents the not-exposed set + the typed contract.

`tools/list` never advertised these tokens (the tool `command` param is a free string; each tool's description enumerates only its supported commands) — the inconsistency was runtime-only, so returning a typed classifiable result (the issue's option *c*) is the right call versus removal (removal would break the census classification + known-stub tracking).

## Verification
- New tests: every not-exposed token returns the `command_not_exposed` shape; `command_not_exposed` is terminal and distinct from `not_implemented`; `DispatcherTests` updated. The channel-level `set_color` internal path (HonestContractOp/AccessibilityChannel tests) is unchanged — it is unreachable through the public dispatcher surface (the dispatcher short-circuits before routing).
- `swift test --no-parallel`: **1861 passed / 0 failed**.
- Strict live E2E (real Logic Pro 12.2): **352/352**, including a new check that `logic_mixer.set_send` returns the typed `command_not_exposed` body live.
- Adversarial review: PROCEED, HIGH confidence — all 7 tokens covered, no unclassified `not_implemented` contradiction in any dispatcher, census stub-detector unaffected, failure-code addition safe, machine-classifiable shape, no dead assertions.