### PR TITLE
fix(doctor): default client inference to Claude Code

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -174,7 +174,6 @@ extension SetupDoctor {
         case "claude_desktop": return (.claudeDesktop, "launch_context")
         case "cursor": return (.cursor, "launch_context")
         case "vscode": return (.vscode, "launch_context")
-        case "terminal": return (.terminal, "launch_context")
         default: break
         }
         if case .registered = claudeRegistration {
@@ -184,7 +183,7 @@ extension SetupDoctor {
         case .registered:
             return (.claudeDesktop, "registration_config")
         case .notRegistered, .configUnavailable:
-            return (.custom, "fallback_custom")
+            return (.claudeCode, "default_claude_code")
         }
     }
 

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -85,7 +85,7 @@ private func doctorV4Report(
     let report = doctorV4Report()
     #expect(report.schema == "logic_pro_mcp_doctor.v4")
     #expect(report.doctorProfile == .full)
-    #expect(report.clientProfile == .terminal)
+    #expect(report.clientProfile == .claudeCode)
     #expect(Set(report.capabilities.keys) == Set([
         "core_transport",
         "track_management",
@@ -100,8 +100,70 @@ private func doctorV4Report(
 
     let object = try #require(sharedJSONObject(encodeJSON(report)))
     #expect(object["doctor_profile"] as? String == "full")
-    #expect(object["client_profile"] as? String == "terminal")
+    #expect(object["client_profile"] as? String == "claude-code")
+    #expect(object["client_profile_basis"] as? String == "registration_config")
     #expect(object["capabilities"] as? [String: Any] != nil)
+}
+
+@Test func doctorV4TerminalInfersClaudeCodeFromRegistrationConfig() throws {
+    let report = doctorV4Report(
+        runtime: doctorV4Runtime(
+            registration: .registered(command: "/opt/homebrew/bin/LogicProMCP"),
+            desktopRegistration: .notRegistered
+        )
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+
+    #expect(report.clientProfile == .claudeCode)
+    #expect(report.clientProfileBasis == "registration_config")
+    #expect(registration.status == .pass)
+    #expect(registration.skipReason == nil)
+}
+
+@Test func doctorV4TerminalDefaultsToClaudeCodeWhenRegistrationIsMissing() throws {
+    let report = doctorV4Report(
+        runtime: doctorV4Runtime(
+            registration: .notRegistered,
+            desktopRegistration: .notRegistered
+        )
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+    let object = try #require(sharedJSONObject(encodeJSON(report)))
+
+    #expect(report.clientProfile == .claudeCode)
+    #expect(report.clientProfileBasis == "default_claude_code")
+    #expect(registration.status == .warn)
+    #expect(registration.skipReason == nil)
+    #expect(object["client_profile_basis"] as? String == "default_claude_code")
+}
+
+@Test func doctorV4UnknownContextDefaultsToClaudeCodeWhenRegistrationIsMissing() throws {
+    let report = doctorV4Report(
+        runtime: doctorV4Runtime(
+            registration: .notRegistered,
+            desktopRegistration: .notRegistered,
+            launchContext: .init(context: "unknown", responsibleHint: "unknown")
+        )
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+
+    #expect(report.clientProfile == .claudeCode)
+    #expect(report.clientProfileBasis == "default_claude_code")
+    #expect(registration.status == .warn)
+    #expect(registration.skipReason == nil)
+}
+
+@Test func doctorV4ExplicitTerminalClientStillOverridesInference() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--client", "terminal"],
+        runtime: doctorV4Runtime(registration: .registered(command: "/opt/homebrew/bin/LogicProMCP"))
+    )
+    let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+
+    #expect(report.clientProfile == .terminal)
+    #expect(report.clientProfileBasis == "explicit_flag")
+    #expect(registration.status == .skipped)
+    #expect(registration.skipReason == "client_not_selected")
 }
 
 @Test func doctorV4SkippedChecksRequireBlockedByOrSkipReason() {


### PR DESCRIPTION
## Summary
- let Terminal context fall through to stronger registration-config inference
- default no-signal/unknown client inference to Claude Code instead of silently skipping its registration check
- preserve explicit `--client` overrides and expose inferred/defaulted basis in JSON

## Verification
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (148 passed)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,232 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- `.build/release/LogicProMCP doctor --json` now reports `claude-code/default_claude_code` and runs `mcp.claude_code_registration`
- `.build/release/LogicProMCP doctor --json --client claude-code` reports `explicit_flag`
- `.build/release/LogicProMCP doctor --json --client terminal` preserves the explicit opt-out
- `.build/release/LogicProMCP doctor --json --client custom` preserves the explicit opt-out
- `.build/release/LogicProMCP --help`

## Test environment note
- The full local run excludes `everyEmittedCategoryExistsInPanelInventory`, which is already machine-dependent on `main`: the checked-in inventory has Bass/Drums while this Mac has additional installed Logic library categories.

Closes #260