### PR TITLE
feat(adr-003): operation registry — logic_mixer vertical (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -499,7 +499,7 @@ actor LogicProServer {
     /// that would otherwise hang the stdio loop is bounded.
     static func commandDeadlineSeconds(tool: String, command: String) -> Double {
         if FeatureFlags.adr003OperationRegistry,
-           tool == ToolID.logicTransport.rawValue,
+           (tool == ToolID.logicTransport.rawValue || tool == ToolID.logicMixer.rawValue),
            let seconds = OperationRegistry.deadlineSeconds(tool: tool, command: command) {
             return seconds
         }
@@ -743,7 +743,7 @@ actor LogicProServer {
 
     static func isMutatingCommand(tool: String, command: String) -> Bool {
         if FeatureFlags.adr003OperationRegistry,
-           tool == ToolID.logicTransport.rawValue,
+           (tool == ToolID.logicTransport.rawValue || tool == ToolID.logicMixer.rawValue),
            let spec = OperationRegistry.spec(tool: tool, command: command) {
             return spec.mutability == Mutability.`mutating`
         }

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -12,10 +12,16 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case transportSetCycleRange = "transport.set_cycle_range"
     case transportToggleCountIn = "transport.toggle_count_in"
     case transportToggleAutopunch = "transport.toggle_autopunch"
+    case mixerSetVolume = "mixer.set_volume"
+    case mixerSetPan = "mixer.set_pan"
+    case mixerSetMasterVolume = "mixer.set_master_volume"
+    case mixerSetPluginParam = "mixer.set_plugin_param"
+    case mixerInsertPlugin = "mixer.insert_plugin"
 }
 
 enum ToolID: String, Sendable, Equatable {
     case logicTransport = "logic_transport"
+    case logicMixer = "logic_mixer"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -98,18 +104,31 @@ enum OperationRegistry {
         let command: String
     }
 
-    private static let allowedOperationIDs: Set<String> = [
-        "transport.play", "transport.stop", "transport.record", "transport.pause",
-        "transport.rewind", "transport.fast_forward", "transport.toggle_cycle",
-        "transport.toggle_metronome", "transport.set_tempo", "transport.goto_position",
-        "transport.set_cycle_range", "transport.toggle_count_in", "transport.toggle_autopunch",
+    private static let allowedOperationIDsByTool: [String: Set<String>] = [
+        ToolID.logicTransport.rawValue: [
+            "transport.play", "transport.stop", "transport.record", "transport.pause",
+            "transport.rewind", "transport.fast_forward", "transport.toggle_cycle",
+            "transport.toggle_metronome", "transport.set_tempo", "transport.goto_position",
+            "transport.set_cycle_range", "transport.toggle_count_in", "transport.toggle_autopunch",
+        ],
+        ToolID.logicMixer.rawValue: [
+            "mixer.set_volume", "mixer.set_pan", "mixer.set_master_volume",
+            "mixer.set_plugin_param", "mixer.insert_plugin",
+        ],
     ]
 
-    private static let allowedCommands: Set<String> = [
-        "play", "stop", "record", "pause", "rewind", "fast_forward", "toggle_cycle",
-        "toggle_metronome", "set_tempo", "goto_position", "set_cycle_range", "toggle_count_in",
-        "toggle_autopunch",
+    private static let allowedCommandsByTool: [String: Set<String>] = [
+        ToolID.logicTransport.rawValue: [
+            "play", "stop", "record", "pause", "rewind", "fast_forward", "toggle_cycle",
+            "toggle_metronome", "set_tempo", "goto_position", "set_cycle_range", "toggle_count_in",
+            "toggle_autopunch",
+        ],
+        ToolID.logicMixer.rawValue: [
+            "set_volume", "set_pan", "set_master_volume", "set_plugin_param", "insert_plugin",
+        ],
     ]
+
+    private static let allowedOperationIDs = Set(allowedOperationIDsByTool.values.flatMap { $0 })
 
     static let specs: [OperationSpec] = ([
         (.transportPlay, "play", .readbackRequired, .defaultInstall),
@@ -139,14 +158,34 @@ enum OperationRegistry {
             availability: entry.3,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
+    } + ([
+        (.mixerSetVolume, "set_volume", .none),
+        (.mixerSetPan, "set_pan", .none),
+        (.mixerSetMasterVolume, "set_master_volume", .none),
+        (.mixerSetPluginParam, "set_plugin_param", .none),
+        (.mixerInsertPlugin, "insert_plugin", .l2),
+    ] as [(OperationID, String, ConfirmationPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicMixer,
+            command: entry.1,
+            mutability: Mutability.`mutating`,
+            confirmation: entry.2,
+            target: .none,
+            verification: .readbackRequired,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
     }
 
     static func spec(tool: String, command: String) -> OperationSpec? {
         specs.first { $0.tool.rawValue == tool && $0.command == command }
     }
 
-    static var mutatingCommands: Set<String> {
-        Set(specs.filter { $0.mutability == Mutability.`mutating` }.map(\.command))
+    static func mutatingCommands(tool: ToolID) -> Set<String> {
+        Set(specs.filter { $0.tool == tool && $0.mutability == Mutability.`mutating` }.map(\.command))
     }
 
     static func deadlineSeconds(tool: String, command: String) -> Double? {
@@ -173,7 +212,7 @@ enum OperationRegistry {
             errors.append("duplicate operation IDs: \(duplicateIDs.joined(separator: ", "))")
         }
 
-        let duplicateCommands = Dictionary(grouping: entries.map(\.command), by: { $0 })
+        let duplicateCommands = Dictionary(grouping: entries.map { "\($0.tool):\($0.command)" }, by: { $0 })
             .filter { $0.value.count > 1 }
             .keys.sorted()
         if !duplicateCommands.isEmpty {
@@ -190,26 +229,47 @@ enum OperationRegistry {
             errors.append("unexpected operation IDs: \(unexpectedIDs.joined(separator: ", "))")
         }
 
-        let actualCommands = Set(entries.map(\.command))
-        let missingCommands = allowedCommands.subtracting(actualCommands).sorted()
-        if !missingCommands.isEmpty {
-            errors.append("missing commands: \(missingCommands.joined(separator: ", "))")
-        }
-        let unexpectedCommands = actualCommands.subtracting(allowedCommands).sorted()
-        if !unexpectedCommands.isEmpty {
-            errors.append("unexpected commands: \(unexpectedCommands.joined(separator: ", "))")
+        for tool in allowedCommandsByTool.keys.sorted() {
+            let toolEntries = entries.filter { $0.tool == tool }
+            let actualCommands = Set(toolEntries.map(\.command))
+            let allowedCommands = allowedCommandsByTool[tool] ?? []
+            let missingCommands = allowedCommands.subtracting(actualCommands).sorted()
+            if !missingCommands.isEmpty {
+                errors.append("missing commands: \(missingCommands.joined(separator: ", "))")
+            }
+            let unexpectedCommands = actualCommands.subtracting(allowedCommands).sorted()
+            if !unexpectedCommands.isEmpty {
+                errors.append("unexpected commands: \(unexpectedCommands.joined(separator: ", "))")
+            }
         }
 
+        let expectedTools = allowedOperationIDsByTool.reduce(into: [String: String]()) { result, entry in
+            for operationID in entry.value {
+                result[operationID] = entry.key
+            }
+        }
         let incorrectTools = entries
-            .filter { $0.tool != ToolID.logicTransport.rawValue }
+            .filter { entry in
+                guard let expectedTool = expectedTools[entry.operationID] else {
+                    return !allowedOperationIDsByTool.keys.contains(entry.tool)
+                }
+                return entry.tool != expectedTool
+            }
             .map { "\($0.command)=\($0.tool)" }
             .sorted()
         if !incorrectTools.isEmpty {
             errors.append("incorrect tools: \(incorrectTools.joined(separator: ", "))")
         }
 
+        let operationPrefixes = [
+            ToolID.logicTransport.rawValue: "transport",
+            ToolID.logicMixer.rawValue: "mixer",
+        ]
         let mismatches = entries
-            .filter { $0.operationID != "transport.\($0.command)" }
+            .filter { entry in
+                guard let prefix = operationPrefixes[entry.tool] else { return true }
+                return entry.operationID != "\(prefix).\(entry.command)"
+            }
             .map { "\($0.operationID)=\($0.command)" }
             .sorted()
         if !mismatches.isEmpty {

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -24,6 +24,14 @@ struct OperationRegistryTests {
         "play", "stop", "record", "pause", "toggle_metronome", "goto_position",
     ]
 
+    private static let mixerCommands: [(OperationID, String)] = [
+        (.mixerSetVolume, "set_volume"),
+        (.mixerSetPan, "set_pan"),
+        (.mixerSetMasterVolume, "set_master_volume"),
+        (.mixerSetPluginParam, "set_plugin_param"),
+        (.mixerInsertPlugin, "insert_plugin"),
+    ]
+
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
         let previous = ProcessInfo.processInfo.environment[key]
@@ -44,8 +52,9 @@ struct OperationRegistryTests {
 
     @Test("transport registry is exact, unique, and valid")
     func completenessAndValidation() {
-        #expect(OperationRegistry.specs.count == 13)
-        #expect(Set(OperationRegistry.specs.map(\.command)).count == 13)
+        let transportSpecs = OperationRegistry.specs.filter { $0.tool == .logicTransport }
+        #expect(transportSpecs.count == 13)
+        #expect(Set(transportSpecs.map(\.command)).count == 13)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
         #expect(DeadlineClass.short.seconds == 25)
         #expect(DeadlineClass.medium.seconds == 90)
@@ -102,7 +111,10 @@ struct OperationRegistryTests {
 
     @Test("all transport metadata matches current runtime truth")
     func metadata() throws {
-        #expect(Set(Self.commands.map(\.1)) == Set(OperationRegistry.specs.map(\.command)))
+        let transportCommands = OperationRegistry.specs
+            .filter { $0.tool == .logicTransport }
+            .map(\.command)
+        #expect(Set(Self.commands.map(\.1)) == Set(transportCommands))
 
         for (id, command) in Self.commands {
             let spec = try #require(OperationRegistry.spec(tool: ToolID.logicTransport.rawValue, command: command))
@@ -127,7 +139,95 @@ struct OperationRegistryTests {
 
     @Test("derived mutating commands equal the unchanged legacy transport set")
     func mutatingParity() {
-        #expect(OperationRegistry.mutatingCommands == LogicProServer.mutatingCommandsByTool["logic_transport"])
+        #expect(OperationRegistry.mutatingCommands(tool: .logicTransport) == LogicProServer.mutatingCommandsByTool["logic_transport"])
+    }
+
+    @Test("mixer registry is exact, unique, and isolated")
+    func mixerCompletenessAndIsolation() {
+        #expect(OperationRegistry.specs.count == 18)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == 18)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 18)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+        #expect(OperationRegistry.spec(tool: ToolID.logicMixer.rawValue, command: "play") == nil)
+        #expect(OperationRegistry.spec(tool: ToolID.logicTransport.rawValue, command: "set_volume") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_midi", command: "set_volume") == nil)
+        #expect(OperationRegistry.spec(tool: ToolID.logicMixer.rawValue, command: "unknown") == nil)
+    }
+
+    @Test("all mixer metadata matches current runtime truth")
+    func mixerMetadata() throws {
+        let mixerSpecs = OperationRegistry.specs.filter { $0.tool == .logicMixer }
+        #expect(Set(Self.mixerCommands.map(\.1)) == Set(mixerSpecs.map(\.command)))
+
+        for (id, command) in Self.mixerCommands {
+            let spec = try #require(OperationRegistry.spec(tool: ToolID.logicMixer.rawValue, command: command))
+            #expect(spec.id == id)
+            #expect(spec.tool == .logicMixer)
+            #expect(spec.command == command)
+            #expect(spec.mutability == Mutability.`mutating`)
+            #expect(spec.confirmation == (command == "insert_plugin" ? .l2 : .none))
+            #expect(spec.target == .none)
+            #expect(spec.verification == .readbackRequired)
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == .short)
+            #expect(spec.availability == .defaultInstall)
+            #expect(spec.capability.rawValue == id.rawValue)
+        }
+    }
+
+    @Test("derived mixer mutations and deadlines equal unchanged legacy behavior")
+    func mixerLegacyParity() {
+        #expect(OperationRegistry.mutatingCommands(tool: .logicMixer) == LogicProServer.mutatingCommandsByTool["logic_mixer"])
+        for (_, command) in Self.mixerCommands {
+            #expect(OperationRegistry.deadlineSeconds(tool: ToolID.logicMixer.rawValue, command: command) == 25)
+        }
+    }
+
+    @Test("validation rejects a mixer command assigned to transport")
+    func mixerWrongToolValidation() throws {
+        var entries = OperationRegistry.specs.map {
+            OperationRegistry.ValidationEntry(
+                operationID: $0.id.rawValue,
+                tool: $0.tool.rawValue,
+                command: $0.command
+            )
+        }
+        let index = try #require(entries.firstIndex { $0.command == "set_volume" })
+        entries[index] = .init(
+            operationID: entries[index].operationID,
+            tool: ToolID.logicTransport.rawValue,
+            command: entries[index].command
+        )
+        #expect(OperationRegistry.validationErrors(for: entries).contains { $0.contains("incorrect tools:") })
+    }
+
+    @Test("flag off uses unchanged legacy mixer decisions")
+    func mixerFlagOff() {
+        withRegistryFlag(nil) {
+            #expect(FeatureFlags.adr003OperationRegistry == false)
+            for (_, command) in Self.mixerCommands {
+                #expect(LogicProServer.mutatingCommandsByTool["logic_mixer"]?.contains(command) == true)
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_mixer", command: command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_mixer", command: command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_mixer", command: "play"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_mixer", command: "play") == 25)
+        }
+    }
+
+    @Test("flag on derives mixer decisions and preserves legacy fallbacks")
+    func mixerFlagOn() {
+        withRegistryFlag("1") {
+            #expect(FeatureFlags.adr003OperationRegistry)
+            for (_, command) in Self.mixerCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_mixer", command: command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_mixer", command: command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_mixer", command: "play"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_mixer", command: "import_file") == 300)
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+        }
     }
 
     @Test("registry deadlines are short and match legacy with the flag unset")


### PR DESCRIPTION
## Summary
Second vertical migration for ADR-003 (Public Operation Contract Registry, #286) — extends the registry (framework merged in #316 for `logic_transport`) to `logic_mixer`'s 5 commands.

- `OperationRegistry.swift` — adds `ToolID.logicMixer`, 5 new `OperationID.mixer*` cases, and 5 new `OperationSpec` entries (`set_volume`/`set_pan`/`set_plugin_param`: readback-verified, no confirmation; `set_master_volume`: readback-verified via MCU echo, honestly non-deterministic per the existing dispatcher description; `insert_plugin`: readback-verified, `.l2` confirmation matching its existing inline confirm-flag check). Validation logic generalized to be tool-scoped (per-tool allowed-command sets, per-tool operation-ID-prefix mismatch detection) so `logic_mixer` and `logic_transport` entries can never cross-contaminate. `mutatingCommands` changed from an unparameterized property to `mutatingCommands(tool:)` since two tools now coexist.
- `LogicProServer.swift` — the existing `FeatureFlags.adr003OperationRegistry` branch (from #316) extended to also cover `logic_mixer`, 2-line change.
- `MixerDispatcher.swift` — **untouched**. This is a pure respecification; no runtime behavior changes anywhere.
- Behind `FeatureFlags.adr003OperationRegistry` (default off) — zero behavior change with the flag off.

### Process note
Implementation was correct on the first pass, but required two CTO interventions to land: (1) the automation got stuck in an unproductive post-implementation repeat-loop (same evidence text re-emitted without progress) — killed and the already-complete/correct diff was reviewed and taken over directly; (2) the original worktree then hit a stuck `swift build` (0% CPU, no `.build` forming) traced to a leftover orphaned process from an earlier session holding resource contention — recovered by cleanly reapplying the diff to a fresh worktree. Neither was a scope or code-quality issue.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`) — 2299/2301 passing. The 2 failures are in `RegionDragSpikeTests.swift` (`regionDragSpikeBlocksCurrentWorkingDirectoryExportDir`), a working-directory/scratch-root safety-guard test that's path-dependent on the worktree's location on disk — confirmed unrelated to this diff (different file/subsystem, no connection to `OperationRegistry`/`LogicProServer`).
- [x] `OperationRegistryTests.swift` filtered run — 13/13 passing, including new mixer-specific tests: exact/unique/isolated registry, legacy-mutating-set parity, cross-tool validation rejection (mixer command mislabeled as transport → `incorrect tools:` error), flag-off regression (legacy behavior byte-for-byte unchanged), flag-on derivation, and `logic_midi` isolation (untouched by either vertical)
- [x] No live Logic Pro/AX/AppleScript/CGEvent interaction anywhere in new tests