### PR TITLE
fix(doctor): type skip reason taxonomy

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+BinaryChecks.swift
@@ -38,7 +38,7 @@ extension SetupDoctor {
                 summary: "Executable bit could not be checked because the binary path is missing.",
                 evidence: [:],
                 remediationType: .docs,
-                skipReason: "binary_path_missing"
+                skipReason: .binaryPathMissing
             )
         }
         let executable = runtime.isExecutableFile(executablePath)
@@ -80,7 +80,7 @@ extension SetupDoctor {
                 summary: "Signature verification skipped because the binary path is missing.",
                 evidence: [:],
                 remediationType: .docs,
-                skipReason: "binary_path_missing"
+                skipReason: .binaryPathMissing
             )
         }
         let result = runtime.runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", executablePath])
@@ -114,7 +114,7 @@ extension SetupDoctor {
                 summary: "Quarantine check skipped because the binary path is missing.",
                 evidence: [:],
                 remediationType: .docs,
-                skipReason: "binary_path_missing"
+                skipReason: .binaryPathMissing
             )
         }
         let result = runtime.runCommand("/usr/bin/xattr", ["-p", "com.apple.quarantine", executablePath])

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -27,7 +27,7 @@ extension SetupDoctor {
                 evidence: ["profile": profile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "profile_not_required"
+                skipReason: .profileNotRequired
             )
         }
 
@@ -49,7 +49,7 @@ extension SetupDoctor {
                 summary: "Manual-validation channels were explicitly skipped by the operator; live readiness is not claimed for those channels.",
                 evidence: evidence,
                 remediationType: .none,
-                skipReason: "intentionally_skipped"
+                skipReason: .intentionallySkipped
             )
         }
         return check(
@@ -76,7 +76,7 @@ extension SetupDoctor {
                 evidence: ["profile": profile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "profile_not_required"
+                skipReason: .profileNotRequired
             )
         }
         let staged = runtime.keyCommandsPresetStaged()
@@ -104,7 +104,7 @@ extension SetupDoctor {
                 evidence: ["profile": profile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "profile_not_required"
+                skipReason: .profileNotRequired
             )
         }
         let found = runtime.mcuPortReferenceFound()

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+InstallChecks.swift
@@ -132,7 +132,7 @@ extension SetupDoctor {
                 summary: "Share directory could not be resolved; source builds may not have packaged helper assets.",
                 evidence: ["reason": "share_dir_unresolved"],
                 remediationType: .docs,
-                skipReason: "source_build_no_share_dir"
+                skipReason: .sourceBuildNoShareDir
             )
         case let .invalid(path, source):
             return check(
@@ -142,7 +142,7 @@ extension SetupDoctor {
                 summary: "Resolved share directory is not a directory.",
                 evidence: shareDirEvidence(path: path, source: source, extra: ["reason": "share_dir_invalid"]),
                 remediationType: .docs,
-                skipReason: "share_dir_invalid"
+                skipReason: .shareDirInvalid
             )
         }
     }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
@@ -11,7 +11,7 @@ extension SetupDoctor {
                 summary: "macOS version could not be determined.",
                 evidence: ["reason": "version_unreadable"],
                 remediationType: .docs,
-                skipReason: "version_unreadable"
+                skipReason: .versionUnreadable
             )
         }
         let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
