### PR TITLE
feat(adr-011): full verified compressor control pure core (#299)

### DIFF
--- a/Sources/LogicProMCP/Compressor/CompressorCapabilityManifest.swift
+++ b/Sources/LogicProMCP/Compressor/CompressorCapabilityManifest.swift
@@ -1,0 +1,107 @@
+enum CompressorCircuitModel: String, Codable, CaseIterable, Hashable, Sendable {
+    case platinum
+    case studioVCA
+    case studioFET
+    case classicVCA
+    case vintageVCA
+    case vintageFET
+    case vintageOpto
+}
+
+enum CompressorParameter: String, Codable, CaseIterable, Hashable, Sendable {
+    case circuitModel
+    case inputGainDb
+    case thresholdDb
+    case ratio
+    case knee
+    case attackMs
+    case releaseMs
+    case autoReleaseEnabled
+    case makeupGainDb
+    case autoGainMode
+    case mixPercent
+    case outputGainDb
+    case limiterEnabled
+}
+
+/// Compressor-specific specialization of ADR-009 capabilities, not a competing registry.
+struct CompressorCapabilityManifest: Sendable {
+    func availableParameters(for circuit: CompressorCircuitModel) -> Set<CompressorParameter> {
+        var parameters = Set(CompressorParameter.allCases)
+        switch circuit {
+        case .platinum, .studioVCA, .studioFET, .classicVCA:
+            break
+        case .vintageVCA:
+            parameters.remove(.autoReleaseEnabled)
+        case .vintageFET:
+            parameters.remove(.knee)
+        case .vintageOpto:
+            parameters.subtract([.knee, .autoReleaseEnabled])
+        }
+        return parameters
+    }
+
+    func capability(
+        circuit: CompressorCircuitModel,
+        parameter: CompressorParameter
+    ) -> VerifiedParameterCapability? {
+        guard availableParameters(for: circuit).contains(parameter) else { return nil }
+        let details = details(for: parameter)
+        return VerifiedParameterCapability(
+            pluginIdentity: PluginIdentity(
+                manufacturer: "Apple",
+                name: "Compressor",
+                type: "effect"
+            ),
+            parameterID: ParameterID(rawValue: parameter.rawValue),
+            displayName: details.displayName,
+            valueType: details.valueType,
+            allowedRange: details.range,
+            writeMethod: .axValue,
+            readbackMethod: .axValue,
+            tolerance: details.tolerance,
+            requiredView: .controls,
+            selectorSignatures: [],
+            qualificationEvidence: [],
+            status: .experimental
+        )
+    }
+
+    private func details(
+        for parameter: CompressorParameter
+    ) -> (
+        displayName: String,
+        valueType: ParameterValueType,
+        range: ClosedRange<Double>,
+        tolerance: Double
+    ) {
+        switch parameter {
+        case .circuitModel:
+            ("Circuit Model", .enumerated, 0 ... 6, 0)
+        case .inputGainDb:
+            ("Input Gain", .decibels, -20 ... 20, 0.1)
+        case .thresholdDb:
+            ("Threshold", .decibels, -60 ... 0, 0.1)
+        case .ratio:
+            ("Ratio", .ratio, 1 ... 30, 0.01)
+        case .knee:
+            ("Knee", .normalized, 0 ... 100, 0.1)
+        case .attackMs:
+            ("Attack", .milliseconds, 0 ... 200, 0.1)
+        case .releaseMs:
+            ("Release", .milliseconds, 5 ... 5_000, 1)
+        case .autoReleaseEnabled:
+            ("Auto Release", .boolean, 0 ... 1, 0)
+        case .makeupGainDb:
+            ("Makeup Gain", .decibels, -20 ... 20, 0.1)
+        case .autoGainMode:
+            ("Auto Gain", .enumerated, 0 ... 2, 0)
+        case .mixPercent:
+            ("Mix", .normalized, 0 ... 100, 0.1)
+        case .outputGainDb:
+            ("Output Gain", .decibels, -20 ... 20, 0.1)
+        case .limiterEnabled:
+            ("Limiter", .boolean, 0 ... 1, 0)
+        }
+    }
+}

--- a/Sources/LogicProMCP/Compressor/CompressorOutcome.swift
+++ b/Sources/LogicProMCP/Compressor/CompressorOutcome.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+struct CompressorStateSnapshot: Codable, Equatable, Sendable {
+    let insertRef: TargetReference?
+    let circuit: CompressorCircuitModel
+    let values: [CompressorParameter: Double]
+    let complete: Bool
+    let partialReason: String?
+
+    init(
+        insertRef: TargetReference?,
+        circuit: CompressorCircuitModel,
+        values: [CompressorParameter: Double],
+        complete: Bool,
+        partialReason: String?
+    ) {
+        self.insertRef = insertRef
+        self.circuit = circuit
+        self.values = values
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            insertRef: try values.decodeIfPresent(TargetReference.self, forKey: .insertRef),
+            circuit: try values.decode(CompressorCircuitModel.self, forKey: .circuit),
+            values: try values.decode([CompressorParameter: Double].self, forKey: .values),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason)
+        )
+    }
+}
+
+func compareOutcome(
+    before: CompressorStateSnapshot,
+    after: CompressorStateSnapshot,
+    requested: [CompressorParameter: Double],
+    tolerance: Double
+) -> [CompressorParameter: (requested: Double, observed: Double, verified: Bool)] {
+    guard before.insertRef == after.insertRef, before.circuit == after.circuit else {
+        return [:]
+    }
+
+    var outcome: [
+        CompressorParameter: (requested: Double, observed: Double, verified: Bool)
+    ] = [:]
+    for (parameter, requestedValue) in requested {
+        guard let observed = after.values[parameter] else { continue }
+        let verified = after.complete
+            && tolerance.isFinite
+            && tolerance >= 0
+            && requestedValue.isFinite
+            && observed.isFinite
+            && abs(observed - requestedValue) <= tolerance
+        outcome[parameter] = (requestedValue, observed, verified)
+    }
+    return outcome
+}
+
+struct SagaEligibility: Sendable {
+    let eligible: Bool
+    let missing: [String]
+}
+
+func sagaEligibility(
+    beforeSnapshot: CompressorStateSnapshot?,
+    readbackPresent: Bool,
+    compensationVerified: Bool
+) -> SagaEligibility {
+    var missing: [String] = []
+    if beforeSnapshot?.complete != true {
+        missing.append("complete_before_snapshot")
+    }
+    if !readbackPresent {
+        missing.append("requested_parameter_readback")
+    }
+    if !compensationVerified {
+        missing.append("verified_compensation")
+    }
+    return SagaEligibility(eligible: missing.isEmpty, missing: missing)
+}

