### PR TITLE
feat(adr-005): operation trace — logic_tracks verified writes (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -225,39 +225,77 @@ struct TrackDispatcher {
                     ]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "track.rename",
                 params: ["index": String(index), "name": name]
             )
             guard result.isSuccess else {
-                return toolTextResult(result.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(result.message, isError: true),
+                    traceID: traceID
+                )
             }
             if let data = result.message.data(using: .utf8),
                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let verified = json["verified"] as? Bool,
                verified == false {
-                return toolTextResult(result.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(result.message, isError: true),
+                    traceID: traceID
+                )
             }
             if let resolvedReference {
                 if var payload = decodedJSONObject(result.message) {
                     payload["track_ref"] = resolvedReference.rawValue
-                    return toolTextResult(HonestContract.jsonString(payload))
+                    return await finalizeTrace(
+                        toolTextResult(HonestContract.jsonString(payload)),
+                        traceID: traceID
+                    )
                 }
-                return toolTextResult(HonestContract.encodeStateA(extras: [
-                    "operation": "track.rename",
-                    "track_ref": resolvedReference.rawValue,
-                ]))
+                return await finalizeTrace(
+                    toolTextResult(HonestContract.encodeStateA(extras: [
+                        "operation": "track.rename",
+                        "track_ref": resolvedReference.rawValue,
+                    ])),
+                    traceID: traceID
+                )
             }
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "mute":
-            return await handleToggle(command: "mute", operation: "track.set_mute", params: params, router: router)
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await handleToggle(
+                command: "mute",
+                operation: "track.set_mute",
+                params: params,
+                router: router,
+                traceID: traceID
+            )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "solo":
-            return await handleToggle(command: "solo", operation: "track.set_solo", params: params, router: router)
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await handleToggle(
+                command: "solo",
+                operation: "track.set_solo",
+                params: params,
+                router: router,
+                traceID: traceID
+            )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "arm":
-            return await handleToggle(command: "arm", operation: "track.set_arm", params: params, router: router)
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await handleToggle(
+                command: "arm",
+                operation: "track.set_arm",
+                params: params,
+                router: router,
+                traceID: traceID
+            )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "record_sequence":
             let result = await handleRecordSequenceSMF(params: params, router: router, cache: cache)
