### PR TITLE
feat(adr-003): operation registry — logic_navigate vertical (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -493,13 +493,19 @@ actor LogicProServer {
         "cleanup_apply", "new", "save", "close", "quit", "play_sequence",
     ]
 
+    static func usesOperationRegistry(tool: String) -> Bool {
+        FeatureFlags.adr003OperationRegistry
+            && (tool == ToolID.logicTransport.rawValue
+                || tool == ToolID.logicMixer.rawValue
+                || tool == ToolID.logicNavigate.rawValue)
+    }
+
     /// Per-command server-side deadline in seconds. Set far above each
     /// command's healthy completion time (sub-second for the fast tier) so a
     /// normal op can never false-trip; only a wedged/occluded Logic session
     /// that would otherwise hang the stdio loop is bounded.
     static func commandDeadlineSeconds(tool: String, command: String) -> Double {
-        if FeatureFlags.adr003OperationRegistry,
-           (tool == ToolID.logicTransport.rawValue || tool == ToolID.logicMixer.rawValue),
+        if usesOperationRegistry(tool: tool),
            let seconds = OperationRegistry.deadlineSeconds(tool: tool, command: command) {
             return seconds
         }
@@ -742,8 +748,7 @@ actor LogicProServer {
     ]
 
     static func isMutatingCommand(tool: String, command: String) -> Bool {
-        if FeatureFlags.adr003OperationRegistry,
-           (tool == ToolID.logicTransport.rawValue || tool == ToolID.logicMixer.rawValue),
+        if usesOperationRegistry(tool: tool),
            let spec = OperationRegistry.spec(tool: tool, command: command) {
             return spec.mutability == Mutability.`mutating`
         }

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -17,11 +17,20 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case mixerSetMasterVolume = "mixer.set_master_volume"
     case mixerSetPluginParam = "mixer.set_plugin_param"
     case mixerInsertPlugin = "mixer.insert_plugin"
+    case navigateGotoBar = "navigate.goto_bar"
+    case navigateGotoMarker = "navigate.goto_marker"
+    case navigateCreateMarker = "navigate.create_marker"
+    case navigateDeleteMarker = "navigate.delete_marker"
+    case navigateRenameMarker = "navigate.rename_marker"
+    case navigateZoomToFit = "navigate.zoom_to_fit"
+    case navigateSetZoom = "navigate.set_zoom"
+    case navigateToggleView = "navigate.toggle_view"
 }
 
 enum ToolID: String, Sendable, Equatable {
     case logicTransport = "logic_transport"
     case logicMixer = "logic_mixer"
+    case logicNavigate = "logic_navigate"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -115,6 +124,11 @@ enum OperationRegistry {
             "mixer.set_volume", "mixer.set_pan", "mixer.set_master_volume",
             "mixer.set_plugin_param", "mixer.insert_plugin",
         ],
+        ToolID.logicNavigate.rawValue: [
+            "navigate.goto_bar", "navigate.goto_marker", "navigate.create_marker",
+            "navigate.delete_marker", "navigate.rename_marker", "navigate.zoom_to_fit",
+            "navigate.set_zoom", "navigate.toggle_view",
+        ],
     ]
 
     private static let allowedCommandsByTool: [String: Set<String>] = [
@@ -125,6 +139,10 @@ enum OperationRegistry {
         ],
         ToolID.logicMixer.rawValue: [
             "set_volume", "set_pan", "set_master_volume", "set_plugin_param", "insert_plugin",
+        ],
+        ToolID.logicNavigate.rawValue: [
+            "goto_bar", "goto_marker", "create_marker", "delete_marker", "rename_marker",
+            "zoom_to_fit", "set_zoom", "toggle_view",
         ],
     ]
 
@@ -176,6 +194,29 @@ enum OperationRegistry {
             retry: .neverAutomatic,
             deadline: .short,
             availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
+    } + ([
+        (.navigateGotoBar, "goto_bar", .readbackRequired, .defaultInstall),
+        (.navigateGotoMarker, "goto_marker", .readbackRequired, .defaultInstall),
+        (.navigateCreateMarker, "create_marker", .readbackRequired, .defaultInstall),
+        (.navigateDeleteMarker, "delete_marker", .none, .requiresKeyBinding),
+        (.navigateRenameMarker, "rename_marker", .none, .unsupported),
+        (.navigateZoomToFit, "zoom_to_fit", .readbackRequired, .defaultInstall),
+        (.navigateSetZoom, "set_zoom", .readbackRequired, .defaultInstall),
+        (.navigateToggleView, "toggle_view", .none, .defaultInstall),
+    ] as [(OperationID, String, VerificationPolicy, AvailabilityPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicNavigate,
+            command: entry.1,
+            mutability: Mutability.`mutating`,
+            confirmation: .none,
+            target: .none,
+            verification: entry.2,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: entry.3,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     }
@@ -264,6 +305,7 @@ enum OperationRegistry {
         let operationPrefixes = [
             ToolID.logicTransport.rawValue: "transport",
             ToolID.logicMixer.rawValue: "mixer",
+            ToolID.logicNavigate.rawValue: "navigate",
         ]
         let mismatches = entries
             .filter { entry in

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -32,6 +32,28 @@ struct OperationRegistryTests {
         (.mixerInsertPlugin, "insert_plugin"),
     ]
 
+    private static let navigateCommands: [(String, String)] = [
+        ("navigate.goto_bar", "goto_bar"),
+        ("navigate.goto_marker", "goto_marker"),
+        ("navigate.create_marker", "create_marker"),
+        ("navigate.delete_marker", "delete_marker"),
+        ("navigate.rename_marker", "rename_marker"),
+        ("navigate.zoom_to_fit", "zoom_to_fit"),
+        ("navigate.set_zoom", "set_zoom"),
+        ("navigate.toggle_view", "toggle_view"),
+    ]
+
+    private static let unverifiedNavigateCommands: Set<String> = [
+        "delete_marker", "rename_marker", "toggle_view",
+    ]
+
+    private static let navigateAvailabilityOverrides: [String: AvailabilityPolicy] = [
+        "delete_marker": .requiresKeyBinding,
+        "rename_marker": .unsupported,
+    ]
+
+    private static let expectedRegistryCount = commands.count + mixerCommands.count + navigateCommands.count
+
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
         let previous = ProcessInfo.processInfo.environment[key]
@@ -144,9 +166,9 @@ struct OperationRegistryTests {
 
     @Test("mixer registry is exact, unique, and isolated")
     func mixerCompletenessAndIsolation() {
-        #expect(OperationRegistry.specs.count == 18)
-        #expect(Set(OperationRegistry.specs.map(\.id)).count == 18)
-        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 18)
+        #expect(OperationRegistry.specs.count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == Self.expectedRegistryCount)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
         #expect(OperationRegistry.validationErrors().isEmpty)
         #expect(OperationRegistry.spec(tool: ToolID.logicMixer.rawValue, command: "play") == nil)
@@ -268,6 +290,92 @@ struct OperationRegistryTests {
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: "import_file") == 300)
             #expect(!LogicProServer.isMutatingCommand(tool: "logic_transport", command: "bounce"))
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_transport", command: "bounce") == 300)
+        }
+    }
+
+    @Test("navigate registry is exact, unique, and isolated")
+    func navigateCompletenessAndIsolation() throws {
+        let tool = try #require(ToolID(rawValue: "logic_navigate"))
+        let navigateSpecs = OperationRegistry.specs.filter { $0.tool == tool }
+        #expect(navigateSpecs.count == Self.navigateCommands.count)
+        #expect(Set(navigateSpecs.map(\.command)) == Set(Self.navigateCommands.map(\.1)))
+        #expect(Set(navigateSpecs.map(\.id.rawValue)) == Set(Self.navigateCommands.map(\.0)))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+        #expect(OperationRegistry.spec(tool: "logic_navigate", command: "play") == nil)
+        #expect(OperationRegistry.spec(tool: ToolID.logicTransport.rawValue, command: "goto_bar") == nil)
+        #expect(OperationRegistry.spec(tool: ToolID.logicMixer.rawValue, command: "goto_bar") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_navigate", command: "unknown") == nil)
+    }
+
+    @Test("all navigate metadata matches current runtime truth")
+    func navigateMetadata() throws {
+        let tool = try #require(ToolID(rawValue: "logic_navigate"))
+
+        for (idRawValue, command) in Self.navigateCommands {
+            let id = try #require(OperationID(rawValue: idRawValue))
+            let spec = try #require(OperationRegistry.spec(tool: tool.rawValue, command: command))
+            #expect(spec.id == id)
+            #expect(spec.tool == tool)
+            #expect(spec.command == command)
+            #expect(spec.mutability == Mutability.`mutating`)
+            #expect(spec.confirmation == .none)
+            #expect(spec.target == .none)
+            #expect(spec.verification == (Self.unverifiedNavigateCommands.contains(command) ? .none : .readbackRequired))
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == .short)
+            #expect(spec.availability == (Self.navigateAvailabilityOverrides[command] ?? .defaultInstall))
+            #expect(spec.capability.rawValue == idRawValue)
+        }
+    }
+
+    @Test("derived navigate mutations and deadlines equal unchanged legacy behavior")
+    func navigateLegacyParity() throws {
+        let tool = try #require(ToolID(rawValue: "logic_navigate"))
+        #expect(OperationRegistry.mutatingCommands(tool: tool) == LogicProServer.mutatingCommandsByTool["logic_navigate"])
+        for (_, command) in Self.navigateCommands {
+            #expect(OperationRegistry.deadlineSeconds(tool: tool.rawValue, command: command) == 25)
+        }
+    }
+
+    @Test("navigate rename marker is honestly marked unsupported")
+    func navigateRenameMarkerUnsupported() throws {
+        let spec = try #require(OperationRegistry.spec(tool: "logic_navigate", command: "rename_marker"))
+        #expect(spec.availability == .unsupported)
+        #expect(spec.verification == .none)
+        #expect(spec.confirmation == .none)
+        #expect(HonestContract.terminalErrorCodes.contains("not_implemented"))
+    }
+
+    @Test("flag off uses unchanged legacy navigate decisions")
+    func navigateFlagOff() {
+        withRegistryFlag(nil) {
+            #expect(FeatureFlags.adr003OperationRegistry == false)
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_navigate"))
+            for (_, command) in Self.navigateCommands {
+                #expect(LogicProServer.mutatingCommandsByTool["logic_navigate"]?.contains(command) == true)
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_navigate", command: command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_navigate", command: "play"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: "play") == 25)
+        }
+    }
+
+    @Test("flag on derives navigate decisions and preserves legacy fallbacks")
+    func navigateFlagOn() {
+        withRegistryFlag("1") {
+            #expect(FeatureFlags.adr003OperationRegistry)
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_transport"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_mixer"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_navigate"))
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            for (_, command) in Self.navigateCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_navigate", command: command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_navigate", command: "play"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: "import_file") == 300)
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
         }
     }
 }


