### PR TITLE
feat(adr-003): operation registry — audio/system/plugins verticals (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -495,9 +495,7 @@ actor LogicProServer {
 
     static func usesOperationRegistry(tool: String) -> Bool {
         FeatureFlags.adr003OperationRegistry
-            && (tool == ToolID.logicTransport.rawValue
-                || tool == ToolID.logicMixer.rawValue
-                || tool == ToolID.logicNavigate.rawValue)
+            && OperationRegistry.registeredToolRawValues.contains(tool)
     }
 
     /// Per-command server-side deadline in seconds. Set far above each

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -25,12 +25,23 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case navigateZoomToFit = "navigate.zoom_to_fit"
     case navigateSetZoom = "navigate.set_zoom"
     case navigateToggleView = "navigate.toggle_view"
+    case audioAnalyzeFile = "audio.analyze_file"
+    case systemHealth = "system.health"
+    case systemPermissions = "system.permissions"
+    case systemRefreshCache = "system.refresh_cache"
+    case systemHelp = "system.help"
+    case pluginsGetInventory = "plugins.get_inventory"
+    case pluginsSetParamVerified = "plugins.set_param_verified"
+    case pluginsInsertVerified = "plugins.insert_verified"
 }
 
 enum ToolID: String, Sendable, Equatable {
     case logicTransport = "logic_transport"
     case logicMixer = "logic_mixer"
     case logicNavigate = "logic_navigate"
+    case logicAudio = "logic_audio"
+    case logicSystem = "logic_system"
+    case logicPlugins = "logic_plugins"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -129,6 +140,15 @@ enum OperationRegistry {
             "navigate.delete_marker", "navigate.rename_marker", "navigate.zoom_to_fit",
             "navigate.set_zoom", "navigate.toggle_view",
         ],
+        ToolID.logicAudio.rawValue: [
+            "audio.analyze_file",
+        ],
+        ToolID.logicSystem.rawValue: [
+            "system.health", "system.permissions", "system.refresh_cache", "system.help",
+        ],
+        ToolID.logicPlugins.rawValue: [
+            "plugins.get_inventory", "plugins.set_param_verified", "plugins.insert_verified",
+        ],
     ]
 
     private static let allowedCommandsByTool: [String: Set<String>] = [
@@ -144,9 +164,19 @@ enum OperationRegistry {
             "goto_bar", "goto_marker", "create_marker", "delete_marker", "rename_marker",
             "zoom_to_fit", "set_zoom", "toggle_view",
         ],
+        ToolID.logicAudio.rawValue: [
+            "analyze_file",
+        ],
+        ToolID.logicSystem.rawValue: [
+            "health", "permissions", "refresh_cache", "help",
+        ],
+        ToolID.logicPlugins.rawValue: [
+            "get_inventory", "set_param_verified", "insert_verified",
+        ],
     ]
 
     private static let allowedOperationIDs = Set(allowedOperationIDsByTool.values.flatMap { $0 })
+    static let registeredToolRawValues = Set(allowedOperationIDsByTool.keys)
 
     static let specs: [OperationSpec] = ([
         (.transportPlay, "play", .readbackRequired, .defaultInstall),
@@ -217,6 +247,59 @@ enum OperationRegistry {
             retry: .neverAutomatic,
             deadline: .short,
             availability: entry.3,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
+    } + ([
+        (.audioAnalyzeFile, "analyze_file", Mutability.readOnly),
+    ] as [(OperationID, String, Mutability)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicAudio,
+            command: entry.1,
+            mutability: entry.2,
+            confirmation: .none,
+            target: .none,
+            verification: .none,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
+    } + ([
+        (.systemHealth, "health", Mutability.readOnly),
+        (.systemPermissions, "permissions", Mutability.readOnly),
+        (.systemRefreshCache, "refresh_cache", Mutability.readOnly),
+        (.systemHelp, "help", Mutability.readOnly),
+    ] as [(OperationID, String, Mutability)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicSystem,
+            command: entry.1,
+            mutability: entry.2,
+            confirmation: .none,
+            target: .none,
+            verification: .none,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
+    } + ([
+        (.pluginsGetInventory, "get_inventory", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+        (.pluginsSetParamVerified, "set_param_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
+        (.pluginsInsertVerified, "insert_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
+    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicPlugins,
+            command: entry.1,
+            mutability: entry.2,
+            confirmation: .none,
+            target: .none,
+            verification: entry.4,
+            retry: .neverAutomatic,
+            deadline: entry.3,
+            availability: .defaultInstall,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     }
@@ -306,6 +389,9 @@ enum OperationRegistry {
             ToolID.logicTransport.rawValue: "transport",
             ToolID.logicMixer.rawValue: "mixer",
             ToolID.logicNavigate.rawValue: "navigate",
+            ToolID.logicAudio.rawValue: "audio",
+            ToolID.logicSystem.rawValue: "system",
+            ToolID.logicPlugins.rawValue: "plugins",
         ]
         let mismatches = entries
             .filter { entry in

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -52,7 +52,9 @@ struct OperationRegistryTests {
         "rename_marker": .unsupported,
     ]
 
-    private static let expectedRegistryCount = commands.count + mixerCommands.count + navigateCommands.count
+    private static let smallToolCount = 8 // logic_audio(1) + logic_system(4) + logic_plugins(3)
+    private static let expectedRegistryCount =
+        commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
 
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
@@ -256,7 +258,9 @@ struct OperationRegistryTests {
     func deadlineParity() {
         withRegistryFlag(nil) {
             #expect(FeatureFlags.adr003OperationRegistry == false)
-            for spec in OperationRegistry.specs {
+            for spec in OperationRegistry.specs where [
+                ToolID.logicTransport, .logicMixer, .logicNavigate,
+            ].contains(spec.tool) {
                 #expect(spec.deadline.seconds == 25)
                 #expect(OperationRegistry.deadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
                 #expect(LogicProServer.commandDeadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
@@ -282,7 +286,9 @@ struct OperationRegistryTests {
     func flagOn() {
         withRegistryFlag("1") {
             #expect(FeatureFlags.adr003OperationRegistry)
-            for spec in OperationRegistry.specs {
+            for spec in OperationRegistry.specs where [
+                ToolID.logicTransport, .logicMixer, .logicNavigate,
+            ].contains(spec.tool) {
                 #expect(LogicProServer.isMutatingCommand(tool: spec.tool.rawValue, command: spec.command))
                 #expect(LogicProServer.commandDeadlineSeconds(tool: spec.tool.rawValue, command: spec.command) == 25)
             }
@@ -375,6 +381,147 @@ struct OperationRegistryTests {
             }
             #expect(!LogicProServer.isMutatingCommand(tool: "logic_navigate", command: "play"))
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: "import_file") == 300)
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+        }
+    }
+
+    private static let smallToolCommands: [(
+        tool: String,
+        id: String,
+        command: String,
+        mutability: Mutability,
+        deadline: DeadlineClass,
+        verification: VerificationPolicy
+    )] = [
+        ("logic_audio", "audio.analyze_file", "analyze_file", .readOnly, .short, .none),
+        ("logic_system", "system.health", "health", .readOnly, .short, .none),
+        ("logic_system", "system.permissions", "permissions", .readOnly, .short, .none),
+        ("logic_system", "system.refresh_cache", "refresh_cache", .readOnly, .short, .none),
+        ("logic_system", "system.help", "help", .readOnly, .short, .none),
+        ("logic_plugins", "plugins.get_inventory", "get_inventory", .readOnly, .short, .none),
+        ("logic_plugins", "plugins.set_param_verified", "set_param_verified", .mutating, .medium, .readbackRequired),
+        ("logic_plugins", "plugins.insert_verified", "insert_verified", .mutating, .medium, .readbackRequired),
+    ]
+
+    @Test("small-tool registries are exact, unique, and isolated")
+    func smallToolCompletenessAndIsolation() throws {
+        #expect(OperationRegistry.specs.count == 34)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == 34)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 34)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+
+        for toolRawValue in ["logic_audio", "logic_system", "logic_plugins"] {
+            let tool = try #require(ToolID(rawValue: toolRawValue))
+            let expected = Self.smallToolCommands.filter { $0.tool == toolRawValue }
+            let actual = OperationRegistry.specs.filter { $0.tool == tool }
+            #expect(Set(actual.map(\.command)) == Set(expected.map(\.command)))
+            #expect(Set(actual.map(\.id.rawValue)) == Set(expected.map(\.id)))
+        }
+
+        #expect(OperationRegistry.spec(tool: "logic_audio", command: "health") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_system", command: "analyze_file") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_plugins", command: "refresh_cache") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_system", command: "list_recent_traces") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_system", command: "get_trace") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_system", command: "clear_traces") == nil)
+    }
+
+    @Test("all small-tool metadata matches current runtime truth")
+    func smallToolMetadata() throws {
+        for entry in Self.smallToolCommands {
+            let tool = try #require(ToolID(rawValue: entry.tool))
+            let id = try #require(OperationID(rawValue: entry.id))
+            let spec = try #require(OperationRegistry.spec(tool: entry.tool, command: entry.command))
+            #expect(spec.id == id)
+            #expect(spec.tool == tool)
+            #expect(spec.command == entry.command)
+            #expect(spec.mutability == entry.mutability)
+            #expect(spec.confirmation == .none)
+            #expect(spec.target == .none)
+            #expect(spec.verification == entry.verification)
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == entry.deadline)
+            #expect(spec.availability == .defaultInstall)
+            #expect(spec.capability.rawValue == entry.id)
+        }
+    }
+
+    @Test("derived small-tool mutations equal unchanged legacy behavior")
+    func smallToolLegacyMutationParity() throws {
+        for toolRawValue in ["logic_audio", "logic_system", "logic_plugins"] {
+            let tool = try #require(ToolID(rawValue: toolRawValue))
+            let expected = Set(Self.smallToolCommands
+                .filter { $0.tool == toolRawValue && $0.mutability == Mutability.`mutating` }
+                .map(\.command))
+            #expect(OperationRegistry.mutatingCommands(tool: tool) == expected)
+            #expect(expected == (LogicProServer.mutatingCommandsByTool[toolRawValue] ?? []))
+        }
+    }
+
+    @Test("read-only registry entries preserve flag-off and flag-on mutability")
+    func smallToolReadOnlyFlagParity() {
+        let entries = Self.smallToolCommands.filter { $0.mutability == .readOnly }
+
+        withRegistryFlag(nil) {
+            for entry in entries {
+                #expect(!LogicProServer.usesOperationRegistry(tool: entry.tool))
+                #expect(!LogicProServer.isMutatingCommand(tool: entry.tool, command: entry.command))
+            }
+        }
+        withRegistryFlag("1") {
+            for entry in entries {
+                #expect(LogicProServer.usesOperationRegistry(tool: entry.tool))
+                #expect(!LogicProServer.isMutatingCommand(tool: entry.tool, command: entry.command))
+            }
+        }
+    }
+
+    @Test("plugin medium deadlines preserve flag-off and flag-on legacy parity")
+    func pluginMediumDeadlineFlagParity() {
+        let commands = ["set_param_verified", "insert_verified"]
+
+        for command in commands {
+            #expect(OperationRegistry.deadlineSeconds(tool: "logic_plugins", command: command) == 90)
+        }
+        withRegistryFlag(nil) {
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_plugins"))
+            for command in commands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_plugins", command: command) == 90)
+            }
+        }
+        withRegistryFlag("1") {
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_plugins"))
+            for command in commands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_plugins", command: command) == 90)
+            }
+        }
+    }
+
+    @Test("small tools use registry only behind the flag and retain legacy fallbacks")
+    func smallToolFlagGateAndFallbacks() {
+        withRegistryFlag(nil) {
+            for entry in Self.smallToolCommands {
+                #expect(!LogicProServer.usesOperationRegistry(tool: entry.tool))
+                #expect(LogicProServer.isMutatingCommand(tool: entry.tool, command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: entry.tool, command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+        withRegistryFlag("1") {
+            for tool in ["logic_transport", "logic_mixer", "logic_navigate", "logic_audio", "logic_system", "logic_plugins"] {
+                #expect(LogicProServer.usesOperationRegistry(tool: tool))
+            }
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            for entry in Self.smallToolCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: entry.tool, command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: entry.tool, command: entry.command)
+                    == entry.deadline.seconds)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_audio", command: "import_file"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_audio", command: "import_file") == 300)
             #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
         }
     }


### PR DESCRIPTION
## Summary
4th vertical increment for ADR-003 (#286) — adds `logic_audio` (1 command), `logic_system` (4), `logic_plugins` (3) to the operation registry, following transport (#316), mixer (#319), navigate (#321).

Two firsts for the registry, both test-pinned:
- **First read-only entries**: `audio.analyze_file`, `system.health`/`permissions`/`refresh_cache`/`help`, `plugins.get_inventory` (all confirmed read-only against the dispatchers — none mutate Logic state).
- **First `.medium` (90s) deadline entries**: `plugins.set_param_verified` / `plugins.insert_verified` — both mutating, `.readbackRequired` (AX-identified target, write, readback; State A only on tolerance match).

- `LogicProServer.usesOperationRegistry` refactored from a 3-way `||` chain to `OperationRegistry.registeredToolRawValues.contains(tool)` so each new vertical enrolls automatically (flag-off semantics byte-identical).
- The two existing "all specs mutating / all 25s" registry assertions are now explicitly scoped to `{transport, mixer, navigate}` (kept at full strength) so they can't silently weaken as read-only / longer-deadline commands join.
- `expectedRegistryCount` updated to include the 8 new specs (documented `smallToolCount` constant).
- Dispatcher runtime untouched; behind `FeatureFlags.adr003OperationRegistry` (default off); no runtime behavior change.

## Test plan
- [x] `swift build -c release` clean
- [x] Full `swift test --no-parallel` — **2316/2316** (run out-of-sandbox by CTO; this run caught and fixed a stale `expectedRegistryCount` the in-sandbox run had missed)
- [x] New tests: read-only-derivation (flag-on `isMutatingCommand` false, matches flag-off legacy), plugins-90s flag parity, cross-tool isolation