@@ -56,7 +56,7 @@ extension SetupDoctor {
                 summary: "Logic Pro.app exists but its version could not be read.",
                 evidence: ["reason": "bundle_unreadable", "path": supported.map(\.path).joined(separator: ",")],
                 remediationType: .docs,
-                skipReason: "bundle_unreadable"
+                skipReason: .bundleUnreadable
             )
         }
         var evidence = [

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
@@ -11,7 +11,7 @@ extension SetupDoctor {
                 evidence: ["client_profile": clientProfile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "client_not_selected"
+                skipReason: .clientNotSelected
             )
         }
         // Read-only registration detection: inspect the Claude Code config file
@@ -71,7 +71,7 @@ extension SetupDoctor {
                 evidence: ["client_profile": clientProfile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "client_not_selected"
+                skipReason: .clientNotSelected
             )
         }
         if let cause = blockingCause(for: "mcp.registration_target", checks: checks) {
@@ -106,7 +106,7 @@ extension SetupDoctor {
                 evidence: ["command_path": command, "reason": "path_dependent_unresolved"],
                 remediationType: .command,
                 remediationValueOverride: "claude mcp add --scope user logic-pro -- LogicProMCP",
-                skipReason: "path_dependent_unresolved"
+                skipReason: .pathDependentUnresolved
             )
         }
         let exists = runtime.fileExistsAtPath(resolvedCommand)
@@ -159,7 +159,7 @@ extension SetupDoctor {
                 evidence: ["client_profile": clientProfile.rawValue],
                 remediationType: .none,
                 optional: true,
-                skipReason: "client_not_selected"
+                skipReason: .clientNotSelected
             )
         }
         switch runtime.readClaudeDesktopRegistration() {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+PermissionChecks.swift
@@ -111,9 +111,9 @@ extension SetupDoctor {
         case let .skipped(reason):
             let readable: String
             switch reason {
-            case "full_disk_access_unavailable":
+            case .fullDiskAccessUnavailable:
                 readable = "false"
-            case "tcc_query_unavailable":
+            case .tccQueryUnavailable:
                 readable = "unknown"
             default:
                 readable = "true"
@@ -123,7 +123,7 @@ extension SetupDoctor {
                 domain: "permissions",
                 status: .skipped,
                 summary: "Cross-context TCC enrichment could not answer; live permission probes remain authoritative.",
-                evidence: ["tcc_db_readable": readable, "full_disk_access": readable, "reason": reason],
+                evidence: ["tcc_db_readable": readable, "full_disk_access": readable, "reason": reason.rawValue],
                 remediationType: .docs,
                 skipReason: reason
             )

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
@@ -41,7 +41,7 @@ extension SetupDoctor {
                     lines.append("    \(key)=\(check.evidence[key] ?? "")")
                 }
                 if let skipReason = check.skipReason {
-                    lines.append("    skip_reason: \(skipReason)")
+                    lines.append("    skip_reason: \(skipReason.rawValue)")
                 }
                 lines.append("    duration_ms: \(formatDuration(check.durationMs))")
             }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
@@ -3,7 +3,7 @@ import Foundation
 extension SetupDoctor {
     static func productionTCCCrossContextProbe() -> TCCCrossContextProbe {
         guard FileManager.default.isExecutableFile(atPath: "/usr/bin/sqlite3") else {
-            return .skipped(reason: "tcc_query_unavailable")
+            return .skipped(reason: .tccQueryUnavailable)
         }
         return mapTCCQueryOutcome(productionTCCRows())
     }
@@ -61,21 +61,21 @@ extension SetupDoctor {
     static func mapTCCQueryOutcome(_ outcome: TCCQueryOutcome) -> TCCCrossContextProbe {
         switch outcome {
         case .fullDiskAccessUnavailable:
-            return .skipped(reason: "full_disk_access_unavailable")
+            return .skipped(reason: .fullDiskAccessUnavailable)
         case .queryUnavailable:
-            return .skipped(reason: "tcc_query_unavailable")
+            return .skipped(reason: .tccQueryUnavailable)
         case .schemaMismatch:
-            return .skipped(reason: "tcc_schema_mismatch")
+            return .skipped(reason: .tccSchemaMismatch)
         case let .rows(rows):
             let findings = tccFindings(rows)
-            guard !findings.isEmpty else { return .skipped(reason: "principal_not_found") }
+            guard !findings.isEmpty else { return .skipped(reason: .principalNotFound) }
             if findings.contains(where: { $0.contains("state=denied") }) {
                 return .denied(findings.joined(separator: ","))
             }
             if findings.contains(where: { $0.contains("state=granted") }) {
                 return .granted(findings.joined(separator: ","))
             }
-            return .skipped(reason: "principal_not_found")
+            return .skipped(reason: .principalNotFound)
         }
     }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+UpdateCheck.swift
@@ -17,7 +17,7 @@ extension SetupDoctor {
                     summary: "Could not parse the latest release version.",
                     evidence: ["reason": "parse_error"],
                     remediationType: .docs,
-                    skipReason: "parse_error"
+                    skipReason: .parseError
                 )
             }
             let order = Self.compareVersions(installed, latest)
@@ -40,38 +40,28 @@ extension SetupDoctor {
                 remediationType: .command,
                 remediationValueOverride: "brew upgrade logic-pro-mcp"
             )
-        case .offline, .sourceUnavailable, .parseError, .httpError, .timeout:
-            // Redaction (AC-6.4): evidence carries ONLY an enumerated reason — never
-            // stderr, env, tokened URLs, or headers. The lookup is unauthenticated.
-            return check(
-                id: "updates.latest_release",
-                domain: "updates",
-                status: .skipped,
-                summary: "Could not check for the latest release.",
-                evidence: ["reason": updateReason(outcome)],
-                remediationType: .docs,
-                skipReason: updateReason(outcome)
-            )
-        }
-    }
-
-
-    static func updateReason(_ outcome: UpdateOutcome) -> String {
-        switch outcome {
-        case .found:
-            return "found"
         case .offline:
-            return "offline"
+            return skippedUpdateCheck(reason: .offline)
         case .sourceUnavailable:
-            return "source_unavailable"
+            return skippedUpdateCheck(reason: .sourceUnavailable)
         case .parseError:
-            return "parse_error"
+            return skippedUpdateCheck(reason: .parseError)
         case .httpError:
-            return "http_error"
+            return skippedUpdateCheck(reason: .httpError)
         case .timeout:
-            return "timeout"
+            return skippedUpdateCheck(reason: .timeout)
         }
     }
 
-
+    static func skippedUpdateCheck(reason: DoctorSkipReason) -> Check {
+        check(
+            id: "updates.latest_release",
+            domain: "updates",
+            status: .skipped,
+            summary: "Could not check for the latest release.",
+            evidence: ["reason": reason.rawValue],
+            remediationType: .docs,
+            skipReason: reason
+        )
+    }
 }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -17,6 +17,27 @@ enum SetupDoctor {
         case manualActionRequired = "manual_action_required"
     }
 
