### PR TITLE
fix(#214): support documented 'lifecycle <action>' read-only plan form

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -63,6 +63,30 @@ enum MainEntrypoint {
             return SetupDoctor.shouldExitWithFailure(report) ? 1 : 0
         }
 
+        if isLifecycleSubcommand(arguments) {
+            // #214: `LogicProMCP lifecycle <install|update|uninstall> [--json]`
+            // is the documented read-only planning surface. Pre-fix the
+            // `lifecycle` verb was unparsed and fell through to server startup
+            // (the audit saw a hang/timeout). It prints the SAME plan the bare
+            // `<action> --dry-run` form produces — no `--dry-run` needed because
+            // the `lifecycle` namespace never executes anything; live execution
+            // stays delegated to Scripts/install.sh / uninstall.sh.
+            guard let command = lifecycleSubcommandAction(arguments) else {
+                let valid = SetupLifecycle.Command.allCases.map(\.rawValue).joined(separator: "|")
+                writeStderr(
+                    "Usage: LogicProMCP lifecycle <\(valid)> [--json]\n"
+                        + "Prints a read-only lifecycle plan (see docs/SETUP.md).\n"
+                )
+                return 1
+            }
+            let plan = SetupLifecycle.plan(command: command, runtime: lifecycleRuntime)
+            let output = arguments.contains("--json")
+                ? encodeJSON(plan)
+                : SetupLifecycle.renderHuman(plan)
+            writeStdout(output + "\n")
+            return 0
+        }
+
         if let command = lifecycleCommand(arguments) {
             // Live execution is intentionally NOT performed here — it is delegated
             // to Scripts/install.sh / uninstall.sh. Without --dry-run we refuse
@@ -191,5 +215,20 @@ enum MainEntrypoint {
     private static func lifecycleCommand(_ arguments: [String]) -> SetupLifecycle.Command? {
         guard let first = Array(arguments.dropFirst()).first else { return nil }
         return SetupLifecycle.Command(rawValue: first)
+    }
+
+    private static func isLifecycleSubcommand(_ arguments: [String]) -> Bool {
+        Array(arguments.dropFirst()).first == "lifecycle"
+    }
+
+    /// The action following the `lifecycle` verb, e.g. `lifecycle install` →
+    /// `.install`. The first non-flag token after `lifecycle` is the action, so
+    /// `lifecycle install --json` and `lifecycle --json install` both resolve.
+    /// Returns nil for a missing or unrecognized action (→ usage error).
+    private static func lifecycleSubcommandAction(_ arguments: [String]) -> SetupLifecycle.Command? {
+        guard let actionRaw = arguments.dropFirst(2).first(where: { !$0.hasPrefix("-") }) else {
+            return nil
+        }
+        return SetupLifecycle.Command(rawValue: actionRaw)
     }
 }

--- a/Tests/LogicProMCPTests/SetupLifecycleTests.swift
+++ b/Tests/LogicProMCPTests/SetupLifecycleTests.swift
@@ -514,6 +514,98 @@ private func launchAgentPath(_ home: URL = lifecycleTestHome) -> String {
     #expect(stderr.contains("Scripts/uninstall.sh"))
 }
 
+@Test func testMainEntrypointLifecycleSubcommandJSONExitsZeroWithoutStartingServer() async throws {
+    // #214: the documented `LogicProMCP lifecycle <action> --json` form must
+    // print the read-only plan and exit 0 WITHOUT starting the server (pre-fix
+    // it was unparsed and fell through to server startup → hang/timeout).
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "lifecycle", "install", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle plan")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stderr.isEmpty)
+    let json = try #require(sharedJSONObject(stdout))
+    #expect(json["schema"] as? String == "logic_pro_mcp_lifecycle_plan.v1")
+    #expect(json["command"] as? String == "install")
+    // Read-only: the wire contract must state the plan does nothing.
+    #expect(json["execution_mode"] as? String == "dry_run_only")
+}
+
+@Test func testMainEntrypointLifecycleSubcommandHumanOutputMatchesDryRunForm() async {
+    // `lifecycle uninstall` (no --dry-run) prints the human plan, exit 0.
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "lifecycle", "uninstall"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle plan")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 0)
+    #expect(stderr.isEmpty)
+    #expect(stdout.contains("Logic Pro MCP lifecycle plan"))
+    #expect(stdout.contains("command: uninstall"))
+    #expect(stdout.contains("execution_mode: dry_run_only"))
+}
+
+@Test func testMainEntrypointLifecycleSubcommandMissingActionShowsUsage() async {
+    var stdout = ""
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "lifecycle"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle usage error")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStdout: { stdout += $0 },
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 1)
+    #expect(stdout.isEmpty)
+    #expect(stderr.contains("Usage: LogicProMCP lifecycle"))
+    #expect(stderr.contains("install|update|uninstall"))
+}
+
+@Test func testMainEntrypointLifecycleSubcommandUnknownActionShowsUsage() async {
+    var stderr = ""
+    let exitCode = await MainEntrypoint.run(
+        arguments: ["LogicProMCP", "lifecycle", "frobnicate", "--json"],
+        permissionCheck: { .init(accessibility: true, automationLogicPro: true) },
+        serverFactory: {
+            Issue.record("Server should not start for a lifecycle usage error")
+            return LifecycleMockMainServer()
+        },
+        approvalStoreFactory: { ManualValidationStore() },
+        lifecycleRuntime: lifecycleRuntime(),
+        writeStderr: { stderr += $0 }
+    )
+
+    #expect(exitCode == 1)
+    #expect(stderr.contains("Usage: LogicProMCP lifecycle"))
+}
+
 @Test func testMainEntrypointUnknownFirstArgStillStartsServer() async {
     // A non-lifecycle, non-doctor first arg must not be hijacked by the lifecycle
     // router — the server still starts.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -196,7 +196,7 @@ Approve MIDIKeyCommands or Scripter only after completing the matching Logic-sid
 
 ## Lifecycle Anchors
 
-`LogicProMCP lifecycle ... --json` is read-only. These anchors are stable remediation targets.
+`LogicProMCP lifecycle <install|update|uninstall> [--json]` prints a read-only lifecycle plan and exits without starting the server — e.g. `LogicProMCP lifecycle install --json`. (The bare `LogicProMCP install --dry-run --json` form produces the same plan.) These anchors are stable remediation targets.
 
 <a id="lifecycle-binaryinstall"></a>
 ### `binary.install`


### PR DESCRIPTION
## Summary

- The documented `LogicProMCP lifecycle <install|update|uninstall> [--json]` form now works: it prints a read-only lifecycle plan and exits 0 **without starting the server**.
- Pre-fix, only the bare `install`/`update`/`uninstall` verbs matched `SetupLifecycle.Command`, so `lifecycle …` fell through to server startup and timed out.
- The `lifecycle` verb is the read-only planning namespace — it prints the same plan the bare `<action> --dry-run` form produces. No `--dry-run` is required because the namespace never executes anything; live execution stays delegated to `Scripts/install.sh` / `uninstall.sh`.
- Missing / unknown actions print a usage error and exit 1.
- `docs/SETUP.md` updated to show the concrete working command.

## Linked issue

- Closes #214

## Risk

- Priority: P2
- Area: docs, setup-release
- User-visible impact: docs command now works as written; no accidental server launch.
- Contract impact: docs only + additive CLI parsing (bare `<action> --dry-run` form unchanged).

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1937 passed** (1933 baseline + 4 new)
- [x] Targeted test: `MainEntrypoint|Lifecycle` (66 passed)
- [x] Real-usage (built binary):

Evidence:
```text
$ .build/debug/LogicProMCP lifecycle install --json
{ ... "schema":"logic_pro_mcp_lifecycle_plan.v1","command":"install","execution_mode":"dry_run_only" ... }
# exit 0, empty stderr, server NOT started

$ .build/debug/LogicProMCP lifecycle
Usage: LogicProMCP lifecycle <install|update|uninstall> [--json]
Prints a read-only lifecycle plan (see docs/SETUP.md).
# exit 1
```

## Release readiness

- [x] Docs updated (docs/SETUP.md).
- [x] Known limitations: `lifecycle` is planning-only by design; live execution is via the install/uninstall scripts.

## Reviewer focus

- `lifecycle` block sits before the bare-action `lifecycleCommand` branch; non-lifecycle first args still start the server (covered by `testMainEntrypointUnknownFirstArgStillStartsServer`).