### PR TITLE
fix(tracks): match Delete Track menu item on English UI (#322)

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -605,17 +605,26 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime = .production
     ) async -> ChannelResult {
         let beforeCount = AXLogicProElements.allTrackHeaders(runtime: runtime).count
-        let click = clickTrackMenu("트랙 삭제", menuName: "트랙", englishMenuName: "Track", runtime: runtime)
+        let click = clickTrackMenu(
+            ["Delete Track", "트랙 삭제"],
+            menuName: "트랙",
+            englishMenuName: "Track",
+            runtime: runtime
+        )
         guard click.isSuccess else {
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "Track > 트랙 삭제 menu item not found / not pressable",
+                hint: "Track > Delete Track / 트랙 삭제 menu item not found / not pressable",
                 extras: ["track_count_before": beforeCount]
             ))
         }
 
+        let menuClicked = (
+            (try? JSONSerialization.jsonObject(with: Data(click.message.utf8))) as? [String: String]
+        )?["menu_clicked"] ?? "Delete Track / 트랙 삭제"
+
         let extras: [String: Any] = [
-            "menu_clicked": "트랙 삭제",
+            "menu_clicked": menuClicked,
             "track_count_before": beforeCount,
             "requested_delta": -1
         ]

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -90,6 +90,57 @@ private final class TrackRenameSession: @unchecked Sendable {
     var selectionCommitted = false
 }
 
+private final class DeleteTrackSession: @unchecked Sendable {
+    var pressedTitles: [String] = []
+}
+
+private func makeDeleteTrackFixture(
+    menuTitle: String,
+    itemTitles: [String]
+) -> (runtime: AXLogicProElements.Runtime, session: DeleteTrackSession) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(380)
+    let window = builder.element(381)
+    let menuBar = builder.element(382)
+    let trackMenu = builder.element(383)
+    let trackList = builder.element(384)
+    let trackHeader = builder.element(385)
+    let itemElements = itemTitles.indices.map { builder.element(390 + $0) }
+    let session = DeleteTrackSession()
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [trackHeader])
+    builder.setAttribute(trackHeader, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setChildren(menuBar, [trackMenu])
+    builder.setAttribute(trackMenu, kAXTitleAttribute as String, menuTitle)
+    builder.setChildren(trackMenu, itemElements)
+    for (element, title) in zip(itemElements, itemTitles) {
+        builder.setAttribute(element, kAXTitleAttribute as String, title)
+    }
+
+    let titlesByID = Dictionary(uniqueKeysWithValues: zip(itemElements, itemTitles).map {
+        (builder.elementID($0.0), $0.1)
+    })
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            guard action == kAXPressAction as String,
+                  let title = titlesByID[builder.elementID(element)] else { return true }
+            session.pressedTitles.append(title)
+            if title == "Delete Track" || title == "트랙 삭제" {
+                builder.setChildren(trackList, [])
+            }
+            return true
+        }
+    )
+    return (runtime, session)
+}
+
 private final class BlockingExecuteProbe: @unchecked Sendable {
     private let entered = DispatchSemaphore(value: 0)
     private let release = DispatchSemaphore(value: 0)
@@ -1877,6 +1928,54 @@ private func makeTempoSliderFixture(
     #expect(result.message.contains("\"observed_track_type\":\"software_instrument\""))
     #expect(result.message.contains("\"track_type_verification_source\":\"menu_clicked\""))
     #expect(result.message.contains("\"verification_source\":\"track_count_delta\""))
+}
+
+@Test func testDeleteTrackUsesExactEnglishMenuItemAndReportsClickedTitle() async throws {
+    let fixture = makeDeleteTrackFixture(
+        menuTitle: "Track",
+        itemTitles: ["Delete Unused Tracks", "Delete Track"]
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteTrack(runtime: fixture.runtime)
+
+    try #require(result.isSuccess, "English-only Track menu must resolve Delete Track, got: \(result.message)")
+    let object = decodeAccessibilityJSON(result.message)
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["menu_clicked"] as? String == "Delete Track")
+    #expect(fixture.session.pressedTitles == ["Delete Track"])
+}
+
+@Test func testDeleteTrackUsesKoreanMenuItemAndReportsClickedTitle() async throws {
+    let fixture = makeDeleteTrackFixture(
+        menuTitle: "트랙",
+        itemTitles: ["트랙 삭제"]
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteTrack(runtime: fixture.runtime)
+
+    try #require(result.isSuccess, "Korean-only 트랙 menu must resolve 트랙 삭제, got: \(result.message)")
+    let object = decodeAccessibilityJSON(result.message)
+    #expect(object["verified"] as? Bool == true)
+    #expect(object["menu_clicked"] as? String == "트랙 삭제")
+    #expect(fixture.session.pressedTitles == ["트랙 삭제"])
+}
+
+@Test func testDeleteTrackMissingItemHintNamesEnglishAndKoreanCandidates() async {
+    let fixture = makeDeleteTrackFixture(
+        menuTitle: "Track",
+        itemTitles: ["Delete Unused Tracks"]
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteTrack(runtime: fixture.runtime)
+
+    #expect(!result.isSuccess)
+    let object = decodeAccessibilityJSON(result.message)
+    #expect(object["error"] as? String == "element_not_found")
+    #expect(
+        object["hint"] as? String ==
+            "Track > Delete Track / 트랙 삭제 menu item not found / not pressable"
+    )
+    #expect(fixture.session.pressedTitles.isEmpty)
 }
 
 @Test func testAccessibilityChannelCreateInstrumentFailsWhenTrackCountDoesNotIncrease() async {


### PR DESCRIPTION
Fixes #322.

## Summary
`logic_tracks.delete` passed only the Korean menu-item label (`"트랙 삭제"`) to `clickTrackMenu`, so on English-UI Logic Pro the AX item lookup failed 100% of the time (State C `element_not_found`) — confirmed live with read-only AX menu enumeration showing the English menu contains exactly "Delete Track".

- Delete path now passes `["Delete Track", "트랙 삭제"]`, matching the established rename precedent (`["Rename Track", "트랙 이름 변경", …]`).
- Failure hint mentions both candidate labels; `menu_clicked` extra now reports the label actually clicked instead of a hardcoded Korean string.
- `clickTrackMenu` helper semantics unchanged (exact-title match — no collision with "Delete Unused Tracks", pinned by test).

## Test plan
- [x] RED→GREEN: synthetic-menu tests for English-only and Korean-only menu trees + exact-match non-collision with "Delete Unused Tracks" (99 test lines)
- [x] `swift build -c release` clean; full `swift test --no-parallel` green in implementation env (2313)
- [ ] Live delete round-trip re-verification on real Logic Pro (CTO, post-merge — evidence will be posted on #322)