### PR TITLE
feat(adr-004): verified mutation saga MVP engine (#287)

### DIFF
--- a/Sources/LogicProMCP/Saga/MutationSaga.swift
+++ b/Sources/LogicProMCP/Saga/MutationSaga.swift
@@ -1,0 +1,548 @@
+import Foundation
+import MCP
+
+enum SagaState: String, Codable, CaseIterable, Equatable, Sendable {
+    case draft
+    case validated
+    case awaitingConfirmation
+    case running
+    case completed
+    case partiallyApplied
+    case reconciling
+    case compensating
+    case fullyCompensated
+    case partiallyCompensated
+    case compensationFailed
+    case rollbackUncertain
+}
+
+struct SagaExpectedInverse: Codable, Equatable, Sendable {
+    let operationID: OperationID
+    let valueParameter: String
+}
+
+struct SagaStep: Codable, Equatable, Sendable {
+    let operationID: OperationID
+    let targetRef: TargetReference?
+    let params: [String: Value]
+    let expectedInverse: SagaExpectedInverse
+}
+
+struct SagaPlan: Codable, Equatable, Sendable {
+    let steps: [SagaStep]
+    let idempotencyKey: String
+}
+
+enum StepResultState: String, Codable, Equatable, Sendable {
+    case stateA = "A"
+    case stateB = "B"
+    case stateC = "C"
+}
+
+struct StepResult: Codable, Equatable, Sendable {
+    let state: StepResultState
+    let writeBoundaryCrossed: Bool
+    let detail: String
+}
+
+struct ObservedState: Codable, Equatable, Sendable {
+    let value: Value
+    let evidence: String
+}
+
+protocol SagaStepExecutor: Sendable {
+    func run(_ step: SagaStep) async -> StepResult
+    func readState(_ step: SagaStep) async -> ObservedState?
+}
+
+enum VerificationDisposition: String, Codable, Equatable, Sendable {
+    case applied
+    case notApplied
+    case unknown
+}
+
+struct VerificationEvidence: Codable, Equatable, Sendable {
+    let disposition: VerificationDisposition
+    let readback: ObservedState?
+}
+
+enum CompensationDisposition: String, Codable, Equatable, Sendable {
+    case verified
+    case notNeeded
+    case failed
+    case uncertain
+}
+
+struct CompensationEvidence: Codable, Equatable, Sendable {
+    let disposition: CompensationDisposition
+    let executionResult: StepResult?
+    let readback: ObservedState?
+}
+
+struct CompensationJournalRecord: Codable, Equatable, Sendable {
+    let stepIndex: Int
+    let beforeState: ObservedState?
+    var writeBoundaryCrossed = false
+    var executionResult: StepResult?
+    var verificationEvidence: VerificationEvidence?
+    var inverseOperation: SagaStep?
+    var compensationEvidence: CompensationEvidence?
+}
+
+enum PreflightIssue: Equatable, Sendable {
+    case featureDisabled
+    case emptyPlan
+    case invalidIdempotencyKey
+    case registryInvalid
+    case operationNotRegistered(stepIndex: Int, operationID: OperationID)
+    case invalidOperationSpec(stepIndex: Int, operationID: OperationID)
+    case operationNotReversible(stepIndex: Int, operationID: OperationID)
+    case staleTarget(stepIndex: Int)
+    case projectEpochMismatch(stepIndex: Int)
+    case invalidExpectedInverse(stepIndex: Int)
+    case automaticReplayBlocked
+}
+
+enum PreflightStatus: Equatable, Sendable {
+    case ready
+    case existingSession
+    case rejected
+}
+
+struct PreflightResult: Sendable {
+    let status: PreflightStatus
+    let issues: [PreflightIssue]
+
+    var passed: Bool { status == .ready }
+}
+
+struct SagaOutcome: Equatable, Sendable {
+    let idempotencyKey: String
+    var state: SagaState
+    var complete: Bool
+    var journal: [CompensationJournalRecord]
+    var stateHistory: [SagaState]
+    var preflightIssues: [PreflightIssue]
+}
+
+actor MutationSaga {
+    private struct ReversibleDefinition: Sendable {
+        let tool: ToolID
+        let command: String
+        let valueParameter: String
+    }
+
+    private static let reversibleDefinitions: [OperationID: ReversibleDefinition] = [
+        .tracksRename: ReversibleDefinition(tool: .logicTracks, command: "rename", valueParameter: "name"),
+        .mixerSetVolume: ReversibleDefinition(tool: .logicMixer, command: "set_volume", valueParameter: "value"),
+        .mixerSetPan: ReversibleDefinition(tool: .logicMixer, command: "set_pan", valueParameter: "value"),
+        .tracksMute: ReversibleDefinition(tool: .logicTracks, command: "mute", valueParameter: "enabled"),
+        .tracksSolo: ReversibleDefinition(tool: .logicTracks, command: "solo", valueParameter: "enabled"),
+        .tracksArm: ReversibleDefinition(tool: .logicTracks, command: "arm", valueParameter: "enabled"),
+    ]
+
+    nonisolated static let reversibleOperationIDs: Set<OperationID> = Set(reversibleDefinitions.keys)
+
+    private let targetRegistry: TargetRegistry
+    private let enabled: Bool
+    private var sessions: [String: SagaOutcome] = [:]
+
+    init(
+        targetRegistry: TargetRegistry,
+        enabled: Bool = FeatureFlags.adr004MutationSaga
+    ) {
+        self.targetRegistry = targetRegistry
+        self.enabled = enabled
+    }
+
+    func preflight(_ plan: SagaPlan) async -> PreflightResult {
+        guard enabled else {
+            return PreflightResult(status: .rejected, issues: [.featureDisabled])
+        }
+        if let existing = sessions[plan.idempotencyKey] {
+            if isReturnable(existing.state) {
+                return PreflightResult(status: .existingSession, issues: [])
+            }
+            return PreflightResult(status: .rejected, issues: [.automaticReplayBlocked])
+        }
+
+        var issues: [PreflightIssue] = []
+        if plan.steps.isEmpty { issues.append(.emptyPlan) }
+        if plan.idempotencyKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.invalidIdempotencyKey)
+        }
+        if !OperationRegistry.validationErrors().isEmpty {
+            issues.append(.registryInvalid)
+        }
+
+        let projectEpoch = await targetRegistry.currentProjectEpoch
+        for (index, step) in plan.steps.enumerated() {
+            let registeredSpec = OperationRegistry.specs.first { $0.id == step.operationID }
+            if registeredSpec == nil {
+                issues.append(.operationNotRegistered(
+                    stepIndex: index,
+                    operationID: step.operationID
+                ))
+            }
+
+            if let definition = Self.reversibleDefinitions[step.operationID] {
+                let spec = OperationRegistry.spec(
+                    tool: definition.tool.rawValue,
+                    command: definition.command
+                )
+                if spec?.id != step.operationID
+                    || spec?.mutability != Mutability.`mutating`
+                    || spec?.verification != .readbackRequired
+                    || spec?.retry != .neverAutomatic
+                    || spec?.availability == .unsupported
+                    || registeredSpec?.tool != definition.tool
+                    || registeredSpec?.command != definition.command
+                {
+                    issues.append(.invalidOperationSpec(
+                        stepIndex: index,
+                        operationID: step.operationID
+                    ))
+                }
+                if step.expectedInverse.operationID != step.operationID
+                    || step.expectedInverse.valueParameter != definition.valueParameter
+                    || step.params[definition.valueParameter] == nil
+                {
+                    issues.append(.invalidExpectedInverse(stepIndex: index))
+                }
+            } else {
+                issues.append(.operationNotReversible(
+                    stepIndex: index,
+                    operationID: step.operationID
+                ))
+            }
+
+            guard let targetRef = step.targetRef,
+                  let binding = await targetRegistry.resolve(targetRef) else {
+                issues.append(.staleTarget(stepIndex: index))
+                continue
+            }
+            if binding.projectEpoch != projectEpoch {
+                issues.append(.projectEpochMismatch(stepIndex: index))
+            }
+        }
+
+        return PreflightResult(
+            status: issues.isEmpty ? .ready : .rejected,
+            issues: issues
+        )
+    }
+
+    func execute<Executor: SagaStepExecutor>(
+        _ plan: SagaPlan,
+        executor: Executor
+    ) async -> SagaOutcome {
+        let result = await preflight(plan)
+        switch result.status {
+        case .existingSession:
+            if let existing = sessions[plan.idempotencyKey] { return existing }
+            return rejectedOutcome(plan, issues: [.automaticReplayBlocked])
+        case .rejected:
+            return rejectedOutcome(plan, issues: result.issues)
+        case .ready:
+            break
+        }
+
+        if let existing = sessions[plan.idempotencyKey] {
+            if isReturnable(existing.state) { return existing }
+            return rejectedOutcome(plan, issues: [.automaticReplayBlocked])
+        }
+
+        var outcome = SagaOutcome(
+            idempotencyKey: plan.idempotencyKey,
+            state: .draft,
+            complete: false,
+            journal: [],
+            stateHistory: [.draft],
+            preflightIssues: []
+        )
+        sessions[plan.idempotencyKey] = outcome
+        advance(.validated, outcome: &outcome)
+        advance(.awaitingConfirmation, outcome: &outcome)
+        advance(.running, outcome: &outcome)
+
+        var appliedIndices: [Int] = []
+        for (index, step) in plan.steps.enumerated() {
+            guard let beforeState = await executor.readState(step),
+                  let desiredValue = step.params[step.expectedInverse.valueParameter] else {
+                outcome.journal.append(CompensationJournalRecord(
+                    stepIndex: index,
+                    beforeState: nil,
+                    verificationEvidence: VerificationEvidence(
+                        disposition: .unknown,
+                        readback: nil
+                    ),
+                    compensationEvidence: CompensationEvidence(
+                        disposition: .notNeeded,
+                        executionResult: nil,
+                        readback: nil
+                    )
+                ))
+                return await compensate(
+                    appliedIndices: appliedIndices,
+                    rollbackIsUncertain: false,
+                    executor: executor,
+                    outcome: outcome
+                )
+            }
+
+            var inverseParams = step.params
+            inverseParams[step.expectedInverse.valueParameter] = beforeState.value
+            let inverse = SagaStep(
+                operationID: step.expectedInverse.operationID,
+                targetRef: step.targetRef,
+                params: inverseParams,
+                expectedInverse: step.expectedInverse
+            )
+            outcome.journal.append(CompensationJournalRecord(
+                stepIndex: index,
+                beforeState: beforeState,
+                inverseOperation: inverse
+            ))
+            sessions[plan.idempotencyKey] = outcome
+
+            let executionResult = await executor.run(step)
+            outcome.journal[index].writeBoundaryCrossed = executionResult.writeBoundaryCrossed
+            outcome.journal[index].executionResult = executionResult
+            sessions[plan.idempotencyKey] = outcome
+
+            switch executionResult.state {
+            case .stateA:
+                let readback = await executor.readState(step)
+                let disposition = classify(
+                    readback,
+                    desiredValue: desiredValue,
+                    beforeState: beforeState
+                )
+                outcome.journal[index].verificationEvidence = VerificationEvidence(
+                    disposition: disposition,
+                    readback: readback
+                )
+                if disposition == .applied {
+                    appliedIndices.append(index)
+                    sessions[plan.idempotencyKey] = outcome
+                    continue
+                }
+                markReconciliation(outcome: &outcome)
+                markNoInverseOrUncertain(
+                    disposition,
+                    readback: readback,
+                    index: index,
+                    outcome: &outcome
+                )
+                return await compensate(
+                    appliedIndices: appliedIndices,
+                    rollbackIsUncertain: disposition == .unknown,
+                    executor: executor,
+                    outcome: outcome
+                )
+
+            case .stateB:
+                markReconciliation(outcome: &outcome)
+                let readback = await executor.readState(step)
+                let disposition = classify(
+                    readback,
+                    desiredValue: desiredValue,
+                    beforeState: beforeState
+                )
+                outcome.journal[index].verificationEvidence = VerificationEvidence(
+                    disposition: disposition,
+                    readback: readback
+                )
+                if disposition == .applied { appliedIndices.append(index) }
+                if disposition != .applied {
+                    markNoInverseOrUncertain(
+                        disposition,
+                        readback: readback,
+                        index: index,
+                        outcome: &outcome
+                    )
+                }
+                return await compensate(
+                    appliedIndices: appliedIndices,
+                    rollbackIsUncertain: disposition == .unknown,
+                    executor: executor,
+                    outcome: outcome
+                )
+
+            case .stateC:
+                if executionResult.writeBoundaryCrossed {
+                    markReconciliation(outcome: &outcome)
+                    let readback = await executor.readState(step)
+                    let disposition = classify(
+                        readback,
+                        desiredValue: desiredValue,
+                        beforeState: beforeState
+                    )
+                    outcome.journal[index].verificationEvidence = VerificationEvidence(
+                        disposition: disposition,
+                        readback: readback
+                    )
+                    if disposition == .applied { appliedIndices.append(index) }
+                    if disposition != .applied {
+                        markNoInverseOrUncertain(
+                            disposition,
+                            readback: readback,
+                            index: index,
+                            outcome: &outcome
+                        )
+                    }
+                    return await compensate(
+                        appliedIndices: appliedIndices,
+                        rollbackIsUncertain: disposition == .unknown,
+                        executor: executor,
+                        outcome: outcome
+                    )
+                }
+
+                outcome.journal[index].verificationEvidence = VerificationEvidence(
+                    disposition: .notApplied,
+                    readback: nil
+                )
+                outcome.journal[index].compensationEvidence = CompensationEvidence(
+                    disposition: .notNeeded,
+                    executionResult: nil,
+                    readback: nil
+                )
+                return await compensate(
+                    appliedIndices: appliedIndices,
+                    rollbackIsUncertain: false,
+                    executor: executor,
+                    outcome: outcome
+                )
+            }
+        }
+
+        outcome.complete = true
+        advance(.completed, outcome: &outcome)
+        return outcome
+    }
+
+    private func compensate<Executor: SagaStepExecutor>(
+        appliedIndices: [Int],
+        rollbackIsUncertain: Bool,
+        executor: Executor,
+        outcome initialOutcome: SagaOutcome
+    ) async -> SagaOutcome {
+        var outcome = initialOutcome
+        if outcome.state != .partiallyApplied && outcome.state != .reconciling {
+            advance(.partiallyApplied, outcome: &outcome)
+        }
+
+        guard !appliedIndices.isEmpty else {
+            advance(rollbackIsUncertain ? .rollbackUncertain : .partiallyApplied, outcome: &outcome)
+            return outcome
+        }
+
+        advance(.compensating, outcome: &outcome)
+        var verifiedCount = 0
+        var uncertain = rollbackIsUncertain
+
+        for index in appliedIndices.reversed() {
+            guard let inverse = outcome.journal[index].inverseOperation,
+                  let beforeState = outcome.journal[index].beforeState else {
+                outcome.journal[index].compensationEvidence = CompensationEvidence(
+                    disposition: .failed,
+                    executionResult: nil,
+                    readback: nil
+                )
+                sessions[outcome.idempotencyKey] = outcome
+                continue
+            }
+
+            let compensationResult = await executor.run(inverse)
+            let readback = await executor.readState(inverse)
+            let disposition: CompensationDisposition
+            if readback?.value == beforeState.value {
+                disposition = .verified
+                verifiedCount += 1
+            } else if readback == nil && compensationResult.writeBoundaryCrossed {
+                disposition = .uncertain
+                uncertain = true
+            } else {
+                disposition = .failed
+            }
+            outcome.journal[index].compensationEvidence = CompensationEvidence(
+                disposition: disposition,
+                executionResult: compensationResult,
+                readback: readback
+            )
+            sessions[outcome.idempotencyKey] = outcome
+        }
+
+        if uncertain {
+            advance(.rollbackUncertain, outcome: &outcome)
+        } else if verifiedCount == appliedIndices.count {
+            advance(.fullyCompensated, outcome: &outcome)
+        } else if verifiedCount > 0 {
+            advance(.partiallyCompensated, outcome: &outcome)
+        } else {
+            advance(.compensationFailed, outcome: &outcome)
+        }
+        return outcome
+    }
+
+    private func classify(
+        _ readback: ObservedState?,
+        desiredValue: Value,
+        beforeState: ObservedState
+    ) -> VerificationDisposition {
+        if readback?.value == desiredValue { return .applied }
+        if readback?.value == beforeState.value { return .notApplied }
+        return .unknown
+    }
+
+    private func markReconciliation(outcome: inout SagaOutcome) {
+        advance(.partiallyApplied, outcome: &outcome)
+        advance(.reconciling, outcome: &outcome)
+    }
+
+    private func markNoInverseOrUncertain(
+        _ disposition: VerificationDisposition,
+        readback: ObservedState?,
+        index: Int,
+        outcome: inout SagaOutcome
+    ) {
+        outcome.journal[index].compensationEvidence = CompensationEvidence(
+            disposition: disposition == .notApplied ? .notNeeded : .uncertain,
+            executionResult: nil,
+            readback: readback
+        )
+        sessions[outcome.idempotencyKey] = outcome
+    }
+
+    private func advance(_ state: SagaState, outcome: inout SagaOutcome) {
+        outcome.state = state
+        if outcome.stateHistory.last != state { outcome.stateHistory.append(state) }
+        sessions[outcome.idempotencyKey] = outcome
+    }
+
+    private func rejectedOutcome(
+        _ plan: SagaPlan,
+        issues: [PreflightIssue]
+    ) -> SagaOutcome {
+        SagaOutcome(
+            idempotencyKey: plan.idempotencyKey,
+            state: .draft,
+            complete: false,
+            journal: [],
+            stateHistory: [.draft],
+            preflightIssues: issues
+        )
+    }
+
+    private func isReturnable(_ state: SagaState) -> Bool {
+        switch state {
+        case .draft, .validated, .awaitingConfirmation, .running, .reconciling, .compensating,
+             .completed:
+            true
+        case .partiallyApplied, .fullyCompensated, .partiallyCompensated,
+             .compensationFailed, .rollbackUncertain:
+            false
+        }
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -25,6 +25,10 @@ enum FeatureFlags: Sendable {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR003_OPERATION_REGISTRY"] == "1"
     }
 
+    static var adr004MutationSaga: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR004_MUTATION_SAGA"] == "1"
+    }
+
     static var adr005OperationTrace: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] == "1"
     }

