### PR TITLE
feat(adr-003): operation registry — logic_project vertical (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -47,6 +47,22 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case editNormalize = "edit.normalize"
     case editDuplicate = "edit.duplicate"
     case editToggleStepInput = "edit.toggle_step_input"
+    case projectNew = "project.new"
+    case projectOpen = "project.open"
+    case projectSave = "project.save"
+    case projectSaveAs = "project.save_as"
+    case projectClose = "project.close"
+    case projectBounce = "project.bounce"
+    case projectIsRunning = "project.is_running"
+    case projectLaunch = "project.launch"
+    case projectQuit = "project.quit"
+    case projectGetRegions = "project.get_regions"
+    case projectExportPlan = "project.export_plan"
+    case projectExportRun = "project.export_run"
+    case projectExportResume = "project.export_resume"
+    case projectAudit = "project.audit"
+    case projectCleanupPlan = "project.cleanup_plan"
+    case projectCleanupApply = "project.cleanup_apply"
 }
 
 enum ToolID: String, Sendable, Equatable {
@@ -57,6 +73,7 @@ enum ToolID: String, Sendable, Equatable {
     case logicSystem = "logic_system"
     case logicPlugins = "logic_plugins"
     case logicEdit = "logic_edit"
+    case logicProject = "logic_project"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -169,6 +186,13 @@ enum OperationRegistry {
             "edit.select_all", "edit.split", "edit.join", "edit.quantize",
             "edit.bounce_in_place", "edit.normalize", "edit.duplicate", "edit.toggle_step_input",
         ],
+        ToolID.logicProject.rawValue: [
+            "project.new", "project.open", "project.save", "project.save_as", "project.close",
+            "project.bounce", "project.is_running", "project.launch", "project.quit",
+            "project.get_regions", "project.export_plan", "project.export_run",
+            "project.export_resume", "project.audit", "project.cleanup_plan",
+            "project.cleanup_apply",
+        ],
     ]
 
     private static let allowedCommandsByTool: [String: Set<String>] = [
@@ -196,6 +220,11 @@ enum OperationRegistry {
         ToolID.logicEdit.rawValue: [
             "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
             "quantize", "bounce_in_place", "normalize", "duplicate", "toggle_step_input",
+        ],
+        ToolID.logicProject.rawValue: [
+            "new", "open", "save", "save_as", "close", "bounce", "is_running", "launch",
+            "quit", "get_regions", "export_plan", "export_run", "export_resume", "audit",
+            "cleanup_plan", "cleanup_apply",
         ],
     ]
 
@@ -355,6 +384,37 @@ enum OperationRegistry {
             availability: entry.2,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
+    } + ([
+        (.projectNew, "new", Mutability.`mutating`, ConfirmationPolicy.l1, VerificationPolicy.readbackRequired, DeadlineClass.medium),
+        (.projectOpen, "open", Mutability.`mutating`, ConfirmationPolicy.l2, VerificationPolicy.readbackRequired, DeadlineClass.long),
+        (.projectSave, "save", Mutability.`mutating`, ConfirmationPolicy.l1, VerificationPolicy.readbackRequired, DeadlineClass.medium),
+        (.projectSaveAs, "save_as", Mutability.`mutating`, ConfirmationPolicy.l2, VerificationPolicy.readbackRequired, DeadlineClass.long),
+        (.projectClose, "close", Mutability.`mutating`, ConfirmationPolicy.l3, VerificationPolicy.none, DeadlineClass.medium),
+        (.projectBounce, "bounce", Mutability.`mutating`, ConfirmationPolicy.l2, VerificationPolicy.readbackRequired, DeadlineClass.long),
+        (.projectIsRunning, "is_running", Mutability.readOnly, ConfirmationPolicy.none, VerificationPolicy.none, DeadlineClass.short),
+        (.projectLaunch, "launch", Mutability.`mutating`, ConfirmationPolicy.l1, VerificationPolicy.readbackRequired, DeadlineClass.short),
+        (.projectQuit, "quit", Mutability.`mutating`, ConfirmationPolicy.l3, VerificationPolicy.readbackRequired, DeadlineClass.medium),
+        (.projectGetRegions, "get_regions", Mutability.readOnly, ConfirmationPolicy.none, VerificationPolicy.none, DeadlineClass.short),
+        (.projectExportPlan, "export_plan", Mutability.readOnly, ConfirmationPolicy.none, VerificationPolicy.none, DeadlineClass.short),
+        (.projectExportRun, "export_run", Mutability.`mutating`, ConfirmationPolicy.l2, VerificationPolicy.readbackRequired, DeadlineClass.long),
+        (.projectExportResume, "export_resume", Mutability.`mutating`, ConfirmationPolicy.l2, VerificationPolicy.readbackRequired, DeadlineClass.long),
+        (.projectAudit, "audit", Mutability.readOnly, ConfirmationPolicy.none, VerificationPolicy.none, DeadlineClass.short),
+        (.projectCleanupPlan, "cleanup_plan", Mutability.readOnly, ConfirmationPolicy.none, VerificationPolicy.none, DeadlineClass.short),
+        (.projectCleanupApply, "cleanup_apply", Mutability.`mutating`, ConfirmationPolicy.l1, VerificationPolicy.readbackRequired, DeadlineClass.medium),
+    ] as [(OperationID, String, Mutability, ConfirmationPolicy, VerificationPolicy, DeadlineClass)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicProject,
+            command: entry.1,
+            mutability: entry.2,
+            confirmation: entry.3,
+            target: .none,
+            verification: entry.4,
+            retry: .neverAutomatic,
+            deadline: entry.5,
+            availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
     }
 
     static func spec(tool: String, command: String) -> OperationSpec? {
@@ -446,6 +506,7 @@ enum OperationRegistry {
             ToolID.logicSystem.rawValue: "system",
             ToolID.logicPlugins.rawValue: "plugins",
             ToolID.logicEdit.rawValue: "edit",
+            ToolID.logicProject.rawValue: "project",
         ]
         let mismatches = entries
             .filter { entry in

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -54,7 +54,8 @@ struct OperationRegistryTests {
 
     private static let smallToolCount = 8 // logic_audio(1) + logic_system(4) + logic_plugins(3)
     private static let expectedRegistryCount =
-        commands.count + mixerCommands.count + navigateCommands.count + smallToolCount + editCommands.count
+        commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
+            + editCommands.count + projectCommands.count
 
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
@@ -555,9 +556,9 @@ struct OperationRegistryTests {
         #expect(editSpecs.count == Self.editCommands.count)
         #expect(Set(editSpecs.map(\.command)) == Set(Self.editCommands.map(\.command)))
         #expect(Set(editSpecs.map(\.id.rawValue)) == Set(Self.editCommands.map(\.id)))
-        #expect(OperationRegistry.specs.count == 48)
-        #expect(Set(OperationRegistry.specs.map(\.id)).count == 48)
-        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == 48)
+        #expect(OperationRegistry.specs.count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == Self.expectedRegistryCount)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
         #expect(OperationRegistry.validationErrors().isEmpty)
 
@@ -618,6 +619,158 @@ struct OperationRegistryTests {
             }
             #expect(!LogicProServer.isMutatingCommand(tool: "logic_edit", command: "play"))
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_edit", command: "play") == 25)
+            #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+        }
+    }
+
+    private static let projectCommands: [(
+        id: String,
+        command: String,
+        mutability: Mutability,
+        deadline: DeadlineClass,
+        verification: VerificationPolicy
+    )] = [
+        ("project.new", "new", .mutating, .medium, .readbackRequired),
+        ("project.open", "open", .mutating, .long, .readbackRequired),
+        ("project.save", "save", .mutating, .medium, .readbackRequired),
+        ("project.save_as", "save_as", .mutating, .long, .readbackRequired),
+        ("project.close", "close", .mutating, .medium, .none),
+        ("project.bounce", "bounce", .mutating, .long, .readbackRequired),
+        ("project.is_running", "is_running", .readOnly, .short, .none),
+        ("project.launch", "launch", .mutating, .short, .readbackRequired),
+        ("project.quit", "quit", .mutating, .medium, .readbackRequired),
+        ("project.get_regions", "get_regions", .readOnly, .short, .none),
+        ("project.export_plan", "export_plan", .readOnly, .short, .none),
+        ("project.export_run", "export_run", .mutating, .long, .readbackRequired),
+        ("project.export_resume", "export_resume", .mutating, .long, .readbackRequired),
+        ("project.audit", "audit", .readOnly, .short, .none),
+        ("project.cleanup_plan", "cleanup_plan", .readOnly, .short, .none),
+        ("project.cleanup_apply", "cleanup_apply", .mutating, .medium, .readbackRequired),
+    ]
+
+    private static func confirmationPolicy(for command: String) -> ConfirmationPolicy {
+        switch DestructivePolicy.level(for: command) {
+        case .l0: .none
+        case .l1: .l1
+        case .l2: .l2
+        case .l3: .l3
+        }
+    }
+
+    @Test("project registry is exact and globally unique")
+    func projectCompletenessAndUniqueness() throws {
+        let tool = try #require(ToolID(rawValue: "logic_project"))
+        let projectSpecs = OperationRegistry.specs.filter { $0.tool == tool }
+        #expect(projectSpecs.count == Self.projectCommands.count)
+        #expect(Set(projectSpecs.map(\.command)) == Set(Self.projectCommands.map(\.command)))
+        #expect(Set(projectSpecs.map(\.id.rawValue)) == Set(Self.projectCommands.map(\.id)))
+        #expect(OperationRegistry.specs.count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+    }
+
+    @Test("all project metadata matches dispatcher and manifest truth")
+    func projectMetadata() throws {
+        let tool = try #require(ToolID(rawValue: "logic_project"))
+
+        for entry in Self.projectCommands {
+            let id = try #require(OperationID(rawValue: entry.id))
+            let spec = try #require(OperationRegistry.spec(tool: tool.rawValue, command: entry.command))
+            #expect(spec.id == id)
+            #expect(spec.tool == tool)
+            #expect(spec.command == entry.command)
+            #expect(spec.mutability == entry.mutability)
+            #expect(spec.target == .none)
+            #expect(spec.verification == entry.verification)
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == entry.deadline)
+            #expect(spec.availability == .defaultInstall)
+            #expect(spec.capability.rawValue == entry.id)
+        }
+    }
+
+    @Test("project mutations exactly match unchanged legacy behavior")
+    func projectLegacyMutationParity() throws {
+        let tool = try #require(ToolID(rawValue: "logic_project"))
+        let expected = Set(Self.projectCommands
+            .filter { $0.mutability == Mutability.`mutating` }
+            .map(\.command))
+        #expect(expected == Set([
+            "new", "open", "save", "save_as", "close", "bounce", "launch", "quit",
+            "export_run", "export_resume", "cleanup_apply",
+        ]))
+        #expect(OperationRegistry.mutatingCommands(tool: tool) == expected)
+        #expect(expected == LogicProServer.mutatingCommandsByTool[tool.rawValue])
+    }
+
+    @Test("project deadlines exactly match legacy short medium and long tiers")
+    func projectDeadlineParity() {
+        #expect(Self.projectCommands.filter { $0.deadline == .short }.count == 6)
+        #expect(Self.projectCommands.filter { $0.deadline == .medium }.count == 5)
+        #expect(Self.projectCommands.filter { $0.deadline == .long }.count == 5)
+
+        for entry in Self.projectCommands {
+            #expect(OperationRegistry.deadlineSeconds(tool: "logic_project", command: entry.command)
+                == entry.deadline.seconds)
+        }
+        withRegistryFlag(nil) {
+            for entry in Self.projectCommands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+        withRegistryFlag("1") {
+            for entry in Self.projectCommands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+    }
+
+    @Test("project confirmation metadata cannot drift from DestructivePolicy")
+    func projectConfirmationPolicyParity() throws {
+        for entry in Self.projectCommands {
+            let spec = try #require(OperationRegistry.spec(
+                tool: "logic_project",
+                command: entry.command
+            ))
+            #expect(spec.confirmation == Self.confirmationPolicy(for: entry.command))
+        }
+    }
+
+    @Test("flag off preserves all legacy project decisions")
+    func projectFlagOff() {
+        withRegistryFlag(nil) {
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_project"))
+            for entry in Self.projectCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_project", command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+    }
+
+    @Test("project flag gate remains cross-tool isolated with legacy fallbacks")
+    func projectFlagGateAndCrossToolIsolation() {
+        #expect(OperationRegistry.spec(tool: "logic_project", command: "play") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_transport", command: "new") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_audio", command: "open") == nil)
+
+        withRegistryFlag("1") {
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_project"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_transport"))
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            for entry in Self.projectCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_project", command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_project", command: "import_file"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: "import_file") == 300)
             #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
         }
     }


