### PR TITLE
release: prepare v3.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [3.7.4] — 2026-06-30
+
+Bug-fix and robustness release closing the v3.7.3 complete-surface QA backlog (#199–#202). No public tool/resource/template surface change (10 tools / 18 resources / 11 templates unchanged).
+
+### Fixed
+
+- A mutating operation that hits the per-command server-side deadline no longer pins the whole write surface. The mutation gate is now reclaimable a short, bounded grace (15s) after the deadline abandons the op — instead of holding until the wedged work returns or the 360s stale-holder TTL — so one timed-out `logic_transport.play` can't leave every other mutating command returning `mutating_operation_in_progress` for minutes. The timeout envelope advertises this (`mutation_gate: "reclaimable_after_grace"`, `gate_reclaim_after_sec`); the reclaim is epoch-guarded so a late release from the abandoned op cannot free a successor's claim (#201).
+- Resource reads (`logic://…`) now run under the same server-side deadline as tool calls. A read backed by a live Accessibility route (`logic://transport/state`, `logic://tracks/{index}/regions`) on a wedged/occluded session previously could block past the client's read timeout and return no JSON-RPC response; it now returns a typed `operation_timeout` resource body. Genuine read errors still propagate unchanged (#199).
+- Indexed resource templates (`logic://tracks/{index}`, `logic://mixer/{strip}`) now fail closed with a typed, classifiable `index_out_of_range` body (carrying `requested_index`, `available_count`, and the exact `available_indices`) for an out-of-range or empty-project index, instead of a raw JSON-RPC `-32602`. The mixer reports its actual (possibly non-contiguous) `trackIndex` set rather than implying a `0..<N` range (#200).
+- Command tokens that are recognised by the dispatchers but deliberately not part of the production MCP contract (`logic_tracks.set_color`, `logic_mixer.set_send`/`set_output`/`set_input`/`toggle_eq`/`reset_strip`/`bypass_plugin`) now return a distinct, machine-classifiable `command_not_exposed` State C (`not_exposed: true`, `supported: false`) instead of a generic `not_implemented`, so a complete-surface harness can classify them as intentionally-unsupported rather than a malfunction. Documented in `docs/API.md` (#202).
+
+### Changed
+
+- Pinned the Model Context Protocol Swift SDK to `0.12.1` (patch update within the existing `from: 0.11.0` range; full suite + strict live E2E green).
+
 ## [3.7.3] — 2026-06-30
 
 Bug-fix and diagnostic-honesty release closing the open GitHub issue backlog (#178, #186–#190). No public tool/resource/template surface change (10 tools / 18 resources / 11 templates unchanged).

--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -3,7 +3,7 @@ class LogicProMcp < Formula
   homepage "https://github.com/MongLong0214/logic-pro-mcp"
   # Single source of truth is Sources/LogicProMCP/Server/ServerConfig.swift
   # (ServerConfig.serverVersion). Bump both together.
-  version "3.7.3"
+  version "3.7.4"
   license "MIT"
 
   # GitHub Actions release artifacts are expected to be true universal

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -6,7 +6,7 @@ BINARY="LogicProMCP"
 ARCHIVE="LogicProMCP-macOS-universal.tar.gz"
 INSTALL_DIR="${LOGIC_PRO_MCP_INSTALL_DIR:-/usr/local/bin}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-VERSION="${LOGIC_PRO_MCP_VERSION:-v3.7.3}"
+VERSION="${LOGIC_PRO_MCP_VERSION:-v3.7.4}"
 SHA256="${LOGIC_PRO_MCP_SHA256:-}"
 EXPECTED_TEAM_ID="${LOGIC_PRO_MCP_TEAM_ID:-}"
 REGISTER_CLAUDE="${LOGIC_PRO_MCP_REGISTER_CLAUDE:-1}"
@@ -168,7 +168,7 @@ fi
 
 if [ "$VERSION" = "latest" ]; then
     echo "  Error: mutable 'latest' installs are not allowed in enterprise mode."
-    echo "    Set LOGIC_PRO_MCP_VERSION to a pinned tag, e.g. v3.7.3."
+    echo "    Set LOGIC_PRO_MCP_VERSION to a pinned tag, e.g. v3.7.4."
     exit 1
 fi
 

--- a/Sources/LogicProMCP/Server/ServerConfig.swift
+++ b/Sources/LogicProMCP/Server/ServerConfig.swift
@@ -5,7 +5,7 @@ import Foundation
 struct ServerConfig: Sendable {
     // MARK: - Server Identity
     static let serverName = "logic-pro-mcp"
-    static let serverVersion = "3.7.3"
+    static let serverVersion = "3.7.4"
 
     // MARK: - MIDI
     // NOTE: source name uses *-Internal suffix for consistency with KeyCmd/Scripter/MCU

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -423,12 +423,12 @@ private func waitForFeedbackEvents(
         "logic://workflow-skills/search?query={query}",
     ]
     #expect(expectedTemplates.isSubset(of: Set(snapshot.templateURIs)))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.7.3 — 10 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.7.4 — 10 tools, \(snapshot.resourceURIs.count) resources, 4 channels")
 }
 
 @Test func testServerCatalogStartupBannerUsesProvidedChannelCount() {
     let banner = ServerCatalog.startupBanner(channelCount: 7)
-    #expect(banner == "Starting logic-pro-mcp v3.7.3 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
+    #expect(banner == "Starting logic-pro-mcp v3.7.4 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }
 
 @Test func testLogicProServerCompositionSnapshotMatchesExpectedOrder() async {
@@ -447,5 +447,5 @@ private func waitForFeedbackEvents(
     ])
     #expect(snapshot.toolNames.count == 10)
     #expect(snapshot.resourceURIs.contains("logic://system/health"))
-    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.7.3 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
+    #expect(snapshot.startupBanner == "Starting logic-pro-mcp v3.7.4 — 10 tools, \(ResourceProvider.resources.count) resources, 7 channels")
 }

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -22,7 +22,7 @@ private func doctorRuntime(
         }
         if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
            arguments == ["list", "--versions", "logic-pro-mcp"] {
-            return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+            return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
         }
         return nil
     }
@@ -273,7 +273,7 @@ private func issue26RepositoryRootURL() -> URL {
             commandHandler: { executable, arguments in
                 if executable == "/opt/homebrew/bin/brew",
                    arguments == ["list", "--versions", "logic-pro-mcp"] {
-                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
                 }
                 return nil
             }
@@ -298,7 +298,7 @@ private func issue26RepositoryRootURL() -> URL {
                 return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
             }
             return nil
         })
@@ -321,7 +321,7 @@ private func issue26RepositoryRootURL() -> URL {
                 return .init(exitCode: 0, stdout: "0081;...;Safari;\n", stderr: "")
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
             }
             return nil
         })
@@ -347,7 +347,7 @@ private func issue26RepositoryRootURL() -> URL {
                 return .init(exitCode: 13, stdout: "", stderr: "Operation not permitted")
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
             }
             return nil
         })
