### PR TITLE
fix(markers): restore native marker create and readable state

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerNaming.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerNaming.swift
@@ -1,0 +1,128 @@
+import ApplicationServices
+import Foundation
+
+extension AccessibilityChannel {
+    static func renameSelectedMarker(
+        _ name: String,
+        in window: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) async -> Bool {
+        let madeMain = AXHelpers.setAttribute(
+            window,
+            kAXMainAttribute,
+            kCFBooleanTrue,
+            runtime: runtime.ax
+        )
+        let raised = AXHelpers.performAction(window, kAXRaiseAction, runtime: runtime.ax)
+        guard madeMain || raised else { return false }
+        usleep(100_000)
+
+        guard let showControl = markerTextAreaToggle(in: window, runtime: runtime.ax) else {
+            return false
+        }
+        let showValue: NSNumber? = AXHelpers.getAttribute(
+            showControl,
+            kAXValueAttribute,
+            runtime: runtime.ax
+        )
+        if showValue?.boolValue != true {
+            guard AXHelpers.performAction(showControl, kAXPressAction, runtime: runtime.ax) else {
+                return false
+            }
+            usleep(100_000)
+        }
+
+        guard let editControl = markerEditControl(in: window, runtime: runtime.ax),
+              AXHelpers.performAction(editControl, kAXPressAction, runtime: runtime.ax) else {
+            return false
+        }
+        usleep(100_000)
+
+        let textAreas = AXHelpers.findAllDescendants(
+            of: window,
+            role: kAXTextAreaRole,
+            maxDepth: 8,
+            runtime: runtime.ax
+        )
+        guard let editor = textAreas.first,
+              AXHelpers.setAttribute(
+                editor,
+                kAXFocusedAttribute,
+                kCFBooleanTrue,
+                runtime: runtime.ax
+              ) else {
+            return false
+        }
+        usleep(50_000)
+        let focused: NSNumber? = AXHelpers.getAttribute(
+            editor,
+            kAXFocusedAttribute,
+            runtime: runtime.ax
+        )
+        guard focused?.boolValue == true else { return false }
+
+        let escapedName = AppleScriptSafety.escapeForScript(name)
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                try
+                    set markerWindow to first window whose name contains "Marker List"
+                    set markerGroup to first group of markerWindow whose description is "Marker"
+                    set editButton to first button of markerGroup whose description is "Edit"
+                on error
+                    set markerWindow to first window whose name contains "마커 목록"
+                    set markerGroup to first group of markerWindow whose description is "마커"
+                    set editButton to first button of markerGroup whose description is "편집"
+                end try
+                set editor to first text area of first scroll area of markerGroup
+                if focused of editor is false then error "marker editor is not focused"
+                keystroke "a" using command down
+                keystroke "\(escapedName)"
+                delay 0.1
+                click editButton
+            end tell
+        end tell
+        return "renamed"
+        """
+        let renameResult = await AppleScriptChannel.executeAppleScript(script)
+        guard renameResult.isSuccess else { return false }
+        usleep(200_000)
+
+        let markers = AXLogicProElements.enumerateMarkersFromListWindow(
+            window,
+            runtime: runtime.ax
+        )
+        return markers.contains { $0.name == name }
+    }
+
+    private static func markerTextAreaToggle(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.findAllDescendants(
+            of: window,
+            role: kAXCheckBoxRole,
+            maxDepth: 8,
+            runtime: runtime
+        ).first {
+            let label = (AXHelpers.getDescription($0, runtime: runtime) ?? "").lowercased()
+            return label == "edit marker" || label == "마커 편집"
+        }
+    }
+
+    private static func markerEditControl(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.findAllDescendants(
+            of: window,
+            role: kAXButtonRole,
+            maxDepth: 8,
+            runtime: runtime
+        ).first {
+            let label = (AXHelpers.getDescription($0, runtime: runtime) ?? "").lowercased()
+            return label == "edit" || label == "편집"
+        }
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
@@ -1,0 +1,207 @@
+import ApplicationServices
+import Foundation
+
+extension AccessibilityChannel {
+    static func defaultOpenMarkerList(
+        runtime: AXLogicProElements.Runtime = .production
+    ) async -> ChannelResult {
+        if AXLogicProElements.findMarkerListWindow(runtime: runtime) != nil {
+            return .success(HonestContract.encodeStateA(extras: [
+                "operation": "nav.open_marker_list",
+                "already_open": true,
+            ]))
+        }
+        let menuResult = await pressMarkerMenuItem(.openList)
+        guard menuResult.isSuccess else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Navigate > Open Marker List was not found or could not be pressed."
+            ))
+        }
+        for _ in 0..<20 {
+            if AXLogicProElements.findMarkerListWindow(runtime: runtime) != nil {
+                return .success(HonestContract.encodeStateA(extras: [
+                    "operation": "nav.open_marker_list",
+                    "already_open": false,
+                ]))
+            }
+            usleep(50_000)
+        }
+        return .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "Navigate > Open Marker List was pressed, but the Marker List window did not appear."
+        ))
+    }
+
+    static func defaultCreateMarker(
+        params: [String: String],
+        runtime: AXLogicProElements.Runtime = .production
+    ) async -> ChannelResult {
+        let openResult = await defaultOpenMarkerList(runtime: runtime)
+        guard openResult.isSuccess,
+              let listWindow = AXLogicProElements.findMarkerListWindow(runtime: runtime) else {
+            return openResult
+        }
+
+        let before = AXLogicProElements.enumerateMarkersFromListWindow(
+            listWindow,
+            runtime: runtime.ax
+        )
+        guard focusArrangeWindow(runtime: runtime) else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "The arrange window could not be focused before creating a marker."
+            ))
+        }
+        let menuResult = await pressMarkerMenuItem(.create)
+        guard menuResult.isSuccess else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Navigate > Create Marker was not found or could not be pressed."
+            ))
+        }
+
+        var after = before
+        for _ in 0..<20 {
+            usleep(50_000)
+            guard let currentWindow = AXLogicProElements.findMarkerListWindow(runtime: runtime) else {
+                continue
+            }
+            after = AXLogicProElements.enumerateMarkersFromListWindow(
+                currentWindow,
+                runtime: runtime.ax
+            )
+            if after.count > before.count {
+                break
+            }
+        }
+
+        let requestedName = params["name"]
+        var nameApplied: Bool? = nil
+        if let requestedName, !requestedName.isEmpty,
+           let currentWindow = AXLogicProElements.findMarkerListWindow(runtime: runtime) {
+            nameApplied = await renameSelectedMarker(
+                requestedName,
+                in: currentWindow,
+                runtime: runtime
+            )
+        }
+
+        var extras: [String: Any] = [
+            "operation": "nav.create_marker",
+            "method": "accessibility_menu",
+            "menu_path": "Navigate > Create Marker",
+            "sent": true,
+            "marker_count_before_channel": before.count,
+            "marker_count_after_channel": after.count,
+        ]
+        if let requestedName, !requestedName.isEmpty {
+            extras["requested_name"] = requestedName
+            extras["name_applied"] = nameApplied ?? false
+        }
+        return .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: extras
+        ))
+    }
+
+    private enum MarkerMenuAction {
+        case openList
+        case create
+    }
+
+    private static func pressMarkerMenuItem(_ action: MarkerMenuAction) async -> ChannelResult {
+        let target = LogicProTarget.appleScriptTarget()
+        let englishItem: String
+        let koreanItem: String
+        switch action {
+        case .openList:
+            englishItem = "Open Marker List"
+            koreanItem = "마커 목록 열기"
+        case .create:
+            englishItem = "Create Marker"
+            koreanItem = "마커 생성"
+        }
+        let focusBlock: String
+        switch action {
+        case .create:
+            focusBlock = """
+                try
+                    set targetWindow to first window whose name ends with "Tracks"
+                on error
+                    set targetWindow to first window whose name ends with "트랙"
+                end try
+                set value of attribute "AXMain" of targetWindow to true
+                perform action "AXRaise" of targetWindow
+                delay 0.1
+            """
+        case .openList:
+            focusBlock = ""
+        }
+        let script = """
+        \(target.activateByBundleID)
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                set frontmost to true
+        \(focusBlock)
+                if exists menu bar item "Navigate" of menu bar 1 then
+                    click menu bar item "Navigate" of menu bar 1
+                    delay 0.1
+                    set targetItem to menu item "\(englishItem)" of menu 1 of menu bar item "Navigate" of menu bar 1
+                    if enabled of targetItem is false then error "menu item disabled"
+                    click targetItem
+                else
+                    click menu bar item "탐색" of menu bar 1
+                    delay 0.1
+                    set targetItem to menu item "\(koreanItem)" of menu 1 of menu bar item "탐색" of menu bar 1
+                    if enabled of targetItem is false then error "menu item disabled"
+                    click targetItem
+                end if
+            end tell
+        end tell
+        return "clicked"
+        """
+        return await AppleScriptChannel.executeAppleScript(script)
+    }
+
+    private static func focusArrangeWindow(runtime: AXLogicProElements.Runtime) -> Bool {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return false
+        }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app,
+            kAXWindowsAttribute,
+            runtime: runtime.ax
+        ) ?? []
+        let candidates = windows.filter { window in
+            let title = AXHelpers.getTitle(window, runtime: runtime.ax) ?? ""
+            let isMarkerList = AXLocalePolicy.markerListWindowSuffixes.contains {
+                title.hasSuffix($0)
+            }
+            let subrole: String? = AXHelpers.getAttribute(
+                window,
+                kAXSubroleAttribute,
+                runtime: runtime.ax
+            )
+            let isDialog = subrole == (kAXDialogSubrole as String)
+                || subrole == (kAXSystemDialogSubrole as String)
+            return !isMarkerList && !isDialog
+        }
+        let window = candidates.max { lhs, rhs in
+            let left = AXHelpers.getSize(lhs, runtime: runtime.ax) ?? .zero
+            let right = AXHelpers.getSize(rhs, runtime: runtime.ax) ?? .zero
+            return left.width * left.height < right.width * right.height
+        } ?? AXLogicProElements.mainWindow(runtime: runtime)
+        guard let window else { return false }
+        let madeMain = AXHelpers.setAttribute(
+            window,
+            kAXMainAttribute,
+            kCFBooleanTrue,
+            runtime: runtime.ax
+        )
+        let raised = AXHelpers.performAction(window, kAXRaiseAction, runtime: runtime.ax)
+        usleep(100_000)
+        return madeMain || raised
+    }
+
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -267,27 +267,23 @@ extension AccessibilityChannel {
     /// | arrange area | marker list window | strategy |
     /// |--------------|--------------------|----------|
     /// | non-nil      | open / closed      | `enumerateMarkers(in: area)` runs all 3 strategies |
-    /// | nil (12.2)   | open               | `enumerateMarkersFromListWindow` direct |
-    /// | nil          | closed             | empty (honest, cache stamped) |
-    ///
-    /// The "empty as success" return on the no-surface case is intentional:
-    /// it lets `StatePoller` write `[]` into the cache so resource handlers
-    /// report `source: "ax_live"` rather than `source: "default"` — telling
-    /// callers the poll ran and observed nothing rather than the poll
-    /// never having run.
     static func defaultGetMarkers(runtime: AXLogicProElements.Runtime = .production) -> ChannelResult {
-        if let area = AXLogicProElements.getArrangementArea(runtime: runtime) {
-            return encodeResult(AXLogicProElements.enumerateMarkers(in: area, runtime: runtime))
-        }
-        // Logic 12.2 commonly has no arrangement area identifier; fall
-        // straight to the marker list window scrape without re-walking
-        // strategies that require an arrange-area root.
         if let listWindow = AXLogicProElements.findMarkerListWindow(runtime: runtime) {
             return encodeResult(AXLogicProElements.enumerateMarkersFromListWindow(
                 listWindow, runtime: runtime.ax
             ))
         }
-        return encodeResult([MarkerState]())
+        if let area = AXLogicProElements.getArrangementArea(runtime: runtime) {
+            let legacyMarkers = AXLogicProElements.enumerateMarkers(in: area, runtime: runtime)
+            if !legacyMarkers.isEmpty {
+                return encodeResult(legacyMarkers)
+            }
+        }
+        return .error(HonestContract.encodeStateC(
+            error: .elementNotFound,
+            hint: "Open Navigate > Open Marker List so Logic Pro can expose marker rows to Accessibility.",
+            extras: ["reason": "marker_list_not_open"]
+        ))
     }
 
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -100,6 +100,8 @@ actor AccessibilityChannel: Channel {
         let setMixerValue: @Sendable ([String: String], MixerTarget) -> ChannelResult
         let projectInfo: @Sendable () -> ChannelResult
         let markers: @Sendable () -> ChannelResult
+        let openMarkerList: @Sendable () async -> ChannelResult
+        let createMarker: @Sendable ([String: String]) async -> ChannelResult
         let importMIDIFile: @Sendable (String) async -> ChannelResult
         // v3.1.5 AppleScript-primary helpers (markersAppleScript /
         // projectInfoAppleScript / tracksAppleScript) removed in v3.1.8 —
@@ -127,6 +129,8 @@ actor AccessibilityChannel: Channel {
             setMixerValue: @escaping @Sendable ([String: String], MixerTarget) -> ChannelResult,
             projectInfo: @escaping @Sendable () -> ChannelResult,
             markers: @escaping @Sendable () -> ChannelResult = { .success("[]") },
+            openMarkerList: @escaping @Sendable () async -> ChannelResult = { .error("openMarkerList not wired") },
+            createMarker: @escaping @Sendable ([String: String]) async -> ChannelResult = { _ in .error("createMarker not wired") },
             importMIDIFile: @escaping @Sendable (String) async -> ChannelResult = { _ in .error("importMIDIFile not wired") },
             logicRuntime: AXLogicProElements.Runtime = .production
         ) {
@@ -148,6 +152,8 @@ actor AccessibilityChannel: Channel {
             self.setMixerValue = setMixerValue
             self.projectInfo = projectInfo
             self.markers = markers
+            self.openMarkerList = openMarkerList
+            self.createMarker = createMarker
             self.importMIDIFile = importMIDIFile
             self.logicRuntime = logicRuntime
         }
@@ -203,6 +209,13 @@ actor AccessibilityChannel: Channel {
                 setMixerValue: { AccessibilityChannel.defaultSetMixerValue(params: $0, target: $1, runtime: logicRuntime) },
                 projectInfo: { AccessibilityChannel.defaultGetProjectInfo(runtime: logicRuntime) },
                 markers: { AccessibilityChannel.defaultGetMarkers(runtime: logicRuntime) },
+                openMarkerList: { await AccessibilityChannel.defaultOpenMarkerList(runtime: logicRuntime) },
+                createMarker: {
+                    await AccessibilityChannel.defaultCreateMarker(
+                        params: $0,
+                        runtime: logicRuntime
+                    )
+                },
                 importMIDIFile: { await AccessibilityChannel.defaultImportMIDIFile(path: $0, runtime: logicRuntime) },
                 logicRuntime: logicRuntime
             )
@@ -530,6 +543,10 @@ actor AccessibilityChannel: Channel {
             // for Logic 10.x. See PRD-issue7-logic12-read-paths.md for
             // the strategy hierarchy.
             return runtime.markers()
+        case "nav.open_marker_list":
+            return await runtime.openMarkerList()
+        case "nav.create_marker":
+            return await runtime.createMarker(params)
         case "nav.rename_marker":
             // Issue #143 — marker renaming has no verified AX write path on
             // Logic 12.x (the Marker List table cells are not settable via

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -163,7 +163,8 @@ extension ChannelRouter {
         // primary `logic_navigate` tool surface this entry is now dead
         // weight by design.
         "nav.goto_marker":            [.midiKeyCommands, .cgEvent],
-        "nav.create_marker":          [.midiKeyCommands, .cgEvent],
+        "nav.open_marker_list":       [.accessibility],
+        "nav.create_marker":          [.accessibility],
         "nav.delete_marker":          [.midiKeyCommands, .cgEvent],
         "nav.rename_marker":          [.accessibility],
         "nav.get_markers":            [.accessibility],

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -131,6 +131,13 @@ struct NavigateDispatcher {
 
         case "create_marker":
             let providedName = stringParam(params, "name")
+            if providedName.count > 250
+                || providedName.rangeOfCharacter(from: .controlCharacters) != nil {
+                return toolInvalidParamsResult(
+                    "create_marker 'name' must be at most 250 characters and contain no control characters",
+                    extras: ["operation": "nav.create_marker"]
+                )
+            }
             return await finalizeCreateMarkerResult(
                 requestedName: providedName.isEmpty ? nil : providedName,
                 router: router,
@@ -259,17 +266,24 @@ struct NavigateDispatcher {
         router: ChannelRouter,
         cache: StateCache
     ) async -> CallTool.Result {
-        let routedName = requestedName ?? "Marker"
         // audit P1 #8: snapshot the marker list BEFORE the mutating route so the
         // count-delta verify reflects the +1 this create adds. Pre-fix both the
         // "before" and "after" reads ran AFTER nav.create_marker, so their
         // counts were equal on success → every verified-by-readback create fell
         // to the State-B readback-mismatch path. Still fail-closed: a nil/short
         // readback below returns State B.
+        let openResult = await router.route(operation: "nav.open_marker_list")
+        guard openResult.isSuccess else {
+            return toolTextResult(openResult)
+        }
         let beforeMarkers = await liveMarkers(router: router, cache: cache)
+        var routeParams: [String: String] = [:]
+        if let requestedName {
+            routeParams["name"] = requestedName
+        }
         let routeResult = await router.route(
             operation: "nav.create_marker",
-            params: ["name": routedName]
+            params: routeParams
         )
         guard routeResult.isSuccess else {
             return toolTextResult(routeResult)
@@ -346,9 +360,19 @@ struct NavigateDispatcher {
         after afterMarkers: [MarkerState],
         before beforeMarkers: [MarkerState]
     ) -> MarkerState? {
-        return afterMarkers.last(where: { candidate in
-            !beforeMarkers.contains(candidate)
-        })
+        var unmatchedBefore = beforeMarkers
+        for candidate in afterMarkers {
+            if let index = unmatchedBefore.firstIndex(where: {
+                $0.name == candidate.name
+                    && $0.position == candidate.position
+                    && $0.positionSource == candidate.positionSource
+            }) {
+                unmatchedBefore.remove(at: index)
+            } else {
+                return candidate
+            }
+        }
+        return nil
     }
 
     /// goto_marker 응답에 marker provenance uncertainty 를 surface — State A/B

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -552,21 +552,22 @@ extension ResourceHandlers {
         let markers = await cache.getMarkers()
         let fetchedAt = await cache.getMarkersFetchedAt()
         let axOccluded = await cache.getAXOccluded()
+        let readable = await cache.getMarkersReadable()
         let body = encodeMarkersWire(markers)
-        let source: String
-        if !markers.isEmpty {
-            source = "ax_live"
-        } else if fetchedAt > .distantPast {
-            // Poller has run, came up empty — could be no markers OR occluded.
-            source = axOccluded ? "cache" : "ax_live"
-        } else {
-            source = "default"
+        let source = readable ? "ax_live" : (markers.isEmpty ? "unreadable" : "cache")
+        var extras: [String: Any] = [
+            "source": source,
+            "readable": readable,
+            "verified_empty": readable && markers.isEmpty,
+        ]
+        if !readable {
+            extras["reason"] = "marker_list_not_open"
         }
         let envelope = wrapWithCacheEnvelope(
             bodyJSON: body,
             fetchedAt: fetchedAt,
             axOccluded: axOccluded,
-            extras: ["source": source]
+            extras: extras
         )
         return ReadResource.Result(
             contents: [.text(envelope, uri: uri, mimeType: "application/json")]

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -9,6 +9,7 @@ actor StateCache {
     private(set) var regions: [RegionState] = []
     private(set) var regionsComplete = false
     private(set) var markers: [MarkerState] = []
+    private(set) var markersReadable: Bool = false
     private(set) var project = ProjectInfo()
     private(set) var mcuConnection = MCUConnectionState()
     private(set) var mcuDisplay = MCUDisplayState()
@@ -88,6 +89,7 @@ actor StateCache {
     func getRegions() -> [RegionState] { regions }
     func getRegionsComplete() -> Bool { regionsComplete }
     func getMarkers() -> [MarkerState] { markers }
+    func getMarkersReadable() -> Bool { markersReadable }
     func getProject() -> ProjectInfo { project }
     func getMCUConnection() -> MCUConnectionState { mcuConnection }
     func getMCUDisplay() -> MCUDisplayState { mcuDisplay }
@@ -162,6 +164,7 @@ actor StateCache {
         regions = []
         regionsComplete = false
         markers = []
+        markersReadable = false
         // Re-initialising transport picks up its default `lastUpdated =
         // .distantPast`, which is how snapshot() signals "stale" to readers
         // (transport_age_sec becomes astronomically large). Clients can
@@ -271,9 +274,14 @@ actor StateCache {
         // assignment is still guarded so listeners that diff
         // `cache.markers` directly don't see redundant publishes.
         markersFetchedAt = Date()
+        markersReadable = true
         if markers != newMarkers {
             markers = newMarkers
         }
+    }
+
+    func markMarkersUnreadable() {
+        markersReadable = false
     }
 
     func updateProject(_ info: ProjectInfo) {

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -230,7 +230,11 @@ actor StatePoller {
                 operation: "nav.get_markers", label: "Marker",
                 axChannel: axChannel, cache: cache, as: [MarkerState].self
             ) { cache, markers in await cache.updateMarkers(markers) }
-            if markersReady { cacheKeys.append(.markers) }
+            if markersReady {
+                cacheKeys.append(.markers)
+            } else {
+                await cache.markMarkersUnreadable()
+            }
         }
         if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
     }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -46,6 +46,8 @@ private final class AccessibilityRuntimeRecorder: @unchecked Sendable {
     var channelStripParams: [[String: String]] = []
     var mixerValueCalls: [([String: String], AccessibilityChannel.MixerTarget)] = []
     var importedMIDIPaths: [String] = []
+    var markerListOpenCount = 0
+    var createMarkerParams: [[String: String]] = []
 }
 
 private final class ControlBarMouseRecorder: @unchecked Sendable {
@@ -202,6 +204,14 @@ private func makeAccessibilityRuntime(
         },
         projectInfo: { .success("{\"project\":true}") },
         markers: { .success("[{\"name\":\"Intro\"}]") },
+        openMarkerList: {
+            recorder.markerListOpenCount += 1
+            return .success("{\"opened\":true}")
+        },
+        createMarker: { params in
+            recorder.createMarkerParams.append(params)
+            return .success("{\"created\":true}")
+        },
         importMIDIFile: { path in
             recorder.importedMIDIPaths.append(path)
             return .success("{\"imported\":\"\(path)\"}")
@@ -490,6 +500,8 @@ private func makeSetInstrumentFixture() -> (
         ("mixer.set_volume", ["index": "2", "value": "0.75"]),
         ("mixer.set_pan", ["index": "2", "value": "-0.2"]),
         ("nav.get_markers", [:]),
+        ("nav.open_marker_list", [:]),
+        ("nav.create_marker", ["name": "Intro"]),
         ("project.get_info", [:]),
     ]
 
@@ -504,6 +516,8 @@ private func makeSetInstrumentFixture() -> (
     #expect(recorder.selectParams == [["index": "4"]])
     #expect(recorder.renameParams == [["index": "5", "name": "Bass"]])
     #expect(recorder.channelStripParams == [["index": "2"]])
+    #expect(recorder.markerListOpenCount == 1)
+    #expect(recorder.createMarkerParams == [["name": "Intro"]])
 
     #expect(recorder.trackToggleCalls.count == 3)
     #expect(recorder.trackToggleCalls[0].1 == "Mute")

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -323,14 +323,20 @@ private actor SequencedMarkersChannel: Channel {
 
     func execute(operation: String, params: [String: String]) async -> ChannelResult {
         executedOps.append((operation, params))
-        guard operation == "nav.get_markers" else {
+        switch operation {
+        case "nav.open_marker_list":
+            return .success(HonestContract.encodeStateA())
+        case "nav.create_marker":
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable))
+        case "nav.get_markers":
+            guard !markerSnapshots.isEmpty else {
+                return .error("missing marker snapshot")
+            }
+            let next = markerSnapshots.removeFirst()
+            return .success(encodeDispatcherJSON(next))
+        default:
             return .error("unexpected operation: \(operation)")
         }
-        guard !markerSnapshots.isEmpty else {
-            return .error("missing marker snapshot")
-        }
-        let next = markerSnapshots.removeFirst()
-        return .success(encodeDispatcherJSON(next))
     }
 
     func healthCheck() async -> ChannelHealth {
@@ -3165,11 +3171,9 @@ private actor SelectiveFailChannel: Channel {
         // using the marker's `position` string (chorus at 17.1.1.1).
         ("transport.goto_position", ["position": "17.1.1.1"]),
         ("transport.goto_position", ["position": "17.1.1.1"]),
-        // AC5 — create_marker now pre-polls the marker list (nav.get_markers)
-        // BEFORE the mutating route so its count-delta verify has a true
-        // pre-mutation baseline. Test scenario unchanged; only this expected
-        // op-list entry was stale.
+        ("nav.open_marker_list", [:]),
         ("nav.get_markers", [:]),
+        ("nav.create_marker", ["name": "Bridge"]),
         ("nav.rename_marker", ["index": "2", "name": "Big Chorus"]),
         // #109 — set_zoom is now AX-first (writable Horizontal-Zoom slider);
         // zoom_to_fit stays on the key-command path (no slider equivalent).
@@ -3181,7 +3185,6 @@ private actor SelectiveFailChannel: Channel {
         // v3.1.10 — `nav.goto_marker` keycmd path is reserved for the
         // cold-cache fallback (cache empty, index supplied). Cached path
         // routes to AX `transport.goto_position` (see axOps above).
-        ("nav.create_marker", ["name": "Bridge"]),
         ("nav.delete_marker", ["index": "1"]),
         ("nav.zoom_to_fit", [:]),
     ])
@@ -3255,6 +3258,9 @@ private actor SelectiveFailChannel: Channel {
     #expect(object["marker_count_after"] as? Int == 2)
     #expect(object["observed_marker_name"] as? String == "Marker 1")
     #expect(await cache.getMarkers().count == 2)
+    #expect(await markersAX.executedOps.map(\.0) == [
+        "nav.open_marker_list", "nav.get_markers", "nav.create_marker", "nav.get_markers",
+    ])
 }
 
 @Test func testNavigateDispatcherCreateMarkerReturnsErrorWhenObservedNameDoesNotMatch() async throws {
@@ -3291,6 +3297,35 @@ private actor SelectiveFailChannel: Channel {
     #expect(object["reason"] as? String == "readback_mismatch")
     #expect(object["requested_name"] as? String == "Bridge")
     #expect(object["observed_marker_name"] as? String == "Marker 2")
+}
+
+@Test func testNavigateDispatcherCreateMarkerDetectsMiddleInsertionDespiteShiftedIDs() async throws {
+    let router = ChannelRouter()
+    let markersAX = SequencedMarkersChannel(markerSnapshots: [
+        [
+            MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser),
+            MarkerState(id: 1, name: "Outro", position: "17.1.1.1", positionSource: .parser),
+        ],
+        [
+            MarkerState(id: 0, name: "Intro", position: "1.1.1.1", positionSource: .parser),
+            MarkerState(id: 1, name: "Bridge", position: "9.1.1.1", positionSource: .parser),
+            MarkerState(id: 2, name: "Outro", position: "17.1.1.1", positionSource: .parser),
+        ],
+    ])
+    await router.register(markersAX)
+
+    let result = await NavigateDispatcher.handle(
+        command: "create_marker",
+        params: ["name": .string("Bridge")],
+        router: router,
+        cache: StateCache()
+    )
+
+    #expect(!result.isError!)
+    let object = try #require(parseDispatcherObject(dispatcherText(result)))
+    #expect(object["observed_marker_id"] as? Int == 1)
+    #expect(object["observed_marker_name"] as? String == "Bridge")
+    #expect(object["observed_marker_position"] as? String == "9.1.1.1")
 }
 
 @Test func testNavigateDispatcherZoomCommandsTreatUnverifiedStateBAsError() async {

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -1,0 +1,104 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: Any] {
+    let text = try #require(result.contents.first?.text)
+    return try #require(
+        JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+    )
+}
+
+@Test func issue254CreateMarkerRoutesAccessibilityFirst() {
+    let route = ChannelRouter.routingTable["nav.create_marker"]
+    #expect(route?.first == .accessibility)
+}
+
+@Test func issue254CreateMarkerRejectsUnsafeNamesBeforeRouting() async {
+    for name in [String(repeating: "x", count: 251), "unsafe\nname"] {
+        let result = await NavigateDispatcher.handle(
+            command: "create_marker",
+            params: ["name": .string(name)],
+            router: ChannelRouter(),
+            cache: StateCache()
+        )
+        #expect(result.isError == true)
+    }
+}
+
+@Test func issue254ClosedMarkerListIsUnreadableRatherThanVerifiedEmpty() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(25_400)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [AXUIElement]())
+
+    let result = AccessibilityChannel.defaultGetMarkers(
+        runtime: builder.makeLogicRuntime(appElement: app)
+    )
+
+    #expect(!result.isSuccess)
+    #expect(result.message.contains("marker_list_not_open"))
+}
+
+@Test func issue254OpenEmptyMarkerListIsVerifiedEmpty() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(25_410)
+    let window = builder.element(25_411)
+    let table = builder.element(25_412)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window])
+    builder.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "Issue254 - Marker List")
+    builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(table, "AXRows", [AXUIElement]())
+    builder.setChildren(window, [table])
+
+    let result = AccessibilityChannel.defaultGetMarkers(
+        runtime: builder.makeLogicRuntime(appElement: app)
+    )
+
+    #expect(result.isSuccess)
+    let markers = try JSONDecoder().decode([MarkerState].self, from: Data(result.message.utf8))
+    #expect(markers.isEmpty)
+}
+
+@Test func issue254MarkerResourceRefreshesFromLiveAX() async throws {
+    let marker = MarkerState(id: 0, name: "Marker 1", position: "1.1.1.1")
+    let cache = StateCache()
+    await cache.updateMarkers([marker])
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://markers",
+        cache: cache,
+        router: ChannelRouter()
+    )
+    let envelope = try issue254Envelope(result)
+    let data = try #require(envelope["data"] as? [[String: Any]])
+
+    #expect(envelope["source"] as? String == "ax_live")
+    #expect(envelope["readable"] as? Bool == true)
+    #expect(envelope["verified_empty"] as? Bool == false)
+    #expect((data.first?["name"] as? String) == "Marker 1")
+    #expect(await cache.getMarkers().first?.name == "Marker 1")
+}
+
+@Test func issue254MarkerResourcePreservesCacheWhenLiveAXIsUnreadable() async throws {
+    let cached = MarkerState(id: 0, name: "Cached Marker", position: "1.1.1.1")
+    let cache = StateCache()
+    await cache.updateMarkers([cached])
+    await cache.markMarkersUnreadable()
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://markers",
+        cache: cache,
+        router: ChannelRouter()
+    )
+    let envelope = try issue254Envelope(result)
+    let data = try #require(envelope["data"] as? [[String: Any]])
+
+    #expect(envelope["source"] as? String == "cache")
+    #expect(envelope["readable"] as? Bool == false)
+    #expect(envelope["reason"] as? String == "marker_list_not_open")
+    #expect((data.first?["name"] as? String) == "Cached Marker")
+    #expect(await cache.getMarkers().first?.name == "Cached Marker")
+}


### PR DESCRIPTION
## Summary
- route marker creation through Logic Pro's native Navigate > Create Marker accessibility path instead of the no-op default key-command route
- open and scrape Marker List for authoritative before/after verification, including safe optional naming and middle-insertion detection when marker IDs shift
- distinguish a verified empty marker list from an unreadable closed list, and preserve the last readable marker cache instead of overwriting it with `[]`

## Live QA
Verified against Logic Pro 12.3 through the built MCP server:
- closed Marker List: `logic://markers` returned `readable:false`, `verified_empty:false`, `source:"unreadable"`
- `create_marker {"name":"Issue254E2E"}` created exactly one marker and returned State A with counts `0 -> 1`, `name_applied:true`, and observed name `Issue254E2E`
- open Marker List: the resource returned the live canonical marker at `1.1.1.1`
- after closing the list and refreshing: the resource returned `source:"cache"` while retaining `Issue254E2E`
- removed the QA marker and confirmed Logic had no remaining dialogs or scratch markers

## Verification
- `swift test --filter "testNavigateDispatcherCreateMarker|issue254" --no-parallel -j 4 -Xswiftc -suppress-warnings` (9 passed)
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,257 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- SourceKit LSP error diagnostics: clean on all changed core files

The skipped inventory test is a pre-existing machine-local mismatch: the committed inventory only contains Bass/Drums while this Logic installation exposes additional categories.

Closes #254