--- a/Tests/LogicProMCPTests/MutationSagaTests.swift
+++ b/Tests/LogicProMCPTests/MutationSagaTests.swift
@@ -1,0 +1,399 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private enum MockSagaBehavior: Sendable {
+    case applyStateA
+    case failBeforeWrite
+    case ambiguousApplied
+    case ambiguousNotApplied
+    case ambiguousUnknown
+}
+
+private actor MockSagaExecutor: SagaStepExecutor {
+    private var states: [TargetReference: Value]
+    private var behaviors: [MockSagaBehavior]
+    private var unknownNextRead: Set<TargetReference> = []
+    private var runs: [SagaStep] = []
+    private var reads = 0
+
+    init(states: [TargetReference: Value], behaviors: [MockSagaBehavior]) {
+        self.states = states
+        self.behaviors = behaviors
+    }
+
+    func run(_ step: SagaStep) async -> StepResult {
+        runs.append(step)
+        let behavior = behaviors.isEmpty ? .applyStateA : behaviors.removeFirst()
+        let target = step.targetRef
+        let desired = step.params[step.expectedInverse.valueParameter]
+
+        switch behavior {
+        case .applyStateA:
+            if let target, let desired { states[target] = desired }
+            return StepResult(state: .stateA, writeBoundaryCrossed: true, detail: "synthetic A")
+        case .failBeforeWrite:
+            return StepResult(state: .stateC, writeBoundaryCrossed: false, detail: "synthetic C")
+        case .ambiguousApplied:
+            if let target, let desired { states[target] = desired }
+            return StepResult(state: .stateB, writeBoundaryCrossed: true, detail: "synthetic B applied")
+        case .ambiguousNotApplied:
+            return StepResult(state: .stateB, writeBoundaryCrossed: true, detail: "synthetic B not applied")
+        case .ambiguousUnknown:
+            if let target { unknownNextRead.insert(target) }
+            return StepResult(state: .stateB, writeBoundaryCrossed: true, detail: "synthetic B unknown")
+        }
+    }
+
+    func readState(_ step: SagaStep) async -> ObservedState? {
+        reads += 1
+        guard let target = step.targetRef else { return nil }
+        if unknownNextRead.remove(target) != nil { return nil }
+        guard let value = states[target] else { return nil }
+        return ObservedState(value: value, evidence: "synthetic readback")
+    }
+
+    func runCount() -> Int { runs.count }
+    func readCount() -> Int { reads }
+    func runOperations() -> [OperationID] { runs.map(\.operationID) }
+    func state(for target: TargetReference) -> Value? { states[target] }
+}
+
+@Suite("Mutation saga", .serialized)
+struct MutationSagaTests {
+    private func bind(
+        _ registry: TargetRegistry,
+        index: Int,
+        name: String
+    ) async -> TargetReference {
+        let descriptor = TargetDescriptor(trackIndex: index, trackName: name)
+        return await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+    }
+
+    private func step(
+        _ operationID: OperationID,
+        target: TargetReference,
+        value: Value
+    ) -> SagaStep {
+        let valueParameter: String
+        switch operationID {
+        case .tracksRename:
+            valueParameter = "name"
+        case .mixerSetVolume, .mixerSetPan:
+            valueParameter = "value"
+        case .tracksMute, .tracksSolo, .tracksArm:
+            valueParameter = "enabled"
+        default:
+            valueParameter = "value"
+        }
+        return SagaStep(
+            operationID: operationID,
+            targetRef: target,
+            params: [valueParameter: value],
+            expectedInverse: SagaExpectedInverse(
+                operationID: operationID,
+                valueParameter: valueParameter
+            )
+        )
+    }
+
+    @Test
+    func testPreflightRejectsInvalidPlansBeforeRun() async {
+        let registry = TargetRegistry()
+        let stale = await bind(registry, index: 0, name: "Stale")
+        await registry.bumpTopologyGeneration()
+        let valid = await bind(registry, index: 1, name: "Valid")
+        let executor = MockSagaExecutor(states: [valid: .string("Before")], behaviors: [])
+        let saga = MutationSaga(targetRegistry: registry, enabled: true)
+
+        let staleOutcome = await saga.execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: valid, value: .string("After")),
+                    step(.mixerSetVolume, target: stale, value: .double(0.8)),
+                ],
+                idempotencyKey: "stale-plan"
+            ),
+            executor: executor
+        )
+
+        #expect(!staleOutcome.complete)
+        #expect(staleOutcome.preflightIssues.contains(.staleTarget(stepIndex: 1)))
+        #expect(await executor.runCount() == 0)
+        #expect(await executor.readCount() == 0)
+
+        let disallowedOutcome = await saga.execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: valid, value: .string("After")),
+                    step(.pluginsInsertVerified, target: valid, value: .string("Compressor")),
+                ],
+                idempotencyKey: "disallowed-plan"
+            ),
+            executor: executor
+        )
+
+        #expect(!disallowedOutcome.complete)
+        #expect(disallowedOutcome.preflightIssues.contains(
+            .operationNotReversible(stepIndex: 1, operationID: .pluginsInsertVerified)
+        ))
+        #expect(await executor.runCount() == 0)
+        #expect(await executor.readCount() == 0)
+    }
+
+    @Test
+    func testTwoStepPlanCompletesWithEvidence() async throws {
+        let registry = TargetRegistry()
+        let renameTarget = await bind(registry, index: 0, name: "Bass")
+        let volumeTarget = await bind(registry, index: 1, name: "Keys")
+        let executor = MockSagaExecutor(
+            states: [renameTarget: .string("Bass"), volumeTarget: .double(0.25)],
+            behaviors: [.applyStateA, .applyStateA]
+        )
+        let saga = MutationSaga(targetRegistry: registry, enabled: true)
+        let outcome = await saga.execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: renameTarget, value: .string("Sub Bass")),
+                    step(.mixerSetVolume, target: volumeTarget, value: .double(0.75)),
+                ],
+                idempotencyKey: "two-step-success"
+            ),
+            executor: executor
+        )
+
+        #expect(outcome.state == .completed)
+        #expect(outcome.complete)
+        #expect(outcome.stateHistory == [
+            .draft, .validated, .awaitingConfirmation, .running, .completed,
+        ])
+        #expect(outcome.journal.count == 2)
+        #expect(outcome.journal.allSatisfy {
+            $0.beforeState != nil
+                && $0.writeBoundaryCrossed
+                && $0.executionResult != nil
+                && $0.verificationEvidence?.disposition == .applied
+                && $0.inverseOperation != nil
+                && $0.compensationEvidence == nil
+        })
+        let renameRecord = try #require(outcome.journal.first)
+        let volumeRecord = try #require(outcome.journal.last)
+        #expect(renameRecord.inverseOperation?.params["name"] == .string("Bass"))
+        #expect(volumeRecord.inverseOperation?.params["value"] == .double(0.25))
+    }
+
+    @Test
+    func testFailureCompensatesAppliedPrefixInReverse() async throws {
+        let registry = TargetRegistry()
+        let renameTarget = await bind(registry, index: 0, name: "Lead")
+        let volumeTarget = await bind(registry, index: 1, name: "Pad")
+        let panTarget = await bind(registry, index: 2, name: "FX")
+        let executor = MockSagaExecutor(
+            states: [
+                renameTarget: .string("Lead"),
+                volumeTarget: .double(0.2),
+                panTarget: .double(0),
+            ],
+            behaviors: [.applyStateA, .applyStateA, .failBeforeWrite, .applyStateA, .applyStateA]
+        )
+        let saga = MutationSaga(targetRegistry: registry, enabled: true)
+        let outcome = await saga.execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: renameTarget, value: .string("Lead Vox")),
+                    step(.mixerSetVolume, target: volumeTarget, value: .double(0.9)),
+                    step(.mixerSetPan, target: panTarget, value: .double(-0.5)),
+                ],
+                idempotencyKey: "reverse-compensation"
+            ),
+            executor: executor
+        )
+
+        #expect(outcome.state == .fullyCompensated)
+        #expect(!outcome.complete)
+        #expect(await executor.runOperations() == [
+            .tracksRename, .mixerSetVolume, .mixerSetPan, .mixerSetVolume, .tracksRename,
+        ])
+        #expect(await executor.state(for: renameTarget) == .string("Lead"))
+        #expect(await executor.state(for: volumeTarget) == .double(0.2))
+        #expect(outcome.journal[0].compensationEvidence?.disposition == .verified)
+        #expect(outcome.journal[1].compensationEvidence?.disposition == .verified)
+        #expect(outcome.journal[2].compensationEvidence?.disposition == .notNeeded)
+        #expect(outcome.journal[0].compensationEvidence?.readback != nil)
+        #expect(outcome.journal[1].compensationEvidence?.readback != nil)
+    }
+
+    @Test
+    func testAmbiguousWriteReconcilesWithoutBlindInverse() async {
+        let registry = TargetRegistry()
+        let appliedTarget = await bind(registry, index: 0, name: "Applied")
+        let notAppliedTarget = await bind(registry, index: 1, name: "Not Applied")
+        let unknownTarget = await bind(registry, index: 2, name: "Unknown")
+
+        let appliedExecutor = MockSagaExecutor(
+            states: [appliedTarget: .bool(false)],
+            behaviors: [.ambiguousApplied, .applyStateA]
+        )
+        let appliedOutcome = await MutationSaga(targetRegistry: registry, enabled: true).execute(
+            SagaPlan(
+                steps: [step(.tracksMute, target: appliedTarget, value: .bool(true))],
+                idempotencyKey: "ambiguous-applied"
+            ),
+            executor: appliedExecutor
+        )
+        #expect(appliedOutcome.state == .fullyCompensated)
+        #expect(await appliedExecutor.runCount() == 2)
+        #expect(appliedOutcome.journal.first?.compensationEvidence?.disposition == .verified)
+
+        let notAppliedExecutor = MockSagaExecutor(
+            states: [notAppliedTarget: .bool(false)],
+            behaviors: [.ambiguousNotApplied]
+        )
+        let notAppliedOutcome = await MutationSaga(targetRegistry: registry, enabled: true).execute(
+            SagaPlan(
+                steps: [step(.tracksSolo, target: notAppliedTarget, value: .bool(true))],
+                idempotencyKey: "ambiguous-not-applied"
+            ),
+            executor: notAppliedExecutor
+        )
+        #expect(notAppliedOutcome.state == .partiallyApplied)
+        #expect(!notAppliedOutcome.complete)
+        #expect(await notAppliedExecutor.runCount() == 1)
+        #expect(notAppliedOutcome.journal.first?.compensationEvidence?.disposition == .notNeeded)
+
+        let unknownExecutor = MockSagaExecutor(
+            states: [unknownTarget: .bool(false)],
+            behaviors: [.ambiguousUnknown]
+        )
+        let unknownOutcome = await MutationSaga(targetRegistry: registry, enabled: true).execute(
+            SagaPlan(
+                steps: [step(.tracksArm, target: unknownTarget, value: .bool(true))],
+                idempotencyKey: "ambiguous-unknown"
+            ),
+            executor: unknownExecutor
+        )
+        #expect(unknownOutcome.state == .rollbackUncertain)
+        #expect(!unknownOutcome.complete)
+        #expect(await unknownExecutor.runCount() == 1)
+        #expect(unknownOutcome.journal.first?.compensationEvidence?.disposition == .uncertain)
+    }
+
+    @Test
+    func testCompensationFailureIsNotTopLevelSuccess() async {
+        let registry = TargetRegistry()
+        let firstTarget = await bind(registry, index: 0, name: "First")
+        let secondTarget = await bind(registry, index: 1, name: "Second")
+        let executor = MockSagaExecutor(
+            states: [firstTarget: .string("First"), secondTarget: .double(0.1)],
+            behaviors: [.applyStateA, .failBeforeWrite, .failBeforeWrite]
+        )
+        let saga = MutationSaga(targetRegistry: registry, enabled: true)
+        let outcome = await saga.execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: firstTarget, value: .string("Changed")),
+                    step(.mixerSetVolume, target: secondTarget, value: .double(0.8)),
+                ],
+                idempotencyKey: "failed-compensation"
+            ),
+            executor: executor
+        )
+
+        #expect(outcome.state == .compensationFailed)
+        #expect(!outcome.complete)
+        #expect(outcome.state != .completed)
+        #expect(outcome.journal.first?.compensationEvidence?.disposition == .failed)
+    }
+
+    @Test
+    func testIdempotencyAndDefaultOff() async {
+        let flag = "LOGIC_MCP_ADR004_MUTATION_SAGA"
+        let previous = getenv(flag).map { String(cString: $0) }
+        unsetenv(flag)
+        defer {
+            if let previous {
+                setenv(flag, previous, 1)
+            } else {
+                unsetenv(flag)
+            }
+        }
+
+        #expect(!FeatureFlags.adr004MutationSaga)
+        let registry = TargetRegistry()
+        let target = await bind(registry, index: 0, name: "Idempotent")
+        let plan = SagaPlan(
+            steps: [step(.tracksRename, target: target, value: .string("Once"))],
+            idempotencyKey: "completed-key"
+        )
+
+        let disabledExecutor = MockSagaExecutor(
+            states: [target: .string("Before")],
+            behaviors: [.applyStateA]
+        )
+        let disabledOutcome = await MutationSaga(targetRegistry: registry).execute(
+            plan,
+            executor: disabledExecutor
+        )
+        #expect(!disabledOutcome.complete)
+        #expect(disabledOutcome.preflightIssues == [.featureDisabled])
+        #expect(await disabledExecutor.runCount() == 0)
+        #expect(await disabledExecutor.readCount() == 0)
+
+        let executor = MockSagaExecutor(
+            states: [target: .string("Before")],
+            behaviors: [.applyStateA]
+        )
+        let saga = MutationSaga(targetRegistry: registry, enabled: true)
+        let first = await saga.execute(plan, executor: executor)
+        let second = await saga.execute(plan, executor: executor)
+        #expect(first == second)
+        #expect(first.state == .completed)
+        #expect(await executor.runCount() == 1)
+
+        let partialPlan = SagaPlan(
+            steps: [step(.tracksSolo, target: target, value: .bool(true))],
+            idempotencyKey: "partial-key"
+        )
+        let partialExecutor = MockSagaExecutor(
+            states: [target: .bool(false)],
+            behaviors: [.ambiguousNotApplied]
+        )
+        let partial = await saga.execute(partialPlan, executor: partialExecutor)
+        let replay = await saga.execute(partialPlan, executor: partialExecutor)
+        #expect(partial.state == .partiallyApplied)
+        #expect(replay.preflightIssues == [.automaticReplayBlocked])
+        #expect(!replay.complete)
+        #expect(await partialExecutor.runCount() == 1)
+    }
+
+    @Test
+    func testStateMachineAndAllowlistAreExact() {
+        #expect(SagaState.allCases == [
+            .draft,
+            .validated,
+            .awaitingConfirmation,
+            .running,
+            .completed,
+            .partiallyApplied,
+            .reconciling,
+            .compensating,
+            .fullyCompensated,
+            .partiallyCompensated,
+            .compensationFailed,
+            .rollbackUncertain,
+        ])
+        #expect(MutationSaga.reversibleOperationIDs == Set([
+            .tracksRename,
+            .mixerSetVolume,
+            .mixerSetPan,
+            .tracksMute,
+            .tracksSolo,
+            .tracksArm,
+        ]))
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,7 +7,7 @@ The core execution order is ADR-002 → ADR-003 → ADR-004 → ADR-001.
 ADR-005 is cross-cutting and applies throughout the entire sequence.
 Every ADR starts in `Proposed` status and advances only with its own implementation and qualification evidence.
 