@@ -566,7 +566,7 @@ private func issue26RepositoryRootURL() -> URL {
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
                arguments == ["list", "--versions", "logic-pro-mcp"] {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
             }
             return nil
         }),
@@ -598,7 +598,7 @@ private func issue26RepositoryRootURL() -> URL {
                 }
                 if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
                    arguments == ["list", "--versions", "logic-pro-mcp"] {
-                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
                 }
                 return nil
             }
@@ -619,7 +619,7 @@ private func issue26RepositoryRootURL() -> URL {
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
                arguments == ["list", "--versions", "logic-pro-mcp"] {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.3\n", stderr: "")
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
             }
             return nil
         })

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -23,7 +23,7 @@ private func readRepoFile(_ relativePath: String) throws -> String {
 @Test func testServerVersionMatchesPackagingArtefacts() throws {
     let sourceVersion = ServerConfig.serverVersion
     #expect(
-        sourceVersion == "3.7.3",
+        sourceVersion == "3.7.4",
         "version surfaces must match the published stable release — bump all packaging artefacts together"
     )
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -151,6 +151,6 @@ A few command tokens are recognised by the dispatchers but are deliberately **no
 
 ## Error Format
 
-State C errors use stable machine-readable strings such as `invalid_params`, `not_implemented`, `command_not_exposed`, `element_not_found`, `readback_mismatch`, `port_unavailable`, `channels_exhausted`, `unsupported_param_readback`, and `confirmation_required`.
+State C errors use stable machine-readable strings such as `invalid_params`, `not_implemented`, `command_not_exposed`, `index_out_of_range`, `element_not_found`, `readback_mismatch`, `port_unavailable`, `channels_exhausted`, `unsupported_param_readback`, and `confirmation_required`.
 
 Clients should branch on `state`, `verified`, `error`, and `retry_safe`; do not parse human prose as the contract.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "logic-pro-mcp",
   "display_name": "Logic Pro MCP Server",
   "description": "Bidirectional, stateful control of Logic Pro from AI assistants. 10 tools + 18 resources + 11 templates across 7 native macOS channels (MCU, MIDI Key Commands, CoreMIDI, Scripter, Accessibility, CGEvent, AppleScript). GitHub Actions release assets are universal (`arm64` + `x86_64`); historical local ADHOC prerelease cuts should be audited via RELEASE-METADATA.json.",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "author": "Isaac (MongLong0214)",
   "license": "MIT",
   "homepage": "https://github.com/MongLong0214/logic-pro-mcp",
@@ -15,7 +15,7 @@
     "macos": {
       "command": "LogicProMCP",
       "args": [],
-      "download_url": "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v3.7.3/LogicProMCP",
+      "download_url": "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v3.7.4/LogicProMCP",
       "install_path": "/usr/local/bin/LogicProMCP"
     }
   },

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
       ]
     }
   ],
