### PR TITLE
feat(adr-009): verified plugin apply-back capability pure core (#292)

### DIFF
--- a/Sources/LogicProMCP/PluginCapability/CapabilityRegistry.swift
+++ b/Sources/LogicProMCP/PluginCapability/CapabilityRegistry.swift
@@ -1,0 +1,77 @@
+struct CapabilityRegistry: Sendable {
+    private let capabilities: [VerifiedParameterCapability]
+
+    init(capabilities: [VerifiedParameterCapability] = Self.candidates) {
+        self.capabilities = capabilities
+    }
+
+    func allCapabilities() -> [VerifiedParameterCapability] {
+        capabilities
+    }
+
+    func publicCapabilities() -> [VerifiedParameterCapability] {
+        capabilities.filter { $0.status == .public && $0.isPubliclyExposable }
+    }
+
+    func capability(
+        pluginIdentity: PluginIdentity,
+        parameterID: ParameterID
+    ) -> VerifiedParameterCapability? {
+        capabilities.first {
+            $0.pluginIdentity == pluginIdentity && $0.parameterID == parameterID
+        }
+    }
+
+    private static let compressor = PluginIdentity(
+        manufacturer: "Apple",
+        name: "Compressor",
+        type: "effect"
+    )
+    private static let gain = PluginIdentity(
+        manufacturer: "Apple",
+        name: "Gain",
+        type: "effect"
+    )
+    private static let limiter = PluginIdentity(
+        manufacturer: "Apple",
+        name: "Limiter",
+        type: "effect"
+    )
+
+    private static let candidates: [VerifiedParameterCapability] = [
+        candidate(compressor, "threshold", "Threshold", .normalized, 0 ... 100, 1),
+        candidate(compressor, "ratio", "Ratio", .ratio, 1 ... 30, 0.01),
+        candidate(compressor, "attack", "Attack", .milliseconds, 0 ... 200, 0.1),
+        candidate(compressor, "release", "Release", .milliseconds, 5 ... 5_000, 1),
+        candidate(compressor, "makeup", "Makeup", .decibels, -20 ... 20, 0.1),
+        candidate(gain, "gain", "Gain", .decibels, -96 ... 24, 0.1),
+        candidate(gain, "phaseInvert", "Phase Invert", .boolean, 0 ... 1, 0),
+        candidate(limiter, "gain", "Gain", .decibels, 0 ... 24, 0.1),
+        candidate(limiter, "outputCeiling", "Output Ceiling", .decibels, -24 ... 0, 0.1),
+        candidate(limiter, "release", "Release", .milliseconds, 10 ... 1_000, 1),
+    ]
+
+    private static func candidate(
+        _ pluginIdentity: PluginIdentity,
+        _ parameterID: String,
+        _ displayName: String,
+        _ valueType: ParameterValueType,
+        _ allowedRange: ClosedRange<Double>,
+        _ tolerance: Double
+    ) -> VerifiedParameterCapability {
+        VerifiedParameterCapability(
+            pluginIdentity: pluginIdentity,
+            parameterID: ParameterID(rawValue: parameterID),
+            displayName: displayName,
+            valueType: valueType,
+            allowedRange: allowedRange,
+            writeMethod: .axValue,
+            readbackMethod: .axValue,
+            tolerance: tolerance,
+            requiredView: .controls,
+            selectorSignatures: [],
+            qualificationEvidence: [],
+            status: .experimental
+        )
+    }
+}

--- a/Sources/LogicProMCP/PluginCapability/CapabilityVerification.swift
+++ b/Sources/LogicProMCP/PluginCapability/CapabilityVerification.swift
@@ -1,0 +1,133 @@
+enum ReadbackVerdict: Equatable, Sendable {
+    case confirmed
+    case mismatch(observed: Double, expected: Double, tolerance: Double)
+    case unsupportedValueType
+}
+
+func verifyReadback(
+    capability: VerifiedParameterCapability,
+    written: Double,
+    observed: Double
+) -> ReadbackVerdict {
+    guard written.isFinite, observed.isFinite,
+          capability.tolerance.isFinite, capability.tolerance >= 0
+    else {
+        return .unsupportedValueType
+    }
+
+    let expected = normalized(written, for: capability.valueType)
+    let actual = normalized(observed, for: capability.valueType)
+    guard abs(actual - expected) <= capability.tolerance else {
+        return .mismatch(
+            observed: actual,
+            expected: expected,
+            tolerance: capability.tolerance
+        )
+    }
+    return .confirmed
+}
+
+private func normalized(_ value: Double, for type: ParameterValueType) -> Double {
+    switch type {
+    case .boolean:
+        value >= 0.5 ? 1 : 0
+    case .enumerated:
+        value.rounded()
+    case .normalized, .decibels, .milliseconds, .hertz, .ratio:
+        value
+    }
+}
+
+struct ParameterSnapshot: Codable, Equatable, Sendable {
+    let pluginIdentity: PluginIdentity
+    let values: [ParameterID: Double]
+}
+
+func snapshotDiff(
+    before: ParameterSnapshot,
+    after: ParameterSnapshot
+) -> [ParameterID: (before: Double, after: Double)] {
+    guard before.pluginIdentity == after.pluginIdentity else { return [:] }
+
+    var result: [ParameterID: (before: Double, after: Double)] = [:]
+    for parameterID in Set(before.values.keys).intersection(after.values.keys) {
+        guard let old = before.values[parameterID],
+              let new = after.values[parameterID],
+              old != new
+        else {
+            continue
+        }
+        result[parameterID] = (before: old, after: new)
+    }
+    return result
+}
+
+struct BatchApplyRequest: Sendable {
+    let pluginIdentity: PluginIdentity
+    let targets: [(ParameterID, Double)]
+}
+
+enum CapabilityError: Error, Equatable, Sendable {
+    case unsupportedParameter(ParameterID)
+    case valueOutOfRange(
+        parameterID: ParameterID,
+        value: Double,
+        allowedRange: ClosedRange<Double>
+    )
+}
+
+struct BatchApplyResult: Equatable, Sendable {
+    let appliedVerified: [ParameterID]
+    let failed: [(ParameterID, ReadbackVerdict)]
+    let complete: Bool
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.appliedVerified == rhs.appliedVerified
+            && lhs.complete == rhs.complete
+            && lhs.failed.count == rhs.failed.count
+            && zip(lhs.failed, rhs.failed).allSatisfy { left, right in
+                left.0 == right.0 && left.1 == right.1
+            }
+    }
+}
+
+enum BatchApplyOutcome: Equatable, Sendable {
+    case complete(BatchApplyResult)
+    case partialFailure(BatchApplyResult)
+
+    init(_ result: BatchApplyResult) {
+        self = result.complete ? .complete(result) : .partialFailure(result)
+    }
+
+    var isSuccess: Bool {
+        if case .complete = self { return true }
+        return false
+    }
+}
+
+func planBatchApply(
+    _ request: BatchApplyRequest,
+    registry: CapabilityRegistry
+) -> Result<[VerifiedParameterCapability], CapabilityError> {
+    var planned: [VerifiedParameterCapability] = []
+    for (parameterID, value) in request.targets {
+        guard let capability = registry.capability(
+            pluginIdentity: request.pluginIdentity,
+            parameterID: parameterID
+        ) else {
+            return .failure(.unsupportedParameter(parameterID))
+        }
+        if let allowedRange = capability.allowedRange,
+           !allowedRange.contains(value) {
+            return .failure(
+                .valueOutOfRange(
+                    parameterID: parameterID,
+                    value: value,
+                    allowedRange: allowedRange
+                )
+            )
+        }
+        planned.append(capability)
+    }
+    return .success(planned)
+}

