### PR TITLE
feat(mcp): v3.9 WS4 — MCP protocol pack (T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **MCP resource subscriptions.** `initialize` now advertises `resources.subscribe:true`, and the server handles `resources/subscribe` / `resources/unsubscribe` for listed resources and concrete resource-template URIs. State-poller updates emit `notifications/resources/updated` for subscribed URIs only when the stable cache payload `data` changes; volatile envelope fields such as `fetched_at`, `cache_age_sec`, and `ax_occluded` are excluded from the diff.
+- **Workflow prompts.** `initialize` now advertises prompts support and `prompts/list` / `prompts/get` expose the existing `WorkflowSkillCatalog` data as MCP prompts, without duplicating workflow definitions.
+- **Tool output schemas and structured content.** All 10 tools now advertise `outputSchema`. `tools/call` preserves the original text response and additionally attaches `structuredContent` whenever that text is a JSON object.
+
 ### Changed
 
 - **BREAKING: `logic_midi` send-only success responses now return Honest Contract State B JSON envelopes.** CoreMIDI/MMC send-only paths (`send_*`, `play_sequence`, `step_input`, `create_virtual_port`, and time-based MMC commands) no longer return plain text on success. Those CoreMIDI/MMC responses now include `success`, `verified`, `state`, `reason`, `operation`, `legacy_message`, and operation-specific byte/message/port details. `mmc_locate` with `bar` is unchanged and keeps its transport readback path.

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -297,6 +297,7 @@ def initialize(client):
     })
     if not resp or "result" not in resp:
         return False
+    client.initialize_response = resp
     client.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
     time.sleep(3)
     return True
@@ -375,6 +376,16 @@ def list_resources(client, req_id=None):
 def list_resource_templates(client, req_id=None):
     return client.send({"jsonrpc": "2.0", "id": req_id or nid(),
                         "method": "resources/templates/list", "params": {}})
+
+
+def list_prompts(client, req_id=None):
+    return client.send({"jsonrpc": "2.0", "id": req_id or nid(),
+                        "method": "prompts/list", "params": {}})
+
+
+def get_prompt(client, name, req_id=None):
+    return client.send({"jsonrpc": "2.0", "id": req_id or nid(),
+                        "method": "prompts/get", "params": {"name": name}})
 
 
 # ── Test runner ──
@@ -859,9 +870,15 @@ def main():
             sys.exit(2)
 
     # ═══════════════════════════════════════════════════════════════
-    # §1 Protocol Contract (10 tests)
+    # §1 Protocol Contract
     # ═══════════════════════════════════════════════════════════════
     section("§1 Protocol Contract")
+
+    init_caps = getattr(client, "initialize_response", {}).get("result", {}).get("capabilities", {})
+    T("initialize advertises resources subscribe", getattr(client, "initialize_response", None),
+      lambda _: init_caps.get("resources", {}).get("subscribe") is True)
+    T("initialize advertises prompts capability", getattr(client, "initialize_response", None),
+      lambda _: init_caps.get("prompts", {}).get("listChanged") is False)
 
     r = list_tools(client)
     tools = r.get("result", {}).get("tools", []) if r else []
@@ -871,6 +888,30 @@ def main():
                  "logic_edit", "logic_navigate", "logic_project", "logic_system",
                  "logic_audio", "logic_plugins"]:
         T(f"  tool '{name}' present", r, lambda _, n=name: n in tool_names)
