### PR TITLE
fix(transport): converge exact tempo fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ The repository ships `server.json` for the official MCP Registry metadata path. 
 
 ## Known Limitations
 
-- **Tempo typing**: `transport.set_tempo` falls back to slider increments when Logic's tempo display cannot accept text input; sub-10-BPM precision may require setting tempo manually once in Logic.
+- **Tempo typing**: `transport.set_tempo` uses bounded coarse and exact AX slider fallbacks when Logic's inline tempo input does not commit, and fails closed if exact readback still cannot be verified.
 - **MIDI region padding**: `record_sequence` regions start at bar 1 and extend to the target bar using inaudible padding; note timing inside the region is exact, but the region can look longer than the phrase.
 - **External MIDI bounce readiness**: MIDI regions on GM Device / External MIDI tracks are not accepted as audible-bounce evidence by project audit or `logic_project.bounce`. Move or recreate the material on Software Instrument tracks before claiming a verified Logic Bounce.
 - **MIDI Key Commands**: Logic 12.2 does not accept the legacy `.plist` Key Commands import; manual MIDI Learn remains required for keycmd-only operations.

--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -1605,13 +1605,10 @@ def main():
             and set_tempo_128_json.get("error") in ("element_not_found", "readback_unavailable")
             and has_tempo_landmarks(set_tempo_128_json)
         ) or (
-            # #189: the slider-increment fallback fails closed (State C) when it
-            # cannot land the requested tempo — it must NEVER report success on a
-            # readback mismatch. Honest evidence: observed tempo + fallback method.
             isinstance(set_tempo_128_json, dict)
             and set_tempo_128_json.get("success") is False
             and set_tempo_128_json.get("error") == "readback_mismatch"
-            and set_tempo_128_json.get("via") == "slider-increment"
+            and set_tempo_128_json.get("via") == "slider-value-nudge"
             and approx_equal(set_tempo_128_json.get("requested"), 128.0)
             and isinstance(set_tempo_128_json.get("observed"), (int, float))
         ),

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -229,12 +229,6 @@ extension AccessibilityChannel {
                 }
             }
             if let afterIncrement = AXHelpers.getValue(slider, runtime: runtime.ax) as? Double {
-                // Honest Contract (#189): the slider-increment fallback steps in
-                // 10-BPM granularity, so it only reaches the requested tempo by
-                // coincidence. Report success ONLY when the observed value matches
-                // the request within tolerance; ANY readback mismatch fails closed
-                // with State C — a write path must never report success when the
-                // observed tempo differs from the requested tempo.
                 if abs(afterIncrement - tempoValue) < 1.0 {
                     return .success(HonestContract.encodeStateA(
                         extras: baseExtras.merging([
@@ -243,12 +237,37 @@ extension AccessibilityChannel {
                         ]) { _, new in new }
                     ))
                 }
+
+                // Logic treats a numeric AXValue write as a one-BPM nudge. The
+                // coarse step leaves at most five BPM, so ten writes are bounded.
+                var observed = afterIncrement
+                for _ in 0..<10 {
+                    let previous = observed
+                    guard AXHelpers.setAttribute(
+                        slider,
+                        kAXValueAttribute,
+                        NSNumber(value: tempoValue),
+                        runtime: runtime.ax
+                    ) else { break }
+                    Thread.sleep(forTimeInterval: 0.02)
+                    guard let next = AXHelpers.getValue(slider, runtime: runtime.ax) as? Double else { break }
+                    observed = next
+                    if abs(observed - tempoValue) < 1.0 {
+                        return .success(HonestContract.encodeStateA(
+                            extras: baseExtras.merging([
+                                "observed": observed,
+                                "via": "slider-value-nudge"
+                            ]) { _, new in new }
+                        ))
+                    }
+                    if observed == previous { break }
+                }
                 return .error(HonestContract.encodeStateC(
                     error: .readbackMismatch,
-                    hint: "tempo write fell back to a 10-BPM increment step that did not land on the requested value (typed entry didn't commit); the slider cannot represent this exact tempo via increment",
+                    hint: "typed tempo entry did not commit and the slider's coarse and exact value fallbacks did not converge",
                     extras: baseExtras.merging([
-                        "observed": afterIncrement,
-                        "via": "slider-increment",
+                        "observed": observed,
+                        "via": "slider-value-nudge",
                         "write_attempted": true,
                         "safe_to_retry": true
                     ]) { _, new in new }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1396,9 +1396,16 @@ private func makeTempoSliderFixture(
     // State C `readback_mismatch` — NEVER report success on a readback mismatch.
     let builder = FakeAXRuntimeBuilder()
     let fixture = makeTempoSliderFixture(builder: builder, tempoValue: 120.0)
-    // Default fake performAction is a no-op, so the increment never moves the
-    // slider; observed stays 120 while 96 was requested.
-    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: fixture.app)
+    let runtime = builder.makeLogicRuntime(
+        appElement: fixture.app,
+        setAttributeHandler: { _, _, _ in false },
+        performActionHandler: { _, _ in true }
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: fixture.app,
+        logicRuntime: runtime
+    )
 
     let result = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "96"])
 
@@ -1406,7 +1413,7 @@ private func makeTempoSliderFixture(
     let obj = decodeAccessibilityJSON(result.message)
     #expect(!((obj["success"] as? Bool)!))
     #expect(obj["error"] as? String == "readback_mismatch")
-    #expect(obj["via"] as? String == "slider-increment")
+    #expect(obj["via"] as? String == "slider-value-nudge")
     #expect((obj["requested"] as? Double) == 96)
     #expect((obj["observed"] as? Double) == 120)
     #expect((obj["safe_to_retry"] as? Bool)!)
@@ -1436,6 +1443,43 @@ private func makeTempoSliderFixture(
     #expect((obj["requested"] as? Double) == 130)
     #expect((obj["observed"] as? Double) == 130)
     #expect(obj["error"] == nil)
+}
+
+@Test func testSetTempoValueNudgeLandsBelowTenBPMDetent() async {
+    let builder = FakeAXRuntimeBuilder()
+    let fixture = makeTempoSliderFixture(builder: builder, tempoValue: 130.0)
+    let runtime = builder.makeLogicRuntime(
+        appElement: fixture.app,
+        setAttributeHandler: { element, attribute, value in
+            guard element == fixture.slider,
+                  attribute == kAXValueAttribute as String,
+                  let target = value as? NSNumber,
+                  let current = builder.attributeValue(element, attribute) as? NSNumber
+            else { return true }
+            let direction = target.doubleValue < current.doubleValue ? -1.0 : 1.0
+            builder.setAttribute(
+                element,
+                attribute,
+                NSNumber(value: current.doubleValue + direction)
+            )
+            return true
+        },
+        performActionHandler: nil
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: fixture.app,
+        logicRuntime: runtime
+    )
+
+    let result = await channel.execute(operation: "transport.set_tempo", params: ["tempo": "128"])
+
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+    #expect((obj["verified"] as? Bool)!)
+    #expect(obj["via"] as? String == "slider-value-nudge")
+    #expect((obj["requested"] as? Double) == 128)
+    #expect((obj["observed"] as? Double) == 128)
 }
 
 @Test func testAccessibilityChannelImportMIDIFileReturnsErrorWhenTrackCountDoesNotIncrease() async throws {


### PR DESCRIPTION
## Summary
- finish sub-10-BPM tempo deltas with bounded numeric AXValue nudges after the coarse slider fallback
- preserve verified State A on exact readback and fail closed with updated fallback diagnostics when convergence is unavailable
- update the live E2E contract and README limitation to reflect exact fallback behavior

## Root cause
When inline tempo typing did not commit, the fallback rounded the remaining delta to 10-BPM AX action detents. A 130 -> 128 request therefore performed zero detents, observed 130 again, and had no finer mutation path.

## Verification
- red: `testSetTempoValueNudgeLandsBelowTenBPMDetent` returned State C with requested 128 / observed 130 before the fix
- green: `swift test --filter Tempo --no-parallel -j 4 -Xswiftc -suppress-warnings` (22 passed)
- SourceKit diagnostics on both changed Swift files (0 errors)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- live fallback probe with mouse/keyboard typing disabled: actual Logic 150 -> 128 via `slider-value-nudge`, then restored 150
- release MCP handshake + `set_tempo(128)` returned verified State A; `logic://transport/state` read 128; invalid tempo 4 returned State C; final restore/readback was 150
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2244 passed after rebasing onto current main)

The skipped inventory test is an existing local-environment mismatch: the committed fixture contains only Bass/Drums while this machine’s Logic library reports additional categories.

Closes #278