### PR TITLE
fix(plugins): open editor for verified param writes

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -399,22 +399,23 @@ extension AccessibilityChannel {
         await AppleScriptChannel.currentDocumentPath()
     }
 
-    /// Attempt to OPEN the plugin window for `(trackName, axDescription)` when it
-    /// is not already open (R6 step 8b), returning the window element once it
-    /// exposes the matching slider, or nil when no window could be opened.
-    /// Injected so tests can deterministically drive the "must open" branch.
-    ///
-    /// Production default: returns nil. Opening a stock-effect plugin window via
-    /// the mixer is empirically brittle (T0 spike §제약 4 — the mixer virtualises
-    /// channel strips, so the insert double-click cannot be driven reliably from
-    /// AX). Until that path is hardened (a separate ticket), the verified write
-    /// only proceeds against an ALREADY-OPEN plugin window; otherwise it fails
-    /// closed with `window_open_failed`. This keeps the production envelope
-    /// honest rather than fabricating a write against a window that was never
-    /// confirmed open.
-    typealias PluginWindowOpener = @Sendable (_ trackName: String, _ axDescription: String) async -> AXUIElementSendable?
+    typealias PluginWindowOpener = @Sendable (
+        _ targetSlot: AXUIElementSendable,
+        _ trackName: String,
+        _ axDescription: String,
+        _ runtime: AXLogicProElements.Runtime
+    ) async -> AXUIElementSendable?
 
-    static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _ in nil }
+    static let livePluginWindowOpener: PluginWindowOpener = { targetSlot, trackName, axDescription, runtime in
+        await openPluginWindowFromTargetSlot(
+            targetSlot.element,
+            trackName: trackName,
+            axDescription: axDescription,
+            runtime: runtime
+        )
+    }
+
+    static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _, _, _ in nil }
 
     /// Steps 2-3 of the R6 precedence shared by both mutating verified ops:
     /// mode validation then the project path gate. Returns a State C envelope to
@@ -515,7 +516,7 @@ extension AccessibilityChannel {
         frontDocumentPath: FrontDocumentPathProvider = liveFrontDocumentPath,
         entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
         paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup = VerifiedPluginCatalog.canonicalParamKey,
-        pluginWindowOpener: PluginWindowOpener = liveNoOpPluginWindowOpener
+        pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener
     ) async -> ChannelResult {
         let operation = "logic_plugins.set_param_verified"
 
@@ -749,12 +750,22 @@ extension AccessibilityChannel {
             forTrackName: trackName, matchingSliderDescription: axDescription, runtime: runtime
         ) {
             window = open
-        } else if let opened = await pluginWindowOpener(trackName, axDescription) {
+        } else if let opened = await pluginWindowOpener(
+            AXUIElementSendable(slots[insert].element),
+            trackName,
+            axDescription,
+            runtime
+        ) {
             window = opened.element
         } else {
             return .error(windowOpenFailedStateC(
                 operation, identity,
-                "no open plugin window titled '\(trackName)' exposes the '\(axDescription)' control, and one could not be opened"
+                "no open plugin window titled '\(trackName)' exposes the '\(axDescription)' control, and one could not be opened",
+                diagnostics: pluginWindowAcquisitionDiagnostics(
+                    trackName: trackName,
+                    axDescription: axDescription,
+                    runtime: runtime
+                )
             ))
         }
 
@@ -902,18 +913,148 @@ extension AccessibilityChannel {
         )
     }
 
