### PR TITLE
fix(ui): use native count-in and step-input toggles

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -140,6 +140,18 @@ enum AXLocalePolicy {
         rationale: "Best-effort cleanup so stale plugin windows do not steal later menu focus."
     )
 
+    static let showStepInputKeyboardMenuItem = LabelSet(
+        canonical: "Show Step Input Keyboard",
+        variants: ["스텝 입력 키보드 보기"],
+        rationale: "Native Window-menu toggle used with independent window-state readback."
+    )
+
+    static let stepInputKeyboardWindowTitle = LabelSet(
+        canonical: "Step Input Keyboard",
+        variants: ["스텝 입력 키보드"],
+        rationale: "Verifies the Step Input Keyboard window opened or closed after the menu action."
+    )
+
     static let editMenuBar = LabelSet(
         canonical: "Edit",
         variants: ["편집"],
@@ -691,6 +703,10 @@ enum AXLocalePolicy {
 
     static let showMixerMenuPath = MenuPath(bar: viewMenuBar, item: showMixerMenuItem)
     static let hidePluginWindowsMenuPath = MenuPath(bar: windowMenuBar, item: hideAllPluginWindowsMenuItem)
+    static let showStepInputKeyboardMenuPath = MenuPath(
+        bar: windowMenuBar,
+        item: showStepInputKeyboardMenuItem
+    )
     static let editUndoMenuPath = MenuPath(bar: editMenuBar, item: undoMenuItemPrefix, itemMode: .prefix)
 
     static func elementMatches(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Editing.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Editing.swift
@@ -1,0 +1,88 @@
+import ApplicationServices
+import Foundation
+
+extension AccessibilityChannel {
+    static func defaultToggleStepInputKeyboard(
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ChannelResult {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime),
+              let menuBar = AXLogicProElements.getMenuBar(runtime: runtime),
+              let windowMenu = AXLocalePolicy.findMenuBarItem(
+                in: menuBar,
+                matching: AXLocalePolicy.showStepInputKeyboardMenuPath.bar,
+                runtime: runtime.ax
+              ),
+              let menuItem = AXLocalePolicy.findMenuItem(
+                under: windowMenu,
+                matching: AXLocalePolicy.showStepInputKeyboardMenuPath.item,
+                mode: AXLocalePolicy.showStepInputKeyboardMenuPath.itemMode,
+                runtime: runtime.ax
+              ) else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Window > Show Step Input Keyboard was not found."
+            ))
+        }
+
+        let enabled: NSNumber? = AXHelpers.getAttribute(
+            menuItem,
+            kAXEnabledAttribute,
+            runtime: runtime.ax
+        )
+        guard enabled?.boolValue != false else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Window > Show Step Input Keyboard is disabled."
+            ))
+        }
+
+        let previousOpen = stepInputKeyboardIsOpen(app: app, runtime: runtime.ax)
+        guard AXHelpers.performAction(menuItem, kAXPressAction, runtime: runtime.ax) else {
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "AXPress failed on Window > Show Step Input Keyboard."
+            ))
+        }
+
+        for _ in 0..<20 {
+            let observedOpen = stepInputKeyboardIsOpen(app: app, runtime: runtime.ax)
+            if observedOpen != previousOpen {
+                return .success(HonestContract.encodeStateA(extras: [
+                    "operation": "edit.toggle_step_input",
+                    "previous_open": previousOpen,
+                    "observed_open": observedOpen,
+                    "via": "window-menu",
+                ]))
+            }
+            usleep(50_000)
+        }
+
+        return .error(HonestContract.encodeStateC(
+            error: .readbackMismatch,
+            hint: "Step Input Keyboard window state did not change after the menu action.",
+            extras: [
+                "operation": "edit.toggle_step_input",
+                "previous_open": previousOpen,
+                "observed_open": previousOpen,
+                "safe_to_retry": true,
+            ]
+        ))
+    }
+
+    private static func stepInputKeyboardIsOpen(
+        app: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app,
+            kAXWindowsAttribute,
+            runtime: runtime
+        ) ?? []
+        return windows.contains { window in
+            AXLocalePolicy.stepInputKeyboardWindowTitle.matches(
+                AXHelpers.getTitle(window, runtime: runtime),
+                mode: .contains
+            )
+        }
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -45,7 +45,7 @@ extension AccessibilityChannel {
         let controlBarMapping: [String: (korean: String, english: String, desired: Bool?)] = [
             "Cycle":      ("사이클",        "Cycle",     nil),
             "Metronome":  ("메트로놈 클릭",  "Metronome", nil),
-            "CountIn":    ("카운트 인",     "Count-in",  nil),
+            "CountIn":    ("카운트 인",     "Count In",  nil),
             "Play":       ("재생",          "Play",      true),
             "Stop":       ("재생",          "Play",      false),
             "Record":     ("녹음",          "Record",    true),

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -88,6 +88,7 @@ actor AccessibilityChannel: Channel {
         let appRoot: @Sendable () -> AXUIElement?
         let transportState: @Sendable () -> ChannelResult
         let toggleTransportButton: @Sendable (String) -> ChannelResult
+        let toggleStepInputKeyboard: @Sendable () -> ChannelResult
         let setTempo: @Sendable ([String: String]) -> ChannelResult
         let setCycleRange: @Sendable ([String: String]) -> ChannelResult
         let tracks: @Sendable () -> ChannelResult
@@ -117,6 +118,7 @@ actor AccessibilityChannel: Channel {
             appRoot: @escaping @Sendable () -> AXUIElement?,
             transportState: @escaping @Sendable () -> ChannelResult,
             toggleTransportButton: @escaping @Sendable (String) -> ChannelResult,
+            toggleStepInputKeyboard: @escaping @Sendable () -> ChannelResult = { .error("toggleStepInputKeyboard not wired") },
             setTempo: @escaping @Sendable ([String: String]) -> ChannelResult,
             setCycleRange: @escaping @Sendable ([String: String]) -> ChannelResult,
             tracks: @escaping @Sendable () -> ChannelResult,
@@ -140,6 +142,7 @@ actor AccessibilityChannel: Channel {
             self.appRoot = appRoot
             self.transportState = transportState
             self.toggleTransportButton = toggleTransportButton
+            self.toggleStepInputKeyboard = toggleStepInputKeyboard
             self.setTempo = setTempo
             self.setCycleRange = setCycleRange
             self.tracks = tracks
@@ -182,6 +185,9 @@ actor AccessibilityChannel: Channel {
                         runtime: logicRuntime,
                         mouseRuntime: controlBarMouseRuntime
                     )
+                },
+                toggleStepInputKeyboard: {
+                    AccessibilityChannel.defaultToggleStepInputKeyboard(runtime: logicRuntime)
                 },
                 setTempo: {
                     AccessibilityChannel.defaultSetTempo(
@@ -265,6 +271,9 @@ actor AccessibilityChannel: Channel {
             return runtime.toggleTransportButton("CountIn")
         case "transport.toggle_autopunch":
             return runtime.toggleTransportButton("AutoPunch")
+
+        case "edit.toggle_step_input":
+            return runtime.toggleStepInputKeyboard()
 
         case "transport.play":
             return runtime.toggleTransportButton("Play")

--- a/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
+++ b/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
@@ -556,7 +556,7 @@ actor MIDIKeyCommandsChannel: KeyCmdCCChannel {
     static let manualValidationDetailSuffix =
         "Manual MIDI Learn required — see docs/SETUP.md §4. " +
         "Effectively keycmd-only (no working non-keycmd fallback on Logic 12.2): " +
-        "edit.duplicate, edit.normalize, edit.toggle_step_input, " +
+        "edit.duplicate, edit.normalize, " +
         "nav.goto_marker, nav.delete_marker, transport.capture_recording. " +
         "Other preset ops have an AX/MCU/AppleScript/CGEvent fallback and do not require keycmd binding. " +
         "Orphans (in mappingTable + routingTable but no MCP tool exposes a call path): " +

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -188,7 +188,7 @@ extension ChannelRouter {
         "edit.quantize":              [.midiKeyCommands, .cgEvent],
         "edit.bounce_in_place":       [.midiKeyCommands, .cgEvent],
         "edit.normalize":             [.midiKeyCommands, .cgEvent],
-        "edit.toggle_step_input":     [.midiKeyCommands, .cgEvent],  // §4.3.1 new command
+        "edit.toggle_step_input":     [.accessibility, .midiKeyCommands, .cgEvent],
         "edit.duplicate":             [.midiKeyCommands, .cgEvent],
 
         "project.new":                [.appleScript, .cgEvent],

--- a/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
+++ b/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
@@ -53,7 +53,7 @@ private func t7StartedChannel(tag: String) async throws -> ChannelHealth {
     #expect(health.detail.contains("transport.capture_recording"))
     #expect(health.detail.contains("edit.duplicate"))
     #expect(health.detail.contains("edit.normalize"))
-    #expect(health.detail.contains("edit.toggle_step_input"))
+    #expect(!health.detail.contains("edit.toggle_step_input"))
     #expect(health.detail.contains("nav.goto_marker"))
     #expect(health.detail.contains("nav.delete_marker"))
     #expect(!health.detail.contains("nav.set_zoom_level"))

--- a/Tests/LogicProMCPTests/Issue255NativeToggleTests.swift
+++ b/Tests/LogicProMCPTests/Issue255NativeToggleTests.swift
@@ -1,0 +1,121 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private let issue255NoMouseRuntime = AXMouseHelper.Runtime(
+    postMouseEvent: { _, _, _ in false },
+    postKeyEvent: { _ in false },
+    postUnicodeScalar: { _ in false },
+    sleepMicros: { _ in }
+)
+
+private func issue255Object(_ raw: String) -> [String: Any]? {
+    guard let data = raw.data(using: .utf8) else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+}
+
+private func issue255Channel(
+    logicRuntime: AXLogicProElements.Runtime
+) -> AccessibilityChannel {
+    AccessibilityChannel(runtime: .axBacked(
+        isTrusted: { true },
+        isLogicProRunning: { true },
+        logicRuntime: logicRuntime,
+        controlBarMouseRuntime: issue255NoMouseRuntime
+    ))
+}
+
+@Test func issue255NativeTogglesRouteAccessibilityFirst() {
+    #expect(ChannelRouter.routingTable["transport.toggle_count_in"]?.first == .accessibility)
+    #expect(ChannelRouter.routingTable["edit.toggle_step_input"]?.first == .accessibility)
+}
+
+@Test func issue255CountInMatchesLogic123ControlBarTitle() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(25_500)
+    let window = builder.element(25_501)
+    let controlBar = builder.element(25_502)
+    let countIn = builder.element(25_503)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [countIn])
+    builder.setAttribute(countIn, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(countIn, kAXTitleAttribute as String, "Count In")
+    builder.setAttribute(countIn, kAXValueAttribute as String, NSNumber(value: false))
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            guard element == countIn, action == kAXPressAction as String else { return false }
+            builder.setAttribute(countIn, kAXValueAttribute as String, NSNumber(value: true))
+            return true
+        }
+    )
+    let channel = issue255Channel(logicRuntime: logicRuntime)
+
+    let result = await channel.execute(operation: "transport.toggle_count_in", params: [:])
+
+    #expect(result.isSuccess)
+    let object = try #require(issue255Object(result.message))
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["observed"] as? Bool == true)
+    #expect(object["button"] as? String == "Count In")
+}
+
+@Test func issue255StepInputUsesWindowMenuAndVerifiesWindowState() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(25_510)
+    let tracksWindow = builder.element(25_511)
+    let stepInputWindow = builder.element(25_512)
+    let menuBar = builder.element(25_513)
+    let windowMenu = builder.element(25_514)
+    let menu = builder.element(25_515)
+    let showStepInput = builder.element(25_516)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, tracksWindow)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [tracksWindow])
+    builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+    builder.setAttribute(tracksWindow, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(tracksWindow, kAXTitleAttribute as String, "Untitled - Tracks")
+    builder.setAttribute(stepInputWindow, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(
+        stepInputWindow,
+        kAXTitleAttribute as String,
+        "Untitled - Step Input Keyboard"
+    )
+
+    builder.setChildren(menuBar, [windowMenu])
+    builder.setAttribute(windowMenu, kAXRoleAttribute as String, kAXMenuBarItemRole as String)
+    builder.setAttribute(windowMenu, kAXTitleAttribute as String, "Window")
+    builder.setChildren(windowMenu, [menu])
+    builder.setAttribute(menu, kAXRoleAttribute as String, kAXMenuRole as String)
+    builder.setChildren(menu, [showStepInput])
+    builder.setAttribute(showStepInput, kAXRoleAttribute as String, kAXMenuItemRole as String)
+    builder.setAttribute(showStepInput, kAXTitleAttribute as String, "Show Step Input Keyboard")
+    builder.setAttribute(showStepInput, kAXEnabledAttribute as String, NSNumber(value: true))
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            guard element == showStepInput, action == kAXPressAction as String else { return false }
+            builder.setAttribute(app, kAXWindowsAttribute as String, [tracksWindow, stepInputWindow])
+            return true
+        }
+    )
+    let channel = issue255Channel(logicRuntime: logicRuntime)
+
+    let result = await channel.execute(operation: "edit.toggle_step_input", params: [:])
+
+    #expect(result.isSuccess)
+    let object = try #require(issue255Object(result.message))
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["previous_open"] as? Bool == false)
+    #expect(object["observed_open"] as? Bool == true)
+    #expect(object["via"] as? String == "window-menu")
+}

--- a/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
+++ b/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
@@ -37,7 +37,6 @@ struct RoutingAuditInvariantTests {
         // path that fires these on Logic 12.2.
         "edit.duplicate",                 // logic_edit.duplicate
         "edit.normalize",                 // logic_edit.normalize
-        "edit.toggle_step_input",         // logic_edit.toggle_step_input
         "nav.goto_marker",                // logic_navigate.goto_marker (with index)
         "nav.delete_marker",              // logic_navigate.delete_marker
         // Channel-only router op — no public MCP tool command exposes it, but

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -107,7 +107,6 @@ Manual binding is only needed for remaining keycmd-only/channel-only paths:
 
 - `edit.duplicate`
 - `edit.normalize`
-- `edit.toggle_step_input`
 - `nav.goto_marker`
 - `nav.delete_marker`
 - `transport.capture_recording`


### PR DESCRIPTION
## Summary
- match Logic Pro 12.3's actual `Count In` Control Bar title so the existing verified AX toggle no longer falls through to an unbound key command
- route `toggle_step_input` through the native Window > Show Step Input Keyboard menu and verify the project-prefixed window title changes before returning State A
- remove Step Input from the manual key-command-only health and setup guidance

## Live QA
The pre-fix branch binary reproduced both reported failures through a real stdio MCP handshake:
- `toggle_count_in` -> State C `channels_exhausted`, `No keyboard shortcut mapped`
- `toggle_step_input` -> State C `channels_exhausted`, `No keyboard shortcut mapped`

The fixed binary returned:
- Count In: State A, `previous:false`, `observed:true`, `button:"Count In"`
- Step Input open: State A, `previous_open:false`, `observed_open:true`, `via:"window-menu"`
- Step Input close: State A, `previous_open:true`, `observed_open:false`

Final UI state was restored: Count In enabled, Step Input closed, only the Tracks window present, and the MCP child exited.

## Verification
- issue #255 regression tests: 3 passed, including red-before-green coverage for actual Logic labels and project-prefixed window titles
- key-command health and routing invariants: 12 passed
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,260 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- SourceKit LSP error diagnostics: clean on changed Swift files

The skipped inventory test is the existing machine-local Logic library mismatch documented on the preceding PRs.

Closes #255