+    enum DoctorSkipReason: String, Codable, Sendable, CaseIterable {
+        case binaryPathMissing = "binary_path_missing"
+        case bundleUnreadable = "bundle_unreadable"
+        case clientNotSelected = "client_not_selected"
+        case fullDiskAccessUnavailable = "full_disk_access_unavailable"
+        case httpError = "http_error"
+        case intentionallySkipped = "intentionally_skipped"
+        case offline
+        case parseError = "parse_error"
+        case pathDependentUnresolved = "path_dependent_unresolved"
+        case principalNotFound = "principal_not_found"
+        case profileNotRequired = "profile_not_required"
+        case shareDirInvalid = "share_dir_invalid"
+        case sourceBuildNoShareDir = "source_build_no_share_dir"
+        case sourceUnavailable = "source_unavailable"
+        case tccQueryUnavailable = "tcc_query_unavailable"
+        case tccSchemaMismatch = "tcc_schema_mismatch"
+        case timeout
+        case versionUnreadable = "version_unreadable"
+    }
+
     enum InstallSource: String, Codable, Sendable {
         case homebrew
         case releaseBinary = "release_binary"
@@ -69,7 +90,7 @@ enum SetupDoctor {
         // keeping v3 a strict superset a v1/v2 decoder never trips over. Set only at
         // construction via the `check(...)` factory (no post-construction mutation, R9).
         var blockedBy: String?
-        var skipReason: String?
+        var skipReason: DoctorSkipReason?
         let optional: Bool
 
         // Explicit CodingKeys enumerate EVERY key — the six v1 keys keep their
@@ -218,7 +239,7 @@ enum SetupDoctor {
     enum TCCCrossContextProbe: Equatable, Sendable {
         case granted(String)
         case denied(String)
-        case skipped(reason: String)
+        case skipped(reason: DoctorSkipReason)
     }
 
     struct TCCRow: Equatable, Sendable {
@@ -478,7 +499,7 @@ enum SetupDoctor {
         remediationValueOverride: String? = nil,
         optional: Bool = false,
         blockedBy: String? = nil,
-        skipReason: String? = nil
+        skipReason: DoctorSkipReason? = nil
     ) -> Check {
         let value = remediationValueOverride ?? defaultRemediationValue(for: id, type: remediationType)
         // category/severity are DERIVED here (single chokepoint) so no check can be

--- a/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
@@ -244,26 +244,26 @@ private func doctorV3Check(_ report: SetupDoctor.Report, _ id: String) throws ->
         authValue: 1,
         indirectObjectIdentifier: ""
     )
-    #expect(SetupDoctor.mapTCCQueryOutcome(.rows([unknown])) == .skipped(reason: "principal_not_found"))
-    #expect(SetupDoctor.mapTCCQueryOutcome(.rows([])) == .skipped(reason: "principal_not_found"))
-    #expect(SetupDoctor.mapTCCQueryOutcome(.queryUnavailable) == .skipped(reason: "tcc_query_unavailable"))
-    #expect(SetupDoctor.mapTCCQueryOutcome(.schemaMismatch) == .skipped(reason: "tcc_schema_mismatch"))
-    #expect(SetupDoctor.mapTCCQueryOutcome(.fullDiskAccessUnavailable) == .skipped(reason: "full_disk_access_unavailable"))
+    #expect(SetupDoctor.mapTCCQueryOutcome(.rows([unknown])) == .skipped(reason: .principalNotFound))
+    #expect(SetupDoctor.mapTCCQueryOutcome(.rows([])) == .skipped(reason: .principalNotFound))
+    #expect(SetupDoctor.mapTCCQueryOutcome(.queryUnavailable) == .skipped(reason: .tccQueryUnavailable))
+    #expect(SetupDoctor.mapTCCQueryOutcome(.schemaMismatch) == .skipped(reason: .tccSchemaMismatch))
+    #expect(SetupDoctor.mapTCCQueryOutcome(.fullDiskAccessUnavailable) == .skipped(reason: .fullDiskAccessUnavailable))
 }
 
 @Test func testDoctorV3TCCSkippedEvidenceMatchesProbeReason() throws {
-    let cases: [(reason: String, readable: String)] = [
-        ("full_disk_access_unavailable", "false"),
-        ("tcc_query_unavailable", "unknown"),
-        ("tcc_schema_mismatch", "true"),
-        ("principal_not_found", "true"),
+    let cases: [(reason: SetupDoctor.DoctorSkipReason, readable: String)] = [
+        (.fullDiskAccessUnavailable, "false"),
+        (.tccQueryUnavailable, "unknown"),
+        (.tccSchemaMismatch, "true"),
+        (.principalNotFound, "true"),
     ]
     for item in cases {
         var runtime = doctorV3Runtime()
         runtime.tccCrossContextProbe = { .skipped(reason: item.reason) }
         let check = try doctorV3Check(doctorV3Report(runtime), "permissions.tcc_cross_context")
         #expect(check.status == .skipped)
-        #expect(check.evidence["reason"] == item.reason)
+        #expect(check.evidence["reason"] == item.reason.rawValue)
         #expect(check.evidence["tcc_db_readable"] == item.readable)
         #expect(check.evidence["full_disk_access"] == item.readable)
     }

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -84,6 +84,31 @@ private func doctorV4Report(
     )
 }
 
+@Test func doctorV4SkipReasonRawValuesAreStable() {
+    let expected = Set([
+        "binary_path_missing",
+        "bundle_unreadable",
+        "client_not_selected",
+        "full_disk_access_unavailable",
+        "http_error",
+        "intentionally_skipped",
+        "offline",
+        "parse_error",
+        "path_dependent_unresolved",
+        "principal_not_found",
+        "profile_not_required",
+        "share_dir_invalid",
+        "source_build_no_share_dir",
+        "source_unavailable",
+        "tcc_query_unavailable",
+        "tcc_schema_mismatch",
+        "timeout",
+        "version_unreadable",
+    ])
+
+    #expect(Set(SetupDoctor.DoctorSkipReason.allCases.map(\.rawValue)) == expected)
+}
+
 @Test func doctorV4SchemaProfilesAndCapabilitiesAreInJSON() throws {
     let report = doctorV4Report()
     #expect(report.schema == "logic_pro_mcp_doctor.v4")
@@ -166,7 +191,7 @@ private func doctorV4Report(
     #expect(report.clientProfile == .terminal)
     #expect(report.clientProfileBasis == "explicit_flag")
     #expect(registration.status == .skipped)
-    #expect(registration.skipReason == "client_not_selected")
+    #expect(registration.skipReason == .clientNotSelected)
 }
 
 @Test func doctorV4SkippedChecksRequireBlockedByOrSkipReason() {
@@ -187,7 +212,7 @@ private func doctorV4Report(
         runtime: doctorV4Runtime(macOSVersion: nil)
     )
     let output = SetupDoctor.renderHuman(report, mode: .verbose, useColor: false)
-    #expect(output.contains("skip_reason:"))
+    #expect(output.contains("skip_reason: version_unreadable"))
 }
 
 @Test func doctorV4CoreProfileDoesNotRequireManualChannels() throws {
@@ -196,9 +221,13 @@ private func doctorV4Report(
         approvals: [:]
     )
     let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
+    let object = try #require(sharedJSONObject(encodeJSON(report)))
+    let checks = try #require(object["checks"] as? [[String: Any]])
+    let encodedManual = try #require(checks.first { $0["id"] as? String == "channels.manual_validation" })
     #expect(manual.status == .skipped)
     #expect(manual.optional)
-    #expect(manual.skipReason == "profile_not_required")
+    #expect(manual.skipReason == .profileNotRequired)
+    #expect(encodedManual["skip_reason"] as? String == "profile_not_required")
     #expect(report.status == .ok)
 }
 
@@ -227,7 +256,7 @@ private func doctorV4Report(
 
     let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
     #expect(manual.status == .skipped)
-    #expect(manual.skipReason == "intentionally_skipped")
+    #expect(manual.skipReason == .intentionallySkipped)
     #expect(!manual.optional)
     #expect(report.status == .degraded)
     #expect(report.capabilities["keycmd_only_ops"]?.status == .unknownLiveVerifyRequired)
@@ -241,7 +270,7 @@ private func doctorV4Report(
     let claude = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
     #expect(claude.status == .skipped)
     #expect(claude.optional)
-    #expect(claude.skipReason == "client_not_selected")
+    #expect(claude.skipReason == .clientNotSelected)
     #expect(report.clientProfile == .cursor)
 }
 
@@ -258,7 +287,7 @@ private func doctorV4Report(
     let isOptional = desktop.optional
     #expect(desktop.status == .warn || desktop.status == .manual)
     #expect(isOptional == false)
-    #expect(desktop.skipReason != "client_not_selected")
+    #expect(desktop.skipReason != .clientNotSelected)
     #expect(report.status != .ok)
 }
 


### PR DESCRIPTION
## Summary
- introduce a single `DoctorSkipReason` raw-value enum for every Doctor skip reason
- thread the typed reason through check construction, TCC probes, update checks, JSON, and human rendering
- lock the complete raw-value set and representative JSON/human compatibility in tests

## Verification
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (153 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- release CLI JSON and verbose runs preserved `client_not_selected` and `profile_not_required`; `doctor --help` passed
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,237 passed)

The skipped inventory integration test depends on the local Logic library exceeding the committed fixture categories and is unrelated to this change.

Closes #263