### PR TITLE
release: evidence-sync v3.9.0 (Formula sha256)

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "7dccfc74fbeee39ba58b50166d034c71b6b49943e088207c3abd9e09cd20b54c"
+    sha256 "c33a9e53bb77f569b434c5fd35fc8d60b033d907799dbf45760296485ee666a0"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
## Summary
Post-publish evidence sync for the **v3.9.0** stable release: fills the Homebrew Formula `sha256` with the actually-published `LogicProMCP-macOS-universal.tar.gz` digest (unknowable until the tag built).

- `sha256` → `c33a9e53bb77f569b434c5fd35fc8d60b033d907799dbf45760296485ee666a0`
- **Cross-verified two ways**: local `shasum -a 256` of the downloaded release asset **and** the release's `SHA256SUMS.txt`.
- Formula `version`/`url`/comment already at v3.9.0 (prepare PR #246); `ruby -c` clean; no stale v3.8.0 refs.

## Release status
- Tag `v3.9.0` published (draft=false, prerelease=false), 5 assets.
- Release workflow **success**: build + swift test gate (first real run of the PR-1 gate) + ADHOC sign + publish + **validate-install macos-14 & macos-15 green**.