### PR TITLE
fix(#215): always list logic://mcu/state so discovery matches the 18-resource docs

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -825,6 +825,9 @@ def main():
         "logic://markers",
         "logic://project/info",
         "logic://midi/ports",
+        # #215: mcu/state is always listed (it is always directly readable and
+        # the docs advertise a stable 18-resource catalog), even MCU-disconnected.
+        "logic://mcu/state",
         "logic://library/inventory",
         "logic://stock-plugins",
         "logic://stock-plugins/census",
@@ -833,6 +836,8 @@ def main():
         "logic://workflow-skills/schema",
     }
     T("resources/list includes required resources", r, lambda r: required_resource_uris.issubset(resource_uris))
+    T("resources/list includes mcu/state even when MCU disconnected (#215)", r,
+      lambda _: "logic://mcu/state" in resource_uris)
 
     r = list_resource_templates(client)
     templates = r.get("result", {}).get("resourceTemplates", []) if r else []
@@ -2190,8 +2195,8 @@ def main():
         "logic://workflow-skills/schema",
         "logic://workflow-skills/logic.workflow.plugins.stock_chain_plan",
         "logic://workflow-skills/search?query=plugin",
-        # mcu/state is read-testable even when filtered from list (direct reads
-        # bypass the connection gate so clients bookmarking the URI still work).
+        # mcu/state is both listed (#215) and directly readable, even when the
+        # MCU surface is disconnected — a read returns { connected: false, … }.
         "logic://mcu/state",
     ]
     for uri in resources_to_test:

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -436,7 +436,7 @@ struct SystemDispatcher {
                   logic://project/audit         — Read-only project/session audit
                   logic://project/cleanup-plan  — Read-only serializable cleanup plan
                   logic://midi/ports            — MIDI ports
-                  logic://mcu/state             — MCU control-surface state (hidden in list when disconnected)
+                  logic://mcu/state             — MCU control-surface state (readable even when disconnected)
                   logic://library/inventory     — Cached Library tree JSON
                   logic://stock-plugins         — Stock plugin intelligence catalog
                   logic://stock-plugins/census  — Stock plugin census metadata

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -6,31 +6,21 @@ import MCP
 /// in the tool list. Clients can watch/poll them to keep a local mirror in
 /// sync without consuming tool-call budget.
 ///
-/// Dynamic surface: the full `resources` list is advertised for capability
-/// announcement, but at `resources/list` request time we filter out MCU-only
-/// resources when the control surface isn't connected so the LLM doesn't
-/// discover probes that would just return empty payloads.
+/// Stable surface: `resources/list` always advertises the full static set,
+/// matching the documented "18 static resources" catalog and the URIs that
+/// are directly readable. `logic://mcu/state` is included even when the MCU
+/// control surface is disconnected — a direct read returns a meaningful
+/// `{ connected: false, … }` payload (not an empty probe), so hiding it from
+/// discovery while it stayed readable made the list disagree with both the
+/// docs and the readable surface (#215).
 struct ResourceProvider {
 
-    /// Full static resource set. Used for capability announcement and
-    /// back-compat with callers that read `.resources` synchronously.
+    /// Full static resource set — the single source of truth for both
+    /// capability announcement and `resources/list`.
     static let resources: [Resource] = baseResources
 
     /// Full static template set.
     static let templates: [Resource.Template] = baseTemplates
-
-    /// Dynamic resource list used at `resources/list` request time.
-    /// When `mcuConnected == false`, hides MCU-only resources so the LLM
-    /// doesn't waste tokens probing offline hardware.
-    static func resources(mcuConnected: Bool) -> [Resource] {
-        mcuConnected ? baseResources : baseResources.filter { !isMCUOnly($0.uri) }
-    }
-
-    /// Dynamic template list. Currently none of the templates are MCU-specific,
-    /// but the factory is exposed for symmetry + future growth.
-    static func templates(mcuConnected _: Bool) -> [Resource.Template] {
-        baseTemplates
-    }
 
     // MARK: - Declarations
 
@@ -243,10 +233,4 @@ struct ResourceProvider {
             mimeType: "application/json"
         ),
     ]
-
-    // MARK: - Filtering
-
-    private static func isMCUOnly(_ uri: String) -> Bool {
-        uri == "logic://mcu/state"
-    }
 }

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -396,11 +396,14 @@ actor LogicProServer {
                 }
             },
             listResources: { _ in
-                // Filter MCU-only resources when the control surface is offline
-                // so the LLM doesn't discover probes that would return empty.
-                let connected = await cache.getMCUConnection().isConnected
-                return ListResources.Result(
-                    resources: ResourceProvider.resources(mcuConnected: connected),
+                // #215: always advertise the full static catalog so discovery
+                // matches the documented "18 static resources" and the URIs
+                // that are directly readable. `logic://mcu/state` stays listed
+                // even when the MCU surface is offline — a direct read returns
+                // a meaningful `{ connected: false, … }` payload, so hiding it
+                // from the list while it remained readable was the discrepancy.
+                ListResources.Result(
+                    resources: ResourceProvider.resources,
                     nextCursor: nil
                 )
             },
@@ -414,9 +417,8 @@ actor LogicProServer {
                 }
             },
             listResourceTemplates: { _ in
-                let connected = await cache.getMCUConnection().isConnected
-                return ListResourceTemplates.Result(
-                    templates: ResourceProvider.templates(mcuConnected: connected)
+                ListResourceTemplates.Result(
+                    templates: ResourceProvider.templates
                 )
             }
         )

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -27,10 +27,12 @@ private let serverResourceText = sharedResourceText
         "logic_system",
         "logic_plugins",
     ])
