### PR TITLE
fix(project): expose partial region inventory

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -20,14 +20,18 @@ extension AccessibilityChannel {
         case .failure(let err):
             return .error(err.message)
         case .success(let result):
-            // When the array is empty, surface traversal counters so we can tell
-            // "no regions exist" from "parser missed them" without re-running a probe.
-            if result.regions.isEmpty {
-                return .success("{\"regions\":[],\"_debug\":{\"layoutItems\":\(result.layoutItemCount),\"nonRegion\":\(result.nonRegionCount)}}")
-            }
-            // Tuple-element keypath inference fails in some Swift versions; map
-            // explicitly to the RegionInfo array instead of `\.info`.
-            return encodeResult(result.regions.map { $0.info })
+            let regions = result.regions.map { $0.info }
+            return encodeResult(RegionInventoryPayload(
+                regions: regions,
+                complete: false,
+                scope: "visible_arrange_area",
+                reason: "logic_ax_viewport_only",
+                returnedCount: regions.count,
+                debug: RegionInventoryPayload.Debug(
+                    layoutItems: result.layoutItemCount,
+                    nonRegion: result.nonRegionCount
+                )
+            ))
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -11,7 +11,7 @@ struct ProjectDispatcher {
 
     static let tool = commandTool(
         name: "logic_project",
-        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan, cleanup_apply. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; bounce requires confirmation and runs a pre-bounce project audit, returning `export_readiness_blocked` before opening the Bounce dialog if blockers such as `external_midi_regions_bounce_risk` are present; get_regions -> {} (returns JSON array of { name, trackIndex, startBar, endBar, kind, rawHelp } parsed from Logic's arrange area via AX); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; export_run -> { ...same as export_plan, confirmed: Bool } GUARDED execution (re-plans, opens, verifies project identity by readback, bounces, verifies each artifact on disk via logic_audio, records logic_pro_mcp_export_run.v1 with HC State A/B/C; never overwrites under fail_if_exists); export_resume -> { ...same as export_run } idempotent resume (skips already-present+verified artifacts, produces the rest); audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; cleanup_apply -> { step_id: String, confirmed: Bool, names?: \"newA,newB\" (CSV aligned to the step's target track indices) | new_name?: String (single target) } executes ONE supported mutating cleanup-plan step (currently rename_* only) through the existing track.rename path so it inherits AX readback + Honest Contract State A/B/C. Fails closed (State C) when confirmed!=true, the step is unknown/unsupported/non-mutating, the audit shows stale/occluded inventory or a track readback gap, or rename names are missing/mismatched. Deletion steps are unsupported by construction and are always refused; others -> {}.",
+        description: "Project lifecycle + read-only project state in Logic Pro. Commands: new, open, save, save_as, close, bounce, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan, cleanup_apply. Params: open -> { path: String }; save_as -> { path: String }; close -> { saving?: \"yes\"|\"no\"|\"ask\" }; bounce/launch/quit -> {}; bounce requires confirmation and runs a pre-bounce project audit, returning `export_readiness_blocked` before opening the Bounce dialog if blockers such as `external_midi_regions_bounce_risk` are present; get_regions -> {} (returns { regions: [{ name, trackIndex, startBar, endBar, kind, rawHelp }], complete, scope, reason, returned_count }; Logic AX currently reports scope=visible_arrange_area and complete=false); export_plan -> { projects: [absolute .logicx], output_root: String, artifacts?: [bounce|stem|preview|variant], collision_policy?: fail_if_exists|skip_existing } dry-run only; export_run -> { ...same as export_plan, confirmed: Bool } GUARDED execution (re-plans, opens, verifies project identity by readback, bounces, verifies each artifact on disk via logic_audio, records logic_pro_mcp_export_run.v1 with HC State A/B/C; never overwrites under fail_if_exists); export_resume -> { ...same as export_run } idempotent resume (skips already-present+verified artifacts, produces the rest); audit -> read-only project/session audit JSON; cleanup_plan -> read-only serializable cleanup plan JSON; cleanup_apply -> { step_id: String, confirmed: Bool, names?: \"newA,newB\" (CSV aligned to the step's target track indices) | new_name?: String (single target) } executes ONE supported mutating cleanup-plan step (currently rename_* only) through the existing track.rename path so it inherits AX readback + Honest Contract State A/B/C. Fails closed (State C) when confirmed!=true, the step is unknown/unsupported/non-mutating, the audit shows stale/occluded inventory or a track readback gap, or rename names are missing/mismatched. Deletion steps are unsupported by construction and are always refused; others -> {}.",
         commandDescription: "Project command to execute"
     )
 
@@ -785,10 +785,13 @@ struct ProjectDispatcher {
 
     private static func refreshRegionCache(from result: ChannelResult, cache: StateCache) async {
         guard result.isSuccess,
-              let regions = try? RegionInfo.decodeToolPayload(result.message) else {
+              let payload = try? RegionInfo.decodeInventoryPayload(result.message) else {
             return
         }
-        await cache.updateRegions(regions.map { $0.asRegionState() })
+        await cache.updateRegions(
+            payload.regions.map { $0.asRegionState() },
+            complete: payload.isComplete
+        )
     }
 
     /// H-1 (2026-05-08 enterprise review): audit phases for L1+ project

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -420,7 +420,7 @@ struct SystemDispatcher {
                   close             -> {} — Close project
                   bounce            -> {} — Open bounce dialog after audit preflight;
                                        export blockers return export_readiness_blocked
-                  get_regions       -> {} — Read arrange regions
+                  get_regions       -> {} — Read visible arrange regions with complete=false scope metadata
                   export_plan       -> { projects, output_root, artifacts? } — Dry-run export manifest plan
                   launch            -> {} — Launch Logic Pro
                   quit              -> {} — Quit Logic Pro

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -470,8 +470,11 @@ extension ResourceHandlers {
         // header isn't in the track array, so track_count is not a reliable
         // existence proxy here.
         if case .success(let payload) = await router.route(operation: "region.get_regions"),
-           let liveRegions = try? RegionInfo.decodeToolPayload(payload) {
-            await cache.updateRegions(liveRegions.map { $0.asRegionState() })
+           let inventory = try? RegionInfo.decodeInventoryPayload(payload) {
+            await cache.updateRegions(
+                inventory.regions.map { $0.asRegionState() },
+                complete: inventory.isComplete
+            )
         }
         let regions = await cache.getRegions().filter { $0.trackIndex == index }
         let json = encodeJSON(regions)

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -7,6 +7,7 @@ actor StateCache {
     private(set) var tracks: [TrackState] = []
     private(set) var channelStrips: [ChannelStripState] = []
     private(set) var regions: [RegionState] = []
+    private(set) var regionsComplete = false
     private(set) var markers: [MarkerState] = []
     private(set) var project = ProjectInfo()
     private(set) var mcuConnection = MCUConnectionState()
@@ -85,6 +86,7 @@ actor StateCache {
         channelStrips.first(where: { $0.trackIndex == index })
     }
     func getRegions() -> [RegionState] { regions }
+    func getRegionsComplete() -> Bool { regionsComplete }
     func getMarkers() -> [MarkerState] { markers }
     func getProject() -> ProjectInfo { project }
     func getMCUConnection() -> MCUConnectionState { mcuConnection }
@@ -114,6 +116,7 @@ actor StateCache {
         tracksFetchedAt: Date,
         regions: [RegionState],
         regionsFetchedAt: Date,
+        regionsComplete: Bool,
         markers: [MarkerState],
         markersFetchedAt: Date,
         channelStrips: [ChannelStripState],
@@ -129,6 +132,7 @@ actor StateCache {
             tracksFetchedAt: tracksFetchedAt,
             regions: regions,
             regionsFetchedAt: regionsFetchedAt,
+            regionsComplete: regionsComplete,
             markers: markers,
             markersFetchedAt: markersFetchedAt,
             channelStrips: channelStrips,
@@ -156,6 +160,7 @@ actor StateCache {
         tracks = []
         channelStrips = []
         regions = []
+        regionsComplete = false
         markers = []
         // Re-initialising transport picks up its default `lastUpdated =
         // .distantPast`, which is how snapshot() signals "stale" to readers
@@ -249,8 +254,9 @@ actor StateCache {
         mixerFetchedAt = Date()
     }
 
-    func updateRegions(_ newRegions: [RegionState]) {
+    func updateRegions(_ newRegions: [RegionState], complete: Bool) {
         regions = newRegions
+        regionsComplete = complete
         regionsFetchedAt = Date()
     }
 

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -227,17 +227,48 @@ struct RegionInfo: Sendable, Codable {
     var rawHelp: String?  // raw AXHelp text — preserved for debugging parser misses
 }
 
-private struct RegionToolPayload: Decodable {
+struct RegionInventoryPayload: Codable, Sendable {
+    struct Debug: Codable, Sendable {
+        let layoutItems: Int
+        let nonRegion: Int
+    }
+
     let regions: [RegionInfo]
+    let complete: Bool?
+    let scope: String?
+    let reason: String?
+    let returnedCount: Int?
+    let debug: Debug?
+
+    var isComplete: Bool { complete ?? true }
+
+    enum CodingKeys: String, CodingKey {
+        case regions
+        case complete
+        case scope
+        case reason
+        case returnedCount = "returned_count"
+        case debug = "_debug"
+    }
 }
 
 extension RegionInfo {
-    static func decodeToolPayload(_ text: String) throws -> [RegionInfo] {
+    static func decodeInventoryPayload(_ text: String) throws -> RegionInventoryPayload {
         if let direct: [RegionInfo] = try? decodeJSON(text) {
-            return direct
+            return RegionInventoryPayload(
+                regions: direct,
+                complete: true,
+                scope: "project",
+                reason: nil,
+                returnedCount: direct.count,
+                debug: nil
+            )
         }
-        let wrapped: RegionToolPayload = try decodeJSON(text)
-        return wrapped.regions
+        return try decodeJSON(text)
+    }
+
+    static func decodeToolPayload(_ text: String) throws -> [RegionInfo] {
+        try decodeInventoryPayload(text).regions
     }
 
     func asRegionState() -> RegionState {

--- a/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
+++ b/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
@@ -261,6 +261,7 @@ enum ProjectSessionAudit {
         let tracksFetchedAt: Date
         let regions: [RegionState]
         let regionsFetchedAt: Date
+        let regionsComplete: Bool
         let markers: [MarkerState]
         let markersFetchedAt: Date
         let channelStrips: [ChannelStripState]
@@ -297,6 +298,7 @@ enum ProjectSessionAudit {
             tracksFetchedAt: s.tracksFetchedAt,
             regions: s.regions,
             regionsFetchedAt: s.regionsFetchedAt,
+            regionsComplete: s.regionsComplete,
             markers: s.markers,
             markersFetchedAt: s.markersFetchedAt,
             channelStrips: s.channelStrips,
@@ -416,7 +418,11 @@ enum ProjectSessionAudit {
                 tracks: tracksEvidence,
                 regions: CountEvidence(
                     count: snapshot.regions.count,
-                    freshness: freshness(fetchedAt: snapshot.regionsFetchedAt, fallbackProvenance: "ax_live", now: snapshot.now)
+                    freshness: freshness(
+                        fetchedAt: snapshot.regionsFetchedAt,
+                        fallbackProvenance: snapshot.regionsComplete ? "ax_live" : "ax_visible_subset",
+                        now: snapshot.now
+                    )
                 ),
                 markers: CountEvidence(
                     count: snapshot.markers.count,
@@ -580,6 +586,17 @@ enum ProjectSessionAudit {
                 nil,
                 ["regions_fetched_at=<none>"],
                 "unavailable"
+            ))
+        } else if !snapshot.regionsComplete {
+            findings.append(finding(
+                "region_inventory_partial",
+                .warn,
+                "export",
+                "Region inventory covers only the visible arrange area; hidden or scrolled lanes may contain additional regions.",
+                "logic://project/audit",
+                nil,
+                ["complete=false", "scope=visible_arrange_area", "visible_region_count=\(snapshot.regions.count)"],
+                "ax_visible_subset"
             ))
         } else if !emptyTracks.isEmpty {
             findings.append(finding(
@@ -942,7 +959,7 @@ enum ProjectSessionAudit {
     }
 
     private static func emptyTrackIndices(_ snapshot: Snapshot) -> [Int] {
-        guard snapshot.regionsFetchedAt > .distantPast else { return [] }
+        guard snapshot.regionsFetchedAt > .distantPast, snapshot.regionsComplete else { return [] }
         let tracksWithRegions = Set(snapshot.regions.map(\.trackIndex))
         return snapshot.tracks
             .filter { !tracksWithRegions.contains($0.id) }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -651,7 +651,7 @@ private func makeSetInstrumentFixture() -> (
 
     #expect(result.isSuccess)
 
-    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    let regions = try RegionInfo.decodeToolPayload(result.message)
     #expect(regions.count == 1)
     #expect(regions[0].name == "Deluxe Classic")
     #expect(regions[0].trackIndex == 0)
@@ -660,7 +660,7 @@ private func makeSetInstrumentFixture() -> (
     #expect(regions[0].kind == "midi")
 }
 
-@Test func testAccessibilityChannelAXBackedRegionsRecognizeTracksContentsAndFilterOffscreen() async throws {
+@Test func testAccessibilityChannelAXBackedRegionsMarkViewportSubsetIncomplete() async throws {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(900)
     let window = builder.element(901)
@@ -716,7 +716,16 @@ private func makeSetInstrumentFixture() -> (
 
     #expect(result.isSuccess)
 
-    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    let payload = try #require(
+        JSONSerialization.jsonObject(with: Data(result.message.utf8)) as? [String: Any]
+    )
+    #expect(payload["complete"] as? Bool == false)
+    #expect(payload["scope"] as? String == "visible_arrange_area")
+    #expect(payload["reason"] as? String == "logic_ax_viewport_only")
+    #expect(payload["returned_count"] as? Int == 2)
+    let regionValue = try #require(payload["regions"])
+    let regionData = try JSONSerialization.data(withJSONObject: regionValue)
+    let regions = try JSONDecoder().decode([RegionInfo].self, from: regionData)
     #expect(regions.count == 2)
     #expect(regions[0].name == "MIDI Region")
     #expect(regions[0].trackIndex == 0)
@@ -790,7 +799,7 @@ private func makeSetInstrumentFixture() -> (
 
     #expect(result.isSuccess)
 
-    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    let regions = try RegionInfo.decodeToolPayload(result.message)
     #expect(regions.count == 1)
     #expect(regions[0].name == "Imported Idea")
     #expect(regions[0].trackIndex == 0)
@@ -838,7 +847,7 @@ private func makeSetInstrumentFixture() -> (
 
     #expect(result.isSuccess)
 
-    let regions = try JSONDecoder().decode([RegionInfo].self, from: Data(result.message.utf8))
+    let regions = try RegionInfo.decodeToolPayload(result.message)
     #expect(regions.count == 1)
     #expect(regions[0].name == "Imported Idea")
     #expect(regions[0].trackIndex == 0)

--- a/Tests/LogicProMCPTests/CleanupExecutionTests.swift
+++ b/Tests/LogicProMCPTests/CleanupExecutionTests.swift
@@ -91,7 +91,7 @@ private func seedEmptyTrackReviewStep(_ cache: StateCache) async -> String {
             endPosition: "5 1 1 1",
             length: "4 0 0 0"
         ),
-    ])
+    ], complete: true)
     return "review_empty_tracks_no_delete"
 }
 

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -2516,7 +2516,7 @@ private actor SelectiveFailChannel: Channel {
             endPosition: "5 1 1 1",
             length: "4 0 0 0"
         ),
-    ])
+    ], complete: true)
 
     let result = await ProjectDispatcher.handle(
         command: "bounce",

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -468,7 +468,7 @@ struct HCGlobalInvariantTests {
                 endPosition: "5 1 1 1",
                 length: "4 0 0 0"
             ),
-        ])
+        ], complete: true)
     }
 
     private static func hcEnvelopeRouter() async -> ChannelRouter {

--- a/Tests/LogicProMCPTests/ProjectDispatcherTests.swift
+++ b/Tests/LogicProMCPTests/ProjectDispatcherTests.swift
@@ -31,7 +31,7 @@ private func seedCacheWithStaleProject(_ cache: StateCache) async {
             endPosition: "4 1 1 1",
             length: "3 0 0 0"
         )
-    ])
+    ], complete: true)
     await cache.updateMarkers([
         MarkerState(id: 0, name: "leftover marker", position: "1.1.1.1")
     ])

--- a/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
+++ b/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
@@ -14,6 +14,7 @@ private func makeAuditSnapshot(
     transport: TransportState? = nil,
     tracks: [TrackState],
     regions: [RegionState] = [],
+    regionsComplete: Bool = true,
     markers: [MarkerState] = [],
     channelStrips: [ChannelStripState] = [],
     fileTrackCount: Int? = nil
@@ -41,12 +42,41 @@ private func makeAuditSnapshot(
         tracksFetchedAt: now,
         regions: regions,
         regionsFetchedAt: now,
+        regionsComplete: regionsComplete,
         markers: markers,
         markersFetchedAt: now,
         channelStrips: channelStrips,
         mixerFetchedAt: now,
         fileTrackCount: fileTrackCount
     )
+}
+
+@Test func testProjectAuditMarksPartialRegionInventoryWithoutEmptyTrackClaims() throws {
+    let tracks = [
+        TrackState(id: 0, name: "Top Lane", type: .softwareInstrument),
+        TrackState(id: 1, name: "Visible Lane", type: .softwareInstrument),
+    ]
+    let regions = [
+        RegionState(
+            id: "1:1:5:Visible",
+            name: "Visible",
+            trackIndex: 1,
+            startPosition: "1 1 1 1",
+            endPosition: "5 1 1 1",
+            length: "4 0 0 0"
+        ),
+    ]
+    let report = ProjectSessionAudit.buildAudit(snapshot: makeAuditSnapshot(
+        tracks: tracks,
+        regions: regions,
+        regionsComplete: false
+    ))
+
+    let partial = try #require(report.findings.first { $0.id == "region_inventory_partial" })
+    #expect(partial.severity == .warn)
+    #expect(partial.provenance == "ax_visible_subset")
+    #expect(report.evidence.exportReadiness.warnings.contains("region_inventory_partial"))
+    #expect(!report.findings.contains { $0.id == "empty_tracks_detected" })
 }
 
 private func messySnapshot(

--- a/Tests/LogicProMCPTests/RegionResourceRefreshTests.swift
+++ b/Tests/LogicProMCPTests/RegionResourceRefreshTests.swift
@@ -75,7 +75,7 @@ private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: 
             endPosition: "100 1 1 1",
             length: "1 0 0 0"
         )
-    ])
+    ], complete: true)
 
     let result = await ProjectDispatcher.handle(
         command: "get_regions",
@@ -85,7 +85,7 @@ private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: 
     )
 
     let text = sharedToolText(result)
-    let toolRegions = try JSONDecoder().decode([RegionInfo].self, from: Data(text.utf8))
+    let toolRegions = try RegionInfo.decodeToolPayload(text)
     #expect(toolRegions.count == 1)
     #expect(toolRegions[0].name == "Live Region")
     #expect(toolRegions[0].trackIndex == 0)
@@ -95,6 +95,7 @@ private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: 
     #expect(cached[0].name == "Live Region")
     #expect(cached[0].startPosition == "1 1 1 1")
     #expect(cached[0].endPosition == "2 1 1 1")
+    #expect(!(await cache.getRegionsComplete()))
 }
 
 @Test func testTrackRegionsResourceRefreshesLiveScanWhenCacheIsStale() async throws {
@@ -112,7 +113,7 @@ private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: 
             endPosition: "100 1 1 1",
             length: "1 0 0 0"
         )
-    ])
+    ], complete: true)
 
     let result = try await ResourceHandlers.read(
         uri: "logic://tracks/0/regions",
@@ -129,4 +130,5 @@ private func makeRegionRefreshFixture() -> (builder: FakeAXRuntimeBuilder, app: 
     let cached = await cache.getRegions()
     #expect(cached.count == 1)
     #expect(cached[0].name == "Live Region")
+    #expect(!(await cache.getRegionsComplete()))
 }

--- a/Tests/LogicProMCPTests/StateCacheTests.swift
+++ b/Tests/LogicProMCPTests/StateCacheTests.swift
@@ -48,7 +48,7 @@ import Testing
     let project = ProjectInfo(name: "Enterprise Mix", trackCount: 24)
 
     await cache.updateTransport(transport)
-    await cache.updateRegions(regions)
+    await cache.updateRegions(regions, complete: true)
     await cache.updateMarkers(markers)
     await cache.updateProject(project)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -192,6 +192,8 @@ Common commands: `new`, `open`, `save`, `save_as`, `close`, `bounce`, `is_runnin
 
 Destructive or file-writing paths require confirmation. `save_as` verifies the resulting `.logicx` package. `audit` marks GM Device / External MIDI tracks with MIDI regions as `external_midi_regions_bounce_risk` export blockers. `bounce` runs that preflight, then opens and verifies Logic's native File > Bounce dialog; the caller completes the settings and destination in Logic. It returns `export_readiness_blocked` before opening the dialog when blockers are present. `export_plan` is read-only; `export_run` and `export_resume` re-plan, open, verify project identity, bounce, and verify artifacts via `logic_audio`.
 
+`get_regions` returns `{ regions, complete, scope, reason, returned_count, _debug }`. Logic's AX tree currently exposes the visible arrange viewport only, so the response reports `complete:false`, `scope:"visible_arrange_area"`, and `reason:"logic_ax_viewport_only"`; callers must not treat `regions` as a project-wide inventory. Project audit preserves that limitation as `ax_visible_subset`, emits `region_inventory_partial`, and withholds empty-track claims for unseen lanes.
+
 ### `logic_audio`
 
 `analyze_file` inspects an existing audio artifact and reports duration, level, silence ratio, and verification status. It does not mutate Logic.


### PR DESCRIPTION
## Summary
- return `project.get_regions` as a compatibility-decodable inventory envelope with `complete`, `scope`, `reason`, and `returned_count` metadata
- preserve region completeness in `StateCache` instead of promoting a visible AX subset to project-wide evidence
- mark partial region evidence as `ax_visible_subset`, emit `region_inventory_partial`, and suppress empty-track claims for unseen lanes

## Verification
- live baseline reproduced the bug: `get_regions` had no completeness metadata and the immediate audit marked the region cache fresh/available and emitted `empty_tracks_detected`
- red response regression: the viewport fixture failed because the old payload was a JSON array, not a metadata object
- red cache/audit regression: compilation failed on the missing `regionsComplete` snapshot field and `StateCache.getRegionsComplete` contract
- `swift test --filter 'testAccessibilityChannelAXBackedRegion|testProjectAudit|RegionResourceRefresh|testStateCache' --no-parallel -j 4 -Xswiftc -suppress-warnings` (`25 passed` after rebase)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (`2250 passed`; skipped test is the known local Logic-library/committed-fixture mismatch)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- SourceKit: no diagnostics in the changed production and primary regression-test files
- live release MCP `get_regions`: `complete=false`, `scope=visible_arrange_area`, `reason=logic_ax_viewport_only`, `returned_count=0` on the current empty viewport
- immediate live audit: `ax_visible_subset` provenance and `region_inventory_partial` export warning present; `empty_tracks_detected` absent

Closes #279
