### PR TITLE
fix(#218): list methods reject invalid pagination cursors with -32602

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -848,6 +848,19 @@ def main():
     }
     T("resources/templates/list includes required templates", r, lambda r: required_template_uris.issubset(template_uris))
 
+    # #218: invalid pagination cursors are rejected with JSON-RPC -32602 (the
+    # server paginates into a single page and never issues a nextCursor), not
+    # silently ignored (which returned a full first page as if no cursor).
+    for method in ["tools/list", "resources/list", "resources/templates/list"]:
+        r = client.send({"jsonrpc": "2.0", "id": nid(), "method": method,
+                         "params": {"cursor": "bogus"}})
+        T(f"{method} rejects invalid cursor with -32602 (#218)", r,
+          lambda _, resp=r: isinstance(resp, dict) and resp.get("error", {}).get("code") == -32602)
+        # A cursor-less call on the same method still returns a normal page.
+        r = client.send({"jsonrpc": "2.0", "id": nid(), "method": method, "params": {}})
+        T(f"{method} without cursor still returns a page (#218)", r,
+          lambda _, resp=r: isinstance(resp, dict) and "result" in resp)
+
     # ═══════════════════════════════════════════════════════════════
     # §2 System Diagnostics (15 tests)
     # ═══════════════════════════════════════════════════════════════

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -771,10 +771,27 @@ actor LogicProServer {
         }
     }
 
+    /// #218: MCP list methods paginate everything into a single page — the
+    /// server never issues a `nextCursor`. So ANY cursor a client sends is a
+    /// stale/fabricated continuation token. Per the MCP pagination guidance,
+    /// reject it with `-32602 invalidParams` instead of silently returning the
+    /// first page (which makes a fresh read indistinguishable from a broken
+    /// continuation and hides client/harness pagination bugs). Absent cursor
+    /// (nil) is the normal first-page read and passes.
+    static func invalidCursorError(_ cursor: String?, method: String) -> MCPError? {
+        guard let cursor else { return nil }
+        return .invalidParams(
+            "Invalid pagination cursor for \(method): \"\(cursor)\". "
+                + "This server returns all results in a single page and never issues a nextCursor, "
+                + "so no cursor value is valid."
+        )
+    }
+
     private func registerTools() async {
         let handlers = makeHandlers(dialogPresent: { AXLogicProElements.dialogPresent() })
         await server.withMethodHandler(ListTools.self) { params in
-            await handlers.listTools(params)
+            if let error = Self.invalidCursorError(params.cursor, method: "tools/list") { throw error }
+            return await handlers.listTools(params)
         }
         await server.withMethodHandler(CallTool.self) { params in
             await handlers.callTool(params)
@@ -786,7 +803,8 @@ actor LogicProServer {
     private func registerResources() async {
         let handlers = makeHandlers()
         await server.withMethodHandler(ListResources.self) { params in
-            await handlers.listResources(params)
+            if let error = Self.invalidCursorError(params.cursor, method: "resources/list") { throw error }
+            return await handlers.listResources(params)
         }
 
         await server.withMethodHandler(ReadResource.self) { params in
@@ -794,7 +812,8 @@ actor LogicProServer {
         }
 
         await server.withMethodHandler(ListResourceTemplates.self) { params in
-            await handlers.listResourceTemplates(params)
+            if let error = Self.invalidCursorError(params.cursor, method: "resources/templates/list") { throw error }
+            return await handlers.listResourceTemplates(params)
         }
     }
 

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -69,6 +69,21 @@ private let serverResourceText = sharedResourceText
     #expect(expectedTemplates.isSubset(of: templateURIs))
 }
 
+@Test func testInvalidPaginationCursorRejectedWithInvalidParams() {
+    // #218: the server paginates into a single page and never issues a
+    // nextCursor, so ANY client cursor is invalid → JSON-RPC -32602. An absent
+    // cursor (nil) is the normal first-page read and must pass.
+    for method in ["tools/list", "resources/list", "resources/templates/list"] {
+        #expect(LogicProServer.invalidCursorError("bogus", method: method)?.code == -32602)
+        #expect(LogicProServer.invalidCursorError("", method: method)?.code == -32602)
+        #expect(LogicProServer.invalidCursorError(nil, method: method) == nil)
+    }
+    // The error message identifies the offending method + cursor.
+    let err = LogicProServer.invalidCursorError("abc", method: "tools/list")
+    #expect(err?.errorDescription?.contains("tools/list") == true)
+    #expect(err?.errorDescription?.contains("abc") == true)
+}
+
 @Test func testLogicProServerHandlersDispatchToolNamesWithoutStartingServer() async {
     let server = LogicProServer()
     let handlers = await server.makeHandlers()


### PR DESCRIPTION
## Summary

- `tools/list`, `resources/list`, and `resources/templates/list` silently ignored a supplied `cursor` and returned the first full page — a client couldn't distinguish a fresh read from a broken continuation token.
- The server paginates everything into a single page and never issues a `nextCursor`, so **any** client cursor is a stale/fabricated token. Each list registration wrapper now rejects a non-nil cursor with `MCPError.invalidParams` (**-32602**) per the MCP pagination guidance.
- An absent cursor (the normal first-page read) still returns a page.

## Linked issue

- Closes #218

## Risk

- Priority: P2
- Area: resources / protocol
- User-visible impact: clients get an explicit invalid-cursor error instead of a misleading first page.
- Contract impact: a non-nil `cursor` on any list method → JSON-RPC `-32602`. Cursor-less list calls unchanged.

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1934 passed** (1933 baseline + 1 new)
- [x] Targeted: `LogicProServerHandler` (12 passed), incl. `invalidCursorError` across all 3 methods
- [x] Real-usage (stdio JSON-RPC wire):

Evidence:
```text
tools/list              {cursor:"bogus"} → -32602 | {} → result ok
resources/list          {cursor:"bogus"} → -32602 | {} → result ok
resources/templates/list{cursor:"bogus"} → -32602 | {} → result ok
```
- Live E2E harness: `<method> rejects invalid cursor with -32602 (#218)` + a cursor-less page check per method.

## Release readiness

- [x] First-page (no-cursor) reads verified unchanged.
- [x] Known limitations: the server is intentionally single-page; if pagination is ever added, emit a real `nextCursor` and accept it here.

## Reviewer focus

- `invalidCursorError` treats an empty-string cursor as invalid too (it is still a provided, non-issuable token).