### PR TITLE
feat(adr-012): spectral analysis + EQ recommendation pure core (#300)

### DIFF
--- a/Sources/LogicProMCP/SpectralEQ/EQRecommendationEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/EQRecommendationEngine.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct EQBandRecommendation: Codable, Equatable, Sendable {
+    let centerHz: Double
+    let gainDb: Double
+    let q: Double
+    let reason: String
+}
+
+enum EQRecommendationOutcome: Equatable, Sendable {
+    case recommendation(bands: [EQBandRecommendation], advisory: Bool)
+    case noSafeRecommendation(reason: String)
+}
+
+func recommendEQ(
+    _ analysis: SpectralAnalysisResult,
+    minimumConfidence: Double = 0.6
+) -> EQRecommendationOutcome {
+    guard analysis.complete else {
+        return .noSafeRecommendation(reason: "analysis_incomplete")
+    }
+    guard analysis.confidence >= minimumConfidence else {
+        return .noSafeRecommendation(reason: "confidence_below_minimum")
+    }
+    guard analysis.classification != .unknown else {
+        return .noSafeRecommendation(reason: "source_classification_unknown")
+    }
+
+    let bands = analysis.resonances.map {
+        EQBandRecommendation(
+            centerHz: $0.hz,
+            gainDb: -abs($0.gainDb),
+            q: $0.q,
+            reason: "resonance_cut"
+        )
+    }
+    return .recommendation(bands: bands, advisory: true)
+}

--- a/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
+++ b/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct SpectralBand: Codable, Equatable, Sendable {
+    let centerHz: Double
+    let energyDb: Double
+}
+
+struct SpectralResonance: Codable, Equatable, Sendable {
+    let hz: Double
+    let gainDb: Double
+    let q: Double
+}
+
+enum SourceClassification: String, Codable, Sendable {
+    case vocal
+    case drums
+    case bass
+    case fullMix
+    case unknown
+}
+
+struct SpectralAnalysisResult: Codable, Equatable, Sendable {
+    let analysisRef: String
+    let bands: [SpectralBand]
+    let resonances: [SpectralResonance]
+    let classification: SourceClassification
+    let confidence: Double
+    let complete: Bool
+    let partialReason: String?
+
+    init(
+        analysisRef: String,
+        bands: [SpectralBand],
+        resonances: [SpectralResonance],
+        classification: SourceClassification,
+        confidence: Double,
+        complete: Bool,
+        partialReason: String?
+    ) {
+        self.analysisRef = analysisRef
+        self.bands = bands
+        self.resonances = resonances
+        self.classification = classification
+        self.confidence = confidence.isFinite ? min(max(confidence, 0), 1) : 0
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            analysisRef: try values.decode(String.self, forKey: .analysisRef),
+            bands: try values.decode([SpectralBand].self, forKey: .bands),
+            resonances: try values.decode([SpectralResonance].self, forKey: .resonances),
+            classification: try values.decode(SourceClassification.self, forKey: .classification),
+            confidence: try values.decode(Double.self, forKey: .confidence),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason)
+        )
+    }
+}
+
+enum AnalysisJobState: String, Codable, Sendable {
+    case queued
+    case decoding
+    case analyzing
+    case completed
+    case failed
+    case cancelled
+}
+
+struct AnalysisJob: Codable, Equatable, Sendable {
+    let ref: String
+    let state: AnalysisJobState
+    let progress: Double
+}
+
+func advance(_ job: AnalysisJob, to state: AnalysisJobState) -> AnalysisJob? {
+    switch (job.state, state) {
+    case (.queued, .decoding),
+         (.decoding, .analyzing),
+         (.analyzing, .completed),
+         (.analyzing, .failed),
+         (.analyzing, .cancelled):
+        return AnalysisJob(ref: job.ref, state: state, progress: job.progress)
+    default:
+        return nil
+    }
+}

