### PR TITLE
release: sync Formula sha256 to v3.10.0 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz release artifact.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "97d2ecdd3321f911bd2a914d5e1c86ab05b945dd2bd6491327480f92bbc0b612"
+    sha256 "27669976b990f41d99ff6a55b2f05fa18ae43a07ec1611884ad6ea2a439ee9ad"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
## Summary
- Sync Formula/logic-pro-mcp.rb sha256 to the published v3.10.0 universal tarball.
- Published SHA256SUMS.txt universal tarball hash: 27669976b990f41d99ff6a55b2f05fa18ae43a07ec1611884ad6ea2a439ee9ad.

## Verification
- ruby -c Formula/logic-pro-mcp.rb
- swift test --filter VersionConsistencyTests
- gh release view v3.10.0 --json assets,isDraft,isPrerelease,publishedAt
- Release workflow 28972722438 success: build + macOS 14/15 validate-install