### PR TITLE
fix(doctor): preserve typed command failures in evidence

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
@@ -83,13 +83,14 @@ extension SetupDoctor {
                 skipReason: "binary_path_missing"
             )
         }
-        guard let output = runtime.runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", executablePath]) else {
+        let result = runtime.runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", executablePath])
+        guard let output = result.output else {
             return check(
                 id: "release.signature",
                 domain: "release",
                 status: .warn,
-                summary: "codesign verification could not be executed.",
-                evidence: ["path": executablePath],
+                summary: commandFailureSummary(command: "codesign", result: result),
+                evidence: commandFailureEvidence(path: executablePath, result: result),
                 remediationType: .docs
             )
         }
@@ -116,13 +117,14 @@ extension SetupDoctor {
                 skipReason: "binary_path_missing"
             )
         }
-        guard let output = runtime.runCommand("/usr/bin/xattr", ["-p", "com.apple.quarantine", executablePath]) else {
+        let result = runtime.runCommand("/usr/bin/xattr", ["-p", "com.apple.quarantine", executablePath])
+        guard let output = result.output else {
             return check(
                 id: "release.quarantine",
                 domain: "release",
                 status: .warn,
-                summary: "xattr quarantine check could not be executed.",
-                evidence: ["path": executablePath],
+                summary: commandFailureSummary(command: "xattr quarantine", result: result),
+                evidence: commandFailureEvidence(path: executablePath, result: result),
                 remediationType: .docs
             )
         }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelProbeSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelProbeSupport.swift
@@ -18,7 +18,7 @@ extension SetupDoctor {
             executable: "/usr/bin/strings",
             arguments: [path],
             timeout: 1.5
-        )?.output?.stdout ?? ""
+        ).output?.stdout ?? ""
         return output.contains("LogicProMCP-MCU-Internal")
     }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
