### PR TITLE
docs: sync v3.7.4 release evidence

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -11,11 +11,11 @@ class LogicProMcp < Formula
   # arm64-only metadata, so inspect RELEASE-METADATA.json when auditing a
   # specific tag.
   #
-  # SHA256 is copied from the published v3.7.3 SHA256SUMS.txt for
+  # SHA256 is copied from the published v3.7.4 SHA256SUMS.txt for
   # LogicProMCP-macOS-universal.tar.gz.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "e09bea4df54d80c58416394ee495715002edfde77ef5a027894762fd0c6f78ba"
+    sha256 "2aac368a876d55f031ee8d815beaf1539b89a7adee8e6336b8ecc0abafa78a45"
   end
 
   depends_on :macos => :sonoma

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
   <a href="https://github.com/MongLong0214/logic-pro-mcp/actions/workflows/ci.yml"><img src="https://github.com/MongLong0214/logic-pro-mcp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square" /></a>
   <a href="https://discord.gg/4M3s79DBzz"><img src="https://img.shields.io/badge/Discord-Community-5865F2.svg?style=flat-square&logo=discord&logoColor=white" /></a>
-  <img src="https://img.shields.io/badge/tests-1847_passing-brightgreen.svg?style=flat-square" />
-  <img src="https://img.shields.io/badge/stable-v3.7.3-blue.svg?style=flat-square" />
+  <img src="https://img.shields.io/badge/tests-1876_passing-brightgreen.svg?style=flat-square" />
+  <img src="https://img.shields.io/badge/stable-v3.7.4-blue.svg?style=flat-square" />
 </p>
 
 <p align="center">
@@ -57,8 +57,8 @@ Logic Pro MCP: region imported, instrument routed, readback exposed through reso
 | Read resources | 18 static resources for health, transport, tracks, mixer, markers, project metadata, project audit/cleanup planning, MIDI ports, MCU state, library inventory, stock plugin/instrument intelligence, Session Players, and workflow skills |
 | Resource templates | 11 templates for track, region, mixer-strip, stock plugin detail/search, stock instrument detail/search, Session Player detail, session-plan dry run, and workflow detail/search lookup |
 | Control channels | MCU, Accessibility, AppleScript, CoreMIDI, CGEvent, Scripter, MIDI Key Commands |
-| Verification line | Current source tree: `1859` Swift tests, release build, and strict fresh live Logic E2E `352/352` |
-| Release state | Published stable `v3.7.3`; previous stable `v3.7.2` remains available for pinned installs |
+| Verification line | Current source tree: `1876` Swift tests, release build, and strict fresh live Logic E2E `352/352` |
+| Release state | Published stable `v3.7.4`; previous stable `v3.7.3` remains available for pinned installs |
 | Community layer | Official Discord for setup support, release notes, reproducible bug triage, product requests, demos, and contributor discussion |
 
 If this project helps you make music with Claude, Cursor, or any MCP client, star the repo. It helps the project reach more Logic Pro users and maintainers.
@@ -109,7 +109,7 @@ Logic Pro MCP uses a different model. It routes each operation to the strongest 
 - **Confirmation levels**: destructive/project and plugin insertion flows require explicit confirmation metadata before execution.
 - **Provenance labels**: read surfaces expose source, freshness, and evidence labels instead of forcing clients to guess.
 - **Installer hardening**: Homebrew pins SHA256; the shell installer refuses to run without explicit hash/team pins unless same-origin provenance is explicitly allowed.
-- **Release honesty**: published `v3.7.3` is the current stable install line, and README claims stay tied to shipped artifacts, release-tree tests, or explicitly linked live evidence.
+- **Release honesty**: published `v3.7.4` is the current stable install line, and README claims stay tied to shipped artifacts, release-tree tests, or explicitly linked live evidence.
 
 ## Quick Start
 
@@ -117,7 +117,7 @@ Logic Pro MCP uses a different model. It routes each operation to the strongest 
 
 The package manifest uses Swift tools 6.0 for compatibility. Current source verification uses Xcode 16.4 / Swift 6.2 in CI.
 
