### PR TITLE
refactor(doctor): execute checks through registry

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
@@ -31,9 +31,15 @@ extension SetupDoctor {
         case updatesLatestRelease = "updates.latest_release"
     }
 
+    enum DoctorCheckInclusionRule: Equatable, Sendable {
+        case always
+        case latestReleaseLookupAvailable
+    }
+
     struct DoctorCheckDefinition: Equatable, Sendable {
         let id: DoctorCheckID
         let dependencies: [DoctorCheckID]
+        let inclusionRule: DoctorCheckInclusionRule
         let optionalByDefault: Bool
         let capabilityGroups: [String]
         let remediationAnchor: String?
@@ -43,6 +49,7 @@ extension SetupDoctor {
         init(
             _ id: DoctorCheckID,
             dependencies: [DoctorCheckID] = [],
+            inclusionRule: DoctorCheckInclusionRule = .always,
             optionalByDefault: Bool = false,
             capabilityGroups: [String] = [],
             remediationAnchor: String? = nil,
@@ -51,6 +58,7 @@ extension SetupDoctor {
         ) {
             self.id = id
             self.dependencies = dependencies
+            self.inclusionRule = inclusionRule
             self.optionalByDefault = optionalByDefault
             self.capabilityGroups = capabilityGroups
             self.remediationAnchor = remediationAnchor
@@ -110,7 +118,12 @@ extension SetupDoctor {
         .init(.channelsKeycmdReference, capabilityGroups: ["keycmd_only_ops"], remediationAnchor: "docs/SETUP.md#doctor-channelskeycmd-reference", profileRule: "keycmd|full"),
         .init(.channelsMCUWiringHint, capabilityGroups: ["mixer_mcu"], remediationAnchor: "docs/SETUP.md#doctor-channelsmcu-wiring-hint", profileRule: "full"),
         .init(.dependenciesClickFallback, remediationAnchor: "docs/SETUP.md#doctor-dependenciesclick-fallback"),
-        .init(.updatesLatestRelease, optionalByDefault: true, remediationAnchor: "docs/SETUP.md#doctor-updateslatest-release"),
+        .init(
+            .updatesLatestRelease,
+            inclusionRule: .latestReleaseLookupAvailable,
+            optionalByDefault: true,
+            remediationAnchor: "docs/SETUP.md#doctor-updateslatest-release"
+        ),
     ]
 
     static let checkDefinitionByID: [String: DoctorCheckDefinition] = Dictionary(

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRunner.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRunner.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+extension SetupDoctor {
+    struct DoctorCheckRunContext {
+        let executablePath: String?
+        let installSource: InstallSource
+        let claudeRegistration: ClaudeRegistration
+        let doctorProfile: DoctorProfile
+        let clientProfile: ClientProfile
+        let permissionStatus: PermissionChecker.PermissionStatus
+        let approvals: [ManualValidationChannel: ManualValidationApproval]
+        let runtime: Runtime
+        let manualStoreHealth: ManualValidationStoreHealth
+        let logicApps: [LogicAppInfo]
+        let staticVersionForPath: (String) -> StaticVersionResult
+    }
+
+    static func runRegisteredChecks(context: DoctorCheckRunContext) -> [Check] {
+        var checks: [Check] = []
+        for definition in checkDefinitions where shouldInclude(definition, context: context) {
+            let start = context.runtime.monotonicNowMs()
+            guard var check = executeRegisteredCheck(definition.id, context: context, checks: checks) else {
+                continue
+            }
+            // Preserve whole-millisecond, sequential timing while registry order drives execution.
+            check.durationMs = (max(0, context.runtime.monotonicNowMs() - start)).rounded()
+            checks.append(check)
+        }
+        return checks
+    }
+
+    private static func shouldInclude(
+        _ definition: DoctorCheckDefinition,
+        context: DoctorCheckRunContext
+    ) -> Bool {
+        switch definition.inclusionRule {
+        case .always:
+            return true
+        case .latestReleaseLookupAvailable:
+            return context.runtime.latestReleaseLookup != nil
+        }
+    }
+
+    private static func executeRegisteredCheck(
+        _ id: DoctorCheckID,
+        context: DoctorCheckRunContext,
+        checks: [Check]
+    ) -> Check? {
+        switch id {
+        case .binaryPath:
+            return binaryPathCheck(executablePath: context.executablePath, runtime: context.runtime)
+        case .binaryExecutable:
+            return binaryExecutableCheck(executablePath: context.executablePath, runtime: context.runtime)
+        case .binaryVersion:
+            return binaryVersionCheck()
+        case .installSource:
+            return installSourceCheck(
+                installSource: context.installSource,
+                executablePath: context.executablePath
+            )
+        case .installBinaryInventory:
+            return installBinaryInventoryCheck(
+                executablePath: context.executablePath,
+                installSource: context.installSource,
+                runtime: context.runtime,
+                claudeRegistration: context.claudeRegistration,
+                staticVersionForPath: context.staticVersionForPath
+            )
+        case .installShareDir:
+            return installShareDirCheck(runtime: context.runtime, installSource: context.installSource)
+        case .releaseSignature:
+            return releaseSignatureCheck(executablePath: context.executablePath, runtime: context.runtime)
+        case .releaseQuarantine:
+            return releaseQuarantineCheck(executablePath: context.executablePath, runtime: context.runtime)
+        case .mcpClaudeCodeRegistration:
+            return claudeRegistrationCheck(
+                registration: context.claudeRegistration,
+                clientProfile: context.clientProfile
+            )
+        case .mcpRegistrationTarget:
+            return mcpRegistrationTargetCheck(
+                registration: context.claudeRegistration,
+                runtime: context.runtime,
+                checks: checks,
+                staticVersionForPath: context.staticVersionForPath,
+                clientProfile: context.clientProfile
+            )
+        case .mcpClaudeDesktopRegistration:
+            return claudeDesktopRegistrationCheck(runtime: context.runtime, clientProfile: context.clientProfile)
+        case .permissionsAccessibility:
+            return accessibilityPermissionCheck(context.permissionStatus)
+        case .permissionsAutomationLogicPro:
+            return automationPermissionCheck(context.permissionStatus)
+        case .permissionsAutomationSystemEvents:
+            return systemEventsAutomationCheck(context.permissionStatus)
+        case .permissionsPostEventAccess:
+            return postEventAccessCheck(context.permissionStatus)
+        case .permissionsLaunchContext:
+            return launchContextCheck(runtime: context.runtime)
+        case .permissionsTCCCrossContext:
+            return tccCrossContextCheck(runtime: context.runtime)
+        case .systemMacOSVersion:
+            return macOSVersionCheck(runtime: context.runtime)
+        case .logicInstallation:
+            return logicInstallationCheck(logicApps: context.logicApps)
+        case .logicVersionSupport:
+            return logicVersionSupportCheck(logicApps: context.logicApps, checks: checks)
+        case .logicApplicationState:
+            return logicApplicationStateCheck(runtime: context.runtime)
+        case .logicBlockingDialog:
+            return logicBlockingDialogCheck(runtime: context.runtime, checks: checks)
+        case .channelsManualValidation:
+            return manualValidationCheck(
+                approvals: context.approvals,
+                profile: context.doctorProfile,
+                storeHealth: context.manualStoreHealth
+            )
+        case .channelsKeycmdReference:
+            return keycmdReferenceCheck(runtime: context.runtime, profile: context.doctorProfile)
+        case .channelsMCUWiringHint:
+            return mcuWiringHintCheck(runtime: context.runtime, profile: context.doctorProfile)
+        case .dependenciesClickFallback:
+            return clickFallbackCheck(
+                runtime: context.runtime,
+                permissionStatus: context.permissionStatus
+            )
+        case .updatesLatestRelease:
+            return context.runtime.latestReleaseLookup.map {
+                updateCheck(outcome: $0(), installSource: context.installSource)
+            }
+        }
+    }
+}

--- a/Sources/LogicProMCP/Utilities/SetupDoctor.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor.swift
@@ -381,73 +381,20 @@ enum SetupDoctor {
             return result
         }
 
-        // Per-check monotonic timing. Each check runs once, in declared order
-        // (sequential — no concurrency), wrapped to stamp `duration_ms`. Checks
-        // are non-throwing, so no exception isolation is required.
-        func timed(_ make: () -> Check) -> Check {
-            let start = runtime.monotonicNowMs()
-            var result = make()
-            // Round to whole milliseconds so the JSON machine contract matches the
-            // human renderer's `formatDuration` precision and sub-millisecond timing
-            // jitter doesn't churn the `--json` bytes run-to-run (sub-ms checks → 0).
-            result.durationMs = (max(0, runtime.monotonicNowMs() - start)).rounded()
-            return result
-        }
-
-        var checks: [Check] = []
-
-        checks.append(timed { binaryPathCheck(executablePath: executablePath, runtime: runtime) })
-        checks.append(timed { binaryExecutableCheck(executablePath: executablePath, runtime: runtime) })
-        checks.append(timed { binaryVersionCheck() })
-        checks.append(timed { installSourceCheck(installSource: installSource, executablePath: executablePath) })
-        checks.append(timed {
-            installBinaryInventoryCheck(
-                executablePath: executablePath,
-                installSource: installSource,
-                runtime: runtime,
-                claudeRegistration: claudeRegistration,
-                staticVersionForPath: staticVersionForPath
-            )
-        })
-        checks.append(timed { installShareDirCheck(runtime: runtime, installSource: installSource) })
-        checks.append(timed { releaseSignatureCheck(executablePath: executablePath, runtime: runtime) })
-        checks.append(timed { releaseQuarantineCheck(executablePath: executablePath, runtime: runtime) })
-        checks.append(timed { claudeRegistrationCheck(registration: claudeRegistration, clientProfile: clientProfile) })
-        checks.append(timed {
-            mcpRegistrationTargetCheck(
-                registration: claudeRegistration,
-                runtime: runtime,
-                checks: checks,
-                staticVersionForPath: staticVersionForPath,
-                clientProfile: clientProfile
-            )
-        })
-        checks.append(timed { claudeDesktopRegistrationCheck(runtime: runtime, clientProfile: clientProfile) })
-        checks.append(timed { accessibilityPermissionCheck(permissionStatus) })
-        checks.append(timed { automationPermissionCheck(permissionStatus) })
-        checks.append(timed { systemEventsAutomationCheck(permissionStatus) })
-        checks.append(timed { postEventAccessCheck(permissionStatus) })
-        checks.append(timed { launchContextCheck(runtime: runtime) })
-        checks.append(timed { tccCrossContextCheck(runtime: runtime) })
-        checks.append(timed { macOSVersionCheck(runtime: runtime) })
-        checks.append(timed { logicInstallationCheck(logicApps: logicApps) })
-        checks.append(timed { logicVersionSupportCheck(logicApps: logicApps, checks: checks) })
-        checks.append(timed { logicApplicationStateCheck(runtime: runtime) })
-        checks.append(timed { logicBlockingDialogCheck(runtime: runtime, checks: checks) })
-        checks.append(timed {
-            manualValidationCheck(
-                approvals: approvals,
-                profile: doctorProfile,
-                storeHealth: manualStoreHealth
-            )
-        })
-        checks.append(timed { keycmdReferenceCheck(runtime: runtime, profile: doctorProfile) })
-        checks.append(timed { mcuWiringHintCheck(runtime: runtime, profile: doctorProfile) })
-        checks.append(timed { clickFallbackCheck(runtime: runtime, permissionStatus: permissionStatus) })
-        // Opt-in update check: emitted only when `--check-updates` armed the lookup seam.
-        if let lookup = runtime.latestReleaseLookup {
-            checks.append(timed { updateCheck(outcome: lookup(), installSource: installSource) })
-        }
+        let runContext = DoctorCheckRunContext(
+            executablePath: executablePath,
+            installSource: installSource,
+            claudeRegistration: claudeRegistration,
+            doctorProfile: doctorProfile,
+            clientProfile: clientProfile,
+            permissionStatus: permissionStatus,
+            approvals: approvals,
+            runtime: runtime,
+            manualStoreHealth: manualStoreHealth,
+            logicApps: logicApps,
+            staticVersionForPath: staticVersionForPath
+        )
+        var checks = runRegisteredChecks(context: runContext)
 
         // Honesty chokepoint (G1/AC-1.5): the report can never claim `ok` while a
         // required permission is ungranted. Extracted to a pure helper so the invariant

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -353,19 +353,43 @@ private func doctorV4Report(
     #expect(Set(ids) == Set(SetupDoctor.DoctorCheckID.allCases.map(\.rawValue)))
     #expect(Set(SetupDoctor.remediationAnchorsByCheckID.keys).isSubset(of: Set(ids)))
     #expect(SetupDoctor.checkDefinitionByID["updates.latest_release"]?.optionalByDefault == true)
+    #expect(
+        SetupDoctor.checkDefinitionByID["updates.latest_release"]?.inclusionRule
+            == .latestReleaseLookupAvailable
+    )
 }
 
 @Test func doctorV4CheckRegistryCoversRenderedChecksAndOrder() {
+    let reportWithoutUpdate = doctorV4Report()
+    #expect(
+        reportWithoutUpdate.checks.map(\.id)
+            == SetupDoctor.orderedCheckIDs.filter { $0 != "updates.latest_release" }
+    )
+
     var runtime = doctorV4Runtime()
     runtime.latestReleaseLookup = { .found(version: ServerConfig.serverVersion) }
 
     let report = doctorV4Report(runtime: runtime)
     let reportIDs = report.checks.map(\.id)
     let registryIDs = Set(SetupDoctor.orderedCheckIDs)
-    let orderedRenderedIDs = SetupDoctor.orderedCheckIDs.filter { Set(reportIDs).contains($0) }
 
     #expect(Set(reportIDs).isSubset(of: registryIDs))
-    #expect(reportIDs == orderedRenderedIDs)
+    #expect(reportIDs == SetupDoctor.orderedCheckIDs)
+}
+
+@Test func doctorV4RegistryRunnerPreservesProfileAndDependencyResults() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "core", "--client", "claude-code"],
+        runtime: doctorV4Runtime(registration: .notRegistered),
+        approvals: [:]
+    )
+    let manual = try #require(report.checks.first { $0.id == "channels.manual_validation" })
+    let target = try #require(report.checks.first { $0.id == "mcp.registration_target" })
+
+    #expect(manual.status == .skipped)
+    #expect(manual.skipReason == .profileNotRequired)
+    #expect(target.status == .skipped)
+    #expect(target.blockedBy == "mcp.claude_code_registration")
 }
 
 @Test func doctorV4DroppedRequiredCheckIsSynthesizedAsFailure() throws {


### PR DESCRIPTION
## Summary
- add a registry-driven Doctor runner with an exhaustive `DoctorCheckID` executor
- make conditional update inclusion a typed registry rule
- replace `generate`'s parallel append list with one runner context and preserve timing, dependency, profile/client, and capability behavior

## Verification
- registry runner focused tests (order, update inclusion, profile skip, dependency block, timing) passed
- `swift test --filter Doctor --no-parallel -j 4 -Xswiftc -suppress-warnings` (155 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- release CLI verified 26 default checks and 27 checks with `--check-updates`, stable first/last order, unique IDs, human output, and help
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,239 passed)

The skipped inventory integration test depends on the local Logic library exceeding the committed fixture categories and is unrelated to this change.

Closes #266