### PR DESCRIPTION
## Summary
Third vertical migration for ADR-003 (#286) — extends the registry to `logic_navigate`'s 8 commands, following `logic_transport` (#316) and `logic_mixer` (#319).

## A real drift-detection catch
The original implementation brief assumed all commands except `rename_marker` had AX readback verification. Direct code inspection (both by the implementer and independently confirmed by the reviewer against `RoutingTable.swift`) found this was wrong for 2 commands:

- `delete_marker` and `toggle_view` route through `[.midiKeyCommands, .cgEvent]` only — **no AX channel exists in their routing chain**, so there is no readback path at all.

Rather than encode the incorrect assumption, the spec was corrected to reflect actual runtime behavior:
- `delete_marker`: `verification: .none`, `availability: .requiresKeyBinding` (confirmed to depend on a user-configured MIDI Learn key command, not a default binding)
- `toggle_view`: `verification: .none`, `availability: .defaultInstall` (works with default Logic key bindings, just unverified)
- `rename_marker`: `verification: .none`, `availability: .unsupported` (genuinely not implemented — no verified AX write path exists on Logic 12.x, documented in the dispatcher's own description)
- The remaining 5 (`goto_bar`/`goto_marker`/`create_marker`/`zoom_to_fit`/`set_zoom`) were re-confirmed to have real readback verification code and kept `.readbackRequired`/`.defaultInstall`

This is exactly the kind of contract-vs-reality drift ADR-003 exists to catch.

- `OperationRegistry.swift` — 8 new `OperationID`/`OperationSpec` entries, `ToolID.logicNavigate`, tool-scoped validation extended.
- `LogicProServer.swift` — existing flag-gate condition extended to cover `logic_navigate`.
- `NavigateDispatcher.swift` — **untouched**, pure respecification.
- Behind `FeatureFlags.adr003OperationRegistry` (default off) — zero behavior change with the flag off.

## Test plan
- [x] `swift build -c release` — clean
- [x] Full suite (`swift test --no-parallel`) — 2310/2310 passing
- [x] `transport`/`mixer` registry entries byte-unchanged; cross-tool isolation preserved