### PR TITLE
feat(adr-010): MIDI note-level independent readback pure core (#293)

### DIFF
--- a/Sources/LogicProMCP/MIDIReadback/MIDINoteCanonicalizer.swift
+++ b/Sources/LogicProMCP/MIDIReadback/MIDINoteCanonicalizer.swift
@@ -1,0 +1,75 @@
+private struct MIDIOverlapKey: Hashable {
+    let pitch: UInt8
+    let channel: UInt8
+}
+
+func canonicalize(_ notes: [MIDINoteEvent], ppq: Int) -> [MIDINoteEvent] {
+    guard ppq > 0 else { return [] }
+
+    var canonical = notes.enumerated()
+        .filter { $0.element.velocity > 0 && $0.element.durationTicks > 0 }
+        .sorted { left, right in
+            let lhs = left.element
+            let rhs = right.element
+            if lhs.startTicks != rhs.startTicks { return lhs.startTicks < rhs.startTicks }
+            if lhs.pitch != rhs.pitch { return lhs.pitch < rhs.pitch }
+            if lhs.channel != rhs.channel { return lhs.channel < rhs.channel }
+            if lhs.velocity != rhs.velocity { return lhs.velocity < rhs.velocity }
+            return left.offset < right.offset
+        }
+        .map(\.element)
+
+    var latestIndex: [MIDIOverlapKey: Int] = [:]
+    for index in canonical.indices {
+        let note = canonical[index]
+        let key = MIDIOverlapKey(pitch: note.pitch, channel: note.channel)
+        if let previousIndex = latestIndex[key] {
+            let previous = canonical[previousIndex]
+            let (previousEnd, overflow) = previous.startTicks.addingReportingOverflow(
+                previous.durationTicks
+            )
+            if overflow || previousEnd > note.startTicks {
+                canonical[previousIndex] = MIDINoteEvent(
+                    pitch: previous.pitch,
+                    startTicks: previous.startTicks,
+                    durationTicks: max(0, note.startTicks - previous.startTicks),
+                    velocity: previous.velocity,
+                    channel: previous.channel
+                )
+            }
+        }
+        latestIndex[key] = index
+    }
+    return canonical.filter { $0.durationTicks > 0 }
+}
+
+func normalizePPQ(
+    _ notes: [MIDINoteEvent],
+    from sourcePPQ: Int,
+    to destinationPPQ: Int
+) -> [MIDINoteEvent] {
+    guard sourcePPQ > 0, destinationPPQ > 0, sourcePPQ != destinationPPQ else {
+        return notes
+    }
+    return notes.map { note in
+        MIDINoteEvent(
+            pitch: note.pitch,
+            startTicks: scale(note.startTicks, from: sourcePPQ, to: destinationPPQ),
+            durationTicks: scale(note.durationTicks, from: sourcePPQ, to: destinationPPQ),
+            velocity: note.velocity,
+            channel: note.channel
+        )
+    }
+}
+
+private func scale(_ value: Int64, from sourcePPQ: Int, to destinationPPQ: Int) -> Int64 {
+    let divisor = Int64(sourcePPQ)
+    let (product, overflow) = value.multipliedReportingOverflow(by: Int64(destinationPPQ))
+    guard !overflow else { return value }
+
+    let quotient = product / divisor
+    let remainder = product % divisor
+    let roundingThreshold = divisor / 2 + divisor % 2
+    guard abs(remainder) >= roundingThreshold else { return quotient }
+    return quotient + (product >= 0 ? 1 : -1)
+}

--- a/Sources/LogicProMCP/MIDIReadback/MIDINoteReadback.swift
+++ b/Sources/LogicProMCP/MIDIReadback/MIDINoteReadback.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+enum MIDIReadbackProvenance: String, Codable, Equatable, Sendable {
+    case eventListAX
+    case controlledSMFExport
+    case projectPackageParser
+    case playbackCapture
+    case none
+}
+
+struct MIDIRegionReference: Codable, Hashable, Sendable {
+    let targetRef: TargetReference
+    let regionIndex: Int?
+}
+
+struct ReadbackContext: Sendable {
+    let localeIdentifier: String?
+    let viewIdentifier: String?
+
+    init(localeIdentifier: String? = nil, viewIdentifier: String? = nil) {
+        self.localeIdentifier = localeIdentifier
+        self.viewIdentifier = viewIdentifier
+    }
+}
+
+struct MIDINoteEvent: Codable, Equatable, Sendable {
+    let pitch: UInt8
+    let startTicks: Int64
+    let durationTicks: Int64
+    let velocity: UInt8
+    let channel: UInt8
+}
+
+struct TempoEvent: Codable, Equatable, Sendable {
+    let tick: Int64
+    let beatsPerMinute: Double
+}
+
+struct TimeSignatureEvent: Codable, Equatable, Sendable {
+    let tick: Int64
+    let numerator: Int
+    let denominator: Int
+}
+
+struct MIDIRegionNoteSnapshot: Codable, Equatable, Sendable {
+    let regionReference: MIDIRegionReference
+    let projectEpoch: UInt64
+    let complete: Bool
+    let partialReason: String?
+    let provenance: MIDIReadbackProvenance
+    let ppq: Int
+    let notes: [MIDINoteEvent]
+    let tempoMap: [TempoEvent]
+    let timeSignatures: [TimeSignatureEvent]
+
+    init(
+        regionReference: MIDIRegionReference,
+        projectEpoch: UInt64,
+        complete: Bool,
+        partialReason: String?,
+        provenance: MIDIReadbackProvenance,
+        ppq: Int,
+        notes: [MIDINoteEvent],
+        tempoMap: [TempoEvent],
+        timeSignatures: [TimeSignatureEvent]
+    ) {
+        self.regionReference = regionReference
+        self.projectEpoch = projectEpoch
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+        self.provenance = provenance
+        self.ppq = ppq
+        self.notes = notes
+        self.tempoMap = tempoMap
+        self.timeSignatures = timeSignatures
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            regionReference: try values.decode(MIDIRegionReference.self, forKey: .regionReference),
+            projectEpoch: try values.decode(UInt64.self, forKey: .projectEpoch),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason),
+            provenance: try values.decode(MIDIReadbackProvenance.self, forKey: .provenance),
+            ppq: try values.decode(Int.self, forKey: .ppq),
+            notes: try values.decode([MIDINoteEvent].self, forKey: .notes),
+            tempoMap: try values.decode([TempoEvent].self, forKey: .tempoMap),
+            timeSignatures: try values.decode([TimeSignatureEvent].self, forKey: .timeSignatures)
+        )
+    }
+}
+
+protocol MIDINoteReadbackProvider: Sendable {
+    var provenance: MIDIReadbackProvenance { get }
+
+    func readNotes(
+        target: MIDIRegionReference,
+        context: ReadbackContext
+    ) async throws -> MIDIRegionNoteSnapshot
+}