-    private static func windowOpenFailedStateC(_ operation: String, _ identity: [String: Any], _ detail: String) -> String {
-        HonestContract.encodeV2StateC(
+    private static func windowOpenFailedStateC(
+        _ operation: String,
+        _ identity: [String: Any],
+        _ detail: String,
+        diagnostics: [String: Any] = [:]
+    ) -> String {
+        var extras: [String: Any] = [
+            "operation": operation,
+            "target_identity": identity,
+            "what_was_attempted": "acquire the plugin window before writing",
+            "what_was_observed": detail,
+            "safe_to_retry": true,
+            "write_attempted": false,
+        ]
+        extras.merge(diagnostics) { current, _ in current }
+        return HonestContract.encodeV2StateC(
             error: .windowOpenFailed,
-            extras: [
-                "operation": operation,
-                "target_identity": identity,
-                "what_was_attempted": "acquire the plugin window before writing",
-                "what_was_observed": detail,
-                "safe_to_retry": true,
-                "write_attempted": false,
-            ]
+            extras: extras
         )
+    }
+
+    private static func openPluginWindowFromTargetSlot(
+        _ targetSlot: AXUIElement,
+        trackName: String,
+        axDescription: String,
+        runtime: AXLogicProElements.Runtime
+    ) async -> AXUIElementSendable? {
+        if let alreadyOpen = AXLogicProElements.openPluginWindow(
+            forTrackName: trackName,
+            matchingSliderDescription: axDescription,
+            runtime: runtime
+        ) {
+            return AXUIElementSendable(alreadyOpen)
+        }
+
+        let rankedControls = rankedPluginSlotOpenControls(in: targetSlot, runtime: runtime.ax)
+        let attempts = rankedControls.filter { $0.rank == 0 }.map(\.element)
+            + [targetSlot]
+            + rankedControls.filter { $0.rank != 0 }.map(\.element)
+        for element in attempts {
+            guard pressOrClick(element, runtime: runtime.ax) else { continue }
+            if let window = await pollOpenPluginWindow(
+                trackName: trackName,
+                axDescription: axDescription,
+                runtime: runtime,
+                timeoutMs: 1_250
+            ) {
+                return AXUIElementSendable(window)
+            }
+        }
+        return nil
+    }
+
+    private static func rankedPluginSlotOpenControls(
+        in targetSlot: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [(rank: Int, element: AXUIElement)] {
+        let children = AXHelpers.getChildren(targetSlot, runtime: runtime)
+        let buttons = children.filter {
+            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXButtonRole as String)
+        }
+        return buttons.compactMap { button -> (rank: Int, element: AXUIElement)? in
+            let text = AXLogicProElements.elementSearchText(button, runtime: runtime)
+            guard !AXLocalePolicy.pluginBypassControl.containsAny(in: text) else { return nil }
+            if text.range(of: "open", options: [.caseInsensitive]) != nil || text.contains("열기") {
+                return (0, button)
+            }
+            if text.range(of: "list", options: [.caseInsensitive]) != nil || text.contains("목록") {
+                return (1, button)
+            }
+            if AXLocalePolicy.pluginOpenOrListControl.containsAny(in: text) {
+                return (1, button)
+            }
+            return (2, button)
+        }
+        .sorted { lhs, rhs in lhs.rank < rhs.rank }
+    }
+
+    private static func pollOpenPluginWindow(
+        trackName: String,
+        axDescription: String,
+        runtime: AXLogicProElements.Runtime,
+        timeoutMs: Int
+    ) async -> AXUIElement? {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1_000.0)
+        repeat {
+            if let window = AXLogicProElements.openPluginWindow(
+                forTrackName: trackName,
+                matchingSliderDescription: axDescription,
+                runtime: runtime
+            ) {
+                return window
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        } while Date() < deadline
+        return nil
+    }
+
+    private static func pressOrClick(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
+        if AXHelpers.performAction(element, kAXPressAction as String, runtime: runtime) {
+            return true
+        }
+        return clickElementCenter(element, runtime: runtime)
+    }
+
+    private static func pluginWindowAcquisitionDiagnostics(
+        trackName: String,
+        axDescription: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> [String: Any] {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return [
+                "opener_action_attempted": true,
+                "requested_window_title": trackName,
+                "requested_slider_description": axDescription,
+                "window_candidates": [],
+            ]
+        }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app, kAXWindowsAttribute as String, runtime: runtime.ax
+        ) ?? []
+        let summaries = windows.prefix(12).map { window -> [String: Any] in
+            let sliders = AXHelpers.findAllDescendants(
+                of: window, role: kAXSliderRole, maxDepth: 4, runtime: runtime.ax
+            )
+            let sliderDescriptions = sliders.compactMap {
+                AXHelpers.getDescription($0, runtime: runtime.ax)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .filter { !$0.isEmpty }
+            return [
+                "title": AXHelpers.getTitle(window, runtime: runtime.ax) ?? "",
+                "role": AXHelpers.getRole(window, runtime: runtime.ax) ?? "",
+                "slider_descriptions": Array(sliderDescriptions.prefix(8)),
+            ]
+        }
+        return [
+            "opener_action_attempted": true,
+            "requested_window_title": trackName,
+            "requested_slider_description": axDescription,
+            "window_candidates": Array(summaries),
+        ]
     }
 
     /// Confirm the header at `track` reads back as AX-selected, retrying briefly

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -42,6 +42,7 @@ private final class LiveFixture: @unchecked Sendable {
         pluginSlotName: String = "Compressor",
         beforeValue: Double = 51,
         pluginWindowPresent: Bool = true,
+        openWindowOnSlotPress: Bool = false,
         forcedAfterValue: Double? = nil,
         otherTracks: Int = 0,
         emptyInsertChain: Bool = false
@@ -73,6 +74,8 @@ private final class LiveFixture: @unchecked Sendable {
         // --- Mixer: one strip per track; target strip carries occupied inserts
         //     up to `insert` so audioPluginInsertSlots reports it occupied. ---
         var strips: [AXUIElement] = []
+        var targetSlot: AXUIElement?
+        var targetOpenButton: AXUIElement?
         for i in 0..<rowCount {
             let strip = b.element(1200 + i)
             b.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
@@ -85,7 +88,12 @@ private final class LiveFixture: @unchecked Sendable {
                 } else {
                     var slots: [AXUIElement] = []
                     for s in 0...insert {
-                        slots.append(LiveFixture.occupiedSlot(b, 1300 + s, name: s == insert ? pluginSlotName : "Plugin \(s)"))
+                        let slot = LiveFixture.occupiedSlot(b, 1300 + s, name: s == insert ? pluginSlotName : "Plugin \(s)")
+                        if s == insert {
+                            targetSlot = slot
+                            targetOpenButton = b.element((1300 + s) * 10 + 2)
+                        }
+                        slots.append(slot)
                     }
                     b.setChildren(strip, slots)
                 }
@@ -124,6 +132,8 @@ private final class LiveFixture: @unchecked Sendable {
         // way Logic re-renders it ("X %") and an optional forced value models a
         // sticky parameter (readback != requested).
         let sliderKey = b.elementID(slider)
+        let targetSlotKey = targetSlot.map { b.elementID($0) }
+        let targetOpenButtonKey = targetOpenButton.map { b.elementID($0) }
         let forced = forcedAfterValue
         let runtime = b.makeLogicRuntime(
             appElement: app,
@@ -138,7 +148,16 @@ private final class LiveFixture: @unchecked Sendable {
                 b.setAttribute(el, kAXValueDescriptionAttribute as String, "\(Int(landed.rounded())) %")
                 return true
             },
-            performActionHandler: nil
+            performActionHandler: { [b] el, action in
+                guard openWindowOnSlotPress, action == (kAXPressAction as String) else {
+                    return true
+                }
+                let key = b.elementID(el)
+                if key == targetSlotKey || key == targetOpenButtonKey {
+                    b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow, pluginWindow])
+                }
+                return true
+            }
         )
         self.runtime = runtime
     }
@@ -175,14 +194,23 @@ private func runLive(
     fixture: LiveFixture,
     params: [String: String],
     frontDoc: String? = expectedPath,
-    opener: @escaping AccessibilityChannel.PluginWindowOpener = { _, _ in nil }
+    opener: AccessibilityChannel.PluginWindowOpener? = nil
 ) async -> [String: Any] {
-    let result = await AccessibilityChannel.defaultSetParamVerified(
-        params: params,
-        runtime: fixture.runtime,
-        frontDocumentPath: { frontDoc },
-        pluginWindowOpener: opener
-    )
+    let result: ChannelResult
+    if let opener {
+        result = await AccessibilityChannel.defaultSetParamVerified(
+            params: params,
+            runtime: fixture.runtime,
+            frontDocumentPath: { frontDoc },
+            pluginWindowOpener: opener
+        )
+    } else {
+        result = await AccessibilityChannel.defaultSetParamVerified(
+            params: params,
+            runtime: fixture.runtime,
+            frontDocumentPath: { frontDoc }
+        )
+    }
     return try! JSONSerialization.jsonObject(
         with: result.message.data(using: .utf8)!, options: []
     ) as! [String: Any]
@@ -426,6 +454,43 @@ private func runChannelEQFixture(
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_open_failed")
     #expect(!((obj["write_attempted"] as? Bool)!))
+    #expect(obj["opener_action_attempted"] as? Bool == true)
+    #expect(obj["requested_window_title"] as? String == trackName)
+    #expect(obj["requested_slider_description"] as? String == "Threshold")
+    let windowCandidates = obj["window_candidates"] as? [[String: Any]]
+    #expect(windowCandidates?.first?["title"] as? String == "AcidWashBass — Tracks")
+}
+
+@Test func testProductionOpenerOpensClosedTargetSlotWindow() async {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(obj["observed_normalized"] as? Double == 60)
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider() async {
+    let fixture = LiveFixture(
+        thresholdDescription: "Output Gain",
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(obj["write_attempted"] as? Bool == false)
+    #expect(obj["opener_action_attempted"] as? Bool == true)
+    let windowCandidates = obj["window_candidates"] as? [[String: Any]]
+    let sliders = windowCandidates?.last?["slider_descriptions"] as? [String]
+    #expect(sliders?.contains("Output Gain") == true)
+    #expect(fixture.currentSliderValue == 51)
 }
 
 @Test func testOpenerFallbackProducesStateA() async {
@@ -448,7 +513,7 @@ private func runChannelEQFixture(
     let obj = await runLive(
         fixture: fixture,
         params: thresholdParams(),
-        opener: { name, desc in
+        opener: { _, name, desc, _ in
             (name == trackName && desc == "Threshold") ? sendable : nil
         }
     )
@@ -479,7 +544,7 @@ private func runChannelEQFixture(
     let obj = await runLive(
         fixture: fixture,
         params: thresholdParams(),
-        opener: { _, _ in sendable }
+        opener: { _, _, _, _ in sendable }
     )
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "param_control_not_found")

--- a/docs/prd/PRD-issue-268-plugin-window-opener.md
+++ b/docs/prd/PRD-issue-268-plugin-window-opener.md
@@ -1,0 +1,134 @@
+# PRD: Issue #268 - set_param_verified Plugin Window Opener
+
+**Version**: 1.0
+**Date**: 2026-07-08
+**Status**: Implemented
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/268
+**Size**: M
+
+## 1. Problem
+
+`logic_plugins.set_param_verified` can see the target Compressor insert through
+`get_inventory`, but fails before writing when the Compressor editor window is not
+already open:
+
+```json
+{
+  "state": "C",
+  "error": "window_open_failed",
+  "write_attempted": false,
+  "what_was_observed": "no open plugin window titled 'Chords' exposes the 'Threshold' control, and one could not be opened"
+}
+```
+
+The current production path says it will try to open the plugin editor, but the
+default opener is a no-op:
+
+```swift
+static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _, _, _ in nil }
+```
+
+So the implementation only succeeds when the right plugin editor window is
+already open. That makes `set_param_verified` brittle even when the inventory,
+track selection, slot identity, and parameter metadata are all valid.
+
+## 2. Goals
+
+- G1: When the target insert is occupied and readable, `set_param_verified`
+  opens/acquires the target plugin editor if no matching editor window is already
+  open.
+- G2: The write remains fail-closed. No parameter write may occur unless a plugin
+  window with the requested control is positively identified.
+- G3: Failure diagnostics include enough window/control evidence to distinguish
+  "could not open" from "opened something but no matching control".
+- G4: The local Logic Pro 12.3 repro for Compressor `threshold` reaches State A.
+- G5: The fix is covered by red-first fixture tests plus live E2E evidence.
+
+## 3. Non-Goals
+
+- NG1: Guaranteeing every plugin/preset/layout in Logic Pro forever. Apple AX UI
+  is not a stable public automation contract.
+- NG2: Adding verified write support for new plugins or parameters.
+- NG3: Reworking the insert-slot inventory enumerator.
+- NG4: Changing the Honest Contract State A/B/C schema.
+
+## 4. Design
+
+### 4.1 Opener responsibility
+
+Replace the no-op production opener with a real opener that:
+
+1. Reuses the selected track and verified insert slot from the existing
+   `performVerifiedParamWrite` path.
+2. Presses/clicks the target occupied insert slot's editor/open control.
+3. Polls Logic's AX windows for a newly available plugin editor.
+4. Accepts the window only if it exposes the requested parameter slider.
+5. Returns nil if no safe window/control match is found.
+
+The opener should be driven by slot provenance, not by title text alone. A title
+match remains useful evidence, but the safety gate is the requested AX control
+inside a window opened from the target slot.
+
+### 4.2 Diagnostics
+
+When window acquisition fails, the State C payload should include a bounded
+census:
+
+- requested track name
+- requested insert index
+- requested slider description
+- visible candidate window titles
+- visible slider descriptions discovered in candidate windows
+- whether an open-slot action was attempted
+
+This evidence must not include local absolute paths, project names beyond the
+already requested track name, or private machine metadata.
+
+### 4.3 Safety invariant
+
+The only acceptable write path is:
+
+```
+verified track selection
+  -> verified occupied insert slot
+  -> open/acquire plugin window
+  -> verify requested AXSlider
+  -> write AXValue
+  -> read back AXValue
+  -> State A only on tolerance match
+```
+
+If any step fails, the response stays State C and `write_attempted:false` until
+the actual slider write step.
+
+## 5. Acceptance Criteria
+
+- AC-1: Fixture test fails on current `main`: closed plugin window plus no
+  opener produces `window_open_failed`.
+- AC-2: Fixture test passes after fix: the default production-style opener opens
+  a target-slot-backed window and `set_param_verified` reaches State A.
+- AC-3: Wrong window/wrong slider fixture remains State C with
+  `write_attempted:false`.
+- AC-4: Diagnostics expose candidate window/slider evidence on acquisition
+  failure.
+- AC-5: Live Logic Pro 12.3 E2E: reproduced Compressor `threshold` target that
+  previously returned `window_open_failed` now returns State A.
+- AC-6: Full relevant tests and build pass; final PR links this PRD and the
+  ticket board.
+
+## 6. Verification Summary
+
+- Red-first fixture reproduced the pre-fix `window_open_failed` path when the
+  plugin window starts closed.
+- The production opener now presses/clicks the target insert slot, polls for the
+  editor window, and accepts it only when the requested slider is present.
+- Safety fixtures cover the opened-but-wrong-slider case and keep
+  `write_attempted:false`.
+- Local Logic Pro 12.3 E2E replay moved the reproduced Compressor `threshold`
+  case from State C `window_open_failed` to State A with
+  `write_source:"ax_plugin_window"` and `verify_source:"ax_plugin_window"`.
+- Final verification commands and PR evidence are tracked in the ticket board.
+
+## 7. Ticket Board
+
+Execution tickets live under `docs/tickets/issue-268-plugin-window-opener/`.

--- a/docs/tickets/issue-268-plugin-window-opener/STATUS.md
+++ b/docs/tickets/issue-268-plugin-window-opener/STATUS.md
@@ -3,7 +3,7 @@
 **PRD**: `docs/prd/PRD-issue-268-plugin-window-opener.md`
 **Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/268
 **Branch**: `fix/issue-268-plugin-window-opener`
-**Current Phase**: review
+**Current Phase**: PR open
 
 ## Ticket Status
 
@@ -12,7 +12,7 @@
 | T1 | Production plugin-window opener | Verified | Red-first tests + State A fixture |
 | T2 | Failure diagnostics | Verified | Candidate window/control evidence in State C |
 | T3 | Live E2E replay | Verified | Local Logic Pro 12.3 repro returns State A |
-| T4 | Production readiness review + PR | In Progress | Review, CI, issue/PR links |
+| T4 | Production readiness review + PR | Verified | Review, CI, issue/PR links |
 
 ## Verification Ledger
 
@@ -28,6 +28,8 @@
 - Manual QA bad input: release-binary MCP call with the wrong `threshold` unit
   returned State C `invalid_params` with `write_attempted:false`.
 - CLI smoke: `.build/release/LogicProMCP --help` printed the expected usage.
+- PR opened: https://github.com/MongLong0214/logic-pro-mcp/pull/271
+- Issue status comment: https://github.com/MongLong0214/logic-pro-mcp/issues/268#issuecomment-4910876825
 - Environment note: a stale ignored `Resources/library-inventory.json` artifact
   was moved out of the repo before full-suite verification; it was not tracked
   source and is not part of this branch.

--- a/docs/tickets/issue-268-plugin-window-opener/STATUS.md
+++ b/docs/tickets/issue-268-plugin-window-opener/STATUS.md
@@ -1,0 +1,33 @@
+# Pipeline Status: issue-268 plugin window opener
+
+**PRD**: `docs/prd/PRD-issue-268-plugin-window-opener.md`
+**Issue**: https://github.com/MongLong0214/logic-pro-mcp/issues/268
+**Branch**: `fix/issue-268-plugin-window-opener`
+**Current Phase**: review
+
+## Ticket Status
+
+| Ticket | Title | Status | Gate |
+|--------|-------|--------|------|
+| T1 | Production plugin-window opener | Verified | Red-first tests + State A fixture |
+| T2 | Failure diagnostics | Verified | Candidate window/control evidence in State C |
+| T3 | Live E2E replay | Verified | Local Logic Pro 12.3 repro returns State A |
+| T4 | Production readiness review + PR | In Progress | Review, CI, issue/PR links |
+
+## Verification Ledger
+
+- Red-first: `testProductionOpenerOpensClosedTargetSlotWindow` failed on the
+  pre-fix no-op opener with State C `window_open_failed`.
+- Focused tests: `swift test --filter PluginSetParamVerifiedLiveTests` passed
+  19/19 after the production opener and fail-closed wrong-slider fixture.
+- Full suite: `swift test --no-parallel` passed 2214 tests.
+- Build: `swift build -c release` passed.
+- Live E2E: branch release binary changed the local Logic Pro 12.3 Compressor
+  `threshold` replay from State C `window_open_failed` to State A verified via
+  `ax_plugin_window`; a second explicit track 2 replay also returned State A.
+- Manual QA bad input: release-binary MCP call with the wrong `threshold` unit
+  returned State C `invalid_params` with `write_attempted:false`.
+- CLI smoke: `.build/release/LogicProMCP --help` printed the expected usage.
+- Environment note: a stale ignored `Resources/library-inventory.json` artifact
+  was moved out of the repo before full-suite verification; it was not tracked
+  source and is not part of this branch.

--- a/docs/tickets/issue-268-plugin-window-opener/T1-production-plugin-window-opener.md
+++ b/docs/tickets/issue-268-plugin-window-opener/T1-production-plugin-window-opener.md
@@ -1,0 +1,22 @@
+# T1 - Production Plugin Window Opener
+
+## Goal
+
+Replace the no-op `set_param_verified` plugin-window opener with a production
+path that opens the target insert's editor window and only proceeds after the
+requested parameter slider is visible.
+
+## Acceptance
+
+- [x] Red fixture proves default closed-window path fails before the fix.
+- [x] Production opener presses/clicks the target occupied insert slot.
+- [x] Window polling accepts only a window exposing the requested slider.
+- [x] `set_param_verified` reaches State A in the closed-window fixture.
+- [x] Wrong-window/wrong-slider cases remain State C and do not write.
+
+## Verification
+
+- Red-first: `testProductionOpenerOpensClosedTargetSlotWindow` failed with the
+  pre-fix no-op opener.
+- `swift test --filter PluginSetParamVerifiedLiveTests` passed 19/19.
+- `swift build -c release` passed.

--- a/docs/tickets/issue-268-plugin-window-opener/T2-window-acquisition-diagnostics.md
+++ b/docs/tickets/issue-268-plugin-window-opener/T2-window-acquisition-diagnostics.md
@@ -1,0 +1,21 @@
+# T2 - Window Acquisition Diagnostics
+
+## Goal
+
+Make `window_open_failed` actionable without weakening fail-closed behavior.
+
+## Acceptance
+
+- [x] State C includes bounded candidate window titles.
+- [x] State C includes bounded slider descriptions found in candidate windows.
+- [x] State C states whether an opener action was attempted.
+- [x] Payload avoids local absolute paths and private machine metadata.
+
+## Verification
+
+- `testNoOpenPluginWindowIsWindowOpenFailed` verifies bounded candidate window
+  diagnostics.
+- `testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider` verifies that
+  an opened window without the requested slider stays State C with
+  `write_attempted:false` and candidate slider evidence.
+- `swift test --filter PluginSetParamVerifiedLiveTests` passed 19/19.

--- a/docs/tickets/issue-268-plugin-window-opener/T3-live-e2e-replay.md
+++ b/docs/tickets/issue-268-plugin-window-opener/T3-live-e2e-replay.md
@@ -1,0 +1,27 @@
+# T3 - Live E2E Replay
+
+## Goal
+
+Replay the local Logic Pro 12.3 issue #268 scenario through the actual MCP
+surface.
+
+## Acceptance
+
+- [x] Preflight `get_inventory` confirms target Compressor slot State A.
+- [x] `set_param_verified` on Compressor `threshold` returns State A.
+- [x] Post-check confirms Logic health remains OK.
+- [x] Project is not dirtied by a failed attempt; successful attempt is either
+  safe apply-back or performed in a scratch/duplicate project.
+
+## Verification
+
+- Live MCP replay through the branch release binary:
+  - `logic_plugins.get_inventory` found the target Compressor slot as State A.
+  - `logic_plugins.set_param_verified` for Compressor `threshold` returned
+    `state:"A"`, `verified:true`, `write_source:"ax_plugin_window"`, and
+    `verify_source:"ax_plugin_window"`.
+  - `logic_system.health` remained ready for the required AX/AppleScript/event
+    surfaces.
+- A second replay explicitly targeted track 2 insert 1 to avoid relying on the
+  previously-open track 1 plugin window; it also returned State A verified.
+- Public PR/issue text must summarize this without local absolute paths.

--- a/docs/tickets/issue-268-plugin-window-opener/T4-production-readiness-review.md
+++ b/docs/tickets/issue-268-plugin-window-opener/T4-production-readiness-review.md
@@ -1,0 +1,47 @@
+# T4 - Production Readiness Review and PR
+
+## Goal
+
+Ship the fix as a reviewable PR with evidence.
+
+## Acceptance
+
+- [x] Diff contains only PRD, tickets, implementation, tests, and evidence.
+- [x] Relevant tests and build pass.
+- [ ] Live E2E evidence is summarized in the PR.
+- [ ] PR links and closes #268.
+- [ ] #268 receives a short status comment pointing to the PR.
+
+## Verification
+
+- `git diff --stat`
+- `gh pr view`
+- `swift test --filter PluginSetParamVerifiedLiveTests` passed 19/19.
+- `swift test --no-parallel` passed 2214/2214.
+- `swift build -c release` passed.
+- LSP diagnostics for changed Swift files are clean.
+
+## Review Notes
+
+- The implementation does not relax State A. It only replaces the missing
+  production opener between the existing occupied-slot gate and the existing
+  slider write/readback gate.
+- Opened windows are not trusted by title alone; the requested AX slider must be
+  found before a write can happen.
+- If acquisition fails, the payload stays State C with `write_attempted:false`
+  and includes bounded candidate window/slider evidence for the next report.
+
+## Runtime Audit
+
+- Hypothesis 1: the original failure is caused by the production opener being a
+  no-op. Evidence: red-first fixture failed with State C `window_open_failed`
+  before the opener was wired, then passed after the target-slot opener.
+- Hypothesis 2: opening the wrong window could cause an unsafe write. Evidence:
+  `testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider` opens a window
+  without the requested `Threshold` slider and still returns State C with
+  `write_attempted:false`.
+- Hypothesis 3: the fix might only work in fixtures and not through the real MCP
+  surface. Evidence: branch release binary E2E on live Logic Pro 12.3 returned
+  State A verified for `logic_plugins.set_param_verified` on Compressor
+  `threshold`; bad input through the same MCP surface returned State C
+  `invalid_params` before any write.

--- a/docs/tickets/issue-268-plugin-window-opener/T4-production-readiness-review.md
+++ b/docs/tickets/issue-268-plugin-window-opener/T4-production-readiness-review.md
@@ -8,14 +8,17 @@ Ship the fix as a reviewable PR with evidence.
 
 - [x] Diff contains only PRD, tickets, implementation, tests, and evidence.
 - [x] Relevant tests and build pass.
-- [ ] Live E2E evidence is summarized in the PR.
-- [ ] PR links and closes #268.
-- [ ] #268 receives a short status comment pointing to the PR.
+- [x] Live E2E evidence is summarized in the PR.
+- [x] PR links and closes #268.
+- [x] #268 receives a short status comment pointing to the PR.
 
 ## Verification
 
 - `git diff --stat`
 - `gh pr view`
+- PR: https://github.com/MongLong0214/logic-pro-mcp/pull/271
+- Issue comment:
+  https://github.com/MongLong0214/logic-pro-mcp/issues/268#issuecomment-4910876825
 - `swift test --filter PluginSetParamVerifiedLiveTests` passed 19/19.
 - `swift test --no-parallel` passed 2214/2214.
 - `swift build -c release` passed.


### PR DESCRIPTION
## Summary

- Replace the production no-op plugin-window opener in `set_param_verified` with a target-slot opener.
- Keep the write path fail-closed: opened windows are accepted only when they expose the requested AX slider before any write.
- Add bounded `window_open_failed` diagnostics with requested window/control and candidate window/slider evidence.
- Add PRD and ticket evidence for issue #268.

## Verification

- LSP diagnostics: clean for changed Swift files.
- `swift test --filter PluginSetParamVerifiedLiveTests` passed 19/19.
- `swift test --no-parallel` passed 2214/2214.
- `swift build -c release` passed.
- Live MCP E2E on Logic Pro 12.3: `logic_plugins.get_inventory` confirmed the target Compressor slot as State A, then `logic_plugins.set_param_verified` on Compressor `threshold` returned State A with `verified:true`, `write_source:"ax_plugin_window"`, `verify_source:"ax_plugin_window"`, and `observed_display:"60 %"`.
- Live MCP E2E bad input: wrong `threshold` unit returned State C `invalid_params` with `write_attempted:false`.
- CLI smoke: `.build/release/LogicProMCP --help` printed the expected usage.

## Safety Notes

This closes the reproduced bug class where the editor window starts closed and the production opener never actually opens it. It does not claim every possible Logic UI/plugin/preset layout is impossible to break; unknown layouts still fail closed with richer diagnostics instead of writing blindly.

Closes #268