--- a/Sources/LogicProMCP/SpectralEQ/SpectralComparison.swift
+++ b/Sources/LogicProMCP/SpectralEQ/SpectralComparison.swift
@@ -1,0 +1,13 @@
+func compareSpectra(
+    _ a: SpectralAnalysisResult,
+    _ b: SpectralAnalysisResult
+) -> [(centerHz: Double, deltaDb: Double)] {
+    let bEnergy = Dictionary(
+        b.bands.map { ($0.centerHz, $0.energyDb) },
+        uniquingKeysWith: { first, _ in first }
+    )
+    return a.bands.compactMap { band in
+        guard let energyDb = bEnergy[band.centerHz] else { return nil }
+        return (centerHz: band.centerHz, deltaDb: energyDb - band.energyDb)
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -56,4 +56,8 @@ enum FeatureFlags: Sendable {
     static var adr011CompressorControl: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR011_COMPRESSOR_CONTROL"] == "1"
     }
+
+    static var adr012SpectralEQ: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR012_SPECTRAL_EQ"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/EQRecommendationTests.swift
+++ b/Tests/LogicProMCPTests/EQRecommendationTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-012 spectral EQ recommendations")
+struct EQRecommendationTests {
+    @Test func lowConfidenceReturnsNoSafeRecommendation() {
+        expectNoSafeRecommendation(recommendEQ(analysis(confidence: 0.59)))
+    }
+
+    @Test func unknownSourceReturnsNoSafeRecommendation() {
+        expectNoSafeRecommendation(recommendEQ(analysis(classification: .unknown)))
+    }
+
+    @Test func incompleteAnalysisReturnsNoSafeRecommendation() {
+        expectNoSafeRecommendation(
+            recommendEQ(analysis(complete: false, partialReason: "analysis interrupted"))
+        )
+    }
+
+    @Test func knownHighConfidenceResonanceProducesAdvisoryCuts() throws {
+        let outcome = recommendEQ(
+            analysis(resonances: [SpectralResonance(hz: 3_200, gainDb: 5, q: 2)])
+        )
+        guard case .recommendation(let bands, let advisory) = outcome else {
+            Issue.record("Expected an advisory recommendation")
+            return
+        }
+
+        let band = try #require(bands.first)
+        #expect(!bands.isEmpty)
+        #expect(advisory)
+        #expect(band.centerHz == 3_200)
+        #expect(band.gainDb == -5)
+        #expect(band.q == 2)
+        #expect(!band.reason.isEmpty)
+    }
+
+    @Test func recommendationsAreAlwaysAdvisoryAndNeverApplied() {
+        let classifications: [SourceClassification] = [.vocal, .drums, .bass, .fullMix]
+
+        for classification in classifications {
+            let outcome = recommendEQ(
+                analysis(
+                    resonances: [SpectralResonance(hz: 800, gainDb: 3, q: 1.5)],
+                    classification: classification
+                )
+            )
+            guard case .recommendation(_, let advisory) = outcome else {
+                Issue.record("Expected a recommendation for \(classification.rawValue)")
+                continue
+            }
+            #expect(advisory)
+        }
+    }
+
+    @Test func jobStateMachineAcceptsOnlyForwardTransitions() throws {
+        let queued = AnalysisJob(ref: "analysis-1", state: .queued, progress: 0.25)
+        let decoding = try #require(advance(queued, to: .decoding))
+        let analyzing = try #require(advance(decoding, to: .analyzing))
+
+        #expect(decoding.ref == queued.ref)
+        #expect(decoding.progress == queued.progress)
+        #expect(analyzing.state == .analyzing)
+        #expect(advance(analyzing, to: .completed)?.state == .completed)
+        #expect(advance(analyzing, to: .failed)?.state == .failed)
+        #expect(advance(analyzing, to: .cancelled)?.state == .cancelled)
+    }
+
+    @Test func jobStateMachineRejectsBacktrackingAndSkippedStates() {
+        let queued = AnalysisJob(ref: "analysis-1", state: .queued, progress: 0)
+        let completed = AnalysisJob(ref: "analysis-1", state: .completed, progress: 1)
+
+        #expect(advance(queued, to: .completed) == nil)
+        #expect(advance(completed, to: .analyzing) == nil)
+    }
+
+    @Test func comparisonReturnsExactDeltasForCommonBands() {
+        let before = analysis(
+            bands: [
+                SpectralBand(centerHz: 100, energyDb: -20),
+                SpectralBand(centerHz: 1_000, energyDb: -10),
+                SpectralBand(centerHz: 5_000, energyDb: -5),
+            ]
+        )
+        let after = analysis(
+            bands: [
+                SpectralBand(centerHz: 100, energyDb: -17),
+                SpectralBand(centerHz: 1_000, energyDb: -12),
+                SpectralBand(centerHz: 9_000, energyDb: -4),
+            ]
+        )
+
+        let comparison = compareSpectra(before, after)
+
+        #expect(comparison.count == 2)
+        #expect(comparison[0].centerHz == 100)
+        #expect(comparison[0].deltaDb == 3)
+        #expect(comparison[1].centerHz == 1_000)
+        #expect(comparison[1].deltaDb == -2)
+    }
+
+    @Test func completeAnalysisAlwaysDropsPartialReason() throws {
+        let complete = analysis(complete: true, partialReason: "stale")
+        let incomplete = analysis(complete: false, partialReason: "analysis interrupted")
+
+        #expect(complete.partialReason == nil)
+        #expect(incomplete.partialReason == "analysis interrupted")
+
+        let decoded = try JSONDecoder().decode(
+            SpectralAnalysisResult.self,
+            from: Data(
+                #"{"analysisRef":"analysis-1","bands":[],"resonances":[],"classification":"vocal","confidence":0.9,"complete":true,"partialReason":"stale"}"#.utf8
+            )
+        )
+        #expect(decoded.partialReason == nil)
+    }
+
+    @Test func confidenceStaysWithinUnitInterval() {
+        #expect(analysis(confidence: -0.1).confidence == 0)
+        #expect(analysis(confidence: 1.1).confidence == 1)
+    }
+
+    @Test func adr012FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR012_SPECTRAL_EQ"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr012SpectralEQ)
+    }
+
+    private func analysis(
+        bands: [SpectralBand] = [],
+        resonances: [SpectralResonance] = [],
+        classification: SourceClassification = .vocal,
+        confidence: Double = 0.9,
+        complete: Bool = true,
+        partialReason: String? = nil
+    ) -> SpectralAnalysisResult {
+        SpectralAnalysisResult(
+            analysisRef: "analysis-1",
+            bands: bands,
+            resonances: resonances,
+            classification: classification,
+            confidence: confidence,
+            complete: complete,
+            partialReason: partialReason
+        )
+    }
+
+    private func expectNoSafeRecommendation(_ outcome: EQRecommendationOutcome) {
+        guard case .noSafeRecommendation(let reason) = outcome else {
+            Issue.record("Expected no_safe_recommendation")
+            return
+        }
+        #expect(!reason.isEmpty)
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR | Name | Category | Status | GitHub issue |
 | --- | --- | --- | --- | --- |
 | ADR-011 | Full Verified Compressor Control | D | `In Implementation` | [#299](https://github.com/MongLong0214/logic-pro-mcp/issues/299) |
-| ADR-012 | Spectral Analysis and EQ Recommendation | D | `Proposed` | [#300](https://github.com/MongLong0214/logic-pro-mcp/issues/300) |
+| ADR-012 | Spectral Analysis and EQ Recommendation | D | `In Implementation` | [#300](https://github.com/MongLong0214/logic-pro-mcp/issues/300) |
 | ADR-013 | Verified Channel EQ Band Control | D | `Proposed` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
 | ADR-015 | Piano Roll Data-level Transform | D | `Proposed` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
@@ -125,6 +125,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Pure unit + outcome + saga logic** — physical-unit conversion (dB / ms / ratio / percent, round-trip stable), before/after outcome comparison against requested values within tolerance, and a saga-eligibility gate that is eligible **only** when a complete before-snapshot, a requested-parameter readback, and verified compensation all exist (an incomplete snapshot is never eligible).
 - 7 deterministic synthetic tests (manifest-specializes-ADR-009-by-circuit, coordinate-only-cannot-be-public-write, unit round-trip, outcome tolerance comparison, saga-requires-all-three, complete-drops-partial-reason, flag-default-off).
 - Deferred (honest scope): the live Controls-view AX parameter write/readback, real circuit-model detection, the MCP surface (`get_compressor_state_verified` / `set_compressor_params_verified` / `apply_compressor_plan_verified` / …), and the ADR-012 recommendation + audio-outcome analysis integration. Those need real Logic and are not claimed here.
+
+### ADR-012 — Spectral Analysis and EQ Recommendation (`In Implementation`)
+- Read-only analysis-result model + async-job state machine + pure recommendation engine only, behind `FeatureFlags.adr012SpectralEQ` (default off), with no runtime path. **Recommendation-only — no EQ write** (Channel EQ writes are owned by ADR-013).
+- **Recommendation honesty core** — `recommendEQ` returns **`noSafeRecommendation`** whenever the analysis is incomplete, its confidence is below the minimum, or the source classification is `unknown`; otherwise it returns advisory band cuts. Every recommendation is marked **`advisory` (never applied)** — a recommendation is not an automatic-adjustment claim, and analysis/apply-back stay separate.
+- **Pure models** — `SpectralAnalysisResult` (bands, resonances, source classification, confidence, `complete`/`partialReason`), an `AnalysisJob` state machine (`queued → decoding → analyzing → completed | failed | cancelled`) that accepts only valid forward transitions (backtracking / skipping → rejected), and a pure `compareSpectra` band-delta comparison.
+- 11 deterministic synthetic tests (low-confidence / unknown-source / incomplete → no-safe-recommendation, high-confidence-resonance → advisory cuts, recommendations-always-advisory-never-applied, job-state forward-only + reject-backtrack/skip, spectra comparison, complete-drops-partial-reason, confidence-in-unit-interval, flag-default-off).
+- Deferred (honest scope): the real FFT / audio-feature extraction from managed artifacts, the async job execution, the MCP surface (`analyze_spectrum` / `compare_spectra` / `recommend_eq` / job control), and any EQ apply-back (ADR-013). Those need real audio and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. Read-only analysis model + async-job state machine + pure recommendation engine, behind `LOGIC_MCP_ADR012_SPECTRAL_EQ` (default off), no runtime path. **Recommendation-only — no EQ write** (owned by ADR-013).

- **Honesty core:** `recommendEQ` returns **`noSafeRecommendation`** on incomplete / low-confidence / unknown-source input; otherwise advisory band cuts. Every recommendation is **`advisory` (never applied)** — recommendation is not an automatic-adjustment claim.
- **Pure models:** `SpectralAnalysisResult`, an `AnalysisJob` state machine (queued→decoding→analyzing→completed|failed|cancelled, forward-only), `compareSpectra`.
- 11 deterministic tests; full suite **2436 tests, 0 failures**.

**Deferred:** real FFT/audio extraction, async execution, MCP surface, EQ apply-back (ADR-013) — need real audio.

Refs #300, #308.