### PR TITLE
fix(#221): prove the mutation gate releases after a failed op (concurrent refusal is correct serialization)

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -2331,6 +2331,20 @@ def main():
             lambda _, resp=r: is_error(resp) and "invalid_params" in tool_text(resp),
         )
 
+    # #221: a fast-FAILING mutation must release the mutation gate so an
+    # immediately-following (serial) mutation is never falsely blocked with
+    # `mutating_operation_in_progress`. rename_marker and set_cycle_range both
+    # fail closed with State C (not_implemented) with or without a live
+    # document and perform no mutation, so this is side-effect-free. NOTE: a
+    # PARALLEL overlap refusal (safe_to_retry:true) is CORRECT serialization,
+    # not a malfunction — the complete-surface contract run fires mutations
+    # serially (client.send awaits each response before the next request).
+    _ = call_tool(client, "logic_navigate", "rename_marker", params={"index": 0, "name": "gate-probe"})
+    r = call_tool(client, "logic_transport", "set_cycle_range", params={"start": 1, "end": 2})
+    _gate = tool_json(r) or {}
+    T("serial mutation after a failed mutation is not gate-blocked (#221)", r,
+      lambda _: _gate.get("error") != "mutating_operation_in_progress")
+
     # ═══════════════════════════════════════════════════════════════
     # §13 Concurrent Stress Test (5 tests)
     # ═══════════════════════════════════════════════════════════════

--- a/Tests/LogicProMCPTests/Issue221MutationGateReleaseTests.swift
+++ b/Tests/LogicProMCPTests/Issue221MutationGateReleaseTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #221: a parallel mutation probe reported a likely false positive — after
+/// `logic_navigate.rename_marker` failed quickly, a later `logic_edit.quantize`
+/// was rejected with `mutating_operation_in_progress(active=rename_marker)`.
+///
+/// Root cause analysis: the MCP swift-sdk dispatches each request in its own
+/// Task (Server.swift), so two mutations fired in parallel genuinely overlap
+/// and the gate CORRECTLY serializes them (one is refused, `safe_to_retry`).
+/// The only way this could be a real defect is if the gate failed to release
+/// when a mutating op FAILED (as opposed to succeeded) — leaving a stuck gate
+/// that blocks all later mutations even under serial use. These tests lock in
+/// the guarantee that a completed mutating op — success OR failure — always
+/// frees the gate, and that a genuinely-overlapping refusal is honest and
+/// transient (`safe_to_retry: true`, resolves once the in-flight op finishes).
+@Suite("Issue221 mutation gate release")
+struct Issue221MutationGateReleaseTests {
+    private func json(_ result: CallTool.Result) -> [String: Any]? {
+        sharedJSONObject(sharedToolText(result))
+    }
+
+    @Test("a fast-FAILING mutating op releases the gate so the next mutation is not blocked")
+    func failingMutationReleasesGateForNextMutation() async {
+        let gate = LogicMutationGate()
+
+        // rename_marker fails fast with a terminal State C — the #221 trigger.
+        let first = await LogicProServer.runWithDeadline(
+            tool: "logic_navigate",
+            command: "rename_marker",
+            deadlineOverride: 5,
+            mutationGate: gate
+        ) {
+            toolTextResult(
+                HonestContract.encodeStateC(error: .notImplemented, hint: "rename_marker not implemented"),
+                isError: true
+            )
+        }
+        #expect(first.isError!)
+        #expect(json(first)?["error"] as? String == "not_implemented")
+        // The gate MUST be free the instant the failed op returns.
+        #expect(gate.currentOperation() == nil, "a failed mutating op must release the gate")
+
+        // The follow-up quantize must NOT be refused by the already-finished
+        // rename_marker — this was the reported false block.
+        let second = await LogicProServer.runWithDeadline(
+            tool: "logic_edit",
+            command: "quantize",
+            deadlineOverride: 5,
+            mutationGate: gate
+        ) {
+            toolTextResult(HonestContract.encodeStateC(error: .channelsExhausted), isError: true)
+        }
+        #expect(json(second)?["error"] as? String != "mutating_operation_in_progress",
+                "quantize must not be blocked by the already-completed rename_marker")
+        #expect(gate.currentOperation() == nil)
+    }
+
+    @Test("a fast-succeeding mutating op releases the gate")
+    func succeedingMutationReleasesGate() async {
+        let gate = LogicMutationGate()
+        _ = await LogicProServer.runWithDeadline(
+            tool: "logic_tracks", command: "mute", deadlineOverride: 5, mutationGate: gate
+        ) {
+            toolTextResult(HonestContract.encodeStateA(extras: ["index": 0]))
+        }
+        #expect(gate.currentOperation() == nil)
+
+        let next = await LogicProServer.runWithDeadline(
+            tool: "logic_tracks", command: "solo", deadlineOverride: 5, mutationGate: gate
+        ) {
+            toolTextResult(HonestContract.encodeStateA(extras: ["index": 0]))
+        }
+        #expect(json(next)?["error"] as? String != "mutating_operation_in_progress")
+    }
+
+    @Test("LogicMutationGate.release frees the gate regardless of op outcome")
+    func gateReleaseIsOutcomeIndependent() {
+        let gate = LogicMutationGate()
+        // Simulate a failed op: acquire then release (the outcome the op
+        // reported is irrelevant to the gate — release always frees it).
+        let claim = gate.tryAcquire(operation: "logic_navigate.rename_marker")
+        #expect(claim != nil)
+        #expect(gate.currentOperation() == "logic_navigate.rename_marker")
+        if let claim { gate.release(claim) }
+        #expect(gate.currentOperation() == nil)
+        // A different mutation can now acquire immediately.
+        let next = gate.tryAcquire(operation: "logic_edit.quantize")
+        #expect(next != nil)
+    }
+
+    @Test("a genuinely-overlapping mutation is refused honestly and the refusal is transient")
+    func concurrentOverlapRefusalIsHonestAndTransient() async {
+        let gate = LogicMutationGate()
+        let blocker = OverlapBlocker()
+        let firstResult = ResultBox()
+
+        // Op A enters work() and blocks — it holds the gate for the duration.
+        let runnerA = Task {
+            let r = await LogicProServer.runWithDeadline(
+                tool: "logic_navigate", command: "rename_marker", deadlineOverride: 30, mutationGate: gate
+            ) {
+                blocker.enterAndWait()
+                return toolTextResult(HonestContract.encodeStateC(error: .notImplemented), isError: true)
+            }
+            firstResult.store(r)
+        }
+
+        // Wait until A is genuinely inside work() holding the gate.
+        while !blocker.hasEntered() { await Task.yield() }
+
+        // Op B overlaps A → correctly refused, safe_to_retry, names A.
+        let refused = await LogicProServer.runWithDeadline(
+            tool: "logic_edit", command: "quantize", deadlineOverride: 5, mutationGate: gate
+        ) {
+            toolTextResult(HonestContract.encodeStateA())
+        }
+        #expect(json(refused)?["error"] as? String == "mutating_operation_in_progress")
+        #expect(json(refused)?["active_operation"] as? String == "logic_navigate.rename_marker")
+        #expect((json(refused)?["safe_to_retry"] as? Bool) == true)
+        #expect((json(refused)?["write_attempted"] as? Bool) == false)
+
+        // A completes → gate frees → B's retry now succeeds (transient refusal).
+        blocker.unblock()
+        await runnerA.value
+        #expect(gate.currentOperation() == nil)
+
+        let retried = await LogicProServer.runWithDeadline(
+            tool: "logic_edit", command: "quantize", deadlineOverride: 5, mutationGate: gate
+        ) {
+            toolTextResult(HonestContract.encodeStateA())
+        }
+        #expect(json(retried)?["error"] as? String != "mutating_operation_in_progress")
+    }
+
+    // MARK: - Test doubles
+
+    private final class OverlapBlocker: @unchecked Sendable {
+        private let lock = NSLock()
+        private var entered = false
+        private let gate = DispatchSemaphore(value: 0)
+
+        func enterAndWait() {
+            lock.lock(); entered = true; lock.unlock()
+            gate.wait()
+        }
+        func hasEntered() -> Bool { lock.lock(); defer { lock.unlock() }; return entered }
+        func unblock() { gate.signal() }
+    }
+
+    private final class ResultBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: CallTool.Result?
+        func store(_ r: CallTool.Result) { lock.lock(); value = r; lock.unlock() }
+    }
+}


