### PR TITLE
feat(adr-002): stable target reference pilot — tracks.rename retry (#285)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -46,7 +46,8 @@ struct PluginsDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        targetRegistry: TargetRegistry? = nil
     ) async -> CallTool.Result {
         switch command {
         case "get_inventory":
@@ -69,8 +70,14 @@ struct PluginsDispatcher {
 
         case "insert_verified":
             return await runVerified(operation: "plugin.insert_verified") {
-                await routedTextResult(router, operation: "plugin.insert_verified",
-                                       params: insertVerifiedParams(params))
+                let result = await router.route(
+                    operation: "plugin.insert_verified",
+                    params: insertVerifiedParams(params)
+                )
+                if FeatureFlags.adr002TargetRef, channelResultIsVerified(result) {
+                    await targetRegistry?.bumpTopologyGeneration()
+                }
+                return toolTextResult(result)
             }
 
         default:

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -20,6 +20,7 @@ struct ProjectDispatcher {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
+        targetRegistry: TargetRegistry? = nil,
         // Single source of truth — use ProcessUtils.isLogicProRunning everywhere
         // (NSRunningApplication-based with multi-fallback). Removed prior OR with
         // PermissionChecker.checkAutomationState() == .granted because permission
@@ -172,7 +173,7 @@ struct ProjectDispatcher {
             // the data was current. clearProjectState() is idempotent and
             // mutation-free on actor state — safe to call on every success
             // even if the poller would have caught up eventually.
-            await invalidateOnSuccess(result, cache: cache)
+            await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
             return toolTextResult(result)
 
         case "open":
@@ -207,7 +208,7 @@ struct ProjectDispatcher {
                 params: ["path": path]
             )
             // v3.1.2 (P0-3) — same cache stale-after-lifecycle bug as `new`.
-            await invalidateOnSuccess(result, cache: cache)
+            await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
             return toolTextResult(result)
 
         case "save":
@@ -284,7 +285,7 @@ struct ProjectDispatcher {
             // v3.1.2 (P0-3) — closing the project leaves the cache stuffed
             // with the just-closed tracks/regions/markers. Clear so resource
             // reads honestly reflect "no project" until the next open.
-            await invalidateOnSuccess(result, cache: cache)
+            await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
             return toolTextResult(result)
 
         case "bounce":
@@ -778,9 +779,16 @@ struct ProjectDispatcher {
     /// transition (`new` / `open` / `close`). Defensive: only fires when the
     /// underlying channel reports success, so a failed AppleScript leaves
     /// the cache untouched (preserves whatever truth the poller had).
-    private static func invalidateOnSuccess(_ result: ChannelResult, cache: StateCache) async {
+    private static func invalidateOnSuccess(
+        _ result: ChannelResult,
+        cache: StateCache,
+        targetRegistry: TargetRegistry?
+    ) async {
         guard result.isSuccess else { return }
         await cache.clearProjectState()
+        if FeatureFlags.adr002TargetRef {
+            await targetRegistry?.bumpProjectEpoch()
+        }
     }
 
     private static func refreshRegionCache(from result: ChannelResult, cache: StateCache) async {

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -6,7 +6,7 @@ struct TrackDispatcher {
 
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename/mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, when LOGIC_MCP_ADR002_TARGET_REF=1, { name: String, target_ref: String, index?: Int }; when the flag is off target_ref is ignored and index remains required; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -20,6 +20,7 @@ struct TrackDispatcher {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
+        targetRegistry: TargetRegistry? = nil,
         dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
         if let operation = modalGuardedTrackOperation(for: command), dialogPresent() {
@@ -78,6 +79,9 @@ struct TrackDispatcher {
             if result.isSuccess, !channelSuccessIsVerified(result) {
                 return toolTextResult(result.message, isError: true)
             }
+            if FeatureFlags.adr002TargetRef, result.isSuccess {
+                await targetRegistry?.bumpTopologyGeneration()
+            }
             return toolTextResult(result)
 
         case "delete":
@@ -116,6 +120,9 @@ struct TrackDispatcher {
                 )
             }
             let result = await router.route(operation: "track.delete")
+            if FeatureFlags.adr002TargetRef, result.isSuccess {
+                await targetRegistry?.bumpTopologyGeneration()
+            }
             return toolTextResult(result)
 
         case "duplicate":
@@ -153,14 +160,53 @@ struct TrackDispatcher {
                 )
             }
             let result = await router.route(operation: "track.duplicate")
+            if FeatureFlags.adr002TargetRef, result.isSuccess {
+                await targetRegistry?.bumpTopologyGeneration()
+            }
             return toolTextResult(result)
 
         case "rename":
-            guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-                return toolInvalidParamsResult(
-                    "rename requires explicit 'index' (Int ≥ 0)",
-                    extras: ["operation": "track.rename"]
-                )
+            let index: Int
+            let resolvedReference: TargetReference?
+            if FeatureFlags.adr002TargetRef, params["target_ref"] != nil {
+                let rawReference = params["target_ref"]?.stringValue?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let rawReference,
+                      !rawReference.isEmpty,
+                      let targetRegistry,
+                      let binding = await targetRegistry.resolve(TargetReference(rawValue: rawReference)),
+                      binding.kind == .track
+                else {
+                    return staleTargetReferenceResult(rawReference)
+                }
+
+                if params["index"] != nil || params["track"] != nil {
+                    guard let requestedIndex = intParamOrNil(params, "index", "track"),
+                          requestedIndex >= 0,
+                          requestedIndex == binding.descriptor.trackIndex
+                    else {
+                        return staleTargetReferenceResult(rawReference)
+                    }
+                }
+
+                let tracks = await cache.getTracks()
+                guard let track = tracks.first(where: { $0.id == binding.descriptor.trackIndex }),
+                      TargetDescriptor(trackIndex: track.id, trackName: track.name).fingerprint
+                        == binding.observedFingerprint
+                else {
+                    return staleTargetReferenceResult(rawReference)
+                }
+                index = binding.descriptor.trackIndex
+                resolvedReference = binding.reference
+            } else {
+                guard let requestedIndex = intParamOrNil(params, "index", "track"), requestedIndex >= 0 else {
+                    return toolInvalidParamsResult(
+                        "rename requires explicit 'index' (Int ≥ 0)",
+                        extras: ["operation": "track.rename"]
+                    )
+                }
+                index = requestedIndex
+                resolvedReference = nil
             }
             let name = stringParam(params, "name")
             guard !name.isEmpty else {
@@ -192,6 +238,16 @@ struct TrackDispatcher {
                verified == false {
                 return toolTextResult(result.message, isError: true)
             }
+            if let resolvedReference {
+                if var payload = decodedJSONObject(result.message) {
+                    payload["track_ref"] = resolvedReference.rawValue
+                    return toolTextResult(HonestContract.jsonString(payload))
+                }
+                return toolTextResult(HonestContract.encodeStateA(extras: [
+                    "operation": "track.rename",
+                    "track_ref": resolvedReference.rawValue,
+                ]))
+            }
             return toolTextResult(result)
 
         case "mute":
@@ -204,7 +260,11 @@ struct TrackDispatcher {
             return await handleToggle(command: "arm", operation: "track.set_arm", params: params, router: router)
 
         case "record_sequence":
-            return await handleRecordSequenceSMF(params: params, router: router, cache: cache)
+            let result = await handleRecordSequenceSMF(params: params, router: router, cache: cache)
+            if FeatureFlags.adr002TargetRef, result.isError != true {
+                await targetRegistry?.bumpTopologyGeneration()
+            }
+            return result
 
         case "arm_only":
             guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
@@ -484,6 +544,17 @@ struct TrackDispatcher {
             return toolTextResult(result.message, isError: true)
         }
         return toolTextResult(result)
+    }
+
+    private static func staleTargetReferenceResult(_ rawReference: String?) -> CallTool.Result {
+        toolStateCResult(
+            .staleTargetReference,
+            hint: "target_ref is stale or does not identify the requested current track",
+            extras: [
+                "operation": "track.rename",
+                "target_ref": rawReference ?? "",
+            ]
+        )
     }
 
     private static func modalGuardedTrackOperation(for command: String) -> String? {

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -131,6 +131,7 @@ extension ResourceHandlers {
     static func readTracks(
         cache: StateCache,
         uri: String,
+        targetRegistry: TargetRegistry? = nil,
         fileReader: LogicProjectFileReader.Runtime
     ) async throws -> ReadResource.Result {
         var liveTracks = await cache.getTracks()
@@ -168,7 +169,25 @@ extension ResourceHandlers {
             }
         }
 
-        let body = encodeJSON(tracksOut)
+        let body: String
+        if FeatureFlags.adr002TargetRef, let targetRegistry {
+            var payload: [[String: Any]] = []
+            payload.reserveCapacity(tracksOut.count)
+            for track in tracksOut {
+                let descriptor = TargetDescriptor(trackIndex: track.id, trackName: track.name)
+                let reference = await targetRegistry.bind(
+                    kind: .track,
+                    descriptor: descriptor,
+                    fingerprint: descriptor.fingerprint
+                )
+                var object = jsonObject(track) as? [String: Any] ?? [:]
+                object["track_ref"] = reference.rawValue
+                payload.append(object)
+            }
+            body = encodeJSONObject(payload)
+        } else {
+            body = encodeJSON(tracksOut)
+        }
         let json = wrapWithCacheEnvelope(
             bodyJSON: body,
             fetchedAt: cacheFetchedAt,

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -20,6 +20,7 @@ extension ResourceHandlers {
         uri: String,
         cache: StateCache,
         router: ChannelRouter,
+        targetRegistry: TargetRegistry? = nil,
         fileReader: LogicProjectFileReader.Runtime = .production
     ) async throws -> ReadResource.Result {
         // Health must be side-effect free so the resource stays aligned with the tool contract.
@@ -83,7 +84,12 @@ extension ResourceHandlers {
             return try await readTransportState(cache: cache, router: router, uri: uri)
 
         case "logic://tracks":
-            return try await readTracks(cache: cache, uri: uri, fileReader: fileReader)
+            return try await readTracks(
+                cache: cache,
+                uri: uri,
+                targetRegistry: targetRegistry,
+                fileReader: fileReader
+            )
 
         case "logic://mixer":
             return try await readMixer(cache: cache, uri: uri)

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -233,6 +233,7 @@ actor LogicProServer {
     private let server: Server
     private let router: ChannelRouter
     private let cache: StateCache
+    private let targetRegistry: TargetRegistry
     private let poller: StatePoller
     private let resourceSubscriptions: ResourceSubscriptionRegistry
     private let resourceNotifier: ResourceUpdateNotifier
@@ -270,6 +271,7 @@ actor LogicProServer {
         )
         let router = ChannelRouter()
         let cache = StateCache()
+        let targetRegistry = TargetRegistry()
         let resourceSubscriptions = ResourceSubscriptionRegistry()
         let resourceNotifier = ResourceUpdateNotifier(registry: resourceSubscriptions)
 
@@ -277,6 +279,7 @@ actor LogicProServer {
         self.server = server
         self.router = router
         self.cache = cache
+        self.targetRegistry = targetRegistry
         self.resourceSubscriptions = resourceSubscriptions
         self.resourceNotifier = resourceNotifier
         self.portManager = MIDIPortManager()
@@ -325,7 +328,15 @@ actor LogicProServer {
                 await resourceNotifier.publishChangedResources(
                     cacheKeys: cacheKeys,
                     cache: cache,
-                    router: router
+                    router: router,
+                    readResource: { uri, cache, router in
+                        try await ResourceHandlers.read(
+                            uri: uri,
+                            cache: cache,
+                            router: router,
+                            targetRegistry: targetRegistry
+                        )
+                    }
                 ) { uri in
                     try await server.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
                 }
@@ -355,6 +366,7 @@ actor LogicProServer {
         let cache = self.cache
         let poller = self.poller
         let mutationGate = self.mutationGate
+        let targetRegistry = self.targetRegistry
 
         return LogicProServerHandlers(
             listTools: { _ in
@@ -393,6 +405,7 @@ actor LogicProServer {
                             params: cmdParams,
                             router: router,
                             cache: cache,
+                            targetRegistry: targetRegistry,
                             dialogPresent: dialogPresent
                         )
                     case "logic_mixer":
@@ -409,6 +422,7 @@ actor LogicProServer {
                             params: cmdParams,
                             router: router,
                             cache: cache,
+                            targetRegistry: targetRegistry,
                             dialogPresent: dialogPresent
                         )
                     case "logic_audio":
@@ -416,7 +430,13 @@ actor LogicProServer {
                     case "logic_system":
                         return await SystemDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, poller: poller)
                     case "logic_plugins":
-                        return await PluginsDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await PluginsDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            targetRegistry: targetRegistry
+                        )
                     default:
                         return toolTextResult("Unknown tool: \(name)", isError: true)
                     }
@@ -440,7 +460,12 @@ actor LogicProServer {
                 // session must return a typed operation_timeout body, never leave
                 // the client with no JSON-RPC response.
                 try await Self.runResourceReadWithDeadline(uri: params.uri) {
-                    try await ResourceHandlers.read(uri: params.uri, cache: cache, router: router)
+                    try await ResourceHandlers.read(
+                        uri: params.uri,
+                        cache: cache,
+                        router: router,
+                        targetRegistry: targetRegistry
+                    )
                 }
             },
             listResourceTemplates: { _ in
@@ -973,10 +998,19 @@ actor LogicProServer {
     }
 
     func publishResourceChangesForTesting(_ cacheKeys: [ResourceCacheKey]) async {
+        let targetRegistry = self.targetRegistry
         await resourceNotifier.publishChangedResources(
             cacheKeys: cacheKeys,
             cache: cache,
-            router: router
+            router: router,
+            readResource: { uri, cache, router in
+                try await ResourceHandlers.read(
+                    uri: uri,
+                    cache: cache,
+                    router: router,
+                    targetRegistry: targetRegistry
+                )
+            }
         ) { uri in
             try await server.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
         }

--- a/Sources/LogicProMCP/State/TargetReference.swift
+++ b/Sources/LogicProMCP/State/TargetReference.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+struct TargetReference: Codable, Hashable, Sendable {
+    let rawValue: String
+}
+
+enum TargetKind: String, Codable, Sendable {
+    case project
+    case track
+    case mixerStrip
+    case pluginInsert
+
+    fileprivate var referencePrefix: String {
+        switch self {
+        case .project: "prj"
+        case .track: "trk"
+        case .mixerStrip: "mix"
+        case .pluginInsert: "ins"
+        }
+    }
+}
+
+struct TargetDescriptor: Hashable, Sendable {
+    let trackIndex: Int
+    let trackName: String
+
+    var fingerprint: String {
+        "\(trackIndex):\(trackName.utf8.count):\(trackName)"
+    }
+}
+
+struct TargetBinding: Sendable {
+    let reference: TargetReference
+    let kind: TargetKind
+    let serverSessionID: UUID
+    let projectEpoch: UInt64
+    let topologyGeneration: UInt64
+    let descriptor: TargetDescriptor
+    let observedFingerprint: String
+    let createdAt: ContinuousClock.Instant
+}
+
+actor TargetRegistry {
+    private let serverSessionID: UUID
+    private var projectEpoch: UInt64 = 0
+    private var topologyGeneration: UInt64 = 0
+    private var bindings: [TargetReference: TargetBinding] = [:]
+
+    init(serverSessionID: UUID = UUID()) {
+        self.serverSessionID = serverSessionID
+    }
+
+    var currentProjectEpoch: UInt64 { projectEpoch }
+    var currentTopologyGeneration: UInt64 { topologyGeneration }
+
+    func bind(
+        kind: TargetKind,
+        descriptor: TargetDescriptor,
+        fingerprint: String
+    ) -> TargetReference {
+        if let binding = bindings.values.first(where: {
+            $0.kind == kind
+                && $0.serverSessionID == serverSessionID
+                && $0.projectEpoch == projectEpoch
+                && $0.topologyGeneration == topologyGeneration
+                && $0.descriptor == descriptor
+                && $0.observedFingerprint == fingerprint
+        }) {
+            return binding.reference
+        }
+
+        let reference = TargetReference(
+            rawValue: "\(kind.referencePrefix)_\(UUID().uuidString)"
+        )
+        bindings[reference] = TargetBinding(
+            reference: reference,
+            kind: kind,
+            serverSessionID: serverSessionID,
+            projectEpoch: projectEpoch,
+            topologyGeneration: topologyGeneration,
+            descriptor: descriptor,
+            observedFingerprint: fingerprint,
+            createdAt: ContinuousClock().now
+        )
+        return reference
+    }
+
+    func resolve(_ reference: TargetReference) -> TargetBinding? {
+        guard hasValidFormat(reference),
+              let binding = bindings[reference],
+              reference.rawValue.hasPrefix("\(binding.kind.referencePrefix)_"),
+              binding.serverSessionID == serverSessionID,
+              binding.projectEpoch == projectEpoch,
+              binding.topologyGeneration == topologyGeneration
+        else {
+            return nil
+        }
+        return binding
+    }
+
+    func bumpProjectEpoch() {
+        projectEpoch += 1
+        bindings.removeAll(keepingCapacity: true)
+    }
+
+    func bumpTopologyGeneration() {
+        topologyGeneration += 1
+        bindings.removeAll(keepingCapacity: true)
+    }
+
+    private func hasValidFormat(_ reference: TargetReference) -> Bool {
+        guard let separator = reference.rawValue.firstIndex(of: "_") else { return false }
+        let uuidString = String(reference.rawValue[reference.rawValue.index(after: separator)...])
+        guard uuidString.count == 36, let uuid = UUID(uuidString: uuidString) else {
+            return false
+        }
+        return uuid.uuidString.caseInsensitiveCompare(uuidString) == .orderedSame
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -1,9 +1,25 @@
 import Foundation
 
 enum FeatureFlags: Sendable {
+    #if DEBUG
+    @TaskLocal static var adr002TargetRefOverride: Bool?
+    #endif
+
     static var adr002TargetRef: Bool {
-        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR002_TARGET_REF"] == "1"
+        #if DEBUG
+        if let adr002TargetRefOverride { return adr002TargetRefOverride }
+        #endif
+        return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR002_TARGET_REF"] == "1"
     }
+
+    #if DEBUG
+    static func withAdr002TargetRefForTests<Result>(
+        _ value: Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $adr002TargetRefOverride.withValue(value, operation: operation)
+    }
+    #endif
 
     static var adr003OperationRegistry: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR003_OPERATION_REGISTRY"] == "1"

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -95,6 +95,7 @@ enum HonestContract {
         case slotOccupied = "slot_occupied"
         case trackSelectionFailed = "track_selection_failed"
         case staleSnapshot = "stale_snapshot"
+        case staleTargetReference = "stale_target_reference"
         case windowOpenFailed = "window_open_failed"
         case windowIdentityUnresolved = "window_identity_unresolved"
         case paramControlNotFound = "param_control_not_found"
@@ -319,6 +320,7 @@ enum HonestContract {
         FailureError.slotOccupied.rawValue,
         FailureError.trackSelectionFailed.rawValue,
         FailureError.staleSnapshot.rawValue,
+        FailureError.staleTargetReference.rawValue,
         FailureError.windowOpenFailed.rawValue,
         FailureError.windowIdentityUnresolved.rawValue,
         FailureError.paramControlNotFound.rawValue,

--- a/Tests/LogicProMCPTests/TargetRegistryTests.swift
+++ b/Tests/LogicProMCPTests/TargetRegistryTests.swift
@@ -1,0 +1,408 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private actor TargetReferenceChannel: Channel {
+    nonisolated let id: ChannelID
+    private let succeeds: Bool
+    private(set) var executedOps: [(String, [String: String])] = []
+
+    init(id: ChannelID, succeeds: Bool = true) {
+        self.id = id
+        self.succeeds = succeeds
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        guard succeeds else { return .error("synthetic failure") }
+        return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "target-reference synthetic channel")
+    }
+}
+
+@Suite(.serialized)
+struct TargetRegistryTests {
+    private func descriptor(index: Int = 0, name: String = "Kick") -> TargetDescriptor {
+        TargetDescriptor(trackIndex: index, trackName: name)
+    }
+
+    @Test
+    func testBindingIsStableAndOpaque() async throws {
+        let registry = TargetRegistry(serverSessionID: UUID())
+        let descriptor = descriptor()
+
+        let first = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        let second = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+
+        #expect(first == second)
+        #expect(first.rawValue.hasPrefix("trk_"))
+        #expect(UUID(uuidString: String(first.rawValue.dropFirst("trk_".count))) != nil)
+        #expect(!first.rawValue.contains(descriptor.trackName))
+        #expect(await registry.resolve(first) != nil)
+    }
+
+    @Test
+    func testTopologyGenerationInvalidatesBinding() async {
+        let registry = TargetRegistry(serverSessionID: UUID())
+        let descriptor = descriptor()
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+
+        await registry.bumpTopologyGeneration()
+
+        #expect(await registry.resolve(reference) == nil)
+        #expect(await registry.currentTopologyGeneration == 1)
+    }
+
+    @Test
+    func testProjectEpochInvalidatesBinding() async {
+        let registry = TargetRegistry(serverSessionID: UUID())
+        let descriptor = descriptor()
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+
+        await registry.bumpProjectEpoch()
+
+        #expect(await registry.resolve(reference) == nil)
+        #expect(await registry.currentProjectEpoch == 1)
+    }
+
+    @Test
+    func testDifferentServerSessionCannotResolveBinding() async {
+        let firstRegistry = TargetRegistry(serverSessionID: UUID())
+        let secondRegistry = TargetRegistry(serverSessionID: UUID())
+        let descriptor = descriptor()
+        let reference = await firstRegistry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+
+        #expect(await firstRegistry.resolve(reference) != nil)
+        #expect(await secondRegistry.resolve(reference) == nil)
+    }
+
+    @Test
+    func testRenameRejectsStaleReferenceAfterTopologyGenerationBump() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = descriptor()
+            let reference = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+            await registry.bumpTopologyGeneration()
+
+            let router = ChannelRouter()
+            let channel = TargetReferenceChannel(id: .accessibility)
+            await router.register(channel)
+            let cache = StateCache()
+            await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: [
+                    "name": .string("New Kick"),
+                    "target_ref": .string(reference.rawValue),
+                ],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+
+            #expect(result.isError == true)
+            #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
+            #expect(await channel.executedOps.isEmpty)
+        }
+    }
+
+    @Test
+    func testRenameRejectsStaleReferenceAfterProjectEpochBump() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = descriptor()
+            let reference = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+            await registry.bumpProjectEpoch()
+
+            let router = ChannelRouter()
+            let channel = TargetReferenceChannel(id: .accessibility)
+            await router.register(channel)
+            let cache = StateCache()
+            await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: [
+                    "name": .string("New Kick"),
+                    "target_ref": .string(reference.rawValue),
+                ],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+
+            #expect(result.isError == true)
+            #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
+            #expect(await channel.executedOps.isEmpty)
+        }
+    }
+
+    @Test
+    func testRenameRejectsMismatchedTargetReferenceWithoutWrite() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = descriptor(index: 0, name: "Kick")
+            let reference = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+
+            let router = ChannelRouter()
+            let channel = TargetReferenceChannel(id: .accessibility)
+            await router.register(channel)
+            let cache = StateCache()
+            await cache.updateTracks([
+                TrackState(id: 0, name: "Kick", type: .audio),
+                TrackState(id: 1, name: "Bass", type: .audio),
+            ])
+
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: [
+                    "index": .int(1),
+                    "name": .string("Wrong Target"),
+                    "target_ref": .string(reference.rawValue),
+                ],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+
+            #expect(result.isError == true)
+            #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
+            #expect(await channel.executedOps.isEmpty)
+        }
+    }
+
+    @Test
+    func testRenameAcceptsResolvedTargetReference() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = descriptor(index: 0, name: "Kick")
+            let reference = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+
+            let router = ChannelRouter()
+            let channel = TargetReferenceChannel(id: .accessibility)
+            await router.register(channel)
+            let cache = StateCache()
+            await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: [
+                    "name": .string("New Kick"),
+                    "target_ref": .string(reference.rawValue),
+                ],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+
+            #expect(result.isError == false)
+            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] as? String == reference.rawValue)
+            let operations = await channel.executedOps
+            #expect(operations.count == 1)
+            #expect(operations.first?.0 == "track.rename")
+            #expect(operations.first?.1 == ["index": "0", "name": "New Kick"])
+        }
+    }
+
+    @Test
+    func testTrackResourceEmitsOpaqueReferenceOnlyWhenEnabled() async throws {
+        let registry = TargetRegistry()
+        let cache = StateCache()
+        await cache.updateTracks([TrackState(id: 0, name: "Kick", type: .audio)])
+
+        let enabledReference = try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let first = try await ResourceHandlers.read(
+                uri: "logic://tracks",
+                cache: cache,
+                router: ChannelRouter(),
+                targetRegistry: registry
+            )
+            let second = try await ResourceHandlers.read(
+                uri: "logic://tracks",
+                cache: cache,
+                router: ChannelRouter(),
+                targetRegistry: registry
+            )
+            let firstData = try #require(sharedJSONObject(sharedResourceText(first))?["data"] as? [[String: Any]])
+            let secondData = try #require(sharedJSONObject(sharedResourceText(second))?["data"] as? [[String: Any]])
+            let firstReference = try #require(firstData.first?["track_ref"] as? String)
+            #expect(firstReference == secondData.first?["track_ref"] as? String)
+            #expect(firstReference.hasPrefix("trk_"))
+            #expect(!firstReference.contains("Kick"))
+            return firstReference
+        }
+
+        let disabled = try await FeatureFlags.withAdr002TargetRefForTests(false) {
+            try await ResourceHandlers.read(
+                uri: "logic://tracks",
+                cache: cache,
+                router: ChannelRouter(),
+                targetRegistry: registry
+            )
+        }
+        let disabledData = try #require(sharedJSONObject(sharedResourceText(disabled))?["data"] as? [[String: Any]])
+        #expect(disabledData.first?["track_ref"] == nil)
+        #expect(enabledReference.hasPrefix("trk_"))
+    }
+
+    @Test
+    func testSuccessfulMutationsBumpRegistryGenerations() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let trackRegistry = TargetRegistry()
+            let trackRouter = ChannelRouter()
+            let accessibility = TargetReferenceChannel(id: .accessibility)
+            let mcu = TargetReferenceChannel(id: .mcu)
+            let keyCommands = TargetReferenceChannel(id: .midiKeyCommands)
+            await trackRouter.register(accessibility)
+            await trackRouter.register(mcu)
+            await trackRouter.register(keyCommands)
+
+            _ = await TrackDispatcher.handle(
+                command: "create_audio",
+                params: [:],
+                router: trackRouter,
+                cache: StateCache(),
+                targetRegistry: trackRegistry
+            )
+            _ = await TrackDispatcher.handle(
+                command: "delete",
+                params: ["index": .int(0)],
+                router: trackRouter,
+                cache: StateCache(),
+                targetRegistry: trackRegistry
+            )
+            _ = await TrackDispatcher.handle(
+                command: "duplicate",
+                params: ["index": .int(0)],
+                router: trackRouter,
+                cache: StateCache(),
+                targetRegistry: trackRegistry
+            )
+            #expect(await trackRegistry.currentTopologyGeneration == 3)
+
+            _ = await PluginsDispatcher.handle(
+                command: "insert_verified",
+                params: [:],
+                router: trackRouter,
+                cache: StateCache(),
+                targetRegistry: trackRegistry
+            )
+            #expect(await trackRegistry.currentTopologyGeneration == 4)
+
+            let projectRegistry = TargetRegistry()
+            let projectRouter = ChannelRouter()
+            await projectRouter.register(TargetReferenceChannel(id: .appleScript))
+            _ = await ProjectDispatcher.handle(
+                command: "new",
+                params: [:],
+                router: projectRouter,
+                cache: StateCache(),
+                targetRegistry: projectRegistry
+            )
+            #expect(await projectRegistry.currentProjectEpoch == 1)
+        }
+    }
+
+    @Test
+    func testFailedOrFlagOffMutationDoesNotBumpGeneration() async {
+        let failedRegistry = TargetRegistry()
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let router = ChannelRouter()
+            await router.register(TargetReferenceChannel(id: .accessibility, succeeds: false))
+            _ = await TrackDispatcher.handle(
+                command: "create_audio",
+                params: [:],
+                router: router,
+                cache: StateCache(),
+                targetRegistry: failedRegistry
+            )
+        }
+        #expect(await failedRegistry.currentTopologyGeneration == 0)
+
+        let disabledRegistry = TargetRegistry()
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let router = ChannelRouter()
+            await router.register(TargetReferenceChannel(id: .accessibility))
+            _ = await TrackDispatcher.handle(
+                command: "create_audio",
+                params: [:],
+                router: router,
+                cache: StateCache(),
+                targetRegistry: disabledRegistry
+            )
+        }
+        #expect(await disabledRegistry.currentTopologyGeneration == 0)
+    }
+
+    @Test
+    func testRenameIgnoresTargetReferenceWhenFeatureDisabled() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            #expect(FeatureFlags.adr002TargetRef == false)
+
+            let router = ChannelRouter()
+            let channel = MockChannel(id: .accessibility)
+            await router.register(channel)
+
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: [
+                    "index": .int(2),
+                    "name": .string("Legacy Rename"),
+                    "target_ref": .string("trk_bogus"),
+                ],
+                router: router,
+                cache: StateCache()
+            )
+
+            #expect(result.isError == false)
+            let operations = await channel.executedOps
+            #expect(operations.count == 1)
+            #expect(operations.first?.0 == "track.rename")
+            #expect(operations.first?.1 == ["index": "2", "name": "Legacy Rename"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the ADR-002 (Session-scoped Stable Target Reference, #285) pilot from the ADR-001~018 Implementation Work Guide (#308) — **on retry** after an earlier attempt was deferred.

- `TargetReference.swift` — opaque `TargetReference` (`trk_<uuid>`), `TargetKind`, `TargetDescriptor`, `TargetBinding`, and a `TargetRegistry` actor (session ID + project epoch + topology generation, bind/resolve/bump). Concurrency safety comes from Swift's actor isolation — no manual CAS/locking needed.
- `TrackDispatcher.swift` — `tracks.rename` pilot implements the full ADR-002 resolve algorithm: format validation → registry lookup → kind check → index consistency check → live fingerprint reconfirmation against the state cache → State C (`stale_target_reference`) on any mismatch, no write. With the flag off, `target_ref` is completely ignored and the legacy `index`-only path is unchanged.
- Topology-generation bumps wired into `delete`/`duplicate`/`record_sequence`; project-epoch bumps wired into project lifecycle commands. Bindings are invalidated on either bump (negative-qualification behavior: stale ref after topology change → resolve fails).
- Behind `FeatureFlags.adr002TargetRef` (default off) — zero runtime behavior change with the flag off.

### Why this succeeded on retry
The first attempt (documented in the earlier completion-report comment on #308) was deferred after its planning/review loop spent 4 sessions, ~2.5 hours, and ~780K tokens designing a full concurrent CAS registry (generation tokens, poison counters, cross-actor atomicity claims, "Inspector-contamination" heuristics) for what was supposed to be a minimal, flag-gated, default-off pilot — and never produced committable code. This retry used a hardened brief: a hard 2-round cap on plan review, a 30-minute planning budget, and an explicit ban on atomic/CAS/poison-counter complexity (reasoning: the flag defaults off, so production concurrency risk is zero regardless). It completed cleanly in roughly 1.5–2 hours with a plain actor.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`, run outside the implementation sandbox) — **2295/2295 passing** (2283 baseline + 12 new)
- [x] New tests (`TargetRegistryTests.swift`): stale ref after topology-generation bump, stale ref after project-epoch bump, cross-server-session isolation, failed/flag-off mutation does not bump generation, `tracks.rename` ignores `target_ref` entirely when the flag is off (regression pin)
- [x] No live Logic Pro/AX/AppleScript/CGEvent interaction anywhere in new tests (mock channel only)