-The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-006 has also entered `In Implementation` with a first, types-only increment (the runtime cache rewiring is deferred pending a live soak — see its status entry). ADR-001, ADR-004, ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
+The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-006 has also entered `In Implementation` with a first, types-only increment (the runtime cache rewiring is deferred pending a live soak — see its status entry). ADR-004 has entered `In Implementation` with a pure in-memory saga engine (reversible-ops-only; live execution and MCP surface deferred — see its status entry). ADR-001, ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
 
 ## Category A — Core execution path
 
@@ -16,7 +16,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-002 | Session-scoped Stable Target Reference | A | `In Implementation` | [#285](https://github.com/MongLong0214/logic-pro-mcp/issues/285) |
 | ADR-003 | Public Operation Contract Registry | A | `In Implementation` | [#286](https://github.com/MongLong0214/logic-pro-mcp/issues/286) |
 | ADR-005 | Operation Trace and Support Bundle | A | `In Implementation` | [#288](https://github.com/MongLong0214/logic-pro-mcp/issues/288) |
-| ADR-004 | Verified Mutation Saga | A | `Proposed` | [#287](https://github.com/MongLong0214/logic-pro-mcp/issues/287) |
+| ADR-004 | Verified Mutation Saga | A | `In Implementation` | [#287](https://github.com/MongLong0214/logic-pro-mcp/issues/287) |
 | ADR-001 | Same-Release Live Qualification Gate | A | `Proposed` | [#284](https://github.com/MongLong0214/logic-pro-mcp/issues/284) |
 
 ## Category B — Shared infrastructure
@@ -71,6 +71,14 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - First increment: pure snapshot value types only — `VersionedSnapshot<Value>` (project epoch, section revision, observed-at, source, completeness, fingerprint), `StateSource` / `Completeness` / `CacheSectionID` enums, and pure `etag` / `cacheAgeMillis(now:)` derivations, behind `FeatureFlags.adr006VersionedCache` (default off).
 - Deliberately scoped out (deferred): the `RefreshCoordinator` (single-flight refresh + backpressure), the actual resource-envelope wiring (`project_epoch` / `section_revision` / `etag` / `cache_age_ms` on reads), and any `StateCache` rewiring. Those require the 30-minute memory-soak and large-project benchmarks from #289's acceptance criteria, which need live qualification and are not claimed here.
 - Deterministic tests only (no runtime path touched): field preservation, etag stability, `cacheAgeMillis` monotonicity + clock-skew guard, `Codable` round-trips, section completeness, flag-default-off.
+
+### ADR-004 — Verified Mutation Saga (`In Implementation`)
+- MVP saga engine only: a pure in-memory `actor MutationSaga` (12-state machine, full-plan preflight, compensation journal) behind `FeatureFlags.adr004MutationSaga` (default off). Step execution is injected via a `SagaStepExecutor` protocol — tests drive it with a synthetic mock; no live Logic and no dispatcher/MCP wiring.
+- **Full-plan preflight gate**: every step's target is resolved against the `TargetRegistry` (ADR-002) and validated against the operation registry (ADR-003); if any step has a stale/mismatched target, an unregistered/non-reversible operation, or an invalid inverse, **no step executes** (the executor is never called — asserted by `runCount == 0`).
+- **Reversible-ops allowlist, exactly six**: `track.rename`, `mixer.set_volume`, `mixer.set_pan`, `tracks.set_mute`, `tracks.set_solo`, `tracks.set_record_arm`. Each inverse restores the captured before-state.
+- **No blind inverse**: on an unverified (State B) or ambiguous write, the engine does a fresh readback and branches — applied → compensate, not-applied → no-op, unknown → `rollbackUncertain`. `fullyCompensated` is reported only after compensation readback confirms restoration; partial outcomes never surface as top-level success (`complete: false`).
+- 7 deterministic tests (synthetic executor): preflight-rejects-before-run, happy-path journal evidence, reverse-order compensation, no-blind-inverse reconciliation, compensation-failure honesty, idempotency + flag-default-off, exact state-machine/allowlist.
+- Deferred (honest scope): live execution against real dispatchers, the public MCP surface, and non-reversible / multi-target operations. Those need real write-path wiring plus live qualification and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
## ADR-004 (Verified Mutation Saga) — MVP engine

Refs #287, #308. Category A kernel increment, **flag-gated and default-off** (`LOGIC_MCP_ADR004_MUTATION_SAGA`) — zero runtime behavior when off. **Engine core only: no live execution, no public MCP surface.**

### What landed
- **`actor MutationSaga`** — 12-state machine (`draft … completed / partiallyApplied / reconciling / compensating / fullyCompensated / partiallyCompensated / compensationFailed / rollbackUncertain`), full-plan preflight, and a compensation journal (before-state, write-boundary, execution result, verification evidence, inverse op, compensation evidence per step).
- Step execution is injected via a **`SagaStepExecutor` protocol** — tests use a synthetic mock. No real dispatcher, no Logic, no MCP command wiring.

### Safety properties (all asserted by tests)
- **Full-plan preflight gate** — every step's target is resolved against `TargetRegistry` (ADR-002) and validated against the operation registry (ADR-003). If *any* step is stale-target / unregistered / non-reversible / has an invalid inverse, **no step executes** (executor never called — `runCount == 0`). Mirrors the guide's "if any item fails, step 1 does not execute."
- **Reversible-ops allowlist, exactly six** — `track.rename`, `mixer.set_volume`, `mixer.set_pan`, `tracks.set_mute`, `tracks.set_solo`, `tracks.set_record_arm`; each inverse restores the captured before-state.
- **No blind inverse** — on State B / ambiguous writes the engine does a fresh readback and branches: applied → compensate, not-applied → no-op, unknown → `rollbackUncertain`. `fullyCompensated` is reported **only after compensation readback confirms restoration**.
- **Partial ≠ success** — partial outcomes always carry `complete: false` / an explicit partial state; a completed idempotency key returns its prior outcome, a partial key refuses automatic replay.
- No ACID / transaction / global-undo wording; Logic global Undo is not used as a rollback engine.

### Tests / evidence
- 7 deterministic tests (synthetic executor, `Mutation saga` suite): preflight-rejects-before-run, happy-path journal evidence, reverse-order compensation, no-blind-inverse reconciliation (applied/not-applied/unknown), compensation-failure honesty, idempotency + flag-default-off, exact state-machine/allowlist.
- Full suite green on this branch (off latest `main`): **`Test run with 2358 tests passed`, 0 failures** (`swift test --no-parallel`).

### Deferred (honest scope)
Live execution against real dispatchers, the public MCP surface, and non-reversible / multi-target operations — those need real write-path wiring plus live qualification and are not claimed here. This PR lands the verified engine core so that wiring can build on a tested state machine.

### Docs
`docs/adr/README.md`: ADR-004 → `In Implementation` with the reversible-only + live-deferred scope noted.