### PR TITLE
feat(adr-001): release qualification gate harness skeleton (#284)

### DIFF
--- a/Scripts/live-qualification-runner.py
+++ b/Scripts/live-qualification-runner.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+# How to run:
+# python3 Scripts/live-qualification-runner.py --artifact PATH --sha256 HEX --release-version VERSION
+"""Emit a non-live ADR-001 qualification attestation skeleton.
+
+Live execution and CI enforcement are deferred: full same-artifact live
+qualification cannot be unattended. This script only concretizes the
+attestation schema and matrix; it never calls Logic Pro or MCP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import itertools
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def artifact_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--release-version", required=True)
+    args = parser.parse_args()
+
+    if not args.artifact.is_file():
+        parser.error(f"artifact is not a file: {args.artifact}")
+    digest = artifact_sha256(args.artifact)
+    if not hmac.compare_digest(digest, args.sha256.lower()):
+        parser.error(f"artifact SHA-256 mismatch: expected {args.sha256.lower()}, actual {digest}")
+
+    cases = []
+    matrix = itertools.product(
+        ("desktop", "creator"),
+        ("en-US", "ko-KR"),
+        ("core", "full"),
+        ("cold", "warm"),
+        ("empty", "medium", "large"),
+    )
+    for variant, locale, profile, cache, fixture in matrix:
+        case_id = f"{variant}/{locale}/{profile}/{cache}/{fixture}"
+        cases.append(
+            {
+                "id": case_id,
+                "status": "not_qualified",
+                "tool": "",
+                "command": "",
+                "trace_id": "",
+                "verified": False,
+                "evidence_files": [],
+            }
+        )
+
+    swift_reference_date = datetime(2001, 1, 1, tzinfo=timezone.utc)
+    timestamp = (datetime.now(timezone.utc) - swift_reference_date).total_seconds()
+    attestation = {
+        "schema": "release-qualification-attestation/v1",
+        "serverVersion": args.release_version,
+        "commitSHA": "not_qualified",
+        "binarySHA256": digest,
+        "logicVariant": "desktop",
+        "logicVersion": "not_qualified",
+        "locale": "en-US",
+        "profile": "core",
+        "startedAt": timestamp,
+        "completedAt": timestamp,
+        "total": len(cases),
+        "passed": 0,
+        "failed": 0,
+        "waived": 0,
+        "cases": cases,
+        "waivers": [],
+        "evidenceManifestSHA256": "",
+    }
+
+    # Promotion policy remains single-sourced in Swift PromotionGate.
+    # TODO(#284): replace placeholders only when the full live matrix can run on one artifact.
+    print(json.dumps(attestation, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/Sources/LogicProMCP/Qualification/PromotionGate.swift
+++ b/Sources/LogicProMCP/Qualification/PromotionGate.swift
@@ -1,0 +1,126 @@
+enum PromotionRejectionReason: Equatable, Sendable {
+    case requiredCaseFailed(caseID: String)
+    case requiredCombinationNotQualified(key: String)
+    case missingArtifact(name: String)
+    case binarySHAMismatch(expected: String, actual: String)
+    case expiredWaiver(caseID: String)
+    case releaseVersionMismatch(expected: String, actual: String)
+}
+
+struct PromotionDecision: Equatable, Sendable {
+    let promotable: Bool
+    let rejections: [PromotionRejectionReason]
+}
+
+struct PromotionGate {
+    func evaluate(
+        attestation: ReleaseQualificationAttestation,
+        releaseVersion: String,
+        expectedBinarySHA256: String,
+        presentArtifacts: Set<String>,
+        requiredArtifacts: Set<String>
+    ) -> PromotionDecision {
+        var rejections: [PromotionRejectionReason] = []
+
+        if SemanticVersion(attestation.serverVersion) == nil
+            || SemanticVersion(releaseVersion) == nil
+            || attestation.serverVersion != releaseVersion {
+            rejections.append(.releaseVersionMismatch(
+                expected: releaseVersion,
+                actual: attestation.serverVersion
+            ))
+        }
+        if !Self.isSHA256(attestation.binarySHA256)
+            || !Self.isSHA256(expectedBinarySHA256)
+            || attestation.binarySHA256 != expectedBinarySHA256 {
+            rejections.append(.binarySHAMismatch(
+                expected: expectedBinarySHA256,
+                actual: attestation.binarySHA256
+            ))
+        }
+        for artifact in requiredArtifacts.subtracting(presentArtifacts).sorted() {
+            rejections.append(.missingArtifact(name: artifact))
+        }
+        let expiredWaiverIDs = Set(attestation.waivers.compactMap { waiver in
+            Self.isExpired(waiver.expiryVersion, at: releaseVersion) ? waiver.caseID : nil
+        })
+        for caseID in expiredWaiverIDs.sorted() {
+            rejections.append(.expiredWaiver(caseID: caseID))
+        }
+        for axis in QualificationAxis.requiredCombinations {
+            let matchingCases = attestation.cases.filter {
+                Self.matchesRequiredAxis(caseID: $0.id, axis: axis)
+            }
+            let failedCaseID = matchingCases
+                .filter { $0.status == .failed }
+                .map(\.id)
+                .sorted()
+                .first
+            if let failedCaseID {
+                rejections.append(.requiredCaseFailed(caseID: failedCaseID))
+            } else if Set(matchingCases.map(\.id)).count != matchingCases.count {
+                rejections.append(.requiredCombinationNotQualified(key: axis.key))
+            } else if !matchingCases.contains(where: {
+                $0.status == .passed && $0.verified && !$0.evidenceFiles.isEmpty
+            }) {
+                rejections.append(.requiredCombinationNotQualified(key: axis.key))
+            }
+        }
+
+        return PromotionDecision(
+            promotable: rejections.isEmpty,
+            rejections: rejections
+        )
+    }
+
+    private static func isExpired(_ expiryVersion: String, at releaseVersion: String) -> Bool {
+        guard let expiry = SemanticVersion(expiryVersion),
+              let release = SemanticVersion(releaseVersion) else {
+            return true
+        }
+        return expiry <= release
+    }
+
+    private static func matchesRequiredAxis(
+        caseID: String,
+        axis: QualificationAxis
+    ) -> Bool {
+        caseID == axis.key || ProjectFixture.allCases.contains {
+            caseID == "\(axis.key)/\($0.rawValue)"
+        }
+    }
+
+    private static func isSHA256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy(\.isHexDigit)
+    }
+}
+
+private struct SemanticVersion: Comparable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init?(_ rawValue: String) {
+        var value = rawValue
+        if value.first == "v" || value.first == "V" {
+            value.removeFirst()
+        }
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }),
+              let major = Int(parts[0]),
+              let minor = Int(parts[1]),
+              let patch = Int(parts[2]) else {
+            return nil
+        }
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+}

--- a/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
+++ b/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+enum QualificationStatus: String, Codable, Sendable {
+    case passed
+    case failed
+    case waived
+    case notQualified = "not_qualified"
+}
+
+enum LogicVariant: String, Codable, CaseIterable, Sendable {
+    case desktop
+    case creatorStudio = "creator"
+}
+
+enum QualificationLocale: String, Codable, CaseIterable, Sendable {
+    case enUS = "en-US"
+    case koKR = "ko-KR"
+}
+
+enum SetupProfile: String, Codable, CaseIterable, Sendable {
+    case core
+    case full
+}
+
+enum CacheState: String, Codable, CaseIterable, Sendable {
+    case cold
+    case warm
+}
+
+enum ProjectFixture: String, Codable, CaseIterable, Sendable {
+    case empty
+    case medium
+    case large
+}
+
+struct QualificationCase: Codable, Equatable, Sendable {
+    let id: String
+    let status: QualificationStatus
+    let tool: String
+    let command: String
+    let traceID: String
+    let verified: Bool
+    let evidenceFiles: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case status
+        case tool
+        case command
+        case traceID = "trace_id"
+        case verified
+        case evidenceFiles = "evidence_files"
+    }
+}
+
+struct QualificationWaiver: Codable, Equatable, Sendable {
+    let caseID: String
+    let reasonCode: String
+    let owningIssue: String
+    let userImpact: String
+    let affectedCapability: String
+    let affectsDefaultProfile: Bool
+    let expiryVersion: String
+    let releaseNoteVisible: Bool
+}
+
+struct ReleaseQualificationAttestation: Codable, Equatable, Sendable {
+    let schema: String
+    let serverVersion: String
+    let commitSHA: String
+    let binarySHA256: String
+    let logicVariant: LogicVariant
+    let logicVersion: String
+    let locale: QualificationLocale
+    let profile: SetupProfile
+    let startedAt: Date
+    let completedAt: Date
+    let total: Int
+    let passed: Int
+    let failed: Int
+    let waived: Int
+    let cases: [QualificationCase]
+    let waivers: [QualificationWaiver]
+    let evidenceManifestSHA256: String
+}
+
+struct QualificationAxis: Equatable, Sendable {
+    let variant: LogicVariant
+    let locale: QualificationLocale
+    let profile: SetupProfile
+    let cache: CacheState
+    let fixture: ProjectFixture
+
+    static let requiredCombinations: [QualificationAxis] = [
+        QualificationAxis(
+            variant: .desktop,
+            locale: .enUS,
+            profile: .core,
+            cache: .cold,
+            fixture: .empty
+        ),
+        QualificationAxis(
+            variant: .desktop,
+            locale: .koKR,
+            profile: .core,
+            cache: .cold,
+            fixture: .empty
+        ),
+        QualificationAxis(
+            variant: .creatorStudio,
+            locale: .enUS,
+            profile: .core,
+            cache: .cold,
+            fixture: .empty
+        ),
+        QualificationAxis(
+            variant: .creatorStudio,
+            locale: .koKR,
+            profile: .core,
+            cache: .cold,
+            fixture: .empty
+        ),
+    ]
+
+    var key: String {
+        "\(variant.rawValue)/\(locale.rawValue)/\(profile.rawValue)/\(cache.rawValue)"
+    }
+}

--- a/Tests/LogicProMCPTests/QualificationGateTests.swift
+++ b/Tests/LogicProMCPTests/QualificationGateTests.swift
@@ -1,0 +1,311 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-001 qualification gate")
+struct QualificationGateTests {
+    private let requiredArtifacts: Set<String> = ["LogicProMCP", "evidence-manifest.json"]
+    private let binarySHA256 = String(repeating: "a", count: 64)
+
+    @Test func allRequiredCombinationsPassedPromotes() {
+        let decision = evaluate(cases: passedRequiredCases())
+
+        #expect(decision.promotable)
+        #expect(decision.rejections.isEmpty)
+    }
+
+    @Test func missingRequiredCombinationRejects() {
+        let missingKey = QualificationAxis.requiredCombinations[0].key
+        let decision = evaluate(cases: Array(passedRequiredCases().dropFirst()))
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.requiredCombinationNotQualified(key: missingKey)))
+    }
+
+    @Test func failedRequiredCaseRejects() {
+        let failedKey = "\(QualificationAxis.requiredCombinations[0].key)/empty"
+        var cases = passedRequiredCases()
+        cases[0] = qualificationCase(id: failedKey, status: .failed)
+
+        let decision = evaluate(cases: cases)
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [.requiredCaseFailed(caseID: failedKey)])
+    }
+
+    @Test func binarySHAMismatchRejects() {
+        let expected = String(repeating: "b", count: 64)
+        let decision = evaluate(cases: passedRequiredCases(), expectedBinarySHA256: expected)
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .binarySHAMismatch(expected: expected, actual: binarySHA256),
+        ])
+    }
+
+    @Test func missingRequiredArtifactRejects() {
+        let decision = evaluate(
+            cases: passedRequiredCases(),
+            presentArtifacts: ["LogicProMCP"]
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.missingArtifact(name: "evidence-manifest.json")))
+    }
+
+    @Test func invalidEqualBinarySHAsReject() {
+        let decision = evaluate(
+            cases: passedRequiredCases(),
+            expectedBinarySHA256: "not-a-sha",
+            attestationSHA256: "not-a-sha"
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .binarySHAMismatch(expected: "not-a-sha", actual: "not-a-sha"),
+        ])
+    }
+
+    @Test func expiredWaiverAtReleaseVersionRejects() {
+        let decision = evaluate(
+            cases: passedRequiredCases(),
+            waivers: [waiver(caseID: "optional-case", expiryVersion: "v1.2.3")]
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.expiredWaiver(caseID: "optional-case")))
+    }
+
+    @Test func validNonRequiredWaiverDoesNotReject() {
+        let decision = evaluate(
+            cases: passedRequiredCases() + [qualificationCase(id: "optional-case", status: .waived)],
+            waivers: [waiver(caseID: "optional-case", expiryVersion: "1.3.0")]
+        )
+
+        #expect(decision.promotable)
+        #expect(decision.rejections.isEmpty)
+    }
+
+    @Test func waivedRequiredCombinationDoesNotCountAsPassed() {
+        let requiredKey = QualificationAxis.requiredCombinations[0].key
+        let waivedKey = "\(requiredKey)/empty"
+        var cases = passedRequiredCases()
+        cases[0] = qualificationCase(id: waivedKey, status: .waived)
+
+        let decision = evaluate(
+            cases: cases,
+            waivers: [waiver(caseID: waivedKey, expiryVersion: "1.3.0")]
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.requiredCombinationNotQualified(key: requiredKey)))
+    }
+
+    @Test func unverifiedPassedRequiredCombinationDoesNotCountAsPassed() {
+        let requiredKey = QualificationAxis.requiredCombinations[0].key
+        var cases = passedRequiredCases()
+        cases[0] = qualificationCase(
+            id: "\(requiredKey)/empty",
+            status: .passed,
+            verified: false
+        )
+
+        let decision = evaluate(cases: cases)
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.requiredCombinationNotQualified(key: requiredKey)))
+    }
+
+    @Test func passedRequiredCombinationWithoutEvidenceDoesNotCountAsPassed() {
+        let requiredKey = QualificationAxis.requiredCombinations[0].key
+        var cases = passedRequiredCases()
+        cases[0] = qualificationCase(
+            id: "\(requiredKey)/empty",
+            status: .passed,
+            evidenceFiles: []
+        )
+
+        let decision = evaluate(cases: cases)
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .requiredCombinationNotQualified(key: requiredKey),
+        ])
+    }
+
+    @Test func failedFixtureBlocksPassedSiblingFixture() {
+        let requiredKey = QualificationAxis.requiredCombinations[0].key
+        let failedID = "\(requiredKey)/medium"
+        let decision = evaluate(
+            cases: passedRequiredCases() + [qualificationCase(id: failedID, status: .failed)]
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [.requiredCaseFailed(caseID: failedID)])
+    }
+
+    @Test func multipleFailedFixturesReportLexicallyFirstID() {
+        let requiredKey = QualificationAxis.requiredCombinations[0].key
+        let largeID = "\(requiredKey)/large"
+        let mediumID = "\(requiredKey)/medium"
+        let decision = evaluate(
+            cases: passedRequiredCases()
+                + [qualificationCase(id: mediumID, status: .failed)]
+                + [qualificationCase(id: largeID, status: .failed)]
+        )
+
+        #expect(decision.rejections == [.requiredCaseFailed(caseID: largeID)])
+    }
+
+    @Test func duplicatePassedCaseIDDoesNotQualify() {
+        let duplicate = passedRequiredCases()[0]
+        let decision = evaluate(cases: passedRequiredCases() + [duplicate])
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .requiredCombinationNotQualified(key: QualificationAxis.requiredCombinations[0].key),
+        ])
+    }
+
+    @Test func duplicateMixedCaseIDDoesNotQualify() {
+        let duplicate = passedRequiredCases()[0]
+        let notQualified = qualificationCase(id: duplicate.id, status: .notQualified)
+        let decision = evaluate(cases: passedRequiredCases() + [notQualified])
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .requiredCombinationNotQualified(key: QualificationAxis.requiredCombinations[0].key),
+        ])
+    }
+
+    @Test func releaseVersionMismatchRejects() {
+        let decision = evaluate(cases: passedRequiredCases(), attestationVersion: "1.2.2")
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(.releaseVersionMismatch(expected: "1.2.3", actual: "1.2.2")))
+    }
+
+    @Test func equalInvalidReleaseVersionsReject() {
+        let decision = evaluate(
+            cases: passedRequiredCases(),
+            attestationVersion: "banana",
+            releaseVersion: "banana"
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections == [
+            .releaseVersionMismatch(expected: "banana", actual: "banana"),
+        ])
+    }
+
+    @Test func attestationCodableRoundTripPreservesDates() throws {
+        let original = attestation(
+            cases: passedRequiredCases(),
+            waivers: [waiver(caseID: "optional-case", expiryVersion: "1.3.0")]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ReleaseQualificationAttestation.self, from: data)
+
+        #expect(decoded == original)
+        #expect(decoded.startedAt == Date(timeIntervalSince1970: 1_000))
+        #expect(decoded.completedAt == Date(timeIntervalSince1970: 1_060))
+    }
+
+    @Test func requiredCombinationKeysAreExact() {
+        #expect(QualificationAxis.requiredCombinations.count == 4)
+        #expect(QualificationAxis.requiredCombinations.map(\.key) == [
+            "desktop/en-US/core/cold",
+            "desktop/ko-KR/core/cold",
+            "creator/en-US/core/cold",
+            "creator/ko-KR/core/cold",
+        ])
+    }
+
+    private func evaluate(
+        cases: [QualificationCase],
+        waivers: [QualificationWaiver] = [],
+        attestationVersion: String = "1.2.3",
+        releaseVersion: String = "1.2.3",
+        expectedBinarySHA256: String? = nil,
+        presentArtifacts: Set<String>? = nil,
+        attestationSHA256: String? = nil
+    ) -> PromotionDecision {
+        PromotionGate().evaluate(
+            attestation: attestation(
+                serverVersion: attestationVersion,
+                binarySHA256: attestationSHA256,
+                cases: cases,
+                waivers: waivers
+            ),
+            releaseVersion: releaseVersion,
+            expectedBinarySHA256: expectedBinarySHA256 ?? binarySHA256,
+            presentArtifacts: presentArtifacts ?? requiredArtifacts,
+            requiredArtifacts: requiredArtifacts
+        )
+    }
+
+    private func attestation(
+        serverVersion: String = "1.2.3",
+        binarySHA256: String? = nil,
+        cases: [QualificationCase],
+        waivers: [QualificationWaiver]
+    ) -> ReleaseQualificationAttestation {
+        ReleaseQualificationAttestation(
+            schema: "release-qualification-attestation/v1",
+            serverVersion: serverVersion,
+            commitSHA: String(repeating: "c", count: 40),
+            binarySHA256: binarySHA256 ?? self.binarySHA256,
+            logicVariant: .desktop,
+            logicVersion: "11.2.0",
+            locale: .enUS,
+            profile: .core,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            completedAt: Date(timeIntervalSince1970: 1_060),
+            total: cases.count,
+            passed: cases.filter { $0.status == .passed }.count,
+            failed: cases.filter { $0.status == .failed }.count,
+            waived: cases.filter { $0.status == .waived }.count,
+            cases: cases,
+            waivers: waivers,
+            evidenceManifestSHA256: String(repeating: "d", count: 64)
+        )
+    }
+
+    private func passedRequiredCases() -> [QualificationCase] {
+        QualificationAxis.requiredCombinations.map {
+            qualificationCase(id: "\($0.key)/empty", status: .passed)
+        }
+    }
+
+    private func qualificationCase(
+        id: String,
+        status: QualificationStatus,
+        verified: Bool? = nil,
+        evidenceFiles: [String]? = nil
+    ) -> QualificationCase {
+        let isVerified = verified ?? (status == QualificationStatus.passed)
+        return QualificationCase(
+            id: id,
+            status: status,
+            tool: "logic_system",
+            command: "doctor",
+            traceID: "lpmcp_00000000-0000-0000-0000-000000000000",
+            verified: isVerified,
+            evidenceFiles: evidenceFiles ?? ["evidence/\(id).json"]
+        )
+    }
+
+    private func waiver(caseID: String, expiryVersion: String) -> QualificationWaiver {
+        QualificationWaiver(
+            caseID: caseID,
+            reasonCode: "known-limitation",
+            owningIssue: "#284",
+            userImpact: "Optional capability unavailable",
+            affectedCapability: "optional-capability",
+            affectsDefaultProfile: false,
+            expiryVersion: expiryVersion,
+            releaseNoteVisible: true
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,7 +7,7 @@ The core execution order is ADR-002 → ADR-003 → ADR-004 → ADR-001.
 ADR-005 is cross-cutting and applies throughout the entire sequence.
 Every ADR starts in `Proposed` status and advances only with its own implementation and qualification evidence.
 
-The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-006 has also entered `In Implementation` with a first, types-only increment (the runtime cache rewiring is deferred pending a live soak — see its status entry). ADR-004 has entered `In Implementation` with a pure in-memory saga engine (reversible-ops-only; live execution and MCP surface deferred — see its status entry). ADR-001, ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
+The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementation`: each has flag-gated (default-off) pilots merged to `main` with deterministic tests and live evidence (see the [Implementation status](#implementation-status) section). They add zero runtime behavior with their flags off. ADR-006 has also entered `In Implementation` with a first, types-only increment (the runtime cache rewiring is deferred pending a live soak — see its status entry). ADR-004 has entered `In Implementation` with a pure in-memory saga engine (reversible-ops-only; live execution and MCP surface deferred — see its status entry). ADR-001 has entered `In Implementation` with a qualification-gate harness skeleton (attestation types + a pure promotion-gate evaluator; the live qualification matrix and release-gate CI enforcement are deferred — see its status entry). This completes the guide's core assurance chain (ADR-002 → 003 → 004 → 001) in flag-gated / harness form. ADR-007 and all Category C/D ADRs remain `Proposed` — they depend on the kernel being not just merged but live-qualified, which is ongoing.
 
 ## Category A — Core execution path
 
@@ -17,7 +17,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-003 | Public Operation Contract Registry | A | `In Implementation` | [#286](https://github.com/MongLong0214/logic-pro-mcp/issues/286) |
 | ADR-005 | Operation Trace and Support Bundle | A | `In Implementation` | [#288](https://github.com/MongLong0214/logic-pro-mcp/issues/288) |
 | ADR-004 | Verified Mutation Saga | A | `In Implementation` | [#287](https://github.com/MongLong0214/logic-pro-mcp/issues/287) |
-| ADR-001 | Same-Release Live Qualification Gate | A | `Proposed` | [#284](https://github.com/MongLong0214/logic-pro-mcp/issues/284) |
+| ADR-001 | Same-Release Live Qualification Gate | A | `In Implementation` | [#284](https://github.com/MongLong0214/logic-pro-mcp/issues/284) |
 
 ## Category B — Shared infrastructure
 
@@ -79,6 +79,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **No blind inverse**: on an unverified (State B) or ambiguous write, the engine does a fresh readback and branches — applied → compensate, not-applied → no-op, unknown → `rollbackUncertain`. `fullyCompensated` is reported only after compensation readback confirms restoration; partial outcomes never surface as top-level success (`complete: false`).
 - 7 deterministic tests (synthetic executor): preflight-rejects-before-run, happy-path journal evidence, reverse-order compensation, no-blind-inverse reconciliation, compensation-failure honesty, idempotency + flag-default-off, exact state-machine/allowlist.
 - Deferred (honest scope): live execution against real dispatchers, the public MCP surface, and non-reversible / multi-target operations. Those need real write-path wiring plus live qualification and are not claimed here.
+
+### ADR-001 — Same-Release Live Qualification Gate (`In Implementation`)
+- Harness skeleton + pure gate logic only. `ReleaseQualificationAttestation` / `QualificationCase` / `QualificationWaiver` value types (matching #284's schema, snake_case JSON keys), the qualification matrix axes (`LogicVariant` / `QualificationLocale` / `SetupProfile` / `CacheState` / `ProjectFixture`), and the exact 4 required combinations (desktop|creator × en-US|ko-KR, core/cold).
+- **Pure `PromotionGate` evaluator** (no I/O, no clock): rejects promotion on any of the six distinct reasons — required case failed, required combination not qualified, missing artifact, binary SHA-256 mismatch, expired waiver, release-version mismatch. A required combination qualifies **only** when a matching case is `passed` **and** `verified` **and** carries evidence — a `waived` / unverified / evidence-less case never satisfies a required combination (`skip is not pass`). Waiver expiry is a pure SemVer comparison; malformed SHA / version inputs fail closed.
+- `Scripts/live-qualification-runner.py` is a **non-live skeleton** — it emits the attestation shape with `not_qualified` placeholders and a `TODO(#284)` marking where the real matrix run plugs in. It performs no Logic / MCP calls.
+- 19 deterministic tests over the gate (all six rejection reasons, the three `skip-is-not-pass` variants, fail-closed-on-malformed, duplicate-case detection, `Codable` date round-trip, exact required-combination keys).
+- Deferred (honest scope): the actual same-artifact live qualification matrix run on real Logic Pro, and wiring the gate into the release pipeline as an enforced CI check. Those need a human-attended real-Logic environment across the full variant/locale/profile matrix and are not claimed here; no CI workflow or release script is modified by this increment.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
## ADR-001 (Same-Release Live Qualification Gate) — harness skeleton

Refs #284, #308. Final Category A kernel increment. **Harness skeleton + pure gate logic only** — no runtime path, no FeatureFlags flag, **no CI-workflow / release-script changes**; adds zero runtime behavior.

### What landed
- **Attestation types** — `ReleaseQualificationAttestation` / `QualificationCase` / `QualificationWaiver` matching #284's schema (snake_case JSON keys: `trace_id`, `evidence_files`), the matrix axis enums (`LogicVariant`, `QualificationLocale`, `SetupProfile`, `CacheState`, `ProjectFixture`), and the exact **4 required combinations** (desktop|creator × en-US|ko-KR, core/cold).
- **Pure `PromotionGate` evaluator** (no I/O, no clock) — rejects promotion on any of six distinct reasons: required case failed, required combination not qualified, missing artifact, binary SHA-256 mismatch, expired waiver, release-version mismatch.
  - A required combination qualifies **only** when a matching case is `passed` **and** `verified` **and** carries evidence — a `waived` / unverified / evidence-less case never satisfies it (**"skip is not pass"**).
  - Waiver expiry is a pure SemVer comparison (`expiry <= release`); malformed SHA / version inputs **fail closed**.
- **`Scripts/live-qualification-runner.py`** — a **non-live skeleton**: emits the attestation shape with `not_qualified` placeholders and a `TODO(#284)` marking where the real matrix run plugs in. No Logic / MCP calls.

### Tests / evidence
- 19 deterministic gate tests: all six rejection reasons, the three `skip-is-not-pass` variants (waived / unverified / no-evidence), fail-closed-on-malformed SHA & version, duplicate-case detection, `Codable` date round-trip, exact required-combination keys.
- Full suite green off latest `main`: **`Test run with 2377 tests passed`, 0 failures** (`swift test --no-parallel`).

### Deferred (honest scope)
The actual **same-artifact live qualification matrix** on real Logic Pro (desktop/creator × en/ko × core/full) and **wiring the gate into the release pipeline as an enforced CI check**. Those need a human-attended real-Logic environment across the full matrix and are not claimed here. This increment lands the tested gate logic + attestation contract so the live runner + CI enforcement can build on a proven core.

### Docs
`docs/adr/README.md`: ADR-001 → `In Implementation` with the harness-only + live-deferred scope; notes this completes the core assurance chain ADR-002 → 003 → 004 → 001 in flag-gated / harness form.