@@ -514,7 +552,8 @@ struct TrackDispatcher {
         command: String,
         operation: String,
         params: [String: Value],
-        router: ChannelRouter
+        router: ChannelRouter,
+        traceID: TraceID? = nil
     ) async -> CallTool.Result {
         guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
             return toolInvalidParamsResult(
@@ -533,6 +572,7 @@ struct TrackDispatcher {
         } else {
             enabled = true
         }
+        await recordWriteBoundary(traceID)
         let result = await router.route(
             operation: operation,
             params: ["index": String(index), "enabled": String(enabled)]
@@ -544,6 +584,66 @@ struct TrackDispatcher {
             return toolTextResult(result.message, isError: true)
         }
         return toolTextResult(result)
+    }
+
+    private static func startTraceIfEnabled(command: String) async -> TraceID? {
+        guard FeatureFlags.adr005OperationTrace,
+              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
+            return nil
+        }
+        switch spec.id {
+        case .tracksRename, .tracksMute, .tracksSolo, .tracksArm:
+            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
+            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+                "operation_id": spec.id.rawValue,
+                "command": command,
+            ])
+            return id
+        default:
+            return nil
+        }
+    }
+
+    private static func recordWriteBoundary(_ traceID: TraceID?) async {
+        guard let traceID else { return }
+        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
+    }
+
+    private static func finalizeTrace(
+        _ result: CallTool.Result,
+        traceID: TraceID?
+    ) async -> CallTool.Result {
+        guard let traceID else { return result }
+        guard case .text(let raw, _, _) = result.content.first else {
+            await OperationTraceStore.shared.record(
+                traceID,
+                phase: .verificationCompleted,
+                attributes: ["readback_state": result.isError == true ? "C" : "A"]
+            )
+            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+            await OperationTraceStore.shared.complete(traceID)
+            return result
+        }
+
+        let object = decodedJSONObject(raw)
+        var attributes = [
+            "readback_state": object?["state"] as? String
+                ?? (result.isError == true ? "C" : "A"),
+        ]
+        if let errorCode = object?["error"] as? String {
+            attributes["error_code"] = errorCode
+        }
+        await OperationTraceStore.shared.record(
+            traceID,
+            phase: .verificationCompleted,
+            attributes: attributes
+        )
+        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(traceID)
+
+        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
+        guard merged != raw else { return result }
+        return toolTextResult(merged, isError: result.isError == true)
     }
 
     private static func staleTargetReferenceResult(_ rawReference: String?) -> CallTool.Result {

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MCP
 import Testing
 @testable import LogicProMCP
 
@@ -442,5 +443,105 @@ extension OperationTraceTests {
         #expect(result.isError == true)
         #expect(await channel.executedOperations.isEmpty)
         #expect(await OperationTraceStore.shared.recent().isEmpty)
+    }
+}
+
+private actor OperationTraceTrackChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private(set) var executedOperations: [String] = []
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOperations.append(operation)
+        switch operation {
+        case "track.rename", "track.set_mute":
+            return .success(
+                "{\"operation\":\"\(operation)\",\"state\":\"A\",\"success\":true,\"verified\":true}"
+            )
+        default:
+            return .error("Unexpected track operation: \(operation)")
+        }
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace track test")
+    }
+}
+
+extension OperationTraceTests {
+    @Test(arguments: ["rename", "mute"])
+    func OperationTraceTracksFlagOff(command: String) async {
+        let previous = replaceOperationTraceFlag(with: nil)
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTrackChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let result = await TrackDispatcher.handle(
+            command: command,
+            params: command == "rename"
+                ? ["index": .int(2), "name": .string("Trace Track")]
+                : ["index": .int(2), "enabled": .bool(true)],
+            router: router,
+            cache: StateCache()
+        )
+
+        let operation = command == "rename" ? "track.rename" : "track.set_mute"
+        #expect(sharedJSONObject(sharedToolText(result))?["trace_id"] == nil)
+        #expect(await channel.executedOperations == [operation])
+        #expect(await OperationTraceStore.shared.recent().isEmpty)
+    }
+
+    @Test(arguments: ["rename", "mute"])
+    func OperationTraceTracksEnabled(command: String) async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTrackChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        var params: [String: Value] = command == "rename"
+            ? ["index": .int(2), "name": .string("Trace Track")]
+            : ["index": .int(2), "enabled": .bool(true)]
+        params["project_path"] = .string("/Users/test/secret.logicx")
+        params["token"] = .string("secret-token")
+        let result = await TrackDispatcher.handle(
+            command: command,
+            params: params,
+            router: router,
+            cache: StateCache()
+        )
+
+        let operationID = command == "rename" ? OperationID.tracksRename : OperationID.tracksMute
+        let operation = command == "rename" ? "track.rename" : "track.set_mute"
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(
+            await OperationTraceStore.shared.trace(TraceID(rawValue: rawID))
+        )
+        #expect(result.isError == false)
+        #expect(trace.operationID == operationID.rawValue)
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+        ])
+        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.completedAt != nil)
+        #expect(await channel.executedOperations == [operation])
+
+        let allowedAttributeKeys: Set<String> = [
+            "operation_id", "command", "target_ref", "project_path_hash",
+            "readback_state", "error_code",
+        ]
+        #expect(trace.events.allSatisfy {
+            Set($0.attributes.keys).isSubset(of: allowedAttributeKeys)
+                && !$0.attributes.values.contains("/Users/test/secret.logicx")
+                && !$0.attributes.values.contains("secret-token")
+        })
     }
 }


### PR DESCRIPTION
## Summary
3rd ADR-005 increment (#288) — extends write-boundary trace instrumentation from `logic_transport` (#317) and `logic_mixer` (#320) to `logic_tracks`' verified single-step writes: **rename, mute, solo, arm**.

- Reuses the proven 3-helper pattern (`startTraceIfEnabled` / `recordWriteBoundary` / `finalizeTrace`), cloned locally in `TrackDispatcher`; `handleToggle` gains an optional `traceID` (default `nil`, existing callers unaffected).
- `rename`'s ADR-002 `target_ref` / State-C logic is untouched — `trace_id` is merged additively alongside `track_ref`.
- Behind `FeatureFlags.adr005OperationTrace` (default off) — zero runtime change with the flag off.
- **Scope honestly bounded**: `create_*`/`delete`/`duplicate`/`record_sequence` (multi-step, ambiguous write boundary) and `logic_navigate` (fire-and-forget, no readback — and its `goto_*` commands proxy through `TransportDispatcher.finalizeGotoPositionResult`, which is intentionally not double-traced) are deferred to a follow-up.

## Test plan
- [x] `swift build -c release` clean
- [x] Full `swift test --no-parallel` — **2345/2345** (out-of-sandbox, CTO)
- [x] New tests: track rename/toggle phase sequence (requestReceived→writeBoundaryCrossed→verificationCompleted→resultEmitted), flag-off regression (no trace_id), privacy allowlist, mock-channel based

Refs #308, #288