### PR TITLE
feat(adr-005): operation trace — logic_mixer write-boundary (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -35,10 +35,13 @@ struct MixerDispatcher {
                     "set_volume 'volume' must be in 0.0..1.0 (got \(volume))"
                 )
             }
-            return await routedTextResult(router, operation: "mixer.set_volume", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mixer.set_volume", params: [
                 "index": String(index),
                 "volume": String(volume),
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "set_pan":
             // RB-1.a — same fail-closed treatment as set_volume.
@@ -57,10 +60,13 @@ struct MixerDispatcher {
                     "set_pan 'value' must be in -1.0..1.0 (got \(pan))"
                 )
             }
-            return await routedTextResult(router, operation: "mixer.set_pan", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mixer.set_pan", params: [
                 "index": String(index),
                 "pan": String(pan),
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "set_send":
             return notExposedCommandResult(
@@ -216,5 +222,65 @@ struct MixerDispatcher {
                 extras: ["operation": "mixer.\(command)"]
             )
         }
+    }
+
+    private static func startTraceIfEnabled(command: String) async -> TraceID? {
+        guard FeatureFlags.adr005OperationTrace,
+              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
+            return nil
+        }
+        switch spec.id {
+        case .mixerSetVolume, .mixerSetPan:
+            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
+            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+                "operation_id": spec.id.rawValue,
+                "command": command,
+            ])
+            return id
+        default:
+            return nil
+        }
+    }
+
+    private static func recordWriteBoundary(_ traceID: TraceID?) async {
+        guard let traceID else { return }
+        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
+    }
+
+    private static func finalizeTrace(
+        _ result: CallTool.Result,
+        traceID: TraceID?
+    ) async -> CallTool.Result {
+        guard let traceID else { return result }
+        guard case .text(let raw, _, _) = result.content.first else {
+            await OperationTraceStore.shared.record(
+                traceID,
+                phase: .verificationCompleted,
+                attributes: ["readback_state": result.isError == true ? "C" : "A"]
+            )
+            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+            await OperationTraceStore.shared.complete(traceID)
+            return result
+        }
+
+        let object = decodedJSONObject(raw)
+        var attributes = [
+            "readback_state": object?["state"] as? String
+                ?? (result.isError == true ? "C" : "A"),
+        ]
+        if let errorCode = object?["error"] as? String {
+            attributes["error_code"] = errorCode
+        }
+        await OperationTraceStore.shared.record(
+            traceID,
+            phase: .verificationCompleted,
+            attributes: attributes
+        )
+        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(traceID)
+
+        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
+        guard merged != raw else { return result }
+        return toolTextResult(merged, isError: result.isError == true)
     }
 }

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -316,3 +316,131 @@ struct OperationTraceTests {
         }
     }
 }
+
+private actor OperationTraceMixerChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private(set) var executedOperations: [String] = []
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOperations.append(operation)
+        switch operation {
+        case OperationID.mixerSetVolume.rawValue:
+            return .success(
+                #"{"operation":"mixer.set_volume","state":"A","success":true,"verified":true}"#
+            )
+        case OperationID.mixerSetPan.rawValue:
+            return .success(
+                #"{"operation":"mixer.set_pan","state":"A","success":true,"verified":true}"#
+            )
+        default:
+            return .error("Unexpected mixer operation: \(operation)")
+        }
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace mixer test")
+    }
+}
+
+extension OperationTraceTests {
+    @Test(arguments: ["set_volume", "set_pan"])
+    func OperationTraceMixerFlagOff(command: String) async {
+        let previous = replaceOperationTraceFlag(with: nil)
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceMixerChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await MixerDispatcher.handle(
+            command: command,
+            params: command == "set_volume"
+                ? ["track": .int(2), "value": .double(0.5)]
+                : ["track": .int(2), "value": .double(-0.25)],
+            router: router,
+            cache: StateCache()
+        )
+
+        let operationID = command == "set_volume"
+            ? OperationID.mixerSetVolume
+            : OperationID.mixerSetPan
+        let expected = command == "set_volume"
+            ? #"{"operation":"mixer.set_volume","state":"A","success":true,"verified":true}"#
+            : #"{"operation":"mixer.set_pan","state":"A","success":true,"verified":true}"#
+        #expect(sharedToolText(result) == expected)
+        #expect(!expected.contains("trace_id"))
+        #expect(await channel.executedOperations == [operationID.rawValue])
+        #expect(await OperationTraceStore.shared.recent().isEmpty)
+    }
+
+    @Test(arguments: ["set_volume", "set_pan"])
+    func OperationTraceMixerEnabled(command: String) async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceMixerChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await MixerDispatcher.handle(
+            command: command,
+            params: command == "set_volume"
+                ? ["track": .int(2), "value": .double(0.5)]
+                : ["track": .int(2), "value": .double(-0.25)],
+            router: router,
+            cache: StateCache()
+        )
+
+        let operationID = command == "set_volume"
+            ? OperationID.mixerSetVolume
+            : OperationID.mixerSetPan
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(
+            await OperationTraceStore.shared.trace(TraceID(rawValue: rawID))
+        )
+        #expect(result.isError == false)
+        #expect(trace.operationID == operationID.rawValue)
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+        ])
+        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.completedAt != nil)
+        #expect(await channel.executedOperations == [operationID.rawValue])
+
+        let allowedAttributeKeys: Set<String> = [
+            "operation_id", "command", "target_ref", "project_path_hash",
+            "readback_state", "error_code",
+        ]
+        #expect(trace.events.allSatisfy {
+            Set($0.attributes.keys).isSubset(of: allowedAttributeKeys)
+        })
+    }
+
+    @Test(arguments: ["set_volume", "set_pan"])
+    func OperationTraceMixerInvalidParamsDoNotTrace(command: String) async {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceMixerChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await MixerDispatcher.handle(
+            command: command,
+            params: ["value": .double(0.5)],
+            router: router,
+            cache: StateCache()
+        )
+
+        #expect(result.isError == true)
+        #expect(await channel.executedOperations.isEmpty)
+        #expect(await OperationTraceStore.shared.recent().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
Extends the ADR-005 (Operation Trace, #288) pilot from `logic_transport` (#317) to `logic_mixer`'s `set_volume`/`set_pan` — the 2 commands with real AX-readback verification (mirroring the 4-of-13 scoping precedent used for the transport pilot).

- `MixerDispatcher.swift` — adds `startTraceIfEnabled`/`recordWriteBoundary`/`finalizeTrace` helpers (mixer-local copies of the proven transport pattern), wraps `set_volume`/`set_pan`'s existing `routedTextResult` call with trace phases (`requestReceived` → `writeBoundaryCrossed` → `verificationCompleted` → `resultEmitted`), merges `trace_id` additively into the existing response via `HonestContract.addExtras`.
- The shared `routedTextResult`/`DispatcherSupport.swift` helper (used by many other dispatchers) is **untouched** — this dispatcher wraps its own call sites rather than modifying the shared helper.
- `OperationTrace.swift` and `TransportDispatcher.swift` (the ADR-005 framework and its transport instrumentation) are **untouched**.
- Behind `FeatureFlags.adr005OperationTrace` (default off) — zero behavior change with the flag off.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`) — 2304/2304 passing
- [x] New tests cover the mixer trace event sequence for both a write-boundary-crossing success and privacy-safe attribute filtering, plus a flag-off regression pin
- [x] No live Logic Pro/AX/AppleScript/CGEvent interaction anywhere in new tests