### PR TITLE
feat(adr-003): operation registry — logic_edit vertical (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -33,6 +33,20 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case pluginsGetInventory = "plugins.get_inventory"
     case pluginsSetParamVerified = "plugins.set_param_verified"
     case pluginsInsertVerified = "plugins.insert_verified"
+    case editUndo = "edit.undo"
+    case editRedo = "edit.redo"
+    case editCut = "edit.cut"
+    case editCopy = "edit.copy"
+    case editPaste = "edit.paste"
+    case editDelete = "edit.delete"
+    case editSelectAll = "edit.select_all"
+    case editSplit = "edit.split"
+    case editJoin = "edit.join"
+    case editQuantize = "edit.quantize"
+    case editBounceInPlace = "edit.bounce_in_place"
+    case editNormalize = "edit.normalize"
+    case editDuplicate = "edit.duplicate"
+    case editToggleStepInput = "edit.toggle_step_input"
 }
 
 enum ToolID: String, Sendable, Equatable {
@@ -42,6 +56,7 @@ enum ToolID: String, Sendable, Equatable {
     case logicAudio = "logic_audio"
     case logicSystem = "logic_system"
     case logicPlugins = "logic_plugins"
+    case logicEdit = "logic_edit"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -149,6 +164,11 @@ enum OperationRegistry {
         ToolID.logicPlugins.rawValue: [
             "plugins.get_inventory", "plugins.set_param_verified", "plugins.insert_verified",
         ],
+        ToolID.logicEdit.rawValue: [
+            "edit.undo", "edit.redo", "edit.cut", "edit.copy", "edit.paste", "edit.delete",
+            "edit.select_all", "edit.split", "edit.join", "edit.quantize",
+            "edit.bounce_in_place", "edit.normalize", "edit.duplicate", "edit.toggle_step_input",
+        ],
     ]
 
     private static let allowedCommandsByTool: [String: Set<String>] = [
@@ -172,6 +192,10 @@ enum OperationRegistry {
         ],
         ToolID.logicPlugins.rawValue: [
             "get_inventory", "set_param_verified", "insert_verified",
+        ],
+        ToolID.logicEdit.rawValue: [
+            "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
+            "quantize", "bounce_in_place", "normalize", "duplicate", "toggle_step_input",
         ],
     ]
 
@@ -302,6 +326,35 @@ enum OperationRegistry {
             availability: .defaultInstall,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
+    } + ([
+        (.editUndo, "undo", AvailabilityPolicy.defaultInstall, VerificationPolicy.none),
+        (.editRedo, "redo", .defaultInstall, .none),
+        (.editCut, "cut", .defaultInstall, .none),
+        (.editCopy, "copy", .defaultInstall, .none),
+        (.editPaste, "paste", .defaultInstall, .none),
+        (.editDelete, "delete", .defaultInstall, .none),
+        (.editSelectAll, "select_all", .defaultInstall, .none),
+        (.editSplit, "split", .defaultInstall, .none),
+        (.editJoin, "join", .defaultInstall, .none),
+        (.editQuantize, "quantize", .defaultInstall, .none),
+        (.editBounceInPlace, "bounce_in_place", .defaultInstall, .none),
+        (.editNormalize, "normalize", .requiresKeyBinding, .none),
+        (.editDuplicate, "duplicate", .requiresKeyBinding, .none),
+        (.editToggleStepInput, "toggle_step_input", .requiresKeyBinding, .none),
+    ] as [(OperationID, String, AvailabilityPolicy, VerificationPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicEdit,
+            command: entry.1,
+            mutability: Mutability.`mutating`,
+            confirmation: .none,
+            target: .none,
+            verification: entry.3,
+            retry: .neverAutomatic,
+            deadline: .short,
+            availability: entry.2,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
     }
 
     static func spec(tool: String, command: String) -> OperationSpec? {
@@ -392,6 +445,7 @@ enum OperationRegistry {
             ToolID.logicAudio.rawValue: "audio",
             ToolID.logicSystem.rawValue: "system",
             ToolID.logicPlugins.rawValue: "plugins",
+            ToolID.logicEdit.rawValue: "edit",
         ]
         let mismatches = entries
             .filter { entry in

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -54,7 +54,7 @@ struct OperationRegistryTests {
 
     private static let smallToolCount = 8 // logic_audio(1) + logic_system(4) + logic_plugins(3)
     private static let expectedRegistryCount =
-        commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
+        commands.count + mixerCommands.count + navigateCommands.count + smallToolCount + editCommands.count
 
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
@@ -405,9 +405,9 @@ struct OperationRegistryTests {
 
     @Test("small-tool registries are exact, unique, and isolated")
     func smallToolCompletenessAndIsolation() throws {
-        #expect(OperationRegistry.specs.count == 34)
-        #expect(Set(OperationRegistry.specs.map(\.id)).count == 34)
-        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 34)
+        #expect(OperationRegistry.specs.count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == Self.expectedRegistryCount)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
         #expect(OperationRegistry.validationErrors().isEmpty)
 
@@ -522,6 +522,102 @@ struct OperationRegistryTests {
             }
             #expect(!LogicProServer.isMutatingCommand(tool: "logic_audio", command: "import_file"))
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_audio", command: "import_file") == 300)
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+        }
+    }
+
+    private static let editCommands: [(
+        id: String,
+        command: String,
+        availability: AvailabilityPolicy,
+        verification: VerificationPolicy
+    )] = [
+        ("edit.undo", "undo", .defaultInstall, .none),
+        ("edit.redo", "redo", .defaultInstall, .none),
+        ("edit.cut", "cut", .defaultInstall, .none),
+        ("edit.copy", "copy", .defaultInstall, .none),
+        ("edit.paste", "paste", .defaultInstall, .none),
+        ("edit.delete", "delete", .defaultInstall, .none),
+        ("edit.select_all", "select_all", .defaultInstall, .none),
+        ("edit.split", "split", .defaultInstall, .none),
+        ("edit.join", "join", .defaultInstall, .none),
+        ("edit.quantize", "quantize", .defaultInstall, .none),
+        ("edit.bounce_in_place", "bounce_in_place", .defaultInstall, .none),
+        ("edit.normalize", "normalize", .requiresKeyBinding, .none),
+        ("edit.duplicate", "duplicate", .requiresKeyBinding, .none),
+        ("edit.toggle_step_input", "toggle_step_input", .requiresKeyBinding, .none),
+    ]
+
+    @Test("edit registry is exact, unique, and isolated")
+    func editCompletenessAndIsolation() throws {
+        let tool = try #require(ToolID(rawValue: "logic_edit"))
+        let editSpecs = OperationRegistry.specs.filter { $0.tool == tool }
+        #expect(editSpecs.count == Self.editCommands.count)
+        #expect(Set(editSpecs.map(\.command)) == Set(Self.editCommands.map(\.command)))
+        #expect(Set(editSpecs.map(\.id.rawValue)) == Set(Self.editCommands.map(\.id)))
+        #expect(OperationRegistry.specs.count == 48)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == 48)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 48)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+
+        #expect(OperationRegistry.spec(tool: "logic_edit", command: "play") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_transport", command: "undo") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_mixer", command: "undo") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_navigate", command: "undo") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_edit", command: "unknown") == nil)
+    }
+
+    @Test("all edit metadata and derived availability match runtime truth")
+    func editMetadataAndAvailability() throws {
+        let tool = try #require(ToolID(rawValue: "logic_edit"))
+
+        for entry in Self.editCommands {
+            let id = try #require(OperationID(rawValue: entry.id))
+            let spec = try #require(OperationRegistry.spec(tool: tool.rawValue, command: entry.command))
+            #expect(spec.id == id)
+            #expect(spec.tool == tool)
+            #expect(spec.command == entry.command)
+            #expect(spec.mutability == Mutability.`mutating`)
+            #expect(spec.confirmation == .none)
+            #expect(spec.target == .none)
+            #expect(spec.verification == entry.verification)
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == .short)
+            #expect(spec.availability == entry.availability)
+            #expect(spec.capability.rawValue == entry.id)
+        }
+    }
+
+    @Test("derived edit mutations and deadlines equal unchanged legacy behavior")
+    func editLegacyParity() throws {
+        let tool = try #require(ToolID(rawValue: "logic_edit"))
+        let commands = Set(Self.editCommands.map(\.command))
+        #expect(OperationRegistry.mutatingCommands(tool: tool) == commands)
+        #expect(OperationRegistry.mutatingCommands(tool: tool) == LogicProServer.mutatingCommandsByTool[tool.rawValue])
+        for command in commands {
+            #expect(OperationRegistry.deadlineSeconds(tool: tool.rawValue, command: command) == 25)
+        }
+    }
+
+    @Test("edit uses registry only behind the flag and remains cross-tool isolated")
+    func editFlagGateAndFallbacks() {
+        withRegistryFlag(nil) {
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_edit"))
+            for entry in Self.editCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_edit", command: entry.command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_edit", command: entry.command) == 25)
+            }
+        }
+        withRegistryFlag("1") {
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_edit"))
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            for entry in Self.editCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_edit", command: entry.command))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_edit", command: entry.command) == 25)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_edit", command: "play"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_edit", command: "play") == 25)
             #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
         }
     }


