### PR TITLE
test: stabilize bootstrap picker wait

### DIFF
--- a/Scripts/logic_session_bootstrap_action_test.py
+++ b/Scripts/logic_session_bootstrap_action_test.py
@@ -1500,6 +1500,16 @@ class BootstrapFreshSessionActionTests(unittest.TestCase):
             "created_before_picker_handled": False,
         }
 
+        class FakeClock:
+            def __init__(self):
+                self.now = 0.0
+
+            def time(self):
+                return self.now
+
+            def sleep(self, duration):
+                self.now += duration
+
         def make_ui_snapshot():
             if state["created"] and not state["track_created"]:
                 if state["send_return_calls"] > 0:
@@ -1595,7 +1605,12 @@ class BootstrapFreshSessionActionTests(unittest.TestCase):
             state["project_picker_visible"] = False
             return True
 
-        with mock.patch("logic_session_bootstrap._send_return_key", side_effect=send_return_key):
+        fake_clock = FakeClock()
+        with (
+            mock.patch("logic_session_bootstrap._send_return_key", side_effect=send_return_key),
+            mock.patch("logic_session_bootstrap.time.sleep", side_effect=fake_clock.sleep),
+            mock.patch("logic_session_bootstrap.time.time", side_effect=fake_clock.time),
+        ):
             result = run_force_new_bootstrap(
                 call_tool=call_tool,
                 document_probe=lambda timeout_sec: (False, None),


### PR DESCRIPTION
## Summary
- make the bootstrap project-picker wait regression deterministic by using the existing fake-clock pattern
- preserve the behavior assertion that first-track creation must not happen before the picker is handled

## Verification
- python3 -m py_compile Scripts/logic_session_bootstrap_action_test.py
- python3 Scripts/logic_session_bootstrap_action_test.py -k test_force_new_waits_for_arrange_window_before_first_track_creation
- python3 Scripts/logic_session_bootstrap_action_test.py
- git diff --check

## Release impact
This is a test-only stabilization required by the v3.9.2 stable release preflight. The previous wall-clock version failed locally before any tag was pushed; no v3.9.2 tag or GitHub Release exists yet.