### PR DESCRIPTION
## Summary

- Root cause: the MCP swift-sdk dispatches each request in **its own `Task`** (`Server.swift`), so two mutations fired in parallel genuinely overlap and the mutation gate **correctly serializes** them — one is refused with `mutating_operation_in_progress` + `safe_to_retry:true`. That is the designed safety behavior, not a malfunction.
- The only way #221 could be a real defect is if the gate failed to **release when a mutating op FAILED** (vs succeeded), stranding a stuck gate that blocks later mutations even under serial use. This PR proves that never happens.
- Adds regression coverage + an honest serial/parallel classification in the live harness.

## Linked issue

- Closes #221

## What was verified

- A completed mutating op — **success or failure** — always frees the gate (`runWithDeadline` releases before resuming the caller).
- `LogicMutationGate.release` is outcome-independent.
- A genuinely-overlapping mutation is refused honestly: names the active op, `safe_to_retry:true`, `write_attempted:false`, and the refusal is **transient** — a retry succeeds once the in-flight op finishes.
- The exact reported scenario: after `rename_marker` fails fast, a following `quantize` is **not** gate-blocked.

## Risk

- Priority: P2
- Area: demo / workflow
- Contract impact: none (behavior unchanged; adds tests + harness classification + docs).

## Verification

- [x] `swift build`
- [x] `swift test --no-parallel` — **1937 passed** (1933 baseline + 4 new)
- [x] Targeted: `Issue221` suite (4 passed)
- [x] Real-usage (stdio JSON-RPC wire):

Evidence:
```text
rename_marker (serial)      → error "not_implemented"
quantize (serial follow-up) → NOT "mutating_operation_in_progress" (gate released)
```
- Live E2E harness: `serial mutation after a failed mutation is not gate-blocked (#221)`; the complete-surface contract run fires mutations serially, and a parallel overlap refusal (`safe_to_retry:true`) is documented as expected serialization.

## Release readiness

- [x] Known limitation documented: under intentional parallel probing, a `mutating_operation_in_progress` (safe_to_retry) refusal is expected — clients retry once the in-flight mutation completes.

## Reviewer focus

- `runWithDeadline` releases the gate inside the work task *before* resuming the continuation, so a serial follow-up can never see a stale holder.