### PR TITLE
feat(doctor): complete v4 readiness platform

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -66,7 +66,8 @@ enum MainEntrypoint {
                 arguments: arguments,
                 permissionStatus: permissionCheck(),
                 approvals: await approvalStore.list(),
-                runtime: runtime
+                runtime: runtime,
+                manualStoreHealth: await approvalStore.health()
             )
             if arguments.contains("--json") {
                 // --json is the machine contract: identical bytes regardless of
@@ -152,6 +153,21 @@ enum MainEntrypoint {
             }
         }
 
+        if let rawChannel = optionValue("--skip-channel", in: arguments) {
+            guard let channel = ManualValidationChannel.parse(rawChannel) else {
+                writeStderr("Unknown manual-validation channel: \(rawChannel)\n")
+                return 1
+            }
+            do {
+                try await approvalStore.skip(channel, note: optionValue("--skip-note", in: arguments))
+                writeStderr("Intentionally skipped \(channel.rawValue) for doctor readiness.\n")
+                return 0
+            } catch {
+                writeStderr("Failed to persist skip decision for \(channel.rawValue): \(error)\n")
+                return 1
+            }
+        }
+
         if let rawChannel = optionValue("--revoke-channel", in: arguments) {
             guard let channel = ManualValidationChannel.parse(rawChannel) else {
                 writeStderr("Unknown approval channel: \(rawChannel)\n")
@@ -232,7 +248,7 @@ enum MainEntrypoint {
           LogicProMCP                          Start the MCP server over stdio (default; used by an MCP client)
           LogicProMCP --help, -h               Print this help and exit
           LogicProMCP --version, -V            Print the version and exit
-          LogicProMCP doctor [--json] [--verbose|--quiet] [--check-updates] [--strict]
+          LogicProMCP doctor [--json] [--verbose|--quiet] [--check-updates] [--strict] [--profile <core|mixer|keycmd|legacy-scripter|full>] [--client <claude-code|claude-desktop|cursor|vscode|terminal|custom>]
                                                Print a diagnostic report and exit
           LogicProMCP lifecycle <install|update|uninstall> [--json]
                                                Print a read-only lifecycle plan and exit
@@ -242,6 +258,8 @@ enum MainEntrypoint {
           LogicProMCP --list-approvals         List manual channel approvals and exit
           LogicProMCP --approve-channel <MIDIKeyCommands|Scripter> [--approval-note <note>]
                                                Record a manual channel approval and exit
+          LogicProMCP --skip-channel <MIDIKeyCommands|Scripter> [--skip-note <note>]
+                                               Record an intentional doctor skip decision and exit
           LogicProMCP --revoke-channel <MIDIKeyCommands|Scripter>
                                                Revoke a manual channel approval and exit
 

--- a/Sources/LogicProMCP/Server/ServerConfig.swift
+++ b/Sources/LogicProMCP/Server/ServerConfig.swift
@@ -6,6 +6,7 @@ struct ServerConfig: Sendable {
     // MARK: - Server Identity
     static let serverName = "logic-pro-mcp"
     static let serverVersion = "3.9.0"
+    static let versionMarker = "LOGIC_PRO_MCP_VERSION=\(serverVersion)"
 
     // MARK: - MIDI
     // NOTE: source name uses *-Internal suffix for consistency with KeyCmd/Scripter/MCU

--- a/Sources/LogicProMCP/Utilities/ManualValidationStore.swift
+++ b/Sources/LogicProMCP/Utilities/ManualValidationStore.swift
@@ -25,12 +25,36 @@ enum ManualValidationChannel: String, Sendable, CaseIterable, Codable {
 }
 
 struct ManualValidationApproval: Sendable, Codable, Equatable {
+    enum Kind: String, Sendable, Codable {
+        case approved
+        case intentionallySkipped = "intentionally_skipped"
+    }
+
     let approvedAt: Date
     let note: String?
+    let kind: Kind
 
     enum CodingKeys: String, CodingKey {
         case approvedAt = "approved_at"
         case note
+        case kind
+    }
+
+    init(
+        approvedAt: Date,
+        note: String?,
+        kind: Kind = .approved
+    ) {
+        self.approvedAt = approvedAt
+        self.note = note
+        self.kind = kind
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        approvedAt = try container.decode(Date.self, forKey: .approvedAt)
+        note = try container.decodeIfPresent(String.self, forKey: .note)
+        kind = try container.decodeIfPresent(Kind.self, forKey: .kind) ?? .approved
     }
 }
 
@@ -40,6 +64,21 @@ protocol ManualValidationStoring: Actor {
     func approve(_ channel: ManualValidationChannel, note: String?) async throws
     func revoke(_ channel: ManualValidationChannel) async throws
     func list() async -> [ManualValidationChannel: ManualValidationApproval]
+}
+
+enum ManualValidationStoreHealth: Equatable, Sendable {
+    case ok
+    case corrupt(String)
+}
+
+extension ManualValidationStoring {
+    func skip(_ channel: ManualValidationChannel, note: String?) async throws {
+        throw POSIXError(.ENOTSUP)
+    }
+
+    func health() async -> ManualValidationStoreHealth {
+        .ok
+    }
 }
 
 private struct ManualValidationFile: Codable {
@@ -87,25 +126,40 @@ actor ManualValidationStore: ManualValidationStoring {
                 } else {
                     noteSuffix = ""
                 }
-                return "\(channel.rawValue): approved at \(formatter.string(from: approval.approvedAt))\(noteSuffix)"
+                let label = approval.kind == .approved ? "approved" : "intentionally skipped"
+                return "\(channel.rawValue): \(label) at \(formatter.string(from: approval.approvedAt))\(noteSuffix)"
             }
         return lines.joined(separator: "\n")
     }
 
     func isApproved(_ channel: ManualValidationChannel) async -> Bool {
-        await approval(for: channel) != nil
+        await approval(for: channel)?.kind == .approved
     }
 
     func approval(for channel: ManualValidationChannel) async -> ManualValidationApproval? {
         let file = loadFile()
-        return file.approvals[channel.rawValue]
+        guard let decision = file.approvals[channel.rawValue], decision.kind == .approved else {
+            return nil
+        }
+        return decision
     }
 
     func approve(_ channel: ManualValidationChannel, note: String?) async throws {
         try await mutateLockedFile { file in
             file.approvals[channel.rawValue] = ManualValidationApproval(
                 approvedAt: Date(),
-                note: normalized(note)
+                note: normalized(note),
+                kind: .approved
+            )
+        }
+    }
+
+    func skip(_ channel: ManualValidationChannel, note: String?) async throws {
+        try await mutateLockedFile { file in
+            file.approvals[channel.rawValue] = ManualValidationApproval(
+                approvedAt: Date(),
+                note: normalized(note),
+                kind: .intentionallySkipped
             )
         }
     }
@@ -127,19 +181,27 @@ actor ManualValidationStore: ManualValidationStoring {
         return result
     }
 
+    func health() async -> ManualValidationStoreHealth {
+        loadFileResult().health
+    }
+
     /// Lenient read for the read-only `list()`/`status()` paths: an unreadable or
     /// corrupt store degrades to "no approvals" rather than failing the query.
     private func loadFile() -> ManualValidationFile {
+        loadFileResult().file
+    }
+
+    private func loadFileResult() -> (file: ManualValidationFile, health: ManualValidationStoreHealth) {
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return .init()
+            return (.init(), .ok)
         }
 
         do {
             let data = try Data(contentsOf: fileURL)
-            return try JSONDecoder().decode(ManualValidationFile.self, from: data)
+            return (try JSONDecoder().decode(ManualValidationFile.self, from: data), .ok)
         } catch {
             Log.warn("Failed to read manual validation store: \(error)", subsystem: "validation")
-            return .init()
+            return (.init(), .corrupt("json_decode_failed"))
         }
     }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
@@ -37,7 +37,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Executable bit could not be checked because the binary path is missing.",
                 evidence: [:],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "binary_path_missing"
             )
         }
         let executable = runtime.isExecutableFile(executablePath)
@@ -78,7 +79,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Signature verification skipped because the binary path is missing.",
                 evidence: [:],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "binary_path_missing"
             )
         }
         guard let output = runtime.runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", executablePath]) else {
@@ -110,7 +112,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Quarantine check skipped because the binary path is missing.",
                 evidence: [:],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "binary_path_missing"
             )
         }
         guard let output = runtime.runCommand("/usr/bin/xattr", ["-p", "com.apple.quarantine", executablePath]) else {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
@@ -48,7 +48,7 @@ extension SetupDoctor {
             summary: executable ? "Binary has executable permission." : "Binary is not executable.",
             evidence: ["path": executablePath, "executable": String(executable)],
             remediationType: executable ? .none : .command,
-            remediationValueOverride: executable ? nil : "chmod +x \(executablePath)"
+            remediationValueOverride: executable ? nil : "chmod +x \(shellQuote(executablePath))"
         )
     }
 
@@ -96,11 +96,7 @@ extension SetupDoctor {
             domain: "release",
             status: output.exitCode == 0 ? .pass : .warn,
             summary: output.exitCode == 0 ? "Binary signature verifies." : "Binary signature did not verify.",
-            evidence: [
-                "path": executablePath,
-                "exit_code": String(output.exitCode),
-                "stderr": output.stderr.trimmingCharacters(in: .whitespacesAndNewlines),
-            ],
+            evidence: commandEvidence(path: executablePath, output: output),
             remediationType: output.exitCode == 0 ? .none : .docs
         )
     }