-  "version": "3.7.3",
+  "version": "3.7.4",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "distribution": {
@@ -31,7 +31,7 @@
             "brew install logic-pro-mcp"
           ]
         },
-        "release": "https://github.com/MongLong0214/logic-pro-mcp/releases/tag/v3.7.3"
+        "release": "https://github.com/MongLong0214/logic-pro-mcp/releases/tag/v3.7.4"
       },
       "discovery": {
         "categories": [


### PR DESCRIPTION
Version-identity bump 3.7.3 → 3.7.4 + CHANGELOG cut for the issue-backlog bug-fix release. The four fixes (#199–#202) are already merged to main (PRs #203–#206); this commit only bumps the release-identity surfaces and cuts the CHANGELOG so `Scripts/release-stable.sh v3.7.4` can publish from clean main.

## Bumped to 3.7.4
- `ServerConfig.serverVersion`, `manifest.json` (version + download_url), `server.json` (version + release URL), `Formula` version, `Scripts/install.sh` default VERSION.
- Version-coupled tests: `VersionConsistencyTests`, startup-banner tests, `SetupDoctor` brew-version probe.
- `CHANGELOG.md`: `[Unreleased]` → `[3.7.4]` (2026-06-30) — the four fixes + the swift-sdk 0.12.1 pin note.

## Intentionally left at v3.7.3 (still the PUBLISHED stable until the tag is pushed)
- README/SETUP/API "published stable" prose + install URLs, the `InstallScriptContract` README/SETUP install-URL assertions, the install-runtime / Cellar-path test fixtures.
- The Formula `sha256` still references the v3.7.3 artifact; re-synced from the v3.7.4 `SHA256SUMS.txt` in the post-publish evidence step.

## Verification
- `swift build` clean; `swift test --no-parallel` **1876 passed / 0 failed**.
- Integrated main already verified: 1876 tests + release build + strict live E2E **352/352** (issue-specific live checks for #200/#202 + carried #188/#189 green).