### PR TITLE
fix(doctor): report Claude config match confidence

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ClaudeConfigSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ClaudeConfigSupport.swift
@@ -23,27 +23,15 @@ extension SetupDoctor {
             serverScopes.append(top)
         }
         if let projects = object["projects"] as? [String: Any] {
-            for case let project as [String: Any] in projects.values {
+            for projectKey in projects.keys.sorted() {
+                guard let project = projects[projectKey] as? [String: Any] else { continue }
                 if let scoped = project["mcpServers"] as? [String: Any] {
                     serverScopes.append(scoped)
                 }
             }
         }
 
-        for scope in serverScopes {
-            for (name, rawEntry) in scope {
-                guard let entry = rawEntry as? [String: Any] else { continue }
-                let nameMatches = name.localizedCaseInsensitiveContains("logic-pro")
-                let command = (entry["command"] as? String) ?? ""
-                let commandMatches = command
-                    .localizedCaseInsensitiveContains("LogicProMCP")
-                if nameMatches && commandMatches {
-                    let environment = entry["env"] as? [String: String] ?? [:]
-                    return .registered(command: command, environment: environment)
-                }
-            }
-        }
-        return .notRegistered
+        return matchClaudeRegistration(in: serverScopes)
     }
 
 
@@ -61,21 +49,36 @@ extension SetupDoctor {
         guard let servers = object["mcpServers"] as? [String: Any] else {
             return .configUnavailable(reason: "config_unreadable")
         }
-        for (name, rawEntry) in servers {
-            guard let entry = rawEntry as? [String: Any] else { continue }
-            let command = (entry["command"] as? String) ?? ""
-            if name.localizedCaseInsensitiveContains("logic-pro")
-                && command.localizedCaseInsensitiveContains("LogicProMCP") {
-                let environment = entry["env"] as? [String: String] ?? [:]
-                return .registered(command: command, environment: environment)
-            }
-        }
-        return .notRegistered
+        return matchClaudeRegistration(in: [servers])
     }
 
 
     static func readClaudeRegistrationForTesting(configURL: URL) -> ClaudeRegistration {
         readProductionClaudeRegistration(configURL: configURL)
+    }
+
+    private static func matchClaudeRegistration(in serverScopes: [[String: Any]]) -> ClaudeRegistration {
+        var nameOnlyMatch: ClaudeRegistration?
+        var commandOnlyMatch: ClaudeRegistration?
+
+        for scope in serverScopes {
+            for name in scope.keys.sorted() {
+                guard let entry = scope[name] as? [String: Any] else { continue }
+                let command = (entry["command"] as? String) ?? ""
+                let nameMatches = name.localizedCaseInsensitiveContains("logic-pro")
+                let commandMatches = command.localizedCaseInsensitiveContains("LogicProMCP")
+                if nameMatches && commandMatches {
+                    let environment = entry["env"] as? [String: String] ?? [:]
+                    return .registered(command: command, environment: environment)
+                }
+                if nameMatches, nameOnlyMatch == nil {
+                    nameOnlyMatch = .nameOnly(name: name, command: command)
+                } else if commandMatches, commandOnlyMatch == nil {
+                    commandOnlyMatch = .commandOnly(name: name, command: command)
+                }
+            }
+        }
+        return nameOnlyMatch ?? commandOnlyMatch ?? .notRegistered
     }
 
     private static func loadClaudeConfigObject(at configURL: URL) -> ClaudeConfigLoadResult {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+MCPChecks.swift
@@ -28,8 +28,26 @@ extension SetupDoctor {
                 domain: "mcp",
                 status: .pass,
                 summary: "Claude Code MCP registration found.",
-                evidence: ["registered": "true", "command": command],
+                evidence: [
+                    "registered": "true",
+                    "command": command,
+                    "match_kind": ClaudeRegistrationMatchKind.nameAndCommand.rawValue,
+                ],
                 remediationType: .none
+            )
+        case let .nameOnly(name, command):
+            return partialClaudeRegistrationCheck(
+                name: name,
+                command: command,
+                matchKind: .nameOnly,
+                summary: "Claude Code MCP registration name matches, but its command does not target LogicProMCP."
+            )
+        case let .commandOnly(name, command):
+            return partialClaudeRegistrationCheck(
+                name: name,
+                command: command,
+                matchKind: .commandOnly,
+                summary: "A Claude Code MCP entry targets LogicProMCP, but its server name does not match logic-pro."
             )
         case .notRegistered:
             return check(
@@ -37,7 +55,7 @@ extension SetupDoctor {
                 domain: "mcp",
                 status: .warn,
                 summary: "Claude Code MCP registration was not found.",
-                evidence: ["registered": "false"],
+                evidence: ["registered": "false", "match_kind": ClaudeRegistrationMatchKind.none.rawValue],
                 remediationType: .command,
                 remediationValueOverride: "claude mcp add --scope user logic-pro -- LogicProMCP"
             )
@@ -51,6 +69,28 @@ extension SetupDoctor {
                 remediationType: .manual
             )
         }
+    }
+
+    static func partialClaudeRegistrationCheck(
+        name: String,
+        command: String,
+        matchKind: ClaudeRegistrationMatchKind,
+        summary: String
+    ) -> Check {
+        check(
+            id: "mcp.claude_code_registration",
+            domain: "mcp",
+            status: .warn,
+            summary: summary,
+            evidence: [
+                "registered": "false",
+                "match_kind": matchKind.rawValue,
+                "server_name": name,
+                "command": command,
+            ],
+            remediationType: .command,
+            remediationValueOverride: "claude mcp remove \(shellQuote(name)) && claude mcp add --scope user logic-pro -- LogicProMCP"
+        )
     }
 
 
