### PR TITLE
feat(midi): v3.9 WS5 — SMF parser foundation + T0 gate evidence (T5a; T5b deferred)

### DIFF
--- a/Scripts/spike-midi-export.py
+++ b/Scripts/spike-midi-export.py
@@ -1,0 +1,959 @@
+#!/usr/bin/env python3
+# SIZE_OK: T0 spike centralizes live MCP orchestration and the required inline SMF extractor.
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+# --- How to run ---
+# 1. Build the server binary first, or set LOGIC_PRO_MCP_BINARY.
+# 2. Run: python3 Scripts/spike-midi-export.py
+# 3. The script prints newline-delimited JSON progress records.
+# ------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+BINARY = os.environ.get("LOGIC_PRO_MCP_BINARY", ".build/release/LogicProMCP")
+TIMEOUT = float(os.environ.get("LOGIC_PRO_MCP_SPIKE_TIMEOUT", "20"))
+SENTINEL_BAR = 3
+SENTINEL_NOTES = "60,0,500,100,1;64,500,500,100,1;67,1000,500,100,1"
+EXPECTED_RELATIVE = [(60, 0.0, 1.0, 1), (64, 1.0, 1.0, 1), (67, 2.0, 1.0, 1)]
+EXPORT_DIR = Path(os.environ.get("LOGIC_PRO_MCP_MIDI_EXPORT_DIR", "/tmp/LogicProMCP-spike"))
+EXPORT_FILENAME = os.environ.get("LOGIC_PRO_MCP_MIDI_EXPORT_FILENAME", "selection.mid")
+EXPORT_POLL_SECONDS = 5.0
+RESOURCE_READY_URI = "logic://tracks"
+RESOURCE_READY_TIMEOUT_SECONDS = 12.0
+RESOURCE_READY_INTERVAL_SECONDS = 1.0
+
+
+EXPORT_MENU_SCRIPT = r'''
+set outputLines to {}
+set titleSeparator to " ||| "
+on cleanText(value)
+    try
+        if value is missing value then return ""
+        return value as text
+    on error
+        return ""
+    end try
+end cleanText
+on recordLine(kind, firstIndex, secondIndex, firstTitle, secondTitle)
+    return kind & tab & (firstIndex as text) & tab & (secondIndex as text) & tab & firstTitle & tab & secondTitle
+end recordLine
+on joinList(textList, separatorText)
+    set cleanedList to {}
+    repeat with textItem in textList
+        copy my cleanText(textItem) to end of cleanedList
+    end repeat
+    set previousDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to separatorText
+    set joinedText to cleanedList as text
+    set AppleScript's text item delimiters to previousDelimiters
+    return joinedText
+end joinList
+on appendSubmenuLines(parentIndex, parentTitle, childTitleList)
+    global outputLines, titleSeparator
+    copy "SUBMENU_TITLES" & tab & (parentIndex as text) & tab & parentTitle & tab & titleSeparator & tab & my joinList(childTitleList, titleSeparator) to end of outputLines
+    repeat with childIndex from 1 to count of childTitleList
+        set childTitle to my cleanText(item childIndex of childTitleList)
+        copy my recordLine("SUBMENU", parentIndex, childIndex, parentTitle, childTitle) to end of outputLines
+    end repeat
+end appendSubmenuLines
+tell application "Logic Pro" to activate
+delay 0.2
+tell application "System Events" to tell process "Logic Pro" to click menu bar item 3 of menu bar 1
+delay 0.2
+tell application "System Events"
+    tell process "Logic Pro"
+        set frontmost to true
+        set fileMenuItem to menu bar item 3 of menu bar 1
+        set fileMenu to menu 1 of fileMenuItem
+        set titleList to name of every menu item of menu 1 of menu bar item 3 of menu bar 1
+        copy "FILE_TITLES" & tab & titleSeparator & tab & my joinList(titleList, titleSeparator) to end of outputLines
+        set foundMIDI to false
+        set foundExportParent to false
+        set clickedFileIndex to 0
+        set clickedSubmenuIndex to 0
+        set clickedTitle to ""
+        set enumeratedParentTitles to my joinList(titleList, titleSeparator)
+        repeat with fileIndex from 1 to count of titleList
+            set fileItem to menu item fileIndex of fileMenu
+            set fileTitle to my cleanText(item fileIndex of titleList)
+            copy my recordLine("FILE", fileIndex, 0, fileTitle, "") to end of outputLines
+            set skipParent to false
+            ignoring case
+                if fileTitle is "Open Recent" then set skipParent to true
+            end ignoring
+            if fileTitle is "최근" then set skipParent to true
+            if skipParent then
+                copy my recordLine("SKIPPED_PARENT", fileIndex, 0, fileTitle, "explicit skip") to end of outputLines
+            else
+                set isExportParent to false
+                ignoring case
+                    if fileTitle is "Export" then set isExportParent to true
+                end ignoring
+                if fileTitle is "보내기" then set isExportParent to true
+                if isExportParent then
+                    set foundExportParent to true
+                    if exists menu 1 of fileItem then
+                        set childTitleList to name of every menu item of menu 1 of fileItem
+                        my appendSubmenuLines(fileIndex, fileTitle, childTitleList)
+                        repeat with subIndex from 1 to count of childTitleList
+                            set subTitle to my cleanText(item subIndex of childTitleList)
+                            if subTitle contains "Selection as MIDI" then
+                                set clickedFileIndex to fileIndex
+                                set clickedSubmenuIndex to subIndex
+                                set clickedTitle to subTitle
+                                click fileItem
+                                delay 0.2
+                                click menu item subIndex of menu 1 of fileItem
+                                set foundMIDI to true
+                                exit repeat
+                            end if
+                        end repeat
+                    end if
+                end if
+            end if
+            if foundMIDI then exit repeat
+        end repeat
+        if foundMIDI is false then
+            key code 53
+            if foundExportParent is false then
+                copy "FAILED" & tab & "No File > Export parent found" & tab & enumeratedParentTitles to end of outputLines
+            else
+                copy "FAILED" & tab & "File > Export found but no child containing MIDI" & tab & enumeratedParentTitles to end of outputLines
+            end if
+        else
+            copy my recordLine("CLICKED", clickedFileIndex, clickedSubmenuIndex, clickedTitle, "") to end of outputLines
+        end if
+    end tell
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+'''
+
+
+SAVE_DIALOG_SCRIPT = r'''
+set targetDir to __TARGET_DIR__
+set fileName to __FILE_NAME__
+set filenameStatus to "default-name"
+set overwriteStatus to "not-needed"
+on cleanText(value)
+    try
+        if value is missing value then return ""
+        return value as text
+    on error
+        return ""
+    end try
+end cleanText
+tell application "Logic Pro" to activate
+delay 0.2
+tell application "System Events"
+    tell process "Logic Pro"
+        set frontmost to true
+        set dialogFound to false
+        repeat with attempt from 1 to 20
+            try
+                if exists sheet 1 of window 1 then
+                    set dialogFound to true
+                    exit repeat
+                end if
+                if exists window 1 then
+                    set windowSubrole to my cleanText(subrole of window 1)
+                    if windowSubrole contains "Dialog" then
+                        set dialogFound to true
+                        exit repeat
+                    end if
+                end if
+            end try
+            delay 0.25
+        end repeat
+        if dialogFound is false then error "Save dialog did not appear"
+        keystroke "g" using {command down, shift down}
+        delay 0.3
+        keystroke targetDir
+        key code 36
+        delay 0.8
+        try
+            if exists sheet 1 of window 1 then
+                set targetSheet to sheet 1 of window 1
+                if exists text field 1 of targetSheet then
+                    set value of text field 1 of targetSheet to fileName
+                    set filenameStatus to "sheet text field 1"
+                end if
+            else if exists text field 1 of window 1 then
+                set value of text field 1 of window 1 to fileName
+                set filenameStatus to "window text field 1"
+            end if
+        on error errMsg number errNum
+            set filenameStatus to "default-name: " & errMsg
+        end try
+        key code 36
+        delay 0.8
+        try
+            if exists sheet 1 of window 1 then
+                key code 36
+                delay 0.3
+                set overwriteStatus to "return-sent"
+            end if
+        on error errMsg number errNum
+            set overwriteStatus to "return-failed: " & errMsg
+        end try
+    end tell
+end tell
+return "SAVE" & tab & filenameStatus & tab & overwriteStatus
+'''
+
+
+DELETE_TRACK_KEYSTROKE_SCRIPT = r'''
+tell application "Logic Pro" to activate
+delay 0.1
+tell application "System Events"
+    tell process "Logic Pro"
+        set frontmost to true
+        key code 51 using {command down}
+        delay 0.5
+        set confirmationStatus to "not-found"
+        try
+            if exists sheet 1 of window 1 then
+                key code 36
+                set confirmationStatus to "sheet-return-sent"
+            else if exists window 1 then
+                set windowSubrole to ""
+                try
+                    set windowSubrole to subrole of window 1 as text
+                end try
+                if windowSubrole contains "Dialog" then
+                    key code 36
+                    set confirmationStatus to "window-return-sent"
+                end if
+            end if
+        on error errMsg number errNum
+            set confirmationStatus to "confirmation-error: " & errMsg
+        end try
+    end tell
+end tell
+return "DELETE_KEYSTROKE" & tab & confirmationStatus
+'''
+
+
+DIALOG_TREE_SCRIPT = r'''
+set outputLines to {}
+on cleanText(value)
+    try
+        if value is missing value then return ""
+        return value as text
+    on error
+        return ""
+    end try
+end cleanText
+on describeElement(kind, item)
+    set itemRole to ""
+    set itemTitle to ""
+    try
+        set itemRole to my cleanText(role of item)
+    end try
+    try
+        set itemTitle to my cleanText(name of item)
+    end try
+    return kind & tab & itemRole & tab & itemTitle
+end describeElement
+tell application "Logic Pro" to activate
+delay 0.1
+tell application "System Events"
+    tell process "Logic Pro"
+        set frontmost to true
+        if exists window 1 then
+            set frontWindow to window 1
+            copy my describeElement("WINDOW", frontWindow) to end of outputLines
+            repeat with childElement in UI elements of frontWindow
+                copy my describeElement("WINDOW_CHILD", childElement) to end of outputLines
+            end repeat
+            repeat with targetSheet in sheets of frontWindow
+                copy my describeElement("SHEET", targetSheet) to end of outputLines
+                repeat with childElement in UI elements of targetSheet
+                    copy my describeElement("CHILD", childElement) to end of outputLines
+                    try
+                        repeat with grandchildElement in UI elements of childElement
+                            copy my describeElement("GRANDCHILD", grandchildElement) to end of outputLines
+                        end repeat
+                    end try
+                end repeat
+            end repeat
+        else
+            copy "NO_WINDOW" & tab & "" & tab & "" to end of outputLines
+        end if
+    end tell
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+'''
+
+
+ESCAPE_SCRIPT = 'tell application "System Events" to key code 53'
+ESCAPE_TWICE_SCRIPT = r'''
+tell application "System Events"
+    key code 53
+    delay 0.3
+    key code 53
+end tell
+'''
+
+
+@dataclass(frozen=True)
+class MidiNote:
+    pitch: int
+    velocity: int
+    start_beats: float
+    duration_beats: float
+    channel: int
+
+
+@dataclass(frozen=True)
+class OsascriptResult:
+    returncode: int
+    stdout_lines: List[str]
+    stderr: str
+    timed_out: bool
+
+
+class MCPClient:
+    def __init__(self) -> None:
+        stderr_dir = tempfile.TemporaryDirectory(prefix="logic-mcp-spike.")
+        self._stderr_dir = stderr_dir
+        self._stderr_file = open(Path(stderr_dir.name) / "stderr.txt", "w")
+        self.proc = subprocess.Popen(
+            [BINARY],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=self._stderr_file,
+            bufsize=0,
+            env=os.environ.copy(),
+        )
+        self.responses: Dict[int, Dict[str, Any]] = {}
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        if self.proc.stdout is None:
+            return
+        for raw_line in self.proc.stdout:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            message_id = message.get("id")
+            if isinstance(message_id, int) and ("result" in message or "error" in message):
+                self.responses[message_id] = message
+
+    def send(self, message: Dict[str, Any], timeout: Optional[float] = None) -> Optional[Dict[str, Any]]:
+        if self.proc.stdin is None:
+            return None
+        try:
+            self.proc.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+            self.proc.stdin.flush()
+        except BrokenPipeError:
+            return None
+        message_id = message.get("id")
+        if not isinstance(message_id, int):
+            return None
+        deadline = time.time() + (timeout if timeout is not None else TIMEOUT)
+        while time.time() < deadline:
+            if message_id in self.responses:
+                return self.responses.pop(message_id)
+            time.sleep(0.02)
+        return None
+
+    def notify(self, message: Dict[str, Any]) -> None:
+        if self.proc.stdin is None:
+            return
+        try:
+            self.proc.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+            self.proc.stdin.flush()
+        except BrokenPipeError:
+            return
+
+    def close(self) -> None:
+        if self.proc.stdin is not None:
+            try:
+                self.proc.stdin.close()
+            except OSError:
+                pass
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+        self._stderr_file.close()
+        self._stderr_dir.cleanup()
+
+
+_NEXT_ID = 1
+
+
+def next_id() -> int:
+    global _NEXT_ID
+    request_id = _NEXT_ID
+    _NEXT_ID += 1
+    return request_id
+
+
+def emit(step: str, status: str, **fields: Any) -> None:
+    failed_statuses = {"blocked", "empty_or_unavailable", "failed", "mismatch", "missing", "timeout"}
+    payload = {
+        "step": step,
+        "step_id": step,
+        "ok": status not in failed_statuses,
+        "status": status,
+        "evidence": fields,
+    }
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def applescript_literal(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def run_osascript(step: str, script: str, timeout: float) -> OsascriptResult:
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout.decode("utf-8", errors="replace") if isinstance(error.stdout, bytes) else (error.stdout or "")
+        stderr = error.stderr.decode("utf-8", errors="replace") if isinstance(error.stderr, bytes) else (error.stderr or "")
+        stdout_lines = [line for line in stdout.splitlines() if line]
+        emit(f"osascript_{step}", "timeout", timeout=timeout, stdout=stdout_lines, stderr=stderr)
+        return OsascriptResult(returncode=124, stdout_lines=stdout_lines, stderr=stderr, timed_out=True)
+    stdout_lines = [line for line in result.stdout.splitlines() if line]
+    emit(
+        f"osascript_{step}",
+        "ok" if result.returncode == 0 else "failed",
+        returncode=result.returncode,
+        stdout=stdout_lines,
+        stderr=result.stderr,
+    )
+    return OsascriptResult(
+        returncode=result.returncode,
+        stdout_lines=stdout_lines,
+        stderr=result.stderr,
+        timed_out=False,
+    )
+
+
+def initialize(client: MCPClient) -> bool:
+    response = client.send({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "midi-export-spike", "version": "1"},
+        },
+    })
+    ok = isinstance(response, dict) and "result" in response
+    emit("initialize", "ok" if ok else "failed", response=response)
+    if ok:
+        client.notify({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(1.0)
+    return ok
+
+
+def call_tool(
+    client: MCPClient,
+    tool: str,
+    command: str,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    arguments: Dict[str, Any] = {"command": command}
+    if params is not None:
+        arguments["params"] = params
+    return client.send({
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    }, timeout=timeout)
+
+
+def read_resource(client: MCPClient, uri: str, timeout: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    return client.send({
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": "resources/read",
+        "params": {"uri": uri},
+    }, timeout=timeout)
+
+
+def list_tools(client: MCPClient) -> List[Dict[str, Any]]:
+    response = client.send({"jsonrpc": "2.0", "id": next_id(), "method": "tools/list", "params": {}})
+    tools = (((response or {}).get("result") or {}).get("tools") or [])
+    return tools if isinstance(tools, list) else []
+
+
+def response_text(response: Optional[Dict[str, Any]], key: str) -> str:
+    try:
+        entries = response["result"][key]
+    except (KeyError, TypeError):
+        return ""
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("type") == "text":
+            return str(entry.get("text", ""))
+    return ""
+
+
+def parsed_json_text(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def tool_json(response: Optional[Dict[str, Any]]) -> Any:
+    return parsed_json_text(response_text(response, "content"))
+
+
+def resource_envelope(response: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(response, dict) or "error" in response:
+        return None
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    contents = result.get("contents")
+    if not isinstance(contents, list) or not contents:
+        return None
+    first = contents[0]
+    if not isinstance(first, dict):
+        return None
+    text = first.get("text")
+    if not isinstance(text, str):
+        return None
+    parsed = parsed_json_text(text)
+    if not isinstance(parsed, dict):
+        return None
+    data = parsed.get("data")
+    if isinstance(data, (list, dict)):
+        return parsed
+    return None
+
+
+def resource_json(response: Optional[Dict[str, Any]]) -> Any:
+    envelope = resource_envelope(response)
+    return envelope["data"] if envelope is not None else None
+
+
+def wait_for_resource_ready(client: MCPClient, uri: str = RESOURCE_READY_URI) -> bool:
+    deadline = time.time() + RESOURCE_READY_TIMEOUT_SECONDS
+    last_response: Optional[Dict[str, Any]] = None
+    while time.time() < deadline:
+        last_response = read_resource(client, uri, timeout=RESOURCE_READY_INTERVAL_SECONDS)
+        if resource_envelope(last_response) is not None:
+            emit("resource_ready", "ok", uri=uri)
+            return True
+        remaining = deadline - time.time()
+        if remaining > 0:
+            time.sleep(min(RESOURCE_READY_INTERVAL_SECONDS, remaining))
+    emit("resource_ready", "timeout", uri=uri, timeout_seconds=RESOURCE_READY_TIMEOUT_SECONDS, response=last_response)
+    return False
+
+
+def tracks_snapshot(client: MCPClient) -> Optional[List[Dict[str, Any]]]:
+    tracks = resource_json(read_resource(client, "logic://tracks"))
+    return tracks if isinstance(tracks, list) else None
+
+
+def read_vlq(data: bytes, offset: int) -> Tuple[int, int]:
+    value = 0
+    for _ in range(4):
+        if offset >= len(data):
+            raise ValueError("truncated VLQ")
+        byte = data[offset]
+        offset += 1
+        value = (value << 7) | (byte & 0x7F)
+        if byte & 0x80 == 0:
+            return value, offset
+    raise ValueError("oversized VLQ")
+
+
+def read_u16(data: bytes, offset: int) -> int:
+    return (data[offset] << 8) | data[offset + 1]
+
+
+def read_u32(data: bytes, offset: int) -> int:
+    return (data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]
+
+
+def extract_smf_notes(path: Path) -> List[MidiNote]:
+    data = path.read_bytes()
+    if data[:4] != b"MThd":
+        raise ValueError("missing MThd")
+    header_len = read_u32(data, 4)
+    fmt = read_u16(data, 8)
+    track_count = read_u16(data, 10)
+    division = read_u16(data, 12)
+    if fmt not in (0, 1) or division & 0x8000:
+        raise ValueError("unsupported SMF header")
+    pos = 8 + header_len
+    notes: List[MidiNote] = []
+    for _ in range(track_count):
+        if data[pos:pos + 4] != b"MTrk":
+            raise ValueError("missing MTrk")
+        length = read_u32(data, pos + 4)
+        pos += 8
+        end = pos + length
+        parse_track(data[pos:end], division, notes)
+        pos = end
+    return sorted(notes, key=lambda n: (n.start_beats, n.pitch, n.channel))
+
+
+def parse_track(data: bytes, division: int, notes: List[MidiNote]) -> None:
+    pos = 0
+    tick = 0
+    running: Optional[int] = None
+    active: Dict[Tuple[int, int], List[Tuple[int, int]]] = {}
+    while pos < len(data):
+        delta, pos = read_vlq(data, pos)
+        tick += delta
+        first = data[pos]
+        pos += 1
+        if first == 0xFF:
+            pos += 1
+            length, pos = read_vlq(data, pos)
+            pos += length
+            running = None
+            continue
+        if first in (0xF0, 0xF7):
+            length, pos = read_vlq(data, pos)
+            pos += length
+            running = None
+            continue
+        data_bytes: List[int] = []
+        if first < 0x80:
+            if running is None:
+                raise ValueError("running status without status")
+            status = running
+            data_bytes.append(first)
+        else:
+            status = first
+            running = status
+        high = status & 0xF0
+        data_count = 1 if high in (0xC0, 0xD0) else 2
+        while len(data_bytes) < data_count:
+            data_bytes.append(data[pos])
+            pos += 1
+        if high not in (0x80, 0x90):
+            continue
+        pitch = data_bytes[0]
+        velocity = data_bytes[1]
+        channel = (status & 0x0F) + 1
+        key = (pitch, channel)
+        if high == 0x90 and velocity > 0:
+            active.setdefault(key, []).append((tick, velocity))
+        else:
+            started = active.get(key, [])
+            if not started:
+                raise ValueError("unmatched note off")
+            start_tick, start_velocity = started.pop(0)
+            notes.append(MidiNote(
+                pitch=pitch,
+                velocity=start_velocity,
+                start_beats=tick_to_beats(start_tick, division),
+                duration_beats=tick_to_beats(tick - start_tick, division),
+                channel=channel,
+            ))
+    if any(active.values()):
+        raise ValueError("dangling notes")
+
+
+def tick_to_beats(ticks: int, division: int) -> float:
+    return ticks / float(division)
+
+
+def sentinel_matches(notes: List[MidiNote]) -> bool:
+    if len(notes) < len(EXPECTED_RELATIVE):
+        return False
+    first_start = notes[0].start_beats
+    observed = [
+        (note.pitch, round(note.start_beats - first_start, 3), round(note.duration_beats, 3), note.channel)
+        for note in notes[:len(EXPECTED_RELATIVE)]
+    ]
+    return observed == EXPECTED_RELATIVE
+
+
+def enumerate_regions(client: MCPClient, track_index: Optional[int]) -> List[Dict[str, Any]]:
+    project_regions = tool_json(call_tool(client, "logic_project", "get_regions"))
+    if isinstance(project_regions, list):
+        emit("enumerate_regions", "ok", source="logic_project.get_regions", count=len(project_regions))
+        return project_regions
+    if track_index is not None:
+        track_regions = resource_json(read_resource(client, f"logic://tracks/{track_index}/regions"))
+        if isinstance(track_regions, list):
+            emit("enumerate_regions", "ok", source="track_regions_resource", count=len(track_regions))
+            return track_regions
+    emit("enumerate_regions", "failed", project_response=project_regions)
+    return []
+
+
+def emit_osascript_records(step: str, lines: List[str]) -> None:
+    for line in lines:
+        parts = line.split("\t")
+        if not parts:
+            continue
+        kind = parts[0]
+        if kind == "FILE_TITLES" and len(parts) >= 3:
+            emit(step, "ok", kind=kind, separator=parts[1], titles=parts[2])
+        elif kind == "SUBMENU_TITLES" and len(parts) >= 5:
+            emit(step, "ok", kind=kind, file_index=parts[1], parent_title=parts[2], separator=parts[3], titles=parts[4])
+        elif kind == "FILE" and len(parts) >= 5:
+            emit(step, "ok", kind=kind, file_index=parts[1], title=parts[3])
+        elif kind == "SKIPPED_PARENT" and len(parts) >= 5:
+            emit(step, "ok", kind=kind, file_index=parts[1], title=parts[3], reason=parts[4])
+        elif kind == "SUBMENU" and len(parts) >= 5:
+            emit(
+                step,
+                "ok",
+                kind=kind,
+                file_index=parts[1],
+                submenu_index=parts[2],
+                parent_title=parts[3],
+                title=parts[4],
+            )
+        elif kind == "CLICKED" and len(parts) >= 5:
+            emit(step, "ok", kind=kind, file_index=parts[1], submenu_index=parts[2], title=parts[3])
+        elif kind == "FAILED" and len(parts) >= 2:
+            parent_titles = parts[2] if len(parts) >= 3 else None
+            emit(step, "failed", kind=kind, reason=parts[1], parent_titles=parent_titles)
+        elif kind == "SAVE" and len(parts) >= 3:
+            emit(step, "ok", kind=kind, filename_status=parts[1], overwrite_status=parts[2])
+        elif kind == "DELETE_KEYSTROKE" and len(parts) >= 2:
+            emit(step, "ok", kind=kind, confirmation_status=parts[1])
+        elif kind in {"WINDOW", "WINDOW_CHILD", "SHEET", "CHILD", "GRANDCHILD", "NO_WINDOW"} and len(parts) >= 3:
+            emit(step, "ok", kind=kind, role=parts[1], title=parts[2])
+        else:
+            emit(step, "ok", raw=line)
+
+
+def send_escape(label: str = "escape_fallback") -> None:
+    run_osascript(label, ESCAPE_SCRIPT, timeout=3)
+
+
+def send_escape_twice(label: str = "escape_twice_fallback") -> None:
+    run_osascript(label, ESCAPE_TWICE_SCRIPT, timeout=4)
+
+
+def report_dialog_ax_tree(label: str) -> None:
+    result = run_osascript(f"{label}_ax_tree", DIALOG_TREE_SCRIPT, timeout=5)
+    emit_osascript_records("dialog_ax_tree", result.stdout_lines)
+
+
+def fail_ui_step(step: str, **evidence: Any) -> None:
+    report_dialog_ax_tree(step)
+    send_escape(f"{step}_escape_fallback")
+    emit(step, "failed", **evidence)
+
+
+def click_export_selection_as_midi() -> bool:
+    result = run_osascript("export_menu_click", EXPORT_MENU_SCRIPT, timeout=8)
+    emit_osascript_records("export_menu_enumeration", result.stdout_lines)
+    clicked = any(line.startswith("CLICKED\t") for line in result.stdout_lines)
+    if result.returncode != 0 or not clicked:
+        fail_ui_step("export_menu_click", returncode=result.returncode, clicked=clicked, stderr=result.stderr)
+        return False
+    return True
+
+
+def handle_save_dialog(export_dir: Path, filename: str) -> bool:
+    script = (
+        SAVE_DIALOG_SCRIPT
+        .replace("__TARGET_DIR__", applescript_literal(str(export_dir)))
+        .replace("__FILE_NAME__", applescript_literal(filename))
+    )
+    result = run_osascript("save_dialog", script, timeout=10)
+    emit_osascript_records("save_dialog", result.stdout_lines)
+    if result.returncode != 0:
+        fail_ui_step("save_dialog", returncode=result.returncode, stderr=result.stderr)
+        return False
+    return True
+
+
+def midi_file_snapshot(export_dir: Path) -> Dict[str, int]:
+    snapshot: Dict[str, int] = {}
+    for path in export_dir.glob("*.mid"):
+        try:
+            snapshot[str(path)] = path.stat().st_mtime_ns
+        except OSError:
+            continue
+    return snapshot
+
+
+def poll_exported_midi(export_dir: Path, before: Dict[str, int]) -> Optional[Path]:
+    deadline = time.time() + EXPORT_POLL_SECONDS
+    latest: Optional[Path] = None
+    while time.time() < deadline:
+        changed: List[Path] = []
+        for path in export_dir.glob("*.mid"):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            if stat.st_size > 0 and stat.st_mtime_ns > before.get(str(path), 0):
+                changed.append(path)
+        if changed:
+            latest = max(changed, key=lambda candidate: candidate.stat().st_mtime_ns)
+            break
+        time.sleep(0.1)
+    emit("poll_exported_midi", "ok" if latest else "failed", path=str(latest) if latest else None, timeout_seconds=EXPORT_POLL_SECONDS)
+    return latest
+
+
+def cleanup_created_tracks(client: MCPClient, original_count: int, created_indices: List[int]) -> None:
+    send_escape_twice("cleanup_pre_escape")
+    try:
+        for index in sorted(set(created_indices), reverse=True):
+            params = {"index": index}
+            response = call_tool(client, "logic_tracks", "select", params, timeout=30)
+            emit("cleanup_track_select", "requested", index=index, params=params, response=tool_json(response) or response_text(response, "content"))
+            delete_result = run_osascript("cleanup_track_delete", DELETE_TRACK_KEYSTROKE_SCRIPT, timeout=6)
+            emit_osascript_records("cleanup_track_delete", delete_result.stdout_lines)
+            if delete_result.returncode != 0:
+                emit("cleanup_track_delete", "failed", index=index, returncode=delete_result.returncode, stderr=delete_result.stderr)
+        final_tracks = tracks_snapshot(client)
+        if final_tracks is None:
+            emit(
+                "cleanup_final_track_count",
+                "failed",
+                baseline_count=original_count,
+                created_track_indices=created_indices,
+                reason="tracks resource read failed or returned malformed envelope",
+            )
+            return
+        final_count = len(final_tracks)
+        emit(
+            "cleanup_final_track_count",
+            "ok" if final_count == original_count else "failed",
+            baseline_count=original_count,
+            final_count=final_count,
+            created_track_indices=created_indices,
+        )
+    finally:
+        send_escape("cleanup_post_escape")
+
+
+def run_probe(client: MCPClient, tools: List[Dict[str, Any]], export_dir: Path) -> Tuple[bool, Optional[int], List[int]]:
+    before_tracks = tracks_snapshot(client)
+    if before_tracks is None:
+        emit("snapshot_tracks", "failed", reason="tracks resource read failed or returned malformed envelope")
+        return False, None, []
+    before_count = len(before_tracks)
+    emit("snapshot_tracks", "ok", count=before_count)
+
+    record_response = call_tool(
+        client,
+        "logic_tracks",
+        "record_sequence",
+        {"bar": SENTINEL_BAR, "notes": SENTINEL_NOTES, "tempo": 120},
+        timeout=60,
+    )
+    record_payload = tool_json(record_response)
+    emit("record_sequence_sentinel", "sent", response=record_payload or response_text(record_response, "content"))
+
+    after_tracks = tracks_snapshot(client)
+    after_count = len(after_tracks) if after_tracks is not None else None
+    created_indices: List[int] = []
+    created_track = None
+    if isinstance(record_payload, dict) and isinstance(record_payload.get("created_track"), int):
+        created_track = record_payload["created_track"]
+    if after_tracks is not None and len(after_tracks) >= before_count + 1:
+        created_indices = list(range(before_count, len(after_tracks)))
+    elif created_track is not None:
+        created_indices = [created_track]
+    if created_track is None and created_indices:
+        created_track = before_count
+    emit(
+        "created_track_identity",
+        "ok" if created_track is not None else "missing",
+        index=created_track,
+        baseline_count=before_count,
+        after_count=after_count,
+        cleanup_indices=created_indices,
+    )
+
+    regions = enumerate_regions(client, created_track)
+    region_identity = regions[-1] if regions else None
+    emit(
+        "region_selection_hypothesis",
+        "ok",
+        marker="HYPOTHESIS_RECORD_SEQUENCE_IMPORTED_REGION_REMAINS_SELECTED",
+        action="skip_explicit_region_selection",
+        proof="exported MIDI sentinel comparison",
+        created_track=created_track,
+        region_identity=region_identity,
+        server_tools_seen=[tool.get("name") for tool in tools],
+    )
+
+    before_files = midi_file_snapshot(export_dir)
+    if not click_export_selection_as_midi():
+        return False, before_count, created_indices
+    if not handle_save_dialog(export_dir, EXPORT_FILENAME):
+        return False, before_count, created_indices
+    exported = poll_exported_midi(export_dir, before_files)
+    if exported is None:
+        fail_ui_step("verify_export_file", expected_dir=str(export_dir), reason="no new or modified MIDI export file found")
+        return False, before_count, created_indices
+
+    notes = extract_smf_notes(exported)
+    matched = sentinel_matches(notes)
+    emit("verify_export_file", "ok" if matched else "mismatch", path=str(exported), parsed_notes=[note.__dict__ for note in notes])
+    if not matched:
+        send_escape("verify_export_file_escape_fallback")
+    return matched, before_count, created_indices
+
+
+def main() -> int:
+    export_dir = EXPORT_DIR
+    export_dir.mkdir(parents=True, exist_ok=True)
+    emit("controlled_export_dir", "ok", path=str(export_dir))
+
+    client = MCPClient()
+    before_count: Optional[int] = None
+    created_track_indices: List[int] = []
+    try:
+        if not initialize(client):
+            return 2
+        if not wait_for_resource_ready(client):
+            return 2
+        tools = list_tools(client)
+        ok, probe_before_count, probe_created_indices = run_probe(client, tools, export_dir)
+        if probe_before_count is not None:
+            before_count = probe_before_count
+            created_track_indices = probe_created_indices
+        return 0 if ok else 2
+    finally:
+        if before_count is not None:
+            cleanup_created_tracks(client, before_count, created_track_indices)
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/LogicProMCP/MIDI/ExportTemporaryFiles.swift
+++ b/Sources/LogicProMCP/MIDI/ExportTemporaryFiles.swift
@@ -1,0 +1,116 @@
+import Darwin
+import Foundation
+
+enum ExportTemporaryFiles {
+    struct TemporaryExportFile {
+        let fileURL: URL
+        let directoryURL: URL
+    }
+
+    private final class ManagedExportFileRegistry: @unchecked Sendable {
+        private let lock = NSLock()
+        private var paths: Set<String> = []
+
+        func register(_ url: URL) {
+            lock.lock()
+            defer { lock.unlock() }
+            paths.insert(ExportTemporaryFiles.canonicalPath(url))
+        }
+
+        func unregisterDirectory(_ url: URL) {
+            let prefix = ExportTemporaryFiles.canonicalPath(url) + "/"
+            lock.lock()
+            defer { lock.unlock() }
+            paths = paths.filter { !$0.hasPrefix(prefix) }
+        }
+
+        func contains(_ path: String) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return paths.contains(ExportTemporaryFiles.canonicalPath(URL(fileURLWithPath: path)))
+        }
+    }
+
+    private static let managedExportFiles = ManagedExportFileRegistry()
+
+    static func temporaryExportFile(
+        baseDirectory: URL = FileManager.default.temporaryDirectory
+    ) throws -> TemporaryExportFile {
+        let directoryURL = try makePrivateTemporaryDirectory(baseDirectory: baseDirectory)
+        let file = TemporaryExportFile(
+            fileURL: directoryURL.appendingPathComponent("\(UUID().uuidString).mid"),
+            directoryURL: directoryURL
+        )
+        managedExportFiles.register(file.fileURL)
+        return file
+    }
+
+    static func cleanupTemporaryExportFile(_ file: TemporaryExportFile) {
+        managedExportFiles.unregisterDirectory(file.directoryURL)
+        try? FileManager.default.removeItem(at: file.directoryURL)
+    }
+
+    static func isManagedTemporaryExportFile(_ path: String) -> Bool {
+        managedExportFiles.contains(path)
+    }
+
+    static func temporaryDirectoryPrefix(
+        baseDirectory: URL = FileManager.default.temporaryDirectory
+    ) -> String {
+        let basePath = baseDirectory
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+        let normalizedBasePath = basePath.hasSuffix("/") ? String(basePath.dropLast()) : basePath
+        return "\(normalizedBasePath)/LogicProMCPExport-\(getuid())-"
+    }
+
+    static func cleanupOrphanFiles(
+        in dir: String = FileManager.default.temporaryDirectory.path,
+        olderThan: TimeInterval = 300
+    ) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: dir) else { return }
+        guard (try? fileManager.destinationOfSymbolicLink(atPath: dir)) == nil else { return }
+
+        let cutoff = Date().addingTimeInterval(-olderThan)
+        guard let entries = try? fileManager.contentsOfDirectory(atPath: dir) else { return }
+        for name in entries {
+            let fullPath = "\(dir)/\(name)"
+            guard (try? fileManager.destinationOfSymbolicLink(atPath: fullPath)) == nil else { continue }
+            guard name.hasPrefix("LogicProMCPExport-\(getuid())-") else { continue }
+            guard let attributes = try? fileManager.attributesOfItem(atPath: fullPath),
+                  let modifiedAt = attributes[.modificationDate] as? Date,
+                  modifiedAt < cutoff,
+                  (attributes[.type] as? FileAttributeType) == .typeDirectory,
+                  (attributes[.ownerAccountID] as? NSNumber)?.uintValue == UInt(getuid()) else { continue }
+            managedExportFiles.unregisterDirectory(URL(fileURLWithPath: fullPath, isDirectory: true))
+            try? fileManager.removeItem(atPath: fullPath)
+        }
+    }
+
+    static func cleanupStartupOrphanFiles(
+        baseDirectory: URL = FileManager.default.temporaryDirectory,
+        olderThan: TimeInterval = 300
+    ) {
+        cleanupOrphanFiles(in: baseDirectory.path, olderThan: olderThan)
+    }
+
+    private static func canonicalPath(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    private static func makePrivateTemporaryDirectory(baseDirectory: URL) throws -> URL {
+        let template = temporaryDirectoryPrefix(baseDirectory: baseDirectory) + "XXXXXX"
+        let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: template.utf8.count + 1)
+        defer { buffer.deallocate() }
+        _ = template.withCString { source in
+            strcpy(buffer, source)
+        }
+        guard let created = mkdtemp(buffer) else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            throw POSIXError(code)
+        }
+        return URL(fileURLWithPath: String(cString: created), isDirectory: true)
+    }
+}

--- a/Sources/LogicProMCP/MIDI/SMFReader.swift
+++ b/Sources/LogicProMCP/MIDI/SMFReader.swift
@@ -1,0 +1,376 @@
+import Foundation
+
+enum SMFReaderError: Error, Equatable {
+    case malformedHeader
+    case unsupportedFormat(Int)
+    case unsupportedDivision(UInt16)
+    case invalidTrackLength
+    case malformedVLQ
+    case malformedEvent
+    case missingEndOfTrack
+    case badEndOfTrackLength
+    case eventAfterEndOfTrack
+    case truncatedEvent
+    case invalidTimeDivision
+    case unmatchedNoteOff(pitch: UInt8, channel: Int)
+    case danglingNotes
+}
+
+struct SMFReader {
+    struct Note: Equatable {
+        let pitch: UInt8
+        let velocity: UInt8
+        let startBar: Int
+        let startBeat: Double
+        let durationBeats: Double
+        let channel: Int
+    }
+
+    static func parse(_ data: Data) throws -> [Note] {
+        var reader = ByteReader([UInt8](data))
+        try reader.expect([0x4D, 0x54, 0x68, 0x64])
+        let headerLength = try reader.readUInt32()
+        guard headerLength >= 6 else { throw SMFReaderError.malformedHeader }
+
+        let format = Int(try reader.readUInt16())
+        guard format == 0 || format == 1 else { throw SMFReaderError.unsupportedFormat(format) }
+        let trackCount = Int(try reader.readUInt16())
+        guard format == 1 || trackCount == 1 else { throw SMFReaderError.malformedHeader }
+
+        let divisionRaw = try reader.readUInt16()
+        guard divisionRaw & 0x8000 == 0 else { throw SMFReaderError.unsupportedDivision(divisionRaw) }
+        let ticksPerQuarter = Int(divisionRaw)
+        guard ticksPerQuarter > 0 else { throw SMFReaderError.unsupportedDivision(divisionRaw) }
+        try reader.skip(Int(headerLength) - 6)
+
+        var notes: [RawNote] = []
+        var timeSignatures: [TimeSignatureChange] = []
+        for _ in 0..<trackCount {
+            try reader.expect([0x4D, 0x54, 0x72, 0x6B])
+            let length = Int(try reader.readUInt32())
+            guard reader.remaining >= length else { throw SMFReaderError.invalidTrackLength }
+            let trackBytes = try reader.readBytes(length)
+            let track = try parseTrack(trackBytes)
+            notes.append(contentsOf: track.notes)
+            timeSignatures.append(contentsOf: track.timeSignatures)
+        }
+        guard reader.isAtEnd else { throw SMFReaderError.invalidTrackLength }
+
+        let map = try TimeMap(ticksPerQuarter: ticksPerQuarter, changes: timeSignatures)
+        return try notes.sorted().map { try map.note(from: $0) }
+    }
+
+    private struct ParsedTrack {
+        let notes: [RawNote]
+        let timeSignatures: [TimeSignatureChange]
+    }
+
+    private struct NoteKey: Hashable {
+        let pitch: UInt8
+        let channel: Int
+    }
+
+    private struct ActiveNote {
+        let tick: Int
+        let velocity: UInt8
+    }
+
+    private struct RawNote: Comparable {
+        let pitch: UInt8
+        let velocity: UInt8
+        let startTick: Int
+        let endTick: Int
+        let channel: Int
+
+        static func < (lhs: RawNote, rhs: RawNote) -> Bool {
+            if lhs.startTick != rhs.startTick { return lhs.startTick < rhs.startTick }
+            if lhs.pitch != rhs.pitch { return lhs.pitch < rhs.pitch }
+            return lhs.channel < rhs.channel
+        }
+    }
+
+    private static func parseTrack(_ bytes: [UInt8]) throws -> ParsedTrack {
+        var reader = ByteReader(bytes)
+        var tick = 0
+        var runningStatus: UInt8?
+        var active: [NoteKey: [ActiveNote]] = [:]
+        var notes: [RawNote] = []
+        var timeSignatures: [TimeSignatureChange] = []
+        var sawEndOfTrack = false
+
+        while !reader.isAtEnd {
+            tick += try reader.readVLQ()
+            let first = try reader.readByte()
+
+            if first == 0xFF {
+                runningStatus = nil
+                if try parseMetaEvent(tick: tick, reader: &reader, timeSignatures: &timeSignatures) {
+                    guard !sawEndOfTrack else { throw SMFReaderError.eventAfterEndOfTrack }
+                    sawEndOfTrack = true
+                    guard reader.isAtEnd else { throw SMFReaderError.eventAfterEndOfTrack }
+                }
+            } else if first == 0xF0 || first == 0xF7 {
+                runningStatus = nil
+                try reader.skip(try reader.readVLQ())
+            } else {
+                try parseChannelEvent(
+                    firstByte: first,
+                    tick: tick,
+                    runningStatus: &runningStatus,
+                    reader: &reader,
+                    active: &active,
+                    notes: &notes
+                )
+            }
+        }
+
+        guard sawEndOfTrack else { throw SMFReaderError.missingEndOfTrack }
+        guard active.values.allSatisfy(\.isEmpty) else { throw SMFReaderError.danglingNotes }
+        return ParsedTrack(notes: notes, timeSignatures: timeSignatures)
+    }
+
+    private static func parseMetaEvent(
+        tick: Int,
+        reader: inout ByteReader,
+        timeSignatures: inout [TimeSignatureChange]
+    ) throws -> Bool {
+        let type = try reader.readByte()
+        let length = try reader.readVLQ()
+
+        if type == 0x2F {
+            guard length == 0 else { throw SMFReaderError.badEndOfTrackLength }
+            return true
+        }
+
+        let payload = try reader.readBytes(length)
+
+        switch type {
+        case 0x51:
+            guard length == 3 else { throw SMFReaderError.malformedEvent }
+        case 0x58:
+            guard length == 4, payload[0] > 0, payload[1] < 8 else { throw SMFReaderError.malformedEvent }
+            timeSignatures.append(TimeSignatureChange(
+                tick: tick,
+                signature: TimeSignature(numerator: Int(payload[0]), denominator: 1 << Int(payload[1]))
+            ))
+        default:
+            break
+        }
+        return false
+    }
+
+    private static func parseChannelEvent(
+        firstByte: UInt8,
+        tick: Int,
+        runningStatus: inout UInt8?,
+        reader: inout ByteReader,
+        active: inout [NoteKey: [ActiveNote]],
+        notes: inout [RawNote]
+    ) throws {
+        var dataBytes: [UInt8] = []
+        let status: UInt8
+
+        if firstByte < 0x80 {
+            guard let running = runningStatus else { throw SMFReaderError.malformedEvent }
+            status = running
+            dataBytes.append(firstByte)
+        } else {
+            guard firstByte < 0xF0 else { throw SMFReaderError.malformedEvent }
+            status = firstByte
+            runningStatus = status
+        }
+
+        let highNibble = status & 0xF0
+        let dataCount = (highNibble == 0xC0 || highNibble == 0xD0) ? 1 : 2
+        while dataBytes.count < dataCount {
+            let byte = try reader.readByte()
+            guard byte < 0x80 else { throw SMFReaderError.malformedEvent }
+            dataBytes.append(byte)
+        }
+
+        guard highNibble == 0x80 || highNibble == 0x90 else { return }
+        let pitch = dataBytes[0]
+        let velocity = dataBytes[1]
+        let channel = Int(status & 0x0F) + 1
+        let key = NoteKey(pitch: pitch, channel: channel)
+
+        if highNibble == 0x90 && velocity > 0 {
+            active[key, default: []].append(ActiveNote(tick: tick, velocity: velocity))
+            return
+        }
+
+        guard var stack = active[key], !stack.isEmpty else {
+            throw SMFReaderError.unmatchedNoteOff(pitch: pitch, channel: channel)
+        }
+        let start = stack.removeFirst()
+        active[key] = stack
+        guard tick > start.tick else { throw SMFReaderError.malformedEvent }
+        notes.append(RawNote(
+            pitch: pitch,
+            velocity: start.velocity,
+            startTick: start.tick,
+            endTick: tick,
+            channel: channel
+        ))
+    }
+
+    private struct TimeSignature: Equatable {
+        let numerator: Int
+        let denominator: Int
+
+        func ticksPerBeat(_ ticksPerQuarter: Int) throws -> Double {
+            guard ticksPerQuarter > 0, denominator > 0 else { throw SMFReaderError.invalidTimeDivision }
+            let ticks = Double(ticksPerQuarter) * 4.0 / Double(denominator)
+            guard ticks > 0, ticks.isFinite else { throw SMFReaderError.invalidTimeDivision }
+            return ticks
+        }
+    }
+
+    private struct TimeSignatureChange {
+        let tick: Int
+        let signature: TimeSignature
+    }
+
+    private struct TimeSegment {
+        let startTick: Int
+        let startBar: Int
+        let startBeat: Double
+        let signature: TimeSignature
+    }
+
+    private struct TimeMap {
+        let ticksPerQuarter: Int
+        let segments: [TimeSegment]
+
+        init(ticksPerQuarter: Int, changes: [TimeSignatureChange]) throws {
+            self.ticksPerQuarter = ticksPerQuarter
+            let defaultSignature = TimeSignature(numerator: 4, denominator: 4)
+            var byTick = [0: defaultSignature]
+            for change in changes where change.tick >= 0 {
+                byTick[change.tick] = change.signature
+            }
+
+            let ordered = byTick
+                .map { TimeSignatureChange(tick: $0.key, signature: $0.value) }
+                .sorted { $0.tick < $1.tick }
+            var built = [TimeSegment(startTick: 0, startBar: 1, startBeat: 1.0, signature: defaultSignature)]
+            for change in ordered {
+                if change.tick == 0 {
+                    built[0] = TimeSegment(startTick: 0, startBar: 1, startBeat: 1.0, signature: change.signature)
+                } else {
+                    let location = try Self.location(of: change.tick, segments: built, ticksPerQuarter: ticksPerQuarter)
+                    built.append(TimeSegment(
+                        startTick: change.tick,
+                        startBar: location.bar,
+                        startBeat: location.beat,
+                        signature: change.signature
+                    ))
+                }
+            }
+            segments = built
+        }
+
+        func note(from raw: RawNote) throws -> Note {
+            let location = try Self.location(of: raw.startTick, segments: segments, ticksPerQuarter: ticksPerQuarter)
+            let durationBeats = try Self.durationBeats(
+                from: raw.startTick,
+                to: raw.endTick,
+                segments: segments,
+                ticksPerQuarter: ticksPerQuarter
+            )
+            return Note(
+                pitch: raw.pitch,
+                velocity: raw.velocity,
+                startBar: location.bar,
+                startBeat: location.beat,
+                durationBeats: durationBeats,
+                channel: raw.channel
+            )
+        }
+
+        private static func durationBeats(
+            from startTick: Int,
+            to endTick: Int,
+            segments: [TimeSegment],
+            ticksPerQuarter: Int
+        ) throws -> Double {
+            guard endTick >= startTick else { throw SMFReaderError.malformedEvent }
+            var current = startTick
+            var total = 0.0
+            while current < endTick {
+                let segment = segments.last { $0.startTick <= current } ?? segments[0]
+                let nextChange = segments.first { $0.startTick > current }?.startTick ?? endTick
+                let segmentEnd = min(endTick, nextChange)
+                total += Double(segmentEnd - current) / (try segment.signature.ticksPerBeat(ticksPerQuarter))
+                current = segmentEnd
+            }
+            return total
+        }
+
+        private static func location(
+            of tick: Int,
+            segments: [TimeSegment],
+            ticksPerQuarter: Int
+        ) throws -> (bar: Int, beat: Double, signature: TimeSignature) {
+            let segment = segments.last { $0.startTick <= tick } ?? segments[0]
+            let ticksPerBeat = try segment.signature.ticksPerBeat(ticksPerQuarter)
+            let beatIndex = segment.startBeat - 1.0 + Double(tick - segment.startTick) / ticksPerBeat
+            let barOffset = Int(floor(beatIndex / Double(segment.signature.numerator)))
+            let beat = 1.0 + beatIndex - Double(barOffset * segment.signature.numerator)
+            return (segment.startBar + barOffset, beat, segment.signature)
+        }
+    }
+}
+
+private struct ByteReader {
+    private let bytes: [UInt8]
+    private(set) var index = 0
+
+    init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    var isAtEnd: Bool { index == bytes.count }
+    var remaining: Int { bytes.count - index }
+
+    mutating func expect(_ expected: [UInt8]) throws {
+        guard try readBytes(expected.count) == expected else { throw SMFReaderError.malformedHeader }
+    }
+
+    mutating func readByte() throws -> UInt8 {
+        guard index < bytes.count else { throw SMFReaderError.malformedEvent }
+        defer { index += 1 }
+        return bytes[index]
+    }
+
+    mutating func readBytes(_ count: Int) throws -> [UInt8] {
+        guard count >= 0 else { throw SMFReaderError.malformedEvent }
+        guard remaining >= count else { throw SMFReaderError.truncatedEvent }
+        defer { index += count }
+        return Array(bytes[index..<(index + count)])
+    }
+
+    mutating func skip(_ count: Int) throws {
+        _ = try readBytes(count)
+    }
+
+    mutating func readUInt16() throws -> UInt16 {
+        let raw = try readBytes(2)
+        return (UInt16(raw[0]) << 8) | UInt16(raw[1])
+    }
+
+    mutating func readUInt32() throws -> UInt32 {
+        let raw = try readBytes(4)
+        return (UInt32(raw[0]) << 24) | (UInt32(raw[1]) << 16) | (UInt32(raw[2]) << 8) | UInt32(raw[3])
+    }
+
+    mutating func readVLQ() throws -> Int {
+        var value = 0
+        for _ in 0..<4 {
+            let byte = try readByte()
+            value = (value << 7) | Int(byte & 0x7F)
+            if byte & 0x80 == 0 { return value }
+        }
+        throw SMFReaderError.malformedVLQ
+    }
+}

--- a/Tests/LogicProMCPTests/ExportTemporaryFilesTests.swift
+++ b/Tests/LogicProMCPTests/ExportTemporaryFilesTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import LogicProMCP
+
+@Test func testExportTemporaryFilesCreatesPrivateRegisteredFile() throws {
+    let base = try temporaryExportTestDirectory()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let file = try ExportTemporaryFiles.temporaryExportFile(baseDirectory: base)
+    defer { ExportTemporaryFiles.cleanupTemporaryExportFile(file) }
+
+    #expect(FileManager.default.fileExists(atPath: file.directoryURL.path))
+    #expect(file.fileURL.path.hasPrefix(file.directoryURL.path + "/"))
+    #expect(file.fileURL.pathExtension == "mid")
+    #expect(ExportTemporaryFiles.isManagedTemporaryExportFile(file.fileURL.path))
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: file.directoryURL.path)
+    let permissions = try #require(attributes[FileAttributeKey.posixPermissions] as? NSNumber)
+    #expect(permissions.intValue & 0o777 == 0o700)
+}
+
+@Test func testExportTemporaryFilesCleanupRemovesDirectoryAndRegistryEntry() throws {
+    let base = try temporaryExportTestDirectory()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let file = try ExportTemporaryFiles.temporaryExportFile(baseDirectory: base)
+    try Data([0x4D, 0x54]).write(to: file.fileURL)
+
+    ExportTemporaryFiles.cleanupTemporaryExportFile(file)
+
+    #expect(!FileManager.default.fileExists(atPath: file.directoryURL.path))
+    #expect(!ExportTemporaryFiles.isManagedTemporaryExportFile(file.fileURL.path))
+}
+
+@Test func testExportTemporaryFilesCleanupDeletesOwnedDirectoriesOnly() throws {
+    let base = try temporaryExportTestDirectory()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let ownedDir = ExportTemporaryFiles.temporaryDirectoryPrefix(baseDirectory: base) + UUID().uuidString
+    let unrelatedFile = base.appendingPathComponent("unrelated.mid")
+    let symlinkTarget = base.appendingPathComponent("attacker-target", isDirectory: true)
+    let symlinkPath = ExportTemporaryFiles.temporaryDirectoryPrefix(baseDirectory: base) + "symlink"
+
+    try FileManager.default.createDirectory(atPath: ownedDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: symlinkTarget, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: "\(ownedDir)/owned.mid", contents: Data([0, 1, 2]))
+    FileManager.default.createFile(atPath: unrelatedFile.path, contents: Data([0, 1, 2]))
+    try FileManager.default.createSymbolicLink(atPath: symlinkPath, withDestinationPath: symlinkTarget.path)
+
+    let oldDate = Date().addingTimeInterval(-600)
+    try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: ownedDir)
+    try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: unrelatedFile.path)
+
+    ExportTemporaryFiles.cleanupOrphanFiles(in: base.path, olderThan: 300)
+
+    #expect(!FileManager.default.fileExists(atPath: ownedDir))
+    #expect(FileManager.default.fileExists(atPath: unrelatedFile.path))
+    #expect(FileManager.default.fileExists(atPath: symlinkTarget.path))
+}
+
+@Test func testExportTemporaryFilesOrphanCleanupUnregistersDeletedFiles() throws {
+    let base = try temporaryExportTestDirectory()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let file = try ExportTemporaryFiles.temporaryExportFile(baseDirectory: base)
+    try Data([0x4D, 0x54]).write(to: file.fileURL)
+    try FileManager.default.setAttributes(
+        [.modificationDate: Date().addingTimeInterval(-600)],
+        ofItemAtPath: file.directoryURL.path
+    )
+
+    #expect(ExportTemporaryFiles.isManagedTemporaryExportFile(file.fileURL.path))
+
+    ExportTemporaryFiles.cleanupOrphanFiles(in: base.path, olderThan: 300)
+
+    #expect(!FileManager.default.fileExists(atPath: file.directoryURL.path))
+    #expect(!ExportTemporaryFiles.isManagedTemporaryExportFile(file.fileURL.path))
+}
+
+@Test func testExportTemporaryFilesCleanupHandlesMissingDirectory() {
+    ExportTemporaryFiles.cleanupOrphanFiles(in: "/tmp/does-not-exist-\(UUID().uuidString)")
+}
+
+private func temporaryExportTestDirectory() throws -> URL {
+    let path = NSTemporaryDirectory() + "ExportTemporaryFilesTests-\(UUID().uuidString)"
+    let url = URL(fileURLWithPath: path, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}

--- a/Tests/LogicProMCPTests/SMFReaderTests.swift
+++ b/Tests/LogicProMCPTests/SMFReaderTests.swift
@@ -1,0 +1,290 @@
+import Testing
+import Foundation
+@testable import LogicProMCP
+
+@Test func testSMFReaderParsesRunningStatus() throws {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x64,
+            0x81, 0x70, 0x40, 0x5A,
+            0x81, 0x70, 0x3C, 0x00,
+            0x00, 0x40, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let notes = try SMFReader.parse(data)
+
+    #expect(notes.count == 2)
+    #expect(notes[0] == SMFReader.Note(pitch: 60, velocity: 100, startBar: 1, startBeat: 1.0, durationBeats: 1.0, channel: 1))
+    #expect(notes[1] == SMFReader.Note(pitch: 64, velocity: 90, startBar: 1, startBeat: 1.5, durationBeats: 0.5, channel: 1))
+}
+
+@Test func testSMFReaderTreatsVelocityZeroNoteOnAsNoteOff() throws {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x40,
+            0x83, 0x60, 0x90, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let note = try #require(try SMFReader.parse(data).first)
+
+    #expect(note.pitch == 60)
+    #expect(note.velocity == 64)
+    #expect(note.durationBeats == 1.0)
+}
+
+@Test func testSMFReaderKeepsSamePitchOverlapsSeparate() throws {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x64,
+            0x81, 0x70, 0x90, 0x3C, 0x50,
+            0x81, 0x70, 0x80, 0x3C, 0x00,
+            0x81, 0x70, 0x80, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let notes = try SMFReader.parse(data)
+
+    #expect(notes.count == 2)
+    #expect(notes[0].pitch == 60)
+    #expect(notes[0].velocity == 100)
+    #expect(notes[0].startBeat == 1.0)
+    #expect(notes[0].durationBeats == 1.0)
+    #expect(notes[1].pitch == 60)
+    #expect(notes[1].velocity == 80)
+    #expect(notes[1].startBeat == 1.5)
+    #expect(notes[1].durationBeats == 1.0)
+}
+
+@Test func testSMFReaderRejectsSMPTEDivision() {
+    let data = smfData(division: 0xE250, tracks: [
+        trackData([0x00, 0xFF, 0x2F, 0x00]),
+    ])
+
+    #expect(throws: SMFReaderError.self) {
+        try SMFReader.parse(data)
+    }
+}
+
+@Test func testSMFReaderRejectsVLQAndTrackLengthBounds() {
+    let oversizedVLQ = smfData(tracks: [
+        trackData([
+            0x81, 0x80, 0x80, 0x80, 0x00, 0x90, 0x3C, 0x64,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+    let overstatedTrackLength = smfDataWithRawTrackLength(
+        declaredTrackLength: 9,
+        trackBytes: [0x00, 0xFF, 0x2F, 0x00]
+    )
+
+    #expect(throws: SMFReaderError.self) {
+        try SMFReader.parse(oversizedVLQ)
+    }
+    #expect(throws: SMFReaderError.self) {
+        try SMFReader.parse(overstatedTrackLength)
+    }
+}
+
+@Test func testSMFReaderRequiresEndOfTrackEvent() {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x40,
+            0x83, 0x60, 0x80, 0x3C, 0x00,
+        ]),
+    ])
+
+    expectSMFReaderError(.missingEndOfTrack, parsing: data)
+}
+
+@Test func testSMFReaderRejectsEndOfTrackWithPayload() {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0xFF, 0x2F, 0x01, 0x00,
+        ]),
+    ])
+
+    expectSMFReaderError(.badEndOfTrackLength, parsing: data)
+}
+
+@Test func testSMFReaderRejectsEventBytesAfterEndOfTrack() {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0xFF, 0x2F, 0x00,
+            0x00, 0x90, 0x3C, 0x40,
+            0x83, 0x60, 0x80, 0x3C, 0x00,
+        ]),
+    ])
+
+    expectSMFReaderError(.eventAfterEndOfTrack, parsing: data)
+}
+
+@Test func testSMFReaderRejectsEventPayloadTruncatedAtTrackEnd() {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0xFF, 0x01, 0x02, 0x7F,
+        ]),
+    ])
+
+    expectSMFReaderError(.truncatedEvent, parsing: data)
+}
+
+@Test func testSMFReaderUsesFractionalTicksPerBeat() throws {
+    let data = smfData(division: 1, tracks: [
+        trackData([
+            0x00, 0xFF, 0x58, 0x04, 0x06, 0x03, 0x18, 0x08,
+            0x00, 0x90, 0x3C, 0x40,
+            0x01, 0x80, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let note = try #require(try SMFReader.parse(data).first)
+
+    #expect(note.durationBeats == 2.0)
+}
+
+@Test func testSMFReaderIntegratesDurationAcrossTimeSignatureChanges() throws {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x40,
+            0x83, 0x60, 0xFF, 0x58, 0x04, 0x06, 0x03, 0x18, 0x08,
+            0x83, 0x60, 0x80, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let note = try #require(try SMFReader.parse(data).first)
+
+    #expect(note.durationBeats == 3.0)
+}
+
+@Test func testSMFReaderMergesFormat1TempoAndTimeSignatureTrack() throws {
+    let tempoAndMeterTrack = trackData([
+        0x00, 0xFF, 0x51, 0x03, 0x07, 0xA1, 0x20,
+        0x00, 0xFF, 0x58, 0x04, 0x03, 0x02, 0x18, 0x08,
+        0x00, 0xFF, 0x2F, 0x00,
+    ])
+    let notesTrack = trackData([
+        0x8B, 0x20, 0x91, 0x3E, 0x5A,
+        0x83, 0x60, 0x81, 0x3E, 0x00,
+        0x00, 0xFF, 0x2F, 0x00,
+    ])
+    let data = smfData(format: 1, tracks: [tempoAndMeterTrack, notesTrack])
+
+    let note = try #require(try SMFReader.parse(data).first)
+
+    #expect(note.pitch == 62)
+    #expect(note.startBar == 2)
+    #expect(note.startBeat == 1.0)
+    #expect(note.durationBeats == 1.0)
+    #expect(note.channel == 2)
+}
+
+@Test func testSMFReaderOutputsOneBasedChannels() throws {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x92, 0x3C, 0x64,
+            0x83, 0x60, 0x82, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    let note = try #require(try SMFReader.parse(data).first)
+
+    #expect(note.channel == 3)
+}
+
+@Test func testSMFReaderFailsClosedOnMalformedFileWithoutPartialResults() {
+    let data = smfData(tracks: [
+        trackData([
+            0x00, 0x90, 0x3C, 0x64,
+            0x83, 0x60, 0x80, 0x3C, 0x00,
+            0x00, 0x90, 0x40, 0x64,
+            0x00, 0xFF, 0x2F, 0x00,
+        ]),
+    ])
+
+    #expect(throws: SMFReaderError.self) {
+        try SMFReader.parse(data)
+    }
+}
+
+@Test func testSMFReaderRoundTripsSMFWriterOutput() throws {
+    let generated = try SMFWriter.generate(
+        events: [
+            SMFWriter.NoteEvent(pitch: 60, offsetTicks: 0, durationTicks: 480, velocity: 100, channel: 0),
+            SMFWriter.NoteEvent(pitch: 64, offsetTicks: 240, durationTicks: 240, velocity: 90, channel: 1),
+        ],
+        bar: 2,
+        tempo: 120,
+        timeSignature: (4, 4)
+    )
+
+    let notes = try SMFReader.parse(generated)
+
+    #expect(notes.count == 2)
+    #expect(notes[0] == SMFReader.Note(pitch: 60, velocity: 100, startBar: 2, startBeat: 1.0, durationBeats: 1.0, channel: 1))
+    #expect(notes[1] == SMFReader.Note(pitch: 64, velocity: 90, startBar: 2, startBeat: 1.5, durationBeats: 0.5, channel: 2))
+}
+
+private func smfData(
+    format: Int = 0,
+    division: Int = 480,
+    tracks: [[UInt8]]
+) -> Data {
+    var data = Data()
+    data.append(contentsOf: [0x4D, 0x54, 0x68, 0x64])
+    data.append(contentsOf: uint32BEForSMFReaderTests(6))
+    data.append(contentsOf: uint16BEForSMFReaderTests(format))
+    data.append(contentsOf: uint16BEForSMFReaderTests(tracks.count))
+    data.append(contentsOf: uint16BEForSMFReaderTests(division))
+    for track in tracks {
+        data.append(contentsOf: track)
+    }
+    return data
+}
+
+private func smfDataWithRawTrackLength(
+    declaredTrackLength: Int,
+    trackBytes: [UInt8]
+) -> Data {
+    var data = smfData(tracks: [])
+    data.replaceSubrange(10..<12, with: uint16BEForSMFReaderTests(1))
+    data.append(contentsOf: [0x4D, 0x54, 0x72, 0x6B])
+    data.append(contentsOf: uint32BEForSMFReaderTests(declaredTrackLength))
+    data.append(contentsOf: trackBytes)
+    return data
+}
+
+private func trackData(_ events: [UInt8]) -> [UInt8] {
+    [0x4D, 0x54, 0x72, 0x6B] + uint32BEForSMFReaderTests(events.count) + events
+}
+
+private func expectSMFReaderError(_ expected: SMFReaderError, parsing data: Data) {
+    do {
+        _ = try SMFReader.parse(data)
+        Issue.record("Expected SMFReaderError.\(expected)")
+    } catch let error as SMFReaderError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected SMFReaderError.\(expected), got \(error)")
+    }
+}
+
+private func uint16BEForSMFReaderTests(_ value: Int) -> [UInt8] {
+    [UInt8((value >> 8) & 0xFF), UInt8(value & 0xFF)]
+}
+
+private func uint32BEForSMFReaderTests(_ value: Int) -> [UInt8] {
+    [
+        UInt8((value >> 24) & 0xFF),
+        UInt8((value >> 16) & 0xFF),
+        UInt8((value >> 8) & 0xFF),
+        UInt8(value & 0xFF),
+    ]
+}

--- a/docs/prd/PRD-v39-hardening-and-midi-read.md
+++ b/docs/prd/PRD-v39-hardening-and-midi-read.md
@@ -86,12 +86,12 @@
 ### US-5 (WS5): MIDI 읽기 경로
 **As a** natural-language user, **I want** 선택 region의 노트를 JSON으로 읽기를, **so that** 읽기→편집→쓰기 루프가 가능하다.
 
-**AC:**
-- [ ] AC-5.1: T0 라이브 스파이크 PASS가 본 구현 게이트 (boomer#5 강화) — **알려진 sentinel region**(record_sequence로 생성한 기지 노트 세트)을 선택 → Export Selection as MIDI File 메뉴(locale-agnostic) → save 다이얼로그를 통제 디렉토리로 유도 → 파일 생성 + **파싱된 노트가 sentinel과 일치**까지 확인. 실패 시 WS5 전체 honest defer
+**AC:** — **T0 게이트 결과 2026-07-07: FAILED → AC-5.3/5.4/5.5(라이브 표면) honest-deferred. AC-5.2(SMFReader)+임시파일 매니저만 T5a로 출하.** 상세 증거: `docs/spikes/midi-export-t0-evidence.md`.
+- [x] AC-5.1 (게이트, **FAILED**): 라이브 스파이크로 File>Export>Selection as MIDI File 메뉴 도달·record_sequence sentinel·region 열거까지는 성공했으나, export **저장 패널이 out-of-process remote-view**라 (a) 내부 컨트롤 AX-불투명, (b) 합성 키보드 입력 미도달(Secure Input OFF 확인, osascript/cliclick/focus-click 3채널 검증), (c) 마우스만으로는 통제 디렉토리+파일명 입력 불가 → 통제-저장 계약 충족 불가. 자동화 시도가 Logic을 modal-stack hang으로 유발(force-quit 복구). 이 repo가 반복 honest-defer해온 라이브-UI 월과 동일 계열.
 - [ ] AC-5.2: `SMFReader` — format 0/1, tempo/time-sig meta, note on/off 페어링, division 기반 tick→bar/beat 변환. **필수 fixture** (boomer#8): running status, velocity-0 note-off, 동일 pitch/channel 중첩 노트, SMPTE division 거부, VLQ/track-length 경계, format-1 멀티트랙 tempo 병합, channel 1-based 출력. malformed SMF는 fail-closed(부분 결과 반환 금지)
-- [ ] AC-5.3: `logic_midi.read_selection_notes` — **State A 조건 강화** (boomer#5): (a) export 파일이 신규 생성(사전 부재+mtime/size 검증), (b) 파싱 성공, (c) export 직전 AX로 선택 identity(region/track) 캡처 후 evidence에 포함. identity 캡처 불가 시 State B. 임시 파일은 **전용 export 레지스트리 매니저** (boomer#7: SMFWriter+TemporaryFiles 대칭 — 전용 디렉토리 생성, symlink escape 방지, 파싱 후 cleanup, 테스트 포함) 경유
-- [ ] AC-5.4: `record_sequence verify_notes:true` (boomer#6 강화) — (a) 기존 선택/플레이헤드 캡처, (b) **생성된 region을 결정론적으로 선택**(기존 region-enumeration 결과의 identity 사용), 선택 검증 실패 시 export 시도 없이 State B, (c) export→파싱→요청 노트 대조 일치 시 State A(노트 evidence), (d) 이전 선택 복원. 기본값 false
-- [ ] AC-5.5: 선택이 없거나 MIDI region이 아닐 때 명시적 typed 에러(State C), 다이얼로그 잔류 없음(Escape 폴백)
+- [~] AC-5.3 (**DEFERRED**, T0 실패): `logic_midi.read_selection_notes` — **State A 조건 강화** (boomer#5): (a) export 파일이 신규 생성(사전 부재+mtime/size 검증), (b) 파싱 성공, (c) export 직전 AX로 선택 identity(region/track) 캡처 후 evidence에 포함. identity 캡처 불가 시 State B. 임시 파일은 **전용 export 레지스트리 매니저** (boomer#7: SMFWriter+TemporaryFiles 대칭 — 전용 디렉토리 생성, symlink escape 방지, 파싱 후 cleanup, 테스트 포함) 경유
+- [~] AC-5.4 (**DEFERRED**, T0 실패): `record_sequence verify_notes:true` (boomer#6 강화) — (a) 기존 선택/플레이헤드 캡처, (b) **생성된 region을 결정론적으로 선택**(기존 region-enumeration 결과의 identity 사용), 선택 검증 실패 시 export 시도 없이 State B, (c) export→파싱→요청 노트 대조 일치 시 State A(노트 evidence), (d) 이전 선택 복원. 기본값 false
+- [~] AC-5.5 (**DEFERRED**, T0 실패): 선택이 없거나 MIDI region이 아닐 때 명시적 typed 에러(State C), 다이얼로그 잔류 없음(Escape 폴백)
 
 ### US-6 (WS6): Channel EQ verified 파라미터 확장
 **AC:**

--- a/docs/spikes/midi-export-t0-evidence.md
+++ b/docs/spikes/midi-export-t0-evidence.md
@@ -1,0 +1,38 @@
+# T0 Live Spike Evidence — MIDI Export Read Path (WS5)
+
+**Date**: 2026-07-07
+**Verdict**: **GATE FAILED → T5b honest-deferred** (T5a ships independently)
+**Environment**: Logic Pro 12.x (build reporting server 3.8.0 baseline), macOS Retina 1920×1080 logical, English menu locale, Korean system locale.
+
+## What the spike proved WORKS (reusable evidence)
+
+1. **Menu navigation to the export command works via AXPress.** Ground-truth captured (English UI):
+   - `File` = menu bar item 3 of menu bar 1.
+   - `File > Export` submenu children (exact order): `Region/Cell to Loop Library…`, `Regions as Audio Files…`, `Audio Files As…`, (sep), `Selection as Audio File…`, **`Selection as MIDI File…`** (index 6), (sep), `Tracks as Audio Files…`, `All Tracks as Audio Files…`, `All MIDI Tracks as MIDI File…`, (sep), `Project as AAF File…`, `Project to Final Cut Pro XML…`, `Project as Spatial Audio…`, `Score as MusicXML…`.
+   - Matching rule that works: descend only into the parent titled exactly `Export`; click the child containing `Selection as MIDI`. (An earlier fuzzy `contains "MIDI"` rule wrongly clicked `Open Recent > "Project 3 — midi"`, a recent-file whose name contained "midi" — fixed to an exact substring + Export-parent guard.)
+2. **`record_sequence` sentinel + region enumeration work.** A 3-note sentinel (C4/E4/G4, bars 1–4) imports as a verified MIDI region; `logic_project.get_regions` returns it with track/bar identity.
+3. **Selection hypothesis holds structurally.** The imported region appears to remain the active selection (no explicit region-select op exists in the public surface; documented as a gap).
+
+## The wall (why the live State-A path is deferred)
+
+Logic's **"Save MIDI File as:" panel is an out-of-process NSSavePanel remote view** hosted by the Logic process (window subrole `AXDialog`, frame = full arrange window). It is **not drivable in this automation context**:
+
+- **Inner controls are AX-opaque.** Enumerating the dialog (`entire contents`, recursive UI-element walk) yields children with empty `role`/`title` — the filename field, `Save`/`Cancel` buttons, and sidebar belong to the remote view service and expose no actionable AX elements to the host process. `AXPress`/`AXCancel` on the dialog return `missing value` / no-op.
+- **Synthetic keyboard input is not delivered to the panel.** `Escape`/`Return`/typed path were verified NOT to reach it via three independent channels — `osascript keystroke`, `cliclick kp/t`, and cliclick after a focus-click — while the dialog stayed open every time. `IsSecureEventInputEnabled` confirmed **False**, so this is not a secure-input block; it is remote-view keyboard-routing (the arrange window retains key focus).
+- **Mouse HID reaches the screen but is insufficient.** `cliclick` mouse-move/click post real HID events (verified), but a Save-As flow requires typing a controlled directory + filename, which needs keyboard — unavailable. Clicking `Save` with defaults would write `Untitled 54.mid` to an uncontrolled location (Macintosh HD root), failing the controlled-directory + sentinel-comparison contract (PRD AC-5.1/5.3).
+- **Failure mode observed:** repeated automation attempts left Logic in a stuck modal stack (File menu tracking + save panel + "Go to folder" overlay), blocking the main event loop (UI frozen ~3 min; AX thread still answered). Recovery required force-terminating Logic. **Operational lesson: never leave a menu open across steps — an open menu's modal tracking loop swallows all subsequent synthetic clicks/keys and can wedge the app.**
+
+## Classification
+
+This is the same class of Logic live-UI wall the project has repeatedly honest-deferred (NG10 sub-bar nav; Logic 12.2 dialog 4-segment `AXSlider`; `.logikcs` programmatic install). The **T0 gate exists precisely to catch this before building the dependent surface** — it did.
+
+## Decision (CTO)
+
+- **Ship T5a** (`SMFReader` + `ExportTemporaryFiles`): environment-independent, fully unit-tested (39 tests), the reusable core value. The parser is correct and covered against the writer's own output plus the fixture matrix (running status, velocity-0 note-off, overlap, SMPTE rejection, VLQ/length bounds, format-1 tempo merge, 1-based channel).
+- **Defer T5b** (`logic_midi.read_selection_notes` live State-A + `record_sequence verify_notes`): blocked on a keyboard-routable / AX-actionable export save panel, or a non-panel export trigger (e.g. region drag-export), neither available here. Revisit if a future Logic build exposes the save panel controls, or if an operator-driven interactive path is acceptable (the menu + parser halves are ready).
+
+## Follow-up candidates (not this PR)
+
+- Region drag-to-Finder export automation (mouse-only, bypasses save panel) — high fragility, separate spike.
+- A public `region.select` op (gap found here) would strengthen any future export-by-identity flow.
+- `cliclick`/HID keyboard routing into out-of-process save panels — investigate `LOGIC_PRO_MCP_CLICLICK` trust path + a dedicated panel-focus step.

--- a/docs/tickets/v39-hardening-and-midi-read/STATUS.md
+++ b/docs/tickets/v39-hardening-and-midi-read/STATUS.md
@@ -13,8 +13,8 @@
 | T2 | HC 전역화 마감 (PR-2) | Todo | - | BREAKING |
 | T3 | 소형 수정 팩 (PR-3) | Todo | - | |
 | T4 | MCP 프로토콜 팩 (PR-4) | Todo | - | SDK 0.12.1 확인됨 |
-| T5a | SMFReader + Export 임시파일 (PR-5) | Todo | - | 순수 유닛 (T5 분할) |
-| T5b | MIDI 읽기 표면 (PR-5) | Todo | - | T0 라이브 게이트, Depends: T5a |
+| T5a | SMFReader + Export 임시파일 (PR-5) | In Review | - | 순수 유닛 (T5 분할), 파서 boomer 정독 중 |
+| T5b | MIDI 읽기 표면 (PR-5) | **Deferred** | - | **T0 라이브 게이트 FAIL** — export 저장 패널 하드 월(docs/spikes/midi-export-t0-evidence.md). 신규 공개 커맨드 없음 |
 | T6 | Channel EQ registry + rename_marker 스파이크 (PR-6) | Todo | - | 라이브 census 게이트 |
 | D-1 | applyback 브랜치 처분 | **Done** | - | 델타 0 (PR #24 기머지), origin+로컬 삭제 2026-07-06 |
 


### PR DESCRIPTION
## Summary
- PRD US-5, tickets T5a/T5b. **T0 live gate FAILED → live read surface honest-deferred**; verified parser foundation ships.
- SMFReader (strict, fail-closed, meter-aware) + ExportTemporaryFiles registry + T0 spike harness + evidence doc.
- **No new public command** — read_selection_notes / verify_notes deferred (docs/spikes/midi-export-t0-evidence.md).

## T0 gate finding
Logic's "Save MIDI File as:" panel is an out-of-process NSSavePanel remote view: AX-opaque inner controls + synthetic keyboard input not delivered (Secure Input OFF, verified 3 channels) + mouse-only can't enter a controlled path/filename. Same class as prior honest-deferred live-UI walls (NG10, .logikcs). Menu-nav + record_sequence + region enumeration all verified working.

## Verification
- independent review adversarial parser review 2R: P1 EOT enforcement + 2×P2 (tick Double math, meter-spanning duration) + P3 exact-error fixtures → all fixed, PASS
- swift test --no-parallel: **2165 PASS**

PR 5/6 of v39-hardening-and-midi-read