-The current published stable release is `v3.7.3` (2026-06-30 KST). It ships ADHOC-signed universal artifacts when Apple Developer ID credentials are absent, plus `SHA256SUMS.txt` and `RELEASE-METADATA.json` for pinned installs. It carries the full v3.7.x runtime surface (10-tool / 18-resource / 11-template) and adds the v3.7.3 issue-backlog bug-fix pass: `set_tempo` now fails closed with State C `readback_mismatch` instead of claiming a slider-increment success it cannot verify, MIDI import preflights Automation → System Events (a separate TCC target) and the `--check-permissions` readiness gate now reflects it, blocking-dialog refusals carry the dialog identity plus a recovery action, fresh-session bootstrap clears unnamed Save prompts via an Escape fallback, and `logic_key_event` accepts `--return`/`--enter` aliases with a `--check` preflight.
+The current published stable release is `v3.7.4` (2026-06-30 KST). It ships ADHOC-signed universal artifacts when Apple Developer ID credentials are absent, plus `SHA256SUMS.txt` and `RELEASE-METADATA.json` for pinned installs. It carries the full v3.7.x runtime surface (10-tool / 18-resource / 11-template) and adds the v3.7.4 complete-surface QA bug-fix pass: a timed-out mutating op no longer pins the write surface (the mutation gate auto-reclaims after a bounded grace), resource reads now fail closed with a typed `operation_timeout` instead of hanging with no response, indexed resource templates return a typed `index_out_of_range` body (with the real available indices) instead of a raw `-32602`, and deliberately not-exposed command tokens return a distinct `command_not_exposed` State C a harness can classify.
 
 ### 1. Install
 
@@ -188,7 +188,7 @@ The installer is **fail-closed**: it refuses to run without explicit `LOGIC_PRO_
 
 ```bash
 brew install cliclick
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.3/Scripts/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.4/Scripts/install.sh -o install.sh
 # inspect install.sh, then:
 LOGIC_PRO_MCP_SHA256=<paste LogicProMCP-macOS-universal.tar.gz SHA256SUMS entry> \
 LOGIC_PRO_MCP_TEAM_ID=<paste team_id from RELEASE-METADATA.json> \
