### PR TITLE
feat(adr-003): operation registry — logic_midi vertical (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -63,6 +63,22 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case projectAudit = "project.audit"
     case projectCleanupPlan = "project.cleanup_plan"
     case projectCleanupApply = "project.cleanup_apply"
+    case midiSendNote = "midi.send_note"
+    case midiSendChord = "midi.send_chord"
+    case midiSendCC = "midi.send_cc"
+    case midiSendProgramChange = "midi.send_program_change"
+    case midiSendPitchBend = "midi.send_pitch_bend"
+    case midiSendAftertouch = "midi.send_aftertouch"
+    case midiSendSysEx = "midi.send_sysex"
+    case midiPlaySequence = "midi.play_sequence"
+    case midiImportFile = "midi.import_file"
+    case midiListPorts = "midi.list_ports"
+    case midiCreateVirtualPort = "midi.create_virtual_port"
+    case midiStepInput = "midi.step_input"
+    case midiMMCPlay = "midi.mmc_play"
+    case midiMMCStop = "midi.mmc_stop"
+    case midiMMCRecord = "midi.mmc_record"
+    case midiMMCLocate = "midi.mmc_locate"
 }
 
 enum ToolID: String, Sendable, Equatable {
@@ -74,6 +90,7 @@ enum ToolID: String, Sendable, Equatable {
     case logicPlugins = "logic_plugins"
     case logicEdit = "logic_edit"
     case logicProject = "logic_project"
+    case logicMidi = "logic_midi"
 }
 
 enum Mutability: Sendable, Equatable {
@@ -193,6 +210,13 @@ enum OperationRegistry {
             "project.export_resume", "project.audit", "project.cleanup_plan",
             "project.cleanup_apply",
         ],
+        ToolID.logicMidi.rawValue: [
+            "midi.send_note", "midi.send_chord", "midi.send_cc", "midi.send_program_change",
+            "midi.send_pitch_bend", "midi.send_aftertouch", "midi.send_sysex",
+            "midi.play_sequence", "midi.import_file", "midi.list_ports",
+            "midi.create_virtual_port", "midi.step_input", "midi.mmc_play", "midi.mmc_stop",
+            "midi.mmc_record", "midi.mmc_locate",
+        ],
     ]
 
     private static let allowedCommandsByTool: [String: Set<String>] = [
@@ -225,6 +249,12 @@ enum OperationRegistry {
             "new", "open", "save", "save_as", "close", "bounce", "is_running", "launch",
             "quit", "get_regions", "export_plan", "export_run", "export_resume", "audit",
             "cleanup_plan", "cleanup_apply",
+        ],
+        ToolID.logicMidi.rawValue: [
+            "send_note", "send_chord", "send_cc", "send_program_change", "send_pitch_bend",
+            "send_aftertouch", "send_sysex", "play_sequence", "import_file", "list_ports",
+            "create_virtual_port", "step_input", "mmc_play", "mmc_stop", "mmc_record",
+            "mmc_locate",
         ],
     ]
 
@@ -415,6 +445,37 @@ enum OperationRegistry {
             availability: .defaultInstall,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
+    } + ([
+        (.midiSendNote, "send_note", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendChord, "send_chord", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendCC, "send_cc", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendProgramChange, "send_program_change", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendPitchBend, "send_pitch_bend", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendAftertouch, "send_aftertouch", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiSendSysEx, "send_sysex", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiPlaySequence, "play_sequence", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.none),
+        (.midiImportFile, "import_file", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired),
+        (.midiListPorts, "list_ports", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+        (.midiCreateVirtualPort, "create_virtual_port", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiStepInput, "step_input", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiMMCPlay, "mmc_play", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiMMCStop, "mmc_stop", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiMMCRecord, "mmc_record", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
+        (.midiMMCLocate, "mmc_locate", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.bestEffort),
+    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy)]).map { entry in
+        OperationSpec(
+            id: entry.0,
+            tool: .logicMidi,
+            command: entry.1,
+            mutability: entry.2,
+            confirmation: .none,
+            target: .none,
+            verification: entry.4,
+            retry: .neverAutomatic,
+            deadline: entry.3,
+            availability: .defaultInstall,
+            capability: CapabilityID(rawValue: entry.0.rawValue)
+        )
     }
 
     static func spec(tool: String, command: String) -> OperationSpec? {
@@ -507,6 +568,7 @@ enum OperationRegistry {
             ToolID.logicPlugins.rawValue: "plugins",
             ToolID.logicEdit.rawValue: "edit",
             ToolID.logicProject.rawValue: "project",
+            ToolID.logicMidi.rawValue: "midi",
         ]
         let mismatches = entries
             .filter { entry in

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -55,7 +55,7 @@ struct OperationRegistryTests {
     private static let smallToolCount = 8 // logic_audio(1) + logic_system(4) + logic_plugins(3)
     private static let expectedRegistryCount =
         commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
-            + editCommands.count + projectCommands.count
+            + editCommands.count + projectCommands.count + midiCommands.count
 
     private func withRegistryFlag(_ value: String?, body: () -> Void) {
         let key = "LOGIC_MCP_ADR003_OPERATION_REGISTRY"
@@ -375,7 +375,7 @@ struct OperationRegistryTests {
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_transport"))
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_mixer"))
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_navigate"))
-            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_midi"))
             for (_, command) in Self.navigateCommands {
                 #expect(LogicProServer.isMutatingCommand(tool: "logic_navigate", command: command))
                 #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_navigate", command: command) == 25)
@@ -514,7 +514,7 @@ struct OperationRegistryTests {
             for tool in ["logic_transport", "logic_mixer", "logic_navigate", "logic_audio", "logic_system", "logic_plugins"] {
                 #expect(LogicProServer.usesOperationRegistry(tool: tool))
             }
-            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_midi"))
             for entry in Self.smallToolCommands {
                 #expect(LogicProServer.isMutatingCommand(tool: entry.tool, command: entry.command)
                     == (entry.mutability == Mutability.`mutating`))
@@ -612,7 +612,7 @@ struct OperationRegistryTests {
         }
         withRegistryFlag("1") {
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_edit"))
-            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_midi"))
             for entry in Self.editCommands {
                 #expect(LogicProServer.isMutatingCommand(tool: "logic_edit", command: entry.command))
                 #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_edit", command: entry.command) == 25)
@@ -762,7 +762,7 @@ struct OperationRegistryTests {
         withRegistryFlag("1") {
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_project"))
             #expect(LogicProServer.usesOperationRegistry(tool: "logic_transport"))
-            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_midi"))
             for entry in Self.projectCommands {
                 #expect(LogicProServer.isMutatingCommand(tool: "logic_project", command: entry.command)
                     == (entry.mutability == Mutability.`mutating`))
@@ -772,6 +772,142 @@ struct OperationRegistryTests {
             #expect(!LogicProServer.isMutatingCommand(tool: "logic_project", command: "import_file"))
             #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_project", command: "import_file") == 300)
             #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: "import_file"))
+        }
+    }
+
+    private static let midiCommands: [(
+        id: String,
+        command: String,
+        mutability: Mutability,
+        deadline: DeadlineClass,
+        verification: VerificationPolicy
+    )] = [
+        ("midi.send_note", "send_note", .mutating, .short, .none),
+        ("midi.send_chord", "send_chord", .mutating, .short, .none),
+        ("midi.send_cc", "send_cc", .mutating, .short, .none),
+        ("midi.send_program_change", "send_program_change", .mutating, .short, .none),
+        ("midi.send_pitch_bend", "send_pitch_bend", .mutating, .short, .none),
+        ("midi.send_aftertouch", "send_aftertouch", .mutating, .short, .none),
+        ("midi.send_sysex", "send_sysex", .mutating, .short, .none),
+        ("midi.play_sequence", "play_sequence", .mutating, .medium, .none),
+        ("midi.import_file", "import_file", .mutating, .long, .readbackRequired),
+        ("midi.list_ports", "list_ports", .readOnly, .short, .none),
+        ("midi.create_virtual_port", "create_virtual_port", .mutating, .short, .none),
+        ("midi.step_input", "step_input", .mutating, .short, .none),
+        ("midi.mmc_play", "mmc_play", .mutating, .short, .none),
+        ("midi.mmc_stop", "mmc_stop", .mutating, .short, .none),
+        ("midi.mmc_record", "mmc_record", .mutating, .short, .none),
+        ("midi.mmc_locate", "mmc_locate", .mutating, .short, .bestEffort),
+    ]
+
+    @Test("MIDI registry is exact, globally unique, and cross-tool isolated")
+    func midiCompletenessAndIsolation() throws {
+        let tool = try #require(ToolID(rawValue: "logic_midi"))
+        let midiSpecs = OperationRegistry.specs.filter { $0.tool == tool }
+        #expect(midiSpecs.count == Self.midiCommands.count)
+        #expect(Set(midiSpecs.map(\.command)) == Set(Self.midiCommands.map(\.command)))
+        #expect(Set(midiSpecs.map(\.id.rawValue)) == Set(Self.midiCommands.map(\.id)))
+        #expect(OperationRegistry.specs.count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)).count == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map { "\($0.tool.rawValue):\($0.command)" }).count
+            == Self.expectedRegistryCount)
+        #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
+        #expect(OperationRegistry.validationErrors().isEmpty)
+
+        #expect(OperationRegistry.spec(tool: "logic_midi", command: "play") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_transport", command: "send_note") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_project", command: "import_file") == nil)
+        #expect(OperationRegistry.spec(tool: "logic_midi", command: "send_note.keycmd") == nil)
+    }
+
+    @Test("all MIDI metadata matches dispatcher and routing truth")
+    func midiMetadata() throws {
+        let tool = try #require(ToolID(rawValue: "logic_midi"))
+
+        for entry in Self.midiCommands {
+            let id = try #require(OperationID(rawValue: entry.id))
+            let spec = try #require(OperationRegistry.spec(tool: tool.rawValue, command: entry.command))
+            #expect(spec.id == id)
+            #expect(spec.tool == tool)
+            #expect(spec.command == entry.command)
+            #expect(spec.mutability == entry.mutability)
+            #expect(spec.confirmation == .none)
+            #expect(spec.target == .none)
+            #expect(spec.verification == entry.verification)
+            #expect(spec.retry == .neverAutomatic)
+            #expect(spec.deadline == entry.deadline)
+            #expect(spec.availability == .defaultInstall)
+            #expect(spec.capability.rawValue == entry.id)
+        }
+    }
+
+    @Test("MIDI mutations exactly match unchanged legacy behavior")
+    func midiLegacyMutationParity() throws {
+        let tool = try #require(ToolID(rawValue: "logic_midi"))
+        let expected = Set(Self.midiCommands
+            .filter { $0.mutability == Mutability.`mutating` }
+            .map(\.command))
+        #expect(expected == Set([
+            "send_note", "send_chord", "send_cc", "send_program_change", "send_pitch_bend",
+            "send_aftertouch", "send_sysex", "play_sequence", "import_file", "create_virtual_port",
+            "step_input", "mmc_play", "mmc_stop", "mmc_record", "mmc_locate",
+        ]))
+        #expect(OperationRegistry.mutatingCommands(tool: tool) == expected)
+        #expect(expected == LogicProServer.mutatingCommandsByTool[tool.rawValue])
+        #expect(!expected.contains("list_ports"))
+    }
+
+    @Test("MIDI deadlines preserve short medium and long legacy tiers")
+    func midiDeadlineParity() {
+        #expect(Self.midiCommands.filter { $0.deadline == .short }.count == 14)
+        #expect(Self.midiCommands.filter { $0.deadline == .medium }.map(\.command) == ["play_sequence"])
+        #expect(Self.midiCommands.filter { $0.deadline == .long }.map(\.command) == ["import_file"])
+
+        for entry in Self.midiCommands {
+            #expect(OperationRegistry.deadlineSeconds(tool: "logic_midi", command: entry.command)
+                == entry.deadline.seconds)
+        }
+        withRegistryFlag(nil) {
+            for entry in Self.midiCommands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+        withRegistryFlag("1") {
+            for entry in Self.midiCommands {
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+    }
+
+    @Test("flag off preserves every legacy MIDI decision")
+    func midiFlagOff() {
+        withRegistryFlag(nil) {
+            #expect(!LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            for entry in Self.midiCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+        }
+    }
+
+    @Test("MIDI flag gate remains cross-tool isolated")
+    func midiFlagGateAndCrossToolIsolation() {
+        withRegistryFlag("1") {
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_midi"))
+            #expect(LogicProServer.usesOperationRegistry(tool: "logic_project"))
+            for entry in Self.midiCommands {
+                #expect(LogicProServer.isMutatingCommand(tool: "logic_midi", command: entry.command)
+                    == (entry.mutability == Mutability.`mutating`))
+                #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: entry.command)
+                    == entry.deadline.seconds)
+            }
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_midi", command: "list_ports"))
+            #expect(!LogicProServer.isMutatingCommand(tool: "logic_midi", command: "is_running"))
+            #expect(LogicProServer.commandDeadlineSeconds(tool: "logic_midi", command: "open") == 300)
         }
     }
 }


### PR DESCRIPTION
## Summary
7th vertical increment for ADR-003 (#286) — registers `logic_midi`'s 16 commands. **9 of 10 tools now covered.**

- 15 mutating / `list_ports` read-only; deadlines `play_sequence` `.medium` (90s), `import_file` `.long` (300s), rest `.short`.
- Verification derived per-command from `MIDIDispatcher` + `RoutingTable`:
  - the 7 send-style ops + `play_sequence` are CoreMIDI fire-and-forget → `.none`
  - `import_file` has AX track/region readback → `.readbackRequired`
  - **`mmc_locate` → `.bestEffort`** (first `.bestEffort` entry) — the `bar` path attempts a transport readback while the `time` path is send-only State B, so best-effort is the honest classification
  - `list_ports` read-only → `.none`
- Existing cross-tool tests that used `logic_midi` as a *not-yet-registered* negative example are correctly flipped to expect registry-driven behavior now that it's registered (the flag-off negatives are preserved).

Dispatcher runtime untouched; flag-gated (default off); no runtime behavior change.

## Test plan
- [x] `swift build -c release` clean
- [x] Full `swift test --no-parallel` — **2336/2336** (out-of-sandbox, CTO)
- [x] New tests: exact/unique, legacy mutating+deadline parity, per-command verification pinning (incl. the `.bestEffort` mmc_locate and `.long` import_file), flag-off regression, cross-tool isolation