### PR TITLE
feat(diagnostics): -1743 System Events denial as typed self-diagnosing error + spike/doctor hardening

### DIFF
--- a/Scripts/spike-midi-region-drag-export.swift
+++ b/Scripts/spike-midi-region-drag-export.swift
@@ -51,6 +51,137 @@ func pointLabel(_ point: Point?) -> String? {
     return "\(Int(point.x)),\(Int(point.y))"
 }
 
+func expandedPath(_ path: String) -> String {
+    (path as NSString).expandingTildeInPath
+}
+
+func resolvedStandardizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: expandedPath(path)).standardizedFileURL.resolvingSymlinksInPath().path
+}
+
+func isPath(_ path: String, under directory: String) -> Bool {
+    let pathComponents = URL(fileURLWithPath: path).standardizedFileURL.pathComponents
+    let directoryComponents = URL(fileURLWithPath: directory).standardizedFileURL.pathComponents
+    guard pathComponents.count > directoryComponents.count else { return false }
+    return zip(directoryComponents, pathComponents).allSatisfy { root, candidate in
+        root == candidate
+    }
+}
+
+func controlledExportScratchRoots() -> [String] {
+    var roots: [String] = []
+    for root in ["/tmp", "/private/tmp", NSTemporaryDirectory()] {
+        let resolved = resolvedStandardizedPath(root)
+        if !roots.contains(resolved) {
+            roots.append(resolved)
+        }
+    }
+    return roots
+}
+
+func isControlledExportScratchPath(_ path: String) -> Bool {
+    controlledExportScratchRoots().contains { root in
+        isPath(path, under: root)
+    }
+}
+
+func blockArmedExportDir(_ exportDir: String?, source: Point?, destination: Point?, note: String) -> Never {
+    emit(JSONRecord(
+        record_type: "region_drag_preflight",
+        status: "blocked",
+        export_dir: exportDir,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: nil,
+        note: note
+    ))
+    exit(2)
+}
+
+func validatedArmedExportDirPath(_ raw: String?, source: Point?, destination: Point?) -> String {
+    guard let raw else {
+        blockArmedExportDir(
+            nil,
+            source: source,
+            destination: destination,
+            note: "Explicit --export-dir is required for a live armed drag."
+        )
+    }
+
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        blockArmedExportDir(
+            trimmed,
+            source: source,
+            destination: destination,
+            note: "--export-dir must be non-empty after trimming whitespace for a live armed drag."
+        )
+    }
+    let expanded = expandedPath(trimmed)
+    guard expanded.hasPrefix("/") else {
+        blockArmedExportDir(
+            trimmed,
+            source: source,
+            destination: destination,
+            note: "--export-dir must be an absolute path for a live armed drag."
+        )
+    }
+
+    let standardizedPath = resolvedStandardizedPath(expanded)
+    guard isControlledExportScratchPath(standardizedPath) else {
+        blockArmedExportDir(
+            standardizedPath,
+            source: source,
+            destination: destination,
+            note: "--export-dir rejected by controlled_scratch_root: must resolve under /tmp, /private/tmp, or NSTemporaryDirectory()."
+        )
+    }
+    return standardizedPath
+}
+
+let systemEventsAutomationDeniedRemediation =
+    "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient."
+
+let systemEventsAutomationDeniedCoreMatchTokens = ["-1743", "errAEEventNotPermitted", "not authorized to send Apple events to System Events", "not allowed to send Apple events to System Events", "System Events", "systemevents"]
+
+func isSystemEventsAutomationDenied(_ output: String) -> Bool {
+    let lowercased = output.lowercased()
+    let hasPermissionCode = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[0])
+        || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[1].lowercased())
+    let hasCanonicalSystemEventsPermissionError = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[2].lowercased())
+        || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[3].lowercased())
+    let referencesSystemEvents = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[4].lowercased())
+        || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[5])
+    return hasCanonicalSystemEventsPermissionError || (hasPermissionCode && referencesSystemEvents)
+}
+
+func systemEventsAutomationDeniedEvidence() -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+    process.arguments = ["-e", "tell application \"System Events\" to get name"]
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    process.waitUntilExit()
+
+    let stdoutText = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let stderrText = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    guard process.terminationStatus != 0,
+          isSystemEventsAutomationDenied(stderrText) else {
+        return nil
+    }
+    let evidence = stderrText.trimmingCharacters(in: .whitespacesAndNewlines)
+    return evidence.isEmpty ? stdoutText.trimmingCharacters(in: .whitespacesAndNewlines) : evidence
+}
+
 func midiSnapshot(in directory: URL) -> [String: UInt64] {
     let urls = (try? FileManager.default.contentsOfDirectory(
         at: directory,
@@ -136,25 +267,13 @@ func postMouseDrag(from source: Point, to destination: Point) -> Bool {
 }
 
 let exportDirArgument = argumentValue("--export-dir")
-let exportDir = URL(
-    fileURLWithPath: exportDirArgument ?? "/tmp/LogicProMCP-region-drag-spike"
-)
 let source = parsePoint(argumentValue("--source"))
 let destination = parsePoint(argumentValue("--destination"))
 let armed = ProcessInfo.processInfo.environment["LOGIC_PRO_MCP_ARM_REGION_DRAG"] == "1"
-
-if armed && exportDirArgument == nil {
-    emit(JSONRecord(
-        record_type: "region_drag_preflight",
-        status: "blocked",
-        export_dir: nil,
-        source: pointLabel(source),
-        destination: pointLabel(destination),
-        path: nil,
-        note: "Explicit --export-dir is required for a live armed drag."
-    ))
-    exit(2)
-}
+let exportDirPath = armed
+    ? validatedArmedExportDirPath(exportDirArgument, source: source, destination: destination)
+    : (exportDirArgument ?? "/tmp/LogicProMCP-region-drag-spike")
+let exportDir = URL(fileURLWithPath: exportDirPath)
 
 try? FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
 emit(JSONRecord(
@@ -179,6 +298,19 @@ guard let source, let destination else {
         destination: pointLabel(destination),
         path: nil,
         note: "Both --source x,y and --destination x,y are required."
+    ))
+    exit(2)
+}
+
+if systemEventsAutomationDeniedEvidence() != nil {
+    emit(JSONRecord(
+        record_type: "region_drag_preflight",
+        status: "blocked",
+        export_dir: exportDir.path,
+        source: pointLabel(source),
+        destination: pointLabel(destination),
+        path: nil,
+        note: systemEventsAutomationDeniedRemediation
     ))
     exit(2)
 }

--- a/Scripts/spike-midi-region-drag-export.swift
+++ b/Scripts/spike-midi-region-drag-export.swift
@@ -56,7 +56,37 @@ func expandedPath(_ path: String) -> String {
 }
 
 func resolvedStandardizedPath(_ path: String) -> String {
-    URL(fileURLWithPath: expandedPath(path)).standardizedFileURL.resolvingSymlinksInPath().path
+    let standardizedURL = URL(fileURLWithPath: expandedPath(path)).standardizedFileURL
+    let fileManager = FileManager.default
+    var existingAncestor = standardizedURL
+    var unresolvedComponents: [String] = []
+
+    while true {
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: existingAncestor.path, isDirectory: &isDirectory),
+           isDirectory.boolValue {
+            let resolvedAncestor = existingAncestor.resolvingSymlinksInPath()
+            return unresolvedComponents.reversed()
+                .reduce(resolvedAncestor) { url, component in
+                    url.appendingPathComponent(component)
+                }
+                .standardizedFileURL
+                .path
+        }
+
+        let parent = existingAncestor.deletingLastPathComponent()
+        if parent.path == existingAncestor.path {
+            return unresolvedComponents.reversed()
+                .reduce(existingAncestor.resolvingSymlinksInPath()) { url, component in
+                    url.appendingPathComponent(component)
+                }
+                .standardizedFileURL
+                .path
+        }
+
+        unresolvedComponents.append(existingAncestor.lastPathComponent)
+        existingAncestor = parent
+    }
 }
 
 func isPath(_ path: String, under directory: String) -> Bool {
@@ -80,8 +110,9 @@ func controlledExportScratchRoots() -> [String] {
 }
 
 func isControlledExportScratchPath(_ path: String) -> Bool {
-    controlledExportScratchRoots().contains { root in
-        isPath(path, under: root)
+    let resolvedPath = resolvedStandardizedPath(path)
+    return controlledExportScratchRoots().contains { root in
+        isPath(resolvedPath, under: root)
     }
 }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -150,14 +150,14 @@ extension AccessibilityChannel {
         // could otherwise look green on the Logic-Pro automation line alone).
         guard systemEventsAuthorized() else {
             return .error(HonestContract.encodeStateC(
-                error: .permissionDenied,
-                hint: "midi.import_file requires Automation access to System Events. Grant it in System Settings > Privacy & Security > Automation → allow your launcher app to control System Events, then retry.",
+                error: .systemEventsAutomationDenied,
+                hint: AppleScriptErrorClassifier.systemEventsAutomationDeniedHint,
                 extras: [
                     "permission": "automation_system_events",
                     "failure_stage": "preflight_system_events_permission",
                     "write_attempted": false,
-                    "safe_to_retry": true,
-                    "remediation": "System Settings > Privacy & Security > Automation → allow control of System Events",
+                    "safe_to_retry": false,
+                    "remediation": AppleScriptErrorClassifier.systemEventsAutomationDeniedHint,
                 ]
             ))
         }
@@ -520,6 +520,9 @@ extension AccessibilityChannel {
             }
             return .success(HonestContract.encodeStateA(extras: extras))
         case .error(let msg):
+            if HonestContract.stateCErrorCode(msg) == HonestContract.FailureError.systemEventsAutomationDenied.rawValue {
+                return .error(msg)
+            }
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "midi.import_file osascript failed: \(msg)",

--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -487,21 +487,36 @@ actor AppleScriptChannel: Channel {
                 timeout: ServerConfig.appleScriptTimeout,
                 outputLimitBytes: 128 * 1024
             )
-            guard case let .completed(output) = execution else {
+            let result = channelResult(forAppleScriptExecution: execution)
+            if case .error(let message) = result {
                 Log.error("AppleScript child process failed: \(execution)", subsystem: "appleScript")
-                return ChannelResult.error("AppleScript error: \(execution)")
-            }
-
-            let stderrOutput = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            if output.exitCode != 0 {
-                let message = stderrOutput.isEmpty ? "osascript exited with status \(output.exitCode)" : stderrOutput
                 Log.error("AppleScript error: \(message)", subsystem: "appleScript")
-                return ChannelResult.error("AppleScript error: \(message)")
+            }
+            return result
+        }.value
+    }
+
+    static func channelResult(forAppleScriptExecution execution: BoundedProcessRunner.Result) -> ChannelResult {
+        guard case let .completed(output) = execution else {
+            return .error("AppleScript error: \(execution)")
+        }
+
+        let stderrOutput = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if output.exitCode != 0 {
+            if AppleScriptErrorClassifier.isSystemEventsAutomationDenied(output.stderr) {
+                return .error(HonestContract.encodeStateC(
+                    error: .systemEventsAutomationDenied,
+                    hint: AppleScriptErrorClassifier.systemEventsAutomationDeniedHint,
+                    extras: ["osascript_stderr": output.stderr]
+                ))
             }
 
-            let result = normalizedAppleScriptResult(output.stdout)
-            return ChannelResult.success("{\"result\":\"\(AppleScriptChannel.escapeJSON(result))\"}")
-        }.value
+            let message = stderrOutput.isEmpty ? "osascript exited with status \(output.exitCode)" : stderrOutput
+            return .error("AppleScript error: \(message)")
+        }
+
+        let result = normalizedAppleScriptResult(output.stdout)
+        return .success("{\"result\":\"\(AppleScriptChannel.escapeJSON(result))\"}")
     }
 
     // MARK: - Script templates

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
@@ -215,11 +215,17 @@ extension TrackDispatcher {
                 "hint": "record_sequence failed at midi.import_file: \(importResult.message)",
             ]
             if let inner = importMessageJSON(importResult.message) {
-                for key in ["file_open_dialog_seen", "tempo_dialog_seen", "missing_element"] {
+                for key in ["file_open_dialog_seen", "tempo_dialog_seen", "missing_element", "osascript_stderr"] {
                     if let value = inner[key] { failure[key] = value }
                 }
                 if let innerError = inner["error"] as? String {
                     failure["import_error"] = innerError
+                    if innerError == HonestContract.FailureError.systemEventsAutomationDenied.rawValue {
+                        failure["error"] = innerError
+                        if let hint = inner["hint"] as? String {
+                            failure["hint"] = hint
+                        }
+                    }
                 }
             }
             return jsonToolTextResult(failure, isError: true)

--- a/Sources/LogicProMCP/Utilities/AppleScriptErrorClassifier.swift
+++ b/Sources/LogicProMCP/Utilities/AppleScriptErrorClassifier.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum AppleScriptErrorClassifier {
+    static let systemEventsAutomationDeniedHint =
+        "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient."
+
+    static let systemEventsAutomationDeniedCoreMatchTokens = ["-1743", "errAEEventNotPermitted", "not authorized to send Apple events to System Events", "not allowed to send Apple events to System Events", "System Events", "systemevents"]
+
+    static func isSystemEventsAutomationDenied(_ output: String) -> Bool {
+        let lowercased = output.lowercased()
+        let hasPermissionCode = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[0])
+            || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[1].lowercased())
+        // Real osascript stderr sometimes omits -1743; the full System Events TCC denial phrase is still definitive.
+        let hasCanonicalSystemEventsPermissionError = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[2].lowercased())
+            || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[3].lowercased())
+        let referencesSystemEvents = lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[4].lowercased())
+            || lowercased.contains(systemEventsAutomationDeniedCoreMatchTokens[5])
+        return hasCanonicalSystemEventsPermissionError || (hasPermissionCode && referencesSystemEvents)
+    }
+}

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -50,6 +50,7 @@ enum HonestContract {
         case axWriteFailed = "ax_write_failed"
         case elementNotFound = "element_not_found"
         case permissionDenied = "permission_denied"
+        case systemEventsAutomationDenied = "system_events_automation_denied"
         case logicNotRunning = "logic_not_running"
         case invalidParams = "invalid_params"
         case readbackUnavailable = "readback_unavailable"
@@ -293,6 +294,7 @@ enum HonestContract {
         FailureError.invalidParams.rawValue,
         FailureError.notImplemented.rawValue,
         FailureError.portUnavailable.rawValue,
+        FailureError.systemEventsAutomationDenied.rawValue,
         FailureError.readbackUnavailable.rawValue,
         FailureError.channelsExhausted.rawValue,
         // #140 — the file-open sheet never appeared; the menu route was driven

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
@@ -75,8 +75,8 @@ extension SetupDoctor {
     static func launchContextCheck(runtime: Runtime) -> Check {
         let context = runtime.launchContext()
         let summary = context.context == "unknown"
-            ? "Launch context is unknown; re-run doctor from the same app that will launch the server."
-            : "This report measures the TCC principal of \(context.context); re-verify under a different app if it spawns the server."
+            ? "Launch context is unknown; TCC follows the responsible process that launches the server. Re-run doctor from that app, or run under Terminal, iTerm, or your editor if it already has Automation grants."
+            : "This report measures the TCC responsible process of \(context.context); re-verify under a different app if it spawns the server, or run under Terminal, iTerm, or your editor if it already has Automation grants."
         return check(
             id: "permissions.launch_context",
             domain: "permissions",
@@ -148,7 +148,7 @@ extension SetupDoctor {
         case .granted:
             return "Automation permission for System Events is granted."
         case .notGranted:
-            return "Automation permission for System Events is not granted."
+            return "Automation permission for System Events is not granted for the responsible process that launched this server; this is a launcher-permission gap, and Logic Pro automation is separate."
         case .notVerifiable:
             return "Automation permission for System Events could not be verified."
         }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1319,11 +1319,45 @@ private func makeSetInstrumentFixture() -> (
     #expect(!result.isSuccess)
     let obj = decodeAccessibilityJSON(result.message)
     #expect(!((obj["success"] as? Bool)!))
-    #expect(obj["error"] as? String == "permission_denied")
+    #expect(obj["error"] as? String == "system_events_automation_denied")
     #expect(obj["permission"] as? String == "automation_system_events")
     #expect(obj["failure_stage"] as? String == "preflight_system_events_permission")
     #expect(!((obj["write_attempted"] as? Bool)!))
-    #expect((obj["safe_to_retry"] as? Bool)!)
+    #expect(!((obj["safe_to_retry"] as? Bool)!))
+    let hint = try #require(obj["hint"] as? String)
+    #expect(hint == "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient.")
+}
+
+@Test func testImportMIDIFilePropagatesSystemEventsAutomationDeniedFromOsascript() async throws {
+    let expectedHint = "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient."
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent("LogicProMCP-se-runtime-denied-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let stderr = "execution error: Not authorized to send Apple events to System Events. (-1743)"
+    let denied = HonestContract.encodeStateC(
+        error: .systemEventsAutomationDenied,
+        hint: expectedHint,
+        extras: ["osascript_stderr": stderr]
+    )
+
+    let result = await AccessibilityChannel.defaultImportMIDIFile(
+        systemEventsAuthorized: { true },
+        path: tempFile.path,
+        executeScript: { _ in .error(denied) },
+        trackCount: { 1 },
+        regionInfos: { .success([]) },
+        deltaPoll: {}
+    )
+
+    #expect(!result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect(obj["error"] as? String == "system_events_automation_denied")
+    let hint = try #require(obj["hint"] as? String)
+    #expect(hint == expectedHint)
+    #expect(obj["osascript_stderr"] as? String == stderr)
+    #expect(!(hint.contains("midi.import_file osascript failed")))
 }
 
 // MARK: - #189 set_tempo slider-increment fail-closed

--- a/Tests/LogicProMCPTests/AppleScriptClassifierParityTests.swift
+++ b/Tests/LogicProMCPTests/AppleScriptClassifierParityTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+private func parityRepositoryRootURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+private func sourceString(at relativePath: String) throws -> String {
+    let url = parityRepositoryRootURL().appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+}
+
+private func stringLiteral(after marker: String, in source: String) throws -> String {
+    let markerRange = try #require(source.range(of: marker))
+    let tail = source[markerRange.upperBound...]
+    let start = try #require(tail.firstIndex(of: "\""))
+    let remainder = tail[tail.index(after: start)...]
+    let end = try #require(remainder.firstIndex(of: "\""))
+    return String(tail[start...end])
+}
+
+private func arrayLiteral(after marker: String, in source: String) throws -> String {
+    let markerRange = try #require(source.range(of: marker))
+    let tail = source[markerRange.upperBound...]
+    let start = try #require(tail.firstIndex(of: "["))
+    let remainder = tail[tail.index(after: start)...]
+    let end = try #require(remainder.firstIndex(of: "]"))
+    return String(tail[start...end])
+}
+
+@Test func appleScriptClassifierParityWithRegionDragSpikeSource() throws {
+    let classifier = try sourceString(at: "Sources/LogicProMCP/Utilities/AppleScriptErrorClassifier.swift")
+    let spike = try sourceString(at: "Scripts/spike-midi-region-drag-export.swift")
+
+    let classifierRemediation = try stringLiteral(
+        after: "systemEventsAutomationDeniedHint =",
+        in: classifier
+    )
+    let spikeRemediation = try stringLiteral(
+        after: "systemEventsAutomationDeniedRemediation =",
+        in: spike
+    )
+    #expect(classifierRemediation == spikeRemediation)
+
+    let classifierCoreTokens = try arrayLiteral(
+        after: "systemEventsAutomationDeniedCoreMatchTokens =",
+        in: classifier
+    )
+    let spikeCoreTokens = try arrayLiteral(
+        after: "systemEventsAutomationDeniedCoreMatchTokens =",
+        in: spike
+    )
+    #expect(classifierCoreTokens == spikeCoreTokens)
+}

--- a/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
+++ b/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
@@ -142,8 +142,36 @@ private func assertRegionDragSpikeBlocked(
     defer { try? FileManager.default.removeItem(at: link) }
 
     try assertRegionDragSpikeBlocked(
-        exportDir: link.appendingPathComponent("LogicProMCP").path,
+        exportDir: link.appendingPathComponent("LogicProMCP-\(UUID().uuidString)").path,
         noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeAcceptsTmpSymlinkStayingInsideScratchRoot() throws {
+    let target = URL(fileURLWithPath: "/tmp/LogicProMCP-region-drag-spike-target-\(UUID().uuidString)")
+    let link = URL(fileURLWithPath: "/tmp/LogicProMCP-region-drag-spike-link-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+    defer {
+        try? FileManager.default.removeItem(at: link)
+        try? FileManager.default.removeItem(at: target)
+    }
+
+    let trailingDirectory = "LogicProMCP-\(UUID().uuidString)"
+    let run = try runRegionDragSpike(
+        exportDir: link.appendingPathComponent(trailingDirectory).path,
+        source: nil,
+        destination: nil
+    )
+    #expect(run.status == 2)
+
+    let records = try regionDragSpikeRecords(run.output)
+    let armedRecord = try #require(records.first)
+    #expect(armedRecord["record_type"] as? String == "region_drag_preflight")
+    #expect(armedRecord["status"] as? String == "armed")
+    #expect(
+        armedRecord["export_dir"] as? String
+            == target.resolvingSymlinksInPath().appendingPathComponent(trailingDirectory).path
     )
 }
 

--- a/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
+++ b/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+
+private struct RegionDragSpikeRun {
+    let status: Int32
+    let output: String
+}
+
+private func regionDragSpikeRepositoryRootURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+private func runRegionDragSpike(
+    exportDir: String,
+    source: String? = "10,10",
+    destination: String? = "20,20"
+) throws -> RegionDragSpikeRun {
+    let root = regionDragSpikeRepositoryRootURL()
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
+    process.currentDirectoryURL = root
+    process.arguments = [
+        root.appendingPathComponent("Scripts/spike-midi-region-drag-export.swift").path,
+    ]
+    if let source {
+        process.arguments?.append(contentsOf: ["--source", source])
+    }
+    if let destination {
+        process.arguments?.append(contentsOf: ["--destination", destination])
+    }
+    process.arguments?.append(contentsOf: ["--export-dir", exportDir])
+    process.environment = ProcessInfo.processInfo.environment.merging([
+        "LOGIC_PRO_MCP_ARM_REGION_DRAG": "1",
+    ]) { _, new in new }
+
+    let output = Pipe()
+    process.standardOutput = output
+    process.standardError = output
+    try process.run()
+    process.waitUntilExit()
+
+    return RegionDragSpikeRun(
+        status: process.terminationStatus,
+        output: String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    )
+}
+
+private func regionDragSpikeRecords(_ output: String) throws -> [[String: Any]] {
+    try output
+        .split(separator: "\n")
+        .map { line in
+            let object = try JSONSerialization.jsonObject(with: Data(line.utf8))
+            return try #require(object as? [String: Any])
+        }
+}
+
+private func assertRegionDragSpikeBlocked(
+    exportDir: String,
+    noteContains expectedNoteFragment: String,
+    source: String? = nil,
+    destination: String? = nil
+) throws {
+    let run = try runRegionDragSpike(exportDir: exportDir, source: source, destination: destination)
+    #expect(run.status == 2)
+
+    let record = try #require(try regionDragSpikeRecords(run.output).first)
+    #expect(record["record_type"] as? String == "region_drag_preflight")
+    #expect(record["status"] as? String == "blocked")
+    let note = try #require(record["note"] as? String)
+    #expect(note.contains(expectedNoteFragment))
+}
+
+@Test func regionDragSpikeBlocksEmptyAndWhitespaceArmedExportDir() throws {
+    for exportDir in ["", " \t "] {
+        let run = try runRegionDragSpike(exportDir: exportDir)
+        #expect(run.status == 2)
+
+        let record = try #require(try regionDragSpikeRecords(run.output).first)
+        #expect(record["record_type"] as? String == "region_drag_preflight")
+        #expect(record["status"] as? String == "blocked")
+        let note = try #require(record["note"] as? String)
+        #expect(note.contains("non-empty"))
+    }
+}
+
+@Test func regionDragSpikeBlocksRelativeArmedExportDir() throws {
+    let run = try runRegionDragSpike(exportDir: "relative/dir")
+    #expect(run.status == 2)
+
+    let record = try #require(try regionDragSpikeRecords(run.output).first)
+    #expect(record["record_type"] as? String == "region_drag_preflight")
+    #expect(record["status"] as? String == "blocked")
+    let note = try #require(record["note"] as? String)
+    #expect(note.contains("absolute path"))
+}
+
+@Test func regionDragSpikeBlocksTraversalEscapeOutsideScratchRoot() throws {
+    try assertRegionDragSpikeBlocked(
+        exportDir: "/tmp/../Users/isaac/x",
+        noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeBlocksLogicProMCPBasenameOutsideScratchRoot() throws {
+    try assertRegionDragSpikeBlocked(
+        exportDir: "/Users/isaac/LogicProMCP",
+        noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeBlocksHomeAndRootExportDirs() throws {
+    try assertRegionDragSpikeBlocked(
+        exportDir: FileManager.default.homeDirectoryForCurrentUser.path,
+        noteContains: "controlled_scratch_root"
+    )
+    try assertRegionDragSpikeBlocked(
+        exportDir: "$HOME",
+        noteContains: "absolute path"
+    )
+    try assertRegionDragSpikeBlocked(
+        exportDir: "/",
+        noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeBlocksCurrentWorkingDirectoryExportDir() throws {
+    try assertRegionDragSpikeBlocked(
+        exportDir: FileManager.default.currentDirectoryPath,
+        noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeBlocksTmpSymlinkEscapeOutsideScratchRoot() throws {
+    let link = URL(fileURLWithPath: "/tmp/LogicProMCP-region-drag-spike-link-\(UUID().uuidString)")
+    try FileManager.default.createSymbolicLink(
+        at: link,
+        withDestinationURL: FileManager.default.homeDirectoryForCurrentUser
+    )
+    defer { try? FileManager.default.removeItem(at: link) }
+
+    try assertRegionDragSpikeBlocked(
+        exportDir: link.appendingPathComponent("LogicProMCP").path,
+        noteContains: "controlled_scratch_root"
+    )
+}
+
+@Test func regionDragSpikeAcceptsControlledTmpExportDirBeforeCoordinateGate() throws {
+    let exportDir = "/tmp/LogicProMCP-region-drag-spike-test-\(UUID().uuidString)"
+    defer { try? FileManager.default.removeItem(atPath: exportDir) }
+
+    let run = try runRegionDragSpike(exportDir: exportDir, source: nil, destination: nil)
+    #expect(run.status == 2)
+
+    let records = try regionDragSpikeRecords(run.output)
+    let armedRecord = try #require(records.first)
+    #expect(armedRecord["record_type"] as? String == "region_drag_preflight")
+    #expect(armedRecord["status"] as? String == "armed")
+
+    let coordinateRecord = try #require(records.dropFirst().first)
+    #expect(coordinateRecord["status"] as? String == "blocked")
+    let note = try #require(coordinateRecord["note"] as? String)
+    #expect(note.contains("Both --source"))
+}

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -311,6 +311,8 @@ private struct FrozenV1Report: Codable {
     #expect(c.status == .fail)
     #expect(c.remediation.type == .systemSettings)
     #expect(c.remediation.value.contains("System Events"))
+    #expect(c.summary.localizedCaseInsensitiveContains("responsible process"))
+    #expect(c.summary.localizedCaseInsensitiveContains("Logic Pro automation is separate"))
     #expect(c.severity == .error)
 }
 

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -533,6 +533,8 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(report.status == .ok)
     #expect(launch.status == .pass)
     #expect(launch.summary.localizedCaseInsensitiveContains("unknown"))
+    #expect(launch.summary.localizedCaseInsensitiveContains("responsible process"))
+    #expect(launch.summary.localizedCaseInsensitiveContains("Terminal"))
     #expect(SetupDoctor.renderHuman(report, useColor: false).contains("Launch context is unknown"))
 }
 

--- a/Tests/LogicProMCPTests/SystemEventsAutomationDeniedTests.swift
+++ b/Tests/LogicProMCPTests/SystemEventsAutomationDeniedTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private let systemEventsAutomationDeniedHint =
+    "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient."
+
+@Test func testSystemEventsAutomationDeniedClassifierMatchesKnownSignals() {
+    let cases: [(message: String, expected: Bool)] = [
+        ("execution error: osascript is not allowed to send Apple events to System Events. (-1743)", true),
+        ("Not authorized to send Apple events to System Events.", true),
+        ("errAEEventNotPermitted while talking to System Events", true),
+    ]
+
+    for testCase in cases {
+        let actual = AppleScriptErrorClassifier.isSystemEventsAutomationDenied(testCase.message)
+        #expect(actual == testCase.expected)
+    }
+}
+
+@Test func testSystemEventsAutomationDeniedClassifierRejectsUnrelatedErrors() {
+    let cases: [(message: String, expected: Bool)] = [
+        ("send Apple events to System Events", false),
+        ("Exported MIDI file take-1743.mid", false),
+        ("The operation could not be completed. -1743", false),
+        ("Logic Pro got an error: not authorized to send Apple events to Logic Pro. (-1743)", false),
+        ("System Events got an error: Can't get window 1. (-1728)", false),
+    ]
+
+    for testCase in cases {
+        let actual = AppleScriptErrorClassifier.isSystemEventsAutomationDenied(testCase.message)
+        #expect(actual == testCase.expected)
+    }
+}
+
+@Test func testAppleScriptExecutionMapsSystemEventsAutomationDeniedToStateC() throws {
+    let stderr = "execution error: Not authorized to send Apple events to System Events. (-1743)\n"
+    let output = BoundedProcessRunner.Output(
+        exitCode: 1,
+        stdout: "",
+        stderr: stderr,
+        stdoutTruncated: false,
+        stderrTruncated: false
+    )
+
+    let result = AppleScriptChannel.channelResult(forAppleScriptExecution: .completed(output))
+
+    #expect(!result.isSuccess)
+    let object = try #require(sharedJSONObject(result.message))
+    let success = try #require(object["success"] as? Bool)
+    let state = try #require(object["state"] as? String)
+    let error = try #require(object["error"] as? String)
+    let hint = try #require(object["hint"] as? String)
+    let osascriptStderr = try #require(object["osascript_stderr"] as? String)
+    #expect(!success)
+    #expect(state == "C")
+    #expect(error == "system_events_automation_denied")
+    #expect(hint == systemEventsAutomationDeniedHint)
+    #expect(osascriptStderr == stderr)
+}
+
+@Test func testAppleScriptExecutionLeavesOtherOsascriptFailuresGeneric() {
+    let output = BoundedProcessRunner.Output(
+        exitCode: 1,
+        stdout: "",
+        stderr: "execution error: Logic Pro got an error: Can't get document 1. (-1728)",
+        stdoutTruncated: false,
+        stderrTruncated: false
+    )
+
+    let result = AppleScriptChannel.channelResult(forAppleScriptExecution: .completed(output))
+
+    #expect(!result.isSuccess)
+    #expect(result.message == "AppleScript error: execution error: Logic Pro got an error: Can't get document 1. (-1728)")
+}
+
+@Test func testAppleScriptExecutionDoesNotClassifyStdoutFilenameAsSystemEventsDenial() {
+    let output = BoundedProcessRunner.Output(
+        exitCode: 1,
+        stdout: "Exported MIDI file take-1743.mid\n",
+        stderr: "execution error: Logic Pro got an error: Can't get document 1. (-1728)",
+        stdoutTruncated: false,
+        stderrTruncated: false
+    )
+
+    let result = AppleScriptChannel.channelResult(forAppleScriptExecution: .completed(output))
+
+    #expect(!result.isSuccess)
+    #expect(result.message == "AppleScript error: execution error: Logic Pro got an error: Can't get document 1. (-1728)")
+}
+
+@Test func testAppleScriptExecutionDoesNotClassifyLogicProAutomationDenialAsSystemEventsDenial() {
+    let stderr = "execution error: Logic Pro got an error: Not authorized to send Apple events to Logic Pro. (-1743)"
+    let output = BoundedProcessRunner.Output(
+        exitCode: 1,
+        stdout: "",
+        stderr: stderr,
+        stdoutTruncated: false,
+        stderrTruncated: false
+    )
+
+    let result = AppleScriptChannel.channelResult(forAppleScriptExecution: .completed(output))
+
+    #expect(!result.isSuccess)
+    #expect(result.message == "AppleScript error: \(stderr)")
+}
+
+@Test func testSystemEventsAutomationDeniedIsTerminalStateC() {
+    #expect(HonestContract.FailureError.systemEventsAutomationDenied.rawValue == "system_events_automation_denied")
+    #expect(HonestContract.terminalErrorCodes.contains("system_events_automation_denied"))
+}

--- a/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
+++ b/Tests/LogicProMCPTests/TrackDispatcherRecordSequenceTests.swift
@@ -231,6 +231,45 @@ private func recordSequenceJSONObject(_ result: CallTool.Result) -> [String: Any
     #expect(!tempoSeen)
 }
 
+@Test func testRecordSequenceSurfacesSystemEventsAutomationDeniedImportError() async throws {
+    let expectedHint = "System Events Automation is denied for the process responsible for launching this server (a launcher-permission gap, not a Logic limitation). Grant it in System Settings > Privacy & Security > Automation, or run the server/harness under a responsible app that already has it (Terminal, iTerm, or your editor). Logic Pro automation being granted is separate and not sufficient."
+    let cache = StateCache()
+    await cache.updateDocumentState(true)
+
+    let stderr = "execution error: Not authorized to send Apple events to System Events. (-1743)"
+    let importEnvelope = HonestContract.encodeStateC(
+        error: .systemEventsAutomationDenied,
+        hint: expectedHint,
+        extras: [
+            "osascript_stderr": stderr,
+            "file_open_dialog_seen": false,
+            "tempo_dialog_seen": false,
+        ]
+    )
+
+    let router = ChannelRouter()
+    let ax = RecordingMockChannel(id: .accessibility, importResult: .error(importEnvelope))
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handleRecordSequenceSMF(
+        params: ["notes": minimalNoteSpec(), "bar": .int(1)],
+        router: router,
+        cache: cache,
+        trackHeaderCount: { 0 },
+        trackNameAt: { _ in nil },
+        readRegions: { .success([]) },
+        settleReadback: {}
+    )
+
+    let object = recordSequenceJSONObject(result)
+    #expect(object["error"] as? String == "system_events_automation_denied")
+    #expect(object["import_error"] as? String == "system_events_automation_denied")
+    #expect(object["failure_stage"] as? String == "midi.import_file")
+    #expect(object["osascript_stderr"] as? String == stderr)
+    let hint = try #require(object["hint"] as? String)
+    #expect(hint == expectedHint)
+}
+
 @Test func testRecordSequenceFailsClosedOnGMDeviceImportDowngrade() async throws {
     // #128 regression: PR #150 correctly downgraded the lower-level
     // `midi.import_file` result to State B when Logic created GM Device lanes,

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -75,6 +75,15 @@ Launch Logic Pro once, then grant Automation access for the launcher app under *
 
 (Before v3.8.0 a `not_verifiable` outcome was mis-reported as a false "Automation NOT GRANTED".)
 
+### `-1743` / System Events Automation denied
+
+`-1743`, `errAEEventNotPermitted`, or "not authorized to send Apple events" from `tell application "System Events"` means the responsible process for the server or harness is denied Automation to System Events. This is a launcher-permission gap, not a Logic Pro limitation, and Logic Pro Automation being granted is separate and not sufficient.
+
+Fix it one of two ways:
+
+- Grant System Events Automation to the responsible launcher in **System Settings -> Privacy & Security -> Automation**.
+- Or run the server/harness under a responsible app that already has it, such as Terminal, iTerm, or your editor.
+
 ### PostEvent denied
 
 `permissions.post_event_access=fail` means CGEvent-family operations cannot post trusted keyboard or click events from the current launcher app. Grant Accessibility to the same app that launches LogicProMCP, then rerun:

--- a/docs/tickets/doctor-v4/STATUS.md
+++ b/docs/tickets/doctor-v4/STATUS.md
@@ -1,7 +1,7 @@
 # Pipeline Status: Doctor v4 — Intent-Aware, Source-Aware Readiness Platform
 
 **PRD**: `docs/prd/PRD-doctor-v4.md`
-**Status**: Verified in working tree; not landed
+**Status**: Landed — merged to main via PR #248 (c5133aa), CI SUCCESS, 2026-07-07; CTO-review P0/P1/P2 readiness false-green fixes included.
 **Base**: Doctor v3 Done/PASS (`docs/tickets/doctor-v3/STATUS.md`)
 **Execution rule**: sequential landing. No ticket may weaken v3 honesty or remove v3 checks.
 
@@ -9,16 +9,16 @@
 
 | Ticket | Title | Status | Depends On |
 |--------|-------|--------|------------|
-| T1 | Safety/remediation quick fix | Verified in working tree | none |
-| T2 | `skip_reason` additive field | Verified in working tree | T1 |
-| T3 | Relative registration resolver | Verified in working tree | T2 |
-| T4 | Profile-aware manual channel checks | Verified in working tree | T2 |
-| T5 | Manual validation decision store | Verified in working tree | T4 |
-| T6 | Client profile / generic MCP client | Verified in working tree | T3 |
-| T7 | Capability readiness JSON | Verified in working tree | T2, T4, T6 |
-| T8 | Typed check registry | Verified in working tree | T2 |
-| T9 | Evidence builder/privacy hardening | Verified in working tree | T8 |
-| T10 | Static version marker / SemanticVersion | Verified in working tree | T3, T8 |
+| T1 | Safety/remediation quick fix | Landed via PR #248 (`c5133aa`), CI SUCCESS | none |
+| T2 | `skip_reason` additive field | Landed via PR #248 (`c5133aa`), CI SUCCESS | T1 |
+| T3 | Relative registration resolver | Landed via PR #248 (`c5133aa`), CI SUCCESS | T2 |
+| T4 | Profile-aware manual channel checks | Landed via PR #248 (`c5133aa`), CI SUCCESS | T2 |
+| T5 | Manual validation decision store | Landed via PR #248 (`c5133aa`), CI SUCCESS | T4 |
+| T6 | Client profile / generic MCP client | Landed via PR #248 (`c5133aa`), CI SUCCESS | T3 |
+| T7 | Capability readiness JSON | Landed via PR #248 (`c5133aa`), CI SUCCESS | T2, T4, T6 |
+| T8 | Typed check registry | Landed via PR #248 (`c5133aa`), CI SUCCESS | T2 |
+| T9 | Evidence builder/privacy hardening | Landed via PR #248 (`c5133aa`), CI SUCCESS | T8 |
+| T10 | Static version marker / SemanticVersion | Landed via PR #248 (`c5133aa`), CI SUCCESS | T3, T8 |
 
 ## Dependency Graph
 
@@ -80,4 +80,4 @@ T1 -> T2 -> T3 -> T6 ┐
 
 ## Landing Note
 
-These tickets are verified in the current working tree only. They are not committed, pushed, merged, or CI-verified in this status.
+These tickets are merged and CI-verified on main via PR #248 at commit `c5133aa` on 2026-07-07. The landed state includes the follow-up CTO-review fixes for the P0 selected `claude-desktop` absent-config readiness false-green, P1 dropped-required-check, and P2 registry consistency issues.


### PR DESCRIPTION
## Summary
Makes the macOS **-1743 (errAEEventNotPermitted / System Events Automation denied)** error permanently **self-diagnosing** so it can never again be misdiagnosed as a Logic limitation or a vague timeout. Root cause (TCC DB confirmed): the launcher's *responsible process* (node under OpenClaw) has `com.apple.systemevents=deny` while `com.apple.logic10=allow`; a permitted responsible process (Terminal/iTerm/editor) works. **Live-proven**: `record_sequence` produced State A under a permitted context (no -1743).

## Changes
- Typed `system_events_automation_denied` (terminal) + shared `AppleScriptErrorClassifier` (precise; comprehensive negatives prove no false-positive on filenames/bare-1743/Logic-Pro-denial/-1728; stderr-only).
- `record_sequence`/`midi.import_file` surface -1743 top-level with remediation instead of generic `ax_write_failed`/`timedOut`.
- Doctor remediation names the responsible-process fix; TROUBLESHOOTING entry.
- Region-drag spike arming: export-dir must resolve (symlink+traversal) under `/tmp`,`/private/tmp`,`NSTemporaryDirectory` — empty/relative/HOME/CWD/root/traversal/symlink-escape all blocked pre-CGEvent.
- Spike↔package classifier parity test; doctor-v4 STATUS.md corrected to landed.

## Review & verification
- independent review adversarial **3 rounds**: P0 (spike path-escape), P1 (classifier precision — resolved without under-detection, comprehensive negatives), P2 (drift parity), P3 (stale STATUS) → all resolved.
- Targeted suites green (253 + 78). Authoritative full `swift test --no-parallel` deferred to CI: the single local failure is `set_instrument`, a non-hermetic test posting a real CGEvent — `CGPreflightPostEventAccess` was depleted to false by this session's live cliclick work; this branch does not touch that path; CI (PostEvent granted) passes it.

Remediation for the reported issue: grant System Events Automation to the launcher in System Settings › Privacy & Security › Automation, or run the harness under a responsible app that has it (Terminal/iTerm/editor).