### PR TITLE
fix(#216): unknown MCP tool returns JSON-RPC -32602, not a tool-result error

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -2291,13 +2291,18 @@ def main():
         r = call_tool(client, tool, cmd)
         T(f"{tool} rejects unknown command", r, lambda _: is_error(r))
 
-    # Unknown tool name
+    # #216: an unknown tool name is rejected at the protocol boundary with a
+    # JSON-RPC -32602 invalidParams error (not a result with isError:true).
     r = call_tool(client, "logic_imaginary", "anything")
-    T("unknown tool name rejected", r, lambda _: is_error(r))
+    T("unknown tool name rejected with JSON-RPC -32602 (#216)", r,
+      lambda _: isinstance(r, dict) and r.get("error", {}).get("code") == -32602)
+    T("unknown tool name error is not a tool result", r,
+      lambda _: isinstance(r, dict) and "result" not in r)
 
-    # Empty tool name
+    # Empty tool name is also not a registered tool → -32602.
     r = call_tool(client, "", "anything")
-    T("empty tool name rejected", r, lambda _: is_error(r))
+    T("empty tool name rejected with JSON-RPC -32602 (#216)", r,
+      lambda _: isinstance(r, dict) and r.get("error", {}).get("code") == -32602)
 
     # Missing command for all 8 tools
     for tool in ["logic_transport", "logic_tracks", "logic_mixer", "logic_midi",

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -38,6 +38,10 @@ enum ServerCatalog {
         PluginsDispatcher.tool,
     ]
 
+    /// O(1) membership set for the registered tool names — used by the
+    /// protocol-boundary validation to reject an unknown `tools/call` name.
+    static let toolNames: Set<String> = Set(tools.map(\.name))
+
     static func startupBanner(channelCount: Int) -> String {
         "Starting \(ServerConfig.serverName) v\(ServerConfig.serverVersion) — \(tools.count) tools, \(ResourceProvider.resources.count) resources, \(channelCount) channels"
     }
@@ -771,13 +775,36 @@ actor LogicProServer {
         }
     }
 
+    /// Protocol-boundary validation for `tools/call`, applied by the SDK
+    /// registration wrapper BEFORE dispatch. Returns the JSON-RPC error the
+    /// server must raise for a malformed request, or nil when the call is
+    /// well-formed enough to dispatch.
+    ///
+    /// #216: an unknown tool `name` is an invalid `tools/call` parameter, so it
+    /// is rejected with `-32602 invalidParams` at the protocol layer instead of
+    /// a successful `result` carrying `isError: true` (which protocol clients
+    /// classify as a tool-level failure, not an invalid MCP request). This is
+    /// the single source of truth for the wire behavior; the dispatch switch's
+    /// `default: "Unknown tool"` branch remains only as unreachable defense.
+    static func toolCallProtocolError(name: String, arguments: [String: Value]?) -> MCPError? {
+        guard ServerCatalog.toolNames.contains(name) else {
+            return .invalidParams("Unknown tool: \(name)")
+        }
+        return nil
+    }
+
     private func registerTools() async {
         let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }
         await server.withMethodHandler(CallTool.self) { params in
-            await handlers.callTool(params)
+            // #216: reject malformed tools/call requests at the protocol
+            // boundary with a JSON-RPC error before dispatch.
+            if let error = Self.toolCallProtocolError(name: params.name, arguments: params.arguments) {
+                throw error
+            }
+            return await handlers.callTool(params)
         }
     }
 

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -689,6 +689,17 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 // ═══════════════════════════════════════════════════════════════════════
 
 @Test func testE2EUnknownToolNameReturnsError() async {
+    // #216: on the wire an unknown tool is rejected at the protocol boundary
+    // with JSON-RPC -32602 invalidParams (the SDK registration wrapper throws
+    // this before dispatch). `handlers.callTool` itself keeps a defensive
+    // "Unknown tool" tool-result for its unreachable internal path.
+    let error = LogicProServer.toolCallProtocolError(
+        name: "logic_nonexistent",
+        arguments: ["command": .string("test")]
+    )
+    #expect(error == .invalidParams("Unknown tool: logic_nonexistent"))
+    #expect(error?.code == -32602)
+
     let h = await makeE2EHandlers()
     let r = await h.callTool(CallTool.Parameters(name: "logic_nonexistent", arguments: ["command": .string("test")]))
     #expect(r.isError!)
@@ -696,9 +707,23 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 }
 
 @Test func testE2EEmptyToolNameReturnsError() async {
+    // #216: an empty tool name is not a registered tool → protocol -32602.
+    let error = LogicProServer.toolCallProtocolError(name: "", arguments: ["command": .string("test")])
+    #expect(error?.code == -32602)
+
     let h = await makeE2EHandlers()
     let r = await h.callTool(CallTool.Parameters(name: "", arguments: ["command": .string("test")]))
     #expect(r.isError!)
+}
+
+@Test func testKnownToolPassesProtocolBoundary() async {
+    // Every registered tool must pass the boundary check (no false -32602).
+    for name in ServerCatalog.tools.map(\.name) {
+        #expect(
+            LogicProServer.toolCallProtocolError(name: name, arguments: ["command": .string("noop")]) == nil,
+            "\(name) must not be rejected at the protocol boundary"
+        )
+    }
 }
 
 @Test func testE2EAllDispatchersHandleMissingCommandGracefully() async {


### PR DESCRIPTION
## Summary

- Calling a non-existent tool returned a successful JSON-RPC `result` with `isError:true`; protocol clients read that as a tool-level failure, not an invalid MCP request.
- The `tools/call` registration wrapper now validates the tool `name` at the protocol boundary and throws `MCPError.invalidParams` (**-32602**) for an unknown/empty name **before dispatch** — the swift-sdk serializes it as a JSON-RPC error (no `result`).
- `LogicProServer.toolCallProtocolError(name:arguments:)` is the single source of truth for the wire behavior; the dispatch switch's `"Unknown tool"` default remains only as unreachable defense-in-depth. `handlers.callTool` stays non-throwing → **no call-site churn**.

## Linked issue

- Closes #216

## Risk

- Priority: P2
- Area: resources / protocol
- User-visible impact: protocol clients now get an unambiguous `-32602` for an unknown tool.
- Contract impact: `tools/call` with an unknown name changes from `result{isError:true}` → JSON-RPC error `-32602`. Valid tool calls unchanged.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1934 passed** (1933 baseline + net 1)
- [x] Targeted: `EndToEnd|LogicProServerHandler` (120 passed), incl. `toolCallProtocolError` boundary + every-known-tool-passes tests
- [x] Real-usage (stdio JSON-RPC wire):

Evidence:
```text
tools/call name="no_such_tool" → JSON-RPC error code -32602, no "result"
tools/call name=""             → JSON-RPC error code -32602, no "result"
tools/call name="logic_system" → result isError:false (unaffected)
```
- Live E2E harness: `unknown tool name rejected with JSON-RPC -32602 (#216)` + "not a tool result" + empty-name variant.

## Release readiness

- [x] Every registered tool verified to pass the boundary (no false -32602).
- [x] Known limitations: none.

## Reviewer focus

- Wrapper throws before `handlers.callTool`; the defensive `default:` branch is now unreachable in production.