### PR TITLE
feat(doctor): group capability readiness summary

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+Rendering.swift
@@ -56,7 +56,51 @@ extension SetupDoctor {
             return "\(id)=\(capability.status.rawValue)"
         }
         guard !rendered.isEmpty else { return }
+        if let readiness = renderCapabilityReadinessSummary(report.capabilities) {
+            lines.append(readiness)
+        }
         lines.append("capabilities: \(rendered.joined(separator: ", "))")
+    }
+
+    static func renderCapabilityReadinessSummary(
+        _ capabilities: [String: CapabilityReadiness]
+    ) -> String? {
+        guard let coreStatus = capabilities["core_transport"]?.status else { return nil }
+        let coreSummary: String
+        switch coreStatus {
+        case .ready:
+            coreSummary = "core ready"
+        case .notReady:
+            coreSummary = "core blocked"
+        case .unknownLiveVerifyRequired:
+            coreSummary = "core incomplete"
+        case .notInProfile:
+            coreSummary = "core not in selected profile"
+        }
+
+        let ordered = capabilityDefinitions.map(\.id)
+        let blocked = ordered.filter { capabilities[$0]?.status == .notReady }
+        let incomplete = ordered.filter { capabilities[$0]?.status == .unknownLiveVerifyRequired }
+        let notInProfile = ordered.filter { capabilities[$0]?.status == .notInProfile }
+        let selectedProfileSummary: String
+        if !blocked.isEmpty {
+            selectedProfileSummary = "selected profile blocked"
+        } else if !incomplete.isEmpty {
+            selectedProfileSummary = "selected profile incomplete"
+        } else {
+            selectedProfileSummary = "selected profile ready"
+        }
+        var groups = [coreSummary, selectedProfileSummary]
+        if !blocked.isEmpty {
+            groups.append("blocked: \(blocked.joined(separator: ", "))")
+        }
+        if !incomplete.isEmpty {
+            groups.append("incomplete: \(incomplete.joined(separator: ", "))")
+        }
+        if !notInProfile.isEmpty {
+            groups.append("not in selected profile: \(notInProfile.joined(separator: ", "))")
+        }
+        return "readiness: \(groups.joined(separator: "; "))"
     }
 
     private static func appendFixPlan(_ report: Report, to lines: inout [String], useColor: Bool) {

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -258,6 +258,47 @@ private func doctorV4Report(
     #expect(output.contains("skip_reason: version_unreadable"))
 }
 
+@Test func doctorV4CapabilityReadinessSummaryGroupsReadyIncompleteAndBlocked() {
+    let readiness: (SetupDoctor.CapabilityStatus) -> SetupDoctor.CapabilityReadiness = { status in
+        SetupDoctor.CapabilityReadiness(status: status, checks: [], liveVerification: nil)
+    }
+
+    #expect(
+        SetupDoctor.renderCapabilityReadinessSummary([
+            "core_transport": readiness(.ready),
+        ]) == "readiness: core ready; selected profile ready"
+    )
+    #expect(
+        SetupDoctor.renderCapabilityReadinessSummary([
+            "core_transport": readiness(.ready),
+            "mixer_mcu": readiness(.unknownLiveVerifyRequired),
+        ]) == "readiness: core ready; selected profile incomplete; incomplete: mixer_mcu"
+    )
+    #expect(
+        SetupDoctor.renderCapabilityReadinessSummary([
+            "core_transport": readiness(.notReady),
+            "midi_import": readiness(.notInProfile),
+            "mixer_mcu": readiness(.unknownLiveVerifyRequired),
+        ])
+            == "readiness: core blocked; selected profile blocked; blocked: core_transport; incomplete: mixer_mcu; not in selected profile: midi_import"
+    )
+}
+
+@Test func doctorV4HumanReadinessSummaryIsAdditiveAndLeavesJSONStable() throws {
+    let report = doctorV4Report(
+        arguments: ["LogicProMCP", "doctor", "--json", "--profile", "core"]
+    )
+    let jsonBefore = encodeJSON(report)
+    let output = SetupDoctor.renderHuman(report, useColor: false)
+    let lines = output.split(separator: "\n").map(String.init)
+    let readinessIndex = try #require(lines.firstIndex(where: { $0.hasPrefix("readiness: ") }))
+    let capabilitiesIndex = try #require(lines.firstIndex(where: { $0.hasPrefix("capabilities: ") }))
+
+    #expect(lines[readinessIndex] == "readiness: core ready; selected profile ready; not in selected profile: midi_import, mixer_ax, mixer_mcu, keycmd_only_ops, legacy_scripter, verified_plugin_applyback")
+    #expect(readinessIndex < capabilitiesIndex)
+    #expect(encodeJSON(report) == jsonBefore)
+}
+
 @Test func doctorV4CoreProfileDoesNotRequireManualChannels() throws {
     let report = doctorV4Report(
         arguments: ["LogicProMCP", "doctor", "--json", "--profile", "core"],


### PR DESCRIPTION
## Summary
- add a compact grouped readiness line for core and the selected profile
- name blocked, incomplete, and out-of-profile capability IDs in registry order
- retain the detailed capabilities line and leave the JSON schema unchanged

## Verification
- focused grouped-renderer and output-order tests
- `swift test --filter Doctor` (158 passed)
- `swift build -c release`
- release CLI checks for core/full human output, JSON schema, and help
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2242 passed)

The skipped inventory test is an existing local-environment mismatch: the committed fixture contains only Bass/Drums while this machine’s Logic library reports additional categories.

Closes #267