### PR TITLE
fix(#219): logic_system.help rejects unknown categories with a typed error

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -864,6 +864,19 @@ def main():
     T("system.help mentions logic_project", r, lambda _: "logic_project" in help_text)
     T("system.help mentions logic_system", r, lambda _: "logic_system" in help_text)
 
+    # #219: an unknown help category returns a typed unknown_category error
+    # (never a silent fall-through to full help with isError:false).
+    r = call_tool(client, "logic_system", "help", params={"category": "bogus"})
+    _uc = tool_json(r) or {}
+    T("system.help unknown category returns typed unknown_category (#219)", r,
+      lambda _: is_error(r) and _uc.get("error") == "unknown_category"
+      and _uc.get("requested_category") == "bogus"
+      and isinstance(_uc.get("valid_categories"), list))
+    # A valid category still succeeds; an absent category still returns full help.
+    r = call_tool(client, "logic_system", "help", params={"category": "transport"})
+    T("system.help valid category succeeds", r,
+      lambda _: not is_error(r) and "logic_transport commands" in tool_text(r))
+
     r = call_tool(client, "logic_system", "health")
     health_text = tool_text(r)
     health = safe_json(health_text)

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -237,6 +237,23 @@ struct SystemDispatcher {
             return toolTextResult("State refresh triggered. Cache will be updated on next poll cycle.")
 
         case "help":
+            // #219: an unknown category used to fall through to full help with
+            // isError:false, hiding client typos. An absent category still means
+            // "full help", but a present-but-unrecognized category now returns a
+            // typed `unknown_category` State C that lists the valid categories.
+            if let requested = params["category"]?.stringValue,
+               !Self.validHelpCategories.contains(requested) {
+                let body = HonestContract.encodeStateC(
+                    error: .unknownCategory,
+                    hint: "Unknown help category '\(requested)'. "
+                        + "Valid categories: \(Self.validHelpCategories.joined(separator: ", ")).",
+                    extras: [
+                        "requested_category": requested,
+                        "valid_categories": Self.validHelpCategories,
+                    ]
+                )
+                return toolTextResult(body, isError: true)
+            }
             let category = stringParam(params, "category", default: "all")
             let helpText = Self.helpText(for: category)
             return toolTextResult(helpText)
@@ -250,6 +267,15 @@ struct SystemDispatcher {
     }
 
     // MARK: - Help text
+
+    /// Accepted `help` categories. `"all"` (and an absent category) returns the
+    /// full help; every other entry maps to a dispatcher-specific section in
+    /// `helpText(for:)`. Kept in lockstep with that switch by
+    /// `SystemDispatcherHelpTests` so a new dispatcher section can't drift out
+    /// of the accepted set.
+    static let validHelpCategories = [
+        "all", "transport", "tracks", "mixer", "midi", "edit", "navigate", "project", "system",
+    ]
 
     private static func helpText(for category: String) -> String {
         switch category {

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -271,8 +271,8 @@ struct SystemDispatcher {
     /// Accepted `help` categories. `"all"` (and an absent category) returns the
     /// full help; every other entry maps to a dispatcher-specific section in
     /// `helpText(for:)`. Kept in lockstep with that switch by
-    /// `SystemDispatcherHelpTests` so a new dispatcher section can't drift out
-    /// of the accepted set.
+    /// `testValidHelpCategoriesStayInLockstepWithHelpText` so a new dispatcher
+    /// section can't drift out of the accepted set.
     static let validHelpCategories = [
         "all", "transport", "tracks", "mixer", "midi", "edit", "navigate", "project", "system",
     ]

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -166,6 +166,11 @@ enum HonestContract {
         /// the response as expected rather than a malfunction. Terminal. #202.
         case commandNotExposed
         case indexOutOfRange
+        /// A `logic_system.help` category token that is not one of the known
+        /// dispatcher categories. Distinct from `.invalidParams` so a client
+        /// can tell a typo'd category apart from a missing required argument,
+        /// and so an unknown category never silently returns full help. #219.
+        case unknownCategory
 
         var rawValue: String {
             switch self {
@@ -209,6 +214,7 @@ enum HonestContract {
             case .unsupportedState: return "unsupported_state"
             case .commandNotExposed: return "command_not_exposed"
             case .indexOutOfRange: return "index_out_of_range"
+            case .unknownCategory: return "unknown_category"
             }
         }
     }
@@ -384,6 +390,11 @@ enum HonestContract {
         // — retrying the same index against the same project state can't succeed;
         // the client must read the parent collection for valid indices.
         FailureError.indexOutOfRange.rawValue,
+        // #219: an unknown help category is terminal — no channel/retry can turn
+        // a bad category token into a valid one; the caller must pick a listed
+        // category. (help doesn't route through the fallback chain; listed for
+        // classification consistency.)
+        FailureError.unknownCategory.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Tests/LogicProMCPTests/CommercialReadinessTests.swift
+++ b/Tests/LogicProMCPTests/CommercialReadinessTests.swift
@@ -316,6 +316,60 @@ private let toolText = sharedToolText
     }
 }
 
+@Test func testSystemHelpUnknownCategoryReturnsTypedError() async {
+    // #219: a present-but-unrecognized category must NOT silently fall back to
+    // full help. It returns a typed unknown_category State C listing the valid
+    // categories so a client can detect a typo.
+    let result = await SystemDispatcher.handle(
+        command: "help",
+        params: ["category": .string("bogus")],
+        router: ChannelRouter(),
+        cache: StateCache()
+    )
+    #expect(result.isError!)
+    let json = (try? JSONSerialization.jsonObject(with: Data(toolText(result).utf8))) as? [String: Any]
+    #expect(json?["error"] as? String == "unknown_category")
+    #expect(json?["success"] as? Bool == false)
+    #expect(json?["requested_category"] as? String == "bogus")
+    let valid = json?["valid_categories"] as? [String]
+    #expect(valid?.contains("transport") == true)
+    #expect(valid?.contains("all") == true)
+    // It must NOT leak the full help text on the error path.
+    #expect(!toolText(result).contains("logic_transport  — Transport control"))
+}
+
+@Test func testSystemHelpAbsentCategoryStillReturnsFullHelp() async {
+    // Regression guard: omitting `category` remains the full-help contract.
+    let result = await SystemDispatcher.handle(
+        command: "help",
+        params: [:],
+        router: ChannelRouter(),
+        cache: StateCache()
+    )
+    #expect(!(result.isError!))
+    #expect(toolText(result).contains("Logic Pro MCP"))
+}
+
+@Test func testValidHelpCategoriesStayInLockstepWithHelpText() async {
+    // Every accepted category (except "all") must map to a category-specific
+    // section; "all" must map to the overview. Prevents drift between the
+    // accepted set and the helpText switch.
+    for category in SystemDispatcher.validHelpCategories {
+        let result = await SystemDispatcher.handle(
+            command: "help",
+            params: ["category": .string(category)],
+            router: ChannelRouter(),
+            cache: StateCache()
+        )
+        #expect(!(result.isError!), "Accepted category \(category) must succeed")
+        if category == "all" {
+            #expect(toolText(result).contains("Logic Pro MCP"))
+        } else {
+            #expect(toolText(result).contains("logic_\(category) commands"))
+        }
+    }
+}
+
 @Test func testSystemHelpEnumeratesEveryRegisteredResourceAndTemplate() async {
     // The help overview is an LLM-facing capability-discovery surface: it must
     // ENUMERATE every registered resource/template, not merely claim the count.


### PR DESCRIPTION
## Summary

- `logic_system` `help` with an unrecognized `category` silently returned full help with `isError:false`, hiding client typos.
- A present-but-unknown category now returns a typed `unknown_category` State C listing the valid categories.
- An **absent** category still returns full help (unchanged); every valid category still works.

## Linked issue

- Closes #219

## Risk

- Priority: P3
- Area: docs (help surface)
- User-visible impact: typo'd categories are now detectable; agents no longer believe a bogus category was accepted.
- Contract impact: State C added for a previously-silent path; new `HonestContract.FailureError.unknownCategory` (`"unknown_category"`), added to `terminalErrorCodes`.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1936 passed** (1933 baseline + 3 new)
- [x] Targeted: help-category tests + lockstep test (4 passed)
- [x] Real-usage (stdio JSON-RPC):

Evidence:
```text
help {category:"bogus"}    → isError:True, error:"unknown_category", valid_categories:[…]
help {category:"transport"}→ isError:False (logic_transport commands)
help (no category)         → isError:False (full help)
```
- Live E2E harness: added `system.help unknown category returns typed unknown_category (#219)`.

## Release readiness

- [x] `validHelpCategories` is the single source of truth, kept in lockstep with `helpText` by `testValidHelpCategoriesStayInLockstepWithHelpText`.
- [x] Known limitations: none.

## Reviewer focus

- Absent-category → full-help contract preserved (regression test added).