@@ -169,8 +209,26 @@ extension SetupDoctor {
                 domain: "mcp",
                 status: .pass,
                 summary: "Claude Desktop MCP registration found.",
-                evidence: ["config_present": "true", "registered": "true"],
+                evidence: [
+                    "config_present": "true",
+                    "registered": "true",
+                    "match_kind": ClaudeRegistrationMatchKind.nameAndCommand.rawValue,
+                ],
                 remediationType: .none
+            )
+        case let .nameOnly(name, command):
+            return partialClaudeDesktopRegistrationCheck(
+                name: name,
+                command: command,
+                matchKind: .nameOnly,
+                summary: "Claude Desktop registration name matches, but its command does not target LogicProMCP."
+            )
+        case let .commandOnly(name, command):
+            return partialClaudeDesktopRegistrationCheck(
+                name: name,
+                command: command,
+                matchKind: .commandOnly,
+                summary: "A Claude Desktop entry targets LogicProMCP, but its server name does not match logic-pro."
             )
         case .notRegistered:
             return check(
@@ -178,7 +236,11 @@ extension SetupDoctor {
                 domain: "mcp",
                 status: .warn,
                 summary: "Claude Desktop config exists but LogicProMCP is not registered.",
-                evidence: ["config_present": "true", "registered": "false"],
+                evidence: [
+                    "config_present": "true",
+                    "registered": "false",
+                    "match_kind": ClaudeRegistrationMatchKind.none.rawValue,
+                ],
                 remediationType: .manual
             )
         case let .configUnavailable(reason):
@@ -194,6 +256,28 @@ extension SetupDoctor {
                 remediationType: .manual
             )
         }
