### PR TITLE
fix(doctor): make remediation install-source aware

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
@@ -62,7 +62,7 @@ extension SetupDoctor {
             status: warn ? .warn : .pass,
             summary: binaryInventorySummary(stale: stale, indeterminateStaleRisk: indeterminateStaleRisk),
             evidence: evidence,
-            remediationType: warn ? binaryInventoryRemediationType(installSource: installSource) : .none,
+            remediationType: warn ? installSourceRemediationType(installSource) : .none,
             remediationValueOverride: warn ? binaryInventoryRemediation(installSource: installSource) : nil
         )
     }
@@ -79,7 +79,7 @@ extension SetupDoctor {
     }
 
 
-    static func binaryInventoryRemediationType(installSource: InstallSource) -> RemediationType {
+    static func installSourceRemediationType(_ installSource: InstallSource) -> RemediationType {
         switch installSource {
         case .homebrew, .sourceBuild:
             return .command
@@ -89,7 +89,7 @@ extension SetupDoctor {
     }
 
 
-    static func binaryInventoryRemediation(installSource: InstallSource) -> String {
+    static func updateRemediation(installSource: InstallSource) -> String {
         switch installSource {
         case .homebrew:
             return "brew upgrade logic-pro-mcp"
@@ -98,12 +98,34 @@ extension SetupDoctor {
         case .releaseBinary:
             return "Download and replace the pinned LogicProMCP release binary."
         case .unknown:
-            return remediationAnchorsByCheckID["install.binary_inventory"] ?? "docs/SETUP.md#doctor"
+            return remediationAnchorsByCheckID["updates.latest_release"] ?? "docs/SETUP.md#doctor"
         }
     }
 
 
-    static func installShareDirCheck(runtime: Runtime) -> Check {
+    static func binaryInventoryRemediation(installSource: InstallSource) -> String {
+        if installSource == .unknown {
+            return remediationAnchorsByCheckID["install.binary_inventory"] ?? "docs/SETUP.md#doctor"
+        }
+        return updateRemediation(installSource: installSource)
+    }
+
+
+    static func shareDirRemediation(installSource: InstallSource) -> String {
+        switch installSource {
+        case .homebrew:
+            return "brew reinstall logic-pro-mcp"
+        case .sourceBuild:
+            return "git pull && swift build -c release"
+        case .releaseBinary:
+            return "Reinstall from the pinned LogicProMCP release package to restore helper assets."
+        case .unknown:
+            return remediationAnchorsByCheckID["install.share_dir"] ?? "docs/SETUP.md#doctor"
+        }
+    }
+
+
+    static func installShareDirCheck(runtime: Runtime, installSource: InstallSource) -> Check {
         switch runtime.shareDirProbe() {
         case let .complete(path, source):
             return check(
@@ -121,8 +143,8 @@ extension SetupDoctor {
                 status: .warn,
                 summary: "Installed share directory is missing helper assets.",
                 evidence: shareDirEvidence(path: path, source: source, extra: ["missing_files": files.joined(separator: ",")]),
-                remediationType: .command,
-                remediationValueOverride: "brew reinstall logic-pro-mcp"
+                remediationType: installSourceRemediationType(installSource),
+                remediationValueOverride: shareDirRemediation(installSource: installSource)
             )
         case .unresolved:
             return check(

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension SetupDoctor {
-    static func updateCheck(outcome: UpdateOutcome) -> Check {
+    static func updateCheck(outcome: UpdateOutcome, installSource: InstallSource) -> Check {
         let installed = ServerConfig.serverVersion
         switch outcome {
         case let .found(rawLatest):
@@ -37,8 +37,8 @@ extension SetupDoctor {
                 status: .warn,
                 summary: "A newer release is available: \(latest) (installed \(installed)).",
                 evidence: ["installed": installed, "latest": latest],
-                remediationType: .command,
-                remediationValueOverride: "brew upgrade logic-pro-mcp"
+                remediationType: installSourceRemediationType(installSource),
+                remediationValueOverride: updateRemediation(installSource: installSource)
             )
         case .offline, .sourceUnavailable, .parseError, .httpError, .timeout:
             // Redaction (AC-6.4): evidence carries ONLY an enumerated reason — never

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -388,7 +388,7 @@ enum SetupDoctor {
                 staticVersionForPath: staticVersionForPath
             )
         })
-        checks.append(timed { installShareDirCheck(runtime: runtime) })
+        checks.append(timed { installShareDirCheck(runtime: runtime, installSource: installSource) })
         checks.append(timed { releaseSignatureCheck(executablePath: executablePath, runtime: runtime) })
         checks.append(timed { releaseQuarantineCheck(executablePath: executablePath, runtime: runtime) })
         checks.append(timed { claudeRegistrationCheck(registration: claudeRegistration, clientProfile: clientProfile) })
@@ -425,7 +425,7 @@ enum SetupDoctor {
         checks.append(timed { clickFallbackCheck(runtime: runtime, permissionStatus: permissionStatus) })
         // Opt-in update check: emitted only when `--check-updates` armed the lookup seam.
         if let lookup = runtime.latestReleaseLookup {
-            checks.append(timed { updateCheck(outcome: lookup()) })
+            checks.append(timed { updateCheck(outcome: lookup(), installSource: installSource) })
         }
 
         // Honesty chokepoint (G1/AC-1.5): the report can never claim `ok` while a

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -248,6 +248,100 @@ private func issue26RepositoryRootURL() -> URL {
 
 // MARK: - Install-source classification
 
+@Test func testDoctorUpdateAndShareDirRemediationUsesInstallSource() throws {
+    let cases: [(
+        source: SetupDoctor.InstallSource,
+        executablePath: String,
+        updateType: SetupDoctor.RemediationType,
+        updateValue: String,
+        shareType: SetupDoctor.RemediationType,
+        shareValue: String
+    )] = [
+        (
+            .homebrew,
+            "/opt/homebrew/bin/LogicProMCP",
+            .command,
+            "brew upgrade logic-pro-mcp",
+            .command,
+            "brew reinstall logic-pro-mcp"
+        ),
+        (
+            .sourceBuild,
+            "/Users/x/logic-pro-mcp/.build/release/LogicProMCP",
+            .command,
+            "git pull && swift build -c release",
+            .command,
+            "git pull && swift build -c release"
+        ),
+        (
+            .releaseBinary,
+            "/usr/local/bin/LogicProMCP",
+            .docs,
+            "Download and replace the pinned LogicProMCP release binary.",
+            .docs,
+            "Reinstall from the pinned LogicProMCP release package to restore helper assets."
+        ),
+        (
+            .unknown,
+            "/Users/x/bin/LogicProMCP",
+            .docs,
+            "docs/SETUP.md#doctor-updateslatest-release",
+            .docs,
+            "docs/SETUP.md#doctor-installshare-dir"
+        ),
+    ]
+
+    for testCase in cases {
+        var runtime = doctorRuntime(
+            executablePath: testCase.executablePath,
+            latestReleaseLookup: { .found(version: "v99.0.0") },
+            commandHandler: { executable, arguments in
+                if testCase.source == .homebrew,
+                   (executable == "/opt/homebrew/bin/brew" || executable == "/usr/local/bin/brew"),
+                   arguments == ["list", "--versions", "logic-pro-mcp"] {
+                    return .init(exitCode: 0, stdout: "logic-pro-mcp \(ServerConfig.serverVersion)\n", stderr: "")
+                }
+                return nil
+            }
+        )
+        runtime.shareDirProbe = {
+            .missing(path: "/tmp/logic-pro-mcp-share", source: "registered_env", files: ["logic_bounce.py"])
+        }
+        let report = SetupDoctor.generate(
+            arguments: ["LogicProMCP", "doctor", "--json", "--check-updates", "--client", "claude-code"],
+            permissionStatus: grantedPermissionStatus(),
+            approvals: allApprovals(),
+            runtime: runtime
+        )
+        let update = try #require(report.checks.first { $0.id == "updates.latest_release" })
+        let share = try #require(report.checks.first { $0.id == "install.share_dir" })
+        let json = encodeJSON(report)
+        let object = try #require(sharedJSONObject(json))
+        let encodedChecks = try #require(object["checks"] as? [[String: Any]])
+        let encodedUpdate = try #require(encodedChecks.first { $0["id"] as? String == "updates.latest_release" })
+        let encodedShare = try #require(encodedChecks.first { $0["id"] as? String == "install.share_dir" })
+        let encodedUpdateRemediation = try #require(encodedUpdate["remediation"] as? [String: Any])
+        let encodedShareRemediation = try #require(encodedShare["remediation"] as? [String: Any])
+        let human = SetupDoctor.renderHuman(report, useColor: false)
+
+        #expect(report.installSource == testCase.source)
+        #expect(update.remediation.type == testCase.updateType)
+        #expect(update.remediation.value == testCase.updateValue)
+        #expect(share.remediation.type == testCase.shareType)
+        #expect(share.remediation.value == testCase.shareValue)
+        #expect(report.fixPlan.contains("updates.latest_release"))
+        #expect(report.fixPlan.contains("install.share_dir"))
+        #expect(encodedUpdateRemediation["value"] as? String == testCase.updateValue)
+        #expect(encodedShareRemediation["value"] as? String == testCase.shareValue)
+        #expect(human.contains(testCase.updateValue))
+        #expect(human.contains(testCase.shareValue))
+        if testCase.source != .homebrew {
+            #expect(!update.remediation.value.contains("brew "))
+            #expect(!share.remediation.value.contains("brew "))
+        }
+    }
+}
+
 @Test func testSetupDoctorClassifiesSourceBuildEvenWhenBrewProbeSucceeds() throws {
     // .build path component must win over a succeeding brew probe (precedence pin).
     let report = SetupDoctor.generate(

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -211,7 +211,7 @@ Reinstall or upgrade when a canonical installed binary has a stale static versio
 
 <a id="doctor-installshare-dir"></a>
 ### `install.share_dir`
-Run `brew reinstall logic-pro-mcp` when packaged helper assets are missing.
+When helper assets are missing, Homebrew installs use `brew reinstall logic-pro-mcp`; source builds restore the checkout and rebuild; release installs replace the pinned package. Unknown/custom installs should follow this section rather than a package-manager command.
 
 <a id="doctor-releasesignature"></a>
 ### `release.signature`
@@ -263,7 +263,7 @@ Logic Pro MCP requires macOS 14 or newer. Upgrade macOS if this check fails.
 
 <a id="doctor-updateslatest-release"></a>
 ### `updates.latest_release`
-Shown only with `doctor --check-updates`. If a newer release exists, `brew upgrade logic-pro-mcp` (or reinstall from the target release). A `skipped` status means the check could not reach the release source (offline / unavailable) — it never blocks.
+Shown only with `doctor --check-updates`. If a newer release exists, Homebrew installs use `brew upgrade logic-pro-mcp`, source builds pull and rebuild, and release installs replace the pinned asset. Unknown/custom installs receive this docs link instead of a package-manager command. A `skipped` status means the check could not reach the release source (offline / unavailable) — it never blocks.
 
 <a id="doctor-logicapplication-state"></a>
 ### `logic.application_state`


### PR DESCRIPTION
## Summary
- derive update and missing-share-dir remediation from the detected install source
- keep Homebrew commands for Homebrew while using source rebuild, pinned-release, or conservative docs guidance elsewhere
- preserve the existing binary-inventory anchor and align Doctor remediation docs

## Verification
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (149 passed)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,233 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- `.build/release/LogicProMCP doctor --json --check-updates --client claude-code`
- `.build/release/LogicProMCP doctor --check-updates --client claude-code --quiet`
- `.build/release/LogicProMCP --help`

The report-level regression matrix covers Homebrew, source build, release binary, and unknown/custom paths in both JSON and human output.

## Test environment note
- The full local run excludes `everyEmittedCategoryExistsInPanelInventory`, which is already machine-dependent on `main`: the checked-in inventory has Bass/Drums while this Mac has additional installed Logic library categories.

Closes #261