--- a/Sources/LogicProMCP/PluginCapability/VerifiedParameterCapability.swift
+++ b/Sources/LogicProMCP/PluginCapability/VerifiedParameterCapability.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct PluginIdentity: Codable, Hashable, Sendable {
+    let manufacturer: String
+    let name: String
+    let type: String
+}
+
+struct ParameterID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+enum ParameterValueType: String, Codable, Sendable {
+    case normalized
+    case decibels
+    case milliseconds
+    case hertz
+    case ratio
+    case enumerated
+    case boolean
+}
+
+enum PluginWriteMethod: String, Codable, Sendable {
+    case axValue
+    case axIncrement
+    case textField
+}
+
+enum PluginReadbackMethod: String, Codable, Sendable {
+    case axValue
+    case displayString
+}
+
+enum PluginView: String, Codable, Sendable {
+    case controls
+    case editor
+}
+
+enum CapabilityStatus: String, Codable, Sendable {
+    case experimental
+    case qualified
+    case `public`
+    case deprecated
+}
+
+struct EvidenceReference: Codable, Hashable, Sendable {
+    let id: String
+    let kind: String
+}
+
+struct VerifiedParameterCapability: Codable, Equatable, Sendable {
+    let pluginIdentity: PluginIdentity
+    let parameterID: ParameterID
+    let displayName: String
+    let valueType: ParameterValueType
+    let allowedRange: ClosedRange<Double>?
+    let writeMethod: PluginWriteMethod
+    let readbackMethod: PluginReadbackMethod
+    let tolerance: Double
+    let requiredView: PluginView
+    let selectorSignatures: Set<String>
+    let qualificationEvidence: [EvidenceReference]
+    let status: CapabilityStatus
+
+    var isPubliclyExposable: Bool {
+        status == .public && !qualificationEvidence.isEmpty
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -44,4 +44,8 @@ enum FeatureFlags: Sendable {
     static var adr008RoutingGraph: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR008_ROUTING_GRAPH"] == "1"
     }
+
+    static var adr009PluginCapabilities: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR009_PLUGIN_CAPABILITIES"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/PluginCapabilityTests.swift
+++ b/Tests/LogicProMCPTests/PluginCapabilityTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-009 plugin capabilities")
+struct PluginCapabilityTests {
+    private let compressor = PluginIdentity(
+        manufacturer: "Apple",
+        name: "Compressor",
+        type: "effect"
+    )
+
+    @Test func candidatesStayExperimentalAndPublicSurfaceIsEmpty() {
+        let registry = CapabilityRegistry()
+        let candidates = registry.allCapabilities()
+
+        #expect(!candidates.isEmpty)
+        #expect(candidates.allSatisfy { $0.status == .experimental })
+        #expect(candidates.allSatisfy { $0.qualificationEvidence.isEmpty })
+        #expect(registry.publicCapabilities().isEmpty)
+    }
+
+    @Test func publicStatusWithoutEvidenceIsNotExposable() {
+        let withoutEvidence = capability(status: .public)
+        let withEvidence = capability(
+            status: .public,
+            evidence: [EvidenceReference(id: "qualification-1", kind: "live_matrix")]
+        )
+
+        #expect(!withoutEvidence.isPubliclyExposable)
+        #expect(withEvidence.isPubliclyExposable)
+    }
+
+    @Test func toleranceProducesConfirmedOrExactMismatch() {
+        let subject = capability(tolerance: 0.1)
+
+        #expect(verifyReadback(capability: subject, written: -12, observed: -11.9) == .confirmed)
+        #expect(
+            verifyReadback(capability: subject, written: -12, observed: -11.89)
+                == .mismatch(observed: -11.89, expected: -12, tolerance: 0.1)
+        )
+    }
+
+    @Test func outOfRangeWriteIsRejectedDuringPreflight() {
+        let parameter = ParameterID(rawValue: "threshold")
+        let registry = CapabilityRegistry(capabilities: [
+            capability(parameterID: parameter, allowedRange: -60 ... 0),
+        ])
+        let request = BatchApplyRequest(
+            pluginIdentity: compressor,
+            targets: [(parameter, 1)]
+        )
+
+        #expect(
+            planBatchApply(request, registry: registry)
+                == .failure(
+                    .valueOutOfRange(
+                        parameterID: parameter,
+                        value: 1,
+                        allowedRange: -60 ... 0
+                    )
+                )
+        )
+    }
+
+    @Test func lookupFindsRegisteredPairAndUnsupportedPreflightFailsClosed() {
+        let registry = CapabilityRegistry()
+        let registered = ParameterID(rawValue: "threshold")
+        let unknown = ParameterID(rawValue: "not_registered")
+
+        #expect(registry.capability(pluginIdentity: compressor, parameterID: registered) != nil)
+        #expect(registry.capability(pluginIdentity: compressor, parameterID: unknown) == nil)
+
+        // Use an in-range value for the registered param so the only preflight
+        // problem is the unsupported param — isolates the fail-closed path this
+        // test asserts (an out-of-range value would fail closed first, correctly,
+        // but on a different typed error).
+        let request = BatchApplyRequest(
+            pluginIdentity: compressor,
+            targets: [(registered, 50), (unknown, 0)]
+        )
+        #expect(
+            planBatchApply(request, registry: registry)
+                == .failure(.unsupportedParameter(unknown))
+        )
+    }
+
+    @Test func partialBatchFailureIsNeverTopLevelSuccess() {
+        let threshold = ParameterID(rawValue: "threshold")
+        let ratio = ParameterID(rawValue: "ratio")
+        let mismatch = ReadbackVerdict.mismatch(
+            observed: 3.5,
+            expected: 4,
+            tolerance: 0.1
+        )
+        let result = BatchApplyResult(
+            appliedVerified: [threshold],
+            failed: [(ratio, mismatch)],
+            complete: false
+        )
+        let outcome = BatchApplyOutcome(result)
+
+        #expect(result == BatchApplyResult(
+            appliedVerified: [threshold],
+            failed: [(ratio, mismatch)],
+            complete: false
+        ))
+        #expect(outcome == .partialFailure(result))
+        #expect(!outcome.isSuccess)
+    }
+
+    @Test func snapshotDiffReportsOnlyChangedValues() throws {
+        let threshold = ParameterID(rawValue: "threshold")
+        let ratio = ParameterID(rawValue: "ratio")
+        let before = ParameterSnapshot(
+            pluginIdentity: compressor,
+            values: [threshold: -12, ratio: 4]
+        )
+        let after = ParameterSnapshot(
+            pluginIdentity: compressor,
+            values: [threshold: -10, ratio: 4]
+        )
+
+        let diff = snapshotDiff(before: before, after: after)
+        let change = try #require(diff[threshold])
+
+        #expect(diff.count == 1)
+        #expect(change.before == -12)
+        #expect(change.after == -10)
+    }
+
+    @Test func parameterValueTypesRoundTrip() throws {
+        let values: [ParameterValueType] = [
+            .normalized,
+            .decibels,
+            .milliseconds,
+            .hertz,
+            .ratio,
+            .enumerated,
+            .boolean,
+        ]
+
+        let data = try JSONEncoder().encode(values)
+        #expect(try JSONDecoder().decode([ParameterValueType].self, from: data) == values)
+    }
+
+    @Test func adr009FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR009_PLUGIN_CAPABILITIES"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr009PluginCapabilities)
+    }
+
+    private func capability(
+        parameterID: ParameterID = ParameterID(rawValue: "threshold"),
+        allowedRange: ClosedRange<Double>? = -60 ... 0,
+        tolerance: Double = 0.01,
+        status: CapabilityStatus = .experimental,
+        evidence: [EvidenceReference] = []
+    ) -> VerifiedParameterCapability {
+        VerifiedParameterCapability(
+            pluginIdentity: compressor,
+            parameterID: parameterID,
+            displayName: "Threshold",
+            valueType: .decibels,
+            allowedRange: allowedRange,
+            writeMethod: .axValue,
+            readbackMethod: .axValue,
+            tolerance: tolerance,
+            requiredView: .controls,
+            selectorSignatures: ["AXSlider:Threshold"],
+            qualificationEvidence: evidence,
+            status: status
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,7 +31,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR | Name | Category | Status | GitHub issue |
 | --- | --- | --- | --- | --- |
 | ADR-008 | Verified Mixer Routing Graph | C | `In Implementation` | [#291](https://github.com/MongLong0214/logic-pro-mcp/issues/291) |
-| ADR-009 | Verified Plugin Apply-back Expansion | C | `Proposed` | [#292](https://github.com/MongLong0214/logic-pro-mcp/issues/292) |
+| ADR-009 | Verified Plugin Apply-back Expansion | C | `In Implementation` | [#292](https://github.com/MongLong0214/logic-pro-mcp/issues/292) |
 | ADR-010 | MIDI Note-level Independent Readback Research | C | `Proposed` | [#293](https://github.com/MongLong0214/logic-pro-mcp/issues/293) |
 
 ## Category D — Capability ADRs
@@ -102,6 +102,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Graph diff** — pure before/after routing comparison (added/removed/changed sends, input/output changes) for a State-A routing diff.
 - 12 deterministic synthetic tests (occupied-slot-no-write, occupied+replace-allowed, stale-epoch-no-write, duplicate-aux-bus-distinguished + name-only-rejects, partial-never-complete, unknown-destination, missing-source/out-of-range, graph diff, Codable round-trip, flag-default-off).
 - Deferred (honest scope): live AX mixer-strip readback (building the graph from real Logic), the popup-driven verified write execution, and live qualification (English/Korean × Desktop/Creator, 32-track fixture). Those need real Logic UI and are not claimed here.
+
+### ADR-009 — Verified Plugin Apply-back Expansion (`In Implementation`)
+- Verified-capability model + registry + pure verification/apply logic only, behind `FeatureFlags.adr009PluginCapabilities` (default off), with no runtime path (no plugin windows are driven).
+- **Honesty core** — `VerifiedParameterCapability` (plugin identity, parameter id, semantic value type + allowed range + tolerance, write/readback method, required view, selector signatures, qualification evidence, lifecycle status) with an `isPubliclyExposable` invariant. The `CapabilityRegistry` seeds candidate parameters (Compressor threshold/ratio/attack/release/makeup, Gain gain/phase-invert, Limiter gain/ceiling/release — Channel EQ deliberately excluded) **all as `experimental` with no evidence**, so `publicCapabilities()` is **empty** — "generic AX control movement is not verified apply-back," and nothing is publicly exposed until live evidence exists.
+- **Pure verification / apply logic** — `verifyReadback` (semantic-value normalization + tolerance → `confirmed` / `mismatch(observed, expected, tolerance)`), `planBatchApply` (all-or-nothing preflight that fails closed on an unsupported parameter or an out-of-range value **before any write**), a `BatchApplyResult` / `BatchApplyOutcome` where a partial application is `complete: false` and **never reports top-level success**, and a `snapshotDiff` for before/after apply-back.
+- 9 deterministic synthetic tests (candidates-experimental + public-surface-empty, public-without-evidence-not-exposable, tolerance confirmed/mismatch, out-of-range-rejected-in-preflight, unsupported-lookup-fails-closed, partial-batch-never-success, snapshot diff, value-type round-trip, flag-default-off).
+- Deferred (honest scope): the live plugin-window verified write/readback, the qualification-evidence collection that would promote any candidate to `public` (A/B proof, idempotency, min/max, closed/open-window starts, wrong track/slot/plugin, en/ko, Desktop/Creator), and the MCP surface (`list_verified_capabilities` / `get_param_verified` / `apply_snapshot_verified` / `diff_snapshot`). Those need real Logic UI and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
## ADR-009 (Verified Plugin Apply-back Expansion) — pure core

Refs #292, #308. Category C increment. **Verified-capability model + registry + pure verification/apply logic only**, behind `LOGIC_MCP_ADR009_PLUGIN_CAPABILITIES` (default off), **no runtime path** — zero runtime behavior.

### Honesty core (the ADR's central rule)
"Do not treat generic AX control movement as public parameter support." The `CapabilityRegistry` seeds candidate parameters (Compressor threshold/ratio/attack/release/makeup, Gain gain/phase-invert, Limiter gain/ceiling/release — **Channel EQ deliberately excluded**) **all as `experimental` with empty evidence**, so `publicCapabilities()` is **empty**. `VerifiedParameterCapability` carries an `isPubliclyExposable` invariant so no parameter can be exposed as `public` without qualification evidence — which only live qualification can produce.

### Pure verification / apply logic
- `verifyReadback` — semantic-value normalization + tolerance → `confirmed` / `mismatch(observed, expected, tolerance)`.
- `planBatchApply` — all-or-nothing preflight that **fails closed on an unsupported parameter or an out-of-range value before any write**.
- `BatchApplyResult` / `BatchApplyOutcome` — a partial application is `complete: false` and **never reports top-level success**.
- `snapshotDiff` — before/after apply-back comparison.

### Tests / evidence
- 9 deterministic synthetic tests: candidates-experimental + public-surface-empty, public-without-evidence-not-exposable, tolerance confirmed/mismatch, out-of-range-rejected-in-preflight, unsupported-lookup-fails-closed, partial-batch-never-success, snapshot diff, value-type round-trip, flag-default-off.
- Full suite green off latest `main`: **`Test run with 2408 tests passed`, 0 failures** (`swift test --no-parallel`). (A self-contradictory test fixture caught in review was corrected.)

### Deferred (honest scope)
The live plugin-window verified write/readback, the qualification-evidence collection that would promote any candidate to `public` (A/B proof, idempotency, min/max, closed/open-window starts, wrong track/slot/plugin, en/ko, Desktop/Creator), and the MCP surface (`list_verified_capabilities` / `get_param_verified` / `apply_snapshot_verified` / `diff_snapshot`). Those need real Logic UI and are not claimed here.

### Docs
`docs/adr/README.md`: ADR-009 → `In Implementation` with the pure-core + live-deferred scope.