### PR TITLE
fix(doctor): recognize editor TCC principals

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+TCCSupport.swift
@@ -1,6 +1,24 @@
 import Foundation
 
 extension SetupDoctor {
+    private static let relevantTCCBundleIDs: Set<String> = [
+        "com.anthropic.claudefordesktop",
+        "com.exafunction.windsurf",
+        "com.microsoft.vscode",
+        "com.microsoft.vscodeinsiders",
+        "com.todesktop.230313mzl4w4u92",
+        "dev.zed.zed",
+    ]
+
+    private static let relevantTCCAppNames: Set<String> = [
+        "claude desktop",
+        "cursor",
+        "visual studio code",
+        "vs code",
+        "windsurf",
+        "zed",
+    ]
+
     static func productionTCCCrossContextProbe() -> TCCCrossContextProbe {
         guard FileManager.default.isExecutableFile(atPath: "/usr/bin/sqlite3") else {
             return .skipped(reason: .tccQueryUnavailable)
@@ -99,10 +117,19 @@ extension SetupDoctor {
 
 
     private static func isRelevantTCCPrincipal(_ client: String) -> Bool {
-        client.localizedCaseInsensitiveContains("claude")
-            || client.localizedCaseInsensitiveContains("terminal")
-            || client.localizedCaseInsensitiveContains("iterm")
-            || client.localizedCaseInsensitiveContains("LogicProMCP")
+        let normalizedClient = client.lowercased()
+        if relevantTCCBundleIDs.contains(normalizedClient) { return true }
+
+        let basename = client.contains("/") ? URL(fileURLWithPath: client).lastPathComponent : client
+        let normalizedName = basename.lowercased().hasSuffix(".app")
+            ? String(basename.dropLast(4)).lowercased()
+            : basename.lowercased()
+        if relevantTCCAppNames.contains(normalizedName) { return true }
+
+        return normalizedClient.contains("claude")
+            || normalizedClient.contains("terminal")
+            || normalizedClient.contains("iterm")
+            || normalizedClient.contains("logicpromcp")
     }
 
 

--- a/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/DoctorV3ProductionReadinessTests.swift
@@ -237,6 +237,45 @@ private func doctorV3Check(_ report: SetupDoctor.Report, _ id: String) throws ->
     #expect(result == .denied("service=appleevents:logic10;principal_hint=Claude.app;state=denied"))
 }
 
+@Test func testDoctorV3TCCRecognizesAgentAndEditorPrincipals() {
+    let cases: [(client: String, principalHint: String)] = [
+        ("/Users/example/Applications/Cursor.app", "Cursor.app"),
+        ("com.todesktop.230313mzl4w4u92", "com.todesktop.230313mzl4w4u92"),
+        ("/Applications/Visual Studio Code.app", "Visual Studio Code.app"),
+        ("com.microsoft.VSCode", "com.microsoft.VSCode"),
+        ("com.microsoft.VSCodeInsiders", "com.microsoft.VSCodeInsiders"),
+        ("/Applications/Windsurf.app", "Windsurf.app"),
+        ("com.exafunction.windsurf", "com.exafunction.windsurf"),
+        ("/Applications/Zed.app", "Zed.app"),
+        ("dev.zed.Zed", "dev.zed.Zed"),
+        ("/Applications/Claude Desktop.app", "Claude Desktop.app"),
+        ("com.anthropic.claudefordesktop", "com.anthropic.claudefordesktop"),
+    ]
+    let rows = cases.map {
+        SetupDoctor.TCCRow(
+            service: "kTCCServiceAccessibility",
+            client: $0.client,
+            authValue: 2,
+            indirectObjectIdentifier: ""
+        )
+    } + [
+        SetupDoctor.TCCRow(
+            service: "kTCCServiceAccessibility",
+            client: "com.example.authorized",
+            authValue: 2,
+            indirectObjectIdentifier: ""
+        ),
+    ]
+
+    let findings = SetupDoctor.tccFindings(rows)
+    #expect(findings.count == cases.count)
+    for item in cases {
+        #expect(findings.contains("service=accessibility;principal_hint=\(item.principalHint);state=granted"))
+    }
+    #expect(findings.allSatisfy { !$0.contains("/Users/example") })
+    #expect(findings.allSatisfy { !$0.contains("authorized") })
+}
+
 @Test func testDoctorV3TCCNoGrantDoesNotPass() {
     let unknown = SetupDoctor.TCCRow(
         service: "kTCCServicePostEvent",


### PR DESCRIPTION
## Summary
- recognize Cursor, VS Code/Insiders, Windsurf, Zed, and Claude Desktop TCC principals by exact app name or known bundle ID
- preserve existing Claude, Terminal, iTerm, and LogicProMCP matching behavior
- keep principal hints path-redacted and avoid broad `zed` substring false positives

## Verification
- `swift test --filter testDoctorV3TCCRecognizesAgentAndEditorPrincipals --no-parallel -j 4 -Xswiftc -suppress-warnings`
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (155 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- release CLI JSON and verbose runs read the real TCC DB and exposed matched `principal_hint` values without full paths; `doctor --help` passed
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,239 passed)

The skipped inventory integration test depends on the local Logic library exceeding the committed fixture categories and is unrelated to this change.

Closes #264