### PR TITLE
release: sync Formula sha256 to published v3.9.1 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "c33a9e53bb77f569b434c5fd35fc8d60b033d907799dbf45760296485ee666a0"
+    sha256 "9e27acb2f888d7eb55c1e04a1c7df26c9d280b92a0184afe8915fc43158d638e"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
Post-release evidence-sync for **v3.9.1**.

- Updates `Formula/logic-pro-mcp.rb` `sha256` → `9e27acb2f888d7eb55c1e04a1c7df26c9d280b92a0184afe8915fc43158d638e` (the published universal tarball hash).
- Verified three ways: matches `SHA256SUMS.txt` from the release, matches an independent `shasum -a 256` of the downloaded `LogicProMCP-macOS-universal.tar.gz`, and a real `brew install` from the corrected formula succeeds with `LogicProMCP --version` → `3.9.1`.
- `release.yml` for v3.9.1 already passed: build + validate-install on **macos-14** and **macos-15**.

Without this, origin's formula pins v3.9.1 with the stale v3.9.0 sha, so a Homebrew install would fail the checksum. This closes the release loop.