### PR DESCRIPTION
## Summary
5th vertical increment for ADR-003 (#286) — registers `logic_edit`'s 14 commands. 7 of 10 tools now covered.

All 14 are mutating, `.short` (25s) deadline, `verification: .none` (routed `[.midiKeyCommands, .cgEvent]` with no AX readback path — `EditDispatcher`'s `treatingUnverifiedAsError` is honesty surfacing, not verification).

**Availability honestly derived from the channel layer (another registry drift-catch):**
- `undo`/`redo`/`cut`/`copy`/`paste`/`delete`/`select_all`/`split`/`join`/`quantize`/`bounce_in_place` → `.defaultInstall` (standard Logic key bindings mapped in `CGEventChannel`)
- `normalize`/`duplicate`/`toggle_step_input` → `.requiresKeyBinding` — the channel's own `MIDIKeyCommandsChannel.manualValidationDetailSuffix` explicitly documents these three as *"keycmd-only (no working non-keycmd fallback on Logic 12.2)"*, requiring manual MIDI Learn.

Note: the initial implementation drafted `toggle_step_input` as `.defaultInstall`/`.readbackRequired`; CTO review against the channel code corrected it to `.requiresKeyBinding`/`.none` to match its documented keycmd-only, fire-and-forget reality.

Dispatcher runtime untouched; flag-gated (`FeatureFlags.adr003OperationRegistry`, default off); no runtime behavior change.

## Test plan
- [x] `swift build -c release` clean
- [x] Full `swift test --no-parallel` — **2323/2323** (out-of-sandbox, CTO)
- [x] New tests: exact/unique, legacy mutating+deadline parity, availability/verification per-command pinning, flag-off regression, cross-tool isolation