### PR TITLE
fix(system): document audio and plugins help

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -284,7 +284,8 @@ struct SystemDispatcher {
     /// `testValidHelpCategoriesStayInLockstepWithHelpText` so a new dispatcher
     /// section can't drift out of the accepted set.
     static let validHelpCategories = [
-        "all", "transport", "tracks", "mixer", "midi", "edit", "navigate", "project", "system",
+        "all", "transport", "tracks", "mixer", "midi", "edit", "navigate", "project",
+        "audio", "plugins", "system",
     ]
 
     private static func helpText(for category: String) -> String {
@@ -428,6 +429,41 @@ struct SystemDispatcher {
                 Read project info via resource: logic://project/info
                 """
 
+        case "audio":
+            return """
+                logic_audio commands:
+                  analyze_file      -> { path: String, output_root?: String,
+                                         min_duration_seconds?: Float,
+                                         expected_duration_seconds?: Float,
+                                         max_duration_drift_seconds?: Float,
+                                         min_file_size_bytes?: Int,
+                                         max_input_file_size_bytes?: Int,
+                                         max_input_duration_seconds?: Float,
+                                         max_decoded_frames?: Int,
+                                         max_peak_dbfs?: Float,
+                                         near_silence_dbfs?: Float,
+                                         max_silence_ratio?: Float,
+                                         expected_sample_rate?: Int,
+                                         expected_channel_count?: Int }
+                                       Read-only analysis of an absolute audio artifact path.
+                """
+
+        case "plugins":
+            return """
+                logic_plugins commands:
+                  get_inventory     -> { track: Int } — Read a drift-safe insert chain
+                  set_param_verified -> { track: Int, insert: Int, plugin: String,
+                                          param: String, value: Float, unit: String,
+                                          mode: "duplicate_applyback",
+                                          project_expected_path: String }
+                  insert_verified   -> { track: Int, insert: Int,
+                                         plugin: "Gain"|"Channel EQ"|"Compressor",
+                                         mode: "duplicate_applyback",
+                                         project_expected_path: String }
+
+                Verified writes return State A only after AX readback matches.
+                """
+
         case "system":
             return """
                 logic_system commands:
@@ -436,7 +472,7 @@ struct SystemDispatcher {
                   refresh_cache     -> {} — Force AX re-poll
                   help              -> { category: String } — Param docs per category
 
-                Categories: transport, tracks, mixer, midi, edit, navigate, project, system
+                Categories: transport, tracks, mixer, midi, edit, navigate, project, audio, plugins, system
 
                 Read health via resource: logic://system/health
 

--- a/Tests/LogicProMCPTests/Issue253HelpCategoriesTests.swift
+++ b/Tests/LogicProMCPTests/Issue253HelpCategoriesTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Test func issue253AudioAndPluginsHelpReturnCategoryDocs() async {
+    for category in ["audio", "plugins"] {
+        let result = await SystemDispatcher.handle(
+            command: "help",
+            params: ["category": .string(category)],
+            router: ChannelRouter(),
+            cache: StateCache()
+        )
+
+        #expect(result.isError == false)
+        #expect(sharedToolText(result).contains("logic_\(category) commands"))
+    }
+}
+
+@Test func issue253UnknownCategoryListsAudioAndPluginsAsValid() async throws {
+    let result = await SystemDispatcher.handle(
+        command: "help",
+        params: ["category": .string("bogus")],
+        router: ChannelRouter(),
+        cache: StateCache()
+    )
+    let object = try #require(
+        JSONSerialization.jsonObject(with: Data(sharedToolText(result).utf8))
+            as? [String: Any]
+    )
+    let validCategories = try #require(object["valid_categories"] as? [String])
+
+    #expect(validCategories.contains("audio"))
+    #expect(validCategories.contains("plugins"))
+}
+
+@Test func issue253SystemHelpFooterListsEveryToolCategory() async {
+    let result = await SystemDispatcher.handle(
+        command: "help",
+        params: ["category": .string("system")],
+        router: ChannelRouter(),
+        cache: StateCache()
+    )
+
+    #expect(sharedToolText(result).contains(
+        "Categories: transport, tracks, mixer, midi, edit, navigate, project, audio, plugins, system"
+    ))
+}


### PR DESCRIPTION
## Summary
- accept `audio` and `plugins` as first-class `logic_system.help` categories
- return command and parameter documentation for `logic_audio` and `logic_plugins` instead of falling through to `unknown_category`
- include both categories in typed `valid_categories` errors and the system help footer

## Live QA
A real stdio MCP handshake reproduced the pre-fix contradiction: `help all` listed both tools, while `help audio` and `help plugins` returned State C `unknown_category`.

The fixed binary returned:
- `help audio`: `logic_audio commands` with `analyze_file` parameters
- `help plugins`: all three plugin commands with verified-write parameters
- `help system`: footer includes `audio, plugins`
- bogus category: typed `valid_categories` includes both entries

## Verification
- issue #253 tests: red with 3 tests / 5 issues before the fix, then 3 passed
- existing category coverage, unknown-category, and allowlist/switch lockstep tests: 3 passed
- `swift test --skip everyEmittedCategoryExistsInPanelInventory --no-parallel -j 4 -Xswiftc -suppress-warnings` (2,263 passed)
- `swift build -c release -j 4 -Xswiftc -suppress-warnings`
- SourceKit LSP error diagnostics: clean

The skipped inventory test is the existing machine-local Logic library mismatch documented on the preceding PRs.

Closes #253