### PR TITLE
docs(midi): add readback vNext live gate harness

### DIFF
--- a/Scripts/spike-midi-region-drag-export.swift
+++ b/Scripts/spike-midi-region-drag-export.swift
@@ -135,12 +135,26 @@ func postMouseDrag(from source: Point, to destination: Point) -> Bool {
     return true
 }
 
+let exportDirArgument = argumentValue("--export-dir")
 let exportDir = URL(
-    fileURLWithPath: argumentValue("--export-dir") ?? "/tmp/LogicProMCP-region-drag-spike"
+    fileURLWithPath: exportDirArgument ?? "/tmp/LogicProMCP-region-drag-spike"
 )
 let source = parsePoint(argumentValue("--source"))
 let destination = parsePoint(argumentValue("--destination"))
 let armed = ProcessInfo.processInfo.environment["LOGIC_PRO_MCP_ARM_REGION_DRAG"] == "1"
+
+if armed && exportDirArgument == nil {
+    emit(JSONRecord(
+        record_type: "region_drag_preflight",
+        status: "blocked",
+        export_dir: nil,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: nil,
+        note: "Explicit --export-dir is required for a live armed drag."
+    ))
+    exit(2)
+}
 
 try? FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
 emit(JSONRecord(

--- a/Scripts/spike-midi-region-drag-export.swift
+++ b/Scripts/spike-midi-region-drag-export.swift
@@ -1,0 +1,208 @@
+#!/usr/bin/env swift
+import CoreGraphics
+import Foundation
+
+struct JSONRecord: Encodable {
+    let record_type: String
+    let status: String
+    let export_dir: String?
+    let source: String?
+    let destination: String?
+    let path: String?
+    let note: String
+}
+
+struct Point {
+    let x: Double
+    let y: Double
+}
+
+func emit(_ record: JSONRecord) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(record),
+          let line = String(data: data, encoding: .utf8) else {
+        return
+    }
+    print(line)
+}
+
+func argumentValue(_ name: String) -> String? {
+    guard let index = CommandLine.arguments.firstIndex(of: name),
+          CommandLine.arguments.indices.contains(index + 1) else {
+        return nil
+    }
+    return CommandLine.arguments[index + 1]
+}
+
+func parsePoint(_ raw: String?) -> Point? {
+    guard let raw else { return nil }
+    let parts = raw.split(separator: ",", maxSplits: 1).map(String.init)
+    guard parts.count == 2,
+          let x = Double(parts[0]),
+          let y = Double(parts[1]) else {
+        return nil
+    }
+    return Point(x: x, y: y)
+}
+
+func pointLabel(_ point: Point?) -> String? {
+    guard let point else { return nil }
+    return "\(Int(point.x)),\(Int(point.y))"
+}
+
+func midiSnapshot(in directory: URL) -> [String: UInt64] {
+    let urls = (try? FileManager.default.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+        options: [.skipsHiddenFiles]
+    )) ?? []
+    var snapshot: [String: UInt64] = [:]
+    for url in urls where url.pathExtension.lowercased() == "mid" {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? NSNumber,
+              size.uint64Value > 0,
+              let modified = attrs[.modificationDate] as? Date else {
+            continue
+        }
+        snapshot[url.path] = UInt64(modified.timeIntervalSince1970 * 1_000_000_000)
+    }
+    return snapshot
+}
+
+func newestChangedMIDI(in directory: URL, before: [String: UInt64]) -> URL? {
+    let deadline = Date().addingTimeInterval(5)
+    while Date() < deadline {
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        let changed = urls.filter { url in
+            guard url.pathExtension.lowercased() == "mid",
+                  let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let size = attrs[.size] as? NSNumber,
+                  size.uint64Value > 0,
+                  let modified = attrs[.modificationDate] as? Date else {
+                return false
+            }
+            let nanos = UInt64(modified.timeIntervalSince1970 * 1_000_000_000)
+            return nanos > (before[url.path] ?? 0)
+        }
+        if let latest = changed.max(by: { left, right in
+            let leftDate = ((try? FileManager.default.attributesOfItem(atPath: left.path)[.modificationDate]) as? Date) ?? .distantPast
+            let rightDate = ((try? FileManager.default.attributesOfItem(atPath: right.path)[.modificationDate]) as? Date) ?? .distantPast
+            return leftDate < rightDate
+        }) {
+            return latest
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+    return nil
+}
+
+func postMouseDrag(from source: Point, to destination: Point) -> Bool {
+    let sourcePoint = CGPoint(x: source.x, y: source.y)
+    let destinationPoint = CGPoint(x: destination.x, y: destination.y)
+    guard let down = CGEvent(
+        mouseEventSource: nil,
+        mouseType: .leftMouseDown,
+        mouseCursorPosition: sourcePoint,
+        mouseButton: .left
+    ),
+        let up = CGEvent(
+            mouseEventSource: nil,
+            mouseType: .leftMouseUp,
+            mouseCursorPosition: destinationPoint,
+            mouseButton: .left
+        ) else {
+        return false
+    }
+    down.post(tap: .cghidEventTap)
+    for step in 1...30 {
+        let fraction = Double(step) / 30.0
+        let x = source.x + (destination.x - source.x) * fraction
+        let y = source.y + (destination.y - source.y) * fraction
+        CGEvent(
+            mouseEventSource: nil,
+            mouseType: .leftMouseDragged,
+            mouseCursorPosition: CGPoint(x: x, y: y),
+            mouseButton: .left
+        )?.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.02)
+    }
+    up.post(tap: .cghidEventTap)
+    return true
+}
+
+let exportDir = URL(
+    fileURLWithPath: argumentValue("--export-dir") ?? "/tmp/LogicProMCP-region-drag-spike"
+)
+let source = parsePoint(argumentValue("--source"))
+let destination = parsePoint(argumentValue("--destination"))
+let armed = ProcessInfo.processInfo.environment["LOGIC_PRO_MCP_ARM_REGION_DRAG"] == "1"
+
+try? FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+emit(JSONRecord(
+    record_type: "region_drag_preflight",
+    status: armed ? "armed" : "blocked",
+    export_dir: exportDir.path,
+    source: pointLabel(source),
+    destination: pointLabel(destination),
+    path: nil,
+    note: armed
+        ? "Armed live mouse drag. Use only with a scratch Logic project and verified source/destination coordinates."
+        : "Refusing live drag until LOGIC_PRO_MCP_ARM_REGION_DRAG=1 is set; this prevents accidental timeline mutation."
+))
+
+guard armed else { exit(2) }
+guard let source, let destination else {
+    emit(JSONRecord(
+        record_type: "region_drag_preflight",
+        status: "blocked",
+        export_dir: exportDir.path,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: nil,
+        note: "Both --source x,y and --destination x,y are required."
+    ))
+    exit(2)
+}
+
+let before = midiSnapshot(in: exportDir)
+guard postMouseDrag(from: source, to: destination) else {
+    emit(JSONRecord(
+        record_type: "region_drag_mouse",
+        status: "failed",
+        export_dir: exportDir.path,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: nil,
+        note: "CGEvent drag could not be constructed."
+    ))
+    exit(2)
+}
+
+if let exported = newestChangedMIDI(in: exportDir, before: before) {
+    emit(JSONRecord(
+        record_type: "region_drag_export_result",
+        status: "new_midi_found",
+        export_dir: exportDir.path,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: exported.path,
+        note: "Controlled file appeared. Parse and sentinel-equality verification must be performed before any State A claim."
+    ))
+    exit(0)
+}
+
+emit(JSONRecord(
+    record_type: "region_drag_export_result",
+    status: "no_midi_found",
+    export_dir: exportDir.path,
+    source: pointLabel(source),
+    destination: pointLabel(destination),
+    path: nil,
+    note: "No controlled .mid file appeared; if drag landed inside Logic, run Cmd+Z and verify scratch-project rollback."
+))
+exit(2)

--- a/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
@@ -191,6 +191,7 @@ struct Issue112CommandDeadlineTests {
         #expect(!((json(result)?["safe_to_retry"] as? Bool)!))
         #expect(!((json(result)?["underlying_operation_stopped"] as? Bool)!))
         #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { blocker.isCompleted() })
+        #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { gate.currentOperation() == nil })
 
         let afterDrain = await LogicProServer.runWithDeadline(
             tool: "logic_tracks",

--- a/docs/prd/PRD-midi-readback-vNext.md
+++ b/docs/prd/PRD-midi-readback-vNext.md
@@ -1,0 +1,145 @@
+# PRD: MIDI Read-Back vNext
+
+**Version**: 0.1
+**Author**: CEO/CTO planning rail (Fable role model, execution by Codex)
+**Date**: 2026-07-07
+**Status**: Draft-ready for ticket execution
+**Size**: L
+
+## 1. Problem Statement
+
+T5a shipped the reusable `SMFReader` and `ExportTemporaryFiles` foundation, but T5b remains honest-deferred. The proven menu path can reach `File > Export > Selection as MIDI File`, and `record_sequence` can create a sentinel MIDI region with region identity, but Logic's Save MIDI File panel is an out-of-process NSSavePanel remote view whose inner controls are AX-opaque and whose keyboard focus does not accept synthetic input (`docs/spikes/midi-export-t0-evidence.md:9`, `docs/spikes/midi-export-t0-evidence.md:13`, `docs/spikes/midi-export-t0-evidence.md:18`, `docs/spikes/midi-export-t0-evidence.md:20`, `docs/spikes/midi-export-t0-evidence.md:21`).
+
+The current repo therefore has a parser and private export-file registry, but no public `logic_midi.read_selection_notes` or `record_sequence verify_notes` State A surface. The release notes explicitly claim no public read-back command was shipped (`CHANGELOG.md:21`, `CHANGELOG.md:43`).
+
+## 2. Goals
+
+- Find at least one evidence-backed path that creates a controlled `.mid` artifact from the selected Logic region without the blocked NSSavePanel path.
+- Keep the State A rule strict: controlled file creation, `SMFReader` parse, sentinel equality, and selected-region identity must all pass.
+- Add `logic_midi.read_selection_notes` only after a live gate proves the selected-region export surface.
+- Add `record_sequence verify_notes:true` only after deterministic created-region selection and export read-back are proven.
+- Preserve the shipped v3.9.0 contract that no read-back command is claimed while the gate is unproven.
+
+## 3. Non-Goals
+
+- Do not weaken T5b into a "best effort" parser of uncontrolled exports.
+- Do not read arbitrary user `.mid` files through this feature; user-supplied import/read is a separate security surface.
+- Do not add a public resource for notes. Export/read-back is a side-effecting tool flow, not a read-only MCP resource.
+- Do not promote operator-assisted/manual flows to default automation without an explicit profile or CLI flag.
+
+## 4. Evidence Baseline
+
+- Working: export-menu navigation under the exact `Export` parent and the `Selection as MIDI File` child (`docs/spikes/midi-export-t0-evidence.md:9`, `docs/spikes/midi-export-t0-evidence.md:11`, `docs/spikes/midi-export-t0-evidence.md:12`).
+- Working: `record_sequence` sentinel import and `logic_project.get_regions` identity (`docs/spikes/midi-export-t0-evidence.md:13`).
+- Blocked: NSSavePanel inner controls expose no actionable AX elements (`docs/spikes/midi-export-t0-evidence.md:20`).
+- Blocked: synthetic keyboard input does not reach the panel, and mouse-only control cannot set a controlled directory/filename (`docs/spikes/midi-export-t0-evidence.md:21`, `docs/spikes/midi-export-t0-evidence.md:22`).
+- Operational risk: menu/panel automation can wedge Logic and require force-termination (`docs/spikes/midi-export-t0-evidence.md:23`).
+- Foundation: `SMFReader` supports format 0/1 and strict malformed-input errors (`Sources/LogicProMCP/MIDI/SMFReader.swift:29`, `Sources/LogicProMCP/MIDI/SMFReader.swift:35`, `Sources/LogicProMCP/MIDI/SMFReader.swift:41`, `Sources/LogicProMCP/MIDI/SMFReader.swift:127`).
+- Foundation: `ExportTemporaryFiles` creates private registered export files and cleans owned directories (`Sources/LogicProMCP/MIDI/ExportTemporaryFiles.swift:36`, `Sources/LogicProMCP/MIDI/ExportTemporaryFiles.swift:48`, `Sources/LogicProMCP/MIDI/ExportTemporaryFiles.swift:53`).
+
+## 5. State A Gate
+
+State A is forbidden unless all four conditions are true:
+
+1. The exported file path is pre-registered by `ExportTemporaryFiles`, absent before export, then present after export with positive size and fresh mtime.
+2. `SMFReader.parse` succeeds and returns no partial result on malformed data.
+3. The exported note set equals the sentinel/requested note set after tempo/time-signature normalization.
+4. The selected region identity captured before export matches the exported region identity or the deterministic created-region identity.
+
+Failure policy:
+
+- Missing controlled file: State C `controlled_export_unavailable`.
+- File exists but parse fails: State C `smf_parse_failed`.
+- Identity unavailable before export: State B `selection_identity_unverified`.
+- Notes mismatch: State C `readback_mismatch`.
+- Modal/menu recovery required: State C `logic_modal_recovery_required`, no retry loop.
+
+## 6. Candidate Surfaces
+
+### 6.1 Region Drag-to-Finder Export
+
+Hypothesis: dragging a selected MIDI region from Logic to a controlled Finder folder may create a `.mid` without the save panel. This is an unverified candidate.
+
+Spike: create a scratch project and sentinel region, open a controlled temp Finder window, capture region bounds, drag to the temp folder with mouse-only HID, assert one new `.mid` under the registered directory, parse and compare.
+
+Failure modes: region drag may create audio/alias/project data instead of MIDI; drag coordinates can hit the wrong region; Finder may rename files nondeterministically; **an errant drag that never leaves Logic's arrange area MOVES the region in the timeline — a destructive project mutation** (CTO). Recovery must close Finder, Escape any open menu/dialog, **and assert in-Logic rollback: Cmd+Z until the region's original position/identity reads back, and the scratch project is discarded without saving**. This candidate is scratch-project-only forever — never against a user project, even after activation (the production surface must create/duplicate its own export context).
+
+Priority: P0. It directly bypasses the blocked keyboard path while preserving controlled-directory evidence.
+
+### 6.2 Non-Panel Export Trigger
+
+Hypothesis: Logic may expose a key command, AppleScript/JXA menu command, Shortcuts action, or hidden export route that writes Selection-as-MIDI without presenting NSSavePanel. This is an unverified candidate.
+
+Spike: enumerate Logic Key Commands export actions, AppleScript dictionaries, and JXA menu events; attempt only read-only discovery first. Any write attempt must target a scratch project and `ExportTemporaryFiles` directory. **CTO note**: assigning a Logic key command is a manual operator step — Logic 12.2+ refuses programmatic key-command import (repo-established; `Scripts/install-keycmds.sh` documents the import refusal), so any keycmd-based route inherits the manual-validation/approval model and cannot be silently autonomous.
+
+Failure modes: key command still opens the same panel; AppleScript may only click the menu; Shortcuts may not expose Logic document export.
+
+Priority: P1. Lower fragility than drag if a real non-panel route exists.
+
+### 6.3 Operator-Assisted Controlled Export
+
+Hypothesis: an explicit operator-approved mode can ask the user to complete the save panel once while the server verifies the resulting file. This cannot be default automation.
+
+Spike: server pre-registers a target path and displays it in a CLI/human prompt; operator saves to that exact path; server watches for file creation, parses, and verifies sentinel equality.
+
+Failure modes: wrong path, wrong region, stale file, operator timeout. This must return State B/C unless the exact path and notes match.
+
+Priority: P2. Useful for power users, but not agent-autonomous.
+
+### 6.4 Logic Project/Package Event Reader
+
+Hypothesis: selected MIDI region data may be recoverable from `.logicx` package internals or existing project readers without exporting. This is an unverified candidate.
+
+Spike: on a scratch project with one sentinel region, save a copy, inspect package deltas and existing `LogicProjectFileReader` capabilities, and verify whether note events are accessible without private or unstable binary parsing.
+
+Failure modes: proprietary chunk format, compressed opaque data, no selected-region mapping, project save side effects.
+
+Priority: P1 if a stable package surface is found; otherwise defer.
+
+### 6.5 Lower-Level Logic/AU/CoreMIDI APIs
+
+Hypothesis: CoreMIDI, AU, or private Logic APIs may expose region contents. This is an unverified candidate and must not rely on private APIs in production without a separate distribution/security decision.
+
+Spike: read-only investigation only; no private API linking in production code during this epic.
+
+Priority: P3 unless public APIs prove sufficient.
+
+### 6.6 Future Logic Build Gate
+
+Hypothesis: a newer Logic build may expose the save panel or region export controls differently. This is a version-gated rerun of the T0 evidence, not an implementation ticket.
+
+Spike: rerun `Scripts/spike-midi-export.py` against the new Logic version and append evidence before any activation.
+
+Priority: ongoing gate.
+
+## 7. Product Surface
+
+When a State A surface is proven:
+
+- Add `logic_midi.read_selection_notes` routed through Accessibility.
+- Return HC envelope with `notes`, `selection_identity`, `export_evidence`, `smf_summary`, and `readback_source`.
+- Add `verify_notes: Bool = false` to `logic_tracks.record_sequence`.
+- Keep default `record_sequence` behavior unchanged when `verify_notes` is false.
+
+## 8. Ticket Board
+
+Execution tickets live under `docs/tickets/midi-readback-vNext/`:
+
+- T0: Region drag-to-Finder export spike.
+- T1: Project/package event-reader spike.
+- T2: Operator-assisted export contract.
+- T3: `read_selection_notes` implementation after a surface gate passes.
+- T4: `record_sequence verify_notes` integration after T3.
+
+Each implementation ticket is blocked until one T0/T1/T2 evidence gate produces a reproducible controlled export/read-back path.
+
+## 9. Manual QA Gate
+
+Manual QA requires a fresh scratch Logic project, a three-note sentinel region, a controlled temp export directory, and captured evidence showing no modal remains open after success or failure. A successful QA run must include both happy path and deliberate wrong-selection/wrong-file failure.
+
+## 10. Open Questions
+
+- Does region drag-to-Finder produce MIDI data or only arrange-region references?
+- Can Logic's own Key Commands assign an export target without opening NSSavePanel?
+- Is an operator-assisted mode acceptable as an explicitly non-default profile?
+- Are `.logicx` internals stable enough to justify a read-only parser, or does that cross into brittle reverse engineering?

--- a/docs/spikes/midi-region-drag-export-harness.md
+++ b/docs/spikes/midi-region-drag-export-harness.md
@@ -12,7 +12,7 @@ claim a State A selected-region read-back surface.
 - Script: `Scripts/spike-midi-region-drag-export.swift`
 - Default behavior: refuses to post mouse events unless
   `LOGIC_PRO_MCP_ARM_REGION_DRAG=1` is set.
-- Required armed arguments: `--source x,y`, `--destination x,y`, optional
+- Required armed arguments: `--source x,y`, `--destination x,y`, and explicit
   `--export-dir <path>`.
 - Controlled file gate: snapshots `.mid` files in the export directory before drag,
   then reports only a newly modified positive-size `.mid`.

--- a/docs/spikes/midi-region-drag-export-harness.md
+++ b/docs/spikes/midi-region-drag-export-harness.md
@@ -1,0 +1,73 @@
+# MIDI Region Drag Export Harness Evidence
+
+Date: 2026-07-07
+
+## Scope
+
+This adds a guarded live harness for `PRD-midi-readback-vNext` T0. It does **not**
+claim a State A selected-region read-back surface.
+
+## Harness
+
+- Script: `Scripts/spike-midi-region-drag-export.swift`
+- Default behavior: refuses to post mouse events unless
+  `LOGIC_PRO_MCP_ARM_REGION_DRAG=1` is set.
+- Required armed arguments: `--source x,y`, `--destination x,y`, optional
+  `--export-dir <path>`.
+- Controlled file gate: snapshots `.mid` files in the export directory before drag,
+  then reports only a newly modified positive-size `.mid`.
+
+## Verified Dry Run
+
+Command:
+
+```bash
+swift Scripts/spike-midi-region-drag-export.swift
+```
+
+Observed result:
+
+```json
+{"record_type":"region_drag_preflight","status":"blocked","note":"Refusing live drag until LOGIC_PRO_MCP_ARM_REGION_DRAG=1 is set; this prevents accidental timeline mutation."}
+```
+
+Exit code: `2` as expected for an unarmed hazardous operation.
+
+## Live Logic Rerun
+
+Command:
+
+```bash
+LOGIC_PRO_MCP_SPIKE_TIMEOUT=12 \
+LOGIC_PRO_MCP_MIDI_EXPORT_DIR=/tmp/LogicProMCP-spike-20260707 \
+LOGIC_PRO_MCP_MIDI_EXPORT_FILENAME=selection-20260707.mid \
+LOGIC_PRO_MCP_BINARY=.build/release/LogicProMCP \
+python3 Scripts/spike-midi-export.py
+```
+
+Observed result:
+
+- Logic Pro 12.3 was running with a visible scratch document.
+- The MCP server initialized and `logic://tracks` became readable.
+- `record_sequence` did not create the sentinel track in this run because the
+  MIDI import menu click failed before the file-open dialog appeared.
+- Failure class: `System Events` Apple-event permission denied (`-1743`) from
+  this harness launch context.
+- Export menu enumeration also failed with the same permission denial, so no
+  controlled `.mid` artifact was created.
+- Cleanup observed no newly-created track from this run.
+
+Verdict: **gate failed**. This rerun proves the current launch context cannot
+drive the import/export menu path. It does not satisfy the controlled export +
+`SMFReader` + sentinel-equality State A gate.
+
+## Remaining Gate
+
+Live Logic QA is still required before T3/T4 can start:
+
+- scratch project only
+- known sentinel MIDI region
+- verified source/destination screen coordinates
+- post-drag `.mid` parse via `SMFReader`
+- sentinel equality
+- in-Logic rollback verification if no controlled file appears

--- a/docs/tickets/midi-readback-vNext/STATUS.md
+++ b/docs/tickets/midi-readback-vNext/STATUS.md
@@ -1,0 +1,49 @@
+# Pipeline Status: MIDI Read-Back vNext
+
+**PRD**: `docs/prd/PRD-midi-readback-vNext.md`
+**Status**: Gate harness added; live State-A proof failed in current launch context
+**Execution rule**: no implementation ticket may start until one evidence gate proves a controlled selected-region read-back path.
+
+## Tickets
+
+| Ticket | Title | Status | Gate |
+|--------|-------|--------|------|
+| T0 | Region drag-to-Finder export spike | Harness dry-run verified | Live controlled export evidence |
+| T1 | Logic project/package event-reader spike | Todo | Saved scratch project note equality |
+| T2 | Operator-assisted export contract | Todo | Explicit non-default profile decision + exact-path proof |
+| T3 | `logic_midi.read_selection_notes` implementation | Blocked | T0 or T1 or T2 PASS |
+| T4 | `record_sequence verify_notes` integration | Blocked | T3 PASS |
+
+## Dependency Graph
+
+```text
+T0 ┐
+T1 ├─> T3 -> T4
+T2 ┘
+```
+
+## Evidence Gate
+
+State A requires:
+
+- registered controlled `.mid` path
+- newly created file with positive size and fresh mtime
+- `SMFReader.parse` success
+- sentinel/requested notes equality
+- selected-region or created-region identity captured
+- no leftover Logic modal/menu
+
+## Current Evidence
+
+- `Scripts/spike-midi-region-drag-export.swift` refuses hazardous live mouse drag unless `LOGIC_PRO_MCP_ARM_REGION_DRAG=1` is set.
+- Dry run verified on 2026-07-07: unarmed execution emits `record_type:"region_drag_preflight"`, `status:"blocked"` and exits `2`.
+- Live rerun on 2026-07-07: `Scripts/spike-midi-export.py` initialized the MCP server and read `logic://tracks`, but `record_sequence` failed before sentinel import because this harness launch context cannot send Apple events to `System Events` (`-1743`). Export menu enumeration failed for the same reason, so no controlled `.mid` artifact was created.
+- No live controlled `.mid` export evidence has been captured yet, so T3/T4 remain blocked.
+
+## Verification
+
+- Unit: Red tests named in each ticket; FAIL-verified before implementation; no dead-`#expect` forms (repo footgun #92).
+- Integration: scratch-project spike scripts.
+- Manual QA: live Logic 12.3 happy path plus deliberate failure path.
+- Review: **cumulative review on every ticket completion (T(n-1)+T(n) diff + full `swift test --no-parallel`)**; full cumulative review before T3; final QA review before public docs/API claim.
+- Safety: all spikes scratch-project-only; T0 drag additionally requires in-Logic rollback assertion (ticket AC) — never a user project.

--- a/docs/tickets/midi-readback-vNext/T0-region-drag-export-spike.md
+++ b/docs/tickets/midi-readback-vNext/T0-region-drag-export-spike.md
@@ -1,0 +1,40 @@
+# T0: Region Drag-to-Finder Export Spike
+
+**PRD Ref**: `PRD-midi-readback-vNext` §6.1
+**Priority**: P0
+**Status**: Harness dry-run verified; live gate pending
+**Depends On**: None
+
+## Objective
+
+Prove or reject the mouse-only region drag export path as a way to bypass the blocked NSSavePanel. The prior T0 proved the save panel cannot be driven by AX or synthetic keyboard input (`docs/spikes/midi-export-t0-evidence.md:18`, `docs/spikes/midi-export-t0-evidence.md:21`).
+
+## Acceptance Criteria
+
+- [ ] A scratch project creates a sentinel MIDI region through `record_sequence`.
+- [ ] A controlled temp Finder folder is opened from a registered `ExportTemporaryFiles` directory.
+- [ ] Dragging the selected MIDI region into Finder creates exactly one new `.mid` file under that directory.
+- [ ] `SMFReader.parse` returns notes equal to the sentinel.
+- [ ] Failure leaves no open Logic menu/dialog and does not modify user projects.
+- [ ] **In-Logic errant-drag rollback (CTO)**: if the drag terminates inside the arrange area (region MOVED — destructive mutation), the spike asserts Cmd+Z rollback until the region's original position/identity reads back, and the scratch project is closed WITHOUT saving. Evidence records the rollback assertion outcome.
+- [ ] **Preconditions verified before any drag**: Accessibility + PostEvent granted (`doctor` pass), Logic frontmost, scratch project confirmed as the active document (never a user project — assert window title/document identity).
+- [ ] Evidence file records screen geometry, pre/post directory listing, parsed notes, and recovery outcome.
+
+## Risk (CTO)
+
+Mouse-drag is the only candidate that can mutate the arrange timeline on failure — treat every non-Finder drop as destructive until rollback is proven. Scratch-only forever (PRD §6.1).
+
+## Red Tests
+
+- `regionDragRejectsUnregisteredDestination`
+- `regionDragStateCWhenNoNewFile`
+- `regionDragStateCWhenParsedNotesMismatch`
+- `regionDragRecoverySendsEscapeOnOpenMenu`
+
+## Implementation Boundary
+
+Spike script only, likely `Scripts/spike-midi-region-drag-export.py`, plus evidence under `docs/spikes/`. No production `Sources/` changes.
+
+## Manual QA Gate
+
+Run against a fresh scratch project. Capture a success or explicit gate-failed transcript.

--- a/docs/tickets/midi-readback-vNext/T1-project-package-event-reader-spike.md
+++ b/docs/tickets/midi-readback-vNext/T1-project-package-event-reader-spike.md
@@ -1,0 +1,32 @@
+# T1: Logic Project/Package Event-Reader Spike
+
+**PRD Ref**: `PRD-midi-readback-vNext` §6.4
+**Priority**: P1
+**Status**: Todo
+**Depends On**: None
+
+## Objective
+
+Determine whether saved `.logicx` project/package data can expose MIDI note events for a known sentinel region without invoking Logic's export panel.
+
+## Acceptance Criteria
+
+- [ ] Create a scratch project with a single known MIDI sentinel region.
+- [ ] Save a copy and inspect only that scratch package.
+- [ ] Document whether note events, region identity, tempo map, and track mapping are recoverable.
+- [ ] If recoverable, define a read-only parser boundary with no partial-result success.
+- [ ] If not recoverable, record why the package surface is opaque or too unstable.
+
+## Red Tests
+
+- `logicProjectReaderRejectsUnknownChunk`
+- `logicProjectReaderDoesNotReturnPartialNotes`
+- `logicProjectReaderRequiresRegionIdentity`
+
+## Implementation Boundary
+
+Read-only spike and optional parser prototype. Do not alter production `LogicProjectFileReader` until evidence proves a stable format.
+
+## Manual QA Gate
+
+Evidence must include before/after package diff inventory and the exact parsed sentinel comparison.

--- a/docs/tickets/midi-readback-vNext/T2-operator-assisted-export-contract.md
+++ b/docs/tickets/midi-readback-vNext/T2-operator-assisted-export-contract.md
@@ -1,0 +1,33 @@
+# T2: Operator-Assisted Export Contract
+
+**PRD Ref**: `PRD-midi-readback-vNext` §6.3
+**Priority**: P2
+**Status**: Todo
+**Depends On**: None
+
+## Objective
+
+Design and prove an explicitly non-default flow where a human operator saves Logic's export panel to a server-registered target path while the server verifies the resulting file.
+
+## Acceptance Criteria
+
+- [ ] The flow is disabled by default and requires an explicit profile/flag.
+- [ ] The server pre-registers the exact output path and rejects stale files.
+- [ ] Timeout, wrong path, wrong region, and parse failure return State B/C, never State A.
+- [ ] Human-facing instructions are concise and do not expose unrelated local paths.
+- [ ] The flow does not become part of normal autonomous agent readiness.
+
+## Red Tests
+
+- `operatorExportRequiresExplicitProfile`
+- `operatorExportRejectsStaleFile`
+- `operatorExportStateCOnWrongPath`
+- `operatorExportStateBWhenSelectionIdentityMissing`
+
+## Implementation Boundary
+
+Contract design plus spike harness. Production surface must wait for an explicit product decision because this introduces human-in-the-loop behavior.
+
+## Manual QA Gate
+
+One success with exact path and one failure with wrong path.

--- a/docs/tickets/midi-readback-vNext/T3-read-selection-notes-implementation.md
+++ b/docs/tickets/midi-readback-vNext/T3-read-selection-notes-implementation.md
@@ -1,0 +1,40 @@
+# T3: `logic_midi.read_selection_notes`
+
+**PRD Ref**: `PRD-midi-readback-vNext` §7
+**Priority**: P0 after any evidence gate PASS
+**Status**: Blocked
+**Depends On**: T0 or T1 or T2 PASS
+
+## Objective
+
+Implement the public selected-region note read-back command only after a controlled export/read surface is proven.
+
+## Acceptance Criteria
+
+- [ ] Add `logic_midi.read_selection_notes` with Accessibility routing.
+- [ ] Return HC State A only when controlled file, parse, note equality, and identity gates pass.
+- [ ] **Note-equality rule pinned (CTO)**: equality = pitch + velocity + onset + duration per note after PPQ/tempo normalization only (tick-resolution scaling between the sentinel spec and the exported SMF division). **No tolerance on note identity** — normalization affects tick math, never which notes exist. The exact normalization mapping is written into this ticket's red tests from the winning T0/T1/T2 evidence artifact before implementation starts.
+- [ ] Return typed State B/C for no selection, non-MIDI selection, identity unavailable, modal recovery, parse failure, and note mismatch.
+- [ ] Include `notes`, `selection_identity`, `smf_summary`, and `readback_source` in the response.
+- [ ] Update docs/API and CHANGELOG only after live PASS evidence exists.
+
+## Red Tests
+
+- `readSelectionNotesStateAWhenSurfaceGatePasses`
+- `readSelectionNotesStateBWhenIdentityUnavailable`
+- `readSelectionNotesStateCWhenNoMidiSelection`
+- `readSelectionNotesStateCWhenControlledFileMissing`
+- `readSelectionNotesDoesNotClaimStateAOnParseFailure`
+
+## Implementation Boundary
+
+Likely files:
+
+- `Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift`
+- `Sources/LogicProMCP/Channels/RoutingTable.swift`
+- new Accessibility helper for the proven surface
+- `Tests/LogicProMCPTests/MIDIReadSelectionTests.swift`
+
+## Manual QA Gate
+
+Scratch project with known sentinel region, happy path plus no-selection failure.

--- a/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
+++ b/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
@@ -1,0 +1,38 @@
+# T4: `record_sequence verify_notes`
+
+**PRD Ref**: `PRD-midi-readback-vNext` §7
+**Priority**: P1 after T3
+**Status**: Blocked
+**Depends On**: T3
+
+## Objective
+
+Add optional note-level verification to `record_sequence` without changing the default import behavior.
+
+## Acceptance Criteria
+
+- [ ] `verify_notes` defaults to false and keeps current response behavior unchanged.
+- [ ] When true, `record_sequence` captures pre-state, creates/imports a region, deterministically selects the created region, exports/reads it through the T3 surface, and compares notes.
+- [ ] Selection failure returns State B before export attempt.
+- [ ] Note mismatch returns State C with expected/observed summary.
+- [ ] Previous selection/playhead restoration is attempted and reported.
+
+## Red Tests
+
+- `recordSequenceVerifyNotesDefaultFalseIsBackwardCompatible`
+- `recordSequenceVerifyNotesStateAOnExactReadback`
+- `recordSequenceVerifyNotesStateBWhenCreatedRegionNotSelectable`
+- `recordSequenceVerifyNotesStateCOnMismatch`
+- `recordSequenceVerifyNotesRestoresPreviousSelectionBestEffort`
+
+## Implementation Boundary
+
+Likely files:
+
+- `Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift`
+- selected-region helper from T3
+- focused dispatcher tests and one live E2E case
+
+## Manual QA Gate
+
+Fresh scratch project, `verify_notes:true` happy path, then deliberate note mismatch fixture.


### PR DESCRIPTION
## Summary
- adds the MIDI readback vNext PRD and implementation ticket set
- adds a region-drag/export spike harness with an explicit arming gate so accidental timeline mutation is prevented
- records the latest live Logic rerun evidence and keeps production implementation tickets blocked until State A evidence is achieved
- fixes the CI race in the shared deadline-gate regression test by waiting for the mutation gate to drain before asserting the next operation

## Verification
- `swift test --filter Issue112CommandDeadlineTests --disable-xctest --parallel` => 14 tests passed
- `swift build -c release`
- `swift Scripts/spike-midi-region-drag-export.swift --export-dir /tmp/LogicProMCP-region-drag-spike-check` => expected safe preflight block, exit 2
- `git diff --check`
- Live Logic rerun: MCP initialized and `logic://tracks` was readable, but `record_sequence` could not complete because System Events Apple events were denied in the current launch context (`-1743`). No controlled MIDI export artifact was produced.

## Gate Status
This PR intentionally does not enable MIDI readback as production-ready. It adds the live gate, docs, and harness; T3/T4 remain blocked until a scratch Logic project proves export/readback end-to-end against actual Logic state.