### PR TITLE
release: sync Formula sha256 to v3.11.0 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz release artifact.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "27669976b990f41d99ff6a55b2f05fa18ae43a07ec1611884ad6ea2a439ee9ad"
+    sha256 "268bffbf17ece58a373e1a1ddca0155d7c04691b7801bb2274327ce44a8ed4b9"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
## Summary
- Sync the Homebrew Formula SHA-256 to the published v3.11.0 `LogicProMCP-macOS-universal.tar.gz` asset.
- Keep the Formula version at 3.11.0.

## Verification
- Compared against the published v3.11.0 `SHA256SUMS.txt`: `268bffbf17ece58a373e1a1ddca0155d7c04691b7801bb2274327ce44a8ed4b9`.
- `git diff --check`
- `ruby -c Formula/logic-pro-mcp.rb`

## Note
- `brew audit [path ...]` is disabled by the current Homebrew CLI, so path-based local audit could not be used.