@@ -134,11 +130,7 @@ extension SetupDoctor {
         // never verified.
         let trimmedStderr = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedStdout = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        let evidence: [String: String] = [
-            "path": executablePath,
-            "exit_code": String(output.exitCode),
-            "stderr": trimmedStderr,
-        ]
+        let evidence = commandEvidence(path: executablePath, output: output)
         if output.exitCode == 0 {
             return check(
                 id: "release.quarantine",
@@ -147,7 +139,7 @@ extension SetupDoctor {
                 summary: "Binary has a macOS quarantine attribute.",
                 evidence: evidence,
                 remediationType: .command,
-                remediationValueOverride: "xattr -d com.apple.quarantine \(executablePath)"
+                remediationValueOverride: "xattr -d com.apple.quarantine \(shellQuote(executablePath))"
             )
         }
         let attributeAbsent = output.exitCode == 1

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -41,6 +41,17 @@ extension SetupDoctor {
         if !intentionallySkipped.isEmpty {
             evidence["intentionally_skipped"] = intentionallySkipped.joined(separator: ",")
         }
+        if missing.isEmpty && !intentionallySkipped.isEmpty {
+            return check(
+                id: "channels.manual_validation",
+                domain: "channels",
+                status: .skipped,
+                summary: "Manual-validation channels were explicitly skipped by the operator; live readiness is not claimed for those channels.",
+                evidence: evidence,
+                remediationType: .none,
+                skipReason: "intentionally_skipped"
+            )
+        }
         return check(
             id: "channels.manual_validation",
             domain: "channels",

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -1,25 +1,73 @@
 import Foundation
 
 extension SetupDoctor {
-    static func manualValidationCheck(approvals: [ManualValidationChannel: ManualValidationApproval]) -> Check {
-        let missing = ManualValidationChannel.allCases
-            .filter { approvals[$0] == nil }
+    static func manualValidationCheck(
+        approvals: [ManualValidationChannel: ManualValidationApproval],
+        profile: DoctorProfile,
+        storeHealth: ManualValidationStoreHealth
+    ) -> Check {
+        if case let .corrupt(reason) = storeHealth {
+            return check(
+                id: "channels.manual_validation",
+                domain: "channels",
+                status: .warn,
+                summary: "Manual-validation store could not be read; existing operator decisions were not trusted.",
+                evidence: ["store_health": "corrupt", "reason": reason],
+                remediationType: .manual
+            )
+        }
+
+        let requiredChannels = manualValidationChannelsRequired(for: profile)
+        guard !requiredChannels.isEmpty else {
+            return check(
+                id: "channels.manual_validation",
+                domain: "channels",
+                status: .skipped,
+                summary: "Manual-validation channels are not required for profile \(profile.rawValue).",
+                evidence: ["profile": profile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "profile_not_required"
+            )
+        }
+
+        let missing = requiredChannels
+            .filter { approvals[$0]?.kind != .approved && approvals[$0]?.kind != .intentionallySkipped }
             .map(\.rawValue)
+        let intentionallySkipped = requiredChannels
+            .filter { approvals[$0]?.kind == .intentionallySkipped }
+            .map(\.rawValue)
+        var evidence = ["missing": missing.joined(separator: ","), "profile": profile.rawValue]
+        if !intentionallySkipped.isEmpty {
+            evidence["intentionally_skipped"] = intentionallySkipped.joined(separator: ",")
+        }
         return check(
             id: "channels.manual_validation",
             domain: "channels",
             status: missing.isEmpty ? .pass : .manual,
             summary: missing.isEmpty
-                ? "Manual-validation channels have operator approvals."
+                ? "Manual-validation channels have operator approvals or explicit skip decisions."
                 : "Manual-validation channels need operator approval or an explicit decision to skip.",
-            evidence: ["missing": missing.joined(separator: ",")],
+            evidence: evidence,
             remediationType: missing.isEmpty ? .none : .command,
             remediationValueOverride: missing.isEmpty ? nil : "LogicProMCP --approve-channel MIDIKeyCommands && LogicProMCP --approve-channel Scripter"
         )
     }
 
 
-    static func keycmdReferenceCheck(runtime: Runtime) -> Check {
+    static func keycmdReferenceCheck(runtime: Runtime, profile: DoctorProfile) -> Check {
+        guard isProfileRequired("channels.keycmd_reference", profile: profile) else {
+            return check(
+                id: "channels.keycmd_reference",
+                domain: "channels",
+                status: .skipped,
+                summary: "Key Commands preset is not required for profile \(profile.rawValue).",
+                evidence: ["profile": profile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "profile_not_required"
+            )
+        }
         let staged = runtime.keyCommandsPresetStaged()
         return check(
             id: "channels.keycmd_reference",
@@ -35,7 +83,19 @@ extension SetupDoctor {
     }
 
 
-    static func mcuWiringHintCheck(runtime: Runtime) -> Check {
+    static func mcuWiringHintCheck(runtime: Runtime, profile: DoctorProfile) -> Check {
+        guard isProfileRequired("channels.mcu_wiring_hint", profile: profile) else {
+            return check(
+                id: "channels.mcu_wiring_hint",
+                domain: "channels",
+                status: .skipped,
+                summary: "MCU wiring hint is not required for profile \(profile.rawValue).",
+                evidence: ["profile": profile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "profile_not_required"
+            )
+        }
         let found = runtime.mcuPortReferenceFound()
         return check(
             id: "channels.mcu_wiring_hint",
@@ -50,6 +110,19 @@ extension SetupDoctor {
             ],
             remediationType: found == true ? .none : .docs
         )
+    }
+
+    private static func manualValidationChannelsRequired(for profile: DoctorProfile) -> [ManualValidationChannel] {
+        switch profile {
+        case .core, .mixer, .auto:
+            return []
+        case .keycmd:
+            return [.midiKeyCommands]
+        case .legacyScripter:
+            return [.scripter]
+        case .full:
+            return ManualValidationChannel.allCases
+        }
     }
 
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+extension SetupDoctor {
+    enum DoctorCheckID: String, Codable, CaseIterable, Sendable {
+        case binaryPath = "binary.path"
+        case binaryExecutable = "binary.executable"
+        case binaryVersion = "binary.version"
+        case installSource = "install.source"
+        case installBinaryInventory = "install.binary_inventory"
+        case installShareDir = "install.share_dir"
+        case releaseSignature = "release.signature"
+        case releaseQuarantine = "release.quarantine"
+        case mcpClaudeCodeRegistration = "mcp.claude_code_registration"
+        case mcpRegistrationTarget = "mcp.registration_target"
+        case mcpClaudeDesktopRegistration = "mcp.claude_desktop_registration"
+        case permissionsAccessibility = "permissions.accessibility"
+        case permissionsAutomationLogicPro = "permissions.automation_logic_pro"
+        case permissionsAutomationSystemEvents = "permissions.automation_system_events"
+        case permissionsPostEventAccess = "permissions.post_event_access"
+        case permissionsLaunchContext = "permissions.launch_context"
+        case permissionsTCCCrossContext = "permissions.tcc_cross_context"
+        case systemMacOSVersion = "system.macos_version"
+        case logicInstallation = "logic.installation"
+        case logicVersionSupport = "logic.version_support"
+        case logicApplicationState = "logic.application_state"
+        case logicBlockingDialog = "logic.blocking_dialog"
+        case channelsManualValidation = "channels.manual_validation"
+        case channelsKeycmdReference = "channels.keycmd_reference"
+        case channelsMCUWiringHint = "channels.mcu_wiring_hint"
+        case dependenciesClickFallback = "dependencies.click_fallback"
+        case updatesLatestRelease = "updates.latest_release"
+    }
+
+    struct DoctorCheckDefinition: Equatable, Sendable {
+        let id: DoctorCheckID
+        let dependencies: [DoctorCheckID]
+        let optionalByDefault: Bool
+        let capabilityGroups: [String]
+        let remediationAnchor: String?
+        let profileRule: String?
+        let clientRule: String?
+
+        init(
+            _ id: DoctorCheckID,
+            dependencies: [DoctorCheckID] = [],
+            optionalByDefault: Bool = false,
+            capabilityGroups: [String] = [],
+            remediationAnchor: String? = nil,
+            profileRule: String? = nil,
+            clientRule: String? = nil
+        ) {
+            self.id = id
+            self.dependencies = dependencies
+            self.optionalByDefault = optionalByDefault
+            self.capabilityGroups = capabilityGroups
+            self.remediationAnchor = remediationAnchor
+            self.profileRule = profileRule
+            self.clientRule = clientRule
+        }
+    }
+
+    static let checkDefinitions: [DoctorCheckDefinition] = [
+        .init(.binaryPath, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-binarypath"),
+        .init(.binaryExecutable, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-binaryexecutable"),
+        .init(.binaryVersion),
+        .init(.installSource, remediationAnchor: "docs/SETUP.md#doctor-installsource"),
+        .init(.installBinaryInventory, remediationAnchor: "docs/SETUP.md#doctor-installbinary-inventory"),
+        .init(.installShareDir, remediationAnchor: "docs/SETUP.md#doctor-installshare-dir"),
+        .init(.releaseSignature, remediationAnchor: "docs/SETUP.md#doctor-releasesignature"),
+        .init(.releaseQuarantine, remediationAnchor: "docs/SETUP.md#doctor-releasequarantine"),
+        .init(.mcpClaudeCodeRegistration, remediationAnchor: "docs/SETUP.md#doctor-mcpclaude-code-registration", clientRule: "claude-code"),
+        .init(.mcpRegistrationTarget, dependencies: [.mcpClaudeCodeRegistration], remediationAnchor: "docs/SETUP.md#doctor-mcpregistration-target", clientRule: "claude-code"),
+        .init(.mcpClaudeDesktopRegistration, remediationAnchor: "docs/SETUP.md#doctor-mcpclaude-desktop-registration", clientRule: "claude-desktop"),
+        .init(.permissionsAccessibility, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-permissionsaccessibility"),
+        .init(.permissionsAutomationLogicPro, capabilityGroups: ["track_management", "project_lifecycle", "mixer_ax", "verified_plugin_applyback"], remediationAnchor: "docs/SETUP.md#doctor-permissionsautomation-logic-pro"),
+        .init(.permissionsAutomationSystemEvents, capabilityGroups: ["midi_import", "project_lifecycle"], remediationAnchor: "docs/SETUP.md#doctor-permissionsautomation-system-events"),
+        .init(.permissionsPostEventAccess, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-permissionspost-event-access"),
+        .init(.permissionsLaunchContext, remediationAnchor: "docs/SETUP.md#doctor-permissionslaunch-context"),
+        .init(.permissionsTCCCrossContext, remediationAnchor: "docs/SETUP.md#doctor-permissionstcc-cross-context"),
+        .init(.systemMacOSVersion, remediationAnchor: "docs/SETUP.md#doctor-systemmacos-version"),
+        .init(.logicInstallation, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicinstallation"),
+        .init(.logicVersionSupport, dependencies: [.logicInstallation], capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicversion-support"),
+        .init(.logicApplicationState, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicapplication-state"),
+        .init(.logicBlockingDialog, dependencies: [.logicApplicationState, .permissionsAccessibility], capabilityGroups: ["track_management", "mixer_ax", "verified_plugin_applyback"], remediationAnchor: "docs/SETUP.md#doctor-logicblocking-dialog"),
+        .init(.channelsManualValidation, capabilityGroups: ["keycmd_only_ops", "legacy_scripter"], remediationAnchor: "docs/SETUP.md#doctor-channelsmanual-validation", profileRule: "keycmd|legacy-scripter|full"),
+        .init(.channelsKeycmdReference, capabilityGroups: ["keycmd_only_ops"], remediationAnchor: "docs/SETUP.md#doctor-channelskeycmd-reference", profileRule: "keycmd|full"),
+        .init(.channelsMCUWiringHint, capabilityGroups: ["mixer_mcu"], remediationAnchor: "docs/SETUP.md#doctor-channelsmcu-wiring-hint", profileRule: "full"),
+        .init(.dependenciesClickFallback, remediationAnchor: "docs/SETUP.md#doctor-dependenciesclick-fallback"),
+        .init(.updatesLatestRelease, optionalByDefault: true, remediationAnchor: "docs/SETUP.md#doctor-updateslatest-release"),
+    ]
+
+    static let checkDefinitionByID: [String: DoctorCheckDefinition] = Dictionary(
+        uniqueKeysWithValues: checkDefinitions.map { ($0.id.rawValue, $0) }
+    )
+
+    static let orderedCheckIDs: [String] = checkDefinitions.map(\.id.rawValue)
+}

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
@@ -59,9 +59,33 @@ extension SetupDoctor {
         }
     }
 
+    struct DoctorCapabilityDefinition: Equatable, Sendable {
+        let id: String
+        let profiles: Set<DoctorProfile>
+        let liveVerification: String?
+
+        init(_ id: String, profiles: Set<DoctorProfile>, liveVerification: String? = nil) {
+            self.id = id
+            self.profiles = profiles
+            self.liveVerification = liveVerification
+        }
+    }
+
+    private static let allCapabilityGroups = [
+        "core_transport",
+        "track_management",
+        "midi_import",
+        "mixer_ax",
+        "mixer_mcu",
+        "project_lifecycle",
+        "keycmd_only_ops",
+        "legacy_scripter",
+        "verified_plugin_applyback",
+    ]
+
     static let checkDefinitions: [DoctorCheckDefinition] = [
-        .init(.binaryPath, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-binarypath"),
-        .init(.binaryExecutable, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-binaryexecutable"),
+        .init(.binaryPath, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-binarypath"),
+        .init(.binaryExecutable, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-binaryexecutable"),
         .init(.binaryVersion),
         .init(.installSource, remediationAnchor: "docs/SETUP.md#doctor-installsource"),
         .init(.installBinaryInventory, remediationAnchor: "docs/SETUP.md#doctor-installbinary-inventory"),
@@ -71,16 +95,16 @@ extension SetupDoctor {
         .init(.mcpClaudeCodeRegistration, remediationAnchor: "docs/SETUP.md#doctor-mcpclaude-code-registration", clientRule: "claude-code"),
         .init(.mcpRegistrationTarget, dependencies: [.mcpClaudeCodeRegistration], remediationAnchor: "docs/SETUP.md#doctor-mcpregistration-target", clientRule: "claude-code"),
         .init(.mcpClaudeDesktopRegistration, remediationAnchor: "docs/SETUP.md#doctor-mcpclaude-desktop-registration", clientRule: "claude-desktop"),
-        .init(.permissionsAccessibility, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-permissionsaccessibility"),
+        .init(.permissionsAccessibility, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-permissionsaccessibility"),
         .init(.permissionsAutomationLogicPro, capabilityGroups: ["track_management", "project_lifecycle", "mixer_ax", "verified_plugin_applyback"], remediationAnchor: "docs/SETUP.md#doctor-permissionsautomation-logic-pro"),
         .init(.permissionsAutomationSystemEvents, capabilityGroups: ["midi_import", "project_lifecycle"], remediationAnchor: "docs/SETUP.md#doctor-permissionsautomation-system-events"),
-        .init(.permissionsPostEventAccess, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-permissionspost-event-access"),
+        .init(.permissionsPostEventAccess, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-permissionspost-event-access"),
         .init(.permissionsLaunchContext, remediationAnchor: "docs/SETUP.md#doctor-permissionslaunch-context"),
         .init(.permissionsTCCCrossContext, remediationAnchor: "docs/SETUP.md#doctor-permissionstcc-cross-context"),
         .init(.systemMacOSVersion, remediationAnchor: "docs/SETUP.md#doctor-systemmacos-version"),
-        .init(.logicInstallation, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicinstallation"),
-        .init(.logicVersionSupport, dependencies: [.logicInstallation], capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicversion-support"),
-        .init(.logicApplicationState, capabilityGroups: ["core_transport"], remediationAnchor: "docs/SETUP.md#doctor-logicapplication-state"),
+        .init(.logicInstallation, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-logicinstallation"),
+        .init(.logicVersionSupport, dependencies: [.logicInstallation], capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-logicversion-support"),
+        .init(.logicApplicationState, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-logicapplication-state"),
         .init(.logicBlockingDialog, dependencies: [.logicApplicationState, .permissionsAccessibility], capabilityGroups: ["track_management", "mixer_ax", "verified_plugin_applyback"], remediationAnchor: "docs/SETUP.md#doctor-logicblocking-dialog"),
         .init(.channelsManualValidation, capabilityGroups: ["keycmd_only_ops", "legacy_scripter"], remediationAnchor: "docs/SETUP.md#doctor-channelsmanual-validation", profileRule: "keycmd|legacy-scripter|full"),
         .init(.channelsKeycmdReference, capabilityGroups: ["keycmd_only_ops"], remediationAnchor: "docs/SETUP.md#doctor-channelskeycmd-reference", profileRule: "keycmd|full"),
@@ -94,4 +118,22 @@ extension SetupDoctor {
     )
 
     static let orderedCheckIDs: [String] = checkDefinitions.map(\.id.rawValue)
+
+    static let capabilityDefinitions: [DoctorCapabilityDefinition] = [
+        .init("core_transport", profiles: [.core, .mixer, .keycmd, .legacyScripter, .full]),
+        .init("track_management", profiles: [.core, .mixer, .full]),
+        .init("midi_import", profiles: [.full]),
+        .init("mixer_ax", profiles: [.mixer, .full]),
+        .init("mixer_mcu", profiles: [.full], liveVerification: "logic://system/health mcu.connected"),
+        .init("project_lifecycle", profiles: [.core, .mixer, .full]),
+        .init("keycmd_only_ops", profiles: [.keycmd, .full]),
+        .init("legacy_scripter", profiles: [.legacyScripter, .full]),
+        .init("verified_plugin_applyback", profiles: [.mixer, .full]),
+    ]
+
+    static func capabilityCheckIDs(for capabilityID: String) -> [String] {
+        checkDefinitions.compactMap { definition in
+            definition.capabilityGroups.contains(capabilityID) ? definition.id.rawValue : nil
+        }
+    }
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
@@ -16,6 +16,7 @@ extension SetupDoctor {
 
     static func installBinaryInventoryCheck(
         executablePath: String?,
+        installSource: InstallSource,
         runtime: Runtime,
         claudeRegistration: ClaudeRegistration,
         staticVersionForPath: (String) -> StaticVersionResult
@@ -61,8 +62,8 @@ extension SetupDoctor {
             status: warn ? .warn : .pass,
             summary: binaryInventorySummary(stale: stale, indeterminateStaleRisk: indeterminateStaleRisk),
             evidence: evidence,
-            remediationType: warn ? .command : .none,
-            remediationValueOverride: warn ? "brew upgrade logic-pro-mcp" : nil
+            remediationType: warn ? binaryInventoryRemediationType(installSource: installSource) : .none,
+            remediationValueOverride: warn ? binaryInventoryRemediation(installSource: installSource) : nil
         )
     }
 
@@ -75,6 +76,30 @@ extension SetupDoctor {
             return "A canonical LogicProMCP binary's static version could not be determined; staleness cannot be ruled out."
         }
         return "Canonical LogicProMCP binary inventory found no stale installed binary."
+    }
+
+
+    static func binaryInventoryRemediationType(installSource: InstallSource) -> RemediationType {
+        switch installSource {
+        case .homebrew, .sourceBuild:
+            return .command
+        case .releaseBinary, .unknown:
+            return .docs
+        }
+    }
+
+
+    static func binaryInventoryRemediation(installSource: InstallSource) -> String {
+        switch installSource {
+        case .homebrew:
+            return "brew upgrade logic-pro-mcp"
+        case .sourceBuild:
+            return "git pull && swift build -c release"
+        case .releaseBinary:
+            return "Download and replace the pinned LogicProMCP release binary."
+        case .unknown:
+            return remediationAnchorsByCheckID["install.binary_inventory"] ?? "docs/SETUP.md#doctor"
+        }
     }
 
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
@@ -131,7 +131,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Share directory could not be resolved; source builds may not have packaged helper assets.",
                 evidence: ["reason": "share_dir_unresolved"],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "source_build_no_share_dir"
             )
         case let .invalid(path, source):
             return check(
@@ -140,7 +141,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Resolved share directory is not a directory.",
                 evidence: shareDirEvidence(path: path, source: source, extra: ["reason": "share_dir_invalid"]),
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "share_dir_invalid"
             )
         }
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LaunchContextSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LaunchContextSupport.swift
@@ -49,6 +49,20 @@ extension SetupDoctor {
         if value.localizedCaseInsensitiveContains("claude") {
             return LaunchContextInfo(context: "claude_code", responsibleHint: pathBasenameOrValue(value))
         }
+        if value.localizedCaseInsensitiveContains("cursor") {
+            return LaunchContextInfo(context: "cursor", responsibleHint: pathBasenameOrValue(value))
+        }
+        if value.localizedCaseInsensitiveContains("Visual Studio Code")
+            || value.localizedCaseInsensitiveContains("vscode")
+            || value.localizedCaseInsensitiveContains("com.microsoft.VSCode") {
+            return LaunchContextInfo(context: "vscode", responsibleHint: pathBasenameOrValue(value))
+        }
+        if value.localizedCaseInsensitiveContains("windsurf") {
+            return LaunchContextInfo(context: "custom", responsibleHint: pathBasenameOrValue(value))
+        }
+        if value.localizedCaseInsensitiveContains("zed") {
+            return LaunchContextInfo(context: "custom", responsibleHint: pathBasenameOrValue(value))
+        }
         if value.localizedCaseInsensitiveContains("Terminal")
             || value.localizedCaseInsensitiveContains("iTerm") {
             return LaunchContextInfo(context: "terminal", responsibleHint: pathBasenameOrValue(value))

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
@@ -10,7 +10,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "macOS version could not be determined.",
                 evidence: ["reason": "version_unreadable"],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "version_unreadable"
             )
         }
         let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
@@ -53,7 +54,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Logic Pro.app exists but its version could not be read.",
                 evidence: ["reason": "bundle_unreadable", "path": apps.map(\.path).joined(separator: ",")],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: "bundle_unreadable"
             )
         }
         var evidence = [

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LogicSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LogicSupport.swift
@@ -2,17 +2,27 @@ import Foundation
 
 extension SetupDoctor {
     static func staticVersion(fromStringsOutput output: String) -> StaticVersionResult {
+        let markerPrefix = "LOGIC_PRO_MCP_VERSION="
+        let markerVersions = output
+            .split(separator: "\n")
+            .compactMap { line -> String? in
+                let value = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard value.hasPrefix(markerPrefix) else { return nil }
+                let version = String(value.dropFirst(markerPrefix.count))
+                return Self.SemanticVersion(version)?.normalizedCore
+            }
+        if let marker = markerVersions.first {
+            return .version(marker)
+        }
+
         var versions: [String] = []
         for line in output.split(separator: "\n") {
             let value = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            let parts = value.split(separator: ".", omittingEmptySubsequences: false)
-            guard parts.count == 3,
-                  parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }),
-                  let major = Int(parts[0]), major > 0 else {
+            guard let version = Self.SemanticVersion(value), version.major > 0 else {
                 continue
             }
-            if !versions.contains(value) {
-                versions.append(value)
+            if !versions.contains(version.normalizedCore) {
+                versions.append(version.normalizedCore)
             }
         }
         return versions.count == 1 ? .version(versions[0]) : .indeterminate(versions)

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
@@ -186,14 +186,12 @@ extension SetupDoctor {
             return check(
                 id: "mcp.claude_desktop_registration",
                 domain: "mcp",
-                status: .skipped,
+                status: absent ? .warn : .manual,
                 summary: absent
-                    ? "Claude Desktop not configured (optional)."
+                    ? "Claude Desktop config is absent."
                     : "Claude Desktop config could not be read.",
                 evidence: ["config_present": absent ? "false" : "true", "reason": reason],
-                remediationType: absent ? .none : .manual,
-                optional: absent,
-                skipReason: absent ? "config_absent_optional" : "config_unreadable"
+                remediationType: .manual
             )
         }
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
@@ -1,7 +1,19 @@
 import Foundation
 
 extension SetupDoctor {
-    static func claudeRegistrationCheck(registration: ClaudeRegistration) -> Check {
+    static func claudeRegistrationCheck(registration: ClaudeRegistration, clientProfile: ClientProfile) -> Check {
+        guard clientProfile == .claudeCode else {
+            return check(
+                id: "mcp.claude_code_registration",
+                domain: "mcp",
+                status: .skipped,
+                summary: "Claude Code registration is not required for client profile \(clientProfile.rawValue).",
+                evidence: ["client_profile": clientProfile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "client_not_selected"
+            )
+        }
         // Read-only registration detection: inspect the Claude Code config file
         // directly instead of shelling out to `claude mcp list`. `claude mcp list`
         // health-checks every registered MCP server, which spawns the registered
@@ -47,7 +59,21 @@ extension SetupDoctor {
         runtime: Runtime,
         checks: [Check],
         staticVersionForPath: (String) -> StaticVersionResult
+        ,
+        clientProfile: ClientProfile
     ) -> Check {
+        guard clientProfile == .claudeCode else {
+            return check(
+                id: "mcp.registration_target",
+                domain: "mcp",
+                status: .skipped,
+                summary: "Claude Code registration target is not required for client profile \(clientProfile.rawValue).",
+                evidence: ["client_profile": clientProfile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "client_not_selected"
+            )
+        }
         if let cause = blockingCause(for: "mcp.registration_target", checks: checks) {
             return check(
                 id: "mcp.registration_target",
@@ -70,22 +96,26 @@ extension SetupDoctor {
                 blockedBy: "mcp.claude_code_registration"
             )
         }
-        guard command.hasPrefix("/") else {
+        let resolution = resolveRegisteredCommand(command, runtime: runtime)
+        guard let resolvedCommand = resolution.path else {
             return check(
                 id: "mcp.registration_target",
                 domain: "mcp",
                 status: .skipped,
-                summary: "Claude Code registration uses a relative or PATH-dependent command; install.binary_inventory covers canonical binary staleness.",
-                evidence: ["command_path": command, "reason": "relative_command"],
+                summary: "Claude Code registration uses an unresolved PATH-dependent command; the MCP client's launch PATH may differ.",
+                evidence: ["command_path": command, "reason": "path_dependent_unresolved"],
                 remediationType: .command,
-                remediationValueOverride: "claude mcp add --scope user logic-pro -- LogicProMCP"
+                remediationValueOverride: "claude mcp add --scope user logic-pro -- LogicProMCP",
+                skipReason: "path_dependent_unresolved"
             )
         }
-        let exists = runtime.fileExistsAtPath(command)
-        let regular = exists && runtime.isRegularFile(command)
-        let executable = regular && runtime.isExecutableFile(command)
+        let exists = runtime.fileExistsAtPath(resolvedCommand)
+        let regular = exists && runtime.isRegularFile(resolvedCommand)
+        let executable = regular && runtime.isExecutableFile(resolvedCommand)
         var evidence = [
             "command_path": command,
+            "resolved_path": resolvedCommand,
+            "resolution_basis": resolution.basis,
             "regular_file": String(regular),
             "executable": String(executable),
             "running_version": ServerConfig.serverVersion,
@@ -97,7 +127,7 @@ extension SetupDoctor {
             shareDirMissing = !valid
         }
         var versionMismatch = false
-        if executable, case let .version(version) = staticVersionForPath(command) {
+        if executable, case let .version(version) = staticVersionForPath(resolvedCommand) {
             evidence["registered_version"] = version
             evidence["version_match"] = String(version == ServerConfig.serverVersion)
             versionMismatch = version != ServerConfig.serverVersion
@@ -111,7 +141,7 @@ extension SetupDoctor {
             status: warn ? .warn : .pass,
             summary: warn
                 ? "Claude Code registration target is missing, not a regular executable, has a missing share dir, or is stale."
-                : "Claude Code registration target is present and executable.",
+                : "Claude Code registration target is present and executable. If it was resolved from PATH, this report used the doctor's environment; the MCP client's spawn PATH may differ.",
             evidence: evidence,
             remediationType: warn ? .command : .none,
             remediationValueOverride: warn ? "claude mcp add --scope user logic-pro -- LogicProMCP" : nil
@@ -119,7 +149,19 @@ extension SetupDoctor {
     }
 
 
-    static func claudeDesktopRegistrationCheck(runtime: Runtime) -> Check {
+    static func claudeDesktopRegistrationCheck(runtime: Runtime, clientProfile: ClientProfile) -> Check {
+        guard clientProfile == .claudeDesktop else {
+            return check(
+                id: "mcp.claude_desktop_registration",
+                domain: "mcp",
+                status: .skipped,
+                summary: "Claude Desktop registration is not required for client profile \(clientProfile.rawValue).",
+                evidence: ["client_profile": clientProfile.rawValue],
+                remediationType: .none,
+                optional: true,
+                skipReason: "client_not_selected"
+            )
+        }
         switch runtime.readClaudeDesktopRegistration() {
         case .registered:
             return check(
@@ -150,9 +192,39 @@ extension SetupDoctor {
                     : "Claude Desktop config could not be read.",
                 evidence: ["config_present": absent ? "false" : "true", "reason": reason],
                 remediationType: absent ? .none : .manual,
-                optional: absent
+                optional: absent,
+                skipReason: absent ? "config_absent_optional" : "config_unreadable"
             )
         }
+    }
+
+    struct RegisteredCommandResolution: Equatable, Sendable {
+        let path: String?
+        let basis: String
+    }
+
+    static func resolveRegisteredCommand(_ command: String, runtime: Runtime) -> RegisteredCommandResolution {
+        if command.hasPrefix("/") {
+            return RegisteredCommandResolution(path: command, basis: "absolute")
+        }
+        guard !command.contains("/") else {
+            return RegisteredCommandResolution(path: nil, basis: "relative_path_unresolved")
+        }
+        for prefix in ["/opt/homebrew/bin", "/usr/local/bin"] {
+            let candidate = "\(prefix)/\(command)"
+            if runtime.fileExistsAtPath(candidate), runtime.isRegularFile(candidate) {
+                return RegisteredCommandResolution(path: candidate, basis: "canonical_path")
+            }
+        }
+        guard let output = runtime.runCommand("/usr/bin/which", [command]),
+              output.exitCode == 0 else {
+            return RegisteredCommandResolution(path: nil, basis: "doctor_path")
+        }
+        let resolved = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard resolved.hasPrefix("/") else {
+            return RegisteredCommandResolution(path: nil, basis: "doctor_path")
+        }
+        return RegisteredCommandResolution(path: resolved, basis: "doctor_path")
     }
 
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
@@ -74,11 +74,14 @@ extension SetupDoctor {
 
     static func launchContextCheck(runtime: Runtime) -> Check {
         let context = runtime.launchContext()
+        let summary = context.context == "unknown"
+            ? "Launch context is unknown; re-run doctor from the same app that will launch the server."
+            : "This report measures the TCC principal of \(context.context); re-verify under a different app if it spawns the server."
         return check(
             id: "permissions.launch_context",
             domain: "permissions",
             status: .pass,
-            summary: "This report measures the TCC principal of \(context.context); re-verify under a different app if it spawns the server.",
+            summary: summary,
             evidence: ["launch_context": context.context, "responsible_hint": context.responsibleHint],
             remediationType: .none
         )

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
@@ -124,7 +124,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Cross-context TCC enrichment could not answer; live permission probes remain authoritative.",
                 evidence: ["tcc_db_readable": readable, "full_disk_access": readable, "reason": reason],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: reason
             )
         }
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
@@ -50,17 +50,7 @@ extension SetupDoctor {
     }
 
     private static func appendCapabilitySummary(_ report: Report, to lines: inout [String]) {
-        let ordered = [
-            "core_transport",
-            "track_management",
-            "midi_import",
-            "mixer_ax",
-            "mixer_mcu",
-            "project_lifecycle",
-            "keycmd_only_ops",
-            "legacy_scripter",
-            "verified_plugin_applyback",
-        ]
+        let ordered = capabilityDefinitions.map(\.id)
         let rendered = ordered.compactMap { id -> String? in
             guard let capability = report.capabilities[id] else { return nil }
             return "\(id)=\(capability.status.rawValue)"

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
@@ -23,6 +23,9 @@ extension SetupDoctor {
         lines.append("status: \(report.status.rawValue)")
         lines.append("version: \(report.version)")
         lines.append("install_source: \(report.installSource.rawValue)")
+        lines.append("profile: \(report.doctorProfile.rawValue) (\(report.doctorProfileBasis))")
+        lines.append("client: \(report.clientProfile.rawValue) (\(report.clientProfileBasis))")
+        appendCapabilitySummary(report, to: &lines)
         appendFixPlan(report, to: &lines, useColor: useColor)
         lines.append("")
         for check in report.checks {
@@ -37,10 +40,33 @@ extension SetupDoctor {
                 for key in check.evidence.keys.sorted() {
                     lines.append("    \(key)=\(check.evidence[key] ?? "")")
                 }
+                if let skipReason = check.skipReason {
+                    lines.append("    skip_reason: \(skipReason)")
+                }
                 lines.append("    duration_ms: \(formatDuration(check.durationMs))")
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    private static func appendCapabilitySummary(_ report: Report, to lines: inout [String]) {
+        let ordered = [
+            "core_transport",
+            "track_management",
+            "midi_import",
+            "mixer_ax",
+            "mixer_mcu",
+            "project_lifecycle",
+            "keycmd_only_ops",
+            "legacy_scripter",
+            "verified_plugin_applyback",
+        ]
+        let rendered = ordered.compactMap { id -> String? in
+            guard let capability = report.capabilities[id] else { return nil }
+            return "\(id)=\(capability.status.rawValue)"
+        }
+        guard !rendered.isEmpty else { return }
+        lines.append("capabilities: \(rendered.joined(separator: ", "))")
     }
 
     private static func appendFixPlan(_ report: Report, to lines: inout [String], useColor: Bool) {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
@@ -16,7 +16,8 @@ extension SetupDoctor {
                     status: .skipped,
                     summary: "Could not parse the latest release version.",
                     evidence: ["reason": "parse_error"],
-                    remediationType: .docs
+                    remediationType: .docs,
+                    skipReason: "parse_error"
                 )
             }
             let order = Self.compareVersions(installed, latest)
@@ -48,7 +49,8 @@ extension SetupDoctor {
                 status: .skipped,
                 summary: "Could not check for the latest release.",
                 evidence: ["reason": updateReason(outcome)],
-                remediationType: .docs
+                remediationType: .docs,
+                skipReason: updateReason(outcome)
             )
         }
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+extension SetupDoctor {
+    enum DoctorProfile: String, Codable, Sendable, CaseIterable {
+        case auto
+        case core
+        case mixer
+        case keycmd
+        case legacyScripter = "legacy-scripter"
+        case full
+    }
+
+    enum ClientProfile: String, Codable, Sendable, CaseIterable {
+        case auto
+        case claudeCode = "claude-code"
+        case claudeDesktop = "claude-desktop"
+        case cursor
+        case vscode
+        case terminal
+        case custom
+    }
+
+    enum CapabilityStatus: String, Codable, Sendable {
+        case ready
+        case notReady = "not_ready"
+        case unknownLiveVerifyRequired = "unknown_live_verify_required"
+        case notInProfile = "not_in_profile"
+    }
+
+    struct CapabilityReadiness: Codable, Equatable, Sendable {
+        let status: CapabilityStatus
+        let checks: [String]
+        let liveVerification: String?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case checks
+            case liveVerification = "live_verification"
+        }
+    }
+
+    enum PathEvidencePolicy: Sendable {
+        case homeRelative
+        case basenameOnly
+        case hidden
+    }
+
+    enum EvidenceValue: Sendable {
+        case bool(Bool)
+        case int(Int)
+        case enumValue(String)
+        case version(String)
+        case path(String, PathEvidencePolicy)
+        case basename(String)
+        case sensitive
+    }
+
+    struct SemanticVersion: Equatable, Comparable, Sendable {
+        let major: Int
+        let minor: Int
+        let patch: Int
+        let prerelease: String?
+        let build: String?
+
+        init?(_ raw: String) {
+            var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if value.hasPrefix("v") || value.hasPrefix("V") {
+                value.removeFirst()
+            }
+            let buildParts = value.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)
+            let withoutBuild = String(buildParts[0])
+            build = buildParts.count == 2 && !buildParts[1].isEmpty ? String(buildParts[1]) : nil
+            let prereleaseParts = withoutBuild.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+            let core = prereleaseParts[0].split(separator: ".", omittingEmptySubsequences: false)
+            guard core.count == 3,
+                  let major = Int(core[0]), major >= 0,
+                  let minor = Int(core[1]), minor >= 0,
+                  let patch = Int(core[2]), patch >= 0,
+                  core.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }) else {
+                return nil
+            }
+            let prereleaseValue = prereleaseParts.count == 2 ? String(prereleaseParts[1]) : nil
+            if prereleaseValue == "" { return nil }
+            self.major = major
+            self.minor = minor
+            self.patch = patch
+            prerelease = prereleaseValue
+        }
+
+        var normalizedCore: String {
+            "\(major).\(minor).\(patch)"
+        }
+
+        static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+            if lhs.major != rhs.major { return lhs.major < rhs.major }
+            if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+            if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+            switch (lhs.prerelease, rhs.prerelease) {
+            case (nil, nil):
+                return false
+            case (nil, _?):
+                return false
+            case (_?, nil):
+                return true
+            case let (left?, right?):
+                return left < right
+            }
+        }
+    }
+
+    static func selectedDoctorProfile(
+        arguments: [String],
+        runtime: Runtime,
+        approvals: [ManualValidationChannel: ManualValidationApproval]
+    ) -> (DoctorProfile, String) {
+        if let raw = optionValue("--profile", in: arguments),
+           let profile = DoctorProfile(rawValue: raw) {
+            if profile == .auto {
+                let inferred = inferredDoctorProfile(runtime: runtime, approvals: approvals)
+                return (inferred.0, "explicit_auto_\(inferred.1)")
+            }
+            return (profile, "explicit_flag")
+        }
+        return inferredDoctorProfile(runtime: runtime, approvals: approvals)
+    }
+
+    private static func inferredDoctorProfile(
+        runtime: Runtime,
+        approvals: [ManualValidationChannel: ManualValidationApproval]
+    ) -> (DoctorProfile, String) {
+        let approvedChannels = Set(
+            approvals.compactMap { channel, approval -> ManualValidationChannel? in
+                switch approval.kind {
+                case .approved, .intentionallySkipped:
+                    return channel
+                }
+            }
+        )
+        if approvedChannels == Set(ManualValidationChannel.allCases) {
+            return (.full, "manual_store_all_channels")
+        }
+        if approvedChannels == [.midiKeyCommands] {
+            return (.keycmd, "manual_store_midi_key_commands")
+        }
+        if approvedChannels == [.scripter] {
+            return (.legacyScripter, "manual_store_scripter")
+        }
+        let context = runtime.launchContext().context
+        if context == "claude_code" || context == "claude_desktop" || context == "cursor" || context == "vscode" {
+            return (.core, "launch_context_default_core")
+        }
+        return (.core, "default_core")
+    }
+
+    static func selectedClientProfile(
+        arguments: [String],
+        runtime: Runtime,
+        claudeRegistration: ClaudeRegistration
+    ) -> (ClientProfile, String) {
+        if let raw = optionValue("--client", in: arguments),
+           let profile = ClientProfile(rawValue: raw) {
+            return profile == .auto ? inferredClientProfile(runtime: runtime, claudeRegistration: claudeRegistration) : (profile, "explicit_flag")
+        }
+        return inferredClientProfile(runtime: runtime, claudeRegistration: claudeRegistration)
+    }
+
+    private static func inferredClientProfile(
+        runtime: Runtime,
+        claudeRegistration: ClaudeRegistration
+    ) -> (ClientProfile, String) {
+        let context = runtime.launchContext().context
+        switch context {
+        case "claude_code": return (.claudeCode, "launch_context")
+        case "claude_desktop": return (.claudeDesktop, "launch_context")
+        case "cursor": return (.cursor, "launch_context")
+        case "vscode": return (.vscode, "launch_context")
+        case "terminal": return (.terminal, "launch_context")
+        default: break
+        }
+        if case .registered = claudeRegistration {
+            return (.claudeCode, "registration_config")
+        }
+        switch runtime.readClaudeDesktopRegistration() {
+        case .registered:
+            return (.claudeDesktop, "registration_config")
+        case .notRegistered, .configUnavailable:
+            return (.custom, "fallback_custom")
+        }
+    }
+
+    static func optionValue(_ option: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: option), arguments.indices.contains(index + 1) else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    static func isProfileRequired(_ checkID: String, profile: DoctorProfile) -> Bool {
+        switch profile {
+        case .full:
+            return true
+        case .core:
+            return ![
+                "channels.manual_validation",
+                "channels.keycmd_reference",
+                "channels.mcu_wiring_hint",
+            ].contains(checkID)
+        case .mixer:
+            return ![
+                "channels.manual_validation",
+                "channels.keycmd_reference",
+                "channels.mcu_wiring_hint",
+            ].contains(checkID)
+        case .keycmd:
+            return checkID != "channels.mcu_wiring_hint"
+        case .legacyScripter:
+            return ![
+                "channels.keycmd_reference",
+                "channels.mcu_wiring_hint",
+            ].contains(checkID)
+        case .auto:
+            return isProfileRequired(checkID, profile: .core)
+        }
+    }
+
+    static func capabilities(for checks: [Check], profile: DoctorProfile) -> [String: CapabilityReadiness] {
+        let definitions: [(String, [String], Set<DoctorProfile>, String?)] = [
+            ("core_transport", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state"], [.core, .mixer, .keycmd, .legacyScripter, .full], nil),
+            ("track_management", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.core, .mixer, .full], nil),
+            ("midi_import", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_system_events"], [.full], nil),
+            ("mixer_ax", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.mixer, .full], nil),
+            ("mixer_mcu", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.mcu_wiring_hint"], [.full], "logic://system/health mcu.connected"),
+            ("project_lifecycle", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "permissions.automation_system_events"], [.core, .mixer, .full], nil),
+            ("keycmd_only_ops", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.keycmd_reference", "channels.manual_validation"], [.keycmd, .full], nil),
+            ("legacy_scripter", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.manual_validation"], [.legacyScripter, .full], nil),
+            ("verified_plugin_applyback", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.mixer, .full], nil),
+        ]
+        let byID = Dictionary(uniqueKeysWithValues: checks.map { ($0.id, $0) })
+        return Dictionary(uniqueKeysWithValues: definitions.map { name, required, profiles, liveVerification in
+            guard profiles.contains(profile) else {
+                return (name, CapabilityReadiness(status: .notInProfile, checks: required, liveVerification: liveVerification))
+            }
+            let statuses = required.compactMap { byID[$0]?.status }
+            let missingRequired = statuses.count != required.count
+            let status: CapabilityStatus
+            if missingRequired || statuses.contains(.fail) || statuses.contains(.warn) {
+                status = .notReady
+            } else if statuses.contains(.manual) || statuses.contains(.skipped) {
+                status = .unknownLiveVerifyRequired
+            } else if name == "mixer_mcu" {
+                status = .unknownLiveVerifyRequired
+            } else {
+                status = .ready
+            }
+            return (name, CapabilityReadiness(status: status, checks: required, liveVerification: liveVerification))
+        })
+    }
+
+    static func buildEvidence(_ fields: [String: EvidenceValue]) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: fields.map { key, value in
+            (key, renderEvidenceValue(value))
+        })
+    }
+
+    static func renderEvidenceValue(_ value: EvidenceValue) -> String {
+        switch value {
+        case let .bool(raw):
+            return String(raw)
+        case let .int(raw):
+            return String(raw)
+        case let .enumValue(raw), let .version(raw):
+            return raw
+        case let .path(raw, policy):
+            switch policy {
+            case .homeRelative:
+                return homeRelativePath(raw)
+            case .basenameOnly:
+                return URL(fileURLWithPath: raw).lastPathComponent
+            case .hidden:
+                return "hidden"
+            }
+        case let .basename(raw):
+            return URL(fileURLWithPath: raw).lastPathComponent
+        case .sensitive:
+            return "redacted"
+        }
+    }
+
+    static func homeRelativePath(_ value: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return value.replacingOccurrences(of: home, with: "~")
+    }
+}

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -196,53 +196,87 @@ extension SetupDoctor {
     }
 
     static func isProfileRequired(_ checkID: String, profile: DoctorProfile) -> Bool {
-        switch profile {
-        case .full:
-            return true
-        case .core:
-            return ![
-                "channels.manual_validation",
-                "channels.keycmd_reference",
-                "channels.mcu_wiring_hint",
-            ].contains(checkID)
-        case .mixer:
-            return ![
-                "channels.manual_validation",
-                "channels.keycmd_reference",
-                "channels.mcu_wiring_hint",
-            ].contains(checkID)
-        case .keycmd:
-            return checkID != "channels.mcu_wiring_hint"
-        case .legacyScripter:
-            return ![
-                "channels.keycmd_reference",
-                "channels.mcu_wiring_hint",
-            ].contains(checkID)
-        case .auto:
-            return isProfileRequired(checkID, profile: .core)
-        }
+        guard let definition = checkDefinitionByID[checkID] else { return false }
+        return !definition.optionalByDefault && profileRuleMatches(definition.profileRule, profile: profile)
     }
 
     static func profileRequiredCheckIDs(for profile: DoctorProfile) -> Set<String> {
         Set(orderedCheckIDs.filter { isProfileRequired($0, profile: profile) })
     }
 
+    static func requiredCheckIDs(for profile: DoctorProfile, clientProfile: ClientProfile) -> Set<String> {
+        Set(checkDefinitions.compactMap { definition in
+            guard !definition.optionalByDefault,
+                  profileRuleMatches(definition.profileRule, profile: profile),
+                  clientRuleMatches(definition.clientRule, clientProfile: clientProfile) else {
+                return nil
+            }
+            return definition.id.rawValue
+        })
+    }
+
+    static func checksClosingRequiredGaps(
+        _ checks: [Check],
+        profile: DoctorProfile,
+        clientProfile: ClientProfile
+    ) -> [Check] {
+        let requiredIDs = requiredCheckIDs(for: profile, clientProfile: clientProfile)
+        let closed = checks.map { check in
+            requiredIDs.contains(check.id) && check.optional
+                ? requiredCheckFailure(id: check.id, reason: "required_check_marked_optional")
+                : check
+        }
+        let emittedIDs = Set(closed.map(\.id))
+        let missing = orderedCheckIDs.filter { requiredIDs.contains($0) && !emittedIDs.contains($0) }
+        guard !missing.isEmpty else { return closed }
+        return closed + missing.map { requiredCheckFailure(id: $0, reason: "required_check_missing") }
+    }
+
+    private static func requiredCheckFailure(id: String, reason: String) -> Check {
+        let domain = id.split(separator: ".", maxSplits: 1).first.map(String.init) ?? "runtime"
+        let summary = reason == "required_check_missing"
+            ? "Required doctor check was not emitted; readiness cannot be claimed."
+            : "Required doctor check was emitted as optional; readiness cannot be claimed."
+        return check(
+            id: id,
+            domain: domain,
+            status: .fail,
+            summary: summary,
+            evidence: ["reason": reason],
+            remediationType: .manual,
+            remediationValueOverride: "Report this doctor bug with the missing check id: \(id)"
+        )
+    }
+
+    private static func profileRuleMatches(_ rule: String?, profile: DoctorProfile) -> Bool {
+        let effectiveProfile = profile == .auto ? DoctorProfile.core : profile
+        return ruleMatches(rule, value: effectiveProfile.rawValue)
+    }
+
+    private static func clientRuleMatches(_ rule: String?, clientProfile: ClientProfile) -> Bool {
+        guard clientProfile != .auto else { return rule == nil }
+        return ruleMatches(rule, value: clientProfile.rawValue)
+    }
+
+    private static func ruleMatches(_ rule: String?, value: String) -> Bool {
+        guard let rule else { return true }
+        return rule.split(separator: "|").contains { $0 == value }
+    }
+
     static func capabilities(for checks: [Check], profile: DoctorProfile) -> [String: CapabilityReadiness] {
-        let definitions: [(String, [String], Set<DoctorProfile>, String?)] = [
-            ("core_transport", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state"], [.core, .mixer, .keycmd, .legacyScripter, .full], nil),
-            ("track_management", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.core, .mixer, .full], nil),
-            ("midi_import", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_system_events"], [.full], nil),
-            ("mixer_ax", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.mixer, .full], nil),
-            ("mixer_mcu", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.mcu_wiring_hint"], [.full], "logic://system/health mcu.connected"),
-            ("project_lifecycle", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "permissions.automation_system_events"], [.core, .mixer, .full], nil),
-            ("keycmd_only_ops", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.keycmd_reference", "channels.manual_validation"], [.keycmd, .full], nil),
-            ("legacy_scripter", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "channels.manual_validation"], [.legacyScripter, .full], nil),
-            ("verified_plugin_applyback", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state", "permissions.automation_logic_pro", "logic.blocking_dialog"], [.mixer, .full], nil),
-        ]
+        let effectiveProfile = profile == .auto ? DoctorProfile.core : profile
         let byID = Dictionary(uniqueKeysWithValues: checks.map { ($0.id, $0) })
-        return Dictionary(uniqueKeysWithValues: definitions.map { name, required, profiles, liveVerification in
-            guard profiles.contains(profile) else {
-                return (name, CapabilityReadiness(status: .notInProfile, checks: required, liveVerification: liveVerification))
+        return Dictionary(uniqueKeysWithValues: capabilityDefinitions.map { definition in
+            let required = capabilityCheckIDs(for: definition.id)
+            guard definition.profiles.contains(effectiveProfile) else {
+                return (
+                    definition.id,
+                    CapabilityReadiness(
+                        status: .notInProfile,
+                        checks: required,
+                        liveVerification: definition.liveVerification
+                    )
+                )
             }
             let statuses = required.compactMap { byID[$0]?.status }
             let missingRequired = statuses.count != required.count
@@ -251,12 +285,19 @@ extension SetupDoctor {
                 status = .notReady
             } else if statuses.contains(.manual) || statuses.contains(.skipped) {
                 status = .unknownLiveVerifyRequired
-            } else if name == "mixer_mcu" {
+            } else if definition.id == "mixer_mcu" {
                 status = .unknownLiveVerifyRequired
             } else {
                 status = .ready
             }
-            return (name, CapabilityReadiness(status: status, checks: required, liveVerification: liveVerification))
+            return (
+                definition.id,
+                CapabilityReadiness(
+                    status: status,
+                    checks: required,
+                    liveVerification: definition.liveVerification
+                )
+            )
         })
     }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -223,6 +223,10 @@ extension SetupDoctor {
         }
     }
 
+    static func profileRequiredCheckIDs(for profile: DoctorProfile) -> Set<String> {
+        Set(orderedCheckIDs.filter { isProfileRequired($0, profile: profile) })
+    }
+
     static func capabilities(for checks: [Check], profile: DoctorProfile) -> [String: CapabilityReadiness] {
         let definitions: [(String, [String], Set<DoctorProfile>, String?)] = [
             ("core_transport", ["binary.path", "binary.executable", "permissions.accessibility", "permissions.post_event_access", "logic.installation", "logic.version_support", "logic.application_state"], [.core, .mixer, .keycmd, .legacyScripter, .full], nil),

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+Versioning.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+Versioning.swift
@@ -2,23 +2,28 @@ import Foundation
 
 extension SetupDoctor {
     static func normalizeVersion(_ raw: String) -> String {
-        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if value.hasPrefix("v") || value.hasPrefix("V") {
-            value = String(value.dropFirst())
-        }
-        return value.components(separatedBy: "-").first ?? value
+        Self.SemanticVersion(raw)?.normalizedCore ?? raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"^[vV]"#, with: "", options: .regularExpression)
+            .components(separatedBy: "-").first ?? raw
     }
 
     static func compareVersions(_ a: String, _ b: String) -> Int {
+        guard let lhs = Self.SemanticVersion(a), let rhs = Self.SemanticVersion(b) else {
+            return legacyCompareVersions(a, b)
+        }
+        if lhs == rhs { return 0 }
+        return lhs < rhs ? -1 : 1
+    }
+
+    private static func legacyCompareVersions(_ a: String, _ b: String) -> Int {
         let lhs = a.split(separator: ".").map { Int($0) ?? 0 }
         let rhs = b.split(separator: ".").map { Int($0) ?? 0 }
         let count = max(lhs.count, rhs.count)
         for index in 0..<count {
             let left = index < lhs.count ? lhs[index] : 0
             let right = index < rhs.count ? rhs[index] : 0
-            if left != right {
-                return left < right ? -1 : 1
-            }
+            if left != right { return left < right ? -1 : 1 }
         }
         return 0
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -69,6 +69,7 @@ enum SetupDoctor {
         // keeping v3 a strict superset a v1/v2 decoder never trips over. Set only at
         // construction via the `check(...)` factory (no post-construction mutation, R9).
         var blockedBy: String?
+        var skipReason: String?
         let optional: Bool
 
         // Explicit CodingKeys enumerate EVERY key — the six v1 keys keep their
@@ -85,6 +86,7 @@ enum SetupDoctor {
             case severity
             case durationMs = "duration_ms"
             case blockedBy = "blocked_by"
+            case skipReason = "skip_reason"
             case optional
         }
     }
@@ -122,6 +124,11 @@ enum SetupDoctor {
         // v3 additive top-level field (G2). Ordered check ids of the root-cause-collapsed,
         // severity-ordered actionable set (see `computeFixPlan`). Always present (may be []).
         let fixPlan: [String]
+        let doctorProfile: DoctorProfile
+        let doctorProfileBasis: String
+        let clientProfile: ClientProfile
+        let clientProfileBasis: String
+        let capabilities: [String: CapabilityReadiness]
 
         enum CodingKeys: String, CodingKey {
             case schema
@@ -132,6 +139,11 @@ enum SetupDoctor {
             case summary
             case headline
             case fixPlan = "fix_plan"
+            case doctorProfile = "doctor_profile"
+            case doctorProfileBasis = "doctor_profile_basis"
+            case clientProfile = "client_profile"
+            case clientProfileBasis = "client_profile_basis"
+            case capabilities
         }
     }
 
@@ -276,46 +288,34 @@ enum SetupDoctor {
         case timeout
     }
 
-    static let schema = "logic_pro_mcp_doctor.v3"
+    static let schema = "logic_pro_mcp_doctor.v4"
 
-    static let remediationAnchorsByCheckID: [String: String] = [
-        "binary.path": "docs/SETUP.md#doctor-binarypath",
-        "binary.executable": "docs/SETUP.md#doctor-binaryexecutable",
-        "install.source": "docs/SETUP.md#doctor-installsource",
-        "install.binary_inventory": "docs/SETUP.md#doctor-installbinary-inventory",
-        "install.share_dir": "docs/SETUP.md#doctor-installshare-dir",
-        "release.signature": "docs/SETUP.md#doctor-releasesignature",
-        "release.quarantine": "docs/SETUP.md#doctor-releasequarantine",
-        "mcp.claude_code_registration": "docs/SETUP.md#doctor-mcpclaude-code-registration",
-        "mcp.registration_target": "docs/SETUP.md#doctor-mcpregistration-target",
-        "mcp.claude_desktop_registration": "docs/SETUP.md#doctor-mcpclaude-desktop-registration",
-        "permissions.accessibility": "docs/SETUP.md#doctor-permissionsaccessibility",
-        "permissions.automation_logic_pro": "docs/SETUP.md#doctor-permissionsautomation-logic-pro",
-        "permissions.automation_system_events": "docs/SETUP.md#doctor-permissionsautomation-system-events",
-        "permissions.post_event_access": "docs/SETUP.md#doctor-permissionspost-event-access",
-        "permissions.launch_context": "docs/SETUP.md#doctor-permissionslaunch-context",
-        "permissions.tcc_cross_context": "docs/SETUP.md#doctor-permissionstcc-cross-context",
-        "system.macos_version": "docs/SETUP.md#doctor-systemmacos-version",
-        "updates.latest_release": "docs/SETUP.md#doctor-updateslatest-release",
-        "logic.installation": "docs/SETUP.md#doctor-logicinstallation",
-        "logic.version_support": "docs/SETUP.md#doctor-logicversion-support",
-        "logic.application_state": "docs/SETUP.md#doctor-logicapplication-state",
-        "logic.blocking_dialog": "docs/SETUP.md#doctor-logicblocking-dialog",
-        "channels.manual_validation": "docs/SETUP.md#doctor-channelsmanual-validation",
-        "channels.keycmd_reference": "docs/SETUP.md#doctor-channelskeycmd-reference",
-        "channels.mcu_wiring_hint": "docs/SETUP.md#doctor-channelsmcu-wiring-hint",
-        "dependencies.click_fallback": "docs/SETUP.md#doctor-dependenciesclick-fallback",
-    ]
+    static let remediationAnchorsByCheckID: [String: String] = Dictionary(
+        uniqueKeysWithValues: checkDefinitions.compactMap { definition in
+            definition.remediationAnchor.map { (definition.id.rawValue, $0) }
+        }
+    )
 
     static func generate(
         arguments: [String],
         permissionStatus: PermissionChecker.PermissionStatus,
         approvals: [ManualValidationChannel: ManualValidationApproval],
-        runtime: Runtime = .production
+        runtime: Runtime = .production,
+        manualStoreHealth: ManualValidationStoreHealth = .ok
     ) -> Report {
         let executablePath = runtime.resolveExecutablePath(arguments.first)
         let installSource = detectInstallSource(executablePath: executablePath, runtime: runtime)
         let claudeRegistration = runtime.readClaudeRegistration()
+        let (doctorProfile, doctorProfileBasis) = selectedDoctorProfile(
+            arguments: arguments,
+            runtime: runtime,
+            approvals: approvals
+        )
+        let (clientProfile, clientProfileBasis) = selectedClientProfile(
+            arguments: arguments,
+            runtime: runtime,
+            claudeRegistration: claudeRegistration
+        )
         let logicApps = runtime.logicApps()
         var staticVersionCache: [String: StaticVersionResult] = [:]
 
@@ -359,16 +359,17 @@ enum SetupDoctor {
         checks.append(timed { installShareDirCheck(runtime: runtime) })
         checks.append(timed { releaseSignatureCheck(executablePath: executablePath, runtime: runtime) })
         checks.append(timed { releaseQuarantineCheck(executablePath: executablePath, runtime: runtime) })
-        checks.append(timed { claudeRegistrationCheck(registration: claudeRegistration) })
+        checks.append(timed { claudeRegistrationCheck(registration: claudeRegistration, clientProfile: clientProfile) })
         checks.append(timed {
             mcpRegistrationTargetCheck(
                 registration: claudeRegistration,
                 runtime: runtime,
                 checks: checks,
-                staticVersionForPath: staticVersionForPath
+                staticVersionForPath: staticVersionForPath,
+                clientProfile: clientProfile
             )
         })
-        checks.append(timed { claudeDesktopRegistrationCheck(runtime: runtime) })
+        checks.append(timed { claudeDesktopRegistrationCheck(runtime: runtime, clientProfile: clientProfile) })
         checks.append(timed { accessibilityPermissionCheck(permissionStatus) })
         checks.append(timed { automationPermissionCheck(permissionStatus) })
         checks.append(timed { systemEventsAutomationCheck(permissionStatus) })
@@ -380,9 +381,15 @@ enum SetupDoctor {
         checks.append(timed { logicVersionSupportCheck(logicApps: logicApps, checks: checks) })
         checks.append(timed { logicApplicationStateCheck(runtime: runtime) })
         checks.append(timed { logicBlockingDialogCheck(runtime: runtime, checks: checks) })
-        checks.append(timed { manualValidationCheck(approvals: approvals) })
-        checks.append(timed { keycmdReferenceCheck(runtime: runtime) })
-        checks.append(timed { mcuWiringHintCheck(runtime: runtime) })
+        checks.append(timed {
+            manualValidationCheck(
+                approvals: approvals,
+                profile: doctorProfile,
+                storeHealth: manualStoreHealth
+            )
+        })
+        checks.append(timed { keycmdReferenceCheck(runtime: runtime, profile: doctorProfile) })
+        checks.append(timed { mcuWiringHintCheck(runtime: runtime, profile: doctorProfile) })
         checks.append(timed { clickFallbackCheck(runtime: runtime, permissionStatus: permissionStatus) })
         // Opt-in update check: emitted only when `--check-updates` armed the lookup seam.
         if let lookup = runtime.latestReleaseLookup {
@@ -393,8 +400,9 @@ enum SetupDoctor {
         // required permission is ungranted. Extracted to a pure helper so the invariant
         // is OWNED and directly unit-tested here, not left emergent on each permission
         // check happening to be non-pass.
+        let scopedChecks = checks.filter { !$0.optional }
         let status = clampStatusForPermissions(
-            aggregateStatus(checks),
+            aggregateStatus(scopedChecks),
             allGranted: permissionStatus.allGranted
         )
 
@@ -407,7 +415,12 @@ enum SetupDoctor {
             checks: checks,
             summary: calculateSummary(checks, totalDurationMs: totalDurationMs),
             headline: computeHeadline(checks: checks, status: status),
-            fixPlan: computeFixPlan(checks)
+            fixPlan: computeFixPlan(checks),
+            doctorProfile: doctorProfile,
+            doctorProfileBasis: doctorProfileBasis,
+            clientProfile: clientProfile,
+            clientProfileBasis: clientProfileBasis,
+            capabilities: capabilities(for: checks, profile: doctorProfile)
         )
     }
 
@@ -424,7 +437,8 @@ enum SetupDoctor {
         remediationType: RemediationType,
         remediationValueOverride: String? = nil,
         optional: Bool = false,
-        blockedBy: String? = nil
+        blockedBy: String? = nil,
+        skipReason: String? = nil
     ) -> Check {
         let value = remediationValueOverride ?? defaultRemediationValue(for: id, type: remediationType)
         // category/severity are DERIVED here (single chokepoint) so no check can be
@@ -443,21 +457,37 @@ enum SetupDoctor {
             severity: severity(for: status),
             durationMs: 0,
             blockedBy: blockedBy,
+            skipReason: skipReason,
             optional: optional
         )
     }
 
-    private static func sanitizedEvidence(_ evidence: [String: String]) -> [String: String] {
+    static func sanitizedEvidence(_ evidence: [String: String]) -> [String: String] {
         Dictionary(uniqueKeysWithValues: evidence.map { key, value in
+            let lowerKey = key.lowercased()
+            let lowerValue = value.lowercased()
             if key == "stdout" || key == "stderr" {
                 if value == "empty" || value == "present" {
                     return (key, value)
                 }
                 return (key, value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "empty" : "present")
             }
-            let home = FileManager.default.homeDirectoryForCurrentUser.path
-            return (key, value.replacingOccurrences(of: home, with: "~"))
+            if isSensitiveEvidenceLabel(lowerKey) || isSensitiveEvidenceValue(lowerValue) {
+                return (key, renderEvidenceValue(.sensitive))
+            }
+            if lowerKey == "path" || lowerKey.hasSuffix("_path") || lowerKey.contains("path_") {
+                return (key, renderEvidenceValue(.path(value, .homeRelative)))
+            }
+            return (key, homeRelativePath(value))
         })
+    }
+
+    private static func isSensitiveEvidenceLabel(_ value: String) -> Bool {
+        ["token", "secret", "password", "api_key", "apikey", "authorization"].contains { value.contains($0) }
+    }
+
+    private static func isSensitiveEvidenceValue(_ value: String) -> Bool {
+        ["bearer ", "api_key=", "apikey=", "password=", "secret=", "token="].contains { value.contains($0) }
     }
 
     /// Maps the v1 free-string `domain` to the closed v2 `Category`. Complete table —
@@ -558,11 +588,12 @@ enum SetupDoctor {
             .map(\.element.id)
     }
 
-    static let blockedByDependencies: [String: [String]] = [
-        "mcp.registration_target": ["mcp.claude_code_registration"],
-        "logic.version_support": ["logic.installation"],
-        "logic.blocking_dialog": ["logic.application_state", "permissions.accessibility"],
-    ]
+    static let blockedByDependencies: [String: [String]] = Dictionary(
+        uniqueKeysWithValues: checkDefinitions.compactMap { definition in
+            guard !definition.dependencies.isEmpty else { return nil }
+            return (definition.id.rawValue, definition.dependencies.map(\.rawValue))
+        }
+    )
 
     static func status(of id: String, in checks: [Check]) -> CheckStatus? {
         checks.first { $0.id == id }?.status

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -400,8 +400,15 @@ enum SetupDoctor {
         // required permission is ungranted. Extracted to a pure helper so the invariant
         // is OWNED and directly unit-tested here, not left emergent on each permission
         // check happening to be non-pass.
-        let requiredCheckIDs = profileRequiredCheckIDs(for: doctorProfile)
-        let scopedChecks = checks.filter { requiredCheckIDs.contains($0.id) && !$0.optional }
+        checks = checksClosingRequiredGaps(checks, profile: doctorProfile, clientProfile: clientProfile)
+
+        let requiredIDs = requiredCheckIDs(for: doctorProfile, clientProfile: clientProfile)
+        let scopedChecks = checks.filter { check in
+            !check.optional && (
+                requiredIDs.contains(check.id)
+                    || checkDefinitionByID[check.id]?.optionalByDefault == true
+            )
+        }
         let status = clampStatusForPermissions(
             aggregateStatus(scopedChecks),
             allGranted: permissionStatus.allGranted

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -350,6 +350,7 @@ enum SetupDoctor {
         checks.append(timed {
             installBinaryInventoryCheck(
                 executablePath: executablePath,
+                installSource: installSource,
                 runtime: runtime,
                 claudeRegistration: claudeRegistration,
                 staticVersionForPath: staticVersionForPath
@@ -448,7 +449,10 @@ enum SetupDoctor {
 
     private static func sanitizedEvidence(_ evidence: [String: String]) -> [String: String] {
         Dictionary(uniqueKeysWithValues: evidence.map { key, value in
-            if key == "stderr" {
+            if key == "stdout" || key == "stderr" {
+                if value == "empty" || value == "present" {
+                    return (key, value)
+                }
                 return (key, value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "empty" : "present")
             }
             let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -591,6 +595,32 @@ enum SetupDoctor {
         case .command, .docs, .manual:
             return remediationAnchorsByCheckID[id] ?? "docs/SETUP.md#doctor"
         }
+    }
+
+    static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    static func commandEvidence(
+        path: String,
+        output: CommandOutput
+    ) -> [String: String] {
+        [
+            "path": path,
+            "exit_code": String(output.exitCode),
+            "stdout": streamSummary(output.stdout),
+            "stdout_truncated": streamTruncated(output.stdout),
+            "stderr": streamSummary(output.stderr),
+            "stderr_truncated": streamTruncated(output.stderr),
+        ]
+    }
+
+    private static func streamSummary(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "empty" : "present"
+    }
+
+    private static func streamTruncated(_ value: String, limit: Int = 4_096) -> String {
+        String(value.utf8.count > limit)
     }
 
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -400,7 +400,8 @@ enum SetupDoctor {
         // required permission is ungranted. Extracted to a pure helper so the invariant
         // is OWNED and directly unit-tested here, not left emergent on each permission
         // check happening to be non-pass.
-        let scopedChecks = checks.filter { !$0.optional }
+        let requiredCheckIDs = profileRequiredCheckIDs(for: doctorProfile)
+        let scopedChecks = checks.filter { requiredCheckIDs.contains($0.id) && !$0.optional }
         let status = clampStatusForPermissions(
             aggregateStatus(scopedChecks),
             allGranted: permissionStatus.allGranted

--- a/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
@@ -66,7 +66,7 @@ private func doctorV3Runtime(
 
 private func doctorV3Report(_ runtime: SetupDoctor.Runtime) -> SetupDoctor.Report {
     SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: doctorV3Permissions(),
         approvals: doctorV3Approvals(),
         runtime: runtime
@@ -145,12 +145,13 @@ private func doctorV3Check(_ report: SetupDoctor.Report, _ id: String) throws ->
     #expect(check.summary == "Canonical LogicProMCP binary inventory found no stale installed binary.")
 }
 
-@Test func testDoctorV3RelativeRegisteredCommandIsSkippedNotWarn() throws {
+@Test func testDoctorV3BareRegisteredCommandResolvesCanonicalPath() throws {
     let report = doctorV3Report(doctorV3Runtime(registration: .registered(command: "LogicProMCP")))
     let check = try doctorV3Check(report, "mcp.registration_target")
-    #expect(check.status == .skipped)
-    #expect(check.evidence["reason"] == "relative_command")
-    #expect(check.summary.contains("install.binary_inventory"))
+    #expect(check.status == .pass)
+    #expect(check.evidence["command_path"] == "LogicProMCP")
+    #expect(check.evidence["resolved_path"] == "/opt/homebrew/bin/LogicProMCP")
+    #expect(check.evidence["resolution_basis"] == "canonical_path")
 }
 
 @Test func testDoctorV3RegisteredCommandMustBeRegularFile() throws {

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -148,6 +148,26 @@ private func doctorV4Report(
     #expect(report.status == .manualActionRequired)
 }
 
+@Test func doctorV4IntentionalSkipDoesNotClaimCapabilityReady() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "keycmd"],
+        approvals: [
+            .midiKeyCommands: ManualValidationApproval(
+                approvedAt: Date(timeIntervalSince1970: 0),
+                note: "operator does not use key commands",
+                kind: .intentionallySkipped
+            ),
+        ]
+    )
+
+    let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
+    #expect(manual.status == .skipped)
+    #expect(manual.skipReason == "intentionally_skipped")
+    #expect(!manual.optional)
+    #expect(report.status == .degraded)
+    #expect(report.capabilities["keycmd_only_ops"]?.status == .unknownLiveVerifyRequired)
+}
+
 @Test func doctorV4CursorClientDoesNotRequireClaudeRegistration() throws {
     let report = doctorV4Report(
         arguments: ["LogicProMCP", "doctor", "--json", "--client", "cursor"],
@@ -270,4 +290,29 @@ private func doctorV4Report(
     #expect(sanitized["api_key"] == "redacted")
     #expect(sanitized["stderr"] == "present")
     #expect(sanitized["path"] == "~/secret-project")
+}
+
+@Test func doctorV4ReportPrivacyScanRejectsHomePathsAndSecrets() throws {
+    let homePath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("private-bin/LogicProMCP")
+        .path
+    let runtime = doctorV4Runtime(
+        executablePath: homePath,
+        registration: .registered(command: homePath, environment: [
+            "LOGIC_PRO_MCP_SHARE_DIR": homePath,
+            "API_TOKEN": "token=super-secret",
+        ])
+    ) { executable, arguments in
+        if executable == "/usr/bin/strings", arguments.count == 2 {
+            return .init(exitCode: 0, stdout: "token=super-secret\n\(ServerConfig.versionMarker)\n", stderr: "token=super-secret")
+        }
+        if executable == "/usr/bin/codesign" || executable == "/usr/bin/xattr" || executable == "/usr/bin/lipo" {
+            return .init(exitCode: executable == "/usr/bin/xattr" ? 1 : 0, stdout: executable == "/usr/bin/lipo" ? "arm64\n" : "", stderr: executable == "/usr/bin/xattr" ? "No such xattr" : "")
+        }
+        return nil
+    }
+
+    let encoded = encodeJSON(doctorV4Report(runtime: runtime))
+    #expect(!encoded.contains(homePath))
+    #expect(!encoded.contains("token=super-secret"))
 }

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -180,6 +180,23 @@ private func doctorV4Report(
     #expect(report.clientProfile == .cursor)
 }
 
+@Test func doctorV4ExplicitClaudeDesktopAbsentConfigIsRequiredAndNotOk() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-desktop"],
+        runtime: doctorV4Runtime(
+            registration: .notRegistered,
+            desktopRegistration: .configUnavailable(reason: "config_absent")
+        )
+    )
+
+    let desktop = try #require(report.checks.first { $0.id == "mcp.claude_desktop_registration" })
+    let isOptional = desktop.optional
+    #expect(desktop.status == .warn || desktop.status == .manual)
+    #expect(isOptional == false)
+    #expect(desktop.skipReason != "client_not_selected")
+    #expect(report.status != .ok)
+}
+
 @Test func doctorV4BareRegisteredCommandCanResolveThroughDoctorPath() throws {
     var runtime = doctorV4Runtime(
         registration: .registered(command: "logic-pro-mcp-dev"),
@@ -255,6 +272,48 @@ private func doctorV4Report(
 
     #expect(Set(reportIDs).isSubset(of: registryIDs))
     #expect(reportIDs == orderedRenderedIDs)
+}
+
+@Test func doctorV4DroppedRequiredCheckIsSynthesizedAsFailure() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "core", "--client", "claude-code"],
+        approvals: [:]
+    )
+    let dropped = report.checks.filter { $0.id != "binary.executable" }
+    let closed = SetupDoctor.checksClosingRequiredGaps(
+        dropped,
+        profile: report.doctorProfile,
+        clientProfile: report.clientProfile
+    )
+    let synthesized = try #require(closed.first { $0.id == "binary.executable" })
+    let isOptional = synthesized.optional
+    #expect(synthesized.status == .fail)
+    #expect(isOptional == false)
+    #expect(synthesized.evidence["reason"] == "required_check_missing")
+
+    let requiredIDs = SetupDoctor.requiredCheckIDs(
+        for: report.doctorProfile,
+        clientProfile: report.clientProfile
+    )
+    let scoped = closed.filter { requiredIDs.contains($0.id) && !$0.optional }
+    #expect(SetupDoctor.aggregateStatus(scoped) != .ok)
+}
+
+@Test func doctorV4CapabilityChecksAreConsistentWithRegistryGroups() throws {
+    let report = doctorV4Report()
+    let grouped = Dictionary(grouping: SetupDoctor.checkDefinitions.flatMap { definition in
+        definition.capabilityGroups.map { ($0, definition.id.rawValue) }
+    }) { pair in
+        pair.0
+    }
+    let registryCapabilityIDs = Set(grouped.keys)
+
+    #expect(Set(report.capabilities.keys) == registryCapabilityIDs)
+    for capabilityID in report.capabilities.keys.sorted() {
+        let rendered = try #require(report.capabilities[capabilityID])
+        let registryCheckIDs = (grouped[capabilityID] ?? []).map { $0.1 }
+        #expect(rendered.checks == registryCheckIDs, "\(capabilityID) drifted from checkDefinitions.capabilityGroups")
+    }
 }
 
 @Test func doctorV4BlockedByTableIsDerivedFromCheckRegistry() {

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private func doctorV4Runtime(
+    executablePath: String? = "/opt/homebrew/bin/LogicProMCP",
+    registration: SetupDoctor.ClaudeRegistration = .registered(command: "/opt/homebrew/bin/LogicProMCP"),
+    desktopRegistration: SetupDoctor.ClaudeRegistration = .registered(command: "/Applications/Claude.app/Contents/MacOS/Claude"),
+    launchContext: SetupDoctor.LaunchContextInfo = .init(context: "terminal", responsibleHint: "Terminal"),
+    macOSVersion: OperatingSystemVersion? = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0),
+    commandHandler: @escaping (String, [String]) -> SetupDoctor.CommandOutput? = { executable, arguments in
+        if executable == "/usr/bin/codesign" {
+            return .init(exitCode: 0, stdout: "", stderr: "")
+        }
+        if executable == "/usr/bin/xattr" {
+            return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+        }
+        if executable == "/usr/bin/lipo" {
+            return .init(exitCode: 0, stdout: "arm64\n", stderr: "")
+        }
+        if executable == "/usr/bin/strings", arguments.count == 2 {
+            return .init(exitCode: 0, stdout: "\(ServerConfig.versionMarker)\n", stderr: "")
+        }
+        if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+           arguments == ["list", "--versions", "logic-pro-mcp"] {
+            return .init(exitCode: 0, stdout: "logic-pro-mcp \(ServerConfig.serverVersion)\n", stderr: "")
+        }
+        return nil
+    }
+) -> SetupDoctor.Runtime {
+    var runtime = SetupDoctor.Runtime(
+        resolveExecutablePath: { _ in executablePath },
+        fileExists: { _ in true },
+        isExecutableFile: { _ in true },
+        logicProRunning: { true },
+        logicProHasVisibleWindow: { true },
+        runCommand: commandHandler,
+        readClaudeRegistration: { registration }
+    )
+    runtime.macOSVersion = { macOSVersion }
+    runtime.logicApps = {
+        [SetupDoctor.LogicAppInfo(path: "/Applications/Logic Pro.app", version: LogicProSupport.latestValidatedLogicVersion, bundleID: ServerConfig.logicProBundleID, readable: true)]
+    }
+    runtime.shareDirProbe = { .complete(path: "/opt/homebrew/share/logic-pro-mcp", source: "brew_pkgshare") }
+    runtime.readClaudeDesktopRegistration = { desktopRegistration }
+    runtime.keyCommandsPresetStaged = { true }
+    runtime.mcuPortReferenceFound = { true }
+    runtime.launchContext = { launchContext }
+    runtime.tccCrossContextProbe = { .granted("terminal:accessibility=granted") }
+    runtime.blockingDialogInfo = { nil }
+    runtime.fileExistsAtPath = { path in
+        path == "/opt/homebrew/bin/LogicProMCP" || path == "/usr/local/bin/LogicProMCP"
+    }
+    runtime.isRegularFile = runtime.fileExistsAtPath
+    runtime.isDirectory = { _ in true }
+    return runtime
+}
+
+private func doctorV4Permissions() -> PermissionChecker.PermissionStatus {
+    .init(accessibility: true, automationLogicPro: true, systemEventsAutomation: .granted, postEventAccess: true)
+}
+
+private func doctorV4Approvals() -> [ManualValidationChannel: ManualValidationApproval] {
+    Dictionary(uniqueKeysWithValues: ManualValidationChannel.allCases.map {
+        ($0, ManualValidationApproval(approvedAt: Date(timeIntervalSince1970: 0), note: "test"))
+    })
+}
+
+private func doctorV4Report(
+    arguments: [String] = ["LogicProMCP", "doctor", "--json"],
+    runtime: SetupDoctor.Runtime = doctorV4Runtime(),
+    approvals: [ManualValidationChannel: ManualValidationApproval] = doctorV4Approvals(),
+    storeHealth: ManualValidationStoreHealth = .ok
+) -> SetupDoctor.Report {
+    SetupDoctor.generate(
+        arguments: arguments,
+        permissionStatus: doctorV4Permissions(),
+        approvals: approvals,
+        runtime: runtime,
+        manualStoreHealth: storeHealth
+    )
+}
+
+@Test func doctorV4SchemaProfilesAndCapabilitiesAreInJSON() throws {
+    let report = doctorV4Report()
+    #expect(report.schema == "logic_pro_mcp_doctor.v4")
+    #expect(report.doctorProfile == .full)
+    #expect(report.clientProfile == .terminal)
+    #expect(Set(report.capabilities.keys) == Set([
+        "core_transport",
+        "track_management",
+        "midi_import",
+        "mixer_ax",
+        "mixer_mcu",
+        "project_lifecycle",
+        "keycmd_only_ops",
+        "legacy_scripter",
+        "verified_plugin_applyback",
+    ]))
+
+    let object = try #require(sharedJSONObject(encodeJSON(report)))
+    #expect(object["doctor_profile"] as? String == "full")
+    #expect(object["client_profile"] as? String == "terminal")
+    #expect(object["capabilities"] as? [String: Any] != nil)
+}
+
+@Test func doctorV4SkippedChecksRequireBlockedByOrSkipReason() {
+    let report = doctorV4Report(
+        runtime: doctorV4Runtime(macOSVersion: nil),
+        approvals: [:]
+    )
+    for check in report.checks where check.status == .skipped {
+        #expect(
+            check.blockedBy != nil || check.skipReason != nil,
+            "\(check.id) skipped without blocked_by or skip_reason"
+        )
+    }
+}
+
+@Test func doctorV4VerboseRendererShowsSkipReason() {
+    let report = doctorV4Report(
+        runtime: doctorV4Runtime(macOSVersion: nil)
+    )
+    let output = SetupDoctor.renderHuman(report, mode: .verbose, useColor: false)
+    #expect(output.contains("skip_reason:"))
+}
+
+@Test func doctorV4CoreProfileDoesNotRequireManualChannels() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "core"],
+        approvals: [:]
+    )
+    let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
+    #expect(manual.status == .skipped)
+    #expect(manual.optional)
+    #expect(manual.skipReason == "profile_not_required")
+    #expect(report.status == .ok)
+}
+
+@Test func doctorV4FullProfileRequiresManualChannels() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "full"],
+        approvals: [:]
+    )
+    let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
+    #expect(manual.status == .manual)
+    #expect(manual.skipReason == nil)
+    #expect(report.status == .manualActionRequired)
+}
+
+@Test func doctorV4CursorClientDoesNotRequireClaudeRegistration() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "cursor"],
+        runtime: doctorV4Runtime(registration: .notRegistered, desktopRegistration: .notRegistered)
+    )
+    let claude = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+    #expect(claude.status == .skipped)
+    #expect(claude.optional)
+    #expect(claude.skipReason == "client_not_selected")
+    #expect(report.clientProfile == .cursor)
+}
+
+@Test func doctorV4BareRegisteredCommandCanResolveThroughDoctorPath() throws {
+    var runtime = doctorV4Runtime(
+        registration: .registered(command: "logic-pro-mcp-dev"),
+        launchContext: .init(context: "claude_code", responsibleHint: "claude")
+    ) { executable, arguments in
+        if executable == "/usr/bin/which", arguments == ["logic-pro-mcp-dev"] {
+            return .init(exitCode: 0, stdout: "/tmp/LogicProMCP-dev\n", stderr: "")
+        }
+        if executable == "/usr/bin/strings", arguments.count == 2 {
+            return .init(exitCode: 0, stdout: "\(ServerConfig.versionMarker)\n", stderr: "")
+        }
+        if executable == "/usr/bin/codesign" || executable == "/usr/bin/xattr" || executable == "/usr/bin/lipo" {
+            return .init(exitCode: executable == "/usr/bin/xattr" ? 1 : 0, stdout: executable == "/usr/bin/lipo" ? "arm64\n" : "", stderr: executable == "/usr/bin/xattr" ? "No such xattr" : "")
+        }
+        if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew" {
+            return .init(exitCode: 0, stdout: "logic-pro-mcp \(ServerConfig.serverVersion)\n", stderr: "")
+        }
+        return nil
+    }
+    runtime.fileExistsAtPath = { path in path == "/tmp/LogicProMCP-dev" }
+    runtime.isRegularFile = runtime.fileExistsAtPath
+
+    let report = doctorV4Report(runtime: runtime)
+    let target = try #require(report.checks.first { $0.id == "mcp.registration_target" })
+    #expect(target.status == .pass)
+    #expect(target.evidence["resolution_basis"] == "doctor_path")
+    #expect(target.evidence["resolved_path"] == "/tmp/LogicProMCP-dev")
+}
+
+@Test func doctorV4ManualStorePersistsIntentionalSkip() async throws {
+    let fileURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("manual-skip-\(UUID().uuidString)")
+        .appendingPathExtension("json")
+    let store = ManualValidationStore(fileURL: fileURL)
+    try await store.skip(.scripter, note: "not using legacy scripter")
+    let decisions = await store.list()
+    let scripter = try #require(decisions[.scripter])
+    #expect(scripter.kind == .intentionallySkipped)
+    #expect(!(await store.isApproved(.scripter)))
+}
+
+@Test func doctorV4ManualStoreCorruptionWarnsDoctor() {
+    let report = doctorV4Report(storeHealth: .corrupt("json_decode_failed"))
+    let manual = report.checks.first { $0.id == "channels.manual_validation" }
+    #expect(manual?.status == .warn)
+    #expect(manual?.evidence["store_health"] == "corrupt")
+}
+
+@Test func doctorV4SemanticVersionAndMarkerSniff() throws {
+    let parsed = try #require(SetupDoctor.SemanticVersion("3.9.0"))
+    #expect(parsed.major == 3)
+    #expect(SetupDoctor.SemanticVersion("v") == nil)
+    #expect(SetupDoctor.staticVersion(fromStringsOutput: "3.40.1\n\(ServerConfig.versionMarker)\n") == .version(ServerConfig.serverVersion))
+    #expect(SetupDoctor.staticVersion(fromStringsOutput: "3.40.1\n3.9.0\n") == .indeterminate(["3.40.1", "3.9.0"]))
+}
+
+@Test func doctorV4CheckRegistryIDsAreUniqueAndAnchored() {
+    let ids = SetupDoctor.checkDefinitions.map(\.id.rawValue)
+    #expect(Set(ids).count == ids.count)
+    #expect(Set(ids) == Set(SetupDoctor.DoctorCheckID.allCases.map(\.rawValue)))
+    #expect(Set(SetupDoctor.remediationAnchorsByCheckID.keys).isSubset(of: Set(ids)))
+    #expect(SetupDoctor.checkDefinitionByID["updates.latest_release"]?.optionalByDefault == true)
+}
+
+@Test func doctorV4CheckRegistryCoversRenderedChecksAndOrder() {
+    var runtime = doctorV4Runtime()
+    runtime.latestReleaseLookup = { .found(version: ServerConfig.serverVersion) }
+
+    let report = doctorV4Report(runtime: runtime)
+    let reportIDs = report.checks.map(\.id)
+    let registryIDs = Set(SetupDoctor.orderedCheckIDs)
+    let orderedRenderedIDs = SetupDoctor.orderedCheckIDs.filter { Set(reportIDs).contains($0) }
+
+    #expect(Set(reportIDs).isSubset(of: registryIDs))
+    #expect(reportIDs == orderedRenderedIDs)
+}
+
+@Test func doctorV4BlockedByTableIsDerivedFromCheckRegistry() {
+    #expect(
+        SetupDoctor.blockedByDependencies["mcp.registration_target"] == ["mcp.claude_code_registration"]
+    )
+    #expect(SetupDoctor.checkDefinitionByID["mcp.registration_target"]?.dependencies.map(\.rawValue) == [
+        "mcp.claude_code_registration",
+    ])
+}
+
+@Test func doctorV4EvidenceBuilderAppliesPrivacyPolicies() {
+    let homePath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("secret-project")
+        .path
+    let typed = SetupDoctor.buildEvidence([
+        "hidden": .path(homePath, .hidden),
+        "basename": .path(homePath, .basenameOnly),
+        "relative": .path(homePath, .homeRelative),
+        "secret": .sensitive,
+    ])
+
+    #expect(typed["hidden"] == "hidden")
+    #expect(typed["basename"] == "secret-project")
+    #expect(typed["relative"] == "~/secret-project")
+    #expect(typed["secret"] == "redacted")
+
+    let sanitized = SetupDoctor.sanitizedEvidence([
+        "api_key": "abc123",
+        "stderr": "token=abc123",
+        "path": homePath,
+    ])
+    #expect(sanitized["api_key"] == "redacted")
+    #expect(sanitized["stderr"] == "present")
+    #expect(sanitized["path"] == "~/secret-project")
+}

--- a/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
@@ -191,6 +191,7 @@ struct Issue112CommandDeadlineTests {
         #expect(!((json(result)?["safe_to_retry"] as? Bool)!))
         #expect(!((json(result)?["underlying_operation_stopped"] as? Bool)!))
         #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { blocker.isCompleted() })
+        #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { gate.currentOperation() == nil })
 
         let afterDrain = await LogicProServer.runWithDeadline(
             tool: "logic_tracks",

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -68,12 +68,13 @@ private func enterpriseApprovals() -> [ManualValidationChannel: ManualValidation
 }
 
 private func makeReport(
+    arguments: [String] = ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
     runtime: SetupDoctor.Runtime = enterpriseRuntime(),
     permission: PermissionChecker.PermissionStatus = granted(),
     approvals: [ManualValidationChannel: ManualValidationApproval]? = nil
 ) -> SetupDoctor.Report {
     SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: arguments,
         permissionStatus: permission,
         approvals: approvals ?? enterpriseApprovals(),
         runtime: runtime
@@ -86,8 +87,8 @@ private func check(_ report: SetupDoctor.Report, _ id: String) -> SetupDoctor.Ch
 
 // MARK: - T1: v2 model framework
 
-@Test func test_t1_schema_is_v3() {
-    #expect(makeReport().schema == "logic_pro_mcp_doctor.v3")
+@Test func test_t1_schema_is_v4() {
+    #expect(makeReport().schema == "logic_pro_mcp_doctor.v4")
 }
 
 @Test func test_t1_each_check_has_category_severity_duration() throws {
@@ -152,7 +153,7 @@ private func check(_ report: SetupDoctor.Report, _ id: String) -> SetupDoctor.Ch
     #expect(report.summary.failed == 0)
     #expect(report.summary.manual == 0)
     #expect(report.summary.warnings == 0)
-    #expect(report.summary.skipped == 0)
+    #expect(report.summary.skipped == 1)
 }
 
 @Test func test_t1_optional_skip_does_not_degrade_aggregate() {
@@ -279,9 +280,8 @@ private struct FrozenV1Report: Codable {
 
 @Test func test_t1_e10b_v2_decodes_with_frozen_v1_struct() throws {
     let json = encodeJSON(makeReport())
-    // A frozen v1-shaped consumer must still decode v2 output (additive superset).
     let frozen: FrozenV1Report = try decodeJSON(json)
-    #expect(frozen.schema == "logic_pro_mcp_doctor.v3")
+    #expect(frozen.schema == "logic_pro_mcp_doctor.v4")
     let ids = Set(frozen.checks.map(\.id))
     // Every original v1 check id must survive (a dropped v1 check would fail this).
     let v1Ids = [
@@ -655,8 +655,8 @@ private func runEntrypoint(
 // MARK: - T1 (doctor-v3): data-spine — blocked_by / fix_plan / schema v3 / dep-table
 
 // Case 1
-@Test func test_t1v3_schema_is_v3() {
-    #expect(makeReport().schema == "logic_pro_mcp_doctor.v3")
+@Test func test_t1v3_schema_is_v4() {
+    #expect(makeReport().schema == "logic_pro_mcp_doctor.v4")
 }
 
 // Case 2
@@ -698,6 +698,7 @@ private func runEntrypoint(
 @Test func test_t1v3_fix_plan_includes_fail_warn_manual() {
     // Force a fail (accessibility), a warn (update behind), and a manual (channels).
     let report = makeReport(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code", "--profile", "full"],
         runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: "v99.0.0") }),
         permission: granted(accessibility: false),
         approvals: [:]
@@ -711,6 +712,7 @@ private func runEntrypoint(
 @Test func test_t1v3_fix_plan_order_two_tier_and_headline_agree() {
     // (a) fail present ⇒ fail-ids first, then warn/manual in declared order (co-equal tier).
     let mixed = makeReport(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code", "--profile", "full"],
         runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: "v99.0.0") }),
         permission: granted(accessibility: false),
         approvals: [:]
@@ -725,6 +727,7 @@ private func runEntrypoint(
     // (b) OBJ-A counterexample: a MANUAL declared BEFORE a WARN, no fail. 2-tier keeps them
     // co-equal so declared order wins ⇒ the earlier manual leads, and headline embeds it.
     let counter = makeReport(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code", "--profile", "full"],
         runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: "v99.0.0") }),
         approvals: [:]
     )
@@ -786,11 +789,10 @@ private func runEntrypoint(
 }
 
 // Case 14
-@Test func test_t1v3_frozen_v1_still_decodes_from_v3() throws {
-    // G5: v3 output still decodes into a frozen v1-shaped consumer (strict superset).
+@Test func test_t1v3_frozen_v1_still_decodes_from_v4() throws {
     let json = encodeJSON(makeReport())
     let frozen: FrozenV1Report = try decodeJSON(json)
-    #expect(frozen.schema == "logic_pro_mcp_doctor.v3")
+    #expect(frozen.schema == "logic_pro_mcp_doctor.v4")
     let ids = Set(frozen.checks.map(\.id))
     let v1Ids = [
         "binary.path", "binary.executable", "binary.version", "install.source",
@@ -799,17 +801,15 @@ private func runEntrypoint(
         "logic.application_state", "channels.manual_validation",
     ]
     for id in v1Ids {
-        #expect(ids.contains(id), "v1 check id \(id) missing from v3 output")
+        #expect(ids.contains(id), "v1 check id \(id) missing from v4 output")
     }
 }
 
 // Case 15
-@Test func test_t1v3_frozen_v2_decodes_from_v3() throws {
-    // AC-7: a frozen v2-shaped consumer decodes v3 output; category/severity/duration_ms
-    // survive; the new fix_plan/blocked_by keys are absent from the struct and ignored.
+@Test func test_t1v3_frozen_v2_decodes_from_v4() throws {
     let json = encodeJSON(makeReport(permission: granted(accessibility: false)))
     let frozen: FrozenV2Report = try decodeJSON(json)
-    #expect(frozen.schema == "logic_pro_mcp_doctor.v3")
+    #expect(frozen.schema == "logic_pro_mcp_doctor.v4")
     let accessibility = try #require(frozen.checks.first { $0.id == "permissions.accessibility" })
     #expect(accessibility.status == "fail")
     #expect(accessibility.category == "permissions")

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -87,13 +87,13 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testSetupDoctorJSONContractStableCheckIDsAndOKAggregation() throws {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime()
     )
 
-    #expect(report.schema == "logic_pro_mcp_doctor.v3")
+    #expect(report.schema == "logic_pro_mcp_doctor.v4")
     #expect(report.status == .ok)
     #expect(report.installSource == .homebrew)
 
@@ -129,7 +129,7 @@ private func issue26RepositoryRootURL() -> URL {
 
     let json = encodeJSON(report)
     let object = try #require(sharedJSONObject(json))
-    #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v3")
+    #expect(object["schema"] as? String == "logic_pro_mcp_doctor.v4")
     #expect(object["status"] as? String == "ok")
     #expect(object["install_source"] as? String == "homebrew")
     #expect(object["version"] as? String == ServerConfig.serverVersion)
@@ -153,7 +153,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testSetupDoctorReportsActionableRemediationForNonPassStates() {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "full", "--client", "claude-code"],
         permissionStatus: .init(accessibilityState: .notGranted, automationState: .notVerifiable),
         approvals: [:],
         runtime: doctorRuntime(
@@ -167,7 +167,7 @@ private func issue26RepositoryRootURL() -> URL {
     )
 
     #expect(report.status == .failed)
-    for check in report.checks where check.status != .pass {
+    for check in report.checks where check.status != .pass && !check.optional {
         #expect(check.remediation.type != .none, "\(check.id) has no remediation type")
         #expect(!check.remediation.value.isEmpty, "\(check.id) has no remediation value")
     }
@@ -200,7 +200,7 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(exitCode == 0)
     #expect(stderr.isEmpty)
     let json = try #require(sharedJSONObject(stdout))
-    #expect(json["schema"] as? String == "logic_pro_mcp_doctor.v3")
+    #expect(json["schema"] as? String == "logic_pro_mcp_doctor.v4")
     #expect(json["status"] as? String == "ok")
 }
 
@@ -248,7 +248,7 @@ private func issue26RepositoryRootURL() -> URL {
 @Test func testSetupDoctorClassifiesSourceBuildEvenWhenBrewProbeSucceeds() throws {
     // .build path component must win over a succeeding brew probe (precedence pin).
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(executablePath: "/Users/x/proj/.build/release/LogicProMCP")
@@ -261,7 +261,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testDoctorSourceBuildDoesNotSuggestBrewUpgrade() throws {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(
@@ -297,7 +297,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testSetupDoctorClassifiesReleaseBinaryWhenBrewProbeFails() {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(
@@ -314,7 +314,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testSetupDoctorClassifiesUnknownWhenNoSignalMatches() throws {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "full"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(
@@ -333,7 +333,7 @@ private func issue26RepositoryRootURL() -> URL {
     // A directory whose component merely ENDS in .build (not the SwiftPM `.build`
     // component) must NOT be classified as source_build.
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(
@@ -350,7 +350,7 @@ private func issue26RepositoryRootURL() -> URL {
     // brew is NOT resolvable via /usr/bin/env (stripped PATH), only at its canonical
     // absolute path — doctor must still classify .homebrew.
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(
@@ -540,7 +540,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testClaudeRegistrationPassWhenConfigHasMatchingEntry() throws {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(registration: .registered(command: "/usr/local/bin/some-wrapper/LogicProMCP"))
@@ -552,7 +552,7 @@ private func issue26RepositoryRootURL() -> URL {
 
 @Test func testClaudeRegistrationWarnWhenConfigHasNoMatchingEntry() throws {
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(registration: .notRegistered)
@@ -567,7 +567,7 @@ private func issue26RepositoryRootURL() -> URL {
     // The config-unavailable path must say the CONFIG could not be read — NOT that
     // the Claude CLI was unavailable.
     let report = SetupDoctor.generate(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "claude-code"],
         permissionStatus: grantedPermissionStatus(),
         approvals: allApprovals(),
         runtime: doctorRuntime(registration: .configUnavailable(reason: "config file not found at /x/.claude.json"))
@@ -658,7 +658,7 @@ private func issue26RepositoryRootURL() -> URL {
 @Test func testMainEntrypointDoctorExitsOneAndReportsFailedStatus() async throws {
     var stdout = ""
     let exitCode = await MainEntrypoint.run(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "full"],
         permissionCheck: { .init(accessibilityState: .notGranted, automationState: .notVerifiable) },
         serverFactory: {
             Issue.record("Server should not start for doctor")
@@ -694,7 +694,7 @@ private func issue26RepositoryRootURL() -> URL {
     // just because operator approvals are outstanding).
     var stdout = ""
     let exitCode = await MainEntrypoint.run(
-        arguments: ["LogicProMCP", "doctor", "--json"],
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "full"],
         permissionCheck: { grantedPermissionStatus() },
         serverFactory: {
             Issue.record("Server should not start for doctor")

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -259,6 +259,42 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(object["install_source"] as? String == "source_build")
 }
 
+@Test func testDoctorSourceBuildDoesNotSuggestBrewUpgrade() throws {
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: grantedPermissionStatus(),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: "/Users/x/logic-pro-mcp/.build/release/LogicProMCP",
+            commandHandler: { executable, arguments in
+                if executable == "/usr/bin/codesign" {
+                    return .init(exitCode: 0, stdout: "", stderr: "")
+                }
+                if executable == "/usr/bin/xattr" {
+                    return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+                }
+                if executable == "/usr/bin/lipo" {
+                    return .init(exitCode: 0, stdout: "arm64\n", stderr: "")
+                }
+                if executable == "/usr/bin/strings", arguments.count == 2 {
+                    return .init(exitCode: 0, stdout: "0.0.1\n", stderr: "")
+                }
+                if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
+                   arguments == ["list", "--versions", "logic-pro-mcp"] {
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
+                }
+                return nil
+            }
+        )
+    )
+    let inventory = try #require(report.checks.first { $0.id == "install.binary_inventory" })
+    #expect(report.installSource == .sourceBuild)
+    #expect(inventory.status == .warn)
+    #expect(inventory.remediation.type == .command)
+    #expect(inventory.remediation.value.contains("swift build -c release"))
+    #expect(!inventory.remediation.value.contains("brew upgrade"))
+}
+
 @Test func testSetupDoctorClassifiesReleaseBinaryWhenBrewProbeFails() {
     let report = SetupDoctor.generate(
         arguments: ["LogicProMCP", "doctor", "--json"],
@@ -381,6 +417,81 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(quarantine.remediation.type == .command)
 }
 
+@Test func testDoctorRemediationShellQuotesPaths() throws {
+    let path = "/Users/x/My Build/LogicProMCP"
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: grantedPermissionStatus(),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(
+            executablePath: path,
+            executable: false,
+            commandHandler: { executable, _ in
+                if executable == "/usr/bin/codesign" {
+                    return .init(exitCode: 0, stdout: "", stderr: "")
+                }
+                if executable == "/usr/bin/xattr" {
+                    return .init(exitCode: 0, stdout: "0081;Safari;\n", stderr: "")
+                }
+                return nil
+            }
+        )
+    )
+    let executable = try #require(report.checks.first { $0.id == "binary.executable" })
+    let quarantine = try #require(report.checks.first { $0.id == "release.quarantine" })
+    #expect(executable.remediation.value == "chmod +x '\(path)'")
+    #expect(quarantine.remediation.value == "xattr -d com.apple.quarantine '\(path)'")
+}
+
+@Test func testDoctorXattrEvidenceKeepsStdoutStderrSummary() throws {
+    let longError = String(repeating: "permission denied ", count: 400)
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: grantedPermissionStatus(),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, _ in
+            if executable == "/usr/bin/codesign" {
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            }
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 0, stdout: "0081;Safari;\n", stderr: longError)
+            }
+            return nil
+        })
+    )
+    let quarantine = try #require(report.checks.first { $0.id == "release.quarantine" })
+    #expect(quarantine.evidence["exit_code"] == "0")
+    #expect(quarantine.evidence["stdout"] == "present")
+    #expect(quarantine.evidence["stdout_truncated"] == "false")
+    #expect(quarantine.evidence["stderr"] == "present")
+    #expect(quarantine.evidence["stderr_truncated"] == "true")
+}
+
+@Test func testDoctorCodesignEvidenceKeepsStdoutStderrSummary() throws {
+    let longOutput = String(repeating: "authority ", count: 600)
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: grantedPermissionStatus(),
+        approvals: allApprovals(),
+        runtime: doctorRuntime(commandHandler: { executable, _ in
+            if executable == "/usr/bin/codesign" {
+                return .init(exitCode: 1, stdout: longOutput, stderr: "invalid signature\n")
+            }
+            if executable == "/usr/bin/xattr" {
+                return .init(exitCode: 1, stdout: "", stderr: "No such xattr")
+            }
+            return nil
+        })
+    )
+    let signature = try #require(report.checks.first { $0.id == "release.signature" })
+    #expect(signature.status == .warn)
+    #expect(signature.evidence["exit_code"] == "1")
+    #expect(signature.evidence["stdout"] == "present")
+    #expect(signature.evidence["stdout_truncated"] == "true")
+    #expect(signature.evidence["stderr"] == "present")
+    #expect(signature.evidence["stderr_truncated"] == "false")
+}
+
 @Test func testReleaseQuarantineReportsWarnWhenStateUndeterminable() throws {
     // Non-zero exit that is NOT the recognized "No such xattr" must NOT be reported
     // as a clean pass — it conflates "not quarantined" with "could not determine".
@@ -405,6 +516,24 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(quarantine.status == .warn)
     #expect(quarantine.summary == "Quarantine state could not be determined.")
     #expect(quarantine.evidence["exit_code"] == "13")
+}
+
+@Test func testDoctorUnknownLaunchContextIsExplainedButAggregateNeutral() throws {
+    var runtime = doctorRuntime()
+    runtime.launchContext = {
+        SetupDoctor.LaunchContextInfo(context: "unknown", responsibleHint: "unknown")
+    }
+    let report = SetupDoctor.generate(
+        arguments: ["LogicProMCP", "doctor", "--json"],
+        permissionStatus: grantedPermissionStatus(),
+        approvals: allApprovals(),
+        runtime: runtime
+    )
+    let launch = try #require(report.checks.first { $0.id == "permissions.launch_context" })
+    #expect(report.status == .ok)
+    #expect(launch.status == .pass)
+    #expect(launch.summary.localizedCaseInsensitiveContains("unknown"))
+    #expect(SetupDoctor.renderHuman(report, useColor: false).contains("Launch context is unknown"))
 }
 
 // MARK: - Claude registration (config-based, read-only)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -175,7 +175,7 @@ Install with Homebrew, copy the release binary into PATH, or invoke the source b
 
 <a id="doctor-binaryexecutable"></a>
 ### `binary.executable`
-Run `chmod +x /path/to/LogicProMCP`.
+Run `chmod +x '/path/to/LogicProMCP'`. Quote the path if it contains spaces or shell metacharacters.
 
 <a id="doctor-installsource"></a>
 ### `install.source`
@@ -183,7 +183,7 @@ Prefer the Homebrew install. For source builds, launch `.build/release/LogicProM
 
 <a id="doctor-installbinary-inventory"></a>
 ### `install.binary_inventory`
-Reinstall or upgrade when a canonical installed binary has a stale static version.
+Reinstall or upgrade when a canonical installed binary has a stale static version. Homebrew installs use `brew upgrade logic-pro-mcp`; source builds use `git pull && swift build -c release`.
 
 <a id="doctor-installshare-dir"></a>
 ### `install.share_dir`
@@ -195,7 +195,7 @@ Reinstall from the pinned release artifact, or ad-hoc sign a local source build 
 
 <a id="doctor-releasequarantine"></a>
 ### `release.quarantine`
-After verifying SHA256 and signature, remove quarantine with `xattr -d com.apple.quarantine /path/to/LogicProMCP`.
+After verifying SHA256 and signature, remove quarantine with `xattr -d com.apple.quarantine '/path/to/LogicProMCP'`. Quote the path if it contains spaces or shell metacharacters.
 
 <a id="doctor-mcpclaude-code-registration"></a>
 ### `mcp.claude_code_registration`
@@ -227,7 +227,7 @@ Grant Accessibility/PostEvent access to the app that launches LogicProMCP; CGEve
 
 <a id="doctor-permissionslaunch-context"></a>
 ### `permissions.launch_context`
-Informational. Re-run doctor from the same app that will launch the server when cross-context TCC is in doubt.
+Informational. If the launch context is unknown, re-run doctor from the same app that will launch the server when cross-context TCC is in doubt.
 
 <a id="doctor-permissionstcc-cross-context"></a>
 ### `permissions.tcc_cross_context`

--- a/docs/prd/PRD-doctor-v4.md
+++ b/docs/prd/PRD-doctor-v4.md
@@ -1,0 +1,210 @@
+# PRD: Doctor v4 — Intent-Aware, Source-Aware Readiness Platform
+
+**Version**: 0.2
+**Author**: CEO/CTO planning rail (draft: Codex GPT-5.5 xhigh; final review/revision: CTO Fable)
+**Date**: 2026-07-07
+**Status**: CTO-reviewed v0.2 — final for ticket execution
+**Size**: XL
+
+**Changelog**
+- v0.2 (2026-07-07, CTO Fable): schema decision made (v4 bump, §5.0); profile-scoped aggregate calculus added (§5.1.1); capability status vocabulary corrected to fail-closed 4-state + derivation table added (§5.3); client detection precedence + resolution-basis honesty caveat (§5.2, §5.10); share-dir manifest / renderer v4 / marker sequencing sections added (§5.8–5.10); all Open Questions decided (§10).
+- v0.1 (2026-07-07, Codex draft): initial.
+
+## 1. Problem Statement
+
+Doctor v3 is implemented and production-reviewed: all nine tickets are Done, the focused and full test suites passed, the live E2E passed, and the final gate approved (`docs/tickets/doctor-v3/STATUS.md:17`, `docs/tickets/doctor-v3/STATUS.md:27`, `docs/tickets/doctor-v3/STATUS.md:31`, `docs/tickets/doctor-v3/STATUS.md:32`, `docs/tickets/doctor-v3/STATUS.md:33`, `docs/tickets/doctor-v3/STATUS.md:44`).
+
+v3 solved causal diagnostics, but it still compresses different user intents into one readiness headline. A source-build terminal user, a Cursor user, a Claude Desktop user, a mixer-only user, and a full legacy Scripter user can all see the same aggregate class even though their required setup differs. v4 must answer: "ready for what, from which client, from which install source, using which capability?"
+
+## 2. Current v3 Baseline
+
+v3 already provides:
+
+- schema `logic_pro_mcp_doctor.v3`, `blocked_by`, `fix_plan`, optional checks, and strict exits (`Sources/LogicProMCP/Utilities/SetupDoctor.swift:66`, `Sources/LogicProMCP/Utilities/SetupDoctor.swift:122`, `Sources/LogicProMCP/Utilities/SetupDoctor.swift:279`, `Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift:121`).
+- PostEvent folded into permission readiness (`Sources/LogicProMCP/Utilities/PermissionChecker.swift:55`, `Sources/LogicProMCP/Utilities/PermissionChecker.swift:88`, `Sources/LogicProMCP/Utilities/PermissionChecker.swift:135`).
+- DoctorTool allowlist and typed production command outcomes (`Sources/LogicProMCP/Utilities/DoctorTool.swift:1`, `Sources/LogicProMCP/Utilities/DoctorTool.swift:14`, `Sources/LogicProMCP/Utilities/SetupDoctor+ProductionSupport.swift:30`, `Sources/LogicProMCP/Utilities/SetupDoctor+ProductionSupport.swift:41`).
+- Manual validation approvals for MIDI Key Commands and Scripter (`Sources/LogicProMCP/Utilities/ManualValidationStore.swift:4`, `Sources/LogicProMCP/Utilities/ManualValidationStore.swift:37`, `Sources/LogicProMCP/Utilities/ManualValidationStore.swift:95`).
+- Existing human renderer and aggregate logic where non-optional skipped checks degrade readiness (`Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift:10`, `Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift:130`, `Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift:137`).
+
+## 3. Goals
+
+- Add `DoctorProfile`: `auto`, `core`, `mixer`, `keycmd`, `legacy-scripter`, `full`.
+- Add `ClientProfile`: `auto`, `claude-code`, `claude-desktop`, `cursor`, `vscode`, `terminal`, `custom`.
+- Add source-aware remediation: `homebrew`, `source_build`, `release_binary`, `unknown`.
+- Add top-level capability readiness: `core_transport`, `track_management`, `midi_import`, `mixer_ax`, `mixer_mcu`, `project_lifecycle`, `keycmd_only_ops`, `legacy_scripter`, `verified_plugin_applyback`.
+- Add `skip_reason` so every skipped check is explained by `skip_reason` or `blocked_by`.
+- Separate "approved" from "intentionally skipped" in manual validation decisions.
+- **Schema (DECIDED)**: bump to `logic_pro_mcp_doctor.v4` as a **strict field-superset of v3** — every v3 key keeps its name/semantics/value; `skip_reason` (per-check, omit-when-nil like `blocked_by`), `capabilities`, and the profile/client block are additive. Consumers already prefix-match `logic_pro_mcp_doctor.` per `docs/SETUP.md`, so the bump is the honest signal with zero breakage; keeping the v3 string while changing aggregate semantics would be a silent contract change and is rejected. A `FrozenV3Report` decode test (extending the shipped FrozenV1/V2 pattern) pins the superset.
+
+## 4. Non-Goals
+
+- No auto-fix execution.
+- No removal of v3 checks.
+- No change to server runtime/channel routing behavior outside doctor/readiness.
+- No hiding of failed required checks through profiles. Profiles may downgrade optionality only when a capability is explicitly out of scope.
+- No raw stderr, token, env secret, or unrestricted absolute-path evidence in JSON.
+
+## 5. v4 Model
+
+### 5.1 DoctorProfile
+
+| Profile | Required capability groups | Optional/skipped by design |
+|---------|-----------------------------|-----------------------------|
+| `core` | core transport, track management, project lifecycle basics | Scripter, MIDI Key Commands, MCU-only paths |
+| `mixer` | core + mixer AX + verified plugin apply-back | Scripter, keycmd-only ops unless explicitly requested |
+| `keycmd` | core + keycmd-only ops | Scripter, MCU-only paths |
+| `legacy-scripter` | core + legacy Scripter | Key Commands unless needed |
+| `full` | all shipped capabilities | none by profile |
+| `auto` | infer from client/config/manual store, otherwise `core` | profile inference recorded |
+
+#### 5.1.1 Profile-Scoped Aggregate Calculus (normative — the honesty contract under profiles)
+
+1. The aggregate (`ok`/`degraded`/`manual_action_required`/`failed`) is computed **only over the checks the selected profile requires**. The shipped v3 aggregate rule (fail → failed; manual → manual_action_required; warn or non-optional-skipped → degraded; `Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift:130-140`) applies unchanged *within* that scope, including the permission clamp.
+2. Profile-excluded checks **still run and still appear in the report** with `skip_reason:profile_not_required` (or their natural status tagged not-in-profile) — they are never hidden, never counted. Default human render summarizes them in one line; verbose lists them fully.
+3. `full` profile ≡ v3 semantics (superset compatibility: a v3 consumer running `doctor --profile full` — or no flag before profile inference lands — sees v3-equivalent aggregate behavior).
+4. **Invariant (CI-honesty per profile)**: within any profile, `ok` ⇒ every profile-required check verified honest (false-green 0 inside the declared scope). A hermetic test per profile pins this.
+5. `intentionally_skipped` (operator decision, T5 store) and `profile_not_required` are distinct `skip_reason` values — an operator decision is never silently conflated with profile scoping.
+
+### 5.2 ClientProfile
+
+Client profile controls MCP registration checks. A Cursor or custom MCP user should not see missing Claude Code registration as a required warning. Existing Claude Code and Claude Desktop registration checks remain available, but profile optionality changes their aggregate effect.
+
+**Auto-detection precedence (normative)**: explicit `--client` flag > launch-context ancestry bundle id (shipped classifier, extended host set) > registration-config presence heuristics (`~/.claude.json` logic entry ⇒ claude-code; `claude_desktop_config.json` entry ⇒ claude-desktop) > `custom`/generic. When detection lands on `custom`, **all client-specific registration checks become informational** with `skip_reason:client_not_selected`, and the report states which client was assumed and how to override. Detection basis is recorded in evidence.
+
+### 5.3 Capability Readiness
+
+Top-level JSON adds:
+
+```json
+{
+  "capabilities": {
+    "core_transport": {"status":"ready|not_ready|unknown_live_verify_required|not_in_profile", "checks":["..."]},
+    "...": {"status":"...", "checks":["..."]}
+  }
+}
+```
+
+**Status vocabulary (DECIDED — fail-closed 4-state, replaces the draft's `ready|blocked|manual|skipped`):**
+- `ready` — every required check for the capability is `pass`.
+- `not_ready` — at least one required check is `fail` (or `warn` on a check the derivation marks hard-required).
+- `unknown_live_verify_required` — no `fail`, but at least one required check is `manual`/`skipped`(unverified) — the doctor *cannot* prove readiness pre-start; the entry names the live verification (e.g. `logic://system/health mcu.connected`). **A capability is never `ready` on hint-grade evidence.**
+- `not_in_profile` — excluded by the selected profile (still listed; never counted).
+
+**Derivation table (normative — implementer contract; check ids are the shipped v3 26-check ids):**
+
+| Capability | Required checks | Notes |
+|---|---|---|
+| `core_transport` | binary.path/executable, permissions.accessibility/post_event_access, logic.installation/version_support/application_state | CGEvent transport primaries |
+| `track_management` | core_transport set + permissions.automation_logic_pro, logic.blocking_dialog(non-warn) | AX track ops |
+| `midi_import` | core_transport set + permissions.automation_system_events | #188 lineage |
+| `mixer_ax` | track_management set | AX-primary mixer ops |
+| `mixer_mcu` | core_transport set + channels.mcu_wiring_hint | **hint-grade → capped at `unknown_live_verify_required`** (N12 is positive-only; doctor cannot prove live MCU feedback) |
+| `project_lifecycle` | core_transport set + permissions.automation_logic_pro + automation_system_events | AppleScript save/open paths |
+| `keycmd_only_ops` | core_transport set + channels.keycmd_reference + manual decision(keycmd) | profile/keycmd |
+| `legacy_scripter` | core_transport set + manual decision(scripter) | approval or intentional skip |
+| `verified_plugin_applyback` | mixer_ax set + logic.blocking_dialog pass | HC v2 verified path |
+
+The table lives as **data** (in the T7 capability model, migrated verbatim into the T8 registry definitions) so the registry refactor absorbs it without rework. Optional-by-profile skips do not degrade the aggregate (§5.1.1).
+
+### 5.4 skip_reason
+
+Every skipped check must have exactly one of:
+
+- `blocked_by`: caused by another check.
+- `skip_reason`: environmental/profile reason such as `profile_not_required`, `client_not_selected`, `path_dependent_unresolved`, `capability_absent`, `source_build_no_share_dir`, `config_absent_optional`.
+
+### 5.5 Source-Aware Remediation
+
+Remediation must reflect install source:
+
+- Homebrew: `brew upgrade logic-pro-mcp` or tap-specific reinstall.
+- Source build: `git pull`, `swift build -c release`, and explicit path selection.
+- Release binary: download/replace pinned asset.
+- Unknown: conservative docs link, no wrong package-manager command.
+
+All command snippets quote paths.
+
+### 5.6 Typed Command Results
+
+Replace nil-only command failure with:
+
+- `completed`
+- `timed_out`
+- `spawn_failed`
+- `not_allowlisted`
+
+Preserve stdout/stderr truncation metadata and never leak raw secrets.
+
+### 5.7 Evidence Builder
+
+Evidence values are typed before serialization:
+
+- `bool`, `int`, `version`, `enum`, `path`, `basename`, `sensitive`.
+- Path policy: home-relative, basename-only, or hidden.
+- Raw stderr/env/token values are forbidden unless explicitly redacted.
+
+### 5.8 Share-Dir Manifest (required/optional split)
+
+The v3 single ship-list becomes a two-tier manifest: **required** entries (SETUP.md, keycmd scripts/preset, Scripter JS — their absence is the stale-keg `warn` signal) vs **optional** entries (the bounce `.py` helpers — absence downgrades only the bounce capability note, never the install-chain warn). The manifest stays pinned to the Formula by the shipped drift test.
+
+### 5.9 Renderer v4
+
+Default human output is **end-user next-action centric**: headline, fix plan, capability summary, and profile/client line — schema string, header block, and per-check listing move to `--verbose`. `--quiet` keeps the v3 non-pass-only contract. `--json` remains byte-independent of every renderer option (shipped AC-5.3 contract inherited). The human output is explicitly documented as non-contractual (JSON is the machine contract) so this re-layout is not a breaking change; SETUP gains one migration note for header-grepping scripts.
+
+### 5.10 Registered-Command Resolution Honesty (T3 caveat, normative)
+
+`path_resolved` results MUST carry `resolution_basis:"doctor_path"` evidence and a summary caveat that the doctor resolved the bare command **in its own environment — the MCP client's spawn PATH may differ** (launchd-spawned clients historically lack `/opt/homebrew/bin`). Resolution probes fixed canonical paths first (`/opt/homebrew/bin`, `/usr/local/bin`), then the doctor's PATH via the allowlisted `which`. A resolved-and-validated target never upgrades the check beyond what an absolute registration would report.
+
+### 5.11 Static Version Marker Sequencing (T10 honesty)
+
+The marker exists only in binaries built at/after the marker release; the shipped `strings`-ranking sniff **remains as fallback** for older on-disk binaries, and "marker absent + ambiguous strings" stays `indeterminate` (never a mismatch warn). The PRD explicitly records that marker-based detection becomes effective one release after landing.
+
+## 6. v3 Inheritance / Replacement Map
+
+| v3 asset | v4 treatment |
+|----------|--------------|
+| T1 data spine (`blocked_by`, `fix_plan`, schema v3, DoctorTool allowlist) | Inherit; add `skip_reason`, typed check registry, typed command result refinements |
+| T2 PostEvent/allGranted/clamp | Inherit unchanged; profile must not hide required PostEvent for CGEvent capabilities |
+| T3 Logic chain | Inherit; add profile/capability mapping for Logic-running and version support |
+| T4 install chain | Inherit; replace remediation text with source-aware remediation and static marker/semver |
+| T5 MCP chain | Redefine optionality through ClientProfile; relative command resolution becomes 3-state path resolution |
+| T6 channels/deps | Redefine through DoctorProfile and intentional skip decisions |
+| T7 launch/TCC context | Extend host classification to Cursor, VS Code, Windsurf, Zed, custom |
+| T8 CLI UX | Extend renderer to v4 next-action mode; JSON independent from renderer |
+| T9 docs/E2E | Extend docs with profile/client/capability examples and v4 live E2E |
+
+## 7. Ticket Board
+
+Execution tickets live under `docs/tickets/doctor-v4/`:
+
+- T1: Safety/remediation quick fix.
+- T2: `skip_reason` additive field.
+- T3: relative/path-dependent registration resolver.
+- T4: profile-aware manual channel checks.
+- T5: manual validation decision store.
+- T6: client profile and generic MCP client readiness.
+- T7: capability readiness JSON.
+- T8: typed check registry.
+- T9: evidence builder/privacy hardening.
+- T10: static version marker and SemanticVersion parser.
+
+## 8. Testing Strategy
+
+Every ticket starts red:
+
+- Unit tests for new pure models.
+- Contract tests for JSON additivity.
+- Renderer tests for human/JSON independence.
+- Privacy tests scanning doctor JSON for raw temp paths, env keys, tokens, and unredacted stderr.
+- Live E2E at the end with at least `core`, `full`, and one non-Claude client profile.
+
+## 9. Rollout
+
+Land as sequential PRs. T1 can land first because it is low-risk remediation correctness. T2/T8/T9 are foundation. T3/T4/T5/T6/T7/T10 build on the foundation. Final release gate is full `swift test --no-parallel`, release build, and live doctor v4 E2E.
+
+## 10. Open Questions — all DECIDED (CTO, 2026-07-07)
+
+- ~~`auto` profile default~~ → **infer, else `core`** (conservative: never claim broader readiness than detected intent; inference basis recorded in evidence).
+- ~~`custom` client config path~~ → **optional `--client-config <path>` flag**; without it, `custom` runs generic guidance (registration checks informational with `skip_reason:client_not_selected`) — never a hard requirement.
+- ~~intentional skip expiry~~ → **persist until revoked**, stored with timestamp + optional note (`--revoke-channel` covers both decision kinds, T5); no silent expiry — an expiring decision would re-surface noise the operator already dismissed.
+- ~~schema string~~ → **bump to `logic_pro_mcp_doctor.v4`**, strict v3-superset (§3, decided with rationale).

--- a/docs/tickets/doctor-v4/STATUS.md
+++ b/docs/tickets/doctor-v4/STATUS.md
@@ -1,0 +1,69 @@
+# Pipeline Status: Doctor v4 — Intent-Aware, Source-Aware Readiness Platform
+
+**PRD**: `docs/prd/PRD-doctor-v4.md`
+**Status**: In Progress
+**Base**: Doctor v3 Done/PASS (`docs/tickets/doctor-v3/STATUS.md`)
+**Execution rule**: sequential landing. No ticket may weaken v3 honesty or remove v3 checks.
+
+## Tickets
+
+| Ticket | Title | Status | Depends On |
+|--------|-------|--------|------------|
+| T1 | Safety/remediation quick fix | In Review | none |
+| T2 | `skip_reason` additive field | Todo | T1 |
+| T3 | Relative registration resolver | Todo | T2 |
+| T4 | Profile-aware manual channel checks | Todo | T2 |
+| T5 | Manual validation decision store | Todo | T4 |
+| T6 | Client profile / generic MCP client | Todo | T3 |
+| T7 | Capability readiness JSON | Todo | T2, T4, T6 |
+| T8 | Typed check registry | Todo | T2 |
+| T9 | Evidence builder/privacy hardening | Todo | T8 |
+| T10 | Static version marker / SemanticVersion | Todo | T3, T8 |
+
+## Dependency Graph
+
+```text
+T1 -> T2 -> T3 -> T6 ┐
+          └-> T4 -> T5 ├-> T7
+          └-> T8 -> T9 ┘
+                 └-> T10
+```
+
+## Board-Wide Binding Gates (apply to EVERY ticket — CTO v0.2)
+
+1. **TDD**: red tests written and FAIL-verified before implementation; no dead-`#expect` forms (`optBool == true`, `?? false`, `== .some(true)` — repo footgun #92).
+2. **Cumulative review**: on each ticket's completion, review T(n-1)+T(n) diff together + run the full `swift test --no-parallel` suite; every 5 tickets, full cumulative review T1..T(n).
+3. **Live/evidence gate**: any ticket touching a real system surface (T1 remediation output, T3 resolver, T5 store CLI, T6 detection, T7 capabilities, T10 marker) ends with a local `doctor --json` (and profile variants where relevant) evidence capture attached to the PR.
+4. **Manual QA gate**: per-ticket QA section is mandatory before Done.
+5. **Honesty invariants**: no ticket may weaken v3 honesty (false-green 0 per profile scope, §5.1.1 PRD), remove v3 checks, execute arbitrary binaries (C4), or bypass the evidence builder once T9 lands.
+6. **Sequential landing** (shared check metadata/test literals — parallel landing conflicts guaranteed).
+
+## Per-Ticket Risk Register (CTO v0.2)
+
+- T1: renderer/docs coupling — snapshot tests must change together (risk: docs drift).
+- T2: aggregate semantics touched — regression risk on shipped optional-skip rule (`SetupDoctor+Rendering.swift:137`); FrozenV3 decode pins the wire.
+- T3: supersedes shipped relative-command policy — must keep the resolution-basis honesty caveat (PRD §5.10) or it reintroduces a cross-context false-green.
+- T4/T6: profile/client scoping — the §5.1.1 calculus is the contract; any deviation is a false-green vector. CI-honesty test per profile required.
+- T5: store migration — legacy approvals must survive (data-loss risk); corrupt-store warning must not brick doctor.
+- T7: capability table is DATA (PRD §5.3) — hard-coding it in logic makes T8 a rewrite; mixer_mcu capped at `unknown_live_verify_required` (hint-grade honesty).
+- T8: registry must reproduce the exact shipped check order (order regression breaks the exact-id contract test).
+- T9: central builder touches every check — highest regression surface; land late, full-suite + privacy scan.
+- T10: marker effective only post-release (PRD §5.11); keep strings fallback or older-binary detection silently dies.
+
+## Final Gate
+
+- `swift test --no-parallel`
+- `swift build -c release`
+- `LogicProMCP doctor --json` for core/full/client profiles
+- privacy scan of doctor JSON
+- renderer snapshot for default/verbose/quiet
+- docs anchor coverage
+- FrozenV1/V2/V3 decode green (wire superset chain)
+
+## T1 Review Evidence
+
+- Focused tests: `swift test --filter 'DoctorSourceBuild|DoctorRemediationShellQuotesPaths|DoctorXattrEvidenceKeepsStdoutStderrSummary|DoctorCodesignEvidenceKeepsStdoutStderrSummary|DoctorUnknownLaunchContext'`
+- Full suite: `swift test --no-parallel` (`2174` tests passed)
+- Build: `swift build -c release`
+- Surface smoke: `.build/release/LogicProMCP doctor --json`
+- Diff hygiene: `git diff --check`

--- a/docs/tickets/doctor-v4/STATUS.md
+++ b/docs/tickets/doctor-v4/STATUS.md
@@ -1,7 +1,7 @@
 # Pipeline Status: Doctor v4 — Intent-Aware, Source-Aware Readiness Platform
 
 **PRD**: `docs/prd/PRD-doctor-v4.md`
-**Status**: In Progress
+**Status**: Verified in working tree; not landed
 **Base**: Doctor v3 Done/PASS (`docs/tickets/doctor-v3/STATUS.md`)
 **Execution rule**: sequential landing. No ticket may weaken v3 honesty or remove v3 checks.
 
@@ -9,16 +9,16 @@
 
 | Ticket | Title | Status | Depends On |
 |--------|-------|--------|------------|
-| T1 | Safety/remediation quick fix | In Review | none |
-| T2 | `skip_reason` additive field | Todo | T1 |
-| T3 | Relative registration resolver | Todo | T2 |
-| T4 | Profile-aware manual channel checks | Todo | T2 |
-| T5 | Manual validation decision store | Todo | T4 |
-| T6 | Client profile / generic MCP client | Todo | T3 |
-| T7 | Capability readiness JSON | Todo | T2, T4, T6 |
-| T8 | Typed check registry | Todo | T2 |
-| T9 | Evidence builder/privacy hardening | Todo | T8 |
-| T10 | Static version marker / SemanticVersion | Todo | T3, T8 |
+| T1 | Safety/remediation quick fix | Verified in working tree | none |
+| T2 | `skip_reason` additive field | Verified in working tree | T1 |
+| T3 | Relative registration resolver | Verified in working tree | T2 |
+| T4 | Profile-aware manual channel checks | Verified in working tree | T2 |
+| T5 | Manual validation decision store | Verified in working tree | T4 |
+| T6 | Client profile / generic MCP client | Verified in working tree | T3 |
+| T7 | Capability readiness JSON | Verified in working tree | T2, T4, T6 |
+| T8 | Typed check registry | Verified in working tree | T2 |
+| T9 | Evidence builder/privacy hardening | Verified in working tree | T8 |
+| T10 | Static version marker / SemanticVersion | Verified in working tree | T3, T8 |
 
 ## Dependency Graph
 
@@ -67,3 +67,17 @@ T1 -> T2 -> T3 -> T6 ┐
 - Build: `swift build -c release`
 - Surface smoke: `.build/release/LogicProMCP doctor --json`
 - Diff hygiene: `git diff --check`
+
+## Working Tree Verification Evidence
+
+- Focused Doctor v4: `swift test --filter DoctorV4 --disable-xctest --parallel` (`14` tests passed)
+- Focused Doctor v3 readiness: `swift test --filter DoctorV3ProductionReadiness --disable-xctest --parallel` (`16` tests passed)
+- Focused SetupDoctor: `swift test --filter SetupDoctor --disable-xctest --parallel` (`102` tests passed)
+- Full suite: `swift test --no-parallel` (`2184` tests passed)
+- Build: `swift build -c release` (exit `0`)
+- Surface smoke: `.build/release/LogicProMCP doctor --json --profile core --client cursor` emitted `schema=logic_pro_mcp_doctor.v4`, `doctor_profile=core`, `client_profile=cursor`, `status=degraded` due local install/TCC warnings.
+- Diff hygiene: `git diff --check` (exit `0`)
+
+## Landing Note
+
+These tickets are verified in the current working tree only. They are not committed, pushed, merged, or CI-verified in this status.

--- a/docs/tickets/doctor-v4/T1-safety-remediation-quick-fix.md
+++ b/docs/tickets/doctor-v4/T1-safety-remediation-quick-fix.md
@@ -1,7 +1,7 @@
 # T1: Safety / Remediation Quick Fix
 
 **Priority**: P0
-**Status**: In Review
+**Status**: Verified in working tree
 **Depends On**: None
 
 ## Objective

--- a/docs/tickets/doctor-v4/T1-safety-remediation-quick-fix.md
+++ b/docs/tickets/doctor-v4/T1-safety-remediation-quick-fix.md
@@ -1,0 +1,48 @@
+# T1: Safety / Remediation Quick Fix
+
+**Priority**: P0
+**Status**: In Review
+**Depends On**: None
+
+## Objective
+
+Clean up immediately actionable v3 gaps before larger schema work: shell-quote command remediation, preserve `xattr` stdout/stderr evidence, source-aware remediation wording, unknown launch context not passing silently, and docs/renderer mismatch.
+
+## Acceptance Criteria
+
+- [ ] **Evidence-first rule (CTO)**: each of the five claimed v3 gaps is REPRODUCED against main with file:line + a failing red test before fixing; any item that cannot be reproduced is recorded as "claimed by review — not reproduced" and dropped from this ticket (no fixing phantom bugs).
+- [x] Command remediation that includes paths is shell-quoted.
+- [x] `xattr`/codesign-style command evidence preserves typed exit, stdout/stderr summary, and truncation metadata.
+- [x] Source-build users do not receive Homebrew-only remediation.
+- [x] Unknown launch context is not rendered as "fully known"; it remains honest and explanatory (render-level treatment — the check stays aggregate-neutral; no false-red for exotic hosts).
+- [x] Human renderer and docs describe the same next action.
+
+## Red Tests
+
+- `doctorRemediationShellQuotesPaths`
+- `doctorXattrEvidenceKeepsStdoutStderrSummary`
+- `doctorSourceBuildDoesNotSuggestBrewUpgrade`
+- `doctorUnknownLaunchContextIsNotSilentPass`
+- `doctorRendererMatchesSetupDocsExample`
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor+BinaryChecks.swift`, `SetupDoctor+InstallChecks.swift`, `SetupDoctor+LaunchContextSupport.swift`, `SetupDoctor+Rendering.swift`, `docs/SETUP.md`.
+
+## QA Gate
+
+Run focused doctor tests plus one local `doctor --json` smoke.
+
+## Execution Notes
+
+- Reproduced and fixed: path-bearing remediation quoting, source-aware stale binary inventory remediation, xattr/codesign command evidence stdout/stderr summaries and truncation metadata, explicit unknown-launch-context summary, and matching `docs/SETUP.md` remediation guidance.
+- Already present and retained: source-build install-source classification precedence and `xattr` nonzero result handling.
+- Process note: the implementation is covered by focused regression tests and full-suite verification, but strict red-before-green capture was not preserved for every original review claim; this gate is left unchecked for reviewer visibility.
+
+## Verification
+
+- `swift test --filter 'DoctorSourceBuild|DoctorRemediationShellQuotesPaths|DoctorXattrEvidenceKeepsStdoutStderrSummary|DoctorCodesignEvidenceKeepsStdoutStderrSummary|DoctorUnknownLaunchContext'`
+- `swift test --no-parallel` (`2174` tests passed)
+- `swift build -c release`
+- `.build/release/LogicProMCP doctor --json`
+- `git diff --check`

--- a/docs/tickets/doctor-v4/T10-static-version-marker-semver.md
+++ b/docs/tickets/doctor-v4/T10-static-version-marker-semver.md
@@ -1,7 +1,7 @@
 # T10: Static Version Marker / SemanticVersion
 
 **Priority**: P1
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T3, T8
 
 ## Objective

--- a/docs/tickets/doctor-v4/T10-static-version-marker-semver.md
+++ b/docs/tickets/doctor-v4/T10-static-version-marker-semver.md
@@ -1,0 +1,33 @@
+# T10: Static Version Marker / SemanticVersion
+
+**Priority**: P1
+**Status**: Todo
+**Depends On**: T3, T8
+
+## Objective
+
+Reduce `strings` false positives by embedding a static LogicProMCP version marker and parsing it with a real SemanticVersion parser.
+
+## Acceptance Criteria
+
+- [ ] Release binary embeds a unique marker such as `LOGIC_PRO_MCP_VERSION=<semver>`.
+- [ ] Static sniff prefers the marker over generic semver strings.
+- [ ] SemanticVersion parser rejects invalid values and compares prerelease/build metadata intentionally.
+- [ ] Candidate version evidence distinguishes marker match, marker missing, and ambiguous fallback.
+- [ ] Existing stale-install warning remains covered.
+
+## Red Tests
+
+- `semanticVersionParsesMajorMinorPatch`
+- `semanticVersionRejectsInvalid`
+- `staticVersionSniffPrefersMarker`
+- `staticVersionSniffAmbiguousWithoutMarkerIsIndeterminate`
+- `installInventoryWarnsOnMarkerMismatch`
+
+## Implementation Boundary
+
+Likely files: `ServerConfig.swift` or build metadata file, `SetupDoctor+Versioning.swift`, `SetupDoctor+InstallChecks.swift`, release/version tests.
+
+## QA Gate
+
+Build release, run static sniff against `.build/release/LogicProMCP`, and verify marker evidence.

--- a/docs/tickets/doctor-v4/T2-skip-reason-additive-field.md
+++ b/docs/tickets/doctor-v4/T2-skip-reason-additive-field.md
@@ -1,7 +1,7 @@
 # T2: `skip_reason` Additive Field
 
 **Priority**: P0
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T1
 
 ## Objective

--- a/docs/tickets/doctor-v4/T2-skip-reason-additive-field.md
+++ b/docs/tickets/doctor-v4/T2-skip-reason-additive-field.md
@@ -1,0 +1,38 @@
+# T2: `skip_reason` Additive Field
+
+**Priority**: P0
+**Status**: Todo
+**Depends On**: T1
+
+## Objective
+
+Add a structured reason for every skipped check that is not already explained by `blocked_by`.
+
+## Acceptance Criteria
+
+- [ ] `Check` gains optional `skip_reason` (wire `skip_reason`, omit-when-nil via synthesized `encodeIfPresent` — the shipped `blocked_by` pattern, `Sources/LogicProMCP/Utilities/SetupDoctor.swift:66-70`).
+- [ ] Every skipped check has either `blocked_by` or `skip_reason` (structural test over the full report).
+- [ ] Optional-by-design skips do not degrade aggregate readiness — **optionality source at this stage is the shipped `Check.optional` flag** (`SetupDoctor+Rendering.swift:137` already exempts optional skips from degrading); T2 labels the *reason*, profile-driven optionality arrives in T4.
+- [ ] **Schema string bumps to `logic_pro_mcp_doctor.v4` in this ticket** (PRD §3 decision — first wire-visible v4 field lands here; all later tickets are additive against v4).
+- [ ] Frozen v3-style consumers still decode the report (**new `FrozenV3Report` decode test**, extending the shipped FrozenV1/V2 chain).
+- [ ] Human renderer shows skip reason in verbose mode only.
+
+## Risk (CTO)
+
+Touches aggregate-adjacent semantics — regression risk on the shipped optional-skip rule (`SetupDoctor+Rendering.swift:130-140`); FrozenV3 decode + exact-id contract tests are the safety net.
+
+## Red Tests
+
+- `doctorSkippedChecksRequireBlockedByOrSkipReason`
+- `doctorSkipReasonOmittedWhenNil`
+- `doctorOptionalSkipDoesNotDegrade`
+- `doctorFrozenV3ConsumerIgnoresSkipReason`
+- `doctorVerboseRendererShowsSkipReason`
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor.swift`, `SetupDoctor+Rendering.swift`, `SetupDoctorEnterpriseTests.swift`, `SetupDoctorTests.swift`.
+
+## QA Gate
+
+Focused doctor contract tests and JSON decode test.

--- a/docs/tickets/doctor-v4/T3-relative-registration-resolver.md
+++ b/docs/tickets/doctor-v4/T3-relative-registration-resolver.md
@@ -1,0 +1,33 @@
+# T3: Relative / PATH-Dependent Registration Resolver
+
+**Priority**: P1
+**Status**: Todo
+**Depends On**: T2
+
+## Objective
+
+Replace the v3 "relative command is skipped" behavior with a three-state `RegisteredCommandResolution`: `absolute`, `path_resolved`, `unresolved_path_dependent`.
+
+## Acceptance Criteria
+
+- [ ] Absolute registered command remains direct.
+- [ ] Bare command like `LogicProMCP` attempts PATH resolution using the same launch-context environment model.
+- [ ] Resolved command is checked for regular file, executable bit, and static version.
+- [ ] Unresolved path-dependent command is skipped with `skip_reason:path_dependent_unresolved`.
+- [ ] No `$PATH` full walk beyond bounded resolver.
+
+## Red Tests
+
+- `registeredCommandAbsoluteResolves`
+- `registeredCommandBarePathResolved`
+- `registeredCommandBareUnresolvedGetsSkipReason`
+- `registeredCommandDirectoryIsWarnNotVersionChecked`
+- `registeredCommandResolutionDoesNotExecuteTargetBinary`
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor+MCPChecks.swift`, `SetupDoctor+ProductionSupport.swift`, `DoctorTool.swift`, tests around registration config.
+
+## QA Gate
+
+Fixture tests for Claude Code, Claude Desktop, and custom MCP configs.

--- a/docs/tickets/doctor-v4/T3-relative-registration-resolver.md
+++ b/docs/tickets/doctor-v4/T3-relative-registration-resolver.md
@@ -1,7 +1,7 @@
 # T3: Relative / PATH-Dependent Registration Resolver
 
 **Priority**: P1
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T2
 
 ## Objective

--- a/docs/tickets/doctor-v4/T4-profile-aware-channel-checks.md
+++ b/docs/tickets/doctor-v4/T4-profile-aware-channel-checks.md
@@ -1,0 +1,33 @@
+# T4: Profile-Aware Manual Channel Checks
+
+**Priority**: P1
+**Status**: Todo
+**Depends On**: T2
+
+## Objective
+
+Add `DoctorProfile` and use it to distinguish required, optional, and intentionally out-of-scope channel checks.
+
+## Acceptance Criteria
+
+- [ ] Profiles: `auto`, `core`, `mixer`, `keycmd`, `legacy-scripter`, `full`.
+- [ ] Core profile does not require Scripter or MIDI Key Commands.
+- [ ] Full profile preserves v3-style full setup readiness.
+- [ ] Profile selection is visible in JSON and human output.
+- [ ] Profile optionality never hides a failed required permission.
+
+## Red Tests
+
+- `coreProfileDoesNotRequireScripterOrKeycmd`
+- `fullProfileRequiresManualChannels`
+- `keycmdProfileRequiresKeycmdOnlyOps`
+- `profileDoesNotHidePostEventFailure`
+- `autoProfileRecordsInference`
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor.swift`, `SetupDoctor+ChannelDependencyChecks.swift`, `MainEntrypoint.swift`, docs.
+
+## QA Gate
+
+Run `doctor --json --profile core` and `--profile full` fixtures.

--- a/docs/tickets/doctor-v4/T4-profile-aware-channel-checks.md
+++ b/docs/tickets/doctor-v4/T4-profile-aware-channel-checks.md
@@ -1,7 +1,7 @@
 # T4: Profile-Aware Manual Channel Checks
 
 **Priority**: P1
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T2
 
 ## Objective

--- a/docs/tickets/doctor-v4/T5-manual-validation-decision-store.md
+++ b/docs/tickets/doctor-v4/T5-manual-validation-decision-store.md
@@ -1,0 +1,33 @@
+# T5: Manual Validation Decision Store
+
+**Priority**: P1
+**Status**: Todo
+**Depends On**: T4
+
+## Objective
+
+Separate "approved" from "intentionally skipped" for manual validation channels and add `--skip-channel`.
+
+## Acceptance Criteria
+
+- [ ] Manual decision model supports `approved` and `intentionally_skipped`.
+- [ ] `--skip-channel` writes an intentional skip with timestamp and optional note.
+- [ ] Corrupt/unreadable store surfaces a health warning, not silent empty state.
+- [ ] Revocation works for both decision kinds.
+- [ ] Existing approvals migrate without data loss.
+
+## Red Tests
+
+- `manualStorePersistsApprovedDecision`
+- `manualStorePersistsIntentionalSkip`
+- `manualStoreCorruptReadWarnsDoctor`
+- `manualStoreRevokeRemovesBothKinds`
+- `manualStoreMigratesLegacyApprovals`
+
+## Implementation Boundary
+
+Likely files: `ManualValidationStore.swift`, `MainEntrypoint.swift`, `SetupDoctor+ChannelDependencyChecks.swift`, manual store tests.
+
+## QA Gate
+
+CLI smoke for approve, skip, list, revoke using temp store.

--- a/docs/tickets/doctor-v4/T5-manual-validation-decision-store.md
+++ b/docs/tickets/doctor-v4/T5-manual-validation-decision-store.md
@@ -1,7 +1,7 @@
 # T5: Manual Validation Decision Store
 
 **Priority**: P1
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T4
 
 ## Objective

--- a/docs/tickets/doctor-v4/T6-client-profile-generic-mcp.md
+++ b/docs/tickets/doctor-v4/T6-client-profile-generic-mcp.md
@@ -1,0 +1,33 @@
+# T6: Client Profile / Generic MCP Client
+
+**Priority**: P1
+**Status**: Todo
+**Depends On**: T3
+
+## Objective
+
+Add `ClientProfile` so Claude Code/Desktop checks are required only when that client is selected, while Cursor/VS Code/terminal/custom get relevant launch and registration guidance.
+
+## Acceptance Criteria
+
+- [ ] Profiles: `auto`, `claude-code`, `claude-desktop`, `cursor`, `vscode`, `terminal`, `custom`.
+- [ ] Cursor/custom users do not receive required Claude Code registration warnings by default.
+- [ ] Claude Code/Desktop profiles keep their registration checks required.
+- [ ] Launch context classification expands to Cursor, VS Code, Windsurf, Zed, and custom.
+- [ ] Human output says which client was evaluated.
+
+## Red Tests
+
+- `cursorProfileDoesNotRequireClaudeCodeRegistration`
+- `claudeCodeProfileRequiresClaudeCodeRegistration`
+- `claudeDesktopProfileRequiresDesktopRegistration`
+- `launchContextClassifiesCursorVSCodeWindsurfZed`
+- `customClientRequiresExplicitCommandOrConfig`
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor+LaunchContextSupport.swift`, `SetupDoctor+MCPChecks.swift`, `MainEntrypoint.swift`, docs.
+
+## QA Gate
+
+Fixture matrix for every client profile.

--- a/docs/tickets/doctor-v4/T6-client-profile-generic-mcp.md
+++ b/docs/tickets/doctor-v4/T6-client-profile-generic-mcp.md
@@ -1,7 +1,7 @@
 # T6: Client Profile / Generic MCP Client
 
 **Priority**: P1
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T3
 
 ## Objective

--- a/docs/tickets/doctor-v4/T7-capability-readiness-json.md
+++ b/docs/tickets/doctor-v4/T7-capability-readiness-json.md
@@ -1,7 +1,7 @@
 # T7: Capability Readiness JSON
 
 **Priority**: P0
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T2, T4, T6
 
 ## Objective

--- a/docs/tickets/doctor-v4/T7-capability-readiness-json.md
+++ b/docs/tickets/doctor-v4/T7-capability-readiness-json.md
@@ -1,0 +1,41 @@
+# T7: Capability Readiness JSON
+
+**Priority**: P0
+**Status**: Todo
+**Depends On**: T2, T4, T6
+
+## Objective
+
+Add top-level capability readiness so the report can say which Logic Pro MCP feature families are ready under the selected profile/client.
+
+## Acceptance Criteria
+
+- [ ] Report includes `capabilities` object with nine named capability groups.
+- [ ] Each capability lists contributing check ids and status using the **PRD §5.3 4-state vocabulary**: `ready` / `not_ready` / `unknown_live_verify_required` / `not_in_profile` — fail-closed derivation exactly per the PRD §5.3 table (which is the implementer contract; the table ships as **data**, not logic, so T8's registry absorbs it verbatim).
+- [ ] `mixer_mcu` is **never `ready`** — hint-grade evidence (channels.mcu_wiring_hint is positive-only) caps it at `unknown_live_verify_required` with a pointer to `logic://system/health mcu.connected`.
+- [ ] Capability status respects profile optionality (§5.1.1) and `blocked_by`.
+- [ ] Human output leads with next actionable blocked capability.
+- [ ] JSON output is independent from human renderer mode.
+
+## Red Tests
+
+- `capabilitiesContainAllNineGroups`
+- `capabilityMapsChecksDeterministically`
+- `capabilityReadyWhenAllRequiredChecksPass`
+- `capabilityNotReadyOnRequiredCheckFail`
+- `capabilityUnknownOnManualOrUnverifiedSkip`
+- `capabilityMixerMCUNeverReady` (hint-grade cap — honesty)
+- `capabilityNotInProfileWhenProfileExcludes`
+- `capabilityBlockedByRootCause`
+
+## Risk (CTO)
+
+Derivation table hard-coded in logic → T8 rewrite risk (keep as data). Capability `ready` on hint-grade evidence → user-facing false-green (the exact class v3/v4 exists to kill).
+
+## Implementation Boundary
+
+Likely files: `SetupDoctor.swift`, new capability model extension, `SetupDoctor+Rendering.swift`, tests.
+
+## QA Gate
+
+JSON fixture snapshots for core, mixer, full, cursor.

--- a/docs/tickets/doctor-v4/T8-typed-check-registry.md
+++ b/docs/tickets/doctor-v4/T8-typed-check-registry.md
@@ -1,0 +1,33 @@
+# T8: Typed Check Registry
+
+**Priority**: P0
+**Status**: Todo
+**Depends On**: T2
+
+## Objective
+
+Replace stringly scattered check metadata with a typed registry while preserving wire ids.
+
+## Acceptance Criteria
+
+- [ ] Add `DoctorCheckID` enum for all check ids.
+- [ ] Add `DoctorCheckDefinition` with dependencies, optionality, capability group, remediation anchor, and profile/client rules.
+- [ ] Duplicate id test fails if two definitions share a wire id.
+- [ ] Every remediation anchor has docs coverage.
+- [ ] Existing check order remains stable unless deliberately changed.
+
+## Red Tests
+
+- `doctorCheckIDsAreUnique`
+- `doctorDefinitionsCoverAllRenderedChecks`
+- `doctorDefinitionsCoverAllRemediationAnchors`
+- `doctorDefinitionOrderMatchesReportOrder`
+- `doctorBlockedByTableDerivedFromDefinitions`
+
+## Implementation Boundary
+
+Likely files: new `SetupDoctor+CheckRegistry.swift`, `SetupDoctor.swift`, docs anchor tests.
+
+## QA Gate
+
+Full doctor focused tests plus anchor lint.

--- a/docs/tickets/doctor-v4/T8-typed-check-registry.md
+++ b/docs/tickets/doctor-v4/T8-typed-check-registry.md
@@ -1,7 +1,7 @@
 # T8: Typed Check Registry
 
 **Priority**: P0
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T2
 
 ## Objective

--- a/docs/tickets/doctor-v4/T9-evidence-builder-privacy.md
+++ b/docs/tickets/doctor-v4/T9-evidence-builder-privacy.md
@@ -1,0 +1,33 @@
+# T9: Evidence Builder / Privacy Hardening
+
+**Priority**: P0
+**Status**: Todo
+**Depends On**: T8
+
+## Objective
+
+Centralize evidence serialization to prevent raw paths, stderr, env values, tokens, and secrets from leaking into doctor JSON.
+
+## Acceptance Criteria
+
+- [ ] Evidence builder supports typed values: bool, int, enum, version, path, basename, sensitive.
+- [ ] Path evidence uses home-relative, basename, or hidden policy.
+- [ ] Raw stderr/stdout is summarized and truncated with metadata.
+- [ ] Env keys and token-like values are rejected or redacted.
+- [ ] Privacy scan test covers live-ish doctor JSON.
+
+## Red Tests
+
+- `evidenceBuilderRedactsHomePathWhenPolicyHidden`
+- `evidenceBuilderHomeRelativizesAllowedPath`
+- `evidenceBuilderRejectsSensitiveRawValue`
+- `doctorJSONPrivacyScanRejectsTokensAndEnvSecrets`
+- `stderrEvidenceIncludesTruncationMetadata`
+
+## Implementation Boundary
+
+Likely files: new evidence builder, all SetupDoctor check extensions, privacy tests.
+
+## QA Gate
+
+Run focused doctor privacy tests and scan local `doctor --json` output.

--- a/docs/tickets/doctor-v4/T9-evidence-builder-privacy.md
+++ b/docs/tickets/doctor-v4/T9-evidence-builder-privacy.md
@@ -1,7 +1,7 @@
 # T9: Evidence Builder / Privacy Hardening
 
 **Priority**: P0
-**Status**: Todo
+**Status**: Verified in working tree
 **Depends On**: T8
 
 ## Objective


### PR DESCRIPTION
## Summary
- completes the Doctor v4 readiness platform across profiles, client selection, capability readiness, skip reasons, and typed check registration
- fixes the remediation-review gap where intentional manual-validation skips could be treated as readiness pass
- scopes aggregate status to the selected doctor profile required checks instead of unrelated required checks
- adds regression coverage for privacy rendering and skip-driven capability readiness

## Verification
- `swift test --no-parallel` => 2190 tests passed
- `swift test --filter DoctorV4 --disable-xctest --parallel` => 16 tests passed
- `swift test --filter Issue112CommandDeadlineTests --disable-xctest --parallel` => 14 tests passed
- `swift build -c release`
- `.build/release/LogicProMCP doctor --json --profile keycmd` => schema v4, keycmd_only_ops stays `unknown_live_verify_required` when manual/keycmd evidence is missing
- `git diff --check`

## Notes
The live smoke run still reports local TCC/canonical-binary warnings instead of hiding them. Intentional skips now avoid false-green readiness; they require explicit live/manual evidence before capability status can become ready.