+    T("tools/list advertises outputSchema for every tool", r,
+      lambda _: len(tools) == 10 and all(isinstance(t.get("outputSchema"), dict) for t in tools))
+
+    r = call_tool(client, "logic_system", "health")
+    health_text = tool_text(r)
+    health_json = safe_json(health_text)
+    T("tools/call includes structuredContent for JSON object text", r,
+      lambda _: isinstance(r.get("result", {}).get("structuredContent"), dict)
+      and r.get("result", {}).get("structuredContent") == health_json)
+
+    r = list_prompts(client)
+    prompts = r.get("result", {}).get("prompts", []) if r else []
+    T("prompts/list returns workflow prompts", r,
+      lambda _: any(p.get("name") == "logic.workflow.readiness.project" for p in prompts))
+    if prompts:
+        prompt_name = prompts[0].get("name")
+        r = get_prompt(client, prompt_name)
+        prompt_messages = r.get("result", {}).get("messages", []) if r else []
+        prompt_text = prompt_messages[0].get("content", {}).get("text", "") if prompt_messages else ""
+        prompt_json = safe_json(prompt_text)
+        T("prompts/get returns workflow JSON", r,
+          lambda _: isinstance(prompt_json, dict) and prompt_json.get("id") == prompt_name)
+    else:
+        T("prompts/get returns workflow JSON", r, lambda _: False)
 
     r = list_resources(client)
     resources = r.get("result", {}).get("resources", []) if r else []

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -26,16 +26,16 @@ struct ServerCompositionSnapshot: Sendable, Equatable {
 
 enum ServerCatalog {
     static let tools: [Tool] = [
-        TransportDispatcher.tool,
-        TrackDispatcher.tool,
-        MixerDispatcher.tool,
-        MIDIDispatcher.tool,
-        EditDispatcher.tool,
-        NavigateDispatcher.tool,
-        ProjectDispatcher.tool,
-        AudioDispatcher.tool,
-        SystemDispatcher.tool,
-        PluginsDispatcher.tool,
+        toolWithOutputSchema(TransportDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(TrackDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(MixerDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(MIDIDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(EditDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(NavigateDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(ProjectDispatcher.tool, outputSchema: honestContractOutputSchema()),
+        toolWithOutputSchema(AudioDispatcher.tool, outputSchema: genericObjectOutputSchema()),
+        toolWithOutputSchema(SystemDispatcher.tool, outputSchema: genericObjectOutputSchema()),
+        toolWithOutputSchema(PluginsDispatcher.tool, outputSchema: honestContractOutputSchema()),
     ]
 
     /// O(1) membership set for the registered tool names — used by the
@@ -234,6 +234,8 @@ actor LogicProServer {
     private let router: ChannelRouter
     private let cache: StateCache
     private let poller: StatePoller
+    private let resourceSubscriptions: ResourceSubscriptionRegistry
+    private let resourceNotifier: ResourceUpdateNotifier
     private let portManager: MIDIPortManager
     private let manualValidationStore: ManualValidationStore
 
@@ -257,18 +259,26 @@ actor LogicProServer {
         runtimeOverrides: LogicProServerRuntimeOverrides? = nil,
         pollerRuntime: StatePoller.Runtime = .production
     ) {
-        self.runtimeOverrides = runtimeOverrides
-        self.server = Server(
+        let server = Server(
             name: ServerConfig.serverName,
             version: ServerConfig.serverVersion,
             capabilities: .init(
-                resources: .init(subscribe: false, listChanged: false),
+                prompts: .init(listChanged: false),
+                resources: .init(subscribe: true, listChanged: false),
                 tools: .init(listChanged: false)
             )
         )
+        let router = ChannelRouter()
+        let cache = StateCache()
+        let resourceSubscriptions = ResourceSubscriptionRegistry()
+        let resourceNotifier = ResourceUpdateNotifier(registry: resourceSubscriptions)
 
-        self.router = ChannelRouter()
-        self.cache = StateCache()
+        self.runtimeOverrides = runtimeOverrides
+        self.server = server
+        self.router = router
+        self.cache = cache
+        self.resourceSubscriptions = resourceSubscriptions
+        self.resourceNotifier = resourceNotifier
         self.portManager = MIDIPortManager()
         self.manualValidationStore = ManualValidationStore()
 
@@ -307,7 +317,20 @@ actor LogicProServer {
             approvalStore: manualValidationStore
         )
 
-        self.poller = StatePoller(axChannel: axChannel, cache: cache, runtime: pollerRuntime)
+        self.poller = StatePoller(
+            axChannel: axChannel,
+            cache: cache,
+            runtime: pollerRuntime,
+            postPoll: { cacheKeys in
+                await resourceNotifier.publishChangedResources(
+                    cacheKeys: cacheKeys,
+                    cache: cache,
+                    router: router
+                ) { uri in
+                    try await server.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
+                }
+            }
+        )
     }
 
     enum StartupError: Error, CustomStringConvertible {
@@ -843,6 +866,7 @@ actor LogicProServer {
 
     private func registerResources() async {
         let handlers = makeHandlers()
+        let subscriptions = self.resourceSubscriptions
         await server.withMethodHandler(ListResources.self) { params in
             if let error = Self.invalidCursorError(params.cursor, method: "resources/list") { throw error }
             return await handlers.listResources(params)
@@ -855,6 +879,27 @@ actor LogicProServer {
         await server.withMethodHandler(ListResourceTemplates.self) { params in
             if let error = Self.invalidCursorError(params.cursor, method: "resources/templates/list") { throw error }
             return await handlers.listResourceTemplates(params)
+        }
+
+        await server.withMethodHandler(ResourceSubscribe.self) { params in
+            try await subscriptions.subscribe(uri: params.uri)
+            return Empty()
+        }
+
+        await server.withMethodHandler(ResourceUnsubscribe.self) { params in
+            try await subscriptions.unsubscribe(uri: params.uri)
+            return Empty()
+        }
+    }
+
+    private func registerPrompts() async {
+        await server.withMethodHandler(ListPrompts.self) { params in
+            if let error = Self.invalidCursorError(params.cursor, method: "prompts/list") { throw error }
+            return WorkflowPromptProvider.list()
+        }
+
+        await server.withMethodHandler(GetPrompt.self) { params in
+            try WorkflowPromptProvider.get(name: params.name)
         }
     }
 
@@ -895,6 +940,35 @@ actor LogicProServer {
             await stopPorts()
         } else {
             await portManager.stop()
+        }
+        await resourceSubscriptions.clear()
+        await resourceNotifier.reset()
+    }
+
+    func startProtocolProbe(transport: any Transport) async throws {
+        await registerTools()
+        await registerResources()
+        await registerPrompts()
+        try await server.start(transport: transport)
+    }
+
+    func stopProtocolProbe() async {
+        await server.stop()
+        await resourceSubscriptions.clear()
+        await resourceNotifier.reset()
+    }
+
+    func replaceTracksForTesting(_ tracks: [TrackState]) async {
+        await cache.updateTracks(tracks)
+    }
+
+    func publishResourceChangesForTesting(_ cacheKeys: [ResourceCacheKey]) async {
+        await resourceNotifier.publishChangedResources(
+            cacheKeys: cacheKeys,
+            cache: cache,
+            router: router
+        ) { uri in
+            try await server.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
         }
     }
 
@@ -946,6 +1020,7 @@ actor LogicProServer {
                 } else {
                     await self.registerTools()
                     await self.registerResources()
+                    await self.registerPrompts()
                 }
             },
             serve: {
@@ -968,6 +1043,8 @@ actor LogicProServer {
                 } else {
                     await poller.stopImmediately()
                 }
+                await self.resourceSubscriptions.clear()
+                await self.resourceNotifier.reset()
             },
             stopChannels: {
                 if let stopChannels = self.runtimeOverrides?.stopChannels {

--- a/Sources/LogicProMCP/Server/ResourceSubscriptions.swift
+++ b/Sources/LogicProMCP/Server/ResourceSubscriptions.swift
@@ -1,0 +1,204 @@
+import CryptoKit
+import Foundation
+import MCP
+
+enum ResourceCacheKey: Hashable, Sendable {
+    case document
+    case project
+    case tracks
+    case transport
+    case mixer
+    case markers
+    case regions
+    case mcu
+}
+
+actor ResourceSubscriptionRegistry {
+    private var uris = Set<String>()
+
+    func subscribe(uri: String) throws {
+        guard ResourceSubscriptionCatalog.isSubscribable(uri) else {
+            throw MCPError.invalidParams("Unknown or unsubscribable resource URI: \(uri)")
+        }
+        uris.insert(uri)
+    }
+
+    func unsubscribe(uri: String) throws {
+        guard ResourceSubscriptionCatalog.isSubscribable(uri) else {
+            throw MCPError.invalidParams("Unknown or unsubscribable resource URI: \(uri)")
+        }
+        uris.remove(uri)
+    }
+
+    func contains(uri: String) -> Bool {
+        uris.contains(uri)
+    }
+
+    func subscribedURIs() -> Set<String> {
+        uris
+    }
+
+    func clear() {
+        uris.removeAll()
+    }
+}
+
+enum ResourceSubscriptionCatalog {
+    static let cacheKeyFanout: [ResourceCacheKey: [String]] = [
+        .document: [
+            "logic://project/info",
+            "logic://tracks",
+            "logic://mixer",
+            "logic://markers",
+            "logic://project/audit",
+            "logic://project/cleanup-plan",
+        ],
+        .project: [
+            "logic://project/info",
+            "logic://project/audit",
+            "logic://project/cleanup-plan",
+        ],
+        .tracks: [
+            "logic://tracks",
+            "logic://tracks/{index}",
+            "logic://project/info",
+            "logic://project/audit",
+            "logic://project/cleanup-plan",
+        ],
+        .transport: [
+            "logic://transport/state",
+            "logic://project/info",
+            "logic://project/audit",
+            "logic://project/cleanup-plan",
+        ],
+        .mixer: [
+            "logic://mixer",
+            "logic://mixer/{strip}",
+            "logic://project/audit",
+            "logic://project/cleanup-plan",
+        ],
+        .markers: [
+            "logic://markers",
+            "logic://project/audit",
+        ],
+        .regions: [
+            "logic://tracks/{index}/regions",
+            "logic://project/audit",
+        ],
+        .mcu: [
+            "logic://mcu/state",
+            "logic://mixer",
+        ],
+    ]
+
+    private static let staticURIs = Set(ResourceProvider.resources.map(\.uri))
+    private static let templateURIs = Set(ResourceProvider.templates.map(\.uriTemplate))
+
+    static func isSubscribable(_ uri: String) -> Bool {
+        guard !uri.contains("{"), !uri.contains("}") else { return false }
+        return WorkflowSkillCatalog.resourceRefResolves(
+            uri,
+            staticURIs: staticURIs,
+            templateURIs: templateURIs
+        )
+    }
+
+    static func affectedSubscribedURIs(cacheKeys: [ResourceCacheKey], subscribedURIs: Set<String>) -> [String] {
+        let fanout = Set(cacheKeys.flatMap { cacheKeyFanout[$0] ?? [] })
+        let affected = subscribedURIs.filter { uri in
+            fanout.contains(uri) || fanout.contains { template in
+                WorkflowSkillCatalog.refMatchesTemplate(uri, template: template)
+            }
+        }
+        return affected.sorted()
+    }
+}
+
+enum ResourceContentHasher {
+    private static let volatileKeys: Set<String> = [
+        "generated_at",
+        "fetched_at",
+        "cache_age_sec",
+        "mcu_last_feedback_age_ms",
+    ]
+
+    static func stableDataHash(fromResourceText text: String) throws -> String {
+        let raw = try JSONSerialization.jsonObject(with: Data(text.utf8))
+        let stablePayload: Any
+        if let object = raw as? [String: Any], let data = object["data"] {
+            stablePayload = strippingVolatileKeys(from: data)
+        } else {
+            stablePayload = strippingVolatileKeys(from: raw)
+        }
+        let canonical = try JSONSerialization.data(withJSONObject: stablePayload, options: [.sortedKeys])
+        let digest = SHA256.hash(data: canonical)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func strippingVolatileKeys(from value: Any) -> Any {
+        if let object = value as? [String: Any] {
+            return object.reduce(into: [String: Any]()) { result, pair in
+                guard !volatileKeys.contains(pair.key) else { return }
+                result[pair.key] = strippingVolatileKeys(from: pair.value)
+            }
+        }
+        if let array = value as? [Any] {
+            return array.map(strippingVolatileKeys)
+        }
+        return value
+    }
+}
+
+actor ResourceUpdateNotifier {
+    private let registry: ResourceSubscriptionRegistry
+    private var lastHashes: [String: String] = [:]
+
+    init(registry: ResourceSubscriptionRegistry) {
+        self.registry = registry
+    }
+
+    func publishChangedResources(
+        cacheKeys: [ResourceCacheKey],
+        cache: StateCache,
+        router: ChannelRouter,
+        readResource: @Sendable (String, StateCache, ChannelRouter) async throws -> ReadResource.Result = { uri, cache, router in
+            try await ResourceHandlers.read(uri: uri, cache: cache, router: router)
+        },
+        notify: @Sendable (String) async throws -> Void
+    ) async {
+        let subscribed = await registry.subscribedURIs()
+        guard !subscribed.isEmpty else { return }
+
+        let uris = ResourceSubscriptionCatalog.affectedSubscribedURIs(
+            cacheKeys: cacheKeys,
+            subscribedURIs: subscribed
+        )
+        for uri in uris {
+            do {
+                let result = try await readResource(uri, cache, router)
+                let hash = try ResourceContentHasher.stableDataHash(
+                    fromResourceText: sharedResourceTextForProduction(result)
+                )
+                guard lastHashes[uri] != hash else { continue }
+                guard await registry.contains(uri: uri) else { continue }
+                lastHashes[uri] = hash
+                do {
+                    try await notify(uri)
+                } catch {
+                    Log.warn("Resource update notify failed for \(uri): \(error)", subsystem: "server")
+                }
+            } catch {
+                Log.warn("Resource update diff failed for \(uri): \(error)", subsystem: "server")
+            }
+        }
+    }
+
+    func reset() {
+        lastHashes.removeAll()
+    }
+
+    private func sharedResourceTextForProduction(_ result: ReadResource.Result) -> String {
+        guard let content = result.contents.first else { return "" }
+        return content.text ?? ""
+    }
+}

--- a/Sources/LogicProMCP/Server/WorkflowPrompts.swift
+++ b/Sources/LogicProMCP/Server/WorkflowPrompts.swift
@@ -1,0 +1,31 @@
+import Foundation
+import MCP
+
+enum WorkflowPromptProvider {
+    static func list(snapshot: WorkflowSkillSnapshot = WorkflowSkillCatalog.defaultSnapshot()) -> ListPrompts.Result {
+        ListPrompts.Result(
+            prompts: snapshot.workflows.map { workflow in
+                Prompt(
+                    name: workflow.id,
+                    title: workflow.title,
+                    description: workflow.intent
+                )
+            },
+            nextCursor: nil
+        )
+    }
+
+    static func get(name: String, snapshot: WorkflowSkillSnapshot = WorkflowSkillCatalog.defaultSnapshot()) throws -> GetPrompt.Result {
+        guard let workflow = WorkflowSkillCatalog.workflow(id: name, snapshot: snapshot) else {
+            throw MCPError.invalidParams("Unknown prompt: \(name)")
+        }
+        let text = encodeJSON(workflow, compact: true)
+        return GetPrompt.Result(
+            description: workflow.intent,
+            messages: [
+                .user(.text(text: text)),
+            ]
+        )
+    }
+}
+

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -69,12 +69,19 @@ actor StatePoller {
     private let axChannel: AccessibilityChannel
     private let cache: StateCache
     private let runtime: Runtime
+    private let postPoll: @Sendable ([ResourceCacheKey]) async -> Void
     private var pollingTask: Task<Void, Never>?
 
-    init(axChannel: AccessibilityChannel, cache: StateCache, runtime: Runtime = .production) {
+    init(
+        axChannel: AccessibilityChannel,
+        cache: StateCache,
+        runtime: Runtime = .production,
+        postPoll: @escaping @Sendable ([ResourceCacheKey]) async -> Void = { _ in }
+    ) {
         self.axChannel = axChannel
         self.cache = cache
         self.runtime = runtime
+        self.postPoll = postPoll
     }
 
     /// Start the background polling loop.
@@ -137,6 +144,7 @@ actor StatePoller {
     }
 
     private func pollOnce(axChannel: AccessibilityChannel, cache: StateCache) async {
+        var cacheKeys: [ResourceCacheKey] = []
         guard runtime.hasVisibleWindow() else {
             // Be conservative: a single missed window check is often a transient
             // AX query glitch (Logic mid-paint, plugin window briefly grabbing
@@ -147,7 +155,9 @@ actor StatePoller {
             if consecutiveWindowMisses >= Self.failureThreshold {
                 await cache.updateDocumentState(false)
                 await cache.updateAXOccluded(false)
+                cacheKeys.append(.document)
             }
+            if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
             return
         }
         consecutiveWindowMisses = 0
@@ -156,10 +166,12 @@ actor StatePoller {
             operation: "project.get_info", label: "ProjectInfo",
             axChannel: axChannel, cache: cache, as: ProjectInfo.self
         ) { cache, info in await cache.updateProject(info) }
+        if projectReady { cacheKeys.append(.project) }
         let tracksReady = await poll(
             operation: "track.get_tracks", label: "Track",
             axChannel: axChannel, cache: cache, as: [TrackState].self
         ) { cache, tracks in await cache.updateTracks(tracks) }
+        if tracksReady { cacheKeys.append(.tracks) }
         let hasDocument = projectReady || tracksReady
         if hasDocument {
             consecutivePollMisses = 0
@@ -185,33 +197,42 @@ actor StatePoller {
                 // do NOT clear hasDocument. fetchedAt timestamps continue
                 // ageing so `cache_age_sec` keeps growing — clients that
                 // treat freshness as a contract still see staleness.
+                if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
                 return
             }
             consecutivePollMisses += 1
             if consecutivePollMisses >= Self.failureThreshold {
                 await cache.updateDocumentState(false)
                 await cache.updateAXOccluded(false)
+                cacheKeys.append(.document)
             }
         }
 
-        guard hasDocument else { return }
+        guard hasDocument else {
+            if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
+            return
+        }
 
-        await poll(
+        let transportReady = await poll(
             operation: "transport.get_state", label: "Transport",
             axChannel: axChannel, cache: cache, as: TransportState.self
         ) { cache, state in await cache.updateTransport(state) }
-        await poll(
+        if transportReady { cacheKeys.append(.transport) }
+        let mixerReady = await poll(
             operation: "mixer.get_state", label: "Mixer",
             axChannel: axChannel, cache: cache, as: [ChannelStripState].self
         ) { cache, strips in await cache.updateChannelStrips(strips) }
+        if mixerReady { cacheKeys.append(.mixer) }
         markerPollTick += 1
         if markerPollTick >= Self.markerPollInterval {
             markerPollTick = 0
-            await poll(
+            let markersReady = await poll(
                 operation: "nav.get_markers", label: "Marker",
                 axChannel: axChannel, cache: cache, as: [MarkerState].self
             ) { cache, markers in await cache.updateMarkers(markers) }
+            if markersReady { cacheKeys.append(.markers) }
         }
+        if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
     }
 
     /// 3 consecutive misses (~9s at the 3s poll interval) before declaring

--- a/Sources/LogicProMCP/Utilities/MCPToolContent.swift
+++ b/Sources/LogicProMCP/Utilities/MCPToolContent.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MCP
 
 func toolTextContent(_ text: String) -> Tool.Content {
@@ -5,11 +6,15 @@ func toolTextContent(_ text: String) -> Tool.Content {
 }
 
 func toolTextResult(_ text: String, isError: Bool = false) -> CallTool.Result {
-    CallTool.Result(content: [toolTextContent(text)], isError: isError)
+    CallTool.Result(
+        content: [toolTextContent(text)],
+        structuredContent: structuredContentValue(fromToolText: text),
+        isError: isError
+    )
 }
 
 func toolTextResult(_ result: ChannelResult) -> CallTool.Result {
-    CallTool.Result(content: [toolTextContent(result.message)], isError: !result.isSuccess)
+    toolTextResult(result.message, isError: !result.isSuccess)
 }
 
 func toolStateCResult(
@@ -63,5 +68,46 @@ func commandTool(name: String, description: String, commandDescription: String) 
         name: name,
         description: description,
         inputSchema: commandParamsToolSchema(commandDescription: commandDescription)
+    )
+}
+
+func structuredContentValue(fromToolText text: String) -> Value? {
+    let data = Data(text.utf8)
+    guard (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else {
+        return nil
+    }
+    return try? JSONDecoder().decode(Value.self, from: data)
+}
+
+func genericObjectOutputSchema() -> Value {
+    .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(true),
+    ])
+}
+
+func honestContractOutputSchema() -> Value {
+    .object([
+        "type": .string("object"),
+        "description": .string("Mutating commands return the Honest Contract envelope (success/verified/state, additional operation-specific keys); read-only commands return command-specific JSON objects."),
+        "properties": .object([
+            "success": .object(["type": .string("boolean")]),
+            "verified": .object(["type": .string("boolean")]),
+            "state": .object(["type": .string("string")]),
+        ]),
+        "additionalProperties": .bool(true),
+    ])
+}
+
+func toolWithOutputSchema(_ tool: Tool, outputSchema: Value) -> Tool {
+    Tool(
+        name: tool.name,
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
+        outputSchema: outputSchema,
+        icons: tool.icons,
+        _meta: tool._meta
     )
 }

--- a/Tests/LogicProMCPTests/MCPProtocolProbeTestSupport.swift
+++ b/Tests/LogicProMCPTests/MCPProtocolProbeTestSupport.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Logging
+import MCP
+import Testing
+@testable import LogicProMCP
+
+actor MCPProtocolProbeTransport: Transport {
+    nonisolated let logger = Logger(label: "logic-pro-mcp.test-probe") { _ in SwiftLogNoOpLogHandler() }
+
+    private var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation?
+    private var queuedFrames: [Data] = []
+    private var sentFrames: [String] = []
+
+    func connect() async throws {}
+
+    func disconnect() async {
+        continuation?.finish()
+        continuation = nil
+    }
+
+    func send(_ data: Data) async throws {
+        sentFrames.append(String(decoding: data, as: UTF8.self))
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Swift.Error> {
+        AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+            self.continuation = continuation
+            for frame in queuedFrames {
+                continuation.yield(frame)
+            }
+            queuedFrames.removeAll()
+        }
+    }
+
+    func queueJSON(_ frame: String) {
+        let data = Data(frame.utf8)
+        if let continuation {
+            continuation.yield(data)
+        } else {
+            queuedFrames.append(data)
+        }
+    }
+
+    func frames() -> [String] {
+        sentFrames
+    }
+}
+
+func probeInitializeFrame(id: Int = 1) -> String {
+    """
+    {"jsonrpc":"2.0","id":\(id),"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"logic-pro-mcp-tests","version":"1.0"}}}
+    """
+}
+
+func probeRequestFrame(id: Int, method: String, params: String) -> String {
+    #"{"jsonrpc":"2.0","id":\#(id),"method":"\#(method)","params":\#(params)}"#
+}
+
+func probeToolCallFrame(id: Int, name: String, command: String, params: String = "{}") -> String {
+    probeRequestFrame(
+        id: id,
+        method: "tools/call",
+        params: #"{"name":"\#(name)","arguments":{"command":"\#(command)","params":\#(params)}}"#
+    )
+}
+
+func waitForProbeFrame(
+    _ transport: MCPProtocolProbeTransport,
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    matching: ([String: Any]) -> Bool
+) async throws -> [String: Any] {
+    let intervalNanoseconds: UInt64 = 5_000_000
+    var waitedNanoseconds: UInt64 = 0
+
+    while waitedNanoseconds < timeoutNanoseconds {
+        for frame in await transport.frames() {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(frame.utf8)) as? [String: Any] else {
+                continue
+            }
+            if matching(object) {
+                return object
+            }
+        }
+        try await Task.sleep(nanoseconds: intervalNanoseconds)
+        waitedNanoseconds += intervalNanoseconds
+    }
+
+    Issue.record("Timed out waiting for matching MCP frame")
+    return [:]
+}
+
+func waitForProbeResponse(
+    _ transport: MCPProtocolProbeTransport,
+    id: Int,
+    timeoutNanoseconds: UInt64 = 1_000_000_000
+) async throws -> [String: Any] {
+    try await waitForProbeFrame(transport, timeoutNanoseconds: timeoutNanoseconds) { frame in
+        frame["id"] as? Int == id
+    }
+}
+
+func waitForProbeNotification(
+    _ transport: MCPProtocolProbeTransport,
+    method: String,
+    timeoutNanoseconds: UInt64 = 1_000_000_000
+) async throws -> [String: Any] {
+    try await waitForProbeFrame(transport, timeoutNanoseconds: timeoutNanoseconds) { frame in
+        frame["method"] as? String == method
+    }
+}
+
+func canonicalJSONObjectData(_ object: Any) throws -> Data {
+    try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+}
+

--- a/Tests/LogicProMCPTests/PromptsTests.swift
+++ b/Tests/LogicProMCPTests/PromptsTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Suite("Prompts")
+struct PromptsTests {
+    @Test("prompts_list_and_get_roundtrip")
+    func promptsListAndGetRoundtrip() async throws {
+        let server = LogicProServer()
+        let transport = MCPProtocolProbeTransport()
+        try await server.startProtocolProbe(transport: transport)
+        defer { Task { await server.stopProtocolProbe() } }
+
+        await transport.queueJSON(probeInitializeFrame(id: 1))
+        _ = try await waitForProbeResponse(transport, id: 1)
+
+        await transport.queueJSON(probeRequestFrame(id: 2, method: "prompts/list", params: "{}"))
+        let listResponse = try await waitForProbeResponse(transport, id: 2)
+        let listResult = try #require(listResponse["result"] as? [String: Any])
+        let prompts = try #require(listResult["prompts"] as? [[String: Any]])
+        let expected = WorkflowSkillCatalog.defaultSnapshot().workflows
+        #expect(prompts.count == expected.count)
+
+        let firstWorkflow = try #require(expected.first)
+        let firstPrompt = try #require(prompts.first)
+        #expect(firstPrompt["name"] as? String == firstWorkflow.id)
+        #expect(firstPrompt["title"] as? String == firstWorkflow.title)
+
+        await transport.queueJSON(probeRequestFrame(
+            id: 3,
+            method: "prompts/get",
+            params: #"{"name":"\#(firstWorkflow.id)"}"#
+        ))
+        let getResponse = try await waitForProbeResponse(transport, id: 3)
+        let getResult = try #require(getResponse["result"] as? [String: Any])
+        #expect(getResult["description"] as? String == firstWorkflow.intent)
+
+        let messages = try #require(getResult["messages"] as? [[String: Any]])
+        let message = try #require(messages.first)
+        let content = try #require(message["content"] as? [String: Any])
+        let text = try #require(content["text"] as? String)
+        let workflowJSON = try #require(sharedJSONObject(text))
+        #expect(workflowJSON["id"] as? String == firstWorkflow.id)
+    }
+
+    @Test("capabilities_advertise_subscribe_and_prompts")
+    func capabilitiesAdvertiseSubscribeAndPrompts() async throws {
+        let server = LogicProServer()
+        let transport = MCPProtocolProbeTransport()
+        try await server.startProtocolProbe(transport: transport)
+        defer { Task { await server.stopProtocolProbe() } }
+
+        await transport.queueJSON(probeInitializeFrame(id: 1))
+        let initializeResponse = try await waitForProbeResponse(transport, id: 1)
+        let result = try #require(initializeResponse["result"] as? [String: Any])
+        let capabilities = try #require(result["capabilities"] as? [String: Any])
+        let resources = try #require(capabilities["resources"] as? [String: Any])
+        let prompts = try #require(capabilities["prompts"] as? [String: Any])
+
+        #expect(try #require(resources["subscribe"] as? Bool))
+        #expect(try #require(prompts["listChanged"] as? Bool) == false)
+    }
+}
+

--- a/Tests/LogicProMCPTests/ResourceSubscriptionTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSubscriptionTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private actor ResourceNotificationSink {
+    private var uris: [String] = []
+
+    func send(uri: String) {
+        uris.append(uri)
+    }
+
+    func snapshot() -> [String] {
+        uris
+    }
+
+    func reset() {
+        uris.removeAll()
+    }
+}
+
+private func resourceResult(_ text: String, uri: String) -> ReadResource.Result {
+    ReadResource.Result(contents: [.text(text, uri: uri, mimeType: "application/json")])
+}
+
+@Suite("ResourceSubscription")
+struct ResourceSubscriptionTests {
+    @Test("subscription_registry_add_remove_cleanup")
+    func subscriptionRegistryAddRemoveCleanup() async throws {
+        let registry = ResourceSubscriptionRegistry()
+
+        try await registry.subscribe(uri: "logic://tracks")
+        #expect(await registry.contains(uri: "logic://tracks"))
+
+        try await registry.unsubscribe(uri: "logic://tracks")
+        #expect(!(await registry.contains(uri: "logic://tracks")))
+
+        try await registry.subscribe(uri: "logic://mixer")
+        await registry.clear()
+        #expect((await registry.subscribedURIs()).isEmpty)
+    }
+
+    @Test("unchanged_poll_emits_no_notification")
+    func unchangedPollEmitsNoNotification() async throws {
+        let registry = ResourceSubscriptionRegistry()
+        let notifier = ResourceUpdateNotifier(registry: registry)
+        let sink = ResourceNotificationSink()
+        let cache = StateCache()
+        let router = ChannelRouter()
+
+        try await registry.subscribe(uri: "logic://tracks")
+        await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+        await notifier.publishChangedResources(cacheKeys: [.tracks], cache: cache, router: router) { uri in
+            await sink.send(uri: uri)
+        }
+        await sink.reset()
+
+        await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+        await notifier.publishChangedResources(cacheKeys: [.tracks], cache: cache, router: router) { uri in
+            await sink.send(uri: uri)
+        }
+
+        #expect(await sink.snapshot() == [])
+    }
+
+    @Test("changed_payload_emits_single_coalesced_notification")
+    func changedPayloadEmitsSingleCoalescedNotification() async throws {
+        let registry = ResourceSubscriptionRegistry()
+        let notifier = ResourceUpdateNotifier(registry: registry)
+        let sink = ResourceNotificationSink()
+        let cache = StateCache()
+        let router = ChannelRouter()
+
+        try await registry.subscribe(uri: "logic://tracks")
+        await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+        await notifier.publishChangedResources(cacheKeys: [.tracks], cache: cache, router: router) { uri in
+            await sink.send(uri: uri)
+        }
+        await sink.reset()
+
+        await cache.updateTracks([
+            TrackState(id: 0, name: "Kick", type: .audio),
+            TrackState(id: 1, name: "Bass", type: .audio),
+        ])
+        await notifier.publishChangedResources(cacheKeys: [.tracks, .tracks], cache: cache, router: router) { uri in
+            await sink.send(uri: uri)
+        }
+
+        #expect(await sink.snapshot() == ["logic://tracks"])
+    }
+
+    @Test("volatile_fields_excluded_from_change_hash")
+    func volatileFieldsExcludedFromChangeHash() throws {
+        let first = #"{"cache_age_sec":0.01,"fetched_at":"2026-07-07T00:00:00Z","ax_occluded":false,"data":{"tracks":[{"id":0,"name":"Kick","fetched_at":"2026-07-07T00:00:00Z"}]}}"#
+        let second = #"{"cache_age_sec":99.9,"fetched_at":"2026-07-07T00:01:39Z","ax_occluded":true,"data":{"tracks":[{"id":0,"name":"Kick","fetched_at":"2026-07-07T00:01:39Z"}]}}"#
+
+        #expect(try ResourceContentHasher.stableDataHash(fromResourceText: first) == ResourceContentHasher.stableDataHash(fromResourceText: second))
+    }
+
+    @Test("audit_fallback_volatile_fields_excluded_from_change_hash")
+    func auditFallbackVolatileFieldsExcludedFromChangeHash() throws {
+        let first = #"{"schema":"logic_pro_mcp_project_audit.v1","generated_at":"2026-07-07T00:00:00Z","status":"degraded","project":{"name":"Song"},"findings":[{"id":"external_midi","severity":"warn"}]}"#
+        let second = #"{"schema":"logic_pro_mcp_project_audit.v1","generated_at":"2026-07-07T00:01:39Z","status":"degraded","project":{"name":"Song"},"findings":[{"id":"external_midi","severity":"warn"}]}"#
+        let changed = #"{"schema":"logic_pro_mcp_project_audit.v1","generated_at":"2026-07-07T00:01:39Z","status":"ok","project":{"name":"Song"},"findings":[]}"#
+
+        #expect(try ResourceContentHasher.stableDataHash(fromResourceText: first) == ResourceContentHasher.stableDataHash(fromResourceText: second))
+        #expect(try ResourceContentHasher.stableDataHash(fromResourceText: first) != ResourceContentHasher.stableDataHash(fromResourceText: changed))
+    }
+
+    @Test("mixer_fallback_volatile_fields_excluded_from_change_hash")
+    func mixerFallbackVolatileFieldsExcludedFromChangeHash() throws {
+        let first = #"{"cache_age_sec":0.1,"data_source":"ax_poll","fetched_at":"2026-07-07T00:00:00Z","mcu_last_feedback_age_ms":10,"strips":[{"trackIndex":0,"name":"Kick","volume":0.7,"cache_age_sec":0.2,"mcu_last_feedback_age_ms":11}]}"#
+        let second = #"{"cache_age_sec":99.9,"data_source":"ax_poll","fetched_at":"2026-07-07T00:01:39Z","mcu_last_feedback_age_ms":500,"strips":[{"trackIndex":0,"name":"Kick","volume":0.7,"cache_age_sec":30.0,"mcu_last_feedback_age_ms":600}]}"#
+        let changed = #"{"cache_age_sec":99.9,"data_source":"ax_poll","fetched_at":"2026-07-07T00:01:39Z","mcu_last_feedback_age_ms":500,"strips":[{"trackIndex":0,"name":"Kick","volume":0.8,"cache_age_sec":30.0,"mcu_last_feedback_age_ms":600}]}"#
+
+        #expect(try ResourceContentHasher.stableDataHash(fromResourceText: first) == ResourceContentHasher.stableDataHash(fromResourceText: second))
+        #expect(try ResourceContentHasher.stableDataHash(fromResourceText: first) != ResourceContentHasher.stableDataHash(fromResourceText: changed))
+    }
+
+    @Test("unsubscribe_during_read_suppresses_notify_and_hash_update")
+    func unsubscribeDuringReadSuppressesNotifyAndHashUpdate() async throws {
+        let registry = ResourceSubscriptionRegistry()
+        let notifier = ResourceUpdateNotifier(registry: registry)
+        let sink = ResourceNotificationSink()
+        let cache = StateCache()
+        let router = ChannelRouter()
+        let payload = #"{"data":{"tracks":[{"id":0,"name":"Kick"}]}}"#
+
+        try await registry.subscribe(uri: "logic://tracks")
+        await notifier.publishChangedResources(
+            cacheKeys: [.tracks],
+            cache: cache,
+            router: router,
+            readResource: { uri, _, _ in
+                try await registry.unsubscribe(uri: uri)
+                return resourceResult(payload, uri: uri)
+            }
+        ) { uri in
+            await sink.send(uri: uri)
+        }
+
+        #expect(await sink.snapshot() == [])
+
+        try await registry.subscribe(uri: "logic://tracks")
+        await notifier.publishChangedResources(
+            cacheKeys: [.tracks],
+            cache: cache,
+            router: router,
+            readResource: { uri, _, _ in resourceResult(payload, uri: uri) }
+        ) { uri in
+            await sink.send(uri: uri)
+        }
+
+        #expect(await sink.snapshot() == ["logic://tracks"])
+    }
+
+    @Test("initialize_subscribe_change_emits_resource_updated_frame")
+    func initializeSubscribeChangeEmitsResourceUpdatedFrame() async throws {
+        let server = LogicProServer()
+        let transport = MCPProtocolProbeTransport()
+        try await server.startProtocolProbe(transport: transport)
+        defer { Task { await server.stopProtocolProbe() } }
+
+        await transport.queueJSON(probeInitializeFrame(id: 1))
+        _ = try await waitForProbeResponse(transport, id: 1)
+
+        await transport.queueJSON(probeRequestFrame(
+            id: 2,
+            method: "resources/subscribe",
+            params: #"{"uri":"logic://tracks"}"#
+        ))
+        _ = try await waitForProbeResponse(transport, id: 2)
+
+        await server.replaceTracksForTesting([TrackState(id: 0, name: "Kick", type: .audio)])
+        await server.publishResourceChangesForTesting([.tracks])
+
+        let notification = try await waitForProbeNotification(
+            transport,
+            method: "notifications/resources/updated"
+        )
+        let params = try #require(notification["params"] as? [String: Any])
+        #expect(params["uri"] as? String == "logic://tracks")
+    }
+}

--- a/Tests/LogicProMCPTests/SerializedStdioTransportTests.swift
+++ b/Tests/LogicProMCPTests/SerializedStdioTransportTests.swift
@@ -103,4 +103,57 @@ struct SerializedStdioTransportTests {
 
         #expect(received == frames)
     }
+
+    @Test("notifications_do_not_corrupt_concurrent_frames")
+    func notificationsDoNotCorruptConcurrentFrames() async throws {
+        var fds: [Int32] = [-1, -1]
+        #expect(pipe(&fds) == 0)
+        let readEnd = fds[0]
+        let writeEnd = fds[1]
+
+        let collected = DataBox()
+        Thread.detachNewThread {
+            var buf = [UInt8](repeating: 0, count: 65536)
+            while true {
+                let r = buf.withUnsafeMutableBytes { Darwin.read(readEnd, $0.baseAddress, $0.count) }
+                if r <= 0 { break }
+                collected.append(buf[0..<r])
+            }
+            collected.finish()
+        }
+
+        let transport = SerializedStdioTransport(output: writeEnd)
+        let responseFrames = (0..<30).map { i in
+            #"{"jsonrpc":"2.0","id":\#(i),"result":{"marker":\#(i),"pad":"\#(String(repeating: "r", count: 2000))"}}"#
+        }
+        let notificationFrames = (0..<30).map { i in
+            #"{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"logic://tracks/\#(i)","pad":"\#(String(repeating: "n", count: 2000))"}}"#
+        }
+        let frames = zip(responseFrames, notificationFrames).flatMap { [$0, $1] }
+
+        await withTaskGroup(of: Void.self) { group in
+            for frame in frames {
+                group.addTask { try? await transport.send(Data(frame.utf8)) }
+            }
+        }
+        close(writeEnd)
+        for _ in 0..<600 where !collected.isDone { try await Task.sleep(nanoseconds: 5_000_000) }
+        #expect(collected.isDone)
+        close(readEnd)
+
+        let lines = collected.snapshot().split(separator: UInt8(ascii: "\n")).filter { !$0.isEmpty }
+        #expect(lines.count == frames.count)
+        var responseCount = 0
+        var notificationCount = 0
+        for line in lines {
+            let object = try #require(JSONSerialization.jsonObject(with: Data(line)) as? [String: Any])
+            if object["id"] != nil {
+                responseCount += 1
+            } else if object["method"] as? String == "notifications/resources/updated" {
+                notificationCount += 1
+            }
+        }
+        #expect(responseCount == responseFrames.count)
+        #expect(notificationCount == notificationFrames.count)
+    }
 }

--- a/Tests/LogicProMCPTests/StructuredContentTests.swift
+++ b/Tests/LogicProMCPTests/StructuredContentTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private actor StructuredContentJSONChannel: Channel {
+    nonisolated let id: ChannelID = .mcu
+    private let response: String
+
+    init(response: String) {
+        self.response = response
+    }
+
+    func start() async throws {}
+    func stop() async {}
+    func healthCheck() async -> ChannelHealth { .healthy(detail: "structured-content-stub") }
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        guard operation == "transport.rewind" else {
+            return .error("unexpected operation: \(operation)")
+        }
+        return .success(response)
+    }
+}
+
+@Suite(.serialized)
+struct StructuredContentTests {
+    @Test("tools_call_includes_structured_content_all_tools")
+    func toolsCallIncludesStructuredContentAllTools() async throws {
+        let server = LogicProServer()
+        let handlers = await server.makeHandlers()
+        let cases: [(tool: String, command: String, params: [String: Value])] = [
+            ("logic_transport", "set_tempo", [:]),
+            ("logic_tracks", "rename", [:]),
+            ("logic_mixer", "set_volume", [:]),
+            ("logic_midi", "send_note", [:]),
+            ("logic_edit", "quantize", [:]),
+            ("logic_navigate", "goto_bar", [:]),
+            ("logic_project", "open", [:]),
+            ("logic_audio", "analyze_file", [:]),
+            ("logic_system", "health", [:]),
+            ("logic_plugins", "set_param_verified", [
+                "track": .int(0),
+                "insert": .int(2),
+                "plugin": .string("Gain"),
+                "param": .string("gain_db"),
+                "value": .double(-4.0),
+                "unit": .string("dB"),
+                "mode": .string("duplicate_applyback"),
+                "project_expected_path": .string("/tmp/x.logicx"),
+            ]),
+        ]
+
+        #expect(ServerCatalog.tools.count == 10)
+        for tool in ServerCatalog.tools {
+            #expect(tool.outputSchema != nil, "\(tool.name) must advertise outputSchema")
+        }
+
+        let gateHeld = VerifiedOpGate.shared.tryAcquire()
+        #expect(gateHeld)
+        defer { VerifiedOpGate.shared.release() }
+
+        for item in cases {
+            let result = await handlers.callTool(.init(
+                name: item.tool,
+                arguments: [
+                    "command": .string(item.command),
+                    "params": .object(item.params),
+                ]
+            ))
+            let text = sharedToolText(result)
+            let textObject = try #require(sharedJSONObject(text), "\(item.tool).\(item.command) must return JSON object text")
+            let structured = try #require(result.structuredContent, "\(item.tool).\(item.command) must include structuredContent")
+            let structuredData = try JSONEncoder().encode(structured)
+            let structuredObject = try #require(JSONSerialization.jsonObject(with: structuredData) as? [String: Any])
+
+            #expect(try canonicalJSONObjectData(structuredObject) == canonicalJSONObjectData(textObject))
+        }
+    }
+
+    @Test("tools_call_probe_includes_structured_content")
+    func toolsCallProbeIncludesStructuredContent() async throws {
+        let server = LogicProServer()
+        let transport = MCPProtocolProbeTransport()
+        try await server.startProtocolProbe(transport: transport)
+        defer { Task { await server.stopProtocolProbe() } }
+
+        await transport.queueJSON(probeInitializeFrame(id: 1))
+        _ = try await waitForProbeResponse(transport, id: 1)
+
+        await transport.queueJSON(probeToolCallFrame(id: 2, name: "logic_system", command: "health"))
+        let response = try await waitForProbeResponse(transport, id: 2)
+        let result = try #require(response["result"] as? [String: Any])
+        let content = try #require(result["content"] as? [[String: Any]])
+        let firstContent = try #require(content.first)
+        let text = try #require(firstContent["text"] as? String)
+        let textObject = try #require(sharedJSONObject(text))
+        let structured = try #require(result["structuredContent"] as? [String: Any])
+
+        #expect(try canonicalJSONObjectData(structured) == canonicalJSONObjectData(textObject))
+    }
+
+    @Test("channel_result_path_dispatcher_response_includes_structured_content")
+    func channelResultPathDispatcherResponseIncludesStructuredContent() async throws {
+        let json = #"{"success":true,"verified":false,"state":"B","operation":"transport.rewind"}"#
+        let router = ChannelRouter()
+        await router.register(StructuredContentJSONChannel(response: json))
+
+        let result = await TransportDispatcher.handle(
+            command: "rewind",
+            params: [:],
+            router: router,
+            cache: StateCache()
+        )
+        let textObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let structured = try #require(result.structuredContent)
+        let structuredData = try JSONEncoder().encode(structured)
+        let structuredObject = try #require(JSONSerialization.jsonObject(with: structuredData) as? [String: Any])
+
+        #expect(try canonicalJSONObjectData(structuredObject) == canonicalJSONObjectData(textObject))
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,6 +8,16 @@ Use tools for actions. Use resources for state. Treat every mutating result as o
 - State B: uncertain success. The server attempted the action but could not verify the result.
 - State C: hard failure. The action did not land and is safe to retry only when `retry_safe` says so.
 
+## MCP Capabilities
+
+`initialize` advertises `resources.subscribe: true`, `resources.listChanged: false`, `prompts.listChanged: false`, and `tools.listChanged: false`.
+
+Resource subscriptions are session-scoped. `resources/subscribe` and `resources/unsubscribe` accept any listed resource URI or concrete resource-template URI. When a subscribed state resource changes, the server sends `notifications/resources/updated` with the changed `uri`. Change detection hashes the stable `data` payload of cache-envelope resources, or the whole payload for non-envelope resources, after recursively excluding volatile keys: `generated_at`, `fetched_at`, `cache_age_sec`, and `mcu_last_feedback_age_ms`.
+
+`prompts/list` and `prompts/get` expose the workflow skill catalog as prompt templates. Prompt definitions are derived from `WorkflowSkillCatalog`, the same source used by `logic://workflow-skills`.
+
+Every tool in `tools/list` advertises an `outputSchema`. Mixed command tools advertise the Honest Contract envelope for mutating commands: mutating commands return the Honest Contract envelope (`success`/`verified`/`state`, additional operation-specific keys); read-only commands return command-specific JSON objects. Honest Contract properties are non-required so read-only responses validate against the mixed-tool schema. Read-only/read-ish tools advertise a generic JSON object. For `tools/call`, when the text response is already a JSON object, the same object is also attached as `structuredContent`; the text payload is unchanged for backward compatibility.
+
 ## Tools
 
 | Tool | Purpose |


### PR DESCRIPTION
## Summary
- PRD US-4, ticket T4 — SDK 0.12.1 confirmed APIs only (lockfile unchanged)
- resource subscribe + resources/updated with content-hash diff contract (volatile-key-stripped, coalesced, race-gated)
- prompts capability (workflow-skills reuse) + structuredContent/outputSchema on all 10 tools (text backward-compatible)
- in-process TestTransport frame-level probe harness + stdio concurrency regression

## Verification
- TDD Red (missing-symbol compile failures) → targeted 52→21 green across rounds
- swift test --no-parallel: **2145 PASS** (orchestrator, authoritative)
- independent review adversarial 2R PASS (hash-churn P1 caught & fixed pre-merge)

PR 4/6 of v39-hardening-and-midi-read