@@ -199,7 +199,7 @@ If you knowingly accept same-origin provenance (hash + Team ID fetched from the 
 
 ```bash
 LOGIC_PRO_MCP_ALLOW_SAME_ORIGIN=1 \
-bash <(curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.3/Scripts/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.4/Scripts/install.sh)
 ```
 
 See [SECURITY.md §Installer trust model](SECURITY.md#installer-trust-model) for the trust tiers and threat model.
@@ -223,22 +223,22 @@ The public docs tree is intentionally scoped: setup, API, troubleshooting, READM
 
 ## Status
 
-**Published stable**: `v3.7.3` is available as a GitHub Release and Homebrew install. It carries the accumulated v3.6.0 -> v3.7.2 set, then adds the v3.7.3 issue-backlog bug-fix pass: a fail-closed `set_tempo` slider-increment path (State C `readback_mismatch`, never a false success), an Automation → System Events preflight for MIDI import plus a `--check-permissions` readiness gate that exits non-zero when that target is denied, blocking-dialog refusals enriched with dialog identity and a Cancel-first recovery action, a fresh-session bootstrap Escape fallback for unnamed Save prompts, and `logic_key_event` `--return`/`--enter`/`--check` support. Published metadata remains `team_id:"ADHOC"` / `signing:"adhoc"` when Developer ID credentials are absent, with universal `x86_64` + `arm64` artifacts produced by GitHub Actions.
+**Published stable**: `v3.7.4` is available as a GitHub Release and Homebrew install. It carries the accumulated v3.6.0 -> v3.7.3 set, then adds the v3.7.4 complete-surface QA bug-fix pass: the mutation gate auto-reclaims a bounded grace after a command-deadline timeout (one hung op no longer pins the write surface), resource reads run under the same deadline backstop as tool calls (typed `operation_timeout`, never a no-response hang), indexed resource templates fail closed with a typed `index_out_of_range` body carrying the real available indices, and not-exposed command tokens return a distinct machine-classifiable `command_not_exposed` State C. Published metadata remains `team_id:"ADHOC"` / `signing:"adhoc"` when Developer ID credentials are absent, with universal `x86_64` + `arm64` artifacts produced by GitHub Actions.
 
-**Previous stable**: `v3.7.2` remains available as the production-readiness hardening release; `v3.7.1` remains available as the public documentation/runtime-surface correction release, `v3.7.0` as the full workflow/demo hardening release, and `v3.6.0` for clients that need the verified plugin apply-back surface without the larger v3.7.x set.
+**Previous stable**: `v3.7.3` remains available as the issue-backlog bug-fix release; `v3.7.2` remains available as the production-readiness hardening release, `v3.7.1` as the public documentation/runtime-surface correction release, `v3.7.0` as the full workflow/demo hardening release, and `v3.6.0` for clients that need the verified plugin apply-back surface without the larger v3.7.x set.
 
 ## Verification
 
 | Gate | Current evidence |
 |------|------------------|
-| Full deterministic suite | Current source tree: `swift test` -> `1859` passed, `0` failed |
+| Full deterministic suite | Current source tree: `swift test` -> `1876` passed, `0` failed |
 | Release build | Current source tree: `swift build -c release` passed |
 | Python E2E syntax | PR #24 verification: `python3 -m py_compile Scripts/live-e2e-test.py` passed |
 | Targeted live plugin proof | Logic Pro 12.2: `logic_plugins.insert_verified track=6 insert=6 plugin=Gain` returned State A with `observed_slot:6`, `write_source:"ax_exact_slot_popup"`, and independent `get_inventory` readback |
 | Track/transport readback proof | Logic Pro 12.2: `logic://tracks` returned `source:"ax_live"`, real names, `placeholder_count:0`, `unknown_type_count:0`; cycle toggle/resource roundtrip reflected live UI state |
 | Strict live Logic Pro 12.2 | Current source tree strict fresh live E2E: `352` passed / `0` skipped / `0` failed |
 | README media | Actual Logic Pro 12.2 capture derivatives are published under `docs/media/` |
-| v3.7.3 release evidence | GitHub Release, Actions logs, and [CHANGELOG.md](CHANGELOG.md) |
+| v3.7.4 release evidence | GitHub Release, Actions logs, and [CHANGELOG.md](CHANGELOG.md) |
 
 Live E2E defaults to the release binary. Protocol/security assertions run on any host; Logic/CoreMIDI-dependent checks skip unless a real Logic Pro session is visible. Strict mode converts live-gated skips to failures, treats missing project state as a failed cycle roundtrip precondition, and launches the MCP server under a trusted shell/tmux parent so macOS TCC evaluates the same parent context used by live client flows.
 

--- a/Tests/LogicProMCPTests/InstallScriptContractTests.swift
+++ b/Tests/LogicProMCPTests/InstallScriptContractTests.swift
@@ -17,8 +17,8 @@ import Testing
     let setup = try scriptContents("docs/SETUP.md")
     let installer = try scriptContents("Scripts/install.sh")
 
-    #expect(readme.contains("v3.7.3/Scripts/install.sh"))
-    #expect(setup.contains("v3.7.3/Scripts/install.sh"))
+    #expect(readme.contains("v3.7.4/Scripts/install.sh"))
+    #expect(setup.contains("v3.7.4/Scripts/install.sh"))
     #expect(installer.contains("awk -v artifact=\"$ARCHIVE\" '$2 == artifact {print $1}'"))
     #expect(readme.contains("verifies the downloaded `LogicProMCP-macOS-universal.tar.gz` archive"))
     #expect(readme.contains("LogicProMCP-macOS-universal.tar.gz SHA256SUMS entry"))

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Current stable surface: Logic Pro MCP v3.7.3 exposes 10 tools, 18 static resources, and 11 resource templates.
+Current stable surface: Logic Pro MCP v3.7.4 exposes 10 tools, 18 static resources, and 11 resource templates.
 
 Use tools for actions. Use resources for state. Treat every mutating result as one of:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
 # Setup
 
-Minimal install and Logic Pro integration guide for Logic Pro MCP v3.7.3.
+Minimal install and Logic Pro integration guide for Logic Pro MCP v3.7.4.
 
 ## Requirements
 
@@ -33,8 +33,8 @@ Pinned shell installer:
 
 ```bash
 brew install cliclick
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.3/Scripts/install.sh -o install.sh
-# inspect install.sh, then copy pins from the v3.7.3 release:
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/logic-pro-mcp/v3.7.4/Scripts/install.sh -o install.sh
+# inspect install.sh, then copy pins from the v3.7.4 release:
 LOGIC_PRO_MCP_SHA256=<sha256 for LogicProMCP-macOS-universal.tar.gz entry> LOGIC_PRO_MCP_TEAM_ID=<team_id> bash install.sh
 ```
 


### PR DESCRIPTION
Post-publish evidence sync — v3.7.4 is now the published stable (GitHub Release `latest`, validate-install green on macos-14 + macos-15).

- **README**: badge, test-count badge (`1876`), release state, release-honesty line, "current published" + "Published stable" prose, install URLs, and the verification table (`1876` tests / strict live `352/352`) now reference `v3.7.4`; previous-stable references shift to `v3.7.3`.
- **docs/API.md, docs/SETUP.md**: current-surface version + install-pin URLs → `v3.7.4`.
- **Formula**: `sha256` synced to the published `v3.7.4` `LogicProMCP-macOS-universal.tar.gz` (`2aac368a…`, verified against the release `SHA256SUMS.txt`); comment updated.
- **InstallScriptContract** README/SETUP install-URL assertions → `v3.7.4`.

## Verification
- `swift build` clean; `InstallScriptContractTests` + `VersionConsistencyTests` green against the synced README/Formula/docs.
- Full suite (`swift test --no-parallel`) already **1876 passed** on the merged release base; this PR changes only docs + version-coupled test assertions.