+    }
+
+    static func partialClaudeDesktopRegistrationCheck(
+        name: String,
+        command: String,
+        matchKind: ClaudeRegistrationMatchKind,
+        summary: String
+    ) -> Check {
+        check(
+            id: "mcp.claude_desktop_registration",
+            domain: "mcp",
+            status: .warn,
+            summary: summary,
+            evidence: [
+                "config_present": "true",
+                "registered": "false",
+                "match_kind": matchKind.rawValue,
+                "server_name": name,
+                "command": command,
+            ],
+            remediationType: .manual
+        )
     }
 
     struct RegisteredCommandResolution: Equatable, Sendable {

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -176,11 +176,14 @@ extension SetupDoctor {
         case "vscode": return (.vscode, "launch_context")
         default: break
         }
-        if case .registered = claudeRegistration {
+        switch claudeRegistration {
+        case .registered, .nameOnly, .commandOnly:
             return (.claudeCode, "registration_config")
+        case .notRegistered, .configUnavailable:
+            break
         }
         switch runtime.readClaudeDesktopRegistration() {
-        case .registered:
+        case .registered, .nameOnly, .commandOnly:
             return (.claudeDesktop, "registration_config")
         case .notRegistered, .configUnavailable:
             return (.claudeCode, "default_claude_code")

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -186,14 +186,38 @@ enum SetupDoctor {
     /// This is a pure config read — it never spawns the registered server, so the
     /// doctor's read-only / run-before-startup contract is honored (no CoreMIDI
     /// ports, no health sweep, no SIGKILL of an indirectly-spawned server).
+    enum ClaudeRegistrationMatchKind: String, Equatable, Sendable {
+        case none
+        case nameOnly = "name_only"
+        case commandOnly = "command_only"
+        case nameAndCommand = "name_and_command"
+    }
+
     enum ClaudeRegistration: Equatable, Sendable {
         /// A logic-pro-style MCP entry resolving to a LogicProMCP binary was found.
         case registered(command: String, environment: [String: String] = [:])
+        case nameOnly(name: String, command: String)
+        case commandOnly(name: String, command: String)
         /// The config was read successfully but no matching registration exists.
         case notRegistered
         /// The config file is absent / unreadable / not valid JSON.
         /// `reason` is a short human-readable explanation for the evidence dict.
         case configUnavailable(reason: String)
+
+        var matchKind: ClaudeRegistrationMatchKind? {
+            switch self {
+            case .registered:
+                return .nameAndCommand
+            case .nameOnly:
+                return .nameOnly
+            case .commandOnly:
+                return .commandOnly
+            case .notRegistered:
+                return ClaudeRegistrationMatchKind.none
+            case .configUnavailable:
+                return nil
+            }
+        }
     }
 
     struct LogicAppInfo: Equatable, Sendable {

--- a/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
+++ b/Sources/LogicProMCP/Utilities/SetupLifecycle.swift
@@ -380,7 +380,7 @@ enum SetupLifecycle {
         switch runtime.claudeRegistration() {
         case .registered:
             registered = true
-        case .notRegistered, .configUnavailable:
+        case .nameOnly, .commandOnly, .notRegistered, .configUnavailable:
             registered = false
         }
         let cliAvailable = runtime.claudeCLIAvailable()

--- a/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
@@ -283,20 +283,41 @@ private func doctorV3Check(_ report: SetupDoctor.Report, _ id: String) throws ->
     #expect(check.evidence["path"] == "~/bin/LogicProMCP")
 }
 
-@Test func testDoctorV3ClaudeRegistrationCapturesShareDirEnv() {
-    let json = """
-    {"mcpServers":{"logic-pro":{"command":"/opt/homebrew/bin/LogicProMCP","env":{"LOGIC_PRO_MCP_SHARE_DIR":"/tmp/share"}}}}
-    """
+@Test func testDoctorV3ClaudeRegistrationReportsMatchKindTaxonomy() throws {
+    let cases: [(json: String, expected: SetupDoctor.ClaudeRegistration, matchKind: String)] = [
+        (
+            "{\"mcpServers\":{\"unrelated\":{\"command\":\"/usr/bin/other\"}}}",
+            .notRegistered,
+            "none"
+        ),
+        (
+            "{\"mcpServers\":{\"logic-pro-old\":{\"command\":\"/usr/bin/other\"}}}",
+            .nameOnly(name: "logic-pro-old", command: "/usr/bin/other"),
+            "name_only"
+        ),
+        (
+            "{\"mcpServers\":{\"studio-tools\":{\"command\":\"/opt/homebrew/bin/LogicProMCP\"}}}",
+            .commandOnly(name: "studio-tools", command: "/opt/homebrew/bin/LogicProMCP"),
+            "command_only"
+        ),
+        (
+            "{\"mcpServers\":{\"a-logic-pro-old\":{\"command\":\"/usr/bin/other\"},\"logic-pro\":{\"command\":\"/opt/homebrew/bin/LogicProMCP\",\"env\":{\"LOGIC_PRO_MCP_SHARE_DIR\":\"/tmp/share\"}}}}",
+            .registered(command: "/opt/homebrew/bin/LogicProMCP", environment: ["LOGIC_PRO_MCP_SHARE_DIR": "/tmp/share"]),
+            "name_and_command"
+        ),
+    ]
     let dir = FileManager.default.temporaryDirectory
         .appendingPathComponent("doctor-v3-config-\(UUID().uuidString)", isDirectory: true)
-    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     let configURL = dir.appendingPathComponent(".claude.json")
-    try? Data(json.utf8).write(to: configURL)
     defer { try? FileManager.default.removeItem(at: dir) }
-    #expect(
-        SetupDoctor.readClaudeRegistrationForTesting(configURL: configURL)
-            == .registered(command: "/opt/homebrew/bin/LogicProMCP", environment: ["LOGIC_PRO_MCP_SHARE_DIR": "/tmp/share"])
-    )
+
+    for item in cases {
+        try Data(item.json.utf8).write(to: configURL)
+        let result = SetupDoctor.readClaudeRegistrationForTesting(configURL: configURL)
+        #expect(result == item.expected)
+        #expect(result.matchKind?.rawValue == item.matchKind)
+    }
 }
 
 @Test func testDoctorV3GenerateReusesClaudeRegistrationAndLogicApps() {

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -140,6 +140,49 @@ private func doctorV4Report(
     #expect(object["client_profile_basis"] as? String == "default_claude_code")
 }
 
+@Test func doctorV4PartialClaudeRegistrationsExposeTargetedGuidance() throws {
+    let cases: [(
+        registration: SetupDoctor.ClaudeRegistration,
+        matchKind: String,
+        summaryFragment: String,
+        remediationFragment: String
+    )] = [
+        (
+            .nameOnly(name: "logic-pro-old", command: "/usr/bin/other"),
+            "name_only",
+            "name matches, but its command does not target LogicProMCP",
+            "remove 'logic-pro-old'"
+        ),
+        (
+            .commandOnly(name: "studio-tools", command: "/opt/homebrew/bin/LogicProMCP"),
+            "command_only",
+            "targets LogicProMCP, but its server name does not match logic-pro",
+            "remove 'studio-tools'"
+        ),
+    ]
+
+    for item in cases {
+        let report = doctorV4Report(
+            runtime: doctorV4Runtime(registration: item.registration)
+        )
+        let check = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
+        let object = try #require(sharedJSONObject(encodeJSON(report)))
+        let checks = try #require(object["checks"] as? [[String: Any]])
+        let encoded = try #require(checks.first { $0["id"] as? String == check.id })
+        let output = SetupDoctor.renderHuman(report, mode: .verbose, useColor: false)
+
+        #expect(check.status == .warn)
+        #expect(report.clientProfile == .claudeCode)
+        #expect(report.clientProfileBasis == "registration_config")
+        let evidence = try #require(encoded["evidence"] as? [String: Any])
+        #expect(evidence["match_kind"] as? String == item.matchKind)
+        #expect(check.evidence["match_kind"] == item.matchKind)
+        #expect(check.summary.contains(item.summaryFragment))
+        #expect(check.remediation.value.contains(item.remediationFragment))
+        #expect(output.contains(item.summaryFragment))
+    }
+}
+
 @Test func doctorV4UnknownContextDefaultsToClaudeCodeWhenRegistrationIsMissing() throws {
     let report = doctorV4Report(
         runtime: doctorV4Runtime(

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -553,6 +553,7 @@ private func issue26RepositoryRootURL() -> URL {
     let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
     #expect(registration.status == .pass)
     #expect(registration.evidence["command"] == "/usr/local/bin/some-wrapper/LogicProMCP")
+    #expect(registration.evidence["match_kind"] == "name_and_command")
 }
 
 @Test func testClaudeRegistrationWarnWhenConfigHasNoMatchingEntry() throws {
@@ -564,6 +565,7 @@ private func issue26RepositoryRootURL() -> URL {
     )
     let registration = try #require(report.checks.first { $0.id == "mcp.claude_code_registration" })
     #expect(registration.status == .warn)
+    #expect(registration.evidence["match_kind"] == "none")
     #expect(registration.remediation.type == .command)
     #expect(!registration.remediation.value.isEmpty)
 }
@@ -600,12 +602,12 @@ private func issue26RepositoryRootURL() -> URL {
     #expect(result == .registered(command: "/opt/homebrew/bin/LogicProMCP"))
 }
 
-@Test func testProductionClaudeRegistrationNotRegisteredWhenCommandDoesNotResolve() {
+@Test func testProductionClaudeRegistrationReportsNameOnlyWhenCommandDoesNotMatch() {
     let json = """
     {"mcpServers":{"logic-pro":{"command":"/usr/bin/other-tool"},"context7":{"command":"npx"}}}
     """
     let result = registrationFromTemporaryConfig(json)
-    #expect(result == .notRegistered)
+    #expect(result == .nameOnly(name: "logic-pro", command: "/usr/bin/other-tool"))
 }
 
 @Test func testProductionClaudeRegistrationConfigUnavailableOnGarbage() {


### PR DESCRIPTION
## Summary
- classify Claude registration matches as `none`, `name_only`, `command_only`, or `name_and_command`
- surface partial matches as targeted Doctor warnings with stable JSON evidence and human guidance
- preserve full-match success while treating partial matches as incomplete in lifecycle and target checks

## Verification
- `swift test --filter ClaudeRegistration --no-parallel -j 4 -Xswiftc -suppress-warnings` (14 passed)
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (153 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- release CLI against isolated Claude configs verified all four match kinds, verbose guidance, malformed config handling, and `doctor --help`
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,237 passed)

The skipped inventory integration test depends on the local Logic library exceeding the committed fixture categories and is unrelated to this change.

Closes #265