### PR TITLE
release: sync Formula sha256 to v3.9.2 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "9e27acb2f888d7eb55c1e04a1c7df26c9d280b92a0184afe8915fc43158d638e"
+    sha256 "97d2ecdd3321f911bd2a914d5e1c86ab05b945dd2bd6491327480f92bbc0b612"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
## Summary
- updates the Homebrew Formula sha256 to the published v3.9.2 universal tarball hash
- keeps the post-release install path aligned with SHA256SUMS.txt

## Verification
- `ruby -c Formula/logic-pro-mcp.rb`
- `git diff --check`
- compared Formula sha256 against `v3.9.2` release `SHA256SUMS.txt`
- downloaded `LogicProMCP-macOS-universal.tar.gz`, verified SHA256SUMS, and ran `./LogicProMCP --version` / `./LogicProMCP --help`

Note: local `brew fetch --formula ./Formula/logic-pro-mcp.rb` is blocked by current Homebrew policy rejecting untapped local formula paths, so checksum verification used the published release SHA256SUMS directly.