### PR TITLE
fix(#217): missing required command is rejected with JSON-RPC -32602

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -2299,12 +2299,21 @@ def main():
     r = call_tool(client, "", "anything")
     T("empty tool name rejected", r, lambda _: is_error(r))
 
-    # Missing command for all 8 tools
+    # #217: a tools/call with a missing/empty required `command` is rejected at
+    # the protocol boundary with JSON-RPC -32602 (not dispatched as an empty
+    # command that returns a misleading domain "Unknown … command: ." error).
     for tool in ["logic_transport", "logic_tracks", "logic_mixer", "logic_midi",
                  "logic_edit", "logic_navigate"]:
+        # missing `arguments` entirely
+        r = client.send({"jsonrpc": "2.0", "id": nid(), "method": "tools/call",
+                         "params": {"name": tool}})
+        T(f"{tool} missing arguments → JSON-RPC -32602 (#217)", r,
+          lambda _, resp=r: isinstance(resp, dict) and resp.get("error", {}).get("code") == -32602)
+        # present-but-empty `arguments` (no command key)
         r = client.send({"jsonrpc": "2.0", "id": nid(), "method": "tools/call",
                          "params": {"name": tool, "arguments": {}}})
-        T(f"{tool} handles missing command", r, lambda _: r is not None)
+        T(f"{tool} missing command → JSON-RPC -32602 (#217)", r,
+          lambda _, resp=r: isinstance(resp, dict) and resp.get("error", {}).get("code") == -32602)
 
     # Fail-closed semantic payload checks. These are environment-independent:
     # the dispatcher must reject before it can route to Logic/CoreMIDI.

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -771,13 +771,39 @@ actor LogicProServer {
         }
     }
 
+    /// Protocol-boundary validation for `tools/call`, applied by the SDK
+    /// registration wrapper BEFORE dispatch. Returns the JSON-RPC error the
+    /// server must raise for a malformed request, or nil when the call is
+    /// well-formed enough to dispatch.
+    ///
+    /// #217: every tool schema marks `command` as required. A `tools/call` with
+    /// a missing `arguments` object or a missing/empty `command` used to
+    /// dispatch as an empty command and return a misleading domain error
+    /// ("Unknown system command: ."). It is now rejected at the protocol layer
+    /// with `-32602 invalidParams` naming the missing field. This validates the
+    /// PRESENCE of `command` only — a present command whose command-specific
+    /// params are missing (e.g. `set_tempo` with no `tempo`) still dispatches
+    /// and returns the dispatcher's typed domain `invalid_params` State C.
+    static func toolCallProtocolError(name: String, arguments: [String: Value]?) -> MCPError? {
+        let command = arguments?["command"]?.stringValue
+        if command == nil || command?.isEmpty == true {
+            return .invalidParams("Missing required argument 'command' for tool '\(name)'")
+        }
+        return nil
+    }
+
     private func registerTools() async {
         let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
             await handlers.listTools(params)
         }
         await server.withMethodHandler(CallTool.self) { params in
-            await handlers.callTool(params)
+            // #217: reject a tools/call with a missing/empty required `command`
+            // at the protocol boundary with a JSON-RPC error before dispatch.
+            if let error = Self.toolCallProtocolError(name: params.name, arguments: params.arguments) {
+                throw error
+            }
+            return await handlers.callTool(params)
         }
     }
 

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -701,7 +701,36 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect(r.isError!)
 }
 
+@Test func testE2EMissingCommandRejectedAtProtocolBoundary() async {
+    // #217: on the wire, a tools/call with a missing `arguments` object or a
+    // missing/empty `command` is rejected with JSON-RPC -32602 invalidParams
+    // (the SDK registration wrapper throws before dispatch), instead of
+    // dispatching as an empty command and returning "Unknown … command: .".
+    let toolNames = [
+        "logic_transport", "logic_tracks", "logic_mixer", "logic_midi",
+        "logic_edit", "logic_navigate", "logic_project", "logic_system",
+    ]
+    for name in toolNames {
+        // Missing `arguments` object entirely.
+        let missingArgs = LogicProServer.toolCallProtocolError(name: name, arguments: nil)
+        #expect(missingArgs?.code == -32602, "\(name): missing arguments → -32602")
+        // Present-but-empty `arguments` (no `command` key).
+        let emptyArgs = LogicProServer.toolCallProtocolError(name: name, arguments: [:])
+        #expect(emptyArgs?.code == -32602, "\(name): empty arguments → -32602")
+        // Empty-string `command`.
+        let emptyCmd = LogicProServer.toolCallProtocolError(name: name, arguments: ["command": .string("")])
+        #expect(emptyCmd?.code == -32602, "\(name): empty command → -32602")
+        // A present command passes the boundary (params validated in dispatch).
+        let present = LogicProServer.toolCallProtocolError(name: name, arguments: ["command": .string("health")])
+        #expect(present == nil, "\(name): present command must pass the boundary")
+    }
+    #expect(LogicProServer.toolCallProtocolError(name: "logic_system", arguments: [:])
+        == .invalidParams("Missing required argument 'command' for tool 'logic_system'"))
+}
+
 @Test func testE2EAllDispatchersHandleMissingCommandGracefully() async {
+    // Defensive internal path: `handlers.callTool` (bypassing the wrapper) must
+    // still return a non-empty result rather than crash for an empty command.
     let h = await makeE2EHandlers()
     let toolNames = [
         "logic_transport", "logic_tracks", "logic_mixer", "logic_midi",


### PR DESCRIPTION
## Summary

- A `tools/call` with a missing `arguments` object or a missing/empty `command` dispatched as an empty command and returned a misleading domain error (`Unknown system command: .`), even though every tool schema marks `command` required.
- The registration wrapper now rejects a missing/empty `command` at the protocol boundary with `MCPError.invalidParams` (**-32602**) naming the missing field, before dispatch.
- **Presence-only** validation: a present command whose command-specific params are missing (e.g. `set_tempo` without `tempo`) still dispatches and returns the dispatcher's typed domain `invalid_params` State C — that separation is preserved and verified.

## Linked issue

- Closes #217

## Risk

- Priority: P2
- Area: workflow / protocol
- User-visible impact: malformed clients get a clear schema/protocol error instead of a misleading domain error.
- Contract impact: missing/empty `command` → JSON-RPC `-32602`. Command-present calls unchanged.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1934 passed** (1933 baseline + net 1)
- [x] Targeted: `EndToEnd` (109 passed), incl. boundary test across all 8 tools
- [x] Real-usage (stdio JSON-RPC wire):

Evidence:
```text
tools/call {name:"logic_system"}                         → JSON-RPC -32602
tools/call {name:"logic_system","arguments":{}}          → JSON-RPC -32602
tools/call {name:"logic_transport",args:{command:"set_tempo"}} → result isError:true, error:"invalid_params" (domain, unchanged)
tools/call {name:"logic_system",args:{command:"help"}}   → result isError:false (unaffected)
```
- Live E2E harness: `<tool> missing arguments/command → JSON-RPC -32602 (#217)`.

## Release readiness

- [x] Semantic-payload (`invalid_params`) domain errors verified unchanged.
- [x] Known limitations: none.

## Reviewer focus

- Boundary rejects `command` absence only; deeper param validation stays in the dispatchers.