@@ -32,7 +32,7 @@ extension SetupDoctor {
         var indeterminateStaleRisk = false
         var indeterminate: [String] = []
         for path in candidates {
-            let arch = runtime.runCommand("/usr/bin/lipo", ["-archs", path])?.stdout
+            let arch = runtime.runCommand("/usr/bin/lipo", ["-archs", path]).output?.stdout
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let isRunningExecutable = standardized(path) == standardized(executablePath ?? "")
             switch staticVersionForPath(path) {
@@ -181,7 +181,7 @@ extension SetupDoctor {
         // /opt/homebrew/bin, which would otherwise make a genuine Homebrew install
         // fall through to .releaseBinary based purely on ambient PATH.
         for brewPath in ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"] {
-            if let brew = runtime.runCommand(brewPath, ["list", "--versions", "logic-pro-mcp"]),
+            if let brew = runtime.runCommand(brewPath, ["list", "--versions", "logic-pro-mcp"]).output,
                brew.exitCode == 0,
                brew.stdout.contains("logic-pro-mcp") {
                 return .homebrew

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
@@ -214,7 +214,7 @@ extension SetupDoctor {
                 return RegisteredCommandResolution(path: candidate, basis: "canonical_path")
             }
         }
-        guard let output = runtime.runCommand("/usr/bin/which", [command]),
+        guard let output = runtime.runCommand("/usr/bin/which", [command]).output,
               output.exitCode == 0 else {
             return RegisteredCommandResolution(path: nil, basis: "doctor_path")
         }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ProductionSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ProductionSupport.swift
@@ -20,22 +20,11 @@ extension SetupDoctor {
             executable: "/usr/bin/which",
             arguments: [raw],
             timeout: 1.0
-        )?.output, output.exitCode == 0 else {
+        ).output, output.exitCode == 0 else {
             return nil
         }
         let path = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return path.isEmpty ? nil : path
-    }
-
-    enum ProductionCommandResult: Equatable, Sendable {
-        case completed(CommandOutput)
-        case timedOut
-        case spawnFailed(String)
-
-        var output: CommandOutput? {
-            if case let .completed(value) = self { return value }
-            return nil
-        }
     }
 
     static func runProductionCommand(
@@ -43,9 +32,9 @@ extension SetupDoctor {
         arguments: [String],
         timeout: TimeInterval,
         enforceAllowlist: Bool = true
-    ) -> ProductionCommandResult? {
+    ) -> CommandResult {
         if enforceAllowlist, DoctorTool.resolve(executable) == nil {
-            return .spawnFailed("doctor_tool_not_allowlisted")
+            return .notAllowlisted
         }
         switch BoundedProcessRunner.run(executable: executable, arguments: arguments, timeout: timeout) {
         case let .completed(output):
@@ -63,7 +52,7 @@ extension SetupDoctor {
         executable: String,
         arguments: [String],
         timeout: TimeInterval
-    ) -> ProductionCommandResult? {
+    ) -> CommandResult {
         runProductionCommand(executable: executable, arguments: arguments, timeout: timeout, enforceAllowlist: false)
     }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
@@ -28,7 +28,7 @@ extension SetupDoctor {
                 executable: "/usr/bin/sqlite3",
                 arguments: ["file:\(db)?immutable=1", sql],
                 timeout: 1.5
-            )?.output else {
+            ).output else {
                 return .queryUnavailable
             }
             if output.exitCode != 0 {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateLookupSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateLookupSupport.swift
@@ -4,34 +4,33 @@ extension SetupDoctor {
     static func productionLatestReleaseLookup() -> UpdateOutcome {
         let repo = "MongLong0214/logic-pro-mcp"
         let url = "https://api.github.com/repos/\(repo)/releases/latest"
-        if let result = runProductionCommand(
+        let result = runProductionCommand(
             executable: "/usr/bin/curl",
             arguments: ["-fsSL", "--max-time", "3", "-H", "Accept: application/vnd.github+json", url],
             timeout: 3.5
-        ) {
-            switch result {
-            case let .completed(output):
-                if output.exitCode == 0 {
-                    return parseLatestTag(from: output.stdout).map { .found(version: $0) } ?? .parseError
-                }
-                if output.exitCode == 28 {
-                    return .timeout
-                }
-                if output.exitCode == 22 {
-                    return .httpError
-                }
-            case .timedOut:
-                return .timeout
-            case .spawnFailed:
-                break
+        )
+        switch result {
+        case let .completed(output):
+            if output.exitCode == 0 {
+                return parseLatestTag(from: output.stdout).map { .found(version: $0) } ?? .parseError
             }
+            if output.exitCode == 28 {
+                return .timeout
+            }
+            if output.exitCode == 22 {
+                return .httpError
+            }
+        case .timedOut:
+            return .timeout
+        case .spawnFailed, .notAllowlisted:
+            break
         }
         for ghPath in ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"] {
             if let gh = runProductionCommand(
                 executable: ghPath,
                 arguments: ["release", "view", "--repo", repo, "--json", "tagName", "-q", ".tagName"],
                 timeout: 3.5
-            )?.output, gh.exitCode == 0 {
+            ).output, gh.exitCode == 0 {
                 let tag = gh.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
                 return tag.isEmpty ? .parseError : .found(version: tag)
             }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -153,6 +153,35 @@ enum SetupDoctor {
         let stderr: String
     }
 
+    enum CommandResult: Equatable, Sendable {
+        case completed(CommandOutput)
+        case timedOut
+        case spawnFailed(String)
+        case notAllowlisted
+
+        var output: CommandOutput? {
+            if case let .completed(value) = self { return value }
+            return nil
+        }
+
+        var failureReason: String? {
+            switch self {
+            case let .completed(output):
+                return output.exitCode == 0 ? nil : "non_zero_exit"
+            case .timedOut:
+                return "timeout"
+            case .spawnFailed:
+                return "spawn_failed"
+            case .notAllowlisted:
+                return "allowlist_rejected"
+            }
+        }
+
+        var commandStatus: String {
+            failureReason ?? "success"
+        }
+    }
+
     /// Result of inspecting the Claude Code config for a logic-pro registration.
     /// This is a pure config read — it never spawns the registered server, so the
     /// doctor's read-only / run-before-startup contract is honored (no CoreMIDI
@@ -217,7 +246,7 @@ enum SetupDoctor {
         let isExecutableFile: (String) -> Bool
         let logicProRunning: () -> Bool
         let logicProHasVisibleWindow: () -> Bool
-        let runCommand: (String, [String]) -> CommandOutput?
+        let runCommand: (String, [String]) -> CommandResult
         let readClaudeRegistration: () -> ClaudeRegistration
         // v2 seams. Defaults keep every existing `Runtime(...)` construction site
         // compiling; `.production` and the test helper supply real/fake impls.
@@ -267,8 +296,11 @@ enum SetupDoctor {
                 ProcessUtils.hasVisibleWindow()
             },
             runCommand: { executable, arguments in
-                guard DoctorTool.resolve(executable) != nil else { return nil }
-                return SetupDoctor.runProductionCommand(executable: executable, arguments: arguments, timeout: 1.5)?.output
+                SetupDoctor.runProductionCommand(
+                    executable: executable,
+                    arguments: arguments,
+                    timeout: 1.5
+                )
             },
             readClaudeRegistration: {
                 SetupDoctor.readProductionClaudeRegistration()
@@ -322,7 +354,7 @@ enum SetupDoctor {
         func staticVersionForPath(_ path: String) -> StaticVersionResult {
             let key = standardized(path)
             if let cached = staticVersionCache[key] { return cached }
-            let strings = runtime.runCommand("/usr/bin/strings", ["-a", path])?.stdout ?? ""
+            let strings = runtime.runCommand("/usr/bin/strings", ["-a", path]).output?.stdout ?? ""
             let result = Self.staticVersion(fromStringsOutput: strings)
             staticVersionCache[key] = result
             return result
@@ -644,14 +676,44 @@ enum SetupDoctor {
         path: String,
         output: CommandOutput
     ) -> [String: String] {
-        [
+        var evidence = [
             "path": path,
             "exit_code": String(output.exitCode),
+            "command_status": output.exitCode == 0 ? "success" : "non_zero_exit",
             "stdout": streamSummary(output.stdout),
             "stdout_truncated": streamTruncated(output.stdout),
             "stderr": streamSummary(output.stderr),
             "stderr_truncated": streamTruncated(output.stderr),
         ]
+        if output.exitCode != 0 {
+            evidence["command_failure_reason"] = "non_zero_exit"
+        }
+        return evidence
+    }
+
+    static func commandFailureEvidence(path: String, result: CommandResult) -> [String: String] {
+        var evidence = [
+            "path": path,
+            "command_status": result.commandStatus,
+            "command_failure_reason": result.failureReason ?? "unknown",
+        ]
+        if case let .spawnFailed(message) = result {
+            evidence["spawn_error"] = streamSummary(message)
+        }
+        return evidence
+    }
+
+    static func commandFailureSummary(command: String, result: CommandResult) -> String {
+        switch result {
+        case .timedOut:
+            return "\(command) verification timed out. Retry and verify the tool is not blocked."
+        case .spawnFailed:
+            return "\(command) verification could not be started. Verify the tool exists and is executable."
+        case .notAllowlisted:
+            return "\(command) verification was blocked by the Doctor command allowlist. Use an allowlisted tool."
+        case .completed:
+            return "\(command) verification failed."
+        }
     }
 
     private static func streamSummary(_ value: String) -> String {

--- a/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
+++ b/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
@@ -632,11 +632,12 @@ enum SetupLifecycle {
     }
 
     private static func productionClaudeCLIAvailable() -> Bool {
-        guard let result = SetupDoctor.runProductionCommandForTesting(
+        let result = SetupDoctor.runProductionCommandForTesting(
             executable: "/usr/bin/which",
             arguments: ["claude"],
             timeout: 1.0
-        ), let output = result.output else {
+        )
+        guard let output = result.output else {
             return false
         }
         return output.exitCode == 0
@@ -647,11 +648,12 @@ enum SetupLifecycle {
         let installDir = resolveInstallDir()
         let binaryPath = installDir + "/LogicProMCP"
         guard FileManager.default.isExecutableFile(atPath: binaryPath) else { return nil }
-        guard let result = SetupDoctor.runProductionCommandForTesting(
+        let result = SetupDoctor.runProductionCommandForTesting(
             executable: binaryPath,
             arguments: ["--version"],
             timeout: 1.5
-        ), let output = result.output, output.exitCode == 0 else {
+        )
+        guard let output = result.output, output.exitCode == 0 else {
             return nil
         }
         let trimmed = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/LogicProMCPTests/DoctorToolAllowlistTests.swift
+++ b/Tests/LogicProMCPTests/DoctorToolAllowlistTests.swift
@@ -35,10 +35,9 @@ private func doctorSourceFilesForProcessLint() throws -> [(String, String)] {
 // Case 11
 @Test func test_t1v3_doctor_tool_allowlist_rejects_arbitrary_binary() {
     // AC-6 fail-closed. `/bin/echo` EXISTS but is NOT allowlisted → the production
-    // runCommand must return nil WITHOUT spawning it (side-effect-free proof).
     // TR1: never pass a real LogicProMCP path here — only /bin/echo + a nonexistent path.
-    #expect(SetupDoctor.Runtime.production.runCommand("/bin/echo", ["harmless"]) == nil)
-    #expect(SetupDoctor.Runtime.production.runCommand("/tmp/nonexistent-doctor-tool", []) == nil)
+    #expect(SetupDoctor.Runtime.production.runCommand("/bin/echo", ["harmless"]) == .notAllowlisted)
+    #expect(SetupDoctor.Runtime.production.runCommand("/tmp/nonexistent-doctor-tool", []) == .notAllowlisted)
 }
 
 // Case 12

--- a/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
@@ -47,7 +47,10 @@ private func doctorV3Runtime(
         isExecutableFile: executable,
         logicProRunning: { true },
         logicProHasVisibleWindow: { true },
-        runCommand: commandHandler,
+        runCommand: { executable, arguments in
+            commandHandler(executable, arguments).map(SetupDoctor.CommandResult.completed)
+                ?? .spawnFailed("test_command_unavailable")
+        },
         readClaudeRegistration: readClaudeRegistration ?? { registration }
     )
     runtime.logicApps = logicApps

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -34,7 +34,10 @@ private func doctorV4Runtime(
         isExecutableFile: { _ in true },
         logicProRunning: { true },
         logicProHasVisibleWindow: { true },
-        runCommand: commandHandler,
+        runCommand: { executable, arguments in
+            commandHandler(executable, arguments).map(SetupDoctor.CommandResult.completed)
+                ?? .spawnFailed("test_command_unavailable")
+        },
         readClaudeRegistration: { registration }
     )
     runtime.macOSVersion = { macOSVersion }

--- a/Tests/LogicProMCPTests/Issue262DoctorCommandFailureTests.swift
+++ b/Tests/LogicProMCPTests/Issue262DoctorCommandFailureTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private func issue262Runtime(_ commandResult: SetupDoctor.CommandResult) -> SetupDoctor.Runtime {
+    SetupDoctor.Runtime(
+        resolveExecutablePath: { _ in "/tmp/LogicProMCP" },
+        fileExists: { _ in true },
+        isExecutableFile: { _ in true },
+        logicProRunning: { true },
+        logicProHasVisibleWindow: { true },
+        runCommand: { _, _ in commandResult },
+        readClaudeRegistration: { .notRegistered }
+    )
+}
+
+@Test func doctorCommandFailuresKeepTypedEvidenceAndActionableSummary() {
+    let cases: [(SetupDoctor.CommandResult, String, String)] = [
+        (.timedOut, "timeout", "Retry"),
+        (.spawnFailed("ENOENT"), "spawn_failed", "Verify the tool exists"),
+        (.notAllowlisted, "allowlist_rejected", "Use an allowlisted tool"),
+    ]
+
+    for (result, failureReason, summaryFragment) in cases {
+        let check = SetupDoctor.releaseSignatureCheck(
+            executablePath: "/tmp/LogicProMCP",
+            runtime: issue262Runtime(result)
+        )
+
+        #expect(check.status == .warn)
+        #expect(check.evidence["command_failure_reason"] == failureReason)
+        #expect(check.evidence["command_status"] == failureReason)
+        #expect(check.summary.localizedCaseInsensitiveContains(summaryFragment))
+        if case .spawnFailed = result {
+            #expect(check.evidence["spawn_error"] == "present")
+        }
+    }
+}
+
+@Test func doctorCommandSuccessKeepsTypedEvidence() {
+    let check = SetupDoctor.releaseSignatureCheck(
+        executablePath: "/tmp/LogicProMCP",
+        runtime: issue262Runtime(.completed(.init(exitCode: 0, stdout: "", stderr: "")))
+    )
+
+    #expect(check.status == .pass)
+    #expect(check.evidence["command_status"] == "success")
+    #expect(check.evidence["command_failure_reason"] == nil)
+}
+
+@Test func doctorCommandNonzeroExitRemainsDistinctFromExecutionFailures() {
+    let check = SetupDoctor.releaseSignatureCheck(
+        executablePath: "/tmp/LogicProMCP",
+        runtime: issue262Runtime(.completed(.init(exitCode: 7, stdout: "", stderr: "invalid signature")))
+    )
+
+    #expect(check.status == .warn)
+    #expect(check.evidence["command_failure_reason"] == "non_zero_exit")
+    #expect(check.evidence["exit_code"] == "7")
+    #expect(check.evidence["command_status"] == "non_zero_exit")
+}
+
+@Test func doctorRuntimeReportsAllowlistRejectionWithoutSpawning() {
+    #expect(SetupDoctor.Runtime.production.runCommand("/bin/echo", ["harmless"]) == .notAllowlisted)
+}

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -16,17 +16,17 @@ private func enterpriseRuntime(
         logicProRunning: { true },
         logicProHasVisibleWindow: { true },
         runCommand: { executable, arguments in
-            if executable == "/usr/bin/codesign" { return .init(exitCode: 0, stdout: "", stderr: "") }
-            if executable == "/usr/bin/xattr" { return .init(exitCode: 1, stdout: "", stderr: "No such xattr") }
-            if executable == "/usr/bin/lipo" { return .init(exitCode: 0, stdout: "arm64\n", stderr: "") }
+            if executable == "/usr/bin/codesign" { return .completed(.init(exitCode: 0, stdout: "", stderr: "")) }
+            if executable == "/usr/bin/xattr" { return .completed(.init(exitCode: 1, stdout: "", stderr: "No such xattr")) }
+            if executable == "/usr/bin/lipo" { return .completed(.init(exitCode: 0, stdout: "arm64\n", stderr: "")) }
             if executable == "/usr/bin/strings", arguments.count == 2 {
-                return .init(exitCode: 0, stdout: "\(ServerConfig.serverVersion)\n", stderr: "")
+                return .completed(.init(exitCode: 0, stdout: "\(ServerConfig.serverVersion)\n", stderr: ""))
             }
             if executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew",
                arguments == ["list", "--versions", "logic-pro-mcp"] {
-                return .init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: "")
+                return .completed(.init(exitCode: 0, stdout: "logic-pro-mcp 3.7.4\n", stderr: ""))
             }
-            return nil
+            return .spawnFailed("test_command_unavailable")
         },
         readClaudeRegistration: { .registered(command: "/opt/homebrew/bin/LogicProMCP") }
     )

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -44,7 +44,10 @@ private func doctorRuntime(
         isExecutableFile: { _ in executable },
         logicProRunning: { logicRunning },
         logicProHasVisibleWindow: { visibleWindow },
-        runCommand: commandHandler,
+        runCommand: { executable, arguments in
+            commandHandler(executable, arguments).map(SetupDoctor.CommandResult.completed)
+                ?? .spawnFailed("test_command_unavailable")
+        },
         readClaudeRegistration: { registration }
     )
     runtime.macOSVersion = { macOSVersion }
@@ -624,8 +627,7 @@ private func issue26RepositoryRootURL() -> URL {
         arguments: ["-c", "head -c \(byteCount) /dev/zero | tr '\\0' 'a'"],
         timeout: 10.0
     )
-    let unwrapped = try #require(result)
-    let output = try #require(unwrapped.output)
+    let output = try #require(result.output)
     #expect(output.stdout.count == byteCount)
     #expect(output.exitCode == 0)
 }
@@ -636,12 +638,11 @@ private func issue26RepositoryRootURL() -> URL {
         arguments: [],
         timeout: 2.0
     )
-    let unwrapped = try #require(result)
-    guard case .spawnFailed = unwrapped else {
-        Issue.record("Expected spawnFailed, got \(unwrapped)")
+    guard case .spawnFailed = result else {
+        Issue.record("Expected spawnFailed, got \(result)")
         return
     }
-    #expect(unwrapped.output == nil)
+    #expect(result.output == nil)
 }
 
 @Test func testProductionCommandReportsTimeoutForSlowChild() throws {
@@ -650,9 +651,8 @@ private func issue26RepositoryRootURL() -> URL {
         arguments: ["-c", "sleep 5"],
         timeout: 0.3
     )
-    let unwrapped = try #require(result)
-    #expect(unwrapped == .timedOut)
-    #expect(unwrapped.output == nil)
+    #expect(result == .timedOut)
+    #expect(result.output == nil)
 }
 
 // MARK: - Entrypoint exit-code contract


### PR DESCRIPTION
## Summary
- preserve Doctor command outcomes as a non-optional typed result through check evaluation
- emit stable `success`, `non_zero_exit`, `timeout`, `spawn_failed`, and `allowlist_rejected` evidence with actionable human summaries
- keep allowlist rejection fail-closed and redact raw spawn errors

## Verification
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (148 passed)
- `swift test --filter doctorCommand --no-parallel -j 4 -Xswiftc -suppress-warnings` (3 passed)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,231 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- `.build/release/LogicProMCP doctor --json --client claude-code`
- `.build/release/LogicProMCP doctor --client claude-code --quiet`
- `.build/release/LogicProMCP --help`

## Test environment note
- The full local run excludes `everyEmittedCategoryExistsInPanelInventory`, which is already machine-dependent on `main`: the checked-in inventory has Bass/Drums while this Mac has additional installed Logic library categories.

Closes #262