-    // MCU disconnected by default in a fresh LogicProServer, so the list
-    // excludes `logic://mcu/state`.
+    // #215: the list always advertises the full static catalog, including
+    // `logic://mcu/state`, even in a fresh (MCU-disconnected) server — the
+    // resource is always directly readable and the docs advertise it as stable.
     let resourceURIs = Set(resources.resources.map(\.uri))
-    let expectedNonMCUResources: Set<String> = [
+    let expectedResources: Set<String> = [
+        "logic://mcu/state",
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -49,8 +51,9 @@ private let serverResourceText = sharedResourceText
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
     ]
-    #expect(expectedNonMCUResources.isSubset(of: resourceURIs))
-    #expect(!resourceURIs.contains("logic://mcu/state"))
+    #expect(expectedResources.isSubset(of: resourceURIs))
+    #expect(resourceURIs.contains("logic://mcu/state"))
+    #expect(resourceURIs.count == 18)
     let templateURIs = Set(templates.templates.map(\.uriTemplate))
     let expectedTemplates: Set<String> = [
         "logic://tracks/{index}",
@@ -313,10 +316,11 @@ private let serverResourceText = sharedResourceText
 
     let handlers = await server.makeHandlers()
     let resources = await handlers.listResources(ListResources.Parameters())
-    // MCU is disconnected in a fresh cache, so `logic://mcu/state` is filtered
-    // out. Non-MCU resources (markers, library/inventory, …) remain visible.
+    // #215: the full static catalog is always listed, including
+    // `logic://mcu/state`, even with a fresh (MCU-disconnected) cache.
     let uris = Set(resources.resources.map(\.uri))
-    let expectedNonMCUResources: Set<String> = [
+    let expectedResources: Set<String> = [
+        "logic://mcu/state",
         "logic://system/health",
         "logic://transport/state",
         "logic://tracks",
@@ -335,8 +339,9 @@ private let serverResourceText = sharedResourceText
         "logic://workflow-skills",
         "logic://workflow-skills/schema",
     ]
-    #expect(expectedNonMCUResources.isSubset(of: uris))
-    #expect(!uris.contains("logic://mcu/state"))
+    #expect(expectedResources.isSubset(of: uris))
+    #expect(uris.contains("logic://mcu/state"))
+    #expect(uris.count == 18)
     // server.start() runs serve() to completion then tears poller/channels/ports
     // down in reverse order. With serve recorded as a no-op, the tail section
     // executes immediately so stopPoller is captured too.

--- a/Tests/LogicProMCPTests/ResourceProviderTests.swift
+++ b/Tests/LogicProMCPTests/ResourceProviderTests.swift
@@ -127,18 +127,20 @@ struct ResourceProviderTests {
         #expect(timestamps == ["2026-06-23T00:00:00Z"])
     }
 
-    // MARK: - Dynamic MCU filtering
+    // MARK: - Stable resource surface (#215)
 
-    @Test("MCU-specific resources are hidden when MCU is disconnected")
-    func mcuFiltering() {
-        let connected = ResourceProvider.resources(mcuConnected: true).map(\.uri)
-        let disconnected = ResourceProvider.resources(mcuConnected: false).map(\.uri)
-
-        #expect(connected.contains("logic://mcu/state"))
-        #expect(!disconnected.contains("logic://mcu/state"))
-        // Non-MCU resources always visible.
-        #expect(disconnected.contains("logic://transport/state"))
-        #expect(disconnected.contains("logic://tracks"))
+    @Test("logic://mcu/state is always listed — matches the docs + readable surface")
+    func mcuStateAlwaysListed() {
+        // #215: `logic://mcu/state` used to be filtered out of the list when
+        // the MCU surface was disconnected, even though it stayed directly
+        // readable and the docs advertise a stable 18-resource catalog. It is
+        // now always present so list == docs == readable surface.
+        let uris = ResourceProvider.resources.map(\.uri)
+        #expect(uris.contains("logic://mcu/state"))
+        #expect(uris.contains("logic://transport/state"))
+        #expect(uris.contains("logic://tracks"))
+        // The documented stable surface is exactly 18 resources.
+        #expect(uris.count == 18)
     }
 
     // MARK: - Template placeholders


### PR DESCRIPTION
## Summary

- `resources/list` filtered out `logic://mcu/state` when the MCU surface was disconnected → 17 resources, while the docs advertise a stable **18** and `logic://mcu/state` stayed directly readable.
- The read returns a meaningful `{ connected: false, … }` payload (not an empty probe), so hiding it from discovery while it stayed readable was the discrepancy.
- Removed the dynamic MCU filtering: `resources/list` now always advertises the full static catalog → **list == docs == readable surface (18)**.

## Linked issue

- Closes #215

## Risk

- Priority: P2
- Area: resources
- User-visible impact: discovery clients now see all 18 documented resources regardless of MCU connection state; no resource became unreadable.
- Contract impact: `resources/list` no longer varies with runtime MCU state (it now matches the documented static catalog). Static `.resources` unchanged.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1933 passed** (replaced the dynamic-filter test with an always-listed test; net-zero count)
- [x] Targeted test: `ResourceProvider|LogicProServerHandler|VersionConsistency` (29 passed)
- [x] Real-usage (stdio JSON-RPC, MCU disconnected):

Evidence:
```text
resources/list → 18 resources; "logic://mcu/state" present: True
```
- Live E2E harness: added `resources/list includes mcu/state even when MCU disconnected (#215)` and put `mcu/state` in the required-resources set.

## Release readiness

- [x] Docs already say "18 static resources"; runtime now matches. `logic_system.help` text updated (`readable even when disconnected`).
- [x] Known limitations: none.

## Reviewer focus

- `ResourceProvider.resources(mcuConnected:)` / `templates(mcuConnected:)` / `isMCUOnly` removed; both list handlers return the static catalog directly.