### PR TITLE
docs(plugins): add Channel EQ vNext live gate harness

### DIFF
--- a/Scripts/spike-channel-eq-au-census.swift
+++ b/Scripts/spike-channel-eq-au-census.swift
@@ -66,11 +66,10 @@ func enumerateParameters(
     name: String,
     description: AudioComponentDescription
 ) {
-    var unit: AudioUnit?
-    guard AudioComponentInstanceNew(component, &unit) == noErr, let unit else {
+    func emitComponentStatus(_ status: String, note: String) {
         emit(JSONRecord(
             record_type: "channel_eq_au_component",
-            status: "instantiate_failed",
+            status: status,
             component_name: name,
             component_type: fourCC(description.componentType),
             component_subtype: fourCC(description.componentSubType),
@@ -84,8 +83,16 @@ func enumerateParameters(
             flags: nil,
             provenance: "factory_metadata",
             activation_evidence: false,
-            note: "Factory metadata cannot prove active Logic insert write/read-back."
+            note: note
         ))
+    }
+
+    var unit: AudioUnit?
+    guard AudioComponentInstanceNew(component, &unit) == noErr, let unit else {
+        emitComponentStatus(
+            "instantiate_failed",
+            note: "Factory metadata cannot prove active Logic insert write/read-back."
+        )
         return
     }
     defer { AudioComponentInstanceDispose(unit) }
@@ -101,40 +108,53 @@ func enumerateParameters(
         &writable
     )
     guard infoStatus == noErr, byteSize > 0 else {
-        emit(JSONRecord(
-            record_type: "channel_eq_au_component",
-            status: "no_parameter_list",
-            component_name: name,
-            component_type: fourCC(description.componentType),
-            component_subtype: fourCC(description.componentSubType),
-            component_manufacturer: fourCC(description.componentManufacturer),
-            parameter_id: nil,
-            parameter_name: nil,
-            min_value: nil,
-            max_value: nil,
-            default_value: nil,
-            unit: nil,
-            flags: nil,
-            provenance: "factory_metadata",
-            activation_evidence: false,
+        emitComponentStatus(
+            "no_parameter_list",
             note: "No active Logic insert handle was obtained."
-        ))
+        )
+        return
+    }
+
+    let parameterIDStride = UInt32(MemoryLayout<AudioUnitParameterID>.stride)
+    guard byteSize % parameterIDStride == 0 else {
+        emitComponentStatus(
+            "parameter_list_size_mismatch",
+            note: "AudioUnit parameter list reported \(byteSize) bytes, not a whole AudioUnitParameterID count."
+        )
         return
     }
 
     var parameterIDs = [AudioUnitParameterID](
         repeating: 0,
-        count: Int(byteSize) / MemoryLayout<AudioUnitParameterID>.size
+        count: Int(byteSize / parameterIDStride)
     )
     var listSize = byteSize
-    guard AudioUnitGetProperty(
-        unit,
-        kAudioUnitProperty_ParameterList,
-        kAudioUnitScope_Global,
-        0,
-        &parameterIDs,
-        &listSize
-    ) == noErr else {
+    let listStatus = parameterIDs.withUnsafeMutableBufferPointer { buffer in
+        guard let baseAddress = buffer.baseAddress else {
+            return OSStatus(-50)
+        }
+        return AudioUnitGetProperty(
+            unit,
+            kAudioUnitProperty_ParameterList,
+            kAudioUnitScope_Global,
+            0,
+            baseAddress,
+            &listSize
+        )
+    }
+    guard listStatus == noErr else {
+        emitComponentStatus(
+            "parameter_list_read_failed",
+            note: "AudioUnitGetProperty(kAudioUnitProperty_ParameterList) failed with OSStatus \(listStatus)."
+        )
+        return
+    }
+    guard listSize % parameterIDStride == 0,
+          Int(listSize / parameterIDStride) == parameterIDs.count else {
+        emitComponentStatus(
+            "parameter_list_size_mismatch",
+            note: "AudioUnit parameter list returned \(listSize) bytes for \(parameterIDs.count) allocated ids."
+        )
         return
     }
 

--- a/Scripts/spike-channel-eq-au-census.swift
+++ b/Scripts/spike-channel-eq-au-census.swift
@@ -1,0 +1,218 @@
+#!/usr/bin/env swift
+import AudioToolbox
+import Foundation
+
+struct JSONRecord: Encodable {
+    let record_type: String
+    let status: String
+    let component_name: String?
+    let component_type: String?
+    let component_subtype: String?
+    let component_manufacturer: String?
+    let parameter_id: UInt32?
+    let parameter_name: String?
+    let min_value: Float?
+    let max_value: Float?
+    let default_value: Float?
+    let unit: UInt32?
+    let flags: UInt32?
+    let provenance: String
+    let activation_evidence: Bool
+    let note: String
+}
+
+func emit(_ record: JSONRecord) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(record),
+          let line = String(data: data, encoding: .utf8) else {
+        return
+    }
+    print(line)
+}
+
+func fourCC(_ value: OSType) -> String {
+    let bytes = [
+        UInt8((value >> 24) & 0xff),
+        UInt8((value >> 16) & 0xff),
+        UInt8((value >> 8) & 0xff),
+        UInt8(value & 0xff),
+    ]
+    return String(bytes: bytes, encoding: .macOSRoman) ?? "\(value)"
+}
+
+func componentName(_ component: AudioComponent) -> String {
+    var cfName: Unmanaged<CFString>?
+    let status = AudioComponentCopyName(component, &cfName)
+    guard status == noErr, let cfName else {
+        return "<unnamed>"
+    }
+    return cfName.takeRetainedValue() as String
+}
+
+func parameterName(_ info: AudioUnitParameterInfo) -> String {
+    if let cfName = info.cfNameString {
+        return cfName.takeUnretainedValue() as String
+    }
+    return withUnsafePointer(to: info.name) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: 52) {
+            String(cString: $0)
+        }
+    }
+}
+
+func enumerateParameters(
+    component: AudioComponent,
+    name: String,
+    description: AudioComponentDescription
+) {
+    var unit: AudioUnit?
+    guard AudioComponentInstanceNew(component, &unit) == noErr, let unit else {
+        emit(JSONRecord(
+            record_type: "channel_eq_au_component",
+            status: "instantiate_failed",
+            component_name: name,
+            component_type: fourCC(description.componentType),
+            component_subtype: fourCC(description.componentSubType),
+            component_manufacturer: fourCC(description.componentManufacturer),
+            parameter_id: nil,
+            parameter_name: nil,
+            min_value: nil,
+            max_value: nil,
+            default_value: nil,
+            unit: nil,
+            flags: nil,
+            provenance: "factory_metadata",
+            activation_evidence: false,
+            note: "Factory metadata cannot prove active Logic insert write/read-back."
+        ))
+        return
+    }
+    defer { AudioComponentInstanceDispose(unit) }
+
+    var byteSize: UInt32 = 0
+    var writable = DarwinBoolean(false)
+    let infoStatus = AudioUnitGetPropertyInfo(
+        unit,
+        kAudioUnitProperty_ParameterList,
+        kAudioUnitScope_Global,
+        0,
+        &byteSize,
+        &writable
+    )
+    guard infoStatus == noErr, byteSize > 0 else {
+        emit(JSONRecord(
+            record_type: "channel_eq_au_component",
+            status: "no_parameter_list",
+            component_name: name,
+            component_type: fourCC(description.componentType),
+            component_subtype: fourCC(description.componentSubType),
+            component_manufacturer: fourCC(description.componentManufacturer),
+            parameter_id: nil,
+            parameter_name: nil,
+            min_value: nil,
+            max_value: nil,
+            default_value: nil,
+            unit: nil,
+            flags: nil,
+            provenance: "factory_metadata",
+            activation_evidence: false,
+            note: "No active Logic insert handle was obtained."
+        ))
+        return
+    }
+
+    var parameterIDs = [AudioUnitParameterID](
+        repeating: 0,
+        count: Int(byteSize) / MemoryLayout<AudioUnitParameterID>.size
+    )
+    var listSize = byteSize
+    guard AudioUnitGetProperty(
+        unit,
+        kAudioUnitProperty_ParameterList,
+        kAudioUnitScope_Global,
+        0,
+        &parameterIDs,
+        &listSize
+    ) == noErr else {
+        return
+    }
+
+    for parameterID in parameterIDs {
+        var parameterInfo = AudioUnitParameterInfo()
+        var parameterInfoSize = UInt32(MemoryLayout<AudioUnitParameterInfo>.size)
+        guard AudioUnitGetProperty(
+            unit,
+            kAudioUnitProperty_ParameterInfo,
+            kAudioUnitScope_Global,
+            parameterID,
+            &parameterInfo,
+            &parameterInfoSize
+        ) == noErr else {
+            continue
+        }
+        emit(JSONRecord(
+            record_type: "channel_eq_au_parameter",
+            status: "factory_metadata_only",
+            component_name: name,
+            component_type: fourCC(description.componentType),
+            component_subtype: fourCC(description.componentSubType),
+            component_manufacturer: fourCC(description.componentManufacturer),
+            parameter_id: parameterID,
+            parameter_name: parameterName(parameterInfo),
+            min_value: parameterInfo.minValue,
+            max_value: parameterInfo.maxValue,
+            default_value: parameterInfo.defaultValue,
+            unit: parameterInfo.unit.rawValue,
+            flags: parameterInfo.flags.rawValue,
+            provenance: "factory_metadata",
+            activation_evidence: false,
+            note: "Candidate id/range only; production activation still requires active Logic insert write/read-back evidence."
+        ))
+    }
+}
+
+var description = AudioComponentDescription(
+    componentType: kAudioUnitType_Effect,
+    componentSubType: 0,
+    componentManufacturer: 0,
+    componentFlags: 0,
+    componentFlagsMask: 0
+)
+
+var found = 0
+var current: AudioComponent?
+while true {
+    current = AudioComponentFindNext(current, &description)
+    guard let component = current else { break }
+    var actualDescription = AudioComponentDescription()
+    guard AudioComponentGetDescription(component, &actualDescription) == noErr else {
+        continue
+    }
+    let name = componentName(component)
+    let lower = name.lowercased()
+    guard lower.contains("channel eq") || lower.contains("nband") || lower.contains("aunbandeq") else {
+        continue
+    }
+    found += 1
+    enumerateParameters(component: component, name: name, description: actualDescription)
+}
+
+emit(JSONRecord(
+    record_type: "channel_eq_au_census_summary",
+    status: found > 0 ? "factory_metadata_only" : "missing",
+    component_name: nil,
+    component_type: nil,
+    component_subtype: nil,
+    component_manufacturer: nil,
+    parameter_id: nil,
+    parameter_name: nil,
+    min_value: nil,
+    max_value: nil,
+    default_value: nil,
+    unit: nil,
+    flags: nil,
+    provenance: "factory_metadata",
+    activation_evidence: false,
+    note: "This spike never attaches to Logic's active hosted insert; it cannot activate registry entries by itself."
+))

--- a/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
+++ b/Tests/LogicProMCPTests/Issue112CommandDeadlineTests.swift
@@ -191,6 +191,7 @@ struct Issue112CommandDeadlineTests {
         #expect(!((json(result)?["safe_to_retry"] as? Bool)!))
         #expect(!((json(result)?["underlying_operation_stopped"] as? Bool)!))
         #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { blocker.isCompleted() })
+        #expect(try await waitUntil(timeoutNanoseconds: 1_000_000_000) { gate.currentOperation() == nil })
 
         let afterDrain = await LogicProServer.runWithDeadline(
             tool: "logic_tracks",

--- a/docs/prd/PRD-channel-eq-verified-params-vNext.md
+++ b/docs/prd/PRD-channel-eq-verified-params-vNext.md
@@ -1,0 +1,133 @@
+# PRD: Channel EQ Verified Params + rename_marker vNext
+
+**Version**: 0.1
+**Author**: CEO/CTO planning rail (Fable role model, execution by Codex)
+**Date**: 2026-07-07
+**Status**: Draft-ready for ticket execution
+**Size**: L
+
+## 1. Problem Statement
+
+Channel EQ insertion is live-verified, but Channel EQ parameter read/write is not. The live census proved `logic_plugins.insert_verified "Channel EQ"` reaches State A, and the plugin editor opens with view-mode controls (`docs/spikes/channel-eq-census.md:18`, `docs/spikes/channel-eq-census.md:20`, `docs/spikes/channel-eq-census.md:21`). It also proved that the Editor view exposes only a custom AX canvas, the Controls view returns zero traversable elements, and no per-band slider/value read-back is reachable via standard GUI AX (`docs/spikes/channel-eq-census.md:25`, `docs/spikes/channel-eq-census.md:27`, `docs/spikes/channel-eq-census.md:28`).
+
+The current verified-param path only activates Compressor `threshold`; other params fail closed as `unsupported_param_readback` (`docs/spikes/channel-eq-census.md:29`, `Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift:508`, `Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift:510`). The stock catalog keeps Channel EQ insert-only and explicitly says the parameter registry is census-gated (`Sources/LogicProMCP/Plugins/StockPluginCatalog.swift:891`, `Sources/LogicProMCP/Plugins/StockPluginCatalog.swift:895`, `Sources/LogicProMCP/Plugins/StockPluginCatalog.swift:896`).
+
+`rename_marker` is similarly honest-deferred. The dispatcher validates index/name, routes `nav.rename_marker`, but the API docs and spike state that Logic 12.x has no verified AX text-edit path and returns State C `not_implemented` (`Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift:157`, `Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift:173`, `docs/API.md:170`, `docs/spikes/channel-eq-census.md:47`, `docs/spikes/channel-eq-census.md:49`).
+
+## 2. Goals
+
+- Find a non-GUI-AX or version-gated GUI path that can produce a real Channel EQ parameter census.
+- Activate Channel EQ parameters only from measured canonical id, source, unit, range, tolerance, write method, and read-back method.
+- Keep unknown Channel EQ params fail-closed with `unsupported_param_readback`.
+- Prove or reject a `rename_marker` State A path with marker identity, editable surface, write, read-back, and rollback.
+
+## 3. Non-Goals
+
+- Do not infer Channel EQ band ids, units, ranges, or tolerances from UI labels alone.
+- Do not register inert/TODO params as production-writable.
+- Do not use visual pixel matching as a read-back source.
+- Do not change marker rename from `not_implemented` unless a live write/read-back/rollback gate passes.
+
+## 4. Non-Negotiable Gates
+
+### Channel EQ State A Gate
+
+No registry activation without a census artifact containing:
+
+- canonical plugin id and parameter id
+- source surface (`audio_unit_api`, `automation_lane`, `preset_roundtrip`, `control_surface_feedback`, or `gui_ax`)
+- unit and value range
+- write method and read-back method
+- tolerance and normalization mapping
+- Logic version and locale
+- live write/read-back proof on a duplicate/scratch project
+
+### rename_marker State A Gate
+
+No implementation without:
+
+- marker list/global-track surface visible
+- marker identity captured before write
+- AX or other deterministic editable text path
+- post-write marker list read-back
+- rollback to original marker name with read-back
+
+## 5. Candidate Surfaces
+
+### 5.1 AudioUnit Parameter API
+
+Hypothesis: Channel EQ parameters may be enumerated and read/written through AU parameter APIs rather than Logic's hosted GUI. This is an unverified candidate.
+
+Main risk: the plugin instance lives inside Logic's process; an external MCP process may not get an `AudioUnit` handle to the loaded insert. If only standalone AU factory metadata is available, it can inform ids/ranges but not prove write/read-back against Logic's active instance.
+
+Priority: P0, because the spike evidence names AU parameter enumeration as the most promising non-GUI path (`docs/spikes/channel-eq-census.md:42`, `docs/spikes/channel-eq-census.md:44`).
+
+### 5.2 Plugin Automation Parameter Surface
+
+Hypothesis: Logic automation lanes may expose plugin parameters with readable names and values even when the plugin window is AX-opaque. This is an unverified candidate.
+
+Risk: automation lane writes may alter project automation data rather than current plugin state; read-back may be lane text rather than parameter value. Must use a scratch duplicate and rollback/delete automation.
+
+Priority: P1.
+
+### 5.3 Logic Project / Preset State Introspection
+
+Hypothesis: saving a Channel EQ setting, plugin preset, or scratch project could expose parameter state in `.aupreset`, plist, or package data.
+
+Risk: preset save may invoke another modal save panel; project chunks may be opaque; values may be serialized but not tied to selected track/insert identity. **CTO cross-reference**: Logic's save panels are the same AX-opaque remote-view class that blocked MIDI export (`docs/spikes/midi-export-t0-evidence.md` — NSSavePanel wall; see `PRD-midi-readback-vNext` §1). Do NOT re-discover this wall — the preset-save spike must first check whether the preset save path presents that panel class, and if so, either reuse the MIDI epic's non-panel findings or route around it (e.g. Logic's channel-strip-setting save that writes to a known directory without a panel, if proven).
+
+Priority: P1 for read-only census, P2 for write/read-back.
+
+### 5.4 Control-Surface / MIDI Feedback
+
+Hypothesis: Logic's control-surface parameter pages may expose Channel EQ values through MCU/OSC feedback.
+
+Risk: plugin parameter page focus and banking are nondeterministic; feedback may be display text rather than exact numeric read-back; writes may require controller assignment state.
+
+Priority: P2.
+
+### 5.5 GUI AX Only-If-Proven
+
+Hypothesis: a future Logic version, a different host context, or a specific view mode may expose per-band controls.
+
+Gate: rerun the census script; activation remains forbidden unless the artifact contains actual `AXSlider`/value elements and write/read-back proof.
+
+Priority: continuous version gate.
+
+### 5.6 rename_marker Marker-List Surface
+
+Hypothesis: Marker List or the global Marker track may provide an editable text field with post-write read-back.
+
+Spike: show Marker global track/list, create a scratch marker, capture marker list before state, attempt rename in a duplicate/scratch project, read back list, rollback original name.
+
+Priority: P1. If the list remains empty or no editable text path appears, keep `not_implemented`.
+
+## 6. Product Surface
+
+Channel EQ activation extends the existing `logic_plugins.set_param_verified` contract. It must not add a parallel API unless the verified-param model cannot represent the proven surface.
+
+`rename_marker` keeps its existing command name and validation rules. If implemented, it returns HC State A only after marker read-back; otherwise it remains State C `not_implemented`.
+
+## 7. Ticket Board
+
+Execution tickets live under `docs/tickets/channel-eq-verified-params-vNext/`:
+
+- T0: AudioUnit parameter API census spike.
+- T1: Preset/project-state census spike.
+- T2: Control-surface/automation feedback spike.
+- T3: Channel EQ registry activation after a census gate passes.
+- T4: `rename_marker` live gate and optional implementation split.
+
+## 8. Testing Strategy
+
+- Unit: registry lookup, canonical id aliases, tolerance math, unsupported param fail-closed.
+- Integration: mock write/read-back surface for the proven method.
+- Live E2E: one Channel EQ State A write/read-back case on a scratch duplicate; one unsupported param State C case.
+- Marker E2E: scratch marker rename, read-back, rollback, and no-marker failure.
+
+## 9. Open Questions
+
+- Can the external process obtain active Logic insert parameter handles, or only factory metadata?
+- Does Logic automation lane text expose exact numeric values or display-only labels?
+- Can preset save/export be driven without another blocked save panel?
+- Does Marker List become AX-editable only when a specific global track/list window is open?

--- a/docs/spikes/channel-eq-au-factory-metadata.md
+++ b/docs/spikes/channel-eq-au-factory-metadata.md
@@ -1,0 +1,70 @@
+# Channel EQ AudioUnit Factory Metadata Spike
+
+Date: 2026-07-07
+
+## Scope
+
+This adds a public AudioUnit metadata census script for
+`PRD-channel-eq-verified-params-vNext` T0. It deliberately does **not** activate
+Channel EQ verified params because the script cannot attach to Logic's active
+hosted insert.
+
+## Harness
+
+- Script: `Scripts/spike-channel-eq-au-census.swift`
+- API: `AudioComponentFindNext`, `AudioComponentInstanceNew`,
+  `kAudioUnitProperty_ParameterList`, `kAudioUnitProperty_ParameterInfo`
+- Provenance emitted for every parameter: `factory_metadata`
+- Activation flag emitted for every parameter: `activation_evidence:false`
+
+## Verified Smoke
+
+Command:
+
+```bash
+swift Scripts/spike-channel-eq-au-census.swift
+```
+
+Observed:
+
+- Apple `AUNBandEQ` was found.
+- Parameter ids/ranges/names were emitted.
+- Every record was marked `factory_metadata_only`.
+- Summary explicitly stated this cannot activate registry entries by itself.
+
+## Product Decision
+
+Factory metadata may seed candidate ids/ranges for a future live census artifact,
+but it is not State A evidence. T3 remains blocked until an active Logic insert
+write/read-back surface exists.
+
+## Live Logic AX Rerun
+
+Command:
+
+```bash
+LOGIC_PRO_MCP_CHANNEL_EQ_CENSUS_TIMEOUT=12 \
+LOGIC_PRO_MCP_BINARY=.build/release/LogicProMCP \
+python3 Scripts/spike-channel-eq-census.py
+```
+
+Observed result:
+
+- Logic Pro 12.3 was running with a visible scratch document.
+- `logic_tracks.create_audio` created a fresh audio track and verified the track
+  count delta.
+- `logic_plugins.insert_verified` inserted `Channel EQ` at insert `0` and
+  returned State A with `verify_source:"ax_plugin_inventory"`.
+- Opening the Channel EQ editor for parameter traversal failed before a
+  parameter census could be captured. The direct editor-opening script hit a
+  script parse failure in this run, while the surrounding escape/cleanup
+  System Events calls hit Apple-event permission denied (`-1743`) from this
+  harness launch context.
+- Cleanup track deletion was attempted but failed through the public
+  `logic_tracks.delete` path because the AX menu delete command was not
+  pressable in this context.
+
+Verdict: **insert verification remains State A, parameter activation remains
+blocked**. This rerun still provides no active hosted-insert parameter
+write/read-back evidence, so no Channel EQ verified-param registry entries are
+production-activated.

--- a/docs/tickets/channel-eq-verified-params-vNext/STATUS.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/STATUS.md
@@ -1,0 +1,45 @@
+# Pipeline Status: Channel EQ Verified Params + rename_marker vNext
+
+**PRD**: `docs/prd/PRD-channel-eq-verified-params-vNext.md`
+**Status**: T0 factory-metadata census smoke verified; live insert verified; parameter activation still blocked
+**Execution rule**: no registry activation and no marker rename implementation without live census/read-back evidence.
+
+## Tickets
+
+| Ticket | Title | Status | Gate |
+|--------|-------|--------|------|
+| T0 | AudioUnit parameter API census spike | Factory-only smoke verified | active-instance or explicit factory-only verdict |
+| T1 | Preset/project-state census spike | Todo | parameter values mapped to track/insert identity |
+| T2 | Automation/control-surface feedback spike | Todo | write/read-back evidence or reject |
+| T3 | Channel EQ registry activation | Blocked | T0/T1/T2 PASS |
+| T4 | `rename_marker` live gate | Todo | marker write/read-back/rollback |
+
+## Dependency Graph
+
+```text
+T0 ┐
+T1 ├─> T3
+T2 ┘
+
+T4 independent, shares live scratch session
+```
+
+## Evidence Gate
+
+Channel EQ State A requires census artifact + duplicate/scratch write/read-back. `rename_marker` State A requires marker identity + editable text path + post-write read-back + rollback.
+
+## Current Evidence
+
+- `Scripts/spike-channel-eq-au-census.swift` enumerates Apple `AUNBandEQ` factory metadata through public AudioUnit APIs.
+- Smoke run verified on 2026-07-07: emitted parameter records with `status:"factory_metadata_only"` and `activation_evidence:false`.
+- Live rerun on 2026-07-07: `logic_tracks.create_audio` and `logic_plugins.insert_verified` proved Channel EQ insert State A on a scratch track, but the parameter editor census did not produce active hosted-insert parameter values/read-back. The run failed at the editor-opening / System Events harness boundary and cleanup track deletion also failed in that context.
+- No active Logic hosted insert write/read-back evidence has been captured, so T3 registry activation remains blocked.
+
+## Verification
+
+- `swift test --no-parallel` after implementation tickets.
+- Live Logic 12.3 E2E evidence for any activated surface.
+- Review gate checks no inferred registry entries.
+- **TDD**: red tests written and FAIL-verified before implementation; no dead-`#expect` forms (repo footgun #92).
+- **Cumulative review (CTO)**: each ticket completion reviews T(n-1)+T(n) diff together + full suite; a full cumulative review runs before T3 (registry activation) and before any T4 production change.
+- **Spike safety**: all spikes run on scratch/duplicate projects only; census/spike scripts must never write user presets, user projects, or shared AU state.

--- a/docs/tickets/channel-eq-verified-params-vNext/T0-audio-unit-parameter-api-spike.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/T0-audio-unit-parameter-api-spike.md
@@ -1,0 +1,33 @@
+# T0: AudioUnit Parameter API Census Spike
+
+**PRD Ref**: `PRD-channel-eq-verified-params-vNext` §5.1
+**Priority**: P0
+**Status**: Factory-only smoke verified; active-instance gate pending
+**Depends On**: None
+
+## Objective
+
+Determine whether public AudioUnit APIs can enumerate and read/write the active Channel EQ instance inside Logic, or only provide factory metadata.
+
+## Acceptance Criteria
+
+- [ ] Enumerate Channel EQ parameter ids/names/ranges through public APIs if possible.
+- [ ] Explicitly classify whether the handle is an active Logic insert or factory metadata only.
+- [ ] **Factory-metadata role pinned (CTO)**: factory metadata may SEED candidate canonical ids/units/ranges for the census artifact, but is NEVER activation evidence — every activated param requires active-instance write/read-back proof from some surface (this or another spike). The census artifact must label each field's provenance (`factory_metadata` vs `active_instance`).
+- [ ] **Isolation (CTO)**: if the spike instantiates Channel EQ in-process for metadata, it must not write any shared AU preset/state that Logic reads (no default-preset mutation, no user `~/Library/Audio/Presets` writes) — read-only instantiation, discard on exit.
+- [ ] If active instance access is possible, perform scratch duplicate write/read-back on at least one safe param.
+- [ ] If not possible, record the process-boundary blocker and do not activate registry entries.
+
+## Red Tests
+
+- `audioUnitCensusRejectsFactoryOnlyAsStateA`
+- `audioUnitCensusRequiresActiveInsertIdentity`
+- `audioUnitCensusRequiresUnitRangeTolerance`
+
+## Implementation Boundary
+
+Spike code only. No production registry changes in this ticket.
+
+## Manual QA Gate
+
+Run with Channel EQ inserted on a scratch track; evidence must distinguish active-instance proof from static metadata.

--- a/docs/tickets/channel-eq-verified-params-vNext/T1-preset-project-state-census.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/T1-preset-project-state-census.md
@@ -1,0 +1,32 @@
+# T1: Preset / Project-State Census Spike
+
+**PRD Ref**: `PRD-channel-eq-verified-params-vNext` §5.3
+**Priority**: P1
+**Status**: Todo
+**Depends On**: None
+
+## Objective
+
+Test whether Channel EQ parameter state can be read from a saved preset, project package, or duplicate scratch project without relying on GUI AX controls.
+
+## Acceptance Criteria
+
+- [ ] Scratch project with Channel EQ inserted and known parameter changes.
+- [ ] Save/export only within a controlled scratch path.
+- [ ] Extract parameter values with canonical id, unit, range, and value mapping.
+- [ ] Prove round-trip by changing a param and observing expected serialized delta.
+- [ ] If any save panel is required and blocked, record an honest defer.
+
+## Red Tests
+
+- `presetCensusRejectsUnmappedSerializedValue`
+- `presetCensusRequiresTrackInsertIdentity`
+- `presetCensusDoesNotUseUncontrolledSavePath`
+
+## Implementation Boundary
+
+Read-only spike/parser prototype. Production activation waits for T3.
+
+## Manual QA Gate
+
+Evidence includes before/after preset or package delta and exact value comparison.

--- a/docs/tickets/channel-eq-verified-params-vNext/T2-automation-control-surface-feedback-spike.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/T2-automation-control-surface-feedback-spike.md
@@ -1,0 +1,31 @@
+# T2: Automation / Control-Surface Feedback Spike
+
+**PRD Ref**: `PRD-channel-eq-verified-params-vNext` §5.2 and §5.4
+**Priority**: P2
+**Status**: Todo
+**Depends On**: None
+
+## Objective
+
+Evaluate Logic automation lanes and control-surface feedback as possible Channel EQ value read-back surfaces.
+
+## Acceptance Criteria
+
+- [ ] Automation-lane path records whether parameter names and values are exact, normalized, or display-only.
+- [ ] MCU/OSC path records whether plugin parameter banking can target Channel EQ deterministically.
+- [ ] Any write attempt is on a scratch duplicate and rolled back.
+- [ ] No production claim if the surface cannot prove track/insert/param identity and numeric read-back.
+
+## Red Tests
+
+- `automationSurfaceRejectsDisplayOnlyReadback`
+- `controlSurfaceRequiresFocusedPluginIdentity`
+- `controlSurfaceStateBOnEchoTimeout`
+
+## Implementation Boundary
+
+Spike scripts and evidence only. No `MCUChannel` production changes unless a later ticket is created.
+
+## Manual QA Gate
+
+Capture both the parameter-targeting step and the read-back payload.

--- a/docs/tickets/channel-eq-verified-params-vNext/T3-channel-eq-registry-activation.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/T3-channel-eq-registry-activation.md
@@ -1,0 +1,39 @@
+# T3: Channel EQ Registry Activation
+
+**PRD Ref**: `PRD-channel-eq-verified-params-vNext` §6
+**Priority**: P0 after census PASS
+**Status**: Blocked
+**Depends On**: T0 or T1 or T2 PASS
+
+## Objective
+
+Activate only census-proven Channel EQ parameters in the existing verified plugin registry.
+
+## Acceptance Criteria
+
+- [ ] Add registry entries only for params with canonical id, source, unit, range, tolerance, write/read-back methods, and live evidence.
+- [ ] Unknown Channel EQ params continue to fail closed with `unsupported_param_readback`.
+- [ ] `logic_plugins.set_param_verified` returns State A only when read-back is within tolerance.
+- [ ] Read-back mismatch rolls back or reports failure according to the existing HC v2 contract.
+- [ ] Docs clearly state exactly which Channel EQ params are verified.
+
+## Red Tests
+
+- `channelEQRegistryRejectsUncensusedParam`
+- `channelEQRegistryResolvesCanonicalParam`
+- `channelEQStateAWithinTolerance`
+- `channelEQStateCOnReadbackMismatch`
+- `channelEQUnsupportedParamStillFailClosed`
+
+## Implementation Boundary
+
+Likely files:
+
+- `Sources/LogicProMCP/Plugins/StockPluginCatalog.swift`
+- `Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift` or a method-specific helper
+- `Tests/LogicProMCPTests/PluginSetParamVerifiedTests.swift`
+- `Scripts/live-e2e-test.py`
+
+## Manual QA Gate
+
+Live scratch duplicate with one State A write and one unsupported-param State C.

--- a/docs/tickets/channel-eq-verified-params-vNext/T4-rename-marker-live-gate.md
+++ b/docs/tickets/channel-eq-verified-params-vNext/T4-rename-marker-live-gate.md
@@ -1,0 +1,35 @@
+# T4: `rename_marker` Live Gate
+
+**PRD Ref**: `PRD-channel-eq-verified-params-vNext` §5.6
+**Priority**: P1
+**Status**: Todo
+**Depends On**: None
+
+## Objective
+
+Prove or reject a marker rename path with read-back and rollback. If the gate fails, keep `rename_marker` as State C `not_implemented`.
+
+## Acceptance Criteria
+
+- [ ] Scratch project creates a marker with a unique name.
+- [ ] Marker List/global Marker track is made visible.
+- [ ] The spike captures marker identity before write.
+- [ ] Rename writes through a deterministic editable text surface.
+- [ ] Post-write marker list read-back matches the new name.
+- [ ] Rollback restores the original marker name and verifies it.
+- [ ] If any step is unproven, evidence records the failed surface and production remains unchanged.
+
+## Red Tests
+
+- `renameMarkerRequiresEditableSurface`
+- `renameMarkerStateARequiresReadback`
+- `renameMarkerRollsBackOriginalName`
+- `renameMarkerRemainsNotImplementedWhenGateFails`
+
+## Implementation Boundary
+
+Spike first. Production changes, if any, are limited to `AXLogicProElements+Markers`, `AccessibilityChannel`, `NavigateDispatcher` tests, docs/API, and live E2E.
+
+## Manual QA Gate
+
+Happy path plus failure when Marker List is hidden or no marker exists.


### PR DESCRIPTION
## Summary
- adds the Channel EQ verified params vNext PRD and ticket set
- adds a factory metadata census harness for Apple AUNBandEQ candidate parameter ids/ranges
- records the latest live Logic evidence: Channel EQ insert was verified, but hosted parameter activation/readback remains blocked
- fixes the CI race in the shared deadline-gate regression test by waiting for the mutation gate to drain before asserting the next operation

## Verification
- `swift test --filter Issue112CommandDeadlineTests --disable-xctest --parallel` => 14 tests passed
- `swift build -c release`
- `swift Scripts/spike-channel-eq-au-census.swift` => emits factory_metadata_only records with activation_evidence=false
- `git diff --check`
- Live Logic rerun: `logic_plugins.insert_verified` inserted Channel EQ at insert 0 with `verify_source: ax_plugin_inventory`; editor/hosted parameter traversal could not complete in the current launch context, and cleanup track deletion did not complete.

## Gate Status
This PR intentionally does not activate Channel EQ parameter aliases or rename_marker as production-ready. It adds the live gate, docs, and harness; T3/T4 remain blocked until active hosted insert write/read-back evidence proves the parameter path against real Logic state.