### PR TITLE
feat(adr-003): operation contract registry pilot — logic_transport (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -473,6 +473,11 @@ actor LogicProServer {
     /// normal op can never false-trip; only a wedged/occluded Logic session
     /// that would otherwise hang the stdio loop is bounded.
     static func commandDeadlineSeconds(tool: String, command: String) -> Double {
+        if FeatureFlags.adr003OperationRegistry,
+           tool == ToolID.logicTransport.rawValue,
+           let seconds = OperationRegistry.deadlineSeconds(tool: tool, command: command) {
+            return seconds
+        }
         if longRunningCommands.contains(command) { return 300 }
         if mediumRunningCommands.contains(command) { return 90 }
         return 25
@@ -712,7 +717,12 @@ actor LogicProServer {
     ]
 
     static func isMutatingCommand(tool: String, command: String) -> Bool {
-        mutatingCommandsByTool[tool]?.contains(command) == true
+        if FeatureFlags.adr003OperationRegistry,
+           tool == ToolID.logicTransport.rawValue,
+           let spec = OperationRegistry.spec(tool: tool, command: command) {
+            return spec.mutability == Mutability.`mutating`
+        }
+        return mutatingCommandsByTool[tool]?.contains(command) == true
     }
 
     private static func operationName(tool: String, command: String) -> String {

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -1,0 +1,221 @@
+enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
+    case transportPlay = "transport.play"
+    case transportStop = "transport.stop"
+    case transportRecord = "transport.record"
+    case transportPause = "transport.pause"
+    case transportRewind = "transport.rewind"
+    case transportFastForward = "transport.fast_forward"
+    case transportToggleCycle = "transport.toggle_cycle"
+    case transportToggleMetronome = "transport.toggle_metronome"
+    case transportSetTempo = "transport.set_tempo"
+    case transportGotoPosition = "transport.goto_position"
+    case transportSetCycleRange = "transport.set_cycle_range"
+    case transportToggleCountIn = "transport.toggle_count_in"
+    case transportToggleAutopunch = "transport.toggle_autopunch"
+}
+
+enum ToolID: String, Sendable, Equatable {
+    case logicTransport = "logic_transport"
+}
+
+enum Mutability: Sendable, Equatable {
+    case `mutating`
+    case readOnly
+}
+
+enum ConfirmationPolicy: Sendable, Equatable {
+    case none
+    case l1
+    case l2
+    case l3
+}
+
+enum TargetPolicy: Sendable, Equatable {
+    case none
+    case requiresStableTarget
+}
+
+enum VerificationPolicy: Sendable, Equatable {
+    case none
+    case readbackRequired
+    case bestEffort
+}
+
+enum RetryPolicy: Sendable, Equatable {
+    case idempotent
+    case beforeWriteBoundaryOnly
+    case neverAutomatic
+}
+
+enum DeadlineClass: Sendable, Equatable {
+    case short
+    case medium
+    case long
+
+    var seconds: Double {
+        switch self {
+        case .short: 25
+        case .medium: 90
+        case .long: 300
+        }
+    }
+}
+
+enum AvailabilityPolicy: Sendable, Equatable {
+    case defaultInstall
+    case requiresProfile
+    case requiresKeyBinding
+    case experimental
+    case unsupported
+}
+
+struct CapabilityID: RawRepresentable, Sendable, Hashable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+struct OperationSpec: Sendable {
+    let id: OperationID
+    let tool: ToolID
+    let command: String
+    let mutability: Mutability
+    let confirmation: ConfirmationPolicy
+    let target: TargetPolicy
+    let verification: VerificationPolicy
+    let retry: RetryPolicy
+    let deadline: DeadlineClass
+    let availability: AvailabilityPolicy
+    let capability: CapabilityID
+}
+
+enum OperationRegistry {
+    struct ValidationEntry: Sendable {
+        let operationID: String
+        let tool: String
+        let command: String
+    }
+
+    private static let allowedOperationIDs: Set<String> = [
+        "transport.play", "transport.stop", "transport.record", "transport.pause",
+        "transport.rewind", "transport.fast_forward", "transport.toggle_cycle",
+        "transport.toggle_metronome", "transport.set_tempo", "transport.goto_position",
+        "transport.set_cycle_range", "transport.toggle_count_in", "transport.toggle_autopunch",
+    ]
+
+    private static let allowedCommands: Set<String> = [
+        "play", "stop", "record", "pause", "rewind", "fast_forward", "toggle_cycle",
+        "toggle_metronome", "set_tempo", "goto_position", "set_cycle_range", "toggle_count_in",
+        "toggle_autopunch",
+    ]
+
+    static let specs: [OperationSpec] = ([
+        (.transportPlay, "play", .readbackRequired, .defaultInstall),
+        (.transportStop, "stop", .readbackRequired, .defaultInstall),
+        (.transportRecord, "record", .readbackRequired, .defaultInstall),
+        (.transportPause, "pause", .readbackRequired, .defaultInstall),
+        (.transportRewind, "rewind", .none, .defaultInstall),
+        (.transportFastForward, "fast_forward", .none, .defaultInstall),
+        (.transportToggleCycle, "toggle_cycle", .none, .defaultInstall),
+        (.transportToggleMetronome, "toggle_metronome", .readbackRequired, .defaultInstall),
+        (.transportSetTempo, "set_tempo", .none, .defaultInstall),
+        (.transportGotoPosition, "goto_position", .readbackRequired, .defaultInstall),
+        (.transportSetCycleRange, "set_cycle_range", .none, .unsupported),
+        (.transportToggleCountIn, "toggle_count_in", .none, .defaultInstall),
+        (.transportToggleAutopunch, "toggle_autopunch", .none, .defaultInstall),
+    ] as [(OperationID, String, VerificationPolicy, AvailabilityPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicTransport,
+            command: entry.1,
+            mutability: Mutability.`mutating`,
+            confirmation: .none,
+            target: .none,
+            verification: entry.2,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: entry.3,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
+    }
+
+    static func spec(tool: String, command: String) -> OperationSpec? {
+        specs.first { $0.tool.rawValue == tool && $0.command == command }
+    }
+
+    static var mutatingCommands: Set<String> {
+        Set(specs.filter { $0.mutability == Mutability.`mutating` }.map(\.command))
+    }
+
+    static func deadlineSeconds(tool: String, command: String) -> Double? {
+        spec(tool: tool, command: command)?.deadline.seconds
+    }
+
+    static func validationErrors(for candidateSpecs: [OperationSpec] = specs) -> [String] {
+        validationErrors(for: candidateSpecs.map {
+            ValidationEntry(operationID: $0.id.rawValue, tool: $0.tool.rawValue, command: $0.command)
+        })
+    }
+
+    static func validationErrors(for entries: [ValidationEntry]) -> [String] {
+        var errors: [String] = []
+
+        if entries.count != allowedOperationIDs.count {
+            errors.append("entry count: expected \(allowedOperationIDs.count), got \(entries.count)")
+        }
+
+        let duplicateIDs = Dictionary(grouping: entries.map(\.operationID), by: { $0 })
+            .filter { $0.value.count > 1 }
+            .keys.sorted()
+        if !duplicateIDs.isEmpty {
+            errors.append("duplicate operation IDs: \(duplicateIDs.joined(separator: ", "))")
+        }
+
+        let duplicateCommands = Dictionary(grouping: entries.map(\.command), by: { $0 })
+            .filter { $0.value.count > 1 }
+            .keys.sorted()
+        if !duplicateCommands.isEmpty {
+            errors.append("duplicate commands: \(duplicateCommands.joined(separator: ", "))")
+        }
+
+        let actualIDs = Set(entries.map(\.operationID))
+        let missingIDs = allowedOperationIDs.subtracting(actualIDs).sorted()
+        if !missingIDs.isEmpty {
+            errors.append("missing operation IDs: \(missingIDs.joined(separator: ", "))")
+        }
+        let unexpectedIDs = actualIDs.subtracting(allowedOperationIDs).sorted()
+        if !unexpectedIDs.isEmpty {
+            errors.append("unexpected operation IDs: \(unexpectedIDs.joined(separator: ", "))")
+        }
+
+        let actualCommands = Set(entries.map(\.command))
+        let missingCommands = allowedCommands.subtracting(actualCommands).sorted()
+        if !missingCommands.isEmpty {
+            errors.append("missing commands: \(missingCommands.joined(separator: ", "))")
+        }
+        let unexpectedCommands = actualCommands.subtracting(allowedCommands).sorted()
+        if !unexpectedCommands.isEmpty {
+            errors.append("unexpected commands: \(unexpectedCommands.joined(separator: ", "))")
+        }
+
+        let incorrectTools = entries
+            .filter { $0.tool != ToolID.logicTransport.rawValue }
+            .map { "\($0.command)=\($0.tool)" }
+            .sorted()
+        if !incorrectTools.isEmpty {
+            errors.append("incorrect tools: \(incorrectTools.joined(separator: ", "))")
+        }
+
+        let mismatches = entries
+            .filter { $0.operationID != "transport.\($0.command)" }
+            .map { "\($0.operationID)=\($0.command)" }
+            .sorted()
+        if !mismatches.isEmpty {
+            errors.append("ID/command mismatches: \(mismatches.joined(separator: ", "))")
+        }
+
+        return errors
+    }
+}

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("Operation registry", .serialized)
+struct OperationRegistryTests {
+    private static let commands: [(OperationID, String)] = [
+        (.transportPlay, "play"),
+        (.transportStop, "stop"),
+        (.transportRecord, "record"),
+        (.transportPause, "pause"),
+        (.transportRewind, "rewind"),
+        (.transportFastForward, "fast_forward"),
+        (.transportToggleCycle, "toggle_cycle"),
+        (.transportToggleMetronome, "toggle_metronome"),
+        (.transportSetTempo, "set_tempo"),
+        (.transportGotoPosition, "goto_position"),
+        (.transportSetCycleRange, "set_cycle_range"),
+        (.transportToggleCountIn, "toggle_count_in"),
+        (.transportToggleAutopunch, "toggle_autopunch"),
+    ]
+
+    private static let readbackCommands: Set<String> = [
+        "play", "stop", "record", "pause", "toggle_metronome", "goto_position",
+    ]
+
+    private func withRegistryFlag(_ value: String?, body: () -> Void) {
+        let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
+        let previous = ProcessInfo.processInfo.environment[key]
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        body()
+    }
+
+    @Test("transport registry is exact, unique, and valid")
+    func completenessAndValidation() {
+        #expect(OperationRegistry.specs.count == 13)
+        #expect(Set(OperationRegistry.specs.map(\.command)).count == 13)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(DeadlineClass.short.seconds == 25)
+        #expect(DeadlineClass.medium.seconds == 90)
+        #expect(DeadlineClass.long.seconds == 300)
+        #expect(OperationRegistry.validationErrors().isEmpty)
+    }
+
+    @Test("raw validation rejects every malformed registry shape")
+    func malformedRawEntries() throws {
+        let entries = OperationRegistry.specs.map {
+            OperationRegistry.ValidationEntry(
+                operationID: $0.id.rawValue,
+                tool: $0.tool.rawValue,
+                command: $0.command
+            )
+        }
+        let first = try #require(entries.first)
+        let second = try #require(entries.dropFirst().first)
+
+        var duplicateID = entries
+        duplicateID.append(.init(operationID: first.operationID, tool: first.tool, command: "duplicate_id_probe"))
+
+        var duplicateCommand = entries
+        duplicateCommand.append(.init(operationID: "transport.duplicate_command_probe", tool: first.tool, command: first.command))
+
+        var unexpectedID = entries
+        unexpectedID[0] = .init(operationID: "transport.unexpected", tool: first.tool, command: first.command)
+
+        var unexpectedCommand = entries
+        unexpectedCommand[0] = .init(operationID: first.operationID, tool: first.tool, command: "unexpected")
+
+        var wrongTool = entries
+        wrongTool[0] = .init(operationID: first.operationID, tool: "logic_midi", command: first.command)
+
+        var mismatch = entries
+        mismatch[0] = .init(operationID: second.operationID, tool: first.tool, command: first.command)
+        mismatch[1] = .init(operationID: first.operationID, tool: second.tool, command: second.command)
+
+        let cases: [([OperationRegistry.ValidationEntry], String)] = [
+            (duplicateID, "duplicate operation IDs:"),
+            (duplicateCommand, "duplicate commands:"),
+            (Array(entries.dropLast()), "entry count:"),
+            (Array(entries.dropLast()), "missing operation IDs:"),
+            (Array(entries.dropLast()), "missing commands:"),
+            (unexpectedID, "unexpected operation IDs:"),
+            (unexpectedCommand, "unexpected commands:"),
+            (wrongTool, "incorrect tools:"),
+            (mismatch, "ID/command mismatches:"),
+        ]
+        for (malformed, message) in cases {
+            #expect(OperationRegistry.validationErrors(for: malformed).contains { $0.contains(message) })
+        }
+    }
+
+    @Test("all transport metadata matches current runtime truth")
+    func metadata() throws {
+        #expect(Set(Self.commands.map(\.1)) == Set(OperationRegistry.specs.map(\.command)))
+
+        for (id, command) in Self.commands {
+            let spec = try #require(OperationRegistry.spec(tool: ToolID.logicTransport.rawValue, command: command))
+            #expect(spec.id == id)
+            #expect(spec.tool == .logicTransport)
+            #expect(spec.command == command)
+            #expect(spec.mutability == Mutability.`mutating`)
+            #expect(spec.confirmation == .none)
+            #expect(spec.target == .none)
+            #expect(spec.verification == (Self.readbackCommands.contains(command) ? .readbackRequired : .none))
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == .short)
+            #expect(spec.availability == (command == "set_cycle_range" ? .unsupported : .defaultInstall))
+            #expect(spec.capability.rawValue == id.rawValue)
+        }
+
+        #expect(OperationRegistry.spec(tool: "logic_transport", command: "set_tempo")?.verification == VerificationPolicy.none)
+        let cycleRange = try #require(OperationRegistry.spec(tool: "logic_transport", command: "set_cycle_range"))
+        #expect(cycleRange.verification == .none)
+        #expect(cycleRange.availability == .unsupported)
+    }
+
+    @Test("derived mutating commands equal the unchanged legacy transport set")
+    func mutatingParity() {
+        #expect(OperationRegistry.mutatingCommands == LogicProServer.mutatingCommandsByTool["logic_transport"])
+    }
+
+    @Test("registry deadlines are short and match legacy with the flag unset")
+    func deadlineParity() {
+        withRegistryFlag(nil) {
+            #expect(FeatureFlags.adr003OperationRegistry == false)
+            for spec in OperationRegistry.specs {
+                #expect(spec.deadline.seconds == 25)
+                #expect(OperationRegistry.deadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
+                #expect(LogicProServer.commandDeadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
+            }
+        }
+    }
+
+    @Test("flag off uses legacy mutability and deadlines")
+    func flagOff() {
+        withRegistryFlag(nil) {
+            #expect(FeatureFlags.adr003OperationRegistry == false)
+            for (_, command) in Self.commands {
+                #expect(LogicProServer.mutatingCommandsByTool["logic_transport"]?.contains(command) == true)
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_transport", command: command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_transport", command: command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_transport", command: "unknown"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_transport", command: "unknown") == 25)
+        }
+    }
+
+    @Test("flag on derives known transport decisions and preserves legacy fallbacks")
+    func flagOn() {
+        withRegistryFlag("1") {
+            #expect(FeatureFlags.adr003OperationRegistry)
+            for spec in OperationRegistry.specs {
+                #expect(LogicProServer.isMutatingCommand(tool: spec.tool.rawValue, command: spec.command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
+            }
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: "import_file") == 300)
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_transport", command: "bounce"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_transport", command: "bounce") == 300)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the ADR-003 (Public Operation Contract Registry, #286) pilot from the ADR-001~018 Implementation Work Guide (#308): a typed `OperationSpec`/`OperationRegistry` covering `logic_transport`'s 13 commands — the smallest vertical, per the ADR's own recommendation.

- `OperationRegistry.swift` — `OperationID`, `OperationSpec` (mutability/confirmation/target/verification/retry/deadline/availability/capability), and a static table for all 13 `logic_transport` commands, matching current runtime truth exactly (including `set_cycle_range`'s known `unsupported` status per #105 — not silently defaulted).
- `LogicProServer.swift` — `isMutatingCommand`/`commandDeadlineSeconds` gain a flag-gated registry-derived branch, scoped to `logic_transport` only. The legacy `mutatingCommandsByTool`/deadline maps are untouched (dual-source, not replaced).
- Behind `FeatureFlags.adr003OperationRegistry` (default off) — zero runtime behavior change with the flag off.

This is Release Train A continuing from #315 (Phase 0 governance). ADR-002 (#285) was attempted as a prior pilot but deferred — its planning/review loop over-engineered a minimal `tracks.rename` pilot into a full CAS registry across 4 sessions/~2.5hrs/~780K tokens without producing code; will be retried with a more constrained brief in a future session.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`, run outside the implementation sandbox to avoid a known environmental hang) — 2274/2274 passing (2267 baseline + 7 new)
- [x] New tests cover: registry completeness/validation, malformed-input rejection (duplicate/missing/unexpected IDs & commands, wrong tool, ID/command mismatch), flag-off regression parity, flag-on derivation parity, cross-tool isolation (`logic_midi` unaffected)
- [x] `git diff` scoped to exactly 3 files, existing `mutatingCommandsByTool`/deadline maps byte-identical