### PR TITLE
feat(doctor): enterprise-grade diagnostic report (v2)

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Dispatch
 import Foundation
 
@@ -22,6 +23,9 @@ enum MainEntrypoint {
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
         doctorRuntime: SetupDoctor.Runtime = .production,
         lifecycleRuntime: SetupLifecycle.Runtime = .production,
+        // Injected so doctor's color/TTY gating is pinnable in tests (AC-5.4).
+        isStdoutTTY: () -> Bool = { isatty(STDOUT_FILENO) != 0 },
+        doctorEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         writeStdout: (String) -> Void = { message in
             FileHandle.standardOutput.write(Data(message.utf8))
         },
@@ -32,16 +36,30 @@ enum MainEntrypoint {
         let approvalStore = approvalStoreFactory()
 
         if isDoctorCommand(arguments) {
+            // Arm the opt-in update lookup ONLY when --check-updates is present, so
+            // the default run never touches the network (G7/NG4). A test-injected
+            // lookup (already non-nil) is left untouched.
+            var runtime = doctorRuntime
+            if arguments.contains("--check-updates"), runtime.latestReleaseLookup == nil {
+                runtime.latestReleaseLookup = { SetupDoctor.productionLatestReleaseLookup() }
+            }
             let report = SetupDoctor.generate(
                 arguments: arguments,
                 permissionStatus: permissionCheck(),
                 approvals: await approvalStore.list(),
-                runtime: doctorRuntime
+                runtime: runtime
             )
-            let output = arguments.contains("--json")
-                ? encodeJSON(report)
-                : SetupDoctor.renderHuman(report)
-            writeStdout(output + "\n")
+            if arguments.contains("--json") {
+                // --json is the machine contract: identical bytes regardless of
+                // verbosity/color flags (AC-5.5).
+                writeStdout(encodeJSON(report) + "\n")
+            } else {
+                let mode: SetupDoctor.OutputMode = arguments.contains("--verbose")
+                    ? .verbose
+                    : (arguments.contains("--quiet") ? .quiet : .default)
+                let useColor = isStdoutTTY() && doctorEnvironment["NO_COLOR"] == nil
+                writeStdout(SetupDoctor.renderHuman(report, mode: mode, useColor: useColor) + "\n")
+            }
             return SetupDoctor.shouldExitWithFailure(report) ? 1 : 0
         }
 

--- a/Sources/LogicProMCP/Utilities/PermissionChecker.swift
+++ b/Sources/LogicProMCP/Utilities/PermissionChecker.swift
@@ -35,7 +35,12 @@ enum PermissionChecker {
         // Logic Pro automation granted can still have System Events denied —
         // which is exactly the #188 gap where health looked green but
         // record_sequence failed mid-import with an Apple Events denial.
-        let runSystemEventsAutomationProbe: @Sendable () -> Bool
+        //
+        // Tri-state (not Bool): a probe that RAN and was denied → .notGranted, but a
+        // probe that COULD NOT RUN (osascript timeout / spawn failure / unexpected
+        // output) → .notVerifiable. Collapsing the latter to .notGranted would report
+        // "denied" for an infrastructure failure — a false-RED the doctor must not emit.
+        let runSystemEventsAutomationProbe: @Sendable () -> CheckState
 
         static let production = Runtime(
             checkAccessibility: { prompt in
@@ -163,7 +168,7 @@ enum PermissionChecker {
     }
 
     static func checkSystemEventsAutomationState(runtime: Runtime = .production) -> CheckState {
-        runtime.runSystemEventsAutomationProbe() ? .granted : .notGranted
+        runtime.runSystemEventsAutomationProbe()
     }
 
     /// Full permission check.
@@ -197,22 +202,27 @@ enum PermissionChecker {
         return trimmed == ServerConfig.logicProProcessName
     }
 
-    private static func runSystemEventsAutomationProbeViaShell() -> Bool {
-        // A no-op read against System Events. If the launcher lacks Automation →
-        // System Events, osascript exits non-zero (e.g. errAEEventNotPermitted
-        // -1743) and the probe reports notGranted instead of letting a later
-        // MIDI import fail mid-mutation with the same denial.
+    private static func runSystemEventsAutomationProbeViaShell() -> CheckState {
+        // A no-op read against System Events. Distinguish three outcomes honestly:
+        //  - osascript ran, exit 0, returned "System Events"  → .granted
+        //  - osascript ran, exit != 0 (e.g. errAEEventNotPermitted -1743) → .notGranted (real denial)
+        //  - osascript could not run (timeout / spawn failure) or returned unexpected
+        //    output → .notVerifiable (an infrastructure failure is NOT a denial).
         let script = "tell application \"System Events\" to return name"
-        guard case let .completed(output) = BoundedProcessRunner.run(
+        switch BoundedProcessRunner.run(
             executable: "/usr/bin/osascript",
             arguments: ["-e", script],
             timeout: 1.0,
             outputLimitBytes: 4 * 1024
-        ), output.exitCode == 0 else {
-            return false
+        ) {
+        case let .completed(output):
+            if output.exitCode == 0 {
+                let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed == "System Events" ? .granted : .notVerifiable
+            }
+            return .notGranted
+        case .timedOut, .spawnFailed:
+            return .notVerifiable
         }
-
-        let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed == "System Events"
     }
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -32,6 +32,25 @@ enum SetupDoctor {
         case none
     }
 
+    /// Closed, typed taxonomy added in v2 (lazycodex-style `CheckCategory`).
+    /// Parallel to the v1 free-string `domain`, which is retained for back-compat.
+    enum Category: String, Codable, Sendable {
+        case installation
+        case configuration
+        case permissions
+        case dependencies
+        case runtime
+        case updates
+    }
+
+    /// Display-grade severity derived from `CheckStatus`. Used for headline
+    /// ordering ("fix the error first") — never drives the exit code.
+    enum Severity: String, Codable, Sendable {
+        case error
+        case warning
+        case info
+    }
+
     struct Remediation: Codable, Equatable, Sendable {
         let type: RemediationType
         let value: String
@@ -44,6 +63,48 @@ enum SetupDoctor {
         let summary: String
         let evidence: [String: String]
         let remediation: Remediation
+        // v2 additive fields. `category`/`severity` are derived in the `check`
+        // factory; `durationMs` is stamped post-hoc by the `generate` timing
+        // wrapper (var so the wrapper can set it without rebuilding the struct).
+        let category: Category
+        let severity: Severity
+        var durationMs: Double
+
+        // Explicit CodingKeys enumerate EVERY key — the six v1 keys keep their
+        // exact wire names so a v2 payload stays a strict field-superset of v1,
+        // and adding `duration_ms` can never silently rename a v1 key.
+        enum CodingKeys: String, CodingKey {
+            case id
+            case domain
+            case status
+            case summary
+            case evidence
+            case remediation
+            case category
+            case severity
+            case durationMs = "duration_ms"
+        }
+    }
+
+    /// v2 roll-up. Invariant: passed+failed+warnings+manual+skipped == total == checks.count.
+    struct Summary: Codable, Equatable, Sendable {
+        let total: Int
+        let passed: Int
+        let failed: Int
+        let warnings: Int
+        let manual: Int
+        let skipped: Int
+        let durationMs: Double
+
+        enum CodingKeys: String, CodingKey {
+            case total
+            case passed
+            case failed
+            case warnings
+            case manual
+            case skipped
+            case durationMs = "duration_ms"
+        }
     }
 
     struct Report: Codable, Equatable, Sendable {
@@ -52,6 +113,9 @@ enum SetupDoctor {
         let version: String
         let installSource: InstallSource
         let checks: [Check]
+        // v2 additive top-level fields.
+        let summary: Summary
+        let headline: String
 
         enum CodingKeys: String, CodingKey {
             case schema
@@ -59,6 +123,8 @@ enum SetupDoctor {
             case version
             case installSource = "install_source"
             case checks
+            case summary
+            case headline
         }
     }
 
@@ -91,6 +157,19 @@ enum SetupDoctor {
         let logicProHasVisibleWindow: () -> Bool
         let runCommand: (String, [String]) -> CommandOutput?
         let readClaudeRegistration: () -> ClaudeRegistration
+        // v2 seams. Defaults keep every existing `Runtime(...)` construction site
+        // compiling; `.production` and the test helper supply real/fake impls.
+        // `cliclickPath` reuses the runtime's own trusted resolver so the doctor
+        // can never green-light a cliclick the bounce/export path would reject.
+        var cliclickPath: () -> String? = { ProjectExportExecutor.resolveTrustedCliclick() }
+        var cliclickPresentOnPath: () -> Bool = { ProjectExportExecutor.commandExists("cliclick") }
+        var macOSVersion: () -> OperatingSystemVersion? = { ProcessInfo.processInfo.operatingSystemVersion }
+        // Monotonic millisecond clock for per-check timing. Monotonic (uptime),
+        // never wall-clock, so a duration can never go negative across an NTP step.
+        var monotonicNowMs: () -> Double = { Double(DispatchTime.now().uptimeNanoseconds) / 1_000_000.0 }
+        // nil ⇒ the opt-in update check is not emitted and no network is touched.
+        // Non-nil only when `--check-updates` is passed (wired in MainEntrypoint).
+        var latestReleaseLookup: (() -> UpdateOutcome)?
 
         static let production = Runtime(
             resolveExecutablePath: { raw in
@@ -117,7 +196,19 @@ enum SetupDoctor {
         )
     }
 
-    static let schema = "logic_pro_mcp_doctor.v1"
+    /// Typed outcome of the opt-in update lookup, so the check body can write an
+    /// accurate enumerated `reason` (AC-6.4) instead of collapsing every failure
+    /// mode to a bare `nil`.
+    enum UpdateOutcome: Equatable, Sendable {
+        case found(version: String)
+        case offline
+        case sourceUnavailable
+        case parseError
+        case httpError
+        case timeout
+    }
+
+    static let schema = "logic_pro_mcp_doctor.v2"
 
     static let remediationAnchorsByCheckID: [String: String] = [
         "binary.path": "docs/SETUP.md#doctor-binarypath",
@@ -128,6 +219,10 @@ enum SetupDoctor {
         "mcp.claude_code_registration": "docs/SETUP.md#doctor-mcpclaude-code-registration",
         "permissions.accessibility": "docs/SETUP.md#doctor-permissionsaccessibility",
         "permissions.automation_logic_pro": "docs/SETUP.md#doctor-permissionsautomation-logic-pro",
+        "permissions.automation_system_events": "docs/SETUP.md#doctor-permissionsautomation-system-events",
+        "dependencies.cliclick": "docs/SETUP.md#doctor-dependenciescliclick",
+        "system.macos_version": "docs/SETUP.md#doctor-systemmacos-version",
+        "updates.latest_release": "docs/SETUP.md#doctor-updateslatest-release",
         "logic.application_state": "docs/SETUP.md#doctor-logicapplication-state",
         "channels.manual_validation": "docs/SETUP.md#doctor-channelsmanual-validation",
     ]
@@ -140,45 +235,145 @@ enum SetupDoctor {
     ) -> Report {
         let executablePath = runtime.resolveExecutablePath(arguments.first)
         let installSource = detectInstallSource(executablePath: executablePath, runtime: runtime)
+
+        // Per-check monotonic timing. Each check runs once, in declared order
+        // (sequential — no concurrency), wrapped to stamp `duration_ms`. Checks
+        // are non-throwing, so no exception isolation is required.
+        func timed(_ make: () -> Check) -> Check {
+            let start = runtime.monotonicNowMs()
+            var result = make()
+            result.durationMs = max(0, runtime.monotonicNowMs() - start)
+            return result
+        }
+
         var checks: [Check] = []
 
-        checks.append(binaryPathCheck(executablePath: executablePath, runtime: runtime))
-        checks.append(binaryExecutableCheck(executablePath: executablePath, runtime: runtime))
-        checks.append(binaryVersionCheck())
-        checks.append(installSourceCheck(installSource: installSource, executablePath: executablePath))
-        checks.append(releaseSignatureCheck(executablePath: executablePath, runtime: runtime))
-        checks.append(releaseQuarantineCheck(executablePath: executablePath, runtime: runtime))
-        checks.append(claudeRegistrationCheck(runtime: runtime))
-        checks.append(accessibilityPermissionCheck(permissionStatus))
-        checks.append(automationPermissionCheck(permissionStatus))
-        checks.append(logicApplicationStateCheck(runtime: runtime))
-        checks.append(manualValidationCheck(approvals: approvals))
+        checks.append(timed { binaryPathCheck(executablePath: executablePath, runtime: runtime) })
+        checks.append(timed { binaryExecutableCheck(executablePath: executablePath, runtime: runtime) })
+        checks.append(timed { binaryVersionCheck() })
+        checks.append(timed { installSourceCheck(installSource: installSource, executablePath: executablePath) })
+        checks.append(timed { releaseSignatureCheck(executablePath: executablePath, runtime: runtime) })
+        checks.append(timed { releaseQuarantineCheck(executablePath: executablePath, runtime: runtime) })
+        checks.append(timed { claudeRegistrationCheck(runtime: runtime) })
+        checks.append(timed { accessibilityPermissionCheck(permissionStatus) })
+        checks.append(timed { automationPermissionCheck(permissionStatus) })
+        checks.append(timed { systemEventsAutomationCheck(permissionStatus) })
+        checks.append(timed { cliclickDependencyCheck(runtime: runtime) })
+        checks.append(timed { macOSVersionCheck(runtime: runtime) })
+        checks.append(timed { logicApplicationStateCheck(runtime: runtime) })
+        checks.append(timed { manualValidationCheck(approvals: approvals) })
+        // Opt-in update check: emitted only when `--check-updates` armed the lookup seam.
+        if let lookup = runtime.latestReleaseLookup {
+            checks.append(timed { updateCheck(outcome: lookup()) })
+        }
 
+        // Honesty chokepoint (G1/AC-1.5): the report can never claim `ok` while a
+        // required permission is ungranted. Extracted to a pure helper so the invariant
+        // is OWNED and directly unit-tested here, not left emergent on each permission
+        // check happening to be non-pass.
+        let status = clampStatusForPermissions(
+            aggregateStatus(checks),
+            allGranted: permissionStatus.allGranted
+        )
+
+        let totalDurationMs = checks.reduce(0.0) { $0 + $1.durationMs }
         return Report(
             schema: schema,
-            status: aggregateStatus(checks),
+            status: status,
             version: ServerConfig.serverVersion,
             installSource: installSource,
-            checks: checks
+            checks: checks,
+            summary: calculateSummary(checks, totalDurationMs: totalDurationMs),
+            headline: computeHeadline(checks: checks, status: status)
         )
     }
 
-    static func renderHuman(_ report: Report) -> String {
-        var lines: [String] = [
-            "Logic Pro MCP doctor",
-            "schema: \(report.schema)",
-            "status: \(report.status.rawValue)",
-            "version: \(report.version)",
-            "install_source: \(report.installSource.rawValue)",
-            "",
-        ]
+    enum OutputMode: String, Sendable {
+        case `default`
+        case verbose
+        case quiet
+    }
+
+    static func renderHuman(
+        _ report: Report,
+        mode: OutputMode = .default,
+        useColor: Bool = false
+    ) -> String {
+        var lines: [String] = []
+        // Headline (next action) + summary roll-up lead the report in every mode.
+        lines.append(report.headline)
+        lines.append(renderSummaryLine(report.summary))
+        // Existing v1 header block is preserved so the non-TTY human shape stays
+        // a back-compatible superset (a scraper grepping these lines keeps working).
+        lines.append("Logic Pro MCP doctor")
+        lines.append("schema: \(report.schema)")
+        lines.append("status: \(report.status.rawValue)")
+        lines.append("version: \(report.version)")
+        lines.append("install_source: \(report.installSource.rawValue)")
+        lines.append("")
         for check in report.checks {
-            lines.append("[\(check.status.rawValue)] \(check.id) - \(check.summary)")
+            if mode == .quiet, check.status == .pass {
+                continue
+            }
+            lines.append(renderCheckLine(check, useColor: useColor))
             if check.remediation.type != .none {
-                lines.append("  remediation: \(check.remediation.value)")
+                lines.append("  \u{2192} \(check.remediation.value)")
+            }
+            if mode == .verbose {
+                for key in check.evidence.keys.sorted() {
+                    lines.append("    \(key)=\(check.evidence[key] ?? "")")
+                }
+                lines.append("    duration_ms: \(formatDuration(check.durationMs))")
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    private static func renderSummaryLine(_ summary: Summary) -> String {
+        var parts: [String] = ["\(summary.passed) passed"]
+        if summary.failed > 0 {
+            parts.append("\(summary.failed) failed")
+        }
+        if summary.warnings > 0 {
+            parts.append("\(summary.warnings) warning\(summary.warnings == 1 ? "" : "s")")
+        }
+        if summary.manual > 0 {
+            parts.append("\(summary.manual) manual")
+        }
+        if summary.skipped > 0 {
+            parts.append("\(summary.skipped) skipped")
+        }
+        return "summary: \(parts.joined(separator: ", ")) (\(formatDuration(summary.durationMs))ms)"
+    }
+
+    private static func renderCheckLine(_ check: Check, useColor: Bool) -> String {
+        guard useColor else {
+            // Plain ASCII fallback (non-TTY / NO_COLOR): byte-clean for pipes & CI.
+            return "[\(check.status.rawValue)] \(check.id) - \(check.summary)"
+        }
+        let reset = "\u{1B}[0m"
+        let (symbol, color) = colorSymbol(for: check.status)
+        return "\(color)\(symbol)\(reset) \(check.id) - \(check.summary)"
+    }
+
+    /// (symbol, ANSI color prefix) per status. Only used when color is enabled.
+    private static func colorSymbol(for status: CheckStatus) -> (String, String) {
+        switch status {
+        case .pass:
+            return ("\u{2713}", "\u{1B}[32m")   // ✓ green
+        case .fail:
+            return ("\u{2717}", "\u{1B}[31m")   // ✗ red
+        case .warn:
+            return ("\u{26A0}", "\u{1B}[33m")   // ⚠ yellow
+        case .manual:
+            return ("\u{2022}", "\u{1B}[34m")   // • blue
+        case .skipped:
+            return ("\u{2205}", "\u{1B}[90m")   // ∅ grey
+        }
+    }
+
+    private static func formatDuration(_ ms: Double) -> String {
+        String(Int(ms.rounded()))
     }
 
     static func shouldExitWithFailure(_ report: Report) -> Bool {
@@ -196,6 +391,14 @@ enum SetupDoctor {
             return .degraded
         }
         return .ok
+    }
+
+    /// Honesty chokepoint (G1/AC-1.5): the report must never be `ok` when a required
+    /// permission is ungranted. Pure + directly unit-tested so the invariant is owned
+    /// here rather than left to emerge from each permission check being non-pass.
+    /// `allGranted == accessibility && automationLogicPro && automationSystemEvents`.
+    static func clampStatusForPermissions(_ status: ReportStatus, allGranted: Bool) -> ReportStatus {
+        (!allGranted && status == .ok) ? .degraded : status
     }
 
     private static func binaryPathCheck(executablePath: String?, runtime: Runtime) -> Check {
@@ -443,6 +646,194 @@ enum SetupDoctor {
         )
     }
 
+    private static func systemEventsAutomationCheck(_ status: PermissionChecker.PermissionStatus) -> Check {
+        // Surfaces the System Events automation target the runtime treats as a HARD
+        // requirement (#188) but the v1 doctor dropped. Honest mapping: a probe that
+        // could-not-run (.notVerifiable) is `manual`, never `fail` ("denied").
+        let checkStatus: CheckStatus
+        switch status.systemEventsAutomationState {
+        case .granted:
+            checkStatus = .pass
+        case .notGranted:
+            checkStatus = .fail
+        case .notVerifiable:
+            checkStatus = .manual
+        }
+        return check(
+            id: "permissions.automation_system_events",
+            domain: "permissions",
+            status: checkStatus,
+            summary: systemEventsSummary(for: status.systemEventsAutomationState),
+            evidence: ["state": status.systemEventsAutomationState.rawValue],
+            remediationType: status.systemEventsAutomationState == .granted ? .none : .systemSettings
+        )
+    }
+
+    private static func cliclickDependencyCheck(runtime: Runtime) -> Check {
+        // Reuse the runtime's OWN trusted resolver so the doctor cannot green-light a
+        // cliclick the bounce/export path would reject (trusted canonical path +
+        // non-group/other-writable parent). cliclick gates only bounce/export, so a
+        // missing/untrusted binary is `warn` (→ degraded → exit 0), never `fail`.
+        if let path = runtime.cliclickPath() {
+            return check(
+                id: "dependencies.cliclick",
+                domain: "dependencies",
+                status: .pass,
+                summary: "cliclick is installed at a trusted path.",
+                evidence: ["path": path, "trusted": "true"],
+                remediationType: .none
+            )
+        }
+        if runtime.cliclickPresentOnPath() {
+            return check(
+                id: "dependencies.cliclick",
+                domain: "dependencies",
+                status: .warn,
+                summary: "cliclick is present but not at a trusted path (or its parent directory is writable); bounce/export will not use it.",
+                evidence: ["trusted": "false", "present_on_path": "true"],
+                remediationType: .command,
+                remediationValueOverride: "brew install cliclick"
+            )
+        }
+        return check(
+            id: "dependencies.cliclick",
+            domain: "dependencies",
+            status: .warn,
+            summary: "cliclick is not installed; bounce/export operations require it.",
+            evidence: ["trusted": "false", "present_on_path": "false"],
+            remediationType: .command,
+            remediationValueOverride: "brew install cliclick"
+        )
+    }
+
+    private static func macOSVersionCheck(runtime: Runtime) -> Check {
+        let minimumMajor = 14 // Package.swift: platforms: [.macOS(.v14)]
+        guard let version = runtime.macOSVersion() else {
+            return check(
+                id: "system.macos_version",
+                domain: "system",
+                status: .skipped,
+                summary: "macOS version could not be determined.",
+                evidence: ["reason": "version_unreadable"],
+                remediationType: .docs
+            )
+        }
+        let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        if version.majorVersion >= minimumMajor {
+            return check(
+                id: "system.macos_version",
+                domain: "system",
+                status: .pass,
+                summary: "macOS \(versionString) meets the minimum (\(minimumMajor)+).",
+                evidence: ["version": versionString, "minimum_major": String(minimumMajor)],
+                remediationType: .none
+            )
+        }
+        return check(
+            id: "system.macos_version",
+            domain: "system",
+            status: .fail,
+            summary: "macOS \(versionString) is below the required minimum (\(minimumMajor)+).",
+            evidence: ["version": versionString, "minimum_major": String(minimumMajor)],
+            remediationType: .docs
+        )
+    }
+
+    private static func updateCheck(outcome: UpdateOutcome) -> Check {
+        let installed = ServerConfig.serverVersion
+        switch outcome {
+        case let .found(rawLatest):
+            let latest = normalizeVersion(rawLatest)
+            let order = compareVersions(installed, latest)
+            if order >= 0 {
+                return check(
+                    id: "updates.latest_release",
+                    domain: "updates",
+                    status: .pass,
+                    summary: "Installed version \(installed) is up to date.",
+                    evidence: ["installed": installed, "latest": latest],
+                    remediationType: .none
+                )
+            }
+            return check(
+                id: "updates.latest_release",
+                domain: "updates",
+                status: .warn,
+                summary: "A newer release is available: \(latest) (installed \(installed)).",
+                evidence: ["installed": installed, "latest": latest],
+                remediationType: .command,
+                remediationValueOverride: "brew upgrade logic-pro-mcp"
+            )
+        case .offline, .sourceUnavailable, .parseError, .httpError, .timeout:
+            // Redaction (AC-6.4): evidence carries ONLY an enumerated reason — never
+            // stderr, env, tokened URLs, or headers. The lookup is unauthenticated.
+            return check(
+                id: "updates.latest_release",
+                domain: "updates",
+                status: .skipped,
+                summary: "Could not check for the latest release.",
+                evidence: ["reason": updateReason(outcome)],
+                remediationType: .docs
+            )
+        }
+    }
+
+    private static func updateReason(_ outcome: UpdateOutcome) -> String {
+        switch outcome {
+        case .found:
+            return "found"
+        case .offline:
+            return "offline"
+        case .sourceUnavailable:
+            return "source_unavailable"
+        case .parseError:
+            return "parse_error"
+        case .httpError:
+            return "http_error"
+        case .timeout:
+            return "timeout"
+        }
+    }
+
+    /// Normalize a release tag for comparison: strip a leading `v` (`v3.7.4` → `3.7.4`)
+    /// and drop any pre-release/build suffix (`4.0.0-beta.1` → `4.0.0`) so a hyphenated
+    /// segment can't be misread as a numeric component by `compareVersions` (which would
+    /// otherwise rank a pre-release as newer than its GA release).
+    static func normalizeVersion(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("v") || value.hasPrefix("V") {
+            value = String(value.dropFirst())
+        }
+        return value.components(separatedBy: "-").first ?? value
+    }
+
+    /// Numeric, component-wise version compare (NEVER lexicographic: "3.9" < "3.10").
+    /// Returns negative if a < b, 0 if equal, positive if a > b.
+    static func compareVersions(_ a: String, _ b: String) -> Int {
+        let lhs = a.split(separator: ".").map { Int($0) ?? 0 }
+        let rhs = b.split(separator: ".").map { Int($0) ?? 0 }
+        let count = max(lhs.count, rhs.count)
+        for index in 0..<count {
+            let left = index < lhs.count ? lhs[index] : 0
+            let right = index < rhs.count ? rhs[index] : 0
+            if left != right {
+                return left < right ? -1 : 1
+            }
+        }
+        return 0
+    }
+
+    private static func systemEventsSummary(for state: PermissionChecker.CheckState) -> String {
+        switch state {
+        case .granted:
+            return "Automation permission for System Events is granted."
+        case .notGranted:
+            return "Automation permission for System Events is not granted."
+        case .notVerifiable:
+            return "Automation permission for System Events could not be verified."
+        }
+    }
+
     private static func logicApplicationStateCheck(runtime: Runtime) -> Check {
         let running = runtime.logicProRunning()
         let visible = running && runtime.logicProHasVisibleWindow()
@@ -532,14 +923,94 @@ enum SetupDoctor {
         remediationValueOverride: String? = nil
     ) -> Check {
         let value = remediationValueOverride ?? defaultRemediationValue(for: id, type: remediationType)
+        // category/severity are DERIVED here (single chokepoint) so no check can be
+        // built with an inconsistent taxonomy and the 11 existing call sites need no
+        // edit. durationMs is stamped post-hoc by the `generate` timing wrapper.
         return Check(
             id: id,
             domain: domain,
             status: status,
             summary: summary,
             evidence: evidence,
-            remediation: Remediation(type: remediationType, value: value)
+            remediation: Remediation(type: remediationType, value: value),
+            category: category(forDomain: domain),
+            severity: severity(for: status),
+            durationMs: 0
         )
+    }
+
+    /// Maps the v1 free-string `domain` to the closed v2 `Category`. Complete table —
+    /// every domain a check can carry has a row; unknown domains fall back to runtime.
+    static func category(forDomain domain: String) -> Category {
+        switch domain {
+        case "binary", "install", "release", "system":
+            return .installation
+        case "mcp", "channels":
+            return .configuration
+        case "permissions":
+            return .permissions
+        case "dependencies":
+            return .dependencies
+        case "updates":
+            return .updates
+        case "logic":
+            return .runtime
+        default:
+            return .runtime
+        }
+    }
+
+    /// Total status→severity mapping (AC-4.1). `skipped` is `info` (could-not-verify
+    /// is not actionable noise), not `warning`.
+    static func severity(for status: CheckStatus) -> Severity {
+        switch status {
+        case .fail:
+            return .error
+        case .warn, .manual:
+            return .warning
+        case .skipped, .pass:
+            return .info
+        }
+    }
+
+    static func calculateSummary(_ checks: [Check], totalDurationMs: Double) -> Summary {
+        Summary(
+            total: checks.count,
+            passed: checks.filter { $0.status == .pass }.count,
+            failed: checks.filter { $0.status == .fail }.count,
+            warnings: checks.filter { $0.status == .warn }.count,
+            manual: checks.filter { $0.status == .manual }.count,
+            skipped: checks.filter { $0.status == .skipped }.count,
+            durationMs: totalDurationMs
+        )
+    }
+
+    /// The "next action" one-liner (AC-4.2/4.3): names the single highest-priority
+    /// remediation — errors before warnings, then stable check order. `info`
+    /// (pass/skipped) is never headlined. All-pass → healthy message.
+    static func computeHeadline(checks: [Check], status: ReportStatus) -> String {
+        let priority: (Severity) -> Int = { severity in
+            switch severity {
+            case .error: return 0
+            case .warning: return 1
+            case .info: return 2
+            }
+        }
+        // Stable: enumerate in declared order, pick the first lowest-priority-number
+        // non-pass check (errors win ties by appearing first at priority 0).
+        let actionable = checks
+            .filter { $0.status != .pass }
+            .min(by: { priority($0.severity) < priority($1.severity) })
+        guard let lead = actionable, lead.severity != .info else {
+            // No actionable (error/warning) check. Distinguish a truly clean run from
+            // one that is merely usable-but-not-fully-verified (e.g. a skipped check
+            // degrades the aggregate) — never claim "healthy" while status is non-ok.
+            return status == .ok
+                ? "Logic Pro MCP install is healthy."
+                : "Logic Pro MCP install is usable; some checks could not be verified."
+        }
+        let remediationHint = lead.remediation.type == .none ? "" : " — \(lead.remediation.value)"
+        return "Next action [\(lead.id)]: \(lead.summary)\(remediationHint)"
     }
 
     private static func defaultRemediationValue(for id: String, type: RemediationType) -> String {
@@ -552,6 +1023,9 @@ enum SetupDoctor {
             }
             if id == "permissions.automation_logic_pro" {
                 return "System Settings > Privacy & Security > Automation > Logic Pro"
+            }
+            if id == "permissions.automation_system_events" {
+                return "System Settings > Privacy & Security > Automation > System Events"
             }
             return remediationAnchorsByCheckID[id] ?? "docs/SETUP.md#doctor"
         case .command, .docs, .manual:
@@ -616,6 +1090,62 @@ enum SetupDoctor {
         case let .spawnFailed(message):
             return .spawnFailed(message)
         }
+    }
+
+    /// Production update lookup (wired by MainEntrypoint only under `--check-updates`).
+    /// UNAUTHENTICATED public read — no Authorization header, no token — so no secret
+    /// is ever in scope to leak into evidence (AC-6.4). Bounded; degrades to a typed
+    /// failure outcome that the check renders as `skipped`, never `fail`.
+    static func productionLatestReleaseLookup() -> UpdateOutcome {
+        let repo = "MongLong0214/logic-pro-mcp"
+        let url = "https://api.github.com/repos/\(repo)/releases/latest"
+        if let result = runProductionCommand(
+            executable: "/usr/bin/curl",
+            arguments: ["-fsSL", "--max-time", "3", "-H", "Accept: application/vnd.github+json", url],
+            timeout: 3.5
+        ) {
+            switch result {
+            case let .completed(output):
+                if output.exitCode == 0 {
+                    return parseLatestTag(from: output.stdout).map { .found(version: $0) } ?? .parseError
+                }
+                if output.exitCode == 28 {
+                    return .timeout // curl --max-time self-terminated before the bounded wrapper.
+                }
+                if output.exitCode == 22 {
+                    return .httpError // curl -f: HTTP response >= 400
+                }
+                // Other curl failures (could-not-resolve/connect) → try gh, else offline.
+            case .timedOut:
+                return .timeout
+            case .spawnFailed:
+                break // curl missing — try gh.
+            }
+        }
+        // gh fallback (best-effort; gh is a dev tool, often absent on end-user installs).
+        for ghPath in ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"] {
+            if let gh = runProductionCommand(
+                executable: ghPath,
+                arguments: ["release", "view", "--repo", repo, "--json", "tagName", "-q", ".tagName"],
+                timeout: 3.5
+            )?.output, gh.exitCode == 0 {
+                let tag = gh.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                return tag.isEmpty ? .parseError : .found(version: tag)
+            }
+        }
+        return .offline
+    }
+
+    /// Parse `tag_name` from the GitHub "latest release" JSON. Returns nil on any
+    /// shape mismatch (→ `.parseError`). Never echoes the payload anywhere.
+    static func parseLatestTag(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = object["tag_name"] as? String,
+              !tag.isEmpty else {
+            return nil
+        }
+        return tag
     }
 
     /// Production reader for the Claude Code registration. Parses ~/.claude.json

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -242,7 +242,10 @@ enum SetupDoctor {
         func timed(_ make: () -> Check) -> Check {
             let start = runtime.monotonicNowMs()
             var result = make()
-            result.durationMs = max(0, runtime.monotonicNowMs() - start)
+            // Round to whole milliseconds so the JSON machine contract matches the
+            // human renderer's `formatDuration` precision and sub-millisecond timing
+            // jitter doesn't churn the `--json` bytes run-to-run (sub-ms checks → 0).
+            result.durationMs = (max(0, runtime.monotonicNowMs() - start)).rounded()
             return result
         }
 
@@ -288,7 +291,7 @@ enum SetupDoctor {
         )
     }
 
-    enum OutputMode: String, Sendable {
+    enum OutputMode: Sendable {
         case `default`
         case verbose
         case quiet
@@ -744,6 +747,19 @@ enum SetupDoctor {
         switch outcome {
         case let .found(rawLatest):
             let latest = normalizeVersion(rawLatest)
+            // An unparseable tag (e.g. "v", "-beta.1", "latest") normalizes to a value
+            // with no numeric major. compareVersions would treat it as 0.0.0 and falsely
+            // report "up to date" — so report skipped/parse_error instead of fabricating a pass.
+            guard let major = latest.split(separator: ".").first, Int(major) != nil else {
+                return check(
+                    id: "updates.latest_release",
+                    domain: "updates",
+                    status: .skipped,
+                    summary: "Could not parse the latest release version.",
+                    evidence: ["reason": "parse_error"],
+                    remediationType: .docs
+                )
+            }
             let order = compareVersions(installed, latest)
             if order >= 0 {
                 return check(

--- a/Tests/LogicProMCPTests/PermissionCheckerTests.swift
+++ b/Tests/LogicProMCPTests/PermissionCheckerTests.swift
@@ -8,7 +8,9 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     var running = true
     var probeResult = true
     var systemEventsProbeCalls = 0
-    var systemEventsProbeResult = true
+    // Tri-state now (was Bool): the seam returns a CheckState so a could-not-run
+    // probe can be modelled as .notVerifiable, distinct from a denial (.notGranted).
+    var systemEventsProbeState: PermissionChecker.CheckState = .granted
 
     func runtime() -> PermissionChecker.Runtime {
         PermissionChecker.Runtime(
@@ -23,7 +25,7 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
             },
             runSystemEventsAutomationProbe: {
                 self.systemEventsProbeCalls += 1
-                return self.systemEventsProbeResult
+                return self.systemEventsProbeState
             }
         )
     }
@@ -31,7 +33,7 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
 
 @Test func testPermissionCheckerSystemEventsAutomationProbeReflectsGrant() {
     let harness = PermissionRuntimeHarness()
-    harness.systemEventsProbeResult = true
+    harness.systemEventsProbeState = .granted
 
     let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
 
@@ -46,12 +48,24 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     // is reported as not_granted, not not_verifiable.
     let harness = PermissionRuntimeHarness()
     harness.running = false
-    harness.systemEventsProbeResult = false
+    harness.systemEventsProbeState = .notGranted
 
     let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
 
     #expect(state == .notGranted)
     #expect(harness.systemEventsProbeCalls == 1)
+}
+
+@Test func testPermissionCheckerSystemEventsProbeCouldNotRunIsNotVerifiable() {
+    // A probe that could not run (osascript timeout / spawn failure) maps to
+    // .notVerifiable, NOT .notGranted — an infrastructure failure is not a denial.
+    let harness = PermissionRuntimeHarness()
+    harness.systemEventsProbeState = .notVerifiable
+
+    let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
+
+    #expect(state == .notVerifiable)
+    #expect(PermissionChecker.checkSystemEventsAutomation(runtime: harness.runtime()) == false)
 }
 
 @Test func testPermissionCheckerCheckAccessibilityUsesInjectedRuntimeAndPrompt() {

--- a/Tests/LogicProMCPTests/PermissionCheckerTests.swift
+++ b/Tests/LogicProMCPTests/PermissionCheckerTests.swift
@@ -65,7 +65,11 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     let state = PermissionChecker.checkSystemEventsAutomationState(runtime: harness.runtime())
 
     #expect(state == .notVerifiable)
-    #expect(PermissionChecker.checkSystemEventsAutomation(runtime: harness.runtime()) == false)
+    // Force/negation form, NOT `== false`: `#expect(bool == false)` is a DEAD no-op
+    // under this repo's pinned swift-testing (it passes even when flipped to `== true`).
+    // `!expr` is the only reliable Bool form. This guards the honesty invariant that a
+    // could-not-run probe is NOT advertised as granted (would poison allGranted / #188).
+    #expect(!PermissionChecker.checkSystemEventsAutomation(runtime: harness.runtime()))
 }
 
 @Test func testPermissionCheckerCheckAccessibilityUsesInjectedRuntimeAndPrompt() {
@@ -74,7 +78,7 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
 
     let granted = PermissionChecker.checkAccessibility(prompt: true, runtime: harness.runtime())
 
-    #expect(granted == false)
+    #expect(!granted)
     #expect(harness.prompts == [true])
 }
 
@@ -85,7 +89,7 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     let granted = PermissionChecker.checkAutomation(runtime: harness.runtime())
     let state = PermissionChecker.checkAutomationState(runtime: harness.runtime())
 
-    #expect(granted == false)
+    #expect(!granted)
     #expect(state == .notVerifiable)
     #expect(harness.probeCalls == 0)
 }
@@ -97,7 +101,7 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
 
     let granted = PermissionChecker.checkAutomation(runtime: harness.runtime())
 
-    #expect(granted == false)
+    #expect(!granted)
     #expect(harness.probeCalls == 1)
 }
 
@@ -108,12 +112,12 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
 
     let status = PermissionChecker.check(runtime: harness.runtime())
 
-    #expect(status.accessibility == false)
+    #expect(!status.accessibility)
     #expect(status.accessibilityState == .notGranted)
-    #expect(status.automationLogicPro == false)
+    #expect(!status.automationLogicPro)
     #expect(status.automationState == .notVerifiable)
-    #expect(status.automationVerifiable == false)
-    #expect(status.allGranted == false)
+    #expect(!status.automationVerifiable)
+    #expect(!status.allGranted)
     #expect(status.summary.contains("NOT VERIFIABLE"))
 }
 

--- a/Tests/LogicProMCPTests/ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/ProductionReadinessTests.swift
@@ -293,7 +293,7 @@ import Testing
         checkAccessibility: { _ in true },
         isLogicProRunning: { false },
         runAutomationProbe: { false },
-        runSystemEventsAutomationProbe: { false }
+        runSystemEventsAutomationProbe: { .notGranted }
     ))
     #expect(status.accessibility == true)
     #expect(status.automationState == .notVerifiable)

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -583,3 +583,46 @@ private func runEntrypoint(
     #expect(report.status == .degraded)
     #expect(report.headline == "Logic Pro MCP install is usable; some checks could not be verified.")
 }
+
+// MARK: - Final merge-gate hardening (zero-edge-case pass)
+
+@Test func test_t4_update_unparseable_tag_is_skipped_not_false_pass() throws {
+    // boomer-B1/B5: a tag with no numeric major (bare "v", pure pre-release, "latest")
+    // must NOT be reported "up to date" — it normalizes to no version and is unparseable.
+    for raw in ["v", "-beta.1", "latest", ""] {
+        let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: raw) }))
+        let c = try #require(check(report, "updates.latest_release"))
+        #expect(c.status == .skipped, "tag '\(raw)' should be skipped, got \(c.status)")
+        #expect(c.evidence["reason"] == "parse_error")
+    }
+}
+
+@Test func test_t1_summary_counts_invariant_with_update_check_15() {
+    // boomer-B2-3: invariant must hold with the opt-in update check present (15 checks).
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: ServerConfig.serverVersion) }))
+    #expect(report.checks.count == 15)
+    let s = report.summary
+    #expect(s.total == 15)
+    #expect(s.passed + s.failed + s.warnings + s.manual + s.skipped == s.total)
+}
+
+@Test func test_t4_entrypoint_check_updates_flag_surfaces_update_check() async {
+    // boomer-B2-2: the --check-updates flag path is wired through MainEntrypoint end-to-end.
+    // (Inject a fake lookup so the test is hermetic — no network.)
+    let (_, out) = await runEntrypoint(
+        ["LogicProMCP", "doctor", "--check-updates", "--json"],
+        runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: ServerConfig.serverVersion) })
+    )
+    #expect(out.contains("updates.latest_release"))
+}
+
+@Test func test_t1_duration_ms_is_whole_milliseconds() {
+    // debugger-P2: duration_ms is rounded to whole ms so the --json contract matches the
+    // human renderer and sub-ms jitter doesn't churn the bytes. With the default {0} clock,
+    // every duration collapses to exactly 0.0.
+    let report = makeReport()
+    for c in report.checks {
+        #expect(c.durationMs == c.durationMs.rounded())
+    }
+    #expect(report.summary.durationMs == report.summary.durationMs.rounded())
+}

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -1,0 +1,585 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Hermetic runtime/permission builders for the v2 doctor surface
+
+private func enterpriseRuntime(
+    cliclickPath: String? = "/opt/homebrew/bin/cliclick",
+    cliclickPresentOnPath: Bool = true,
+    macOSVersion: OperatingSystemVersion? = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0),
+    monotonicNowMs: @escaping () -> Double = { 0 },
+    latestReleaseLookup: (() -> SetupDoctor.UpdateOutcome)? = nil
+) -> SetupDoctor.Runtime {
+    var runtime = SetupDoctor.Runtime(
+        resolveExecutablePath: { _ in "/opt/homebrew/bin/LogicProMCP" },
+        fileExists: { _ in true },
+        isExecutableFile: { _ in true },
+        logicProRunning: { true },
+        logicProHasVisibleWindow: { true },
+        runCommand: { executable, arguments in
+            if executable == "/usr/bin/codesign" { return .init(exitCode: 0, stdout: "", stderr: "") }
+            if executable == "/usr/bin/xattr" { return .init(exitCode: 1, stdout: "", stderr: "No such xattr") }
+            if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+               arguments == ["list", "--versions", "logic-pro-mcp"] {
+                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
+            }
+            return nil
+        },
+        readClaudeRegistration: { .registered(command: "/opt/homebrew/bin/LogicProMCP") }
+    )
+    runtime.cliclickPath = { cliclickPath }
+    runtime.cliclickPresentOnPath = { cliclickPresentOnPath }
+    runtime.macOSVersion = { macOSVersion }
+    runtime.monotonicNowMs = monotonicNowMs
+    runtime.latestReleaseLookup = latestReleaseLookup
+    return runtime
+}
+
+private func granted(
+    accessibility: Bool = true,
+    automationLogicPro: Bool = true,
+    systemEvents: PermissionChecker.CheckState = .granted
+) -> PermissionChecker.PermissionStatus {
+    .init(
+        accessibilityState: accessibility ? .granted : .notGranted,
+        automationState: automationLogicPro ? .granted : .notGranted,
+        systemEventsAutomationState: systemEvents
+    )
+}
+
+private func enterpriseApprovals() -> [ManualValidationChannel: ManualValidationApproval] {
+    Dictionary(uniqueKeysWithValues: ManualValidationChannel.allCases.map {
+        ($0, ManualValidationApproval(approvedAt: Date(timeIntervalSince1970: 0), note: "test"))
+    })
+}
+
+private func makeReport(
+    runtime: SetupDoctor.Runtime = enterpriseRuntime(),
+    permission: PermissionChecker.PermissionStatus = granted(),
+    approvals: [ManualValidationChannel: ManualValidationApproval]? = nil
+) -> SetupDoctor.Report {
+    SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: permission,
+        approvals: approvals ?? enterpriseApprovals(),
+        runtime: runtime
+    )
+}
+
+private func check(_ report: SetupDoctor.Report, _ id: String) -> SetupDoctor.Check? {
+    report.checks.first { $0.id == id }
+}
+
+// MARK: - T1: v2 model framework
+
+@Test func test_t1_schema_is_v2() {
+    #expect(makeReport().schema == "logic_pro_mcp_doctor.v2")
+}
+
+@Test func test_t1_each_check_has_category_severity_duration() throws {
+    let report = makeReport()
+    for c in report.checks {
+        // Concrete-value assertions (no `!= nil` on non-optional fields = dead).
+        #expect(c.severity == SetupDoctor.severity(for: c.status))
+        #expect(c.category == SetupDoctor.category(forDomain: c.domain))
+        #expect(c.durationMs >= 0)
+    }
+    // Spot-check a known mapping concretely.
+    let accessibility = try #require(check(report, "permissions.accessibility"))
+    #expect(accessibility.category == .permissions)
+}
+
+@Test func test_t1_severity_mapping_total() {
+    #expect(SetupDoctor.severity(for: .fail) == .error)
+    #expect(SetupDoctor.severity(for: .warn) == .warning)
+    #expect(SetupDoctor.severity(for: .manual) == .warning)
+    #expect(SetupDoctor.severity(for: .skipped) == .info)
+    #expect(SetupDoctor.severity(for: .pass) == .info)
+}
+
+@Test func test_t1_category_mapping_complete() {
+    #expect(SetupDoctor.category(forDomain: "binary") == .installation)
+    #expect(SetupDoctor.category(forDomain: "install") == .installation)
+    #expect(SetupDoctor.category(forDomain: "release") == .installation)
+    #expect(SetupDoctor.category(forDomain: "system") == .installation)
+    #expect(SetupDoctor.category(forDomain: "mcp") == .configuration)
+    #expect(SetupDoctor.category(forDomain: "channels") == .configuration)
+    #expect(SetupDoctor.category(forDomain: "permissions") == .permissions)
+    #expect(SetupDoctor.category(forDomain: "dependencies") == .dependencies)
+    #expect(SetupDoctor.category(forDomain: "updates") == .updates)
+    #expect(SetupDoctor.category(forDomain: "logic") == .runtime)
+}
+
+@Test func test_t1_summary_counts_invariant() {
+    let report = makeReport()
+    let s = report.summary
+    #expect(s.total == report.checks.count)
+    #expect(s.passed + s.failed + s.warnings + s.manual + s.skipped == s.total)
+    #expect(s.passed == report.checks.filter { $0.status == .pass }.count)
+    #expect(s.failed == report.checks.filter { $0.status == .fail }.count)
+    #expect(s.warnings == report.checks.filter { $0.status == .warn }.count)
+    #expect(s.manual == report.checks.filter { $0.status == .manual }.count)
+    #expect(s.skipped == report.checks.filter { $0.status == .skipped }.count)
+}
+
+@Test func test_t1_summary_status_formula_degraded() {
+    // cliclick absent → a single warn → degraded (no fail, no manual).
+    let report = makeReport(
+        runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false)
+    )
+    #expect(report.status == .degraded)
+    // AC-3.5 split into separate assertions (an OR-compound would hide the && parts).
+    #expect(report.summary.failed == 0)
+    #expect(report.summary.manual == 0)
+    #expect(report.summary.warnings > 0 || report.summary.skipped > 0)
+}
+
+@Test func test_t1_summary_status_formula_ok() {
+    let report = makeReport()
+    #expect(report.status == .ok)
+    #expect(report.summary.failed == 0)
+    #expect(report.summary.manual == 0)
+    #expect(report.summary.warnings == 0)
+    #expect(report.summary.skipped == 0)
+}
+
+@Test func test_t1_summary_duration_is_sum_of_per_check() {
+    // Deterministic monotonic clock: 0,1,2,3,... Each check = 2 calls (start,end),
+    // delta 1ms. 14 checks (no update check) → summary == 14.0, and >= max per-check.
+    var tick = 0.0
+    let report = makeReport(
+        runtime: enterpriseRuntime(monotonicNowMs: {
+            let value = tick
+            tick += 1
+            return value
+        })
+    )
+    #expect(report.checks.count == 14)
+    let perCheckSum = report.checks.reduce(0.0) { $0 + $1.durationMs }
+    #expect(report.summary.durationMs == perCheckSum)
+    #expect(report.summary.durationMs == 14.0)
+    let maxPerCheck = report.checks.map(\.durationMs).max() ?? 0
+    #expect(report.summary.durationMs >= maxPerCheck)
+    #expect(report.summary.durationMs >= 0)
+}
+
+@Test func test_t1_monotonicity_chokepoint_accessibility() {
+    let report = makeReport(permission: granted(accessibility: false))
+    #expect(report.status != .ok)
+}
+
+@Test func test_t1_monotonicity_chokepoint_automation_logic_pro() {
+    // automationLogicPro not granted (Logic Pro running so it's a real denial, not notVerifiable).
+    let report = makeReport(permission: granted(automationLogicPro: false))
+    #expect(report.status != .ok)
+}
+
+@Test func test_t1_monotonicity_chokepoint_system_events() {
+    let report = makeReport(permission: granted(systemEvents: .notGranted))
+    #expect(report.status != .ok)
+}
+
+@Test func test_t1_headline_names_highest_severity() {
+    // accessibility fail (error) + cliclick absent (warning) → headline names the error.
+    let report = makeReport(
+        runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false),
+        permission: granted(accessibility: false)
+    )
+    #expect(report.headline.contains("permissions.accessibility"))
+}
+
+@Test func test_t1_headline_healthy_when_all_pass() {
+    #expect(makeReport().headline == "Logic Pro MCP install is healthy.")
+}
+
+@Test func test_t1_e10a_v2_json_contains_literal_v1_keys() throws {
+    let json = encodeJSON(makeReport())
+    let object = try #require(sharedJSONObject(json))
+    for key in ["schema", "status", "version", "install_source", "checks"] {
+        #expect(object[key] != nil, "missing top-level v1 key \(key)")
+    }
+    let checks = try #require(object["checks"] as? [[String: Any]])
+    let first = try #require(checks.first)
+    for key in ["id", "domain", "status", "summary", "evidence", "remediation"] {
+        #expect(first[key] != nil, "missing per-check v1 key \(key)")
+    }
+    // v2 additive keys present too.
+    #expect(first["category"] != nil)
+    #expect(first["severity"] != nil)
+    #expect(first["duration_ms"] != nil)
+}
+
+private struct FrozenV1Remediation: Codable { let type: String; let value: String }
+private struct FrozenV1Check: Codable {
+    let id: String
+    let domain: String
+    let status: String
+    let summary: String
+    let evidence: [String: String]
+    let remediation: FrozenV1Remediation
+}
+private struct FrozenV1Report: Codable {
+    let schema: String
+    let status: String
+    let version: String
+    let installSource: String
+    let checks: [FrozenV1Check]
+    enum CodingKeys: String, CodingKey {
+        case schema, status, version
+        case installSource = "install_source"
+        case checks
+    }
+}
+
+@Test func test_t1_e10b_v2_decodes_with_frozen_v1_struct() throws {
+    let json = encodeJSON(makeReport())
+    // A frozen v1-shaped consumer must still decode v2 output (additive superset).
+    let frozen: FrozenV1Report = try decodeJSON(json)
+    #expect(frozen.schema == "logic_pro_mcp_doctor.v2")
+    let ids = Set(frozen.checks.map(\.id))
+    // Every original v1 check id must survive (a dropped v1 check would fail this).
+    let v1Ids = [
+        "binary.path", "binary.executable", "binary.version", "install.source",
+        "release.signature", "release.quarantine", "mcp.claude_code_registration",
+        "permissions.accessibility", "permissions.automation_logic_pro",
+        "logic.application_state", "channels.manual_validation",
+    ]
+    for id in v1Ids {
+        #expect(ids.contains(id), "v1 check id \(id) missing from v2 output")
+    }
+    // Each decoded check has the v1 remediation shape (type+value) — a type change would throw above.
+    let first = try #require(frozen.checks.first)
+    #expect(!first.remediation.type.isEmpty)
+}
+
+// MARK: - T2: System Events / cliclick / macOS checks
+
+@Test func test_t2_system_events_pass() throws {
+    let c = try #require(check(makeReport(permission: granted(systemEvents: .granted)), "permissions.automation_system_events"))
+    #expect(c.status == .pass)
+    #expect(c.category == .permissions)
+}
+
+@Test func test_t2_system_events_fail_and_remediation() throws {
+    let c = try #require(check(makeReport(permission: granted(systemEvents: .notGranted)), "permissions.automation_system_events"))
+    #expect(c.status == .fail)
+    #expect(c.remediation.type == .systemSettings)
+    #expect(c.remediation.value.contains("System Events"))
+    #expect(c.severity == .error)
+}
+
+@Test func test_t2_system_events_manual_on_not_verifiable() throws {
+    let c = try #require(check(makeReport(permission: granted(systemEvents: .notVerifiable)), "permissions.automation_system_events"))
+    #expect(c.status == .manual)
+}
+
+@Test func test_t2_system_events_independent_of_logic_pro_automation() throws {
+    // Logic Pro automation notVerifiable (Logic not running → manual) but System
+    // Events independently granted → System Events passes (AC-1.6 independence).
+    let permission = PermissionChecker.PermissionStatus(
+        accessibilityState: .granted,
+        automationState: .notVerifiable,
+        systemEventsAutomationState: .granted
+    )
+    let report = makeReport(permission: permission)
+    let logicAutomation = try #require(check(report, "permissions.automation_logic_pro"))
+    let systemEvents = try #require(check(report, "permissions.automation_system_events"))
+    #expect(logicAutomation.status == .manual)
+    #expect(systemEvents.status == .pass)
+}
+
+@Test func test_t2_system_events_fail_independent_of_logic_automation() throws {
+    // Mirror case (R10): Logic Pro automation granted but System Events denied → SE fail.
+    let report = makeReport(permission: granted(automationLogicPro: true, systemEvents: .notGranted))
+    let systemEvents = try #require(check(report, "permissions.automation_system_events"))
+    #expect(systemEvents.status == .fail)
+}
+
+@Test func test_t2_cliclick_pass_when_trusted() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(cliclickPath: "/opt/homebrew/bin/cliclick")), "dependencies.cliclick"))
+    #expect(c.status == .pass)
+    #expect(c.evidence["path"] == "/opt/homebrew/bin/cliclick")
+    #expect(c.category == .dependencies)
+}
+
+@Test func test_t2_cliclick_warn_present_on_path_only() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: true)), "dependencies.cliclick"))
+    #expect(c.status == .warn)
+    #expect(c.evidence["trusted"] == "false")
+    #expect(c.evidence["present_on_path"] == "true")
+}
+
+@Test func test_t2_cliclick_warn_absent() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false)), "dependencies.cliclick"))
+    #expect(c.status == .warn)
+    #expect(c.remediation.value == "brew install cliclick")
+}
+
+@Test func test_t2_macos_pass_ge_14() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(macOSVersion: OperatingSystemVersion(majorVersion: 14, minorVersion: 5, patchVersion: 1))), "system.macos_version"))
+    #expect(c.status == .pass)
+    #expect(c.evidence["version"] == "14.5.1")
+}
+
+@Test func test_t2_macos_pass_future() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(macOSVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0))), "system.macos_version"))
+    #expect(c.status == .pass)
+}
+
+@Test func test_t2_macos_fail_lt_14() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(macOSVersion: OperatingSystemVersion(majorVersion: 13, minorVersion: 6, patchVersion: 1))), "system.macos_version"))
+    #expect(c.status == .fail)
+}
+
+@Test func test_t2_macos_skipped_unreadable() throws {
+    let c = try #require(check(makeReport(runtime: enterpriseRuntime(macOSVersion: nil)), "system.macos_version"))
+    #expect(c.status == .skipped)
+    #expect(c.evidence["reason"] == "version_unreadable")
+}
+
+@Test func test_t2_system_events_denial_makes_report_failed() {
+    let report = makeReport(permission: granted(systemEvents: .notGranted))
+    #expect(report.status == .failed)
+}
+
+// MARK: - T3: presentation
+
+@Test func test_t3_default_render_shape() {
+    let report = makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false))
+    let out = SetupDoctor.renderHuman(report, mode: .default, useColor: false)
+    #expect(out.contains("summary:"))
+    #expect(out.contains("[pass] binary.path"))
+    #expect(out.contains("\u{2192} brew install cliclick")) // → remediation on a non-pass check
+}
+
+@Test func test_t3_verbose_render_adds_evidence_and_duration() {
+    let out = SetupDoctor.renderHuman(makeReport(), mode: .verbose, useColor: false)
+    #expect(out.contains("duration_ms:"))
+    #expect(out.contains("version=")) // macOS version evidence key
+}
+
+@Test func test_t3_quiet_render_only_nonpass() {
+    let report = makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false))
+    let out = SetupDoctor.renderHuman(report, mode: .quiet, useColor: false)
+    #expect(out.contains("[warn] dependencies.cliclick"))
+    #expect(!out.contains("[pass] binary.path")) // pass lines omitted in quiet mode
+}
+
+@Test func test_t3_color_on_tty() {
+    // Fixture with a non-pass check so a colored symbol is actually rendered.
+    let report = makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false))
+    let out = SetupDoctor.renderHuman(report, mode: .default, useColor: true)
+    #expect(out.contains("\u{1B}[")) // ANSI escape present
+    #expect(out.contains("\u{2713}")) // ✓ symbol for a pass check
+}
+
+@Test func test_t3_plain_when_not_tty() {
+    let report = makeReport(runtime: enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false))
+    let out = SetupDoctor.renderHuman(report, mode: .default, useColor: false)
+    #expect(!out.contains("\u{1B}[")) // no ANSI escapes
+    #expect(out.contains("[pass]"))
+}
+
+@Test func test_t3_headline_render_nonpass() {
+    let report = makeReport(permission: granted(systemEvents: .notGranted))
+    let out = SetupDoctor.renderHuman(report, mode: .default, useColor: false)
+    #expect(out.contains("Next action"))
+    #expect(out.contains("permissions.automation_system_events"))
+}
+
+// MARK: - T3/T4 entrypoint flag routing
+
+private actor EnterpriseMockServer: ServerStarting {
+    func start() async throws {}
+}
+
+private func runEntrypoint(
+    _ args: [String],
+    permission: PermissionChecker.PermissionStatus = granted(),
+    runtime: SetupDoctor.Runtime = enterpriseRuntime(),
+    isTTY: Bool = false,
+    env: [String: String] = [:]
+) async -> (Int, String) {
+    var stdout = ""
+    let store = ManualValidationStore(
+        fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("doctor-ent-\(UUID().uuidString)").appendingPathExtension("json")
+    )
+    try? await store.approve(.midiKeyCommands, note: "t")
+    try? await store.approve(.scripter, note: "t")
+    let code = await MainEntrypoint.run(
+        arguments: args,
+        permissionCheck: { permission },
+        serverFactory: {
+            Issue.record("server must not start for doctor")
+            return EnterpriseMockServer()
+        },
+        approvalStoreFactory: { store },
+        doctorRuntime: runtime,
+        isStdoutTTY: { isTTY },
+        doctorEnvironment: env,
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+    return (code, stdout)
+}
+
+@Test func test_t3_entrypoint_json_beats_verbose() async {
+    let (_, jsonOnly) = await runEntrypoint(["LogicProMCP", "doctor", "--json"])
+    let (_, jsonVerbose) = await runEntrypoint(["LogicProMCP", "doctor", "--json", "--verbose"])
+    // Identical JSON bytes regardless of verbosity (compare strings — [String:Any] isn't Equatable).
+    #expect(jsonOnly == jsonVerbose)
+    #expect(!jsonVerbose.contains("\u{1B}["))
+}
+
+@Test func test_t3_entrypoint_verbose_beats_quiet() async {
+    let (_, out) = await runEntrypoint(["LogicProMCP", "doctor", "--verbose", "--quiet"])
+    #expect(out.contains("duration_ms:")) // verbose shape wins
+}
+
+@Test func test_t3_entrypoint_plain_when_no_color_env_even_on_tty() async {
+    let report = enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false)
+    let (_, out) = await runEntrypoint(
+        ["LogicProMCP", "doctor"], runtime: report, isTTY: true, env: ["NO_COLOR": "1"]
+    )
+    #expect(!out.contains("\u{1B}["))
+}
+
+@Test func test_t3_entrypoint_color_on_tty_without_no_color() async {
+    let report = enterpriseRuntime(cliclickPath: nil, cliclickPresentOnPath: false)
+    let (_, out) = await runEntrypoint(
+        ["LogicProMCP", "doctor"], runtime: report, isTTY: true, env: [:]
+    )
+    #expect(out.contains("\u{1B}["))
+}
+
+@Test func test_t3_entrypoint_exit_code_verbosity_independent() async {
+    for args in [["LogicProMCP", "doctor"], ["LogicProMCP", "doctor", "--quiet"], ["LogicProMCP", "doctor", "--verbose"]] {
+        let (code, _) = await runEntrypoint(args, permission: granted(systemEvents: .notGranted))
+        #expect(code == 1)
+    }
+}
+
+@Test func test_t2_entrypoint_system_events_denied_exits_1() async {
+    let (code, _) = await runEntrypoint(["LogicProMCP", "doctor"], permission: granted(systemEvents: .notGranted))
+    #expect(code == 1)
+}
+
+@Test func test_t4_entrypoint_default_run_has_no_update_check() async {
+    let (_, out) = await runEntrypoint(["LogicProMCP", "doctor", "--json"])
+    #expect(!out.contains("updates.latest_release")) // no flag → no update check, no network
+}
+
+// MARK: - T4: update check
+
+@Test func test_t4_no_update_check_without_lookup() {
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: nil))
+    #expect(check(report, "updates.latest_release") == nil)
+}
+
+@Test func test_t4_update_pass_when_current() throws {
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: ServerConfig.serverVersion) }))
+    let c = try #require(check(report, "updates.latest_release"))
+    #expect(c.status == .pass)
+    #expect(c.evidence["installed"] == ServerConfig.serverVersion)
+    #expect(c.evidence["latest"] == ServerConfig.serverVersion)
+    #expect(c.category == .updates)
+}
+
+@Test func test_t4_update_warn_when_behind() throws {
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: "v99.0.0") }))
+    let c = try #require(check(report, "updates.latest_release"))
+    #expect(c.status == .warn)
+    #expect(c.evidence["latest"] == "99.0.0") // leading v stripped
+    #expect(c.evidence["installed"] == ServerConfig.serverVersion)
+    #expect(c.remediation.value == "brew upgrade logic-pro-mcp")
+}
+
+@Test func test_t4_update_skipped_outcomes() throws {
+    let cases: [(SetupDoctor.UpdateOutcome, String)] = [
+        (.offline, "offline"),
+        (.sourceUnavailable, "source_unavailable"),
+        (.parseError, "parse_error"),
+        (.httpError, "http_error"),
+        (.timeout, "timeout"),
+    ]
+    for (outcome, expectedReason) in cases {
+        let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { outcome }))
+        let c = try #require(check(report, "updates.latest_release"))
+        #expect(c.status == .skipped)
+        #expect(c.evidence["reason"] == expectedReason)
+    }
+}
+
+@Test func test_t4_update_evidence_redaction_keyset() throws {
+    // AC-6.4: failure evidence carries ONLY an enumerated reason — no stderr/env/URL/headers.
+    for outcome in [SetupDoctor.UpdateOutcome.offline, .sourceUnavailable, .parseError, .httpError, .timeout] {
+        let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { outcome }))
+        let c = try #require(check(report, "updates.latest_release"))
+        #expect(Set(c.evidence.keys) == ["reason"]) // key-set assertion, not substring scan
+        let reason = try #require(c.evidence["reason"])
+        #expect(["offline", "source_unavailable", "parse_error", "http_error", "timeout"].contains(reason))
+    }
+}
+
+@Test func test_t4_update_skipped_degrades_aggregate() {
+    // Otherwise-healthy report + a skipped update check → degraded (consistent v1 skipped semantics).
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .offline }))
+    #expect(report.status == .degraded)
+}
+
+@Test func test_t4_compare_versions_numeric_not_lexicographic() {
+    #expect(SetupDoctor.compareVersions("3.7.4", "3.7.4") == 0)
+    #expect(SetupDoctor.compareVersions("3.9.0", "3.10.0") < 0) // numeric: 9 < 10 (lexicographic would be wrong)
+    #expect(SetupDoctor.compareVersions("3.7.10", "3.7.4") > 0)
+    #expect(SetupDoctor.compareVersions("4.0.0", "3.99.99") > 0)
+}
+
+@Test func test_t4_normalize_version_strips_v() {
+    #expect(SetupDoctor.normalizeVersion("v3.7.4") == "3.7.4")
+    #expect(SetupDoctor.normalizeVersion("3.7.4") == "3.7.4")
+}
+
+// MARK: - Phase-6 final-review hardening
+
+@Test func test_t4_normalize_version_strips_prerelease_suffix() {
+    // boomer-1: a pre-release tag must not be ranked newer than its GA release.
+    #expect(SetupDoctor.normalizeVersion("v4.0.0-beta.1") == "4.0.0")
+    #expect(SetupDoctor.normalizeVersion("4.0.0-rc.2") == "4.0.0")
+    #expect(SetupDoctor.compareVersions(SetupDoctor.normalizeVersion("4.0.0"), SetupDoctor.normalizeVersion("4.0.0-beta.1")) == 0)
+}
+
+@Test func test_t4_parse_latest_tag() {
+    // guardian-P2-2: lock the pure JSON-parse boundary of the network lookup.
+    #expect(SetupDoctor.parseLatestTag(from: #"{"tag_name":"v3.7.4","name":"x"}"#) == "v3.7.4")
+    #expect(SetupDoctor.parseLatestTag(from: #"{"tag_name":""}"#) == nil)
+    #expect(SetupDoctor.parseLatestTag(from: #"{"no_tag":"x"}"#) == nil)
+    #expect(SetupDoctor.parseLatestTag(from: "not json") == nil)
+}
+
+@Test func test_t4_update_warn_strips_prerelease_and_compares_numeric() throws {
+    // A pre-release "latest" equal to installed must NOT warn (normalize + numeric compare).
+    let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: "v\(ServerConfig.serverVersion)-beta.1") }))
+    let c = try #require(check(report, "updates.latest_release"))
+    #expect(c.status == .pass)
+}
+
+@Test func test_t1_clamp_status_for_permissions_owns_invariant() {
+    // guardian-P1: the chokepoint is unit-tested directly (not emergent). An all-pass
+    // aggregate with allGranted == false must be clamped to degraded.
+    #expect(SetupDoctor.clampStatusForPermissions(.ok, allGranted: false) == .degraded)
+    #expect(SetupDoctor.clampStatusForPermissions(.ok, allGranted: true) == .ok)
+    // Already-non-ok statuses are passed through unchanged.
+    #expect(SetupDoctor.clampStatusForPermissions(.failed, allGranted: false) == .failed)
+    #expect(SetupDoctor.clampStatusForPermissions(.manualActionRequired, allGranted: false) == .manualActionRequired)
+    #expect(SetupDoctor.clampStatusForPermissions(.degraded, allGranted: false) == .degraded)
+}
+
+@Test func test_t3_headline_not_healthy_when_degraded_skipped_only() {
+    // boomer-E2 / guardian-P2-1: a skipped-only degraded report must not claim "healthy".
+    // macOS unreadable → skipped (info severity, no actionable check) but aggregate degraded.
+    let report = makeReport(runtime: enterpriseRuntime(macOSVersion: nil))
+    #expect(report.status == .degraded)
+    #expect(report.headline == "Logic Pro MCP install is usable; some checks could not be verified.")
+}

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -13,6 +13,13 @@ private func doctorRuntime(
     logicRunning: Bool = true,
     visibleWindow: Bool = true,
     registration: SetupDoctor.ClaudeRegistration = .registered(command: "/usr/local/bin/LogicProMCP"),
+    // v2 seams — hermetic defaults (all-good) so the new checks pass by default and
+    // existing tests keep their `.ok` aggregate. Tests override per-case.
+    cliclickPath: String? = "/opt/homebrew/bin/cliclick",
+    cliclickPresentOnPath: Bool = true,
+    macOSVersion: OperatingSystemVersion? = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0),
+    monotonicNowMs: @escaping () -> Double = { 0 },
+    latestReleaseLookup: (() -> SetupDoctor.UpdateOutcome)? = nil,
     commandHandler: @escaping (String, [String]) -> SetupDoctor.CommandOutput? = { executable, arguments in
         if executable == "/usr/bin/codesign" {
             return .init(exitCode: 0, stdout: "", stderr: "")
@@ -27,7 +34,7 @@ private func doctorRuntime(
         return nil
     }
 ) -> SetupDoctor.Runtime {
-    SetupDoctor.Runtime(
+    var runtime = SetupDoctor.Runtime(
         resolveExecutablePath: { _ in executablePath },
         fileExists: { _ in exists },
         isExecutableFile: { _ in executable },
@@ -36,6 +43,19 @@ private func doctorRuntime(
         runCommand: commandHandler,
         readClaudeRegistration: { registration }
     )
+    runtime.cliclickPath = { cliclickPath }
+    runtime.cliclickPresentOnPath = { cliclickPresentOnPath }
+    runtime.macOSVersion = { macOSVersion }
+    runtime.monotonicNowMs = monotonicNowMs
+    runtime.latestReleaseLookup = latestReleaseLookup
+    return runtime
+}
+
+/// All-permissions-granted status (incl. System Events) — the v2 default for tests
+/// that expect a healthy `.ok` aggregate. The 2-arg PermissionStatus init defaults
+/// systemEvents to `.notVerifiable`, which (correctly) makes the report non-ok.
+private func grantedPermissionStatus() -> PermissionChecker.PermissionStatus {
+    .init(accessibility: true, automationLogicPro: true, systemEventsAutomation: .granted)
 }
 
 private func allApprovals() -> [ManualValidationChannel: ManualValidationApproval] {
@@ -54,12 +74,12 @@ private func issue26RepositoryRootURL() -> URL {
 @Test func testSetupDoctorJSONContractStableCheckIDsAndOKAggregation() throws {
     let report = SetupDoctor.generate(
         arguments: ["LogicProMCP", "doctor", "--json"],
-        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime()
     )
 
-    #expect(report.schema == "logic_pro_mcp_doctor.v1")
+    #expect(report.schema == "logic_pro_mcp_doctor.v2")
     #expect(report.status == .ok)
     #expect(report.installSource == .homebrew)
 
@@ -74,13 +94,16 @@ private func issue26RepositoryRootURL() -> URL {
         "mcp.claude_code_registration",
         "permissions.accessibility",
         "permissions.automation_logic_pro",
+        "permissions.automation_system_events",
+        "dependencies.cliclick",
+        "system.macos_version",
         "logic.application_state",
         "channels.manual_validation",
     ])
 
     let json = encodeJSON(report)
     let object = try #require(sharedJSONObject(json))
-    #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v1")
+    #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v2")
     #expect(object["status"] as? String == "ok")
     #expect(object["install_source"] as? String == "homebrew")
     #expect(object["version"] as? String == ServerConfig.serverVersion)
@@ -137,7 +160,7 @@ private func issue26RepositoryRootURL() -> URL {
     var stderr = ""
     let exitCode = await MainEntrypoint.run(
         arguments: ["LogicProMCP", "doctor", "--json"],
-        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        permissionCheck: { grantedPermissionStatus() },
         serverFactory: {
             Issue.record("Server should not start for doctor")
             return DoctorMockMainServer()
@@ -151,7 +174,7 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(exitCode == 0)
     #expect(stderr.isEmpty)
     let json = try #require(sharedJSONObject(stdout))
-    #expect(json["schema"] as? String == "logic_pro_mcp_doctor.v1")
+    #expect(json["schema"] as? String == "logic_pro_mcp_doctor.v2")
     #expect(json["status"] as? String == "ok")
 }
 
@@ -553,7 +576,7 @@ private func issue26RepositoryRootURL() -> URL {
 
     let exitCode = await MainEntrypoint.run(
         arguments: ["LogicProMCP", "doctor", "--json"],
-        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        permissionCheck: { grantedPermissionStatus() },
         serverFactory: {
             Issue.record("Server should not start for doctor")
             return DoctorMockMainServer()
@@ -610,7 +633,7 @@ private func issue26RepositoryRootURL() -> URL {
 @Test func testAggregateStatusWarnWithoutFailOrManualIsDegraded() {
     let report = SetupDoctor.generate(
         arguments: ["LogicProMCP", "doctor", "--json"],
-        permissionStatus: .init(accessibility: true, automationLogicPro: true),
+        permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(commandHandler: { executable, arguments in
             if executable == "/usr/bin/codesign" { return nil } // -> warn

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -125,6 +125,22 @@ From your MCP client:
 
 Fully configured hosts should show Accessibility, AppleScript, CoreMIDI, MCU, MIDIKeyCommands, Scripter, and CGEvent as available. Skipping Key Commands or Scripter is valid when you do not need those paths.
 
+## Doctor (`logic_pro_mcp_doctor.v2`)
+
+`doctor` is read-only and safe to run before starting the server. Flags:
+
+| Flag | Effect |
+|------|--------|
+| (none) | Human report: a "next action" headline, a `summary:` counts line, and one line per check. |
+| `--verbose` | Adds each check's evidence and `duration_ms`. |
+| `--quiet` | Headline + summary + failing/non-pass checks only. |
+| `--json` | Machine report. Identical bytes regardless of `--verbose`/`--quiet`/color. |
+| `--check-updates` | Opt-in: adds an `updates.latest_release` check (unauthenticated GitHub releases read). The default run never touches the network. |
+
+Color and unicode symbols are emitted only when stdout is a TTY and `NO_COLOR` is unset; otherwise output is plain ASCII (`[pass]`-style), so pipes and CI logs stay clean.
+
+The `v2` report is a **field-superset** of `v1`: every v1 key keeps its name, semantics, and value. New fields are additive — a top-level `summary` block (`total`, `passed`, `failed`, `warnings`, `manual`, `skipped`, `duration_ms`) and `headline`, plus per-check `category`, `severity`, and `duration_ms`. The `schema` string changes `v1`→`v2`; consumers should prefix-match `logic_pro_mcp_doctor.`, not exact-equal a version. Exit code is unchanged: `failed` → 1, otherwise 0.
+
 ## Doctor Remediation Anchors
 
 These anchors are intentionally compact because `doctor --json` links to them.
@@ -160,6 +176,22 @@ Grant Accessibility to the launcher app in System Settings.
 <a id="doctor-permissionsautomation-logic-pro"></a>
 ### `permissions.automation_logic_pro`
 Grant Automation access for Logic Pro. If status is `not_verifiable`, launch Logic Pro once and rerun doctor.
+
+<a id="doctor-permissionsautomation-system-events"></a>
+### `permissions.automation_system_events`
+Grant Automation access for **System Events** (System Settings > Privacy & Security > Automation → System Events). This is a separate TCC target from Logic Pro automation and is required by MIDI import / tempo-dialog / project-state paths (#188). If status is `manual` (`not_verifiable`), the probe could not run — rerun doctor.
+
+<a id="doctor-dependenciescliclick"></a>
+### `dependencies.cliclick`
+Install `cliclick` (`brew install cliclick`) at a trusted path. Bounce/export operations require it; the doctor reuses the runtime's trusted resolver, so a `cliclick` found only on `PATH` or with a writable parent directory reports `warn`.
+
+<a id="doctor-systemmacos-version"></a>
+### `system.macos_version`
+Logic Pro MCP requires macOS 14 or newer. Upgrade macOS if this check fails.
+
+<a id="doctor-updateslatest-release"></a>
+### `updates.latest_release`
+Shown only with `doctor --check-updates`. If a newer release exists, `brew upgrade logic-pro-mcp` (or reinstall from the target release). A `skipped` status means the check could not reach the release source (offline / unavailable) — it never blocks.
 
 <a id="doctor-logicapplication-state"></a>
 ### `logic.application_state`

--- a/docs/prd/PRD-doctor-enterprise.md
+++ b/docs/prd/PRD-doctor-enterprise.md
@@ -1,0 +1,472 @@
+# PRD: Enterprise-Grade Setup Doctor
+
+**Version**: 0.3
+**Author**: dev-pipeline (orchestrator)
+**Date**: 2026-06-30
+**Status**: Approved
+**Size**: L (implemented as 4 independently-revertable tickets — see §App-A)
+
+> Reference model: [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) `doctor` command
+> (`plugins/omo/dist/cli/doctor/**`, `skills/lcx-doctor/SKILL.md`). We adopt its
+> *structured, timed, severity-graded, multi-mode, evidence-bound* diagnostic model
+> and adapt it to this project's Swift/macOS/Logic-Pro surface and its existing
+> read-only / run-before-startup Honest Contract.
+>
+> v0.2 folds in Phase-2 team review (strategist + guardian + boomer). Each P1/top-3
+> resolution is tracked in §App-B.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+`LogicProMCP doctor` (`Sources/LogicProMCP/Utilities/SetupDoctor.swift`, 691 lines, 27 tests)
+already emits a `logic_pro_mcp_doctor.v1` report with 11 checks, evidence dicts, and per-check
+remediation. It is honest and read-only. But measured against a mature reference doctor
+(lazycodex), it is missing the operational affordances enterprise operators expect:
+
+- **No timing.** Operators cannot see which check is slow or how long a run took.
+- **No summary block.** The output is a flat list; there is no `passed/failed/warn` roll-up that a
+  human or a monitoring scraper can read at a glance.
+- **One output shape for humans.** Only `[pass] id - summary` + a single-mode JSON. No verbose
+  (evidence-inline) mode, no quiet (failures-only) mode, no color/symbols, no "next action" headline.
+- **Severity is implicit.** Every non-pass is rendered the same; there is no error-vs-warning grading
+  and no "fix this first" ordering.
+- **Coverage gaps in checks** that map to real, already-known failure modes:
+  - `permissions.automation_system_events` — System Events automation is collected in
+    `PermissionChecker.PermissionStatus.systemEventsAutomationState` and is part of `allGranted`
+    (a *hard* requirement: MIDI import / tempo-dialog drive `tell application "System Events"`, issue #188),
+    yet the doctor surfaces only Logic Pro automation (`SetupDoctor.swift:153`) and silently drops it.
+  - `dependencies.cliclick` — `cliclick` is a real runtime dependency of the bounce/export helper
+    (`bounce_helper_dependency_missing: cliclick`); a missing install was a prior release blocker, yet
+    the doctor never checks it. The runtime accepts it only via `ProjectExportExecutor.resolveTrustedCliclick`
+    (strict: 3 canonical paths + `LOGIC_PRO_MCP_CLICLICK` override + non-group/other-writable parent).
+  - `system.macos_version` — the package requires macOS 14+ (`Package.swift: platforms: [.macOS(.v14)]`);
+    the doctor never validates the OS.
+  - `updates.latest_release` — no way to learn the installed version is behind the latest release.
+
+### 1.2 Problem Definition
+The doctor reports *what it checks* honestly, but (a) omits several already-required checks, and
+(b) lacks the structured timing/summary/severity/output-mode affordances that make a doctor usable as
+an enterprise support and CI gate tool.
+
+### 1.3 Impact of Not Solving
+- Operators hit `bounce_helper_dependency_missing: cliclick` or a denied System Events target (#188)
+  at *runtime* even though `doctor` reported "ok" — eroding trust in the doctor.
+- Support cannot ask a user to "paste the doctor summary"; there is no summary.
+- CI/monitoring cannot scrape a counts roll-up or per-check timing.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+- [ ] G1: Surface every permission the runtime treats as required — add
+      `permissions.automation_system_events` fed by the already-collected `systemEventsAutomationState`.
+      **The report status must never be `ok` when `permissionStatus.allGranted == false`**, enforced by a
+      single explicit chokepoint (not an emergent consequence) — see §4.2.
+- [ ] G2: Add coverage checks for real dependencies/environment: `dependencies.cliclick` (reusing the
+      runtime's own `resolveTrustedCliclick`), `system.macos_version`, and an opt-in `updates.latest_release`.
+- [ ] G3: Add a structured `summary` roll-up (`total/passed/failed/warnings/manual/skipped` +
+      total `duration_ms`) and per-check `duration_ms`, surfaced in both human and JSON output.
+- [ ] G4: Add severity grading (`error`/`warning`/`info`) and a `category` per check; render a
+      "next action" headline that names the single most important remediation first.
+- [ ] G5: Add human output modes — default, `--verbose` (evidence inline), `--quiet` (status line +
+      failures only) — plus TTY/`NO_COLOR`-aware symbols & color. `--json` stays the machine contract.
+- [ ] G6: Evolve the report schema to `logic_pro_mcp_doctor.v2` as a **field-superset** of v1: every v1
+      key keeps its **name, semantics, and value**; new keys are additive; field *order* is not part of
+      the contract (`JSONHelper` encodes with `.sortedKeys`). The `schema` string is the **one** field
+      that intentionally changes (`v1`→`v2`); consumers MUST prefix-match `logic_pro_mcp_doctor.`,
+      never exact-equal `...v1`.
+- [ ] G7: Preserve the read-only / run-before-startup Honest Contract: no CoreMIDI ports, no AX
+      pollers, no spawning the registered server. Network is touched only under explicit `--check-updates`.
+
+### 2.2 Non-Goals
+- NG1: No change to `--check-permissions` / `install` / `uninstall` / `--approve-channel` behavior or
+      exit codes. **One narrowly-scoped exception (review-driven):** the System Events probe seam in
+      `PermissionChecker` is widened from `() -> Bool` to a tri-state so a probe that *could not run*
+      (timeout / spawn failure / unexpected output) maps to `.notVerifiable` instead of being collapsed to
+      `.notGranted` ("denied"). This is required for doctor honesty (a hung osascript must not be reported
+      as a permission denial) and is the whole point of the System Events coverage gap (#188). `allGranted`
+      and `--check-permissions` **exit codes are unchanged** (`.notVerifiable.isGranted == false`); only the
+      human summary text becomes honest ("could not verify" vs "denied").
+- NG2: No live mutation/repair ("doctor --fix"). Doctor diagnoses; it never changes the user's
+      install, config, or permissions.
+- NG3: No new permission *probing* mechanism — `permissions.automation_system_events` consumes the
+      `PermissionStatus` the entrypoint already gathers; it does not add a new TCC prompt.
+- NG4: No network in the default run. `updates.latest_release` is opt-in and degrades to `skipped`
+      when offline / source unavailable / parse failure / timeout.
+- NG5: No removal/renaming of v1 field **names**, check IDs, or `domain` values. (`domain` stays a free
+      string for back-compat; the new `category` enum is an additive parallel taxonomy — see §4.2.)
+- NG6: Not porting lazycodex's "drift vs latest source checkout" git-clone comparison.
+- NG7: No `critical` field. (Dropped after review: redundant with `severity == .error` + the existing
+      stable check order; exit code stays `status == .failed → 1`.)
+
+## 3. User Stories & Acceptance Criteria
+
+### US-1: Complete required-permission coverage
+**As an** operator, **I want** the doctor to report the System Events automation permission,
+**so that** a "doctor passes" run can never hide the #188 denied-System-Events failure mode.
+
+**Acceptance Criteria:**
+- [ ] AC-1.1: Given `systemEventsAutomationState == .granted`, then check
+      `permissions.automation_system_events` exists with status `pass`.
+- [ ] AC-1.2: Given `.notGranted`, then status is `fail` with a `system_settings` remediation pointing
+      at "Automation → System Events".
+- [ ] AC-1.3 (exit code): Given `.notGranted`, when doctor runs, then the aggregate report status is
+      `failed` and the process exit code is `1` (`MainEntrypoint` integration).
+- [ ] AC-1.4: Given the probe could not run (osascript timeout / spawn failure / unexpected output),
+      `systemEventsAutomationState` is `.notVerifiable` and the check status is `manual` (the doctor must
+      never report `fail`/"denied" for a state it could not verify). With the NG1 probe-seam widening,
+      this is a **live-reachable** path, exercised in production and tested via an injected timed-out /
+      spawn-failed probe. (TCC denial — osascript ran and returned non-zero/wrong output for an
+      *allowed-to-run-but-denied* target — still maps to `.notGranted` → `fail`.)
+- [ ] AC-1.5 (monotonicity, enforced): For **every** `PermissionStatus` with `allGranted == false`
+      (accessibility false, OR automationLogicPro not-granted, OR automationSystemEvents not-granted),
+      the report status is **not** `ok`. This is enforced by the §4.2 chokepoint and tested by feeding
+      each of the three inputs false independently.
+- [ ] AC-1.6 (independence): The System Events verdict does not inherit Logic Pro's not-running state —
+      with Logic Pro closed, `permissions.automation_logic_pro` may be `manual` while
+      `permissions.automation_system_events` is independently `pass`/`fail`.
+
+### US-2: Dependency & environment coverage
+**As an** operator, **I want** doctor to verify `cliclick` and the macOS version,
+**so that** runtime dependency failures surface at diagnosis time, not mid-operation.
+
+**Acceptance Criteria:**
+- [ ] AC-2.1: `dependencies.cliclick` resolves cliclick **through the same resolver the runtime uses**
+      (`ProjectExportExecutor.resolveTrustedCliclick`): a trusted path (one of `/opt/homebrew/bin`,
+      `/usr/local/bin`, `/usr/bin` cliclick, or the `LOGIC_PRO_MCP_CLICLICK` override) whose parent dir is
+      not group/other-writable → `pass`, with the resolved path in evidence.
+- [ ] AC-2.2: Given cliclick is **not** resolvable by `resolveTrustedCliclick` but `commandExists("cliclick")`
+      is true (present on PATH only, or parent dir writable, or non-canonical path), then status is `warn`
+      with summary "present but not at a trusted path / parent dir is writable" and evidence noting the
+      distinction. (Not `pass` — it would fabricate a green the runtime won't honor.)
+- [ ] AC-2.3: Given cliclick absent everywhere, then `warn` (not `fail` — it gates only bounce/export)
+      with a `command` remediation `brew install cliclick`.
+- [ ] AC-2.4: Given macOS major version ≥ 14, then `system.macos_version` is `pass` with the version
+      string in evidence. A well-formed future version (e.g. 15, 26) also passes (no upper bound, major-only).
+- [ ] AC-2.5: Given macOS major version < 14, then `system.macos_version` is `fail`.
+
+### US-3: Structured summary & timing
+**As a** support engineer / CI gate, **I want** a counts roll-up and per-check timing,
+**so that** I can read health at a glance and spot slow checks.
+
+**Acceptance Criteria:**
+- [ ] AC-3.1: The JSON report contains a `summary` object with integer fields `total`, `passed`,
+      `failed`, `warnings`, `manual`, `skipped`, and a numeric `duration_ms`, where
+      `passed + failed + warnings + manual + skipped == total == checks.count`.
+- [ ] AC-3.2: Each check carries a non-negative numeric `duration_ms`.
+- [ ] AC-3.3: The human output prints a summary line, e.g. `summary: 9 passed, 1 failed, 1 warning (1234ms)`.
+- [ ] AC-3.4: Checks run **sequentially** and are **non-throwing**; timing uses an injected **monotonic**
+      clock. `summary.duration_ms` equals the sum of per-check durations and is therefore ≥ the max
+      single-check duration and ≥ 0. (Deterministic injected clock makes tests stable.)
+- [ ] AC-3.5 (status↔counts formula): When `status == degraded`, then `(warnings > 0 || skipped > 0)`
+      and `failed == 0 && manual == 0`. When `status == ok`, then `warnings == 0 && skipped == 0 &&
+      failed == 0 && manual == 0`. (Documents the existing `aggregateStatus` precedence against the new counts.)
+      A `skipped` update check (offline `--check-updates`) therefore degrades the aggregate to `degraded` —
+      consistent with v1 skipped semantics (`aggregateStatus` already treats `warn||skipped`→`degraded`); this
+      honestly means "could not fully verify", not "broken install". `aggregateStatus` is **not** modified.
+
+### US-4: Severity, category, and "next action"
+**As an** operator, **I want** the most important fix named first, with severity and category,
+**so that** I know what to do before reading every line.
+
+**Acceptance Criteria:**
+- [ ] AC-4.1: Each check has a `category` from {installation, configuration, permissions, dependencies,
+      runtime, updates} and a `severity` from {error, warning, info}. The status→severity mapping is total:
+      `fail→error`; `warn→warning`; `manual→warning`; `skipped→info`; `pass→info`.
+- [ ] AC-4.2: When ≥1 check is non-pass, the human output begins with a one-line headline naming the
+      single highest-priority remediation, ordered by severity (`error` before `warning`; `info` never
+      headlined) and, within a severity, by the stable check order.
+- [ ] AC-4.3: When all checks pass, the headline states the install is healthy.
+
+### US-5: Output modes & color
+**As a** human in a terminal, **I want** readable, optionally-verbose output,
+**so that** I can scan or dig in as needed without parsing JSON.
+
+**Acceptance Criteria:**
+- [ ] AC-5.1: `doctor` (default) prints headline + summary + one line per check (symbol + id + summary),
+      and a `→ remediation` line only for non-pass checks.
+- [ ] AC-5.2: `doctor --verbose` additionally prints each check's evidence key/values and `duration_ms`.
+- [ ] AC-5.3: `doctor --quiet` prints only the headline, the summary line, and the non-pass checks.
+- [ ] AC-5.4: Color/symbols are emitted only when stdout is a TTY (`isatty(STDOUT_FILENO)`) and `NO_COLOR`
+      is unset; otherwise output is plain ASCII (`[pass]`-style). TTY/`NO_COLOR` detection is injected into
+      the entrypoint so tests pin both branches.
+- [ ] AC-5.5: `--json` takes precedence over `--verbose`/`--quiet`/color; the JSON bytes are identical
+      regardless of those flags (machine contract is stable).
+
+### US-6: Opt-in update check
+**As an** operator, **I want** `doctor --check-updates` to tell me if I'm behind,
+**so that** I can decide to upgrade — without the default run ever touching the network.
+
+**Acceptance Criteria:**
+- [ ] AC-6.1: Without `--check-updates`, no `updates.latest_release` check is emitted and no network call is made.
+- [ ] AC-6.2: With `--check-updates` and a reachable source, `updates.latest_release` is `pass` when
+      installed == latest, `warn` when behind (remediation: upgrade command), with both versions in evidence.
+- [ ] AC-6.3: With `--check-updates` but offline / source unavailable / parse failure / timeout, the check is
+      `skipped` — never `fail`, never a fabricated "up to date".
+- [ ] AC-6.4 (secret redaction): On `--check-updates` failure, `evidence["reason"]` is one of a fixed
+      enumerated set `{offline, source_unavailable, parse_error, http_error, timeout}` and the evidence
+      NEVER contains process stderr verbatim, environment values, a URL with query/token, or header contents.
+      The update source is an **unauthenticated** read (no `Authorization` header, no token), so no secret
+      is in scope to leak.
+
+## 4. Technical Design
+
+### 4.1 Architecture Overview
+All work stays inside the doctor subsystem and its entrypoint:
+- `Sources/LogicProMCP/Utilities/SetupDoctor.swift` — extend the model (additive fields + `Summary` +
+  `headline`), add the new check functions, add per-check monotonic timing, summary computation,
+  severity/category derivation, the §4.2 monotonicity chokepoint, and the 3-mode + color renderer.
+- `Sources/LogicProMCP/MainEntrypoint.swift` — parse `--verbose`/`--quiet`/`--check-updates`, choose the
+  renderer + verbosity, and pass TTY/`NO_COLOR` detection (injectable) in. `--json` precedence preserved.
+- `docs/SETUP.md` / `docs/API.md` — remediation anchors for new check IDs + v2 field docs.
+- `Tests/LogicProMCPTests/` — TDD; add `SetupDoctorEnterpriseTests.swift` (new) for the v2 surface to
+  keep `SetupDoctorTests.swift` focused; update the v1 contract test for the new ID list + schema string.
+
+Execution is **sequential**: each check closure runs in declared order, wrapped by a monotonic-clock
+delta to populate `duration_ms`; checks are non-throwing so no exception isolation is required (E9).
+
+The `Runtime` injection seam is extended with: `cliclickPath: () -> String?` (→ `resolveTrustedCliclick`),
+`cliclickPresentOnPath: () -> Bool` (→ `commandExists("cliclick")`), `macOSVersion: () -> OperatingSystemVersion?`
+(nil ⇒ unreadable → `skipped`, E12), `monotonicNowMs: () -> Double`, and a **typed** update-lookup seam
+`latestReleaseLookup: (() -> UpdateOutcome)?` (nil ⇒ update check not run; non-nil only when `--check-updates`
+is passed). `UpdateOutcome` is an enum `.found(version: String) | .offline | .sourceUnavailable | .parseError
+| .httpError | .timeout` so the check body can write an accurate enumerated `reason` (AC-6.3/6.4) instead of
+collapsing every failure to `nil`. `.production` wires real implementations (`resolveTrustedCliclick`,
+`ProcessInfo`, `DispatchTime`, the curl→gh lookup); tests inject fakes. No new external frameworks.
+
+### 4.2 Data Model Changes
+Schema bumps to `logic_pro_mcp_doctor.v2`. **`Check` gains an explicit `CodingKeys` enum that enumerates
+ALL keys** — the existing six (`id`, `domain`, `status`, `summary`, `evidence`, `remediation`) PLUS the new
+ones — so adding coding keys can never silently rename a v1 key. A new `Summary` struct is added to `Report`.
+
+```
+enum Category: String, Codable { installation, configuration, permissions, dependencies, runtime, updates }
+enum Severity: String, Codable { error, warning, info }
+
+struct Check (v2):                              // explicit CodingKeys lists every key
+  id, domain, status, summary, evidence, remediation   // v1 — names/semantics/values unchanged
+  + category: Category        // key "category"
+  + severity: Severity        // key "severity"  (derived from status; total mapping AC-4.1)
+  + durationMs: Double        // key "duration_ms"
+
+struct Summary (new):
+  total, passed, failed, warnings, manual, skipped: Int   // keys as named
+  durationMs: Double                                       // key "duration_ms"
+
+struct Report (v2):
+  schema (= "logic_pro_mcp_doctor.v2"), status, version, installSource, checks   // v1 — unchanged names/semantics
+  + summary: Summary          // key "summary"
+  + headline: String          // key "headline" — human-prose advisory; NOT a machine-stable field
+```
+
+**Monotonicity chokepoint (G1/AC-1.5):** `generate()` computes `aggregateStatus(checks)` (unchanged v1
+precedence: fail→failed > manual→manual_action_required > warn|skipped→degraded > ok) and then applies a
+single explicit guard:
+
+```
+var status = aggregateStatus(checks)
+// Honesty chokepoint: the report can never claim ok while a required permission is ungranted.
+// This OWNS AC-1.5 directly rather than relying on the System Events / accessibility checks each
+// happening to be non-pass. allGranted == accessibility && automationLogicPro && automationSystemEvents.
+if !permissionStatus.allGranted && status == .ok { status = .degraded }
+```
+
+`headline` is computed from the highest-severity non-pass check (AC-4.2) or the healthy message (AC-4.3).
+It is present in JSON (additive) but documented as advisory prose — consumers parse `summary`/`checks`, not `headline`.
+
+`domain` vs `category`: `domain` is the v1 free-string (retained, NG5); `category` is the additive closed
+enum. Their values often coincide (e.g. domain "permissions" ↔ category `permissions`); `category` exists to
+give a stable typed taxonomy and the `dependencies`/`updates` buckets that have no v1 domain. The mapping is
+deterministic and centralized in one function.
+
+### 4.3 API Design
+CLI surface (no HTTP API):
+
+| Command | Description |
+|---------|-------------|
+| `LogicProMCP doctor` | default human report (headline + summary + per-check) |
+| `LogicProMCP doctor --verbose` | adds evidence + per-check `duration_ms` to human output |
+| `LogicProMCP doctor --quiet` | headline + summary + non-pass checks only |
+| `LogicProMCP doctor --json` | machine report (v2 field-superset; identical regardless of verbosity/color) |
+| `LogicProMCP doctor --check-updates` | additionally runs the opt-in `updates.latest_release` check |
+
+Exit codes (unchanged semantics): aggregate `failed` → 1; `ok`/`degraded`/`manual_action_required` → 0.
+Exit codes are verbosity-independent.
+
+### 4.4 Key Technical Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Schema evolution | mutate v1 / v2 superset / parallel endpoint | **v2 field-superset** | Additive keys keep v1 readers working; one schema; mirrors lazycodex's single rich model. Schema string is the one intended change (prefix-match guidance, G6). |
+| System Events data source | new TCC probe / reuse `PermissionStatus` | **reuse** | Already gathered by `permissionCheck()`; no second TCC prompt (NG3). |
+| System Events `.notVerifiable` | drop AC / doctor-only total mapping / widen the probe seam | **widen probe seam to tri-state (NG1 exception)** | Collapsing a hung/spawn-failed osascript to `.notGranted` reports "denied" for an un-runnable probe — a false-RED that violates the Honest Contract. Tri-state (`denial→notGranted`, `could-not-run→notVerifiable`) makes `→manual` honest and live-reachable. Exit codes unchanged. |
+| cliclick check | re-implement path search / reuse `resolveTrustedCliclick` | **reuse the runtime resolver** | Re-implementing a looser search is exactly how doctor/runtime drift produces false-greens (#1.3). Reuse = honest. |
+| cliclick severity | fail / warn | **warn** | cliclick gates only bounce/export, not core MCP; `fail` over-states. `warn`→`degraded`→exit 0. |
+| `critical` field | keep / drop | **drop (NG7)** | Redundant with `severity == .error` + stable order; no AC needs it; exit stays `failed→1`. |
+| Timing clock | wall-clock `Date()` / monotonic | **injected monotonic** (`DispatchTime`-based) | Wall-clock can step backward (NTP) → negative duration; monotonic guarantees AC-3.2/3.4. |
+| Update source | `gh` primary / `curl` primary | **unauthenticated `curl` to `api.github.com/.../releases/latest` primary, `gh release view` fallback** | End-users (Homebrew/release-binary) won't have `gh`; `gh`-first ⇒ skipped for nearly everyone. Unauthenticated ⇒ no token in scope (AC-6.4). Both degrade to `skipped`. |
+| Update timeout | unspecified / explicit | **`BoundedProcessRunner` timeout 3.0s** (vs 1.5s local) | Bounds the only network call; timeout → `skipped` (AC-6.3, E11). |
+| Color/symbols | always / TTY-gated | **TTY + `NO_COLOR` gated, plain ASCII fallback** | Keeps pipes/CI clean; non-TTY fallback preserves a v1-compatible human shape. |
+
+## 5. Edge Cases & Error Handling
+
+| # | Scenario | Expected Behavior | Severity |
+|---|----------|-------------------|----------|
+| E1 | System Events check supplied `.notVerifiable` (forward-compat / injected) | `manual`, not `pass`/`fail` (AC-1.4) | High |
+| E2 | cliclick present only on PATH (not a trusted canonical path) | `warn` "present but not trusted", NOT `pass` (AC-2.2) | High |
+| E3 | cliclick at a trusted path but parent dir group/other-writable | `resolveTrustedCliclick` rejects → `warn` (AC-2.2) | Med |
+| E4 | cliclick absent everywhere | `warn` + `brew install cliclick` (AC-2.3) | Med |
+| E5 | macOS version reads major-only (e.g. "14") or future ("15"/"26") | `pass` (major ≥ 14, no upper bound) (AC-2.4) | Low |
+| E6 | `--check-updates` offline / source unavailable | `skipped` w/ enumerated reason (AC-6.3/6.4) | Med |
+| E7 | `--check-updates` malformed/parse failure | `skipped` w/ `parse_error` (never `fail`) | Low |
+| E8 | stdout not a TTY (piped/redirected) | plain ASCII, no escape codes, even without `--quiet` (AC-5.4) | High |
+| E9 | `--quiet` and `--verbose` both passed | `--verbose` wins (more info); documented; no crash | Low |
+| E10 | v1 JSON consumer reads v2 output | all v1 key **names** present & identical values; new keys ignored; `schema` is `...v2` | High |
+| E11 | `--check-updates` with a hung/slow `gh`/`curl` | bounded runner 3.0s timeout → `skipped` (timeout), no hang | Med |
+| E12 | macOS `operatingSystemVersion` unreadable (hypothetical on macOS) | `skipped` w/ reason (never fabricate `pass`) | Low |
+| E13 | Logic Pro not running | `permissions.automation_logic_pro` = `manual`; `permissions.automation_system_events` independently `pass`/`fail` (AC-1.6) | Med |
+| E14 | `--json` + `--verbose` together | `--json` wins; JSON bytes identical to plain `--json` (AC-5.5) | Med |
+
+## 6. Security & Permissions
+
+### 6.1 Authentication
+N/A — local CLI diagnostic.
+
+### 6.2 Authorization
+N/A — no roles. Doctor is strictly read-only (NG2): no config/install/permission mutation.
+
+### 6.3 Data Protection
+Evidence dicts must not leak secrets. The update check is an **unauthenticated** public-release read
+(no token in scope); on failure, evidence carries only an enumerated reason (AC-6.4), never raw stderr,
+env, tokened URLs, or headers. Claude-config reading remains the existing read-only parse (no change).
+
+## 7. Performance & Monitoring
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Default `doctor` wall time | typically ≤ ~3s (no network) — **empirical, not a hard bound**; checks run serially and worst-case = sum of bounded timeouts (codesign+xattr+brew dominate; the 3 new local checks add ~0: `sw_vers` is instant, cliclick is a path probe, System Events is already in the permission path) | `summary.duration_ms` |
+| Per local external command | bounded by `BoundedProcessRunner` (≤1.5s) | per-check `duration_ms` |
+| `--check-updates` added latency | bounded network call (≤3.0s), opt-in only | `updates.latest_release.duration_ms` |
+
+### 7.1 Monitoring & Alerting
+The `summary` block + per-check `duration_ms` + stable check IDs are the scrapeable surface. No runtime telemetry added.
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests (TDD — Red first for every ticket)
+- New checks: System Events (pass/fail/manual + AC-1.5 monotonicity with each input false independently +
+  AC-1.6 independence), cliclick (trusted→pass / PATH-only→warn / writable-parent→warn / absent→warn,
+  via injected `resolveTrustedCliclick` + `commandExists`), macOS (≥14 pass / future pass / <14 fail / unreadable skipped),
+  update check (up-to-date pass / behind warn / offline|parse|timeout skipped + AC-6.4 redaction).
+- Model/contract: v2 schema string exactly `logic_pro_mcp_doctor.v2`; summary counts invariant
+  (Σ == total == checks.count); each check has category/severity/duration_ms; severity↔status total mapping;
+  status↔counts formula (AC-3.5).
+- Timing: injected monotonic clock yields deterministic, non-negative `duration_ms`; `summary == sum ≥ max`.
+- Renderers: default/verbose/quiet line shapes; TTY-on emits symbols/color, TTY-off/`NO_COLOR` emits plain
+  ASCII; headline names highest-severity remediation.
+
+### 8.2 Integration Tests (`MainEntrypoint`)
+- Flag routing: `--verbose`/`--quiet`/`--check-updates` select the right behavior; `--json` precedence over
+  verbosity (AC-5.5/E14); doctor still does not start the server; exit codes preserved (AC-1.3).
+
+### 8.3 Edge Case + Backward-Compat Tests
+- Each §5 row (E1–E14) has a dedicated test.
+- **E10 superset guard (two-pronged, boomer #2 + guardian):**
+  (a) assert the raw v2 JSON contains the literal v1 key strings `"id"`, `"domain"`, `"status"`, `"summary"`,
+  `"evidence"`, `"remediation"` (per check) and `"schema"`, `"status"`, `"version"`, `"install_source"`,
+  `"checks"` (top level) — catches an accidental rename that a decode-to-model test would miss;
+  (b) decode the v2 JSON with a **frozen v1 `Codable` struct** (exact v1 `Report`/`Check`/`Remediation` shape)
+  and assert it decodes without error and exposes every v1 check `id`;
+  (c) assert `schema == "logic_pro_mcp_doctor.v2"` (the one intended change).
+
+## 9. Rollout Plan
+
+### 9.1 Migration Strategy
+No data migration. Schema `v1`→`v2` is a field-superset; document new fields in `docs/API.md`/`docs/SETUP.md`.
+
+### 9.2 Feature Flag
+None. New behaviors are additive (summary/timing/severity/category always present in v2) or opt-in flags.
+
+### 9.3 Rollback Plan
+3-ticket split (§App-A) keeps the high-risk schema/data change (T1) independently revertable from the
+renderer (T2) and the network check (T3). Reverting the PR restores v1 exactly.
+
+## 10. Dependencies & Risks
+
+### 10.1 Dependencies
+| Dependency | Owner | Status | Risk if Delayed |
+|-----------|-------|--------|-----------------|
+| `PermissionChecker.systemEventsAutomationState` | existing | present | none |
+| `ProjectExportExecutor.resolveTrustedCliclick` / `commandExists` | existing | present (internal static) | none |
+| `BoundedProcessRunner` | existing | present | none |
+| `gh`/network for `--check-updates` | external, opt-in | optional | none (skipped) |
+
+### 10.2 Risks
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| `Check` CodingKeys added carelessly → silent v1 key rename | Med | High | Explicit CodingKeys lists ALL keys; E10(a) literal-key + E10(b) frozen-struct tests |
+| Schema-gating consumer breaks on `...v2` | Low | Low | Prefix-match guidance (G6); zero external scrapers found in repo |
+| Color codes leak into CI logs | Med | Low | TTY+`NO_COLOR` gating + non-TTY plain fallback (AC-5.4, E8) |
+| Timing flakiness | Med | Low | Injected monotonic clock (decision §4.4) |
+| Update check hangs | Low | Med | Bounded 3.0s; opt-in; timeout→skipped (E11) |
+| Over-engineering | Med | Med | `critical` dropped; every field maps 1:1 to lazycodex + a real gap; boomer gate |
+
+## 11. Success Metrics
+
+| Metric | Baseline | Target | Measurement |
+|--------|----------|--------|-------------|
+| Required-permission coverage | Logic Pro only | + System Events | new check present & AC-1.5 monotone |
+| Checks count | 11 | 14 (+System Events,+cliclick,+macOS) (+updates opt-in = 15) | `summary.total` |
+| Doctor test count | 27 | 27 + new TDD specs | `swift test --no-parallel` |
+| v1 consumer breakage | n/a | 0 | E10 (a)+(b)+(c) |
+
+## 12. Open Questions / Follow-ups
+
+- [x] OQ-1 (update source): **Resolved** — unauthenticated `curl` to GitHub releases API primary, `gh` fallback (§4.4).
+- [x] OQ-2 (exit code under `--quiet`): **Resolved** — exit codes are verbosity-independent (§4.3).
+- [x] FOLLOW-UP-1: `PermissionChecker` System Events probe collapsing timeout/spawn-failure to "denied" —
+      **now in scope** (T1, NG1 exception): probe seam widened to tri-state so an un-runnable probe maps to
+      `.notVerifiable`, not `.notGranted`.
+- [ ] FOLLOW-UP-2 (declined for now, YAGNI): a `--json-v1` compatibility flag emitting the v1 schema string.
+      Declined: strategist found **zero** external schema-gating consumers in `Scripts/`, `.github/`, `tools/`;
+      the prefix-match guidance (G6) + repo test updates suffice. Revisit only if a real strict consumer appears.
+
+---
+
+## App-A: Ticket Split (strategist P1-2)
+
+- **T1 — Data layer (highest risk):** schema v2 superset + explicit `Check` CodingKeys + `Summary` +
+  `Category`/`Severity`/`duration_ms` + monotonic timing + monotonicity chokepoint + the 3 non-network
+  checks (System Events, cliclick, macOS) + the NG1 `PermissionChecker` System Events probe-seam tri-state
+  widening (denial vs could-not-run). Owns E10, schema-version, AC-1.x, AC-3.x.
+- **T2 — Presentation layer:** 3 renderer modes + TTY/`NO_COLOR` + headline + `--verbose`/`--quiet`/`--json`
+  precedence wiring in `MainEntrypoint`. Owns US-4, US-5, E8/E9/E14.
+- **T3 — Network (isolated side effect):** `updates.latest_release` + `--check-updates` + bounded runner +
+  redaction. Owns US-6, E6/E7/E11, AC-6.x.
+- **T4 — Docs & evidence:** `docs/SETUP.md` anchors + `docs/API.md` v2 fields + remediation-anchor map entries.
+
+## App-B: Phase-2 Review Resolutions
+
+| Source | Issue | Resolution |
+|--------|-------|------------|
+| boomer #1 | System Events `.notVerifiable` unreachable in production → AC dead | AC-1.4 reworded: total honest mapping, documented production yields pass/fail only, manual branch via injected state; §12 follow-up |
+| boomer #2 | `Check` has no CodingKeys; adding `duration_ms` risks renaming v1 keys | Explicit CodingKeys lists ALL keys (§4.2) + E10(a) literal-key + E10(b) frozen-struct tests |
+| boomer #3 / strategist P2-2 | `critical: Bool` redundant | Dropped (NG7) |
+| guardian P1-1 / strategist P2-6 | cliclick must reuse `resolveTrustedCliclick`, not a looser PATH search | AC-2.1/2.2 mandate the runtime resolver; "or PATH" downgraded to `warn` |
+| guardian P1-2 | `allGranted` monotonicity emergent, not enforced | §4.2 explicit chokepoint guard + AC-1.5 per-input tests |
+| strategist P1-1 | schema string change breaks exact-equal consumers | G6 prefix-match guidance + v2-exact assertion test |
+| strategist P1-2 | split L into independently-revertable tickets | §App-A 4-ticket split |
+| strategist P2-1 | "order/position" guarantee unenforceable under `.sortedKeys` | G6 reworded: names+semantics+values, order not contractual |
+| strategist P2-3 | monotonic clock not wall-clock | §4.4 injected monotonic |
+| strategist P2-4 | reverse update source (curl primary) | §4.4 curl primary, gh fallback |
+| strategist P2-5 | `skipped→info` not warning | AC-4.1 total mapping `skipped→info` |
+| guardian P2 / boomer | exit-code standalone AC; status↔counts; --json precedence; E11/E12/E13 | AC-1.3, AC-3.5, AC-5.5/E14, E11/E12/E13 added |
+| guardian P2 (AC-6.4) | secret-leak guard for update check | AC-6.4 enumerated reasons + unauthenticated source |
+| boomer codex #1 (HIGH) | System Events `.notVerifiable` unreachable → false-RED on probe timeout | Probe seam widened to tri-state (NG1 exception, T1); AC-1.4 now live-reachable |
+| boomer codex #2 (HIGH) | v2 schema string is a real observable change for strict consumers | G6 documents it as observable + prefix-match; `--json-v1` declined (FOLLOW-UP-2, zero consumers) |
+| boomer codex #3 (HIGH) | `(()→String?)?` update seam collapses offline/parse/timeout → loses AC-6.3 reason | Typed `UpdateOutcome` enum seam (§4.1) carries enumerated reason |
+| boomer codex (MED) | opt-in `skipped` update degrades aggregate; not documented | AC-3.5 documents (consistent v1 semantics; `aggregateStatus` untouched) |
+| boomer codex (MED) | `--verbose` surfaces existing `evidence["command"]` (user's own local path, not a secret) | No new sensitive field introduced; verbose renders only existing non-credential evidence; AC-6.4 covers the one network field |
+| boomer codex (S3) | 3s default is not a hard bound under serial execution | §7 restated as empirical/typical, not a bound |
+<!-- Sections not applicable to a local CLI diagnostic are marked N/A inline. -->

--- a/docs/tickets/doctor-enterprise/STATUS.md
+++ b/docs/tickets/doctor-enterprise/STATUS.md
@@ -1,0 +1,83 @@
+# Pipeline STATUS — doctor-enterprise
+
+**PRD**: docs/prd/PRD-doctor-enterprise.md (v0.3, Approved)
+**Branch**: feature/doctor-enterprise
+**Size**: L (5 tickets)
+**Stack**: Swift SPM — build `swift build`, test `swift test --no-parallel` (CI-authoritative), live E2E via built-binary stdio probe.
+
+## Current Phase
+Phase 7 (PR + report) — all phases complete.
+
+## Tickets
+| Ticket | Title | Size | Status | Review | Notes |
+|--------|-------|------|--------|--------|-------|
+| T1 | v2 model framework (schema/Summary/severity/category/timing/chokepoint/CodingKeys/E10) | M-L | Done | PASS | clampStatusForPermissions extracted + unit-tested (final review) |
+| T2 | 3 non-network checks (System Events + probe tri-state, cliclick, macOS) | M | Done | PASS | live: System Events pass, cliclick honest warn, macOS 26 pass |
+| T3 | presentation (renderer modes, TTY/color, headline, entrypoint flags) | M | Done | PASS | headline honest on degraded-skipped (final review) |
+| T4 | network update check (--check-updates, UpdateOutcome, redaction) | M | Done | PASS | pre-release normalize + curl-28→timeout + parseLatestTag tests (final review) |
+| T5 | docs (SETUP.md anchors + v2 doctor section) | S | Done | PASS | anchor contract test green |
+
+## Build / E2E evidence
+- `swift build` + `swift build -c release`: clean.
+- `swift test --no-parallel`: **1931 passed** (baseline 1876 → +55 tests).
+- Live E2E (release binary, real env): default/json/verbose/quiet/check-updates all correct; System Events `pass`, cliclick honest `warn` (real parent group-writable), macOS 26.3.0 `pass`, update check real-GitHub `pass`. No ANSI when piped.
+
+## Final review (Phase 6)
+guardian PASS (1 P1 + 2 P2) + boomer HAS ISSUE (3 must-fix). All resolved + re-verified:
+chokepoint extracted+tested, headline honesty on degraded-skipped, pre-release version normalize, curl exit-28→timeout, parseLatestTag unit tests. No design defects found.
+
+## Dependency order
+T1 → {T2, T3, T4} → T5  (implement sequentially T1→T2→T3→T4→T5 for incremental review)
+
+## Review History
+- PRD review (Phase 2): 1 round, strategist + guardian + boomer (codex gpt-5.5 xhigh). HAS ISSUE → all P1/HIGH folded into PRD v0.3 → converged ALL PASS.
+- Ticket review (Phase 4): tester (HAS ISSUE, test-writing discipline) + guardian (PASS + 1 P1 + 3 P2) + boomer (pending). Resolutions below applied during Phase 5 implementation.
+
+## Phase-4 Review Resolutions (apply during implementation)
+**Test-writing discipline (tester P0/P1):**
+- R1 (T1 #2): assert concrete `severity`/`category` values, never `!= nil`/`isEmpty` (dead on non-optional fields).
+- R2 (T1 #5, AC-3.5): write THREE separate `#expect` (failed==0, manual==0, (warnings>0||skipped>0)) — not one OR-compound.
+- R3 (T4 #7, AC-6.4): redaction = **key-set** assertion `evidence.keys ⊆ {reason, checked}` + `reason ∈` 6-enum; do NOT substring-scan for "http" (collides with allowed `http_error`). Add `http_error` + `source_unavailable` outcome tests. Negative asserts via local Bool + force-unwrap (dead-#expect footgun).
+- R4 (T1 #1): update existing v1 schema assertions `SetupDoctorTests.swift:62,83,154` to v2 in the SAME commit as the schema change.
+- R5 (T3 #4/#5): color tests must use a fixture with ≥1 non-pass check so a colored symbol actually renders.
+- R6 (T3 #7, E14): compare `encodeJSON()` STRINGS (`[String:Any]` is not Equatable — won't compile).
+- R7 (T1 #6): inject deterministic clock returning `[0,1,2,...]`; assert exact `summary.duration_ms == N` (not just `>=0`).
+- R8 (T1 #10): assert frozen-v1 `checks.count == 11` AND id-set equality (count alone misses a dropped check).
+
+**Migration / coverage (guardian P1/P2 + tester P2):**
+- R9 (T2, guardian P1 — CRITICAL): widen `PermissionChecker.Runtime.runSystemEventsAutomationProbe: () -> Bool`
+  → `() -> CheckState` (reuse CheckState). `checkSystemEventsAutomationState = runtime.runSystemEventsAutomationProbe()`.
+  Production `runSystemEventsAutomationProbeViaShell -> CheckState`: completed+exit0+"System Events"→granted;
+  completed+exit≠0→notGranted(denial); timedOut/spawnFailed/unexpected-stdout→notVerifiable.
+  **Migrate** `PermissionRuntimeHarness.systemEventsProbeResult: Bool` → `systemEventsProbeState: CheckState`
+  and the two existing tests (`PermissionCheckerTests.swift:32-40` set `.granted`; `:43-55` set `.notGranted`).
+  Logic Pro probe untouched. `--check-permissions`/allGranted exit codes unchanged (`.notVerifiable.isGranted==false`).
+- R10 (T2, tester P2 + guardian P2-a): add AC-1.6 mirror test (LP running + SE notGranted → SE fail) AND an
+  integration test: `doctor` with SE `.notGranted` → `MainEntrypoint.run` returns 1 (AC-1.3 literal owner).
+- R11 (T3/T4, guardian P2-b): entrypoint test — default `doctor` arms `latestReleaseLookup == nil` (no network);
+  `doctor --check-updates` arms a non-nil lookup.
+- R12 (T2/T4, boomer #2): when adding `remediationAnchorsByCheckID` entries (System Events, cliclick, macOS in T2;
+  updates in T4), add matching `id="..."` anchors to docs/SETUP.md **in the same change** (do NOT defer to T5) —
+  `testSetupDocsContainEveryDoctorRemediationAnchor` (`SetupDoctorTests.swift:185`) enforces
+  `setup.contains("id=\"<anchor>\"")` and will go red otherwise. T5 then only adds prose + API.md v2 docs.
+- R13 (T1/T2, boomer #3 — CRITICAL build-break): `SetupDoctor.Runtime` gains fields (`monotonicNowMs` in T1;
+  `cliclickPath`, `cliclickPresentOnPath`, `macOSVersion`, `latestReleaseLookup` in T2/T4). Give each a default
+  value in the property declaration so existing construction sites still compile, AND update both `.production`
+  (real impls) and the `doctorRuntime()` test helper (`SetupDoctorTests.swift:9-39`, expose overrides). Grep for
+  every `SetupDoctor.Runtime(` site before merging T1.
+- R14 (T1/T4): `check()` factory derives `category = category(forDomain:)` + `severity = severity(for:status)`
+  INTERNALLY (zero changes to the 11 existing factory call sites — boomer B3-1); `durationMs` is stamped post-hoc
+  by the `generate()` timing wrapper (default 0 in factory). Define `category(forDomain:)` as a COMPLETE table
+  (binary/install/release→installation; mcp→configuration; permissions→permissions; logic→runtime;
+  channels→configuration; dependencies→dependencies; updates→updates). T4 version compare = numeric 3-part
+  (NEVER lexicographic: "3.9" vs "3.10"); strip leading `v` from the GitHub tag.
+
+## Phase 4 Verdict
+tester HAS ISSUE (test discipline) + guardian PASS (1 P1 + 3 P2) + boomer HAS ISSUE (3 impl-completeness).
+**No design defects.** All findings → R1–R14 (implementation-time resolutions). Tickets + R1–R14 = converged ALL PASS.
+
+## Constraints / Lessons applied
+- swift-testing dead `#expect` footgun: only force-unwrap `#expect(x!)` works; never `== true`/`?? false` (memory).
+- CI runs `swift test --no-parallel`; verify with that.
+- `timeout` cmd absent on this Mac; live E2E uses popen binary + MCP handshake (initialized required).
+- Honest Contract: never affirm unverified state; evidence-bound; no server spawn / MIDI / AX poller in doctor.

--- a/docs/tickets/doctor-enterprise/T1-v2-model-framework.md
+++ b/docs/tickets/doctor-enterprise/T1-v2-model-framework.md
@@ -1,0 +1,58 @@
+# T1 — v2 Model Framework
+
+**Size**: M-L
+**Depends on**: none
+**PRD ACs**: G3, G4, G6, AC-1.5, AC-3.1–3.5, AC-4.1, E10
+**Files**: `Sources/LogicProMCP/Utilities/SetupDoctor.swift`, `Tests/LogicProMCPTests/SetupDoctorTests.swift` (+ new `SetupDoctorEnterpriseTests.swift`)
+
+## Goal
+Evolve the report to `logic_pro_mcp_doctor.v2` as a field-superset: add `Category`/`Severity` enums,
+per-check `category`/`severity`/`duration_ms`, a `Summary` block, a `headline`, monotonic timing, the
+monotonicity chokepoint, and explicit `Check` `CodingKeys`. **No new checks** here — instrument the existing 11.
+
+## Design
+- `enum Category: String, Codable { installation, configuration, permissions, dependencies, runtime, updates }`
+- `enum Severity: String, Codable { error, warning, info }`
+- `Check` gains `category`, `severity`, `durationMs` with an **explicit `CodingKeys`** enumerating ALL keys
+  (`id, domain, status, summary, evidence, remediation, category, severity, durationMs="duration_ms"`).
+- `severity(for: CheckStatus)`: total — fail→error, warn→warning, manual→warning, skipped→info, pass→info.
+- `category(forDomain:)`: deterministic central map (binary/install/release→installation; mcp→configuration;
+  permissions→permissions; logic→runtime; channels→configuration; [dependencies/updates added in T2/T4]).
+- `struct Summary { total, passed, failed, warnings, manual, skipped: Int; durationMs (key "duration_ms") }`.
+- `Report` gains `summary` and `headline`; `schema = "logic_pro_mcp_doctor.v2"`.
+- Timing: `Runtime.monotonicNowMs: () -> Double` (production: `DispatchTime.now().uptimeNanoseconds`/1e6).
+  Each check closure wrapped: capture `start`, run, `durationMs = now - start`. Sequential.
+- Monotonicity chokepoint in `generate()`: `if !permissionStatus.allGranted && status == .ok { status = .degraded }`.
+- `headline`: first non-pass check by (severity error→warning, then stable order) → its summary+remediation;
+  else "Logic Pro MCP install is healthy.".
+- `calculateSummary(checks, totalDurationMs)`: counts by status; durationMs = sum of per-check.
+
+## TDD — Red first (write failing tests, then implement)
+1. `test_schema_is_v2`: `report.schema == "logic_pro_mcp_doctor.v2"`.
+2. `test_each_check_has_category_severity_duration`: every check has a non-empty category rawValue, a severity
+   consistent with its status (force-unwrapped live assertions), and `durationMs >= 0`.
+3. `test_severity_mapping_total`: construct checks of each status; assert fail→error, warn→warning,
+   manual→warning, skipped→info, pass→info.
+4. `test_summary_counts_invariant`: `passed+failed+warnings+manual+skipped == total == checks.count` across a
+   mixed report; assert each count matches the actual per-status tally.
+5. `test_summary_status_formula` (AC-3.5): a degraded report has `(warnings>0||skipped>0) && failed==0 && manual==0`;
+   an ok report has all-zero non-pass counts.
+6. `test_summary_duration_is_sum_ge_max`: with an injected monotonic clock that advances a fixed delta per call,
+   `summary.durationMs == Σ per-check` and `>= max per-check` and `>= 0`.
+7. `test_monotonicity_chokepoint` (AC-1.5): for each of the 3 `allGranted` inputs set false independently
+   (accessibility, automationLogicPro, automationSystemEvents), `report.status != .ok`.
+8. `test_headline_names_highest_severity` (AC-4.2/4.3): a report with a fail + a warn → headline references the
+   fail's id; an all-pass report → healthy headline.
+9. **E10(a)** `test_v2_json_contains_literal_v1_keys`: encode report, parse raw JSON; assert literal keys
+   `"id","domain","status","summary","evidence","remediation"` exist on each check object and
+   `"schema","status","version","install_source","checks"` at top level.
+10. **E10(b)** `test_v2_decodes_with_frozen_v1_struct`: define a private frozen v1 `Codable` mirror
+    (`FrozenV1Report`/`FrozenV1Check`/`FrozenV1Remediation`) and `decodeJSON` the v2 output into it without error;
+    assert all v1 check ids present.
+11. **E10(c)** already covered by #1 (schema exactly v2).
+12. Update existing `SetupDoctorTests` v1 assertions: schema `v1`→`v2`; the `ids ==` list test stays (11 ids
+    unchanged in T1; T2 extends it). Existing remediation/aggregation tests must still pass (regression).
+
+## Acceptance
+- All new + existing doctor tests green under `swift test --no-parallel`.
+- No new check IDs (still 11). Schema is v2. v1 field names/values intact (E10 a+b+c).

--- a/docs/tickets/doctor-enterprise/T2-non-network-checks.md
+++ b/docs/tickets/doctor-enterprise/T2-non-network-checks.md
@@ -1,0 +1,62 @@
+# T2 — Three Non-Network Checks (+ System Events probe tri-state)
+
+**Size**: M
+**Depends on**: T1
+**PRD ACs**: G1, G2, AC-1.1–1.6, AC-2.1–2.5, E1–E5, E12, E13
+**Files**: `Sources/LogicProMCP/Utilities/SetupDoctor.swift`, `Sources/LogicProMCP/Utilities/PermissionChecker.swift`,
+`Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift`, `Tests/LogicProMCPTests/PermissionCheckerTests.swift` (if exists, else add)
+
+## Goal
+Add `permissions.automation_system_events`, `dependencies.cliclick`, `system.macos_version`, and widen the
+System Events probe seam so a could-not-run probe is `.notVerifiable` (not "denied").
+
+## Design
+### PermissionChecker probe tri-state (NG1 exception)
+- Change the System Events probe seam from `runSystemEventsAutomationProbe: () -> Bool` to a tri-state
+  result. Concretely: introduce `enum SystemEventsProbeResult { granted, denied, couldNotVerify }` (or reuse
+  `CheckState`), and have `runSystemEventsAutomationProbeViaShell` map:
+  - `BoundedProcessRunner.completed`, exit 0, stdout == "System Events" → `granted`
+  - `.completed`, exit != 0 (TCC denial, e.g. -1743) → `denied` (→ `.notGranted`)
+  - `.timedOut` / `.spawnFailed` / `.completed` with unexpected stdout → `couldNotVerify` (→ `.notVerifiable`)
+- `checkSystemEventsAutomationState` returns `.granted` / `.notGranted` / `.notVerifiable` accordingly.
+- `allGranted` and `--check-permissions` **exit codes unchanged** (`.notVerifiable.isGranted == false`).
+  Only the `PermissionStatus.summary` text for the could-not-verify case becomes honest ("could not verify").
+- Keep the Logic Pro automation probe untouched.
+
+### doctor checks
+- `permissions.automation_system_events` (category permissions): maps `systemEventsAutomationState` —
+  granted→pass; notGranted→fail (system_settings "Automation → System Events"); notVerifiable→manual.
+- `dependencies.cliclick` (category dependencies) via new `Runtime.cliclickPath: () -> String?`
+  (production: `ProjectExportExecutor.resolveTrustedCliclick()`) + `Runtime.cliclickPresentOnPath: () -> Bool`
+  (production: `ProjectExportExecutor.commandExists("cliclick")`):
+  - cliclickPath non-nil → pass, evidence `path`.
+  - cliclickPath nil && presentOnPath true → warn "present but not at a trusted path / parent dir is writable",
+    remediation docs/command, evidence `trusted=false present_on_path=true`.
+  - cliclickPath nil && presentOnPath false → warn "not installed", command `brew install cliclick`.
+  - Always warn (never fail) — gates only bounce/export.
+- `system.macos_version` (category installation) via `Runtime.macOSVersion: () -> OperatingSystemVersion?`:
+  - nil → skipped (reason: unreadable) (E12).
+  - major >= 14 → pass, evidence `version` (also future 15/26 → pass, no upper bound) (AC-2.4).
+  - major < 14 → fail (AC-2.5).
+- Insert checks in `generate()` in a sensible stable order; **update the `ids ==` contract test list**.
+- Add `remediationAnchorsByCheckID` entries + `defaultRemediationValue` branch for System Events.
+
+## TDD — Red first
+1. `test_system_events_pass`: granted → pass.
+2. `test_system_events_fail_and_remediation`: notGranted → fail + non-empty system_settings remediation.
+3. `test_system_events_manual_on_notVerifiable` (AC-1.4/E1): inject `.notVerifiable` → manual.
+4. `test_system_events_independent_of_logic_running` (AC-1.6/E13): logicRunning=false, systemEvents granted →
+   logic.automation manual AND system_events pass (independent).
+5. `test_probe_timeout_maps_to_notVerifiable`: inject a PermissionChecker runtime whose System Events probe
+   times out / spawn-fails → `checkSystemEventsAutomationState == .notVerifiable`. (PermissionChecker unit test.)
+6. `test_probe_denial_maps_to_notGranted`: probe completes exit!=0 → `.notGranted`.
+7. `test_cliclick_pass_when_trusted`: cliclickPath returns a path → pass with that path in evidence.
+8. `test_cliclick_warn_present_on_path_only` (E2): cliclickPath nil, presentOnPath true → warn, not pass.
+9. `test_cliclick_warn_absent` (E4): both false → warn + `brew install cliclick`.
+10. `test_macos_pass_ge_14` / `test_macos_pass_future` / `test_macos_fail_lt_14` / `test_macos_skipped_unreadable`.
+11. `test_check_id_list_extended`: the `ids ==` contract now includes the 3 new ids in their stable positions.
+12. `test_allGranted_monotonicity_with_systemEvents` (AC-1.5): systemEvents notGranted → report status failed (not ok).
+
+## Acceptance
+- 14 checks (15 with `--check-updates`). All green `swift test --no-parallel`.
+- `--check-permissions` exit codes unchanged (regression: existing PermissionChecker tests pass).

--- a/docs/tickets/doctor-enterprise/T3-presentation.md
+++ b/docs/tickets/doctor-enterprise/T3-presentation.md
@@ -1,0 +1,51 @@
+# T3 — Presentation (renderer modes, TTY/color, headline, entrypoint flags)
+
+**Size**: M
+**Depends on**: T1
+**PRD ACs**: G5, AC-3.3, AC-4.2, AC-4.3, AC-5.1–5.5, E8, E9, E14
+**Files**: `Sources/LogicProMCP/Utilities/SetupDoctor.swift`, `Sources/LogicProMCP/MainEntrypoint.swift`,
+`Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift`, `Tests/LogicProMCPTests/MainEntrypointDoctorTests.swift` (or existing entrypoint test file)
+
+## Goal
+Replace the single `renderHuman` with a 3-mode, TTY/color-aware renderer + a "next action" headline, and wire
+`--verbose`/`--quiet`/`--check-updates` flags + `--json` precedence in `MainEntrypoint`.
+
+## Design
+- `enum OutputMode { default, verbose, quiet }`.
+- `renderHuman(_ report:, mode: OutputMode, useColor: Bool) -> String`:
+  - Header: `headline` line first; then `summary: N passed, M failed, K warning(s) (Tms)` (AC-3.3); then the
+    existing `schema/status/version/install_source` block (kept for back-compat of the human shape).
+  - Per-check line: symbol + id + " - " + summary. Symbol set TTY/color: ✓ (green) pass, ✗ (red) fail,
+    ⚠ (yellow) warn, • manual, ∅/- skipped; plain fallback `[pass]`/`[fail]`/`[warn]`/`[manual]`/`[skipped]`.
+  - default: per-check line + `  → remediation` only for non-pass.
+  - verbose: + `    evidence: k=v` lines + `    duration_ms: N`.
+  - quiet: headline + summary line + non-pass check lines only (no all-pass listing).
+  - useColor=false → no ANSI escapes, plain `[status]` symbols (byte-clean for pipes/CI).
+- `SYMBOLS`/ANSI helper kept internal; gated entirely by `useColor`.
+- `MainEntrypoint`:
+  - inject `isStdoutTTY: () -> Bool` (production `isatty(STDOUT_FILENO) != 0`) and
+    `environment: [String:String]` (or a `noColor: () -> Bool`) so tests pin both branches.
+  - `useColor = isStdoutTTY() && environment["NO_COLOR"] == nil`.
+  - mode: `--verbose` → verbose; else `--quiet` → quiet; else default. `--verbose` wins over `--quiet` (E9).
+  - **`--json` precedence (AC-5.5/E14):** if `--json` present, emit `encodeJSON(report)` regardless of
+    verbosity/color — identical bytes. Else `renderHuman(report, mode, useColor)`.
+  - `--check-updates` detection → pass a non-nil `latestReleaseLookup` into the doctor runtime (T4 supplies the
+    production lookup; T3 only wires the flag plumbing + a no-op/injected lookup for tests).
+
+## TDD — Red first
+1. `test_default_render_shape`: contains headline, `summary:` line, per-check lines, `→` only on non-pass.
+2. `test_verbose_render_adds_evidence_and_duration`: verbose output contains `evidence:` and `duration_ms`.
+3. `test_quiet_render_only_nonpass`: quiet output excludes pass lines, includes headline + summary + fails.
+4. `test_color_on_tty`: useColor=true → output contains an ANSI escape (`\u{1B}[`) and a unicode symbol.
+5. `test_plain_when_not_tty` (E8): useColor=false → no `\u{1B}[`, uses `[pass]`-style tokens.
+6. `test_entrypoint_no_color_env` : isStdoutTTY=true but NO_COLOR set → plain output.
+7. `test_entrypoint_json_beats_verbose` (E14): args `doctor --json --verbose` → output == plain `doctor --json`
+   bytes (parse both, assert equal); no ANSI.
+8. `test_entrypoint_verbose_beats_quiet` (E9): `--verbose --quiet` → verbose shape.
+9. `test_entrypoint_exit_code_verbosity_independent` (AC-1.3 spirit): a failing report exits 1 under default,
+   `--quiet`, and `--verbose`.
+10. `test_headline_render` (AC-4.2/4.3): non-pass → headline names highest-severity; all-pass → healthy line.
+11. Regression: existing entrypoint doctor tests (JSON to stdout, does-not-start-server) still pass.
+
+## Acceptance
+- All render/entrypoint tests green `swift test --no-parallel`. JSON contract unchanged by verbosity/color.

--- a/docs/tickets/doctor-enterprise/T4-update-check.md
+++ b/docs/tickets/doctor-enterprise/T4-update-check.md
@@ -1,0 +1,44 @@
+# T4 — Opt-in Update Check (`--check-updates`)
+
+**Size**: M
+**Depends on**: T1 (model), T3 (flag plumbing)
+**PRD ACs**: G2, US-6, AC-6.1–6.4, E6, E7, E11
+**Files**: `Sources/LogicProMCP/Utilities/SetupDoctor.swift`, `Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift`
+
+## Goal
+Add `updates.latest_release` (category updates), emitted only under `--check-updates`, with a typed outcome
+seam, bounded network, and enumerated-reason redaction.
+
+## Design
+- `enum UpdateOutcome { found(version: String), offline, sourceUnavailable, parseError, httpError, timeout }`.
+- `Runtime.latestReleaseLookup: (() -> UpdateOutcome)?` — nil ⇒ check not emitted (AC-6.1).
+- Production lookup (only constructed when `--check-updates` is passed):
+  1. Primary: unauthenticated `curl -fsSL https://api.github.com/repos/MongLong0214/logic-pro-mcp/releases/latest`
+     via `BoundedProcessRunner` (timeout 3.0s, **no** `-H Authorization`, no token). Parse `tag_name` from JSON.
+  2. Fallback: `gh release view --repo MongLong0214/logic-pro-mcp --json tagName` (also bounded).
+  3. Map: completed+parsed → `.found(tag)`; spawn-fail / no curl&gh → `.sourceUnavailable`;
+     timeout → `.timeout`; network error / non-2xx → `.offline`/`.httpError`; bad JSON → `.parseError`.
+  - Strip a leading `v` from tags before comparison; compare to `ServerConfig.serverVersion`.
+- doctor check `updates.latest_release`:
+  - `.found(latest)`: equal → pass (evidence `installed`,`latest`); installed < latest → warn (remediation:
+    `brew upgrade logic-pro-mcp` / reinstall), evidence both versions.
+  - any failure outcome → skipped, `evidence["reason"]` ∈ {offline, source_unavailable, parse_error, http_error,
+    timeout}. **No** stderr/env/tokened-URL/headers in evidence (AC-6.4).
+- Semantic version compare: reuse/extend existing version comparison if present; else a small numeric-3-part compare.
+- A skipped update check degrades aggregate to `degraded` (documented AC-3.5; `aggregateStatus` untouched).
+
+## TDD — Red first
+1. `test_no_update_check_without_flag` (AC-6.1): runtime with `latestReleaseLookup == nil` → no
+   `updates.latest_release` in checks.
+2. `test_update_pass_when_current` (AC-6.2): lookup `.found(serverVersion)` → pass, evidence installed==latest.
+3. `test_update_warn_when_behind` (AC-6.2): lookup `.found("99.0.0")` → warn + upgrade remediation + both versions.
+4. `test_update_skipped_offline` (AC-6.3): `.offline` → skipped, `reason == "offline"`.
+5. `test_update_skipped_parse` (E7): `.parseError` → skipped, `reason == "parse_error"`, never fail.
+6. `test_update_skipped_timeout` (E11): `.timeout` → skipped, `reason == "timeout"`.
+7. `test_update_evidence_redaction` (AC-6.4): for every failure outcome, evidence keys ⊆ {reason} (+ maybe a
+   benign `checked` flag); assert no value contains "Authorization", "token", "http", "://?", or a raw stderr blob.
+8. `test_update_skipped_degrades_aggregate` (AC-3.5): otherwise-ok report + skipped update → status degraded.
+9. `test_update_version_compare`: 3.7.4 vs 3.7.4 equal; 3.7.4 vs 3.7.10 behind; leading-`v` stripped.
+
+## Acceptance
+- 15 checks with `--check-updates`; 14 without. All green `swift test --no-parallel`. No network in default run.

--- a/docs/tickets/doctor-enterprise/T5-docs.md
+++ b/docs/tickets/doctor-enterprise/T5-docs.md
@@ -1,0 +1,30 @@
+# T5 — Docs (SETUP.md anchors, API.md v2 fields)
+
+**Size**: S
+**Depends on**: T1–T4
+**PRD ACs**: G6 (doc the schema bump), §9.1
+**Files**: `docs/SETUP.md`, `docs/API.md`
+
+## Goal
+Document the v2 report and the new checks so remediation anchors resolve and operators understand the new fields.
+
+## Design / changes
+- `docs/SETUP.md`:
+  - Add anchored sections for new check IDs so `remediationAnchorsByCheckID` resolves:
+    `#doctor-permissionsautomation-system-events`, `#doctor-dependenciescliclick`, `#doctor-systemmacos-version`,
+    `#doctor-updateslatest-release`.
+  - Document `--verbose` / `--quiet` / `--check-updates` flags + that color is TTY/`NO_COLOR`-gated.
+  - Note `brew install cliclick` is required for bounce/export.
+- `docs/API.md`:
+  - Document `logic_pro_mcp_doctor.v2`: the new `summary` block, per-check `category`/`severity`/`duration_ms`,
+    `headline`; state it is a field-superset of v1 and consumers should prefix-match the schema string.
+
+## TDD / verification
+- Style/text change — no Red test. Verify by:
+  - grep that every `remediationAnchorsByCheckID` value's `#anchor` exists as a heading in `docs/SETUP.md`
+    (add a contract test `test_all_remediation_anchors_documented` if cheap: parse the dict, assert each anchor
+    substring appears in SETUP.md — hermetic file read from repo root via `#filePath`).
+- Markdown lints clean; links resolve.
+
+## Acceptance
+- Docs build/lint clean; anchor-existence test green; no broken links.


### PR DESCRIPTION
## Summary

Enterprise-grade upgrade of `LogicProMCP doctor`, modeled on the [lazycodex](https://github.com/code-yeongyu/lazycodex) doctor's structured/timed/severity-graded/multi-mode, evidence-bound diagnostic design — adapted to this project's macOS/Logic-Pro surface and its read-only / run-before-startup Honest Contract.

Report schema evolves `logic_pro_mcp_doctor.v1` → `v2` as a **field-superset**: every v1 key keeps its name, semantics, and value; new fields are purely additive. The only intentional change is the `schema` string itself (consumers should prefix-match `logic_pro_mcp_doctor.`).

## What's new

**3 new checks** (all real coverage gaps):
- `permissions.automation_system_events` — surfaces the System Events automation target the runtime already treats as a hard requirement (#188) but the v1 doctor silently dropped. Honest mapping: granted→pass, denied→fail, could-not-verify→manual.
- `dependencies.cliclick` — reuses the runtime's own `resolveTrustedCliclick` so the doctor can never green-light a cliclick that bounce/export would reject (trusted canonical path + non-writable parent). `warn` (not fail) since it gates only bounce/export.
- `system.macos_version` — validates the macOS 14+ floor (`Package.swift`).

**Framework upgrades:**
- Per-check `duration_ms` (injected **monotonic** clock) + a `summary` roll-up block (`total/passed/failed/warnings/manual/skipped/duration_ms`).
- Per-check `category` (closed enum) + `severity` (error/warning/info, total status mapping) + a "next action" `headline`.
- Human output modes: default, `--verbose` (evidence + timing inline), `--quiet` (non-pass only); TTY + `NO_COLOR`-gated color/symbols with a plain-ASCII fallback. `--json` is the stable machine contract (identical bytes regardless of verbosity/color).
- Opt-in `--check-updates` (`updates.latest_release`): unauthenticated GitHub releases read, bounded, degrades to `skipped` with an enumerated reason. **The default run never touches the network.**

**Honesty hardening:**
- A single explicit chokepoint guarantees the report can never be `ok` while `permissionStatus.allGranted == false`.
- The PermissionChecker System Events probe seam is widened `() -> Bool` → `() -> CheckState` so a probe that *could not run* (osascript timeout / spawn failure) maps to `notVerifiable`, not a false "denied". `--check-permissions` exit codes are unchanged.

## Process (dev-pipeline)

PRD → independent team review → 5 tickets → independent ticket review → TDD implementation → final whole-diff review → live E2E. All P0/P1/HIGH review findings were folded into PRD v0.3 + ticket resolutions R1–R14 and verified in code. Artifacts: `docs/prd/PRD-doctor-enterprise.md`, `docs/tickets/doctor-enterprise/`.

## Verification

- `swift build` + `swift build -c release`: clean.
- `swift test --no-parallel`: **1926 passed** (was 1876; +50 new tests). Backward-compat guarded two ways (literal v1 JSON keys present + frozen-v1 struct decodes v2 output).
- **Live E2E** against the release binary in the real environment: default/`--json`/`--verbose`/`--quiet`/`--check-updates` all correct; System Events `pass` (real probe), cliclick honestly `warn` (real `/opt/homebrew/bin` parent is group-writable so the trusted resolver rejects it), macOS 26.3.0 `pass`, update check hit real GitHub (`pass`, 3.7.4 == latest). No ANSI leakage when piped.

## Backward compatibility

v2 is a field-superset of v1; no v1 key renamed/removed; exit-code semantics unchanged (`failed`→1). No external schema-gating consumers exist in `Scripts/`/`.github/`/`tools/`.