### PR TITLE
feat(plugins): v3.9 WS6 — Channel EQ verified-param scaffold + census gate (T6; activation deferred)

### DIFF
--- a/Scripts/spike-channel-eq-census.py
+++ b/Scripts/spike-channel-eq-census.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+# SIZE_OK: Live census harness centralizes MCP setup, read-only AX crawl, and cleanup for one ordered run.
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+# --- How to run ---
+# 1. Build the release server binary first, or set LOGIC_PRO_MCP_BINARY.
+# 2. Run: python3 Scripts/spike-channel-eq-census.py
+# 3. The script prints newline-delimited JSON progress and parameter records.
+# ------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+
+BINARY = os.environ.get("LOGIC_PRO_MCP_BINARY", ".build/release/LogicProMCP")
+TIMEOUT = float(os.environ.get("LOGIC_PRO_MCP_CHANNEL_EQ_CENSUS_TIMEOUT", "30"))
+RESOURCE_READY_TIMEOUT_SECONDS = 12.0
+RESOURCE_READY_INTERVAL_SECONDS = 1.0
+CHANNEL_EQ_PLUGIN = "Channel EQ"
+
+ESCAPE_SCRIPT = 'tell application "System Events" to key code 53'
+
+CURRENT_DOCUMENT_PATH_SCRIPT = r'''
+tell application "Logic Pro"
+    try
+        return POSIX path of (path of front document as alias)
+    on error
+        try
+            return path of front document as text
+        on error
+            return ""
+        end try
+    end try
+end tell
+'''
+
+OPEN_CHANNEL_EQ_EDITOR_SCRIPT = r'''
+on cleanText(value)
+    try
+        if value is missing value then return ""
+        return value as text
+    on error
+        return ""
+    end try
+end cleanText
+
+on attrText(item, attrName)
+    try
+        return my cleanText(value of attribute attrName of item)
+    on error
+        return ""
+    end try
+end attrText
+
+on pressChannelEQOpenButton(item, depth)
+    if depth > 12 then return false
+    set itemRole to my attrText(item, "AXRole")
+    set itemDescription to my attrText(item, "AXDescription")
+    if itemRole is "AXGroup" and itemDescription contains "Channel EQ" then
+        try
+            repeat with childElement in UI elements of item
+                set childRole to my attrText(childElement, "AXRole")
+                if childRole is "AXButton" then
+                    click childElement
+                    return true
+                end if
+            end repeat
+        end try
+    end if
+    try
+        repeat with childElement in UI elements of item
+            if my pressChannelEQOpenButton(childElement, depth + 1) then return true
+        end repeat
+    end try
+    return false
+end pressChannelEQOpenButton
+
+tell application "Logic Pro" to activate
+delay 0.2
+tell application "System Events"
+    key code 53
+    delay 0.1
+    tell process "Logic Pro"
+        set frontmost to true
+        repeat with targetWindow in windows
+            if my pressChannelEQOpenButton(targetWindow, 0) then
+                delay 0.5
+                key code 53
+                return "OPEN" & tab & "clicked"
+            end if
+        end repeat
+    end tell
+    key code 53
+end tell
+return "OPEN" & tab & "missing"
+'''
+
+CHANNEL_EQ_PARAM_CENSUS_SCRIPT = r'''
+set outputLines to {}
+
+on cleanText(value)
+    try
+        if value is missing value then return ""
+        return value as text
+    on error
+        return ""
+    end try
+end cleanText
+
+on attrText(item, attrName)
+    try
+        return my cleanText(value of attribute attrName of item)
+    on error
+        return ""
+    end try
+end attrText
+
+on appendInspectable(item, depth, windowTitle)
+    global outputLines
+    if depth > 12 then return
+    set itemRole to my attrText(item, "AXRole")
+    if itemRole is "AXSlider" or itemRole is "AXCheckBox" or itemRole is "AXPopUpButton" then
+        set fields to {"PARAM", windowTitle, itemRole, my attrText(item, "AXDescription"), my attrText(item, "AXTitle"), my attrText(item, "AXValue"), my attrText(item, "AXValueDescription"), my attrText(item, "AXMinValue"), my attrText(item, "AXMaxValue")}
+        set AppleScript's text item delimiters to tab
+        copy (fields as text) to end of outputLines
+    end if
+    try
+        repeat with childElement in UI elements of item
+            my appendInspectable(childElement, depth + 1, windowTitle)
+        end repeat
+    end try
+end appendInspectable
+
+tell application "Logic Pro" to activate
+delay 0.2
+tell application "System Events"
+    key code 53
+    delay 0.1
+    tell process "Logic Pro"
+        set frontmost to true
+        set inspectedDialog to false
+        repeat with targetWindow in windows
+            set windowSubrole to my attrText(targetWindow, "AXSubrole")
+            if windowSubrole contains "Dialog" then
+                set inspectedDialog to true
+                my appendInspectable(targetWindow, 0, my attrText(targetWindow, "AXTitle"))
+            end if
+        end repeat
+        if inspectedDialog is false and exists window 1 then
+            my appendInspectable(window 1, 0, my attrText(window 1, "AXTitle"))
+        end if
+    end tell
+    key code 53
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+'''
+
+
+@dataclass(frozen=True)
+class OsascriptResult:
+    returncode: int
+    stdout_lines: List[str]
+    stderr: str
+    timed_out: bool
+
+
+class MCPClient:
+    def __init__(self) -> None:
+        stderr_dir = tempfile.TemporaryDirectory(prefix="logic-mcp-channel-eq-census.")
+        self._stderr_dir = stderr_dir
+        self._stderr_file = open(Path(stderr_dir.name) / "stderr.txt", "w")
+        self.proc = subprocess.Popen(
+            [BINARY],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=self._stderr_file,
+            bufsize=0,
+            env=os.environ.copy(),
+        )
+        self.responses: Dict[int, Dict[str, Any]] = {}
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        if self.proc.stdout is None:
+            return
+        for raw_line in self.proc.stdout:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            message_id = message.get("id")
+            if isinstance(message_id, int) and ("result" in message or "error" in message):
+                self.responses[message_id] = message
+
+    def send(self, message: Dict[str, Any], timeout: Optional[float] = None) -> Optional[Dict[str, Any]]:
+        if self.proc.stdin is None:
+            return None
+        try:
+            self.proc.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+            self.proc.stdin.flush()
+        except BrokenPipeError:
+            return None
+        message_id = message.get("id")
+        if not isinstance(message_id, int):
+            return None
+        deadline = time.time() + (timeout if timeout is not None else TIMEOUT)
+        while time.time() < deadline:
+            if message_id in self.responses:
+                return self.responses.pop(message_id)
+            time.sleep(0.02)
+        return None
+
+    def notify(self, message: Dict[str, Any]) -> None:
+        if self.proc.stdin is None:
+            return
+        try:
+            self.proc.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+            self.proc.stdin.flush()
+        except BrokenPipeError:
+            return
+
+    def close(self) -> None:
+        if self.proc.stdin is not None:
+            try:
+                self.proc.stdin.close()
+            except OSError:
+                pass
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+        self._stderr_file.close()
+        self._stderr_dir.cleanup()
+
+
+_NEXT_ID = 1
+
+
+def next_id() -> int:
+    global _NEXT_ID
+    request_id = _NEXT_ID
+    _NEXT_ID += 1
+    return request_id
+
+
+def emit(record_type: str, status: str, **fields: Any) -> None:
+    payload: Dict[str, Any] = {
+        "record_type": record_type,
+        "ok": status not in {"blocked", "failed", "missing", "timeout"},
+        "status": status,
+    }
+    payload.update(fields)
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def run_osascript(step: str, script: str, timeout: float = 8.0) -> OsascriptResult:
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout.decode("utf-8", errors="replace") if isinstance(error.stdout, bytes) else (error.stdout or "")
+        stderr = error.stderr.decode("utf-8", errors="replace") if isinstance(error.stderr, bytes) else (error.stderr or "")
+        lines = [line for line in stdout.splitlines() if line]
+        emit("osascript", "timeout", step=step, stdout=lines, stderr=stderr, timeout_seconds=timeout)
+        return OsascriptResult(124, lines, stderr, True)
+    lines = [line for line in result.stdout.splitlines() if line]
+    emit("osascript", "ok" if result.returncode == 0 else "failed", step=step, stdout=lines, stderr=result.stderr)
+    return OsascriptResult(result.returncode, lines, result.stderr, False)
+
+
+def send_escape(label: str) -> None:
+    run_osascript(label, ESCAPE_SCRIPT, timeout=4.0)
+
+
+def initialize(client: MCPClient) -> bool:
+    response = client.send({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "channel-eq-census-spike", "version": "1"},
+        },
+    })
+    ok = isinstance(response, dict) and "result" in response
+    emit("initialize", "ok" if ok else "failed", response=response)
+    if ok:
+        client.notify({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(1.0)
+    return ok
+
+
+def call_tool(
+    client: MCPClient,
+    tool: str,
+    command: str,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    arguments: Dict[str, Any] = {"command": command}
+    if params is not None:
+        arguments["params"] = params
+    return client.send({
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    }, timeout=timeout)
+
+
+def read_resource(client: MCPClient, uri: str, timeout: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    return client.send({
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": "resources/read",
+        "params": {"uri": uri},
+    }, timeout=timeout)
+
+
+def parsed_json_text(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def response_text(response: Optional[Dict[str, Any]], key: str) -> str:
+    try:
+        entries = response["result"][key]
+    except (KeyError, TypeError):
+        return ""
+    if not isinstance(entries, list):
+        return ""
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("type") == "text":
+            return str(entry.get("text", ""))
+    return ""
+
+
+def tool_json(response: Optional[Dict[str, Any]]) -> Any:
+    return parsed_json_text(response_text(response, "content"))
+
+
+def resource_envelope(response: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(response, dict) or "error" in response:
+        return None
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    contents = result.get("contents")
+    if not isinstance(contents, list) or not contents:
+        return None
+    first = contents[0]
+    if not isinstance(first, dict):
+        return None
+    text = first.get("text")
+    if not isinstance(text, str):
+        return None
+    parsed = parsed_json_text(text)
+    if not isinstance(parsed, dict):
+        return None
+    data = parsed.get("data")
+    if isinstance(data, (list, dict)):
+        return parsed
+    return None
+
+
+def resource_json(response: Optional[Dict[str, Any]]) -> Any:
+    envelope = resource_envelope(response)
+    return envelope["data"] if envelope is not None else None
+
+
+def wait_for_resource_ready(client: MCPClient, uri: str = "logic://tracks") -> bool:
+    deadline = time.time() + RESOURCE_READY_TIMEOUT_SECONDS
+    last_response: Optional[Dict[str, Any]] = None
+    while time.time() < deadline:
+        last_response = read_resource(client, uri, timeout=RESOURCE_READY_INTERVAL_SECONDS)
+        if resource_envelope(last_response) is not None:
+            emit("resource_ready", "ok", uri=uri)
+            return True
+        time.sleep(RESOURCE_READY_INTERVAL_SECONDS)
+    emit("resource_ready", "timeout", uri=uri, response=last_response)
+    return False
+
+
+def tracks_snapshot(client: MCPClient) -> Optional[List[Dict[str, Any]]]:
+    tracks = resource_json(read_resource(client, "logic://tracks"))
+    return tracks if isinstance(tracks, list) else None
+
+
+def current_document_path(client: MCPClient) -> Optional[str]:
+    project_info = resource_json(read_resource(client, "logic://project/info"))
+    if isinstance(project_info, dict):
+        raw = project_info.get("file_path") or project_info.get("filePath")
+        if isinstance(raw, str) and raw.strip():
+            return raw
+    result = run_osascript("front_document_path", CURRENT_DOCUMENT_PATH_SCRIPT, timeout=5.0)
+    if result.returncode == 0 and result.stdout_lines:
+        path = result.stdout_lines[0].strip()
+        return path if path else None
+    return None
+
+
+def created_track_index(before: List[Dict[str, Any]], after: List[Dict[str, Any]], create_payload: Any) -> Optional[int]:
+    if isinstance(create_payload, dict):
+        raw = create_payload.get("observed_track_index")
+        if isinstance(raw, int):
+            return raw
+    before_ids = {track.get("id") for track in before if isinstance(track.get("id"), int)}
+    for track in after:
+        raw_id = track.get("id")
+        if isinstance(raw_id, int) and raw_id not in before_ids:
+            return raw_id
+    return len(after) - 1 if len(after) == len(before) + 1 else None
+
+
+def first_empty_insert(client: MCPClient, track_index: int) -> Optional[int]:
+    response = call_tool(client, "logic_plugins", "get_inventory", {"track": track_index}, timeout=20)
+    payload = tool_json(response)
+    emit("plugin_inventory", "ok" if isinstance(payload, dict) else "failed", track=track_index, response=payload or response)
+    if not isinstance(payload, dict) or payload.get("state") != "A":
+        return None
+    plugins = payload.get("plugins")
+    if not isinstance(plugins, list):
+        return None
+    for item in plugins:
+        if not isinstance(item, dict):
+            continue
+        if item.get("read_status") == "empty" and item.get("occupied") is False and isinstance(item.get("insert"), int):
+            return item["insert"]
+    return None
+
+
+def create_audio_track(client: MCPClient) -> Optional[int]:
+    send_escape("pre_create_audio_escape")
+    before = tracks_snapshot(client)
+    if before is None:
+        emit("create_audio_track", "blocked", reason="logic://tracks unavailable before create")
+        return None
+    response = call_tool(client, "logic_tracks", "create_audio", {}, timeout=30)
+    payload = tool_json(response)
+    send_escape("post_create_audio_escape")
+    after = tracks_snapshot(client)
+    if after is None:
+        emit("create_audio_track", "failed", reason="logic://tracks unavailable after create", response=payload or response)
+        return None
+    index = created_track_index(before, after, payload)
+    emit("create_audio_track", "ok" if index is not None else "failed", index=index, response=payload or response)
+    return index
+
+
+def insert_channel_eq(client: MCPClient, track_index: int, insert_index: int, project_path: str) -> bool:
+    send_escape("pre_insert_escape")
+    params = {
+        "track": track_index,
+        "insert": insert_index,
+        "plugin": CHANNEL_EQ_PLUGIN,
+        "mode": "duplicate_applyback",
+        "project_expected_path": project_path,
+    }
+    response = call_tool(client, "logic_plugins", "insert_verified", params, timeout=60)
+    payload = tool_json(response)
+    send_escape("post_insert_escape")
+    ok = isinstance(payload, dict) and payload.get("state") == "A"
+    emit("insert_channel_eq", "ok" if ok else "failed", params=params, response=payload or response)
+    return ok
+
+
+def cleanup_created_track(client: MCPClient, track_index: Optional[int]) -> None:
+    send_escape("cleanup_pre_escape")
+    if track_index is None:
+        emit("cleanup_track_delete", "missing", reason="no created track index")
+        send_escape("cleanup_post_escape")
+        return
+    response = call_tool(client, "logic_tracks", "delete", {"index": track_index}, timeout=30)
+    payload = tool_json(response)
+    emit("cleanup_track_delete", "ok" if isinstance(payload, dict) and payload.get("state") == "A" else "failed", index=track_index, response=payload or response)
+    send_escape("cleanup_post_escape")
+
+
+def parse_number(raw: str) -> Optional[float]:
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def unit_from_value_description(value_description: str) -> Optional[str]:
+    stripped = value_description.strip()
+    if not stripped:
+        return None
+    match = re.search(r"[-+]?\d+(?:\.\d+)?\s*([^0-9\s].*)$", stripped)
+    if match is None:
+        return None
+    unit = match.group(1).strip()
+    return unit or None
+
+
+def canonical_id_for(index: int, role: str, description: str, title: str) -> str:
+    seed = description.strip() or title.strip() or role.strip() or "parameter"
+    slug = re.sub(r"[^a-z0-9]+", "_", seed.lower()).strip("_")
+    if not slug:
+        slug = "parameter"
+    return "census_%03d_%s" % (index, slug)
+
+
+def emit_parameter_records(lines: List[str]) -> int:
+    count = 0
+    for line in lines:
+        parts = line.split("\t")
+        if len(parts) < 9 or parts[0] != "PARAM":
+            continue
+        count += 1
+        window_title, role, description, title, raw_value, value_description, raw_min, raw_max = parts[1:9]
+        unit = unit_from_value_description(value_description)
+        print(json.dumps({
+            "record_type": "channel_eq_parameter",
+            "canonical_id": canonical_id_for(count, role, description, title),
+            "canonical_id_source": "census_candidate_from_ax_description",
+            "ax_role": role or None,
+            "ax_description": description or None,
+            "ax_title": title or None,
+            "editor_window_title": window_title or None,
+            "current_value": parse_number(raw_value),
+            "current_value_raw": raw_value or None,
+            "current_unit": unit,
+            "ax_value_description": value_description or None,
+            "ax_min": parse_number(raw_min),
+            "ax_max": parse_number(raw_max),
+        }, sort_keys=True), flush=True)
+    emit("parameter_census", "ok" if count else "missing", count=count)
+    return count
+
+
+def run_census() -> int:
+    client = MCPClient()
+    created_index: Optional[int] = None
+    try:
+        if not initialize(client):
+            return 2
+        if not wait_for_resource_ready(client):
+            return 2
+        project_path = current_document_path(client)
+        if project_path is None:
+            emit("project_path", "blocked", reason="front document path unavailable")
+            return 2
+        emit("project_path", "ok", project_expected_path=project_path)
+        created_index = create_audio_track(client)
+        if created_index is None:
+            return 2
+        insert_index = first_empty_insert(client, created_index)
+        if insert_index is None:
+            emit("empty_insert", "blocked", track=created_index)
+            return 2
+        if not insert_channel_eq(client, created_index, insert_index, project_path):
+            return 2
+        open_result = run_osascript("open_channel_eq_editor", OPEN_CHANNEL_EQ_EDITOR_SCRIPT, timeout=10.0)
+        opened = any(line == "OPEN\tclicked" for line in open_result.stdout_lines)
+        emit("open_channel_eq_editor", "ok" if opened else "failed", stdout=open_result.stdout_lines)
+        if not opened:
+            return 2
+        census_result = run_osascript("channel_eq_param_census", CHANNEL_EQ_PARAM_CENSUS_SCRIPT, timeout=10.0)
+        if census_result.returncode != 0:
+            emit("parameter_census", "failed", stderr=census_result.stderr)
+            return 2
+        return 0 if emit_parameter_records(census_result.stdout_lines) > 0 else 2
+    finally:
+        cleanup_created_track(client, created_index)
+        client.close()
+
+
+def main() -> int:
+    return run_census()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -513,6 +513,8 @@ extension AccessibilityChannel {
         params: [String: String],
         runtime: AXLogicProElements.Runtime = .production,
         frontDocumentPath: FrontDocumentPathProvider = liveFrontDocumentPath,
+        entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
+        paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup = VerifiedPluginCatalog.canonicalParamKey,
         pluginWindowOpener: PluginWindowOpener = liveNoOpPluginWindowOpener
     ) async -> ChannelResult {
         let operation = "logic_plugins.set_param_verified"
@@ -569,23 +571,16 @@ extension AccessibilityChannel {
                 ]
             ))
         }
-        guard let paramKey = VerifiedPluginCatalog.canonicalParamKey(pluginID: pluginID, alias: paramAlias) else {
-            return .error(HonestContract.encodeV2StateC(
-                error: .unknownPluginIdentity,
-                extras: [
-                    "operation": operation,
-                    "target_identity": resolvedIdentity(track: track, insert: insert, pluginID: pluginID),
-                    "what_was_attempted": "resolve parameter '\(paramAlias)' for \(pluginID)",
-                    "what_was_observed": "no parameter alias mapping for this plugin",
-                    "safe_to_retry": false,
-                    "write_attempted": false,
-                ]
-            ))
-        }
+        let paramKey = VerifiedPluginCatalog.canonicalParamKey(
+            pluginID: pluginID,
+            alias: paramAlias,
+            paramAliasLookup: paramAliasLookup
+        ) ?? paramAlias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         // Unit honesty (R8): a caller unit that disagrees with the declared
         // canonical unit is invalid_params.
-        if let unit, let expectedUnit = VerifiedPluginCatalog.paramUnit(pluginID: pluginID, paramKey: paramKey),
+        if let unit,
+           let expectedUnit = VerifiedPluginCatalog.paramUnit(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup),
            unit.caseInsensitiveCompare(expectedUnit) != .orderedSame {
             return .error(invalidParamsStateC(
                 operation,
@@ -593,7 +588,7 @@ extension AccessibilityChannel {
             ))
         }
         // Range validation (R6 step 1) against the declared display range.
-        if let range = VerifiedPluginCatalog.paramRange(pluginID: pluginID, paramKey: paramKey),
+        if let range = VerifiedPluginCatalog.paramRange(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup),
            value < range.min || value > range.max {
             return .error(invalidParamsStateC(
                 operation,
@@ -604,7 +599,7 @@ extension AccessibilityChannel {
         // Step 5 — capability preflight. Only `.writeReadback` (Compressor
         // threshold, T0 spike) proceeds to the live write; every other parameter
         // has no write/readback method and fail-closes BEFORE any write (AC10).
-        let capability = VerifiedPluginCatalog.paramCapability(pluginID: pluginID, paramKey: paramKey)
+        let capability = VerifiedPluginCatalog.paramCapability(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup)
         switch capability {
         case .unknownParameter, .unsupported:
             return .error(HonestContract.encodeV2StateC(
@@ -632,6 +627,7 @@ extension AccessibilityChannel {
                 paramAlias: paramAlias,
                 requested: value,
                 runtime: runtime,
+                entryLookup: entryLookup,
                 pluginWindowOpener: pluginWindowOpener
             )
         }
@@ -654,10 +650,15 @@ extension AccessibilityChannel {
         paramAlias: String,
         requested: Double,
         runtime: AXLogicProElements.Runtime,
+        entryLookup: VerifiedPluginCatalog.EntryLookup,
         pluginWindowOpener: PluginWindowOpener
     ) async -> ChannelResult {
         let identity = resolvedIdentity(track: track, insert: insert, pluginID: pluginID)
-        guard let axDescription = VerifiedPluginCatalog.paramAXDescription(pluginID: pluginID, paramKey: paramKey) else {
+        guard let axDescription = VerifiedPluginCatalog.paramAXDescription(
+            pluginID: pluginID,
+            paramKey: paramKey,
+            entryLookup: entryLookup
+        ) else {
             // A `.writeReadback` parameter must declare its AX matcher; absence is
             // a catalog defect, surfaced honestly rather than guessed around.
             return .error(HonestContract.encodeV2StateC(
@@ -673,7 +674,11 @@ extension AccessibilityChannel {
                 ]
             ))
         }
-        let tolerance = VerifiedPluginCatalog.paramTolerance(pluginID: pluginID, paramKey: paramKey) ?? 1.0
+        let tolerance = VerifiedPluginCatalog.paramTolerance(
+            pluginID: pluginID,
+            paramKey: paramKey,
+            entryLookup: entryLookup
+        ) ?? 1.0
 
         // Step 6 — track verified select. Drive the AX-native selection ladder,
         // then confirm the target header reads back as selected (a write that the

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -848,6 +848,24 @@ enum StockPluginCatalog {
         ),
     ]
 
+    /// TODO(channel-eq-census): fill from docs/spikes/channel-eq-census.md only after live AX census.
+    private static let channelEQParameters = [
+        StockPluginParameterMetadata(
+            id: "todo_channel_eq_census_param_1",
+            displayName: "TODO Channel EQ census parameter 1",
+            unit: nil,
+            valueRange: nil,
+            writeMethod: nil,
+            readbackMethod: nil,
+            tolerance: nil,
+            axDescription: nil,
+            availabilityState: .inferred,
+            provenance: .inferred(
+                reason: "census-gated TODO placeholder; fill canonical id, AX description, unit/range/tolerance, and readback evidence from docs/spikes/channel-eq-census.md"
+            )
+        ),
+    ]
+
     /// Compressor `threshold` — the first verified-writable stock parameter.
     /// Current public release evidence records the AX write/readback boundary:
     /// the control is an
@@ -885,7 +903,14 @@ enum StockPluginCatalog {
     /// (e.g. "Ringshifter", "DeEsser 2", "Vintage B3").
     private static let seeds: [Seed] = [
         // EQ
-        fx("channel_eq", "Channel EQ", "EQ", write: .insertOnly),
+        fx(
+            "channel_eq",
+            "Channel EQ",
+            "EQ",
+            write: .insertOnly,
+            parameters: channelEQParameters,
+            notes: ["Channel EQ parameter registry is census-gated; fill TODO placeholders from docs/spikes/channel-eq-census.md"]
+        ),
         fx("linear_phase_eq", "Linear Phase EQ", "EQ"),
         fx("match_eq", "Match EQ", "EQ"),
         fx("single_band_eq", "Single Band EQ", "EQ"),

--- a/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
@@ -19,6 +19,11 @@ import Foundation
 ///
 /// This module is deterministic and contains NO live AX interaction.
 enum VerifiedPluginCatalog {
+    typealias EntryLookup = @Sendable (_ pluginID: String) -> StockPluginCatalogEntry?
+    typealias ParamAliasLookup = @Sendable (_ pluginID: String, _ alias: String) -> String?
+
+    static let productionEntryLookup: EntryLookup = { StockPluginCatalog.entry(id: $0) }
+
 
     /// Display-name / alias → canonical `logic.stock.*` id table.
     ///
@@ -55,6 +60,9 @@ enum VerifiedPluginCatalog {
         "logic.stock.effect.compressor": [
             "threshold": "threshold",
         ],
+        "logic.stock.effect.channel_eq": [
+            "todo_channel_eq_census_param_1": "todo_channel_eq_census_param_1",
+        ],
     ]
 
     /// Resolve a caller-supplied plugin alias to its canonical catalog id, or
@@ -75,6 +83,14 @@ enum VerifiedPluginCatalog {
         let normalized = alias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !normalized.isEmpty else { return nil }
         return paramAliases[pluginID]?[normalized]
+    }
+
+    static func canonicalParamKey(
+        pluginID: String,
+        alias: String,
+        paramAliasLookup: ParamAliasLookup
+    ) -> String? {
+        paramAliasLookup(pluginID, alias)
     }
 
     /// Map a slot's observed display name (from AX readback) to a canonical
@@ -107,8 +123,12 @@ enum VerifiedPluginCatalog {
     /// "param map이 선언하지 않은 unit은 State C `invalid_params`"); a mismatch is
     /// reported by the caller as `invalid_params`, so this returns the capability
     /// independent of unit and exposes the expected unit separately.
-    static func paramCapability(pluginID: String, paramKey: String) -> ParamCapability {
-        guard let entry = StockPluginCatalog.entry(id: pluginID),
+    static func paramCapability(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> ParamCapability {
+        guard let entry = entryLookup(pluginID),
               let param = entry.parameters.first(where: { $0.id == paramKey }) else {
             return .unknownParameter
         }
@@ -120,15 +140,23 @@ enum VerifiedPluginCatalog {
     /// The canonical unit a (canonical) plugin parameter declares, or nil when
     /// the parameter is unknown. Used to enforce unit honesty (R8) before a
     /// write: a caller `unit` that disagrees is `invalid_params`.
-    static func paramUnit(pluginID: String, paramKey: String) -> String? {
-        StockPluginCatalog.entry(id: pluginID)?
+    static func paramUnit(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> String? {
+        entryLookup(pluginID)?
             .parameters.first(where: { $0.id == paramKey })?.unit
     }
 
     /// The valid display-value range a (canonical) plugin parameter declares, or
     /// nil when unknown. Used for range validation (R6 step 1).
-    static func paramRange(pluginID: String, paramKey: String) -> StockPluginValueRange? {
-        StockPluginCatalog.entry(id: pluginID)?
+    static func paramRange(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> StockPluginValueRange? {
+        entryLookup(pluginID)?
             .parameters.first(where: { $0.id == paramKey })?.valueRange
     }
 
@@ -137,16 +165,24 @@ enum VerifiedPluginCatalog {
     /// the parameter has no stable description matcher. The verified write path
     /// (R6 step 9) matches a window slider by this description; a parameter
     /// without one cannot reach a verified write (it stays `.unsupported`).
-    static func paramAXDescription(pluginID: String, paramKey: String) -> String? {
-        StockPluginCatalog.entry(id: pluginID)?
+    static func paramAXDescription(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> String? {
+        entryLookup(pluginID)?
             .parameters.first(where: { $0.id == paramKey })?.axDescription
     }
 
     /// The verified write/readback tolerance (in the parameter's own unit) for a
     /// (canonical) plugin parameter, or nil when unknown / not verified-writable.
     /// R6 step 13: |observed - requested| <= tolerance ⇒ State A.
-    static func paramTolerance(pluginID: String, paramKey: String) -> Double? {
-        StockPluginCatalog.entry(id: pluginID)?
+    static func paramTolerance(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> Double? {
+        entryLookup(pluginID)?
             .parameters.first(where: { $0.id == paramKey })?.tolerance
     }
 }

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -39,6 +39,7 @@ private final class LiveFixture: @unchecked Sendable {
         insert: Int = 6,
         trackSelected: Bool = true,
         thresholdDescription: String = "Threshold",
+        pluginSlotName: String = "Compressor",
         beforeValue: Double = 51,
         pluginWindowPresent: Bool = true,
         forcedAfterValue: Double? = nil,
@@ -84,7 +85,7 @@ private final class LiveFixture: @unchecked Sendable {
                 } else {
                     var slots: [AXUIElement] = []
                     for s in 0...insert {
-                        slots.append(LiveFixture.occupiedSlot(b, 1300 + s, name: s == insert ? "Compressor" : "Plugin \(s)"))
+                        slots.append(LiveFixture.occupiedSlot(b, 1300 + s, name: s == insert ? pluginSlotName : "Plugin \(s)"))
                     }
                     b.setChildren(strip, slots)
                 }
@@ -204,6 +205,102 @@ private func thresholdParams(
     return p
 }
 
+private let channelEQFixtureParamID = "__test_channel_eq_band_gain"
+private let channelEQFixtureAXDescription = "__TEST Channel EQ Band Gain"
+
+private func channelEQFixtureEntryLookup(pluginID: String) -> StockPluginCatalogEntry? {
+    guard pluginID == "logic.stock.effect.channel_eq" else {
+        return StockPluginCatalog.entry(id: pluginID)
+    }
+    let provenance = StockPluginProvenance.verified(
+        source: "test_fixture",
+        method: "ax_plugin_window",
+        observedAt: "2026-07-07T00:00:00Z",
+        logicVersion: nil,
+        locale: "en_US",
+        evidence: ["parameter_readback", "test_fixture_only"]
+    )
+    return StockPluginCatalogEntry(
+        id: "logic.stock.effect.channel_eq",
+        displayName: "Channel EQ",
+        type: .effect,
+        category: "EQ",
+        availabilityState: .verified,
+        provenance: provenance,
+        insertPaths: [
+            StockPluginInsertPath(
+                path: ["Audio FX", "EQ", "Channel EQ"],
+                availabilityState: .verified,
+                provenance: provenance
+            ),
+        ],
+        slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true),
+        knownPresets: [],
+        parameters: [
+            StockPluginParameterMetadata(
+                id: channelEQFixtureParamID,
+                displayName: "Test Channel EQ Band Gain",
+                unit: "dB",
+                valueRange: StockPluginValueRange(min: -24, max: 24, defaultValue: 0),
+                writeMethod: "ax_slider_axvalue",
+                readbackMethod: "ax_slider_axvalue",
+                tolerance: 0.5,
+                axDescription: channelEQFixtureAXDescription,
+                availabilityState: .verified,
+                provenance: provenance
+            ),
+        ],
+        safeWriteCapabilities: .parameterWriteReadback,
+        limitations: ["test fixture only; production Channel EQ registry is census-gated"]
+    )
+}
+
+private func channelEQFixtureParamAlias(pluginID: String, alias: String) -> String? {
+    guard pluginID == "logic.stock.effect.channel_eq" else {
+        return VerifiedPluginCatalog.canonicalParamKey(pluginID: pluginID, alias: alias)
+    }
+    let normalized = alias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case channelEQFixtureParamID.lowercased():
+        return channelEQFixtureParamID
+    default:
+        return nil
+    }
+}
+
+private func channelEQFixtureParams(
+    param: String = channelEQFixtureParamID,
+    value: String = "3.0",
+    unit: String = "dB"
+) -> [String: String] {
+    thresholdParams(value: value, unit: unit).merging([
+        "plugin": "Channel EQ",
+        "param": param,
+    ]) { _, new in new }
+}
+
+private func runChannelEQFixture(
+    forcedAfterValue: Double? = nil,
+    params: [String: String] = channelEQFixtureParams()
+) async throws -> [String: Any] {
+    let fixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        forcedAfterValue: forcedAfterValue
+    )
+    let result = await AccessibilityChannel.defaultSetParamVerified(
+        params: params,
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath },
+        entryLookup: channelEQFixtureEntryLookup,
+        paramAliasLookup: channelEQFixtureParamAlias
+    )
+    let data = try #require(result.message.data(using: .utf8))
+    let obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    return obj
+}
+
 // MARK: - State A: full round-trip (before 51 → set 60 → after 60)
 
 @Test func testCompressorThresholdVerifiedWriteReachesStateA() async {
@@ -235,6 +332,48 @@ private func thresholdParams(
     let obj = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
     #expect(obj["state"] as? String == "A")
     #expect(obj["observed_normalized"] as? Double == 60.7)
+}
+
+@Test func testChannelEQFixtureParamResolvesAndVerifiesStateAWithinTolerance() async throws {
+    let canonical = VerifiedPluginCatalog.canonicalParamKey(
+        pluginID: "logic.stock.effect.channel_eq",
+        alias: channelEQFixtureParamID,
+        paramAliasLookup: channelEQFixtureParamAlias
+    )
+    #expect(canonical == channelEQFixtureParamID)
+    #expect(VerifiedPluginCatalog.paramCapability(
+        pluginID: "logic.stock.effect.channel_eq",
+        paramKey: channelEQFixtureParamID,
+        entryLookup: channelEQFixtureEntryLookup
+    ) == .writeReadback)
+
+    let obj = try await runChannelEQFixture(forcedAfterValue: 3.4)
+
+    #expect(obj["state"] as? String == "A")
+    #expect(try #require(obj["verified"] as? Bool))
+    #expect(obj["observed_normalized"] as? Double == 3.4)
+    #expect(obj["tolerance"] as? Double == 0.5)
+    let identity = try #require(obj["target_identity"] as? [String: Any])
+    #expect(identity["plugin_id"] as? String == "logic.stock.effect.channel_eq")
+}
+
+@Test func testChannelEQFixtureParamOutsideToleranceIsReadbackMismatch() async throws {
+    let obj = try await runChannelEQFixture(forcedAfterValue: 1.0)
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "readback_mismatch")
+    #expect(try #require(obj["verified"] as? Bool) == false)
+    #expect(try #require(obj["write_attempted"] as? Bool))
+    #expect(obj["requested_normalized"] as? Double == 3.0)
+    #expect(obj["observed_normalized"] as? Double == 1.0)
+}
+
+@Test func testChannelEQFixtureUnsupportedParamFailsClosedUnsupportedParamReadback() async throws {
+    let obj = try await runChannelEQFixture(params: channelEQFixtureParams(param: "unregistered_channel_eq_param"))
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "unsupported_param_readback")
+    #expect(try #require(obj["write_attempted"] as? Bool) == false)
 }
 
 // MARK: - State C: tolerance exceeded → readback_mismatch + rollback

--- a/Tests/LogicProMCPTests/VerifiedPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/VerifiedPluginCatalogTests.swift
@@ -88,6 +88,15 @@ import Testing
     #expect(VerifiedPluginCatalog.paramAXDescription(pluginID: id, paramKey: "threshold") == "Threshold")
 }
 
+@Test func testChannelEQCensusPlaceholderStaysUnsupportedUntilCensus() {
+    let id = "logic.stock.effect.channel_eq"
+    let param = "todo_channel_eq_census_param_1"
+    #expect(VerifiedPluginCatalog.canonicalParamKey(pluginID: id, alias: param) == param)
+    #expect(VerifiedPluginCatalog.paramCapability(pluginID: id, paramKey: param) == .unsupported)
+    #expect(VerifiedPluginCatalog.paramTolerance(pluginID: id, paramKey: param) == nil)
+    #expect(VerifiedPluginCatalog.paramAXDescription(pluginID: id, paramKey: param) == nil)
+}
+
 // MARK: - Unit + range exposure (R8)
 
 @Test func testGainParamUnitAndRange() {

--- a/docs/spikes/channel-eq-census.md
+++ b/docs/spikes/channel-eq-census.md
@@ -1,0 +1,49 @@
+# Channel EQ AX Parameter Census
+
+**Status: GATE FAILED (2026-07-07) — registry activation honest-deferred.** Scaffold ships; no production Channel EQ verified param is activated.
+
+Source script: `Scripts/spike-channel-eq-census.py`
+Enumerator: `logic_plugins.get_inventory` for insert-slot readback, then read-only System Events AX crawl of the open Channel EQ editor window.
+
+## Run Metadata
+
+- Date: 2026-07-07
+- Logic Pro version: 12.x (server baseline 3.8.0)
+- macOS: Retina 1920×1080 logical
+- System locale: Korean; Logic UI language: English
+- Project: `~/Music/Logic/Untitled 54.logicx` (scratch)
+- Track index: 1 (Audio 1); Insert index: 0
+- Probe command: `python3 Scripts/spike-channel-eq-census.py`
+
+## What WORKS (verified live)
+
+- **`logic_plugins.insert_verified "Channel EQ"` → State A.** Inserted `logic.stock.effect.channel_eq` at slot 0 via `ax_exact_slot_popup`, verified by `ax_plugin_inventory` (this is the existing shipped verified-insert path — solid).
+- Plugin editor opens as an `AXDialog` window titled by track name (`Audio 1`), with 15 top-level UI elements including a **View menu** (`AXMenuButton` desc=`view`) offering **`Controls`** and **`Editor`** view modes.
+
+## The wall (why parameter census + registry activation is deferred)
+
+The Channel EQ **parameter controls are not reachable through standard AX traversal** in either view mode:
+
+- **Editor (graphical) view**: parameters are drawn on a custom `AXGroup` (desc=`EQ`) canvas — no per-band `AXSlider`/`AXValueIndicator` exposed. `entire contents` of the window filtered for slider/value roles = empty.
+- **Controls view**: switching via the View menu works, but `entire contents` of the plugin window then returns **0 elements** — the AU parameter view is a hosted/remote view opaque to host-process AX recursion (same opacity class as the out-of-process save panel in the T5 spike). The graphical `EQ` group is gone and no traversable slider tree replaces it.
+- The existing shipped verified-param path only ever activated **one** parameter (Compressor `threshold`, a single earlier T0 spike; every other param fails closed with `unsupported_param_readback` — see `AccessibilityChannel+VerifiedPlugins.swift:509`). Channel EQ's per-band freq/gain/Q are not reachable by the same `AXSlider`-by-description mechanism.
+
+Per PRD AC-6.1 the registry may only be filled from real census values (guessing AX ids/units/tolerances is explicitly forbidden). Since the AX surface does not expose those values here, **no registry entry is activated.** The scaffold (census probe, inert TODO entries, test seam) ships ready for a future run on a build/host where the AU parameter view is AX-traversable, or via a different enumeration surface (e.g. an AU parameter API rather than the GUI).
+
+## Parameter Census
+
+Not obtainable in this environment (AU parameter view AX-opaque). Table intentionally left unfilled — activating entries from non-evidence would violate AC-6.1/AC-6.3.
+
+## Registry Decisions
+
+- Production Channel EQ entries: **left inert (TODO)** — none activated.
+- Unregistered Channel EQ params continue to fail closed with `unsupported_param_readback` (unchanged contract).
+
+## Follow-up candidates (not this PR)
+
+- Enumerate AU parameters via the AudioUnit parameter API (`AudioUnitGetProperty`/`kAudioUnitProperty_ParameterList`) instead of the GUI AX tree — would bypass the opaque hosted view entirely and is the most promising path to a real census.
+- Investigate whether a specific Logic build or the "Controls" view exposes `AXSlider` descriptions on other hosts.
+
+## rename_marker spike (AC-6.6) — DEFERRED
+
+Same session probe: `logic_navigate.create_marker` did not surface a renamable marker in `logic://markers` (list read empty post-create; markers require the Marker global track / Marker List visible, and a verified rename needs a reliable AX text-edit path this environment has not demonstrated — cf. the goto-position "마디 slider not found" and save-panel keyboard-routing walls). rename_marker remains `not_implemented` (unchanged); no false capability advertised.

--- a/docs/tickets/v39-hardening-and-midi-read/STATUS.md
+++ b/docs/tickets/v39-hardening-and-midi-read/STATUS.md
@@ -15,7 +15,7 @@
 | T4 | MCP 프로토콜 팩 (PR-4) | Todo | - | SDK 0.12.1 확인됨 |
 | T5a | SMFReader + Export 임시파일 (PR-5) | In Review | - | 순수 유닛 (T5 분할), 파서 boomer 정독 중 |
 | T5b | MIDI 읽기 표면 (PR-5) | **Deferred** | - | **T0 라이브 게이트 FAIL** — export 저장 패널 하드 월(docs/spikes/midi-export-t0-evidence.md). 신규 공개 커맨드 없음 |
-| T6 | Channel EQ registry + rename_marker 스파이크 (PR-6) | Todo | - | 라이브 census 게이트 |
+| T6 | Channel EQ registry + rename_marker 스파이크 (PR-6) | In Review | - | **라이브 census 게이트 FAIL** → registry 활성화 defer, 스캐폴드만 출하. rename_marker도 defer. (docs/spikes/channel-eq-census.md) |
 | D-1 | applyback 브랜치 처분 | **Done** | - | 델타 0 (PR #24 기머지), origin+로컬 삭제 2026-07-06 |
 
 ## Review History


### PR DESCRIPTION
## Summary
- PRD US-6, ticket T6. **Live census GATE FAILED → registry activation + rename_marker honest-deferred**; verified scaffold ships.
- Channel EQ insert_verified works live (State A); its AU parameter view is AX-opaque (Editor + Controls) → no per-band freq/gain/Q reachable. Evidence: docs/spikes/channel-eq-census.md.
- **No production Channel EQ param activated** — only inert TODO; unknown params still fail closed; Compressor threshold unchanged.
- Census probe + test seam (prod defaults unchanged) + fixture-id tests.

## Verification
- independent review adversarial honesty review: **PASS, 0 findings** (no unverifiable param advertised; fail-closed intact; no Compressor regression; no dead asserts; probe __main__-guarded)
- swift test --no-parallel: **2169 PASS**

PR 6/6 of v39-hardening-and-midi-read