--- a/Sources/LogicProMCP/MIDIReadback/MIDINoteVerification.swift
+++ b/Sources/LogicProMCP/MIDIReadback/MIDINoteVerification.swift
@@ -1,0 +1,128 @@
+enum RegionMatchVerdict: Sendable {
+    case exactMatch
+    case mismatch(
+        added: [MIDINoteEvent],
+        removed: [MIDINoteEvent],
+        changed: [(MIDINoteEvent, MIDINoteEvent)]
+    )
+    case incompleteCannotVerify(reason: String)
+}
+
+extension RegionMatchVerdict: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.exactMatch, .exactMatch):
+            true
+        case let (.incompleteCannotVerify(left), .incompleteCannotVerify(right)):
+            left == right
+        case let (
+            .mismatch(leftAdded, leftRemoved, leftChanged),
+            .mismatch(rightAdded, rightRemoved, rightChanged)
+        ):
+            leftAdded == rightAdded
+                && leftRemoved == rightRemoved
+                && leftChanged.count == rightChanged.count
+                && zip(leftChanged, rightChanged).allSatisfy { left, right in
+                    left.0 == right.0 && left.1 == right.1
+                }
+        default:
+            false
+        }
+    }
+}
+
+func verifyRegion(
+    observed: MIDIRegionNoteSnapshot,
+    expected: [MIDINoteEvent],
+    expectedPPQ: Int
+) -> RegionMatchVerdict {
+    guard observed.complete else {
+        return .incompleteCannotVerify(
+            reason: observed.partialReason ?? "MIDI note scan is incomplete"
+        )
+    }
+    guard observed.provenance != .none else {
+        return .incompleteCannotVerify(reason: "Independent readback provenance is required")
+    }
+    guard observed.ppq > 0, expectedPPQ > 0 else {
+        return .incompleteCannotVerify(reason: "PPQ must be positive")
+    }
+
+    let actual = canonicalize(observed.notes, ppq: observed.ppq)
+    let wanted = canonicalize(
+        normalizePPQ(expected, from: expectedPPQ, to: observed.ppq),
+        ppq: observed.ppq
+    )
+    guard actual != wanted else { return .exactMatch }
+
+    let differences = noteDifferences(expected: wanted, observed: actual)
+    return .mismatch(
+        added: differences.added,
+        removed: differences.removed,
+        changed: differences.changed
+    )
+}
+
+func diffRegions(
+    before: MIDIRegionNoteSnapshot,
+    after: MIDIRegionNoteSnapshot
+) -> (added: [MIDINoteEvent], removed: [MIDINoteEvent]) {
+    let comparisonPPQ = max(max(before.ppq, after.ppq), 1)
+    let previous = canonicalize(
+        normalizePPQ(before.notes, from: before.ppq, to: comparisonPPQ),
+        ppq: comparisonPPQ
+    )
+    let current = canonicalize(
+        normalizePPQ(after.notes, from: after.ppq, to: comparisonPPQ),
+        ppq: comparisonPPQ
+    )
+
+    // ponytail: O(n²) preserves duplicate-note multiset semantics; index if qualified
+    // providers make very large region diffs a measured hot path.
+    var unmatchedPrevious = previous
+    var added: [MIDINoteEvent] = []
+    for note in current {
+        if let index = unmatchedPrevious.firstIndex(of: note) {
+            unmatchedPrevious.remove(at: index)
+        } else {
+            added.append(note)
+        }
+    }
+    return (added: added, removed: unmatchedPrevious)
+}
+
+private func noteDifferences(
+    expected: [MIDINoteEvent],
+    observed: [MIDINoteEvent]
+) -> (
+    added: [MIDINoteEvent],
+    removed: [MIDINoteEvent],
+    changed: [(MIDINoteEvent, MIDINoteEvent)]
+) {
+    var remainingObserved = observed
+    var remainingExpected: [MIDINoteEvent] = []
+    for note in expected {
+        if let index = remainingObserved.firstIndex(of: note) {
+            remainingObserved.remove(at: index)
+        } else {
+            remainingExpected.append(note)
+        }
+    }
+
+    var removed: [MIDINoteEvent] = []
+    var changed: [(MIDINoteEvent, MIDINoteEvent)] = []
+    for note in remainingExpected {
+        if let index = remainingObserved.firstIndex(where: { sameIdentity($0, note) }) {
+            changed.append((note, remainingObserved.remove(at: index)))
+        } else {
+            removed.append(note)
+        }
+    }
+    return (added: remainingObserved, removed: removed, changed: changed)
+}
+
+private func sameIdentity(_ lhs: MIDINoteEvent, _ rhs: MIDINoteEvent) -> Bool {
+    lhs.pitch == rhs.pitch
+        && lhs.channel == rhs.channel
+        && lhs.startTicks == rhs.startTicks
+}