### PR DESCRIPTION
## Summary
6th vertical increment for ADR-003 (#286) — registers `logic_project`'s 16 commands. **8 of 10 tools now covered.**

Registry firsts, all test-pinned:
- **First confirmation-policy entries**, pinned to `DestructivePolicy.level(for:)` by a drift-detection test (`confirmationPolicy(for:)` maps the live policy → the spec's `ConfirmationPolicy`): `quit`/`close` → `.l3`; `save_as`/`bounce`/`open`/`export_run`/`export_resume` → `.l2`; `save`/`new`/`launch`/`cleanup_apply` → `.l1`; `is_running`/`get_regions`/`export_plan`/`audit`/`cleanup_plan` read-only → `.none`.
- **First `.long` (300s) deadline entries** (`open`/`save_as`/`bounce`/`export_run`/`export_resume`).
- 11 mutating / 5 read-only, deadlines matched to the manifest, verification derived per-command from `ProjectDispatcher`.

Also hardens the test suite: replaced the edit vertical's stale hardcoded `specs.count == 48` (and the project block's `== 50`) with the self-updating `Self.expectedRegistryCount`, so per-vertical count assertions can't go stale as more tools register.

Dispatcher runtime untouched; flag-gated (`FeatureFlags.adr003OperationRegistry`, default off); no runtime behavior change.

## Test plan
- [x] `swift build -c release` clean
- [x] Full `swift test --no-parallel` — **2330/2330** (out-of-sandbox, CTO)
- [x] New tests: exact/unique/global-count, DestructivePolicy confirmation drift-detection, deadline parity (first `.long`), read-only derivation, flag-off regression, cross-tool isolation