--- a/Sources/LogicProMCP/Compressor/CompressorUnits.swift
+++ b/Sources/LogicProMCP/Compressor/CompressorUnits.swift
@@ -1,0 +1,26 @@
+enum CompressorUnit: Sendable {
+    case decibels
+    case milliseconds
+    case ratio
+    case percent
+    case enumerated
+    case boolean
+}
+
+func displayToNormalized(
+    _ value: Double,
+    unit _: CompressorUnit,
+    range: ClosedRange<Double>
+) -> Double {
+    let width = range.upperBound - range.lowerBound
+    guard width != 0 else { return 0 }
+    return (value - range.lowerBound) / width
+}
+
+func normalizedToDisplay(
+    _ value: Double,
+    unit _: CompressorUnit,
+    range: ClosedRange<Double>
+) -> Double {
+    range.lowerBound + value * (range.upperBound - range.lowerBound)
+}

--- a/Sources/LogicProMCP/Compressor/CompressorWritePlane.swift
+++ b/Sources/LogicProMCP/Compressor/CompressorWritePlane.swift
@@ -1,0 +1,20 @@
+enum CompressorWritePlane: Int, Comparable, Hashable, Sendable {
+    case controlsViewAX = 0
+    case mcuC4 = 1
+    case qualifiedNativeAdapter = 2
+    case coordinateOnly = 3
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+func canPublicVerifiedWrite(_ plane: CompressorWritePlane) -> Bool {
+    plane != .coordinateOnly
+}
+
+func preferredPlane(
+    available: Set<CompressorWritePlane>
+) -> CompressorWritePlane? {
+    available.min()
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -52,4 +52,8 @@ enum FeatureFlags: Sendable {
     static var adr010MidiReadback: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR010_MIDI_READBACK"] == "1"
     }
+
+    static var adr011CompressorControl: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR011_COMPRESSOR_CONTROL"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/CompressorCapabilityTests.swift
+++ b/Tests/LogicProMCPTests/CompressorCapabilityTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-011 compressor capabilities")
+struct CompressorCapabilityTests {
+    @Test func manifestSpecializesADR009CapabilitiesByCircuit() throws {
+        let manifest = CompressorCapabilityManifest()
+        let platinum = manifest.availableParameters(for: .platinum)
+        let vintageOpto = manifest.availableParameters(for: .vintageOpto)
+
+        #expect(platinum != vintageOpto)
+        #expect(platinum.contains(.knee))
+        #expect(!vintageOpto.contains(.knee))
+        #expect(manifest.capability(circuit: .vintageOpto, parameter: .knee) == nil)
+
+        for circuit in CompressorCircuitModel.allCases {
+            for parameter in manifest.availableParameters(for: circuit) {
+                let capability = try #require(
+                    manifest.capability(circuit: circuit, parameter: parameter)
+                )
+                #expect(capability.status == .experimental)
+                #expect(capability.qualificationEvidence.isEmpty)
+                #expect(!capability.isPubliclyExposable)
+            }
+        }
+    }
+
+    @Test func coordinateOnlyCannotBecomeAPublicVerifiedWrite() {
+        #expect(!canPublicVerifiedWrite(.coordinateOnly))
+        #expect(canPublicVerifiedWrite(.controlsViewAX))
+        #expect(preferredPlane(available: [.coordinateOnly]) == .coordinateOnly)
+        #expect(
+            preferredPlane(available: [.coordinateOnly, .qualifiedNativeAdapter, .mcuC4])
+                == .mcuC4
+        )
+        #expect(
+            preferredPlane(available: [.qualifiedNativeAdapter, .controlsViewAX])
+                == .controlsViewAX
+        )
+        #expect(preferredPlane(available: []) == nil)
+    }
+
+    @Test func physicalUnitsRoundTripThroughNormalizedValues() {
+        let cases: [(CompressorUnit, Double, ClosedRange<Double>)] = [
+            (.decibels, -12, -60 ... 0),
+            (.milliseconds, 250, 5 ... 5_000),
+            (.ratio, 4, 1 ... 30),
+            (.percent, 65, 0 ... 100),
+        ]
+
+        for (unit, display, range) in cases {
+            let normalized = displayToNormalized(display, unit: unit, range: range)
+            let roundTrip = normalizedToDisplay(normalized, unit: unit, range: range)
+            #expect(abs(roundTrip - display) < 1e-9)
+        }
+    }
+
+    @Test func outcomeComparisonUsesRequestedReadbackTolerance() throws {
+        let before = snapshot(values: [.thresholdDb: -18, .ratio: 2])
+        let after = snapshot(values: [.thresholdDb: -11.95, .ratio: 3.8])
+        let outcome = compareOutcome(
+            before: before,
+            after: after,
+            requested: [.thresholdDb: -12, .ratio: 4],
+            tolerance: 0.1
+        )
+        let threshold = try #require(outcome[.thresholdDb])
+        let ratio = try #require(outcome[.ratio])
+
+        #expect(threshold.requested == -12)
+        #expect(threshold.observed == -11.95)
+        #expect(threshold.verified)
+        #expect(ratio.requested == 4)
+        #expect(ratio.observed == 3.8)
+        #expect(!ratio.verified)
+    }
+
+    @Test func sagaRequiresCompleteBeforeReadbackAndVerifiedCompensation() {
+        let before = snapshot()
+
+        #expect(
+            sagaEligibility(
+                beforeSnapshot: before,
+                readbackPresent: true,
+                compensationVerified: true
+            ).eligible
+        )
+
+        let missingBefore = sagaEligibility(
+            beforeSnapshot: nil,
+            readbackPresent: true,
+            compensationVerified: true
+        )
+        #expect(!missingBefore.eligible)
+        #expect(missingBefore.missing == ["complete_before_snapshot"])
+
+        let missingReadback = sagaEligibility(
+            beforeSnapshot: before,
+            readbackPresent: false,
+            compensationVerified: true
+        )
+        #expect(!missingReadback.eligible)
+        #expect(missingReadback.missing == ["requested_parameter_readback"])
+
+        let missingCompensation = sagaEligibility(
+            beforeSnapshot: before,
+            readbackPresent: true,
+            compensationVerified: false
+        )
+        #expect(!missingCompensation.eligible)
+        #expect(missingCompensation.missing == ["verified_compensation"])
+
+        let incomplete = sagaEligibility(
+            beforeSnapshot: snapshot(complete: false, partialReason: "controls unavailable"),
+            readbackPresent: true,
+            compensationVerified: true
+        )
+        #expect(!incomplete.eligible)
+        #expect(incomplete.missing == ["complete_before_snapshot"])
+    }
+
+    @Test func completeSnapshotAlwaysDropsPartialReason() throws {
+        let complete = snapshot(complete: true, partialReason: "stale")
+        let incomplete = snapshot(complete: false, partialReason: "controls unavailable")
+
+        #expect(complete.partialReason == nil)
+        #expect(incomplete.partialReason == "controls unavailable")
+
+        let decoded = try JSONDecoder().decode(
+            CompressorStateSnapshot.self,
+            from: Data(
+                #"{"insertRef":null,"circuit":"platinum","values":[],"complete":true,"partialReason":"stale"}"#.utf8
+            )
+        )
+        #expect(decoded.partialReason == nil)
+    }
+
+    @Test func adr011FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR011_COMPRESSOR_CONTROL"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr011CompressorControl)
+    }
+
+    private func snapshot(
+        values: [CompressorParameter: Double] = [:],
+        complete: Bool = true,
+        partialReason: String? = nil
+    ) -> CompressorStateSnapshot {
+        CompressorStateSnapshot(
+            insertRef: TargetReference(rawValue: "ins_test"),
+            circuit: .platinum,
+            values: values,
+            complete: complete,
+            partialReason: partialReason
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 
 | ADR | Name | Category | Status | GitHub issue |
 | --- | --- | --- | --- | --- |
-| ADR-011 | Full Verified Compressor Control | D | `Proposed` | [#299](https://github.com/MongLong0214/logic-pro-mcp/issues/299) |
+| ADR-011 | Full Verified Compressor Control | D | `In Implementation` | [#299](https://github.com/MongLong0214/logic-pro-mcp/issues/299) |
 | ADR-012 | Spectral Analysis and EQ Recommendation | D | `Proposed` | [#300](https://github.com/MongLong0214/logic-pro-mcp/issues/300) |
 | ADR-013 | Verified Channel EQ Band Control | D | `Proposed` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
@@ -117,6 +117,14 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Pure canonicalization + verification** — `canonicalize` (velocity-0 note-off normalization, overlapping same-pitch trimming, stable sort, PPQ normalization, tempo map kept separate from note ticks) and `verifyRegion`, which returns **`incompleteCannotVerify` for any snapshot with `complete:false` or `provenance == .none` — an incomplete or non-independent scan can never report a full State-A exact match** — otherwise `exactMatch` or `mismatch(added/removed/changed)`; plus a region diff.
 - 10 deterministic synthetic tests (incomplete-cannot-match, missing-provenance-cannot-match, canonicalization velocity-0/overlap/sort, PPQ-normalization-match, exact + added/removed/changed verification, region diff, provider-gate-no-public-before-qualification, complete-drops-partial-reason, flag-default-off).
 - Deferred (honest scope): the live Event List AX and controlled SMF-export provider implementations, the qualification evidence that would promote a provider to `public`, the project-package format-stability spike, and the MCP surface (`read_selected_region_notes` / `verify_region_against_sequence` / `diff_region_notes`). Those need real Logic and are not claimed here.
+
+### ADR-011 — Full Verified Compressor Control (`In Implementation`)
+- Compressor capability manifest + pure unit/plane/outcome logic only, behind `FeatureFlags.adr011CompressorControl` (default off), with no runtime path (no Compressor UI is driven).
+- **Specializes ADR-009, does not compete with it** — `CompressorCapabilityManifest` describes per-circuit-model parameter availability (Logic circuit types expose different parameter sets) and returns ADR-009 `VerifiedParameterCapability` values (all `experimental`, no evidence); it reuses the ADR-009 registry types rather than defining a second one.
+- **Write-plane honesty** — `CompressorWritePlane` priority (Controls-view AX › MCU/C4 › qualified native adapter › coordinate-only); `canPublicVerifiedWrite` is **false for the coordinate-only plane**, so a blind-coordinate / image-only route can never be claimed as a public verified write.
+- **Pure unit + outcome + saga logic** — physical-unit conversion (dB / ms / ratio / percent, round-trip stable), before/after outcome comparison against requested values within tolerance, and a saga-eligibility gate that is eligible **only** when a complete before-snapshot, a requested-parameter readback, and verified compensation all exist (an incomplete snapshot is never eligible).
+- 7 deterministic synthetic tests (manifest-specializes-ADR-009-by-circuit, coordinate-only-cannot-be-public-write, unit round-trip, outcome tolerance comparison, saga-requires-all-three, complete-drops-partial-reason, flag-default-off).
+- Deferred (honest scope): the live Controls-view AX parameter write/readback, real circuit-model detection, the MCP surface (`get_compressor_state_verified` / `set_compressor_params_verified` / `apply_compressor_plan_verified` / …), and the ADR-012 recommendation + audio-outcome analysis integration. Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. Compressor capability manifest + pure unit/plane/outcome logic, behind `LOGIC_MCP_ADR011_COMPRESSOR_CONTROL` (default off), no runtime path.

- **Specializes ADR-009 (not a competing registry):** `CompressorCapabilityManifest` gives per-circuit-model parameter availability and returns ADR-009 `VerifiedParameterCapability` values (all `experimental`); `PluginCapability/` unchanged.
- **Write-plane honesty:** `canPublicVerifiedWrite` is **false for the coordinate-only plane** — a blind-coordinate/image-only route can never be a public verified write.
- **Pure logic:** dB/ms/ratio/percent conversion (round-trip stable), before/after outcome comparison within tolerance, and a saga-eligibility gate requiring complete before-snapshot + readback + verified compensation (incomplete never eligible).
- 7 deterministic tests; full suite **2425 tests, 0 failures**.

**Deferred:** live Controls-view AX write/readback, circuit-model detection, MCP surface, ADR-012 recommendation + audio analysis — need real Logic.

Refs #299, #308.