### PR TITLE
feat(adr-005): operation trace pilot — logic_transport write-boundary (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -159,6 +159,11 @@ struct SystemDispatcher {
         cache: StateCache,
         poller: StatePoller? = nil
     ) async -> CallTool.Result {
+        if FeatureFlags.adr005OperationTrace,
+           let traceResult = await handleTraceCommand(command: command, params: params) {
+            return traceResult
+        }
+
         switch command {
         case "health":
             let report = await router.healthReport()
@@ -269,10 +274,79 @@ struct SystemDispatcher {
             return toolTextResult(helpText)
 
         default:
-            return toolTextResult(
-                "Unknown system command: \(command). Available: health, permissions, refresh_cache, help",
-                isError: true
-            )
+            return unknownCommandResult(command)
+        }
+    }
+
+    private static func unknownCommandResult(_ command: String) -> CallTool.Result {
+        toolTextResult(
+            "Unknown system command: \(command). Available: health, permissions, refresh_cache, help",
+            isError: true
+        )
+    }
+
+    private static func handleTraceCommand(
+        command: String,
+        params: [String: Value]
+    ) async -> CallTool.Result? {
+        switch command {
+        case "list_recent_traces":
+            let limit: Int
+            if params["limit"] == nil {
+                limit = OperationTraceStore.defaultMaximumTraceCount
+            } else if let requested = intParamOrNil(params, "limit") {
+                limit = min(max(0, requested), OperationTraceStore.defaultMaximumTraceCount)
+            } else {
+                return toolInvalidParamsResult("list_recent_traces 'limit' must be an integer")
+            }
+            let traces = await OperationTraceStore.shared.recent(limit: limit)
+            let summaries: [[String: Any]] = traces.map { trace in
+                var summary: [String: Any] = [
+                    "trace_id": trace.traceID.rawValue,
+                    "operation_id": trace.operationID,
+                    "phase_count": trace.events.count,
+                ]
+                if let state = trace.events.reversed().compactMap({
+                    $0.attributes["readback_state"]
+                }).first {
+                    summary["readback_state"] = state
+                }
+                return summary
+            }
+            return toolTextResult(HonestContract.jsonString(["traces": summaries]))
+
+        case "get_trace":
+            guard let rawID = params["trace_id"]?.stringValue else {
+                return toolInvalidParamsResult("get_trace requires string 'trace_id'")
+            }
+            guard TraceID.isValid(rawID) else {
+                return toolInvalidParamsResult("get_trace 'trace_id' is malformed")
+            }
+            guard let trace = await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)) else {
+                return toolStateCResult(
+                    .elementNotFound,
+                    hint: "No operation trace exists for the requested trace_id"
+                )
+            }
+            let events: [[String: Any]] = trace.events.map { event in
+                [
+                    "phase": event.phase.rawValue,
+                    "timestamp": String(describing: event.timestamp),
+                    "attributes": event.attributes,
+                ]
+            }
+            return toolTextResult(HonestContract.jsonString([
+                "trace_id": trace.traceID.rawValue,
+                "operation_id": trace.operationID,
+                "events": events,
+            ]))
+
+        case "clear_traces":
+            await OperationTraceStore.shared.clear()
+            return toolTextResult(HonestContract.jsonString(["success": true]))
+
+        default:
+            return nil
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -16,30 +16,50 @@ struct TransportDispatcher {
         sleep: @escaping (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
         dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
+        let traceID = await startTraceIfEnabled(command: command)
         if let operation = modalGuardedTransportOperation(for: command), dialogPresent() {
-            return blockingLogicDialogResult(operation: operation)
+            return await finalizeTrace(
+                blockingLogicDialogResult(operation: operation),
+                traceID: traceID
+            )
         }
 
         switch command {
         case "play":
-            return await handleVerifiedTransportCommand(
+            let result = await handleVerifiedTransportCommand(
                 action: .play,
                 router: router,
-                sleep: sleep
+                sleep: sleep,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "stop":
-            return await verifiedStopResult(router: router, cache: cache, sleep: sleep)
+            let result = await verifiedStopResult(
+                router: router,
+                cache: cache,
+                sleep: sleep,
+                traceID: traceID
+            )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "record":
-            return await handleVerifiedTransportCommand(
+            let result = await handleVerifiedTransportCommand(
                 action: .record,
                 router: router,
-                sleep: sleep
+                sleep: sleep,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "pause":
-            return await verifiedPauseResult(router: router, cache: cache, sleep: sleep)
+            let result = await verifiedPauseResult(
+                router: router,
+                cache: cache,
+                sleep: sleep,
+                traceID: traceID
+            )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "rewind":
             let result = await router.route(operation: "transport.rewind")
@@ -196,6 +216,66 @@ struct TransportDispatcher {
         }
     }
 
+    private static func startTraceIfEnabled(command: String) async -> TraceID? {
+        guard FeatureFlags.adr005OperationTrace,
+              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
+            return nil
+        }
+        switch spec.id {
+        case .transportPlay, .transportStop, .transportRecord, .transportPause:
+            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
+            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+                "operation_id": spec.id.rawValue,
+                "command": command,
+            ])
+            return id
+        default:
+            return nil
+        }
+    }
+
+    private static func recordWriteBoundary(_ traceID: TraceID?) async {
+        guard let traceID else { return }
+        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
+    }
+
+    private static func finalizeTrace(
+        _ result: CallTool.Result,
+        traceID: TraceID?
+    ) async -> CallTool.Result {
+        guard let traceID else { return result }
+        guard case .text(let raw, _, _) = result.content.first else {
+            await OperationTraceStore.shared.record(
+                traceID,
+                phase: .verificationCompleted,
+                attributes: ["readback_state": result.isError == true ? "C" : "A"]
+            )
+            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+            await OperationTraceStore.shared.complete(traceID)
+            return result
+        }
+
+        let object = decodedJSONObject(raw)
+        var attributes = [
+            "readback_state": object?["state"] as? String
+                ?? (result.isError == true ? "C" : "A"),
+        ]
+        if let errorCode = object?["error"] as? String {
+            attributes["error_code"] = errorCode
+        }
+        await OperationTraceStore.shared.record(
+            traceID,
+            phase: .verificationCompleted,
+            attributes: attributes
+        )
+        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(traceID)
+
+        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
+        guard merged != raw else { return result }
+        return toolTextResult(merged, isError: result.isError == true)
+    }
+
     private static func modalGuardedTransportOperation(for command: String) -> String? {
         switch command {
         case "play": return "transport.play"
@@ -218,7 +298,8 @@ struct TransportDispatcher {
     private static func verifiedStopResult(
         router: ChannelRouter,
         cache: StateCache,
-        sleep: @escaping (UInt64) async -> Void
+        sleep: @escaping (UInt64) async -> Void,
+        traceID: TraceID?
     ) async -> CallTool.Result {
         if let beforeState = await readTransportState(router: router),
            beforeState.isPlaying == false,
@@ -240,6 +321,7 @@ struct TransportDispatcher {
             )))
         }
 
+        await recordWriteBoundary(traceID)
         let writeResult = await router.route(operation: "transport.stop")
         guard writeResult.isSuccess else {
             return toolTextResult(writeResult)
@@ -310,7 +392,8 @@ struct TransportDispatcher {
     private static func verifiedPauseResult(
         router: ChannelRouter,
         cache: StateCache,
-        sleep: @escaping (UInt64) async -> Void
+        sleep: @escaping (UInt64) async -> Void,
+        traceID: TraceID?
     ) async -> CallTool.Result {
         if let beforeState = await readTransportState(router: router),
            beforeState.isPlaying == false {
@@ -327,6 +410,7 @@ struct TransportDispatcher {
             )))
         }
 
+        await recordWriteBoundary(traceID)
         let writeResult = await router.route(operation: "transport.pause")
         let writePayload = jsonValue(from: writeResult.message)
 
@@ -577,7 +661,8 @@ struct TransportDispatcher {
     private static func handleVerifiedTransportCommand(
         action: VerifiedTransportAction,
         router: ChannelRouter,
-        sleep: @escaping (UInt64) async -> Void
+        sleep: @escaping (UInt64) async -> Void,
+        traceID: TraceID?
     ) async -> CallTool.Result {
         let beforeState = await readTransportState(router: router)
         if let beforeState, action.matches(beforeState) {
@@ -593,6 +678,7 @@ struct TransportDispatcher {
             )))
         }
 
+        await recordWriteBoundary(traceID)
         let writeResult = await router.route(operation: action.operation)
         let writePayload = jsonValue(from: writeResult.message)
         var attempts = 0

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+struct TraceID: RawRepresentable, Codable, Sendable, Hashable, CustomStringConvertible {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init() {
+        rawValue = "lpmcp_\(UUID().uuidString)"
+    }
+
+    var description: String { rawValue }
+
+    static func isValid(_ value: String) -> Bool {
+        value.hasPrefix("lpmcp_")
+            && UUID(uuidString: String(value.dropFirst("lpmcp_".count))) != nil
+    }
+}
+
+enum TracePhase: String, Codable, Sendable, CaseIterable {
+    case requestReceived = "request.received"
+    case inputValidated = "input.validated"
+    case targetResolved = "target.resolved"
+    case mutationGateWaitStarted = "mutation_gate.wait_started"
+    case mutationGateAcquired = "mutation_gate.acquired"
+    case routeEvaluated = "route.evaluated"
+    case channelStarted = "channel.started"
+    case writeBoundaryCrossed = "write_boundary.crossed"
+    case channelCompleted = "channel.completed"
+    case verificationPoll = "verification.poll"
+    case verificationCompleted = "verification.completed"
+    case compensationStarted = "compensation.started"
+    case resultEmitted = "result.emitted"
+}
+
+enum TracePrivacyClass: String, Codable, Sendable {
+    case publicDiagnostic
+    case hashed
+    case presenceOnly
+    case secret
+}
+
+struct TraceEvent: Sendable {
+    let phase: TracePhase
+    let timestamp: ContinuousClock.Instant
+    let attributes: [String: String]
+    let privacyClasses: [String: TracePrivacyClass]
+}
+
+struct OperationTrace: Sendable {
+    let traceID: TraceID
+    let operationID: String
+    let startedAt: ContinuousClock.Instant
+    var events: [TraceEvent]
+    var completedAt: ContinuousClock.Instant?
+}
+
+actor OperationTraceStore {
+    static let shared = OperationTraceStore()
+    static let defaultMaximumTraceCount = 128
+    static let defaultMaximumBytes = 8 * 1024 * 1024
+
+    let maximumTraceCount: Int
+    let maximumBytes: Int
+
+    private var traces: [TraceID: OperationTrace] = [:]
+    private var order: [TraceID] = []
+    private var byteCounts: [TraceID: Int] = [:]
+    private var totalBytes = 0
+
+    init(
+        maximumTraceCount: Int = OperationTraceStore.defaultMaximumTraceCount,
+        maximumBytes: Int = OperationTraceStore.defaultMaximumBytes
+    ) {
+        self.maximumTraceCount = max(0, maximumTraceCount)
+        self.maximumBytes = max(0, maximumBytes)
+    }
+
+    func start(operationID: String) -> TraceID {
+        let id = TraceID()
+        let trace = OperationTrace(
+            traceID: id,
+            operationID: operationID,
+            startedAt: .now,
+            events: [],
+            completedAt: nil
+        )
+        traces[id] = trace
+        order.append(id)
+        let byteCount = estimatedBytes(for: trace)
+        byteCounts[id] = byteCount
+        totalBytes += byteCount
+        evictIfNeeded()
+        if traces[id] == nil, byteCount > maximumBytes {
+            Log.warn("Operation trace rejected because it exceeds the byte budget", subsystem: .server)
+        }
+        return id
+    }
+
+    func record(
+        _ id: TraceID,
+        phase: TracePhase,
+        attributes: [String: String] = [:]
+    ) {
+        guard var trace = traces[id] else { return }
+        let filtered = Self.filteredAttributes(attributes)
+        trace.events.append(TraceEvent(
+            phase: phase,
+            timestamp: .now,
+            attributes: filtered.values,
+            privacyClasses: filtered.privacyClasses
+        ))
+        replace(trace)
+        evictIfNeeded()
+        if traces[id] == nil {
+            Log.warn("Operation trace evicted after exceeding the byte budget", subsystem: .server)
+        }
+    }
+
+    func complete(_ id: TraceID) {
+        guard var trace = traces[id] else { return }
+        trace.completedAt = .now
+        replace(trace)
+        evictIfNeeded()
+    }
+
+    func trace(_ id: TraceID) -> OperationTrace? {
+        traces[id]
+    }
+
+    func recent(limit: Int = OperationTraceStore.defaultMaximumTraceCount) -> [OperationTrace] {
+        let count = min(max(0, limit), maximumTraceCount)
+        return order.reversed().prefix(count).compactMap { traces[$0] }
+    }
+
+    func clear() {
+        traces.removeAll(keepingCapacity: true)
+        order.removeAll(keepingCapacity: true)
+        byteCounts.removeAll(keepingCapacity: true)
+        totalBytes = 0
+    }
+
+    private func replace(_ trace: OperationTrace) {
+        let id = trace.traceID
+        totalBytes -= byteCounts[id] ?? 0
+        traces[id] = trace
+        let byteCount = estimatedBytes(for: trace)
+        byteCounts[id] = byteCount
+        totalBytes += byteCount
+    }
+
+    private func evictIfNeeded() {
+        while order.count > maximumTraceCount || totalBytes > maximumBytes {
+            guard let oldest = order.first else { break }
+            order.removeFirst()
+            traces.removeValue(forKey: oldest)
+            totalBytes -= byteCounts.removeValue(forKey: oldest) ?? 0
+        }
+    }
+
+    private func estimatedBytes(for trace: OperationTrace) -> Int {
+        var count = trace.traceID.rawValue.utf8.count + trace.operationID.utf8.count + 64
+        for event in trace.events {
+            count += event.phase.rawValue.utf8.count + 96
+            for (key, value) in event.attributes {
+                count += key.utf8.count + value.utf8.count
+                count += event.privacyClasses[key]?.rawValue.utf8.count ?? 0
+            }
+        }
+        if trace.completedAt != nil { count += 16 }
+        return count
+    }
+
+    private static func filteredAttributes(
+        _ attributes: [String: String]
+    ) -> (values: [String: String], privacyClasses: [String: TracePrivacyClass]) {
+        let classes: [String: TracePrivacyClass] = [
+            "operation_id": .publicDiagnostic,
+            "command": .publicDiagnostic,
+            "target_ref": .publicDiagnostic,
+            "project_path_hash": .hashed,
+            "readback_state": .publicDiagnostic,
+            "error_code": .publicDiagnostic,
+        ]
+        var values: [String: String] = [:]
+        var privacyClasses: [String: TracePrivacyClass] = [:]
+        for (key, value) in attributes {
+            guard let privacyClass = classes[key] else { continue }
+            values[key] = value
+            privacyClasses[key] = privacyClass
+        }
+        return (values, privacyClasses)
+    }
+}

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -1,0 +1,318 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private let operationTraceFlagKey = "LOGIC_MCP_ADR005_OPERATION_TRACE"
+
+private func replaceOperationTraceFlag(with value: String?) -> String? {
+    let previous: String?
+    if let current = getenv(operationTraceFlagKey) {
+        previous = String(cString: current)
+    } else {
+        previous = nil
+    }
+    if let value {
+        setenv(operationTraceFlagKey, value, 1)
+    } else {
+        unsetenv(operationTraceFlagKey)
+    }
+    return previous
+}
+
+private actor OperationTraceTransportChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private var states: [String]
+    private(set) var executedOperations: [String] = []
+
+    init(states: [String]) {
+        self.states = states
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOperations.append(operation)
+        guard operation == "transport.get_state" else {
+            return .success("Mock: \(operation)")
+        }
+        guard !states.isEmpty else { return .error("state unavailable") }
+        return .success(states.count > 1 ? states.removeFirst() : states[0])
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace transport test")
+    }
+}
+
+@Suite(.serialized)
+struct OperationTraceTests {
+    @Test func OperationTraceTransportFlagOff() async {
+        let previous = replaceOperationTraceFlag(with: nil)
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+
+        let router = ChannelRouter()
+        await router.register(MockChannel(id: .accessibility))
+
+        let result = await TransportDispatcher.handle(
+            command: "play",
+            params: [:],
+            router: router,
+            cache: StateCache(),
+            sleep: { _ in }
+        )
+
+        let expected = #"{"operation":"transport.play","poll_attempts":12,"reason":"readback_unavailable","state":"B","success":true,"verified":false,"verify_source":"transport_state","write_attempted":true,"write_result":"Mock: transport.play"}"#
+        #expect(sharedToolText(result) == expected)
+        #expect(result.isError == true)
+        #expect(!expected.contains("trace_id"))
+    }
+
+    @Test func OperationTraceStoreFIFO() async {
+        let store = OperationTraceStore(maximumTraceCount: 128, maximumBytes: 8 * 1024 * 1024)
+        var ids: [TraceID] = []
+        for _ in 0..<129 {
+            let id = await store.start(operationID: OperationID.transportPlay.rawValue)
+            ids.append(id)
+            await store.complete(id)
+        }
+
+        let recent = await store.recent(limit: 200)
+        #expect(recent.count == 128)
+        #expect(recent.first?.traceID == ids.last)
+        #expect(recent.last?.traceID == ids[1])
+        #expect(await store.trace(ids[0]) == nil)
+        #expect(ids.allSatisfy {
+            $0.rawValue.hasPrefix("lpmcp_")
+                && UUID(uuidString: String($0.rawValue.dropFirst("lpmcp_".count))) != nil
+        })
+    }
+
+    @Test func OperationTraceStorePrivacy() async throws {
+        let store = OperationTraceStore(maximumTraceCount: 2, maximumBytes: 8 * 1024)
+        let id = await store.start(operationID: OperationID.transportPlay.rawValue)
+        await store.record(id, phase: .requestReceived, attributes: [
+            "operation_id": OperationID.transportPlay.rawValue,
+            "command": "play",
+            "target_ref": "opaque-sentinel",
+            "project_path_hash": "hash-sentinel",
+            "readback_state": "A",
+            "error_code": "none",
+            "unknown_key": "sentinel",
+            "project_path": "sentinel",
+            "prompt": "sentinel",
+            "token": "sentinel",
+            "environment": "sentinel",
+        ])
+
+        let trace = try #require(await store.trace(id))
+        let event = try #require(trace.events.first)
+        #expect(Set(event.attributes.keys) == [
+            "operation_id", "command", "target_ref", "project_path_hash",
+            "readback_state", "error_code",
+        ])
+        #expect(event.privacyClasses["project_path_hash"] == .hashed)
+        #expect(event.attributes["unknown_key"] == nil)
+        #expect(event.attributes["project_path"] == nil)
+        #expect(event.attributes["prompt"] == nil)
+        #expect(event.attributes["token"] == nil)
+        #expect(event.attributes["environment"] == nil)
+    }
+
+    @Test func OperationTraceStoreByteBudget() async {
+        let store = OperationTraceStore(maximumTraceCount: 128, maximumBytes: 512)
+        let first = await store.start(operationID: OperationID.transportPlay.rawValue)
+        await store.record(first, phase: .requestReceived, attributes: ["command": "play"])
+        await store.complete(first)
+
+        let oversized = await store.start(operationID: OperationID.transportRecord.rawValue)
+        await store.record(
+            oversized,
+            phase: .requestReceived,
+            attributes: ["command": String(repeating: "x", count: 1_024)]
+        )
+        await store.complete(oversized)
+
+        #expect(await store.recent(limit: 128).count <= 1)
+        #expect(await store.trace(oversized) == nil)
+    }
+
+    @Test func OperationTraceTransportEnabled() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTransportChannel(states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+        ])
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await TransportDispatcher.handle(
+            command: "play",
+            params: [:],
+            router: router,
+            cache: StateCache(),
+            sleep: { _ in }
+        )
+
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
+        #expect(result.isError == false)
+        #expect(trace.operationID == OperationID.transportPlay.rawValue)
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+        ])
+        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.completedAt != nil)
+        #expect(await channel.executedOperations == [
+            "transport.get_state", "transport.play", "transport.get_state",
+        ])
+    }
+
+    @Test func OperationTraceTransportNoWrite() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTransportChannel(states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+        ])
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await TransportDispatcher.handle(
+            command: "stop",
+            params: [:],
+            router: router,
+            cache: StateCache(),
+            sleep: { _ in }
+        )
+
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
+        #expect(!trace.events.map(\.phase).contains(.writeBoundaryCrossed))
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .verificationCompleted, .resultEmitted,
+        ])
+        #expect(trace.events[1].attributes["readback_state"] == "A")
+        #expect(await channel.executedOperations == ["transport.get_state"])
+    }
+
+    @Test func OperationTraceSystemLifecycle() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let id = await OperationTraceStore.shared.start(operationID: OperationID.transportPlay.rawValue)
+        await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+            "operation_id": OperationID.transportPlay.rawValue,
+            "command": "play",
+            "unknown_key": "sentinel",
+        ])
+        await OperationTraceStore.shared.record(id, phase: .verificationCompleted, attributes: [
+            "readback_state": "A",
+        ])
+        await OperationTraceStore.shared.record(id, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(id)
+
+        let router = ChannelRouter()
+        let cache = StateCache()
+        let listResult = await SystemDispatcher.handle(
+            command: "list_recent_traces",
+            params: ["limit": .int(999)],
+            router: router,
+            cache: cache
+        )
+        let list = try #require(sharedJSONObject(sharedToolText(listResult)))
+        let summaries = try #require(list["traces"] as? [[String: Any]])
+        #expect(summaries.count == 1)
+        #expect(summaries[0]["trace_id"] as? String == id.rawValue)
+        #expect(summaries[0]["operation_id"] as? String == OperationID.transportPlay.rawValue)
+        #expect(summaries[0]["phase_count"] as? Int == 3)
+        #expect(summaries[0]["readback_state"] as? String == "A")
+
+        let zeroResult = await SystemDispatcher.handle(
+            command: "list_recent_traces",
+            params: ["limit": .int(-4)],
+            router: router,
+            cache: cache
+        )
+        #expect((sharedJSONObject(sharedToolText(zeroResult))?["traces"] as? [Any])?.isEmpty == true)
+
+        let getResult = await SystemDispatcher.handle(
+            command: "get_trace",
+            params: ["trace_id": .string(id.rawValue)],
+            router: router,
+            cache: cache
+        )
+        let get = try #require(sharedJSONObject(sharedToolText(getResult)))
+        let events = try #require(get["events"] as? [[String: Any]])
+        #expect(events.map { $0["phase"] as? String } == [
+            "request.received", "verification.completed", "result.emitted",
+        ])
+        #expect(events.allSatisfy { $0["timestamp"] is String })
+        #expect((events[0]["attributes"] as? [String: String])?["unknown_key"] == nil)
+
+        let clearResult = await SystemDispatcher.handle(
+            command: "clear_traces",
+            params: [:],
+            router: router,
+            cache: cache
+        )
+        #expect(sharedJSONObject(sharedToolText(clearResult))?["success"] as? Bool == true)
+        #expect(await OperationTraceStore.shared.recent(limit: 128).isEmpty)
+    }
+
+    @Test func OperationTraceSystemErrors() async {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+        let router = ChannelRouter()
+        let cache = StateCache()
+
+        let missing = await SystemDispatcher.handle(
+            command: "get_trace", params: [:], router: router, cache: cache
+        )
+        let malformed = await SystemDispatcher.handle(
+            command: "get_trace",
+            params: ["trace_id": .string("not-a-trace-id")],
+            router: router,
+            cache: cache
+        )
+        let unknown = await SystemDispatcher.handle(
+            command: "get_trace",
+            params: ["trace_id": .string("lpmcp_00000000-0000-0000-0000-000000000000")],
+            router: router,
+            cache: cache
+        )
+
+        #expect(missing.isError == true)
+        #expect(sharedJSONObject(sharedToolText(missing))?["error"] as? String == "invalid_params")
+        #expect(malformed.isError == true)
+        #expect(sharedJSONObject(sharedToolText(malformed))?["error"] as? String == "invalid_params")
+        #expect(unknown.isError == true)
+        #expect(sharedJSONObject(sharedToolText(unknown))?["error"] as? String == "element_not_found")
+    }
+
+    @Test func OperationTraceSystemFlagOff() async {
+        let previous = replaceOperationTraceFlag(with: nil)
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        let router = ChannelRouter()
+        let cache = StateCache()
+
+        for command in ["list_recent_traces", "get_trace", "clear_traces"] {
+            let result = await SystemDispatcher.handle(
+                command: command, params: [:], router: router, cache: cache
+            )
+            #expect(result.isError == true)
+            #expect(
+                sharedToolText(result)
+                    == "Unknown system command: \(command). Available: health, permissions, refresh_cache, help"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the ADR-005 (Operation Trace and Privacy-safe Support Bundle, #288) pilot from the ADR-001~018 Implementation Work Guide (#308) — trace ID + event-phase model, piloted on `logic_transport`'s verified handlers.

- `OperationTrace.swift` — `TraceID`, `TracePhase` (13 phases per the ADR spec), `OperationTraceStore` actor with a bounded ring buffer (128 traces / 8 MiB default, FIFO eviction on either limit) and a strict privacy allowlist (only `operation_id`/`command`/`target_ref`/`project_path_hash`/`readback_state`/`error_code` pass through — everything else, including raw paths/prompts/tokens/env values, is silently dropped).
- `TransportDispatcher.swift` — write-boundary (`write_boundary.crossed`) and lifecycle phase instrumentation, scoped to the 4 commands with real readback verification (`play`/`stop`/`record`/`pause`) — the other 9 transport commands are honest fire-and-forget with no verification to trace. `trace_id` is merged additively into the existing State A/B/C envelope via `HonestContract.addExtras` (no new encoding path).
- `SystemDispatcher.swift` — 3 new `logic_system` commands: `list_recent_traces`, `get_trace`, `clear_traces`. (`export_support_bundle` is out of scope for this pilot.)
- Behind `FeatureFlags.adr005OperationTrace` (default off) — zero runtime behavior change, zero `trace_id` in any response, with the flag off.

Continues Release Train A from #315 (Phase 0 governance) and #316 (ADR-003 pilot, merged). ADR-002 (#285) was attempted as a prior pilot but deferred — see the completion report on #308 for details.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`, run outside the implementation sandbox) — 2283/2283 passing (2274 baseline + 9 new)
- [x] New tests cover: flag-off regression (exact response-string pin, no `trace_id`), bounded FIFO eviction, byte-budget eviction, privacy allowlist rejection of unknown/sensitive keys, full flag-on trace lifecycle for both write and no-write paths, `logic_system` trace command lifecycle + error handling, flag-off for `logic_system` trace commands
- [x] No live Logic Pro/AX/AppleScript/CGEvent interaction anywhere in new tests (mock channel only)