### PR TITLE
feat(adr-006): versioned snapshot value types — first increment (#289)

### DIFF
--- a/Sources/LogicProMCP/State/VersionedSnapshot.swift
+++ b/Sources/LogicProMCP/State/VersionedSnapshot.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum StateSource: String, Sendable, Codable {
+    case axLive
+    case appleScript
+    case mcuEcho
+    case coreMIDI
+    case cache
+    case unknown
+}
+
+enum Completeness: String, Sendable, Codable {
+    case complete
+    case partial
+    case unknown
+}
+
+struct VersionedSnapshot<Value: Sendable>: Sendable {
+    let projectEpoch: UInt64
+    let sectionRevision: UInt64
+    let observedAt: ContinuousClock.Instant
+    let source: StateSource
+    let completeness: Completeness
+    let fingerprint: String
+    let value: Value
+
+    var etag: String { fingerprint }
+
+    func cacheAgeMillis(now: ContinuousClock.Instant) -> Int64 {
+        let duration = observedAt.duration(to: now)
+        guard duration > .zero else { return 0 }
+        let components = duration.components
+        return components.seconds * 1_000
+            + components.attoseconds / 1_000_000_000_000_000
+    }
+}
+
+enum CacheSectionID: String, Sendable, CaseIterable {
+    case transport
+    case tracks
+    case mixer
+    case project
+    case pluginInventory
+    case libraryInventory
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -28,4 +28,8 @@ enum FeatureFlags: Sendable {
     static var adr005OperationTrace: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] == "1"
     }
+
+    static var adr006VersionedCache: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR006_VERSIONED_CACHE"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/VersionedSnapshotTests.swift
+++ b/Tests/LogicProMCPTests/VersionedSnapshotTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-006 versioned snapshot")
+struct VersionedSnapshotTests {
+    @Test func snapshotPreservesFields() {
+        let observedAt = ContinuousClock.now
+        let snapshot = VersionedSnapshot(
+            projectEpoch: 7,
+            sectionRevision: 11,
+            observedAt: observedAt,
+            source: .axLive,
+            completeness: .partial,
+            fingerprint: "tracks:v7",
+            value: ["Kick", "Snare"]
+        )
+
+        #expect(snapshot.projectEpoch == 7)
+        #expect(snapshot.sectionRevision == 11)
+        #expect(snapshot.observedAt == observedAt)
+        #expect(snapshot.source == .axLive)
+        #expect(snapshot.completeness == .partial)
+        #expect(snapshot.fingerprint == "tracks:v7")
+        #expect(snapshot.value == ["Kick", "Snare"])
+    }
+
+    @Test func etagIsStableForFingerprint() {
+        let observedAt = ContinuousClock.now
+        let first = makeSnapshot(fingerprint: "same", observedAt: observedAt)
+        let second = makeSnapshot(fingerprint: "same", observedAt: observedAt + .seconds(1))
+        let different = makeSnapshot(fingerprint: "different", observedAt: observedAt)
+
+        #expect(first.etag == first.fingerprint)
+        #expect(first.etag == second.etag)
+        #expect(first.etag != different.etag)
+    }
+
+    @Test func cacheAgeMillisUsesObservedAt() {
+        let observedAt = ContinuousClock.now
+        let snapshot = makeSnapshot(fingerprint: "age", observedAt: observedAt)
+
+        #expect(snapshot.cacheAgeMillis(now: observedAt) == 0)
+        #expect(snapshot.cacheAgeMillis(now: observedAt + .milliseconds(1_234)) == 1_234)
+        #expect(snapshot.cacheAgeMillis(now: observedAt - .milliseconds(1)) == 0)
+    }
+
+    @Test func sourceAndCompletenessRoundTrip() throws {
+        let sources: [StateSource] = [.axLive, .appleScript, .mcuEcho, .coreMIDI, .cache, .unknown]
+        let completeness: [Completeness] = [.complete, .partial, .unknown]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let decodedSources = try decoder.decode([StateSource].self, from: encoder.encode(sources))
+        let decodedCompleteness = try decoder.decode(
+            [Completeness].self,
+            from: encoder.encode(completeness)
+        )
+
+        #expect(decodedSources.map(\.rawValue) == [
+            "axLive",
+            "appleScript",
+            "mcuEcho",
+            "coreMIDI",
+            "cache",
+            "unknown",
+        ])
+        #expect(decodedCompleteness.map(\.rawValue) == ["complete", "partial", "unknown"])
+    }
+
+    @Test func cacheSectionsAreComplete() {
+        #expect(CacheSectionID.allCases.map(\.rawValue) == [
+            "transport",
+            "tracks",
+            "mixer",
+            "project",
+            "pluginInventory",
+            "libraryInventory",
+        ])
+    }
+
+    @Test func versionedCacheFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR006_VERSIONED_CACHE"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr006VersionedCache)
+    }
+
+    private func makeSnapshot(
+        fingerprint: String,
+        observedAt: ContinuousClock.Instant
+    ) -> VersionedSnapshot<String> {
+        VersionedSnapshot(
+            projectEpoch: 1,
+            sectionRevision: 2,
+            observedAt: observedAt,
+            source: .cache,
+            completeness: .complete,
+            fingerprint: fingerprint,
+            value: "value"
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,7 +7,7 @@ The core execution order is ADR-002 → ADR-003 → ADR-004 → ADR-001.
 ADR-005 is cross-cutting and applies throughout the entire sequence.
 Every ADR starts in `Proposed` status and advances only with its own implementation and qualification evidence.
 
-The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-001, ADR-004, ADR-006, ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
+The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-006 has also entered `In Implementation` with a first, types-only increment (the runtime cache rewiring is deferred pending a live soak — see its status entry). ADR-001, ADR-004, ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
 
 ## Category A — Core execution path
 
@@ -23,7 +23,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 
 | ADR | Name | Category | Status | GitHub issue |
 | --- | --- | --- | --- | --- |
-| ADR-006 | Versioned Cache | B | `Proposed` | [#289](https://github.com/MongLong0214/logic-pro-mcp/issues/289) |
+| ADR-006 | Versioned Cache | B | `In Implementation` | [#289](https://github.com/MongLong0214/logic-pro-mcp/issues/289) |
 | ADR-007 | AX Selector Atlas | B | `Proposed` | [#290](https://github.com/MongLong0214/logic-pro-mcp/issues/290) |
 
 ## Category C — Expansion foundations
@@ -64,8 +64,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - Merged: #318.
 
 ### ADR-005 — Operation Trace and Support Bundle (`In Implementation`)
-- `OperationTraceStore` actor (bounded ring buffer, privacy allowlist), trace-ID + event-phase model with explicit `write_boundary.crossed` instrumentation, piloted on the verified `logic_transport` and `logic_mixer` write paths behind `FeatureFlags.adr005OperationTrace`. `logic_system` trace query commands added.
-- Merged: #317, #320.
+- `OperationTraceStore` actor (bounded ring buffer, privacy allowlist), trace-ID + event-phase model with explicit `write_boundary.crossed` instrumentation, piloted on the verified `logic_transport`, `logic_mixer`, and `logic_tracks` (rename / mute / solo / arm) write paths behind `FeatureFlags.adr005OperationTrace`. `logic_system` trace query commands added.
+- Merged: #317, #320, #330.
+
+### ADR-006 — Versioned Cache (`In Implementation`)
+- First increment: pure snapshot value types only — `VersionedSnapshot<Value>` (project epoch, section revision, observed-at, source, completeness, fingerprint), `StateSource` / `Completeness` / `CacheSectionID` enums, and pure `etag` / `cacheAgeMillis(now:)` derivations, behind `FeatureFlags.adr006VersionedCache` (default off).
+- Deliberately scoped out (deferred): the `RefreshCoordinator` (single-flight refresh + backpressure), the actual resource-envelope wiring (`project_epoch` / `section_revision` / `etag` / `cache_age_ms` on reads), and any `StateCache` rewiring. Those require the 30-minute memory-soak and large-project benchmarks from #289's acceptance criteria, which need live qualification and are not claimed here.
+- Deterministic tests only (no runtime path touched): field preservation, etag stability, `cacheAgeMillis` monotonicity + clock-skew guard, `Codable` round-trips, section completeness, flag-default-off.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
## ADR-006 (Versioned Cache) — first increment

Refs #289, #308. Kernel-adjacent Category B pilot, **flag-gated and default-off** — zero runtime behavior change when off.

### What landed
- **`VersionedSnapshot<Value: Sendable>`** — project epoch, section revision, observed-at, source, completeness, fingerprint — with pure `etag` and `cacheAgeMillis(now:)` derivations (clock-skew guarded).
- **`StateSource` / `Completeness` / `CacheSectionID`** enums (`Sendable`, `Codable`/`CaseIterable` as appropriate).
- **`FeatureFlags.adr006VersionedCache`** (`LOGIC_MCP_ADR006_VERSIONED_CACHE`, default off), same pattern as adr002/003/005.

### Deliberately deferred (honest scope)
The runtime rewiring is **not** in this PR and is not claimed:
- `RefreshCoordinator` (single-flight refresh + backpressure)
- resource-envelope wiring (`project_epoch` / `section_revision` / `etag` / `cache_age_ms` on reads)
- any `StateCache` changes

Those depend on the **30-minute memory-soak + large-project benchmarks** in #289's acceptance criteria, which require live qualification I can't run unattended. This increment lands the pure types + calculations so the envelope work has a tested foundation.

### Tests / evidence
- New `VersionedSnapshotTests` (6, deterministic, no runtime path touched): field preservation, etag stability, `cacheAgeMillis` monotonicity + clock-skew guard, `Codable` round-trips, section completeness, flag-default-off. **All live assertions** (no dead-`#expect`).
- Full suite green on this branch (off latest `main`): **`Test run with 2351 tests passed`, 0 failures** (`swift test --no-parallel`).

### Docs
- `docs/adr/README.md`: ADR-006 → `In Implementation` with the deferral note above; corrected the stale ADR-005 trace entry to include `logic_tracks` (#330).