### PR TITLE
fix(#212): --version prints version and exits without starting the server

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -33,6 +33,21 @@ enum MainEntrypoint {
             FileHandle.standardError.write(Data(message.utf8))
         }
     ) async -> Int {
+        // `--version` is a terminal global flag: print the version and exit
+        // WITHOUT creating the approval store, checking permissions, or —
+        // critically — starting the long-lived MCP server channels (#212).
+        // Placed before every other branch so no side effect runs first.
+        //
+        // Emits the bare version string only: SetupLifecycle
+        // .productionInstalledBinaryVersion() runs the installed binary with
+        // `--version`, requires exit 0, and compares the trimmed stdout for
+        // EQUALITY against ServerConfig.serverVersion to detect install drift.
+        // Any prefix (e.g. "logic-pro-mcp 3.7.4") would break that equality.
+        if hasFlag("--version", or: "-V", in: arguments) {
+            writeStdout(ServerConfig.serverVersion + "\n")
+            return 0
+        }
+
         let approvalStore = approvalStoreFactory()
 
         if isDoctorCommand(arguments) {
@@ -175,6 +190,15 @@ enum MainEntrypoint {
             Log.error("Server failed: \(error)", subsystem: "main")
             return 1
         }
+    }
+
+    /// True when a terminal global flag (`--version`, `--help`, …) appears
+    /// anywhere in the user-supplied arguments (the program path at index 0 is
+    /// ignored). These flags print-and-exit, so they are checked before any
+    /// subcommand parsing or server startup.
+    private static func hasFlag(_ flag: String, or alias: String? = nil, in arguments: [String]) -> Bool {
+        let userArgs = arguments.dropFirst()
+        return userArgs.contains(flag) || (alias.map { userArgs.contains($0) } ?? false)
     }
 
     private static func optionValue(_ option: String, in arguments: [String]) -> String? {

--- a/Tests/LogicProMCPTests/MainEntrypointTests.swift
+++ b/Tests/LogicProMCPTests/MainEntrypointTests.swift
@@ -22,6 +22,49 @@ private actor MockMainServer: ServerStarting {
     }
 }
 
+@Test func testMainEntrypointVersionFlagPrintsBareVersionAndExitsWithoutServer() async {
+    // #212: `--version` must print the version and exit 0 WITHOUT starting the
+    // MCP server channels (pre-fix it started the server and timed out).
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "--version"],
+        permissionCheck: {
+            Issue.record("Permission check should not run for --version")
+            return .init(accessibility: false, automationLogicPro: false)
+        },
+        serverFactory: {
+            Issue.record("Server must not be created for --version")
+            return MockMainServer()
+        },
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 0)
+    // Bare version only — SetupLifecycle.productionInstalledBinaryVersion()
+    // compares this stdout for equality against ServerConfig.serverVersion.
+    #expect(stdout == ServerConfig.serverVersion + "\n")
+    #expect(stdout.trimmingCharacters(in: .whitespacesAndNewlines) == ServerConfig.serverVersion)
+    #expect(stderr.isEmpty)
+}
+
+@Test func testMainEntrypointVersionShortFlagPrintsVersion() async {
+    var stdout = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "-V"],
+        serverFactory: {
+            Issue.record("Server must not be created for -V")
+            return MockMainServer()
+        },
+        writeStdout: { stdout += $0 },
+        writeStderr: { _ in }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stdout.trimmingCharacters(in: .whitespacesAndNewlines) == ServerConfig.serverVersion)
+}
+
 @Test func testMainEntrypointReturnsSuccessForGrantedPermissions() async {
     var stderr = ""
     let exitCode = await MainEntrypoint.run(


### PR DESCRIPTION
## Summary

- `LogicProMCP --version` now prints the bare version and exits 0 **without starting the MCP server**.
- Pre-fix it fell through to `serverFactory()` and started the long-lived channels (MIDI port manager, etc.), yielding empty stdout and no exit within the audit deadline.
- `--version` and its short alias `-V` are handled as a terminal global flag before any subcommand parsing or server startup.

## Linked issue

- Closes #212

## Risk

- Priority: P2
- Area: setup-release (CLI)
- User-visible impact: `--version` is now usable and fast; `SetupLifecycle.productionInstalledBinaryVersion()` (runs installed binary with `--version`) no longer hangs → installed-version detection is reliable.
- Contract impact: none (new CLI flag behavior; no MCP contract change)

## Design note — why bare version

`SetupLifecycle.productionInstalledBinaryVersion()` compares the trimmed `--version` stdout for **equality** against `ServerConfig.serverVersion` to detect install drift. Emitting the bare `3.7.4` (not `logic-pro-mcp 3.7.4`) preserves that equality.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1935 passed** (1933 baseline + 2 new)
- [x] Targeted test: `MainEntrypointTests` (26 passed), incl. server-not-created + exact-stdout assertions
- [x] Real-usage (built binary):

Evidence:
```text
$ .build/debug/LogicProMCP --version
3.7.4            # exit 0, 0.58s, empty stderr, server NOT started
$ .build/debug/LogicProMCP -V
3.7.4            # exit 0
```

## Release readiness

- [x] No behavior change to the MCP contract; docs unaffected.
- [x] Known limitations: none.

## Reviewer focus

- Flag is checked before `approvalStoreFactory()`/permission/doctor/lifecycle branches, so no side effect runs first.