--- a/Sources/LogicProMCP/MIDIReadback/MIDIProviderGate.swift
+++ b/Sources/LogicProMCP/MIDIReadback/MIDIProviderGate.swift
@@ -1,0 +1,72 @@
+struct MIDIProviderQualification: Codable, Equatable, Sendable {
+    let provenance: MIDIReadbackProvenance
+    let qualified: Bool
+    let requiredProofs: [String]
+}
+
+struct QualifiedProviderRegistry: Sendable {
+    private let candidates: [MIDIProviderQualification]
+
+    init() {
+        candidates = Self.unqualifiedCandidates
+    }
+
+    func publicProvider() -> MIDIReadbackProvenance? {
+        candidates.first { $0.qualified }?.provenance
+    }
+
+    func candidateProvenances() -> [MIDIReadbackProvenance] {
+        candidates.map(\.provenance)
+    }
+
+    func qualificationStatuses() -> [MIDIProviderQualification] {
+        candidates
+    }
+
+    private static let unqualifiedCandidates = [
+        MIDIProviderQualification(
+            provenance: .eventListAX,
+            qualified: false,
+            requiredProofs: [
+                "selected region identity",
+                "first and last row plus count/end completeness",
+                "Event List filter verification",
+                "English and Korean locale coverage",
+                "Desktop and Creator variant coverage",
+                "Logic version drift detection",
+            ]
+        ),
+        MIDIProviderQualification(
+            provenance: .controlledSMFExport,
+            qualified: false,
+            requiredProofs: [
+                "selected region identity",
+                "random private temporary destination",
+                "symlink and traversal rejection",
+                "export UI mutation restoration",
+                "complete SMF parse",
+                "Logic version drift detection",
+            ]
+        ),
+        MIDIProviderQualification(
+            provenance: .projectPackageParser,
+            qualified: false,
+            requiredProofs: [
+                "project format stability spike",
+                "selected region identity",
+                "complete note extraction",
+                "cross-version drift detection",
+            ]
+        ),
+        MIDIProviderQualification(
+            provenance: .playbackCapture,
+            qualified: false,
+            requiredProofs: [
+                "selected region playback identity",
+                "capture completeness",
+                "documented secondary-provenance limitation",
+                "proof that rendered behavior is not claimed as original region data",
+            ]
+        ),
+    ]
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -48,4 +48,8 @@ enum FeatureFlags: Sendable {
     static var adr009PluginCapabilities: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR009_PLUGIN_CAPABILITIES"] == "1"
     }
+
+    static var adr010MidiReadback: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR010_MIDI_READBACK"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/MIDINoteReadbackTests.swift
+++ b/Tests/LogicProMCPTests/MIDINoteReadbackTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite struct MIDINoteReadbackTests {
+    @Test func incompleteSnapshotCannotReportExactMatch() {
+        let note = makeNote(pitch: 60)
+        let observed = makeSnapshot(complete: false, partialReason: "virtualized rows", notes: [note])
+
+        guard case .incompleteCannotVerify(let reason) = verifyRegion(
+            observed: observed,
+            expected: [note],
+            expectedPPQ: 480
+        ) else {
+            Issue.record("An incomplete scan must never report a full match")
+            return
+        }
+        #expect(reason == "virtualized rows")
+    }
+
+    @Test func missingIndependentProvenanceCannotReportExactMatch() {
+        let note = makeNote(pitch: 60)
+        let observed = makeSnapshot(provenance: .none, notes: [note])
+
+        guard case .incompleteCannotVerify = verifyRegion(
+            observed: observed,
+            expected: [note],
+            expectedPPQ: 480
+        ) else {
+            Issue.record("Server-owned input without independent provenance is not readback")
+            return
+        }
+    }
+
+    @Test func canonicalizationRemovesVelocityZeroTrimsOverlapAndSorts() {
+        let canonical = canonicalize([
+            makeNote(pitch: 67, start: 20, duration: 10, velocity: 70, channel: 1),
+            makeNote(pitch: 64, start: 0, duration: 100, velocity: 90),
+            makeNote(pitch: 60, start: 0, duration: 20, velocity: 110, channel: 1),
+            makeNote(pitch: 60, start: 0, duration: 20, velocity: 90),
+            makeNote(pitch: 64, start: 60, duration: 30, velocity: 80),
+            makeNote(pitch: 70, start: 5, duration: 10, velocity: 0),
+        ], ppq: 480)
+
+        #expect(canonical == [
+            makeNote(pitch: 60, start: 0, duration: 20, velocity: 90),
+            makeNote(pitch: 60, start: 0, duration: 20, velocity: 110, channel: 1),
+            makeNote(pitch: 64, start: 0, duration: 60, velocity: 90),
+            makeNote(pitch: 67, start: 20, duration: 10, velocity: 70, channel: 1),
+            makeNote(pitch: 64, start: 60, duration: 30, velocity: 80),
+        ])
+    }
+
+    @Test func ppqNormalizationAllowsExactMatch() {
+        let expected = [makeNote(pitch: 60, start: 480, duration: 240)]
+        let observed = makeSnapshot(
+            ppq: 960,
+            notes: [makeNote(pitch: 60, start: 960, duration: 480)]
+        )
+
+        #expect(verifyRegion(observed: observed, expected: expected, expectedPPQ: 480) == .exactMatch)
+    }
+
+    @Test func verificationMatchesCanonicalNotes() {
+        let expected = [
+            makeNote(pitch: 64, start: 60, duration: 30, velocity: 80),
+            makeNote(pitch: 64, start: 0, duration: 100, velocity: 90),
+            makeNote(pitch: 70, start: 5, duration: 10, velocity: 0),
+        ]
+        let observed = makeSnapshot(notes: [
+            makeNote(pitch: 64, start: 0, duration: 60, velocity: 90),
+            makeNote(pitch: 64, start: 60, duration: 30, velocity: 80),
+        ])
+
+        #expect(verifyRegion(observed: observed, expected: expected, expectedPPQ: 480) == .exactMatch)
+    }
+
+    @Test func verificationReportsAddedRemovedAndChangedNotes() {
+        let changedBefore = makeNote(pitch: 60, start: 0, duration: 100)
+        let changedAfter = makeNote(pitch: 60, start: 0, duration: 80)
+        let unchanged = makeNote(pitch: 62, start: 120, duration: 50)
+        let removedNote = makeNote(pitch: 64, start: 240, duration: 60)
+        let addedNote = makeNote(pitch: 65, start: 300, duration: 40)
+        let observed = makeSnapshot(notes: [changedAfter, unchanged, addedNote])
+
+        guard case .mismatch(let added, let removed, let changed) = verifyRegion(
+            observed: observed,
+            expected: [changedBefore, unchanged, removedNote],
+            expectedPPQ: 480
+        ) else {
+            Issue.record("Expected a structured mismatch")
+            return
+        }
+        #expect(added == [addedNote])
+        #expect(removed == [removedNote])
+        #expect(changed.count == 1)
+        #expect(changed.first?.0 == changedBefore)
+        #expect(changed.first?.1 == changedAfter)
+    }
+
+    @Test func regionDiffReportsAddedAndRemovedNotes() {
+        let removedNote = makeNote(pitch: 60)
+        let unchanged = makeNote(pitch: 62, start: 120)
+        let addedNote = makeNote(pitch: 64, start: 240)
+
+        let result = diffRegions(
+            before: makeSnapshot(notes: [removedNote, unchanged]),
+            after: makeSnapshot(notes: [unchanged, addedNote])
+        )
+
+        #expect(result.added == [addedNote])
+        #expect(result.removed == [removedNote])
+    }
+
+    @Test func providerGateHasNoPublicProviderBeforeQualification() {
+        let registry = QualifiedProviderRegistry()
+
+        #expect(registry.publicProvider() == nil)
+        #expect(registry.candidateProvenances() == [
+            .eventListAX,
+            .controlledSMFExport,
+            .projectPackageParser,
+            .playbackCapture,
+        ])
+        #expect(registry.qualificationStatuses().allSatisfy {
+            !$0.qualified && !$0.requiredProofs.isEmpty
+        })
+    }
+
+    @Test func completeSnapshotDropsPartialReason() {
+        let complete = makeSnapshot(complete: true, partialReason: "must be discarded")
+        let incomplete = makeSnapshot(complete: false, partialReason: "last row unavailable")
+
+        #expect(complete.partialReason == nil)
+        #expect(incomplete.partialReason == "last row unavailable")
+    }
+
+    @Test func featureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR010_MIDI_READBACK"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr010MidiReadback)
+    }
+
+    private func makeSnapshot(
+        complete: Bool = true,
+        partialReason: String? = nil,
+        provenance: MIDIReadbackProvenance = .eventListAX,
+        ppq: Int = 480,
+        notes: [MIDINoteEvent] = []
+    ) -> MIDIRegionNoteSnapshot {
+        MIDIRegionNoteSnapshot(
+            regionReference: MIDIRegionReference(
+                targetRef: TargetReference(rawValue: "trk_test"),
+                regionIndex: 0
+            ),
+            projectEpoch: 1,
+            complete: complete,
+            partialReason: partialReason,
+            provenance: provenance,
+            ppq: ppq,
+            notes: notes,
+            tempoMap: [],
+            timeSignatures: []
+        )
+    }
+
+    private func makeNote(
+        pitch: UInt8,
+        start: Int64 = 0,
+        duration: Int64 = 120,
+        velocity: UInt8 = 100,
+        channel: UInt8 = 0
+    ) -> MIDINoteEvent {
+        MIDINoteEvent(
+            pitch: pitch,
+            startTicks: start,
+            durationTicks: duration,
+            velocity: velocity,
+            channel: channel
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | --- | --- | --- | --- | --- |
 | ADR-008 | Verified Mixer Routing Graph | C | `In Implementation` | [#291](https://github.com/MongLong0214/logic-pro-mcp/issues/291) |
 | ADR-009 | Verified Plugin Apply-back Expansion | C | `In Implementation` | [#292](https://github.com/MongLong0214/logic-pro-mcp/issues/292) |
-| ADR-010 | MIDI Note-level Independent Readback Research | C | `Proposed` | [#293](https://github.com/MongLong0214/logic-pro-mcp/issues/293) |
+| ADR-010 | MIDI Note-level Independent Readback Research | C | `In Implementation` | [#293](https://github.com/MongLong0214/logic-pro-mcp/issues/293) |
 
 ## Category D — Capability ADRs
 
@@ -109,6 +109,14 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Pure verification / apply logic** — `verifyReadback` (semantic-value normalization + tolerance → `confirmed` / `mismatch(observed, expected, tolerance)`), `planBatchApply` (all-or-nothing preflight that fails closed on an unsupported parameter or an out-of-range value **before any write**), a `BatchApplyResult` / `BatchApplyOutcome` where a partial application is `complete: false` and **never reports top-level success**, and a `snapshotDiff` for before/after apply-back.
 - 9 deterministic synthetic tests (candidates-experimental + public-surface-empty, public-without-evidence-not-exposable, tolerance confirmed/mismatch, out-of-range-rejected-in-preflight, unsupported-lookup-fails-closed, partial-batch-never-success, snapshot diff, value-type round-trip, flag-default-off).
 - Deferred (honest scope): the live plugin-window verified write/readback, the qualification-evidence collection that would promote any candidate to `public` (A/B proof, idempotency, min/max, closed/open-window starts, wrong track/slot/plugin, en/ko, Desktop/Creator), and the MCP surface (`list_verified_capabilities` / `get_param_verified` / `apply_snapshot_verified` / `diff_snapshot`). Those need real Logic UI and are not claimed here.
+
+### ADR-010 — MIDI Note-level Independent Readback (`In Implementation`)
+- Provider abstraction + note data model + pure canonicalization / verification + a provider ship-gate only, behind `FeatureFlags.adr010MidiReadback` (default off), with no runtime path (no provider is implemented or invoked).
+- **Provider abstraction** — a `MIDINoteReadbackProvider` protocol + `MIDIReadbackProvenance` (Event List AX, controlled SMF export, project-package parser, playback capture) and the `MIDIRegionNoteSnapshot` / `MIDINoteEvent` data model (with `complete` / `partialReason`, epoch, provenance, PPQ, notes, tempo map, time signatures). No provider is wired — the server's own input note list is explicitly **not** used as readback.
+- **Provider ship-gate (honesty core)** — a `QualifiedProviderRegistry` where **all four candidate providers are unqualified**, so `publicProvider()` returns **nil** — "no qualified provider means no public API." Each candidate records the exact proofs it must pass to qualify (selected-region identity, completeness, filter/temp-path/traversal safety, en/ko + Desktop/Creator, version-drift), so promotion requires live evidence, not code.
+- **Pure canonicalization + verification** — `canonicalize` (velocity-0 note-off normalization, overlapping same-pitch trimming, stable sort, PPQ normalization, tempo map kept separate from note ticks) and `verifyRegion`, which returns **`incompleteCannotVerify` for any snapshot with `complete:false` or `provenance == .none` — an incomplete or non-independent scan can never report a full State-A exact match** — otherwise `exactMatch` or `mismatch(added/removed/changed)`; plus a region diff.
+- 10 deterministic synthetic tests (incomplete-cannot-match, missing-provenance-cannot-match, canonicalization velocity-0/overlap/sort, PPQ-normalization-match, exact + added/removed/changed verification, region diff, provider-gate-no-public-before-qualification, complete-drops-partial-reason, flag-default-off).
+- Deferred (honest scope): the live Event List AX and controlled SMF-export provider implementations, the qualification evidence that would promote a provider to `public`, the project-package format-stability spike, and the MCP surface (`read_selected_region_notes` / `verify_region_against_sequence` / `diff_region_notes`). Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category C research increment. Provider abstraction + note data model + pure canonicalization/verification + provider ship-gate, behind `LOGIC_MCP_ADR010_MIDI_READBACK` (default off), no runtime path.

**Honesty core:** `QualifiedProviderRegistry.publicProvider()` returns **nil** — all four candidate providers (Event List AX / controlled SMF export / project-package parser / playback capture) are unqualified, each recording the proofs it must pass; "no qualified provider means no public API." The server's own input note list is explicitly not used as readback. `verifyRegion` returns **`incompleteCannotVerify`** for any `complete:false` or `provenance==none` snapshot — an incomplete or non-independent scan can never report a full State-A match.

**Pure logic:** `canonicalize` (velocity-0 note-off, overlap trim, stable sort, PPQ normalization, tempo map separated) + `verifyRegion` (exactMatch / mismatch added·removed·changed) + region diff. 10 deterministic tests; full suite **2418 tests, 0 failures**.

**Deferred:** live Event List AX / SMF-export providers, qualification evidence, project-package format spike, MCP surface — need real Logic.

Refs #293, #308.