### PR TITLE
fix(project): open native Bounce dialog

### DIFF
--- a/Scripts/logic_bounce_ui.py
+++ b/Scripts/logic_bounce_ui.py
@@ -424,17 +424,18 @@ def wait_for_bounce_dialog(run_osa: RunOsa = osa, sleep_fn: Callable[[float], No
 def open_bounce_dialog_via_menu(run_osa: RunOsa = osa) -> bool:
     result = _process_body(
         """set frontmost to true
-try
-    click menu item 1 of menu 1 of menu item "바운스" of menu 1 of menu bar item "파일" of menu bar 1
-    return "ok"
-on error
+repeat with targetName in {"프로젝트 또는 섹션…", "프로젝트 또는 섹션...", "Project or Section…", "Project or Section..."}
     try
-        click menu item 1 of menu 1 of menu item "Bounce" of menu 1 of menu bar item "File" of menu bar 1
+        click menu item (targetName as text) of menu 1 of menu item "바운스" of menu 1 of menu bar item "파일" of menu bar 1
         return "ok"
     on error
-        return ""
+        try
+            click menu item (targetName as text) of menu 1 of menu item "Bounce" of menu 1 of menu bar item "File" of menu bar 1
+            return "ok"
+        end try
     end try
-end try""",
+end repeat
+return """"",
         run_osa=run_osa,
     )
     return result == "ok"

--- a/Scripts/logic_bounce_ui_test.py
+++ b/Scripts/logic_bounce_ui_test.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import logic_bounce
 from logic_bounce import click_bounce_settings_confirm
+from logic_bounce_ui import open_bounce_dialog_via_menu
 
 
 def _completed_jxa_snapshot(snapshot) -> subprocess.CompletedProcess[str]:
@@ -164,6 +165,18 @@ class LogicBounceUITests(unittest.TestCase):
         self.assertTrue(opened)
         self.assertEqual(strategies, ["key_command", "file_menu"])
         self.assertEqual(state["strategies"], ["key_command", "file_menu"])
+
+    def test_open_bounce_dialog_via_menu_targets_project_or_section(self):
+        scripts = []
+
+        def fake_osa(script, timeout=logic_bounce.OSA_TIMEOUT_SEC):
+            scripts.append(script)
+            return "ok"
+
+        self.assertTrue(open_bounce_dialog_via_menu(run_osa=fake_osa))
+        self.assertIn('"Project or Section…"', scripts[0])
+        self.assertIn('"프로젝트 또는 섹션…"', scripts[0])
+        self.assertNotIn("menu item 1", scripts[0])
 
     def test_save_panel_present_detects_bounce_save_panel_snapshot(self):
         snapshot = {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -110,6 +110,117 @@ extension AccessibilityChannel {
         ))
     }
 
+    static func openBounceDialogViaMenu(
+        systemEventsAuthorized: @Sendable () -> Bool = { PermissionChecker.checkSystemEventsAutomation() },
+        executeScript: @escaping @Sendable (String) async -> ChannelResult = {
+            await AppleScriptChannel.executeAppleScript($0)
+        }
+    ) async -> ChannelResult {
+        guard systemEventsAuthorized() else {
+            return .error(HonestContract.encodeStateC(
+                error: .systemEventsAutomationDenied,
+                hint: AppleScriptErrorClassifier.systemEventsAutomationDeniedHint,
+                extras: [
+                    "operation": "project.bounce",
+                    "failure_stage": "preflight_system_events_permission",
+                    "write_attempted": false,
+                    "safe_to_retry": false,
+                ]
+            ))
+        }
+
+        let processTarget = LogicProTarget.appleScriptTarget().systemEventsProcessTarget
+        let script = """
+        tell application "System Events"
+            tell \(processTarget)
+                set frontmost to true
+                set menuClicked to false
+                repeat with targetName in {"프로젝트 또는 섹션…", "프로젝트 또는 섹션...", "Project or Section…", "Project or Section..."}
+                    if menuClicked is false then
+                        try
+                            click menu item (targetName as text) of menu 1 of menu item "바운스" of menu 1 of menu bar item "파일" of menu bar 1
+                            set menuClicked to true
+                        on error
+                            try
+                                click menu item (targetName as text) of menu 1 of menu item "Bounce" of menu 1 of menu bar item "File" of menu bar 1
+                                set menuClicked to true
+                            end try
+                        end try
+                    end if
+                end repeat
+                if menuClicked is false then return "BOUNCE_MENU_ITEM_NOT_FOUND"
+                repeat 10 times
+                    set bounceName to ""
+                    try
+                        set bounceName to name of front window
+                    end try
+                    try
+                        set bounceName to bounceName & " " & name of sheet 1 of front window
+                    end try
+                    if bounceName contains "Bounce" or bounceName contains "바운스" then
+                        return "BOUNCE_DIALOG_OPENED"
+                    end if
+                    delay 0.2
+                end repeat
+                return "BOUNCE_DIALOG_NOT_FOUND"
+            end tell
+        end tell
+        """
+
+        let result = await executeScript(script)
+        guard result.isSuccess else {
+            if HonestContract.stateCErrorCode(result.message)
+                == HonestContract.FailureError.systemEventsAutomationDenied.rawValue {
+                return result
+            }
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "File > Bounce menu execution failed",
+                extras: [
+                    "operation": "project.bounce",
+                    "failure_stage": "open_bounce_menu",
+                    "write_attempted": true,
+                    "safe_to_retry": true,
+                    "cause": result.message,
+                ]
+            ))
+        }
+
+        if result.message.contains("BOUNCE_DIALOG_OPENED") {
+            return .success(HonestContract.encodeStateA(extras: [
+                "operation": "project.bounce",
+                "requested": "bounce_dialog_open",
+                "observed": "bounce_dialog_open",
+                "dialog_opened": true,
+                "bounce_fired": false,
+                "via": "file-menu",
+                "next_action": "Review the Bounce settings in Logic, then confirm and choose the destination.",
+            ]))
+        }
+        if result.message.contains("BOUNCE_MENU_ITEM_NOT_FOUND") {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "File > Bounce > Project or Section menu item was not found",
+                extras: [
+                    "operation": "project.bounce",
+                    "failure_stage": "locate_bounce_menu_item",
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ))
+        }
+        return .error(HonestContract.encodeStateC(
+            error: .dialogNotFound,
+            hint: "File > Bounce menu was clicked but the Bounce dialog did not appear within 2 seconds",
+            extras: [
+                "operation": "project.bounce",
+                "failure_stage": "verify_bounce_dialog",
+                "write_attempted": true,
+                "safe_to_retry": true,
+            ]
+        ))
+    }
+
     private static func clickMenuItem(
         _ itemTitle: String,
         menuName: String,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -434,6 +434,8 @@ actor AccessibilityChannel: Channel {
                 return .error("Missing 'path' parameter for project.save_as")
             }
             return await AccessibilityChannel.saveAsViaAXDialog(path: path, runtime: runtime.logicRuntime)
+        case "project.bounce":
+            return await AccessibilityChannel.openBounceDialogViaMenu()
 
         // MARK: - Track creation via menu click
         case "track.create_instrument":

--- a/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
+++ b/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
@@ -557,8 +557,7 @@ actor MIDIKeyCommandsChannel: KeyCmdCCChannel {
         "Manual MIDI Learn required — see docs/SETUP.md §4. " +
         "Effectively keycmd-only (no working non-keycmd fallback on Logic 12.2): " +
         "edit.duplicate, edit.normalize, edit.toggle_step_input, " +
-        "nav.goto_marker, nav.delete_marker, " +
-        "project.bounce, transport.capture_recording. " +
+        "nav.goto_marker, nav.delete_marker, transport.capture_recording. " +
         "Other preset ops have an AX/MCU/AppleScript/CGEvent fallback and do not require keycmd binding. " +
         "Orphans (in mappingTable + routingTable but no MCP tool exposes a call path): " +
         "automation.set_mode, note.up_semitone, note.up_octave, note.down_semitone, note.down_octave, " +

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -190,7 +190,6 @@ extension ChannelRouter {
         "edit.toggle_step_input":     [.midiKeyCommands, .cgEvent],  // §4.3.1 new command
         "edit.duplicate":             [.midiKeyCommands, .cgEvent],
 
-        // Project — AppleScript primary for new/open/close lifecycle, KeyCmd for save/bounce
         "project.new":                [.appleScript, .cgEvent],
         "project.open":               [.appleScript],
         // #110: AppleScript-first — the direct `save front document` is the
@@ -201,7 +200,7 @@ extension ChannelRouter {
         "project.save_as":            [.accessibility, .appleScript],
         "project.close":              [.appleScript, .cgEvent],
         "project.get_info":           [.accessibility],
-        "project.bounce":             [.midiKeyCommands, .cgEvent],
+        "project.bounce":             [.accessibility, .midiKeyCommands, .cgEvent],
         "project.is_running":         [],
         "project.launch":             [.appleScript],
         "project.quit":               [.appleScript],

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -976,7 +976,7 @@ enum WorkflowSkillCatalog {
             evidenceLevel: .deterministic,
             productionReady: true,
             dependsOn: [],
-            limitations: ["Does not perform a bounce/export; project.bounce is keycmd-only on Logic 12.2."],
+            limitations: ["Does not perform a bounce/export."],
             mutationKind: .readOnly
         )
     }

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -299,6 +299,13 @@ private func waitUntil(
     #expect(result.isSuccess)
 }
 
+@Test func testProjectBouncePrefersNativeAccessibilityMenu() throws {
+    let chain = try #require(ChannelRouter.routingTable["project.bounce"])
+
+    #expect(chain.first == .accessibility)
+    #expect(chain.contains(.midiKeyCommands))
+}
+
 @Test func testRouterAllOperationsHaveChannel() async {
     let table = ChannelRouter.v2RoutingTable
     let systemOps = ["system.health", "system.cache_state", "system.refresh", "system.permissions", "project.is_running"]

--- a/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
+++ b/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
@@ -57,7 +57,7 @@ private func t7StartedChannel(tag: String) async throws -> ChannelHealth {
     #expect(health.detail.contains("nav.goto_marker"))
     #expect(health.detail.contains("nav.delete_marker"))
     #expect(!health.detail.contains("nav.set_zoom_level"))
-    #expect(health.detail.contains("project.bounce"))
+    #expect(!health.detail.contains("project.bounce"))
 }
 
 @Test func testKeyCmdChannelDetailListsOrphanOps() async throws {

--- a/Tests/LogicProMCPTests/Issue256BounceMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue256BounceMenuTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("Issue #256 native Bounce menu")
+struct Issue256BounceMenuTests {
+    final class Probe: @unchecked Sendable {
+        var called = false
+        var script = ""
+    }
+
+    private func object(_ result: ChannelResult) throws -> [String: Any] {
+        try #require(
+            JSONSerialization.jsonObject(with: Data(result.message.utf8)) as? [String: Any]
+        )
+    }
+
+    @Test("menu click is verified by Bounce dialog readback")
+    func verifiedDialogOpen() async throws {
+        let probe = Probe()
+        let result = await AccessibilityChannel.openBounceDialogViaMenu(
+            systemEventsAuthorized: { true },
+            executeScript: { script in
+                probe.called = true
+                probe.script = script
+                return .success(#"{"result":"BOUNCE_DIALOG_OPENED"}"#)
+            }
+        )
+
+        let json = try object(result)
+        #expect(result.isSuccess)
+        #expect((json["verified"] as? Bool)!)
+        #expect(json["via"] as? String == "file-menu")
+        #expect((json["dialog_opened"] as? Bool)!)
+        #expect(!((json["bounce_fired"] as? Bool)!))
+        #expect(probe.called)
+        #expect(probe.script.contains("\"Project or Section…\""))
+        #expect(probe.script.contains("\"프로젝트 또는 섹션…\""))
+        #expect(!probe.script.contains("menu item 1"))
+        #expect(probe.script.contains("BOUNCE_DIALOG_OPENED"))
+    }
+
+    @Test("System Events denial fails before opening the menu")
+    func permissionDenied() async throws {
+        let probe = Probe()
+        let result = await AccessibilityChannel.openBounceDialogViaMenu(
+            systemEventsAuthorized: { false },
+            executeScript: { _ in
+                probe.called = true
+                return .success("unexpected")
+            }
+        )
+
+        let json = try object(result)
+        #expect(!result.isSuccess)
+        #expect(json["error"] as? String == "system_events_automation_denied")
+        #expect(!((json["write_attempted"] as? Bool)!))
+        #expect(!probe.called)
+    }
+
+    @Test("missing native menu item returns a targeted terminal failure")
+    func menuItemMissing() async throws {
+        let result = await AccessibilityChannel.openBounceDialogViaMenu(
+            systemEventsAuthorized: { true },
+            executeScript: { _ in .success(#"{"result":"BOUNCE_MENU_ITEM_NOT_FOUND"}"#) }
+        )
+
+        let json = try object(result)
+        #expect(!result.isSuccess)
+        #expect(json["error"] as? String == "element_not_found")
+        #expect(json["failure_stage"] as? String == "locate_bounce_menu_item")
+    }
+
+    @Test("menu click without a dialog fails closed")
+    func dialogMissing() async throws {
+        let result = await AccessibilityChannel.openBounceDialogViaMenu(
+            systemEventsAuthorized: { true },
+            executeScript: { _ in .success(#"{"result":"BOUNCE_DIALOG_NOT_FOUND"}"#) }
+        )
+
+        let json = try object(result)
+        #expect(!result.isSuccess)
+        #expect(json["error"] as? String == "dialog_not_found")
+        #expect(json["failure_stage"] as? String == "verify_bounce_dialog")
+        #expect((json["write_attempted"] as? Bool)!)
+    }
+}

--- a/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
+++ b/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
@@ -40,8 +40,6 @@ struct RoutingAuditInvariantTests {
         "edit.toggle_step_input",         // logic_edit.toggle_step_input
         "nav.goto_marker",                // logic_navigate.goto_marker (with index)
         "nav.delete_marker",              // logic_navigate.delete_marker
-        "project.bounce",                 // logic_project.bounce
-
         // Channel-only router op — no public MCP tool command exposes it, but
         // it remains a real mappingTable/routingTable path if a future surface
         // promotes it.

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,7 +190,7 @@ Common commands: `goto_bar`, `goto_marker`, `create_marker`, `delete_marker`, `r
 
 Common commands: `new`, `open`, `save`, `save_as`, `close`, `bounce`, `is_running`, `launch`, `quit`, `get_regions`, `export_plan`, `export_run`, `export_resume`, `audit`, `cleanup_plan`, `cleanup_apply`.
 
-Destructive or file-writing paths require confirmation. `save_as` verifies the resulting `.logicx` package. `audit` marks GM Device / External MIDI tracks with MIDI regions as `external_midi_regions_bounce_risk` export blockers. `bounce` runs that preflight and returns `export_readiness_blocked` before opening the Bounce dialog when blockers are present. `export_plan` is read-only; `export_run` and `export_resume` re-plan, open, verify project identity, bounce, and verify artifacts via `logic_audio`.
+Destructive or file-writing paths require confirmation. `save_as` verifies the resulting `.logicx` package. `audit` marks GM Device / External MIDI tracks with MIDI regions as `external_midi_regions_bounce_risk` export blockers. `bounce` runs that preflight, then opens and verifies Logic's native File > Bounce dialog; the caller completes the settings and destination in Logic. It returns `export_readiness_blocked` before opening the dialog when blockers are present. `export_plan` is read-only; `export_run` and `export_resume` re-plan, open, verify project identity, bounce, and verify artifacts via `logic_audio`.
 
 ### `logic_audio`
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -110,7 +110,6 @@ Manual binding is only needed for remaining keycmd-only/channel-only paths:
 - `edit.toggle_step_input`
 - `nav.goto_marker`
 - `nav.delete_marker`
-- `project.bounce`
 - `transport.capture_recording`
 
 Most normal tool calls route through Accessibility, AppleScript, MCU, CoreMIDI, or CGEvent without manual MIDI Learn.

--- a/docs/demo/FEATURE-COVERAGE.md
+++ b/docs/demo/FEATURE-COVERAGE.md
@@ -17,7 +17,7 @@
 - `navigate.goto_bar`, `set_zoom`
 - `transport.record` / `stop`, `project.save` (AppleScript), `audio.analyze_file` (loudness/peak/duration)
 - `midi.mmc_locate`
-- **Bounce:** `File ▸ Bounce ▸ Project or Section…` renders a valid AIFF (used for the demo audio) — see bug #256 for the MCP-command gap.
+- **Bounce:** `logic_project.bounce {confirmed:true}` opens the verified native `File ▸ Bounce ▸ Project or Section…` dialog; that path rendered the valid AIFF used for the demo audio.
 
 ## Honest State-B (attempted, readback-unavailable — not failures)
 Send-only or cgevent ops that correctly report "sent, unverified": all `midi.send_*` / `play_sequence` / `step_input` / `mmc_*`, `edit.*` (undo/redo/cut/copy/paste/split/join/quantize/select_all/bounce_in_place), `navigate.toggle_view` / `zoom_to_fit`, `tracks.duplicate` / `set_automation`, `transport.rewind` / `fast_forward` / `toggle_metronome`, `mixer.set_master_volume` (MCU, no readback). `logic://mixer` returns `ax_poll` strips **after `refresh_cache`** (the read-only resource reflects the poller cache; `mixer_not_visible` before a poll is expected).
@@ -31,9 +31,9 @@ Send-only or cgevent ops that correctly report "sent, unverified": all `midi.sen
 | [#253](https://github.com/MongLong0214/logic-pro-mcp/issues/253) | help category gap | p3 | `logic_system.help audio` / `plugins` → `unknown_category` though both are real tools |
 | [#254](https://github.com/MongLong0214/logic-pro-mcp/issues/254) | marker surface | p2 | `create_marker` no-ops (cgevent; native menu works) **and** `logic://markers` reads empty even when a marker exists → goto/delete unusable |
 | [#255](https://github.com/MongLong0214/logic-pro-mcp/issues/255) | keycmd routing | p3 | `toggle_count_in` / `toggle_step_input` → `channels_exhausted` despite a working Control-Bar/menu path |
-| [#256](https://github.com/MongLong0214/logic-pro-mcp/issues/256) | bounce routing | p2 | `project.bounce` → `channels_exhausted` (no key mapping); native `File ▸ Bounce` works — export non-functional via MCP |
+| [#256](https://github.com/MongLong0214/logic-pro-mcp/issues/256) | bounce routing | p2 | Fixed in source: `project.bounce` now prefers the native File menu and verifies that the Bounce dialog opened. |
 
-Root theme for #254/#255/#256: several commands route only through an unbound Logic key command and fail with `channels_exhausted` instead of using the available menu/Control-Bar path.
+Root theme for #254/#255: several commands route only through an unbound Logic key command and fail with `channels_exhausted` instead of using the available menu/Control-Bar path.
 
 ## Demo composition (what's on screen)
 82 BPM, D minor lofi. `record_sequence` × 3 → **Chords** (Dm7–B♭maj7–Gm7–A7), **Bass** (D–B♭–G–A roots), **Lead** (D-pentatonic motif), all Studio Grand piano; **Drummer** (SoCal). Piano roll opened on Chords; real-time playback. Audio bed = Logic's own bounce of this loop (11.7 s, 48 kHz/24-bit, −0.1 dBFS peak).


### PR DESCRIPTION
## Summary
- route `project.bounce` through the native Accessibility File menu before optional key-command fallbacks
- select the localized `Project or Section…` item by name instead of the unstable first submenu position
- verify the Bounce dialog opened and report `bounce_fired=false`; update the shared Python export helper and key-command documentation

## Verification
- red regression: routing previously preferred `.midiKeyCommands`; both Swift and Python menu tests exposed `menu item 1`
- `swift test --filter 'Bounce|bounce|KeyCmdChannelDetail|RoutingAuditInvariant' --no-parallel -j 4 -Xswiftc -suppress-warnings` (`39 passed`)
- `python3 -m unittest logic_bounce_test logic_bounce_ui_test logic_bounce_support_test logic_bounce_main_test` (`62 passed`)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (`2249 passed`; the skipped inventory test is the known local Logic-library/committed-fixture mismatch)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- SourceKit: no diagnostics in all changed Swift files
- live release MCP: `logic_project.bounce {confirmed:true}` returned verified State A with `dialog_opened=true`, `bounce_fired=false`, and `via=file-menu`
- live cleanup: Escape restored `Untitled 54 - Tracks` with `sheets=0`; no destination was accepted and no artifact was created
- live negative path: `confirmed:false` preserved the L2 `confirmation_required` response without opening a dialog

Closes #256
