### PR TITLE
feat(adr-013): verified channel EQ band control pure core (#301)

### DIFF
--- a/Sources/LogicProMCP/ChannelEQ/ChannelEQBandValidation.swift
+++ b/Sources/LogicProMCP/ChannelEQ/ChannelEQBandValidation.swift
@@ -1,0 +1,60 @@
+private let channelEQFrequencyRange = 20.0 ... 20_000.0
+private let channelEQGainRange = -24.0 ... 24.0
+private let channelEQSlopeRange = 6.0 ... 48.0
+private let channelEQQRange = 0.1 ... 100.0
+
+enum EQBandRejection: Equatable, Sendable {
+    case eqAbsent
+    case bandOutOfRange(Int)
+    case frequencyOutOfRange(Double)
+    case gainOutOfRange(Double)
+    case qOutOfRange(Double)
+    case coordinateOnlyPlaneNotPublic
+    case staleTarget
+}
+
+func validateBandWrite(
+    state: ChannelEQState,
+    band: Int,
+    frequencyHz: Double,
+    gainOrSlope: Double,
+    q: Double,
+    plane: EQWritePlane,
+    expectedEpoch: UInt64?,
+    actualEpoch: UInt64?
+) -> [EQBandRejection] {
+    var rejections: [EQBandRejection] = []
+    if !state.present {
+        rejections.append(.eqAbsent)
+    }
+    if !(1 ... 8).contains(band) {
+        rejections.append(.bandOutOfRange(band))
+    }
+    if !channelEQFrequencyRange.contains(frequencyHz) {
+        rejections.append(.frequencyOutOfRange(frequencyHz))
+    }
+    if let range = gainOrSlopeRange(for: band), !range.contains(gainOrSlope) {
+        rejections.append(.gainOutOfRange(gainOrSlope))
+    }
+    if !channelEQQRange.contains(q) {
+        rejections.append(.qOutOfRange(q))
+    }
+    if !plane.isPublicVerifiedWritable {
+        rejections.append(.coordinateOnlyPlaneNotPublic)
+    }
+    if let expectedEpoch, actualEpoch != expectedEpoch {
+        rejections.append(.staleTarget)
+    }
+    return rejections
+}
+
+private func gainOrSlopeRange(for band: Int) -> ClosedRange<Double>? {
+    switch band {
+    case 1, 8:
+        channelEQSlopeRange
+    case 2 ... 7:
+        channelEQGainRange
+    default:
+        nil
+    }
+}

--- a/Sources/LogicProMCP/ChannelEQ/ChannelEQOutcome.swift
+++ b/Sources/LogicProMCP/ChannelEQ/ChannelEQOutcome.swift
@@ -1,0 +1,40 @@
+func compareChannelEQ(
+    before: ChannelEQState,
+    after: ChannelEQState
+) -> [(band: Int, field: String, before: Double, after: Double)] {
+    guard before.insertRef == after.insertRef else { return [] }
+
+    var changes: [(band: Int, field: String, before: Double, after: Double)] = []
+    for oldBand in before.bands.sorted(by: { $0.band < $1.band }) {
+        guard let newBand = after.bands.first(where: { $0.band == oldBand.band }) else {
+            continue
+        }
+        if oldBand.frequencyHz != newBand.frequencyHz {
+            changes.append((oldBand.band, "frequencyHz", oldBand.frequencyHz, newBand.frequencyHz))
+        }
+        if oldBand.gainOrSlope != newBand.gainOrSlope {
+            changes.append((oldBand.band, "gainOrSlope", oldBand.gainOrSlope, newBand.gainOrSlope))
+        }
+        if oldBand.q != newBand.q {
+            changes.append((oldBand.band, "q", oldBand.q, newBand.q))
+        }
+    }
+    return changes
+}
+
+func sagaEligibility(
+    beforeSnapshot: ChannelEQState?,
+    restoreVerified: Bool
+) -> (eligible: Bool, missing: [String]) {
+    var missing: [String] = []
+    if beforeSnapshot?.present != true
+        || beforeSnapshot?.complete != true
+        || beforeSnapshot?.bands.count != 8
+    {
+        missing.append("full_8_band_before_snapshot")
+    }
+    if !restoreVerified {
+        missing.append("verified_restore")
+    }
+    return (eligible: missing.isEmpty, missing: missing)
+}

--- a/Sources/LogicProMCP/ChannelEQ/ChannelEQState.swift
+++ b/Sources/LogicProMCP/ChannelEQ/ChannelEQState.swift
@@ -1,0 +1,56 @@
+enum EQBandRole: String, Codable, Sendable {
+    case highPass
+    case lowShelf
+    case parametric1
+    case parametric2
+    case parametric3
+    case parametric4
+    case highShelf
+    case lowPass
+}
+
+struct ChannelEQBandState: Codable, Equatable, Sendable {
+    let band: Int
+    let filterRole: EQBandRole
+    let frequencyHz: Double
+    let gainOrSlope: Double
+    let q: Double
+    let enabled: Bool
+}
+
+struct ChannelEQState: Codable, Equatable, Sendable {
+    let insertRef: TargetReference?
+    let present: Bool
+    let bands: [ChannelEQBandState]
+    let masterGainDb: Double?
+    let complete: Bool
+    let partialReason: String?
+
+    init(
+        insertRef: TargetReference?,
+        present: Bool,
+        bands: [ChannelEQBandState],
+        masterGainDb: Double?,
+        complete: Bool,
+        partialReason: String?
+    ) {
+        self.insertRef = insertRef
+        self.present = present && bands.count == 8
+        self.bands = bands
+        self.masterGainDb = masterGainDb
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            insertRef: try values.decodeIfPresent(TargetReference.self, forKey: .insertRef),
+            present: try values.decode(Bool.self, forKey: .present),
+            bands: try values.decode([ChannelEQBandState].self, forKey: .bands),
+            masterGainDb: try values.decodeIfPresent(Double.self, forKey: .masterGainDb),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason)
+        )
+    }
+}

--- a/Sources/LogicProMCP/ChannelEQ/EQWritePlane.swift
+++ b/Sources/LogicProMCP/ChannelEQ/EQWritePlane.swift
@@ -1,0 +1,18 @@
+enum EQWritePlane: Int, Comparable, Sendable {
+    case c4ControlSurface = 0
+    case qualifiedAXControls = 1
+    case coordinateOnly = 2
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+extension EQWritePlane {
+    // Instance member (not a free `canPublicVerifiedWrite(_:)` overload) so it
+    // does not collide with the identically-named ADR-011 compressor helper —
+    // a bare `.coordinateOnly` at a call site would otherwise be ambiguous.
+    var isPublicVerifiedWritable: Bool {
+        self != .coordinateOnly
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -60,4 +60,8 @@ enum FeatureFlags: Sendable {
     static var adr012SpectralEQ: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR012_SPECTRAL_EQ"] == "1"
     }
+
+    static var adr013ChannelEQ: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR013_CHANNEL_EQ"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/ChannelEQTests.swift
+++ b/Tests/LogicProMCPTests/ChannelEQTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-013 Channel EQ")
+struct ChannelEQTests {
+    @Test func absentEQRejectsBandWrite() {
+        let rejections = validateBandWrite(
+            state: state(present: false),
+            band: 3,
+            frequencyHz: 1_000,
+            gainOrSlope: 0,
+            q: 1,
+            plane: .c4ControlSurface,
+            expectedEpoch: 7,
+            actualEpoch: 7
+        )
+
+        #expect(rejections == [.eqAbsent])
+    }
+
+    @Test func coordinateOnlyPlaneIsNeverPublic() {
+        #expect(!EQWritePlane.coordinateOnly.isPublicVerifiedWritable)
+        #expect(EQWritePlane.c4ControlSurface.isPublicVerifiedWritable)
+        #expect(EQWritePlane.qualifiedAXControls.isPublicVerifiedWritable)
+        #expect(EQWritePlane.c4ControlSurface < .qualifiedAXControls)
+    }
+
+    @Test func bandAndParameterRangesFailClosed() {
+        let snapshot = state()
+
+        #expect(
+            validateBandWrite(
+                state: snapshot,
+                band: 0,
+                frequencyHz: 1_000,
+                gainOrSlope: 0,
+                q: 1,
+                plane: .c4ControlSurface,
+                expectedEpoch: nil,
+                actualEpoch: nil
+            ).contains(.bandOutOfRange(0))
+        )
+
+        let invalidValues = validateBandWrite(
+            state: snapshot,
+            band: 3,
+            frequencyHz: 19,
+            gainOrSlope: 25,
+            q: 0.09,
+            plane: .c4ControlSurface,
+            expectedEpoch: nil,
+            actualEpoch: nil
+        )
+        #expect(
+            invalidValues == [
+                .frequencyOutOfRange(19),
+                .gainOutOfRange(25),
+                .qOutOfRange(0.09),
+            ]
+        )
+
+        #expect(
+            validateBandWrite(
+                state: snapshot,
+                band: 1,
+                frequencyHz: 20,
+                gainOrSlope: 0,
+                q: 100,
+                plane: .qualifiedAXControls,
+                expectedEpoch: nil,
+                actualEpoch: nil
+            ).contains(.gainOutOfRange(0))
+        )
+    }
+
+    @Test func staleEpochRejectsBandWrite() {
+        let rejections = validateBandWrite(
+            state: state(),
+            band: 4,
+            frequencyHz: 500,
+            gainOrSlope: -2,
+            q: 1.2,
+            plane: .qualifiedAXControls,
+            expectedEpoch: 4,
+            actualEpoch: 5
+        )
+
+        #expect(rejections == [.staleTarget])
+    }
+
+    @Test func validPresentBandWritePassesPreflight() {
+        let rejections = validateBandWrite(
+            state: state(),
+            band: 3,
+            frequencyHz: 1_000,
+            gainOrSlope: -2,
+            q: 1,
+            plane: .c4ControlSurface,
+            expectedEpoch: 9,
+            actualEpoch: 9
+        )
+
+        #expect(rejections.isEmpty)
+    }
+
+    @Test func sagaRequiresFullBeforeSnapshotAndVerifiedRestore() {
+        let eligible = sagaEligibility(beforeSnapshot: state(), restoreVerified: true)
+        #expect(eligible.eligible)
+        #expect(eligible.missing.isEmpty)
+
+        let missingRestore = sagaEligibility(beforeSnapshot: state(), restoreVerified: false)
+        #expect(!missingRestore.eligible)
+        #expect(missingRestore.missing == ["verified_restore"])
+
+        let incomplete = sagaEligibility(
+            beforeSnapshot: state(complete: false, partialReason: "readback incomplete"),
+            restoreVerified: true
+        )
+        #expect(!incomplete.eligible)
+        #expect(incomplete.missing == ["full_8_band_before_snapshot"])
+
+        let absent = sagaEligibility(beforeSnapshot: state(present: false), restoreVerified: true)
+        #expect(!absent.eligible)
+        #expect(absent.missing == ["full_8_band_before_snapshot"])
+
+        let missing = sagaEligibility(beforeSnapshot: nil, restoreVerified: true)
+        #expect(!missing.eligible)
+        #expect(missing.missing == ["full_8_band_before_snapshot"])
+    }
+
+    @Test func comparisonReportsExactChangedBandParameters() {
+        let before = state()
+        var changedBands = bands()
+        changedBands[2] = band(
+            3,
+            .parametric1,
+            frequencyHz: 300,
+            gainOrSlope: -3,
+            q: 1.2,
+            enabled: false
+        )
+        changedBands[7] = band(8, .lowPass, frequencyHz: 16_000, gainOrSlope: 12, q: 1.5)
+
+        let changes = compareChannelEQ(before: before, after: state(bands: changedBands))
+
+        #expect(changes.count == 4)
+        #expect(changes[0].band == 3)
+        #expect(changes[0].field == "frequencyHz")
+        #expect(changes[0].before == 250)
+        #expect(changes[0].after == 300)
+        #expect(changes[1].band == 3)
+        #expect(changes[1].field == "gainOrSlope")
+        #expect(changes[1].before == 0)
+        #expect(changes[1].after == -3)
+        #expect(changes[2].band == 3)
+        #expect(changes[2].field == "q")
+        #expect(changes[2].before == 1)
+        #expect(changes[2].after == 1.2)
+        #expect(changes[3].band == 8)
+        #expect(changes[3].field == "q")
+        #expect(changes[3].before == 1)
+        #expect(changes[3].after == 1.5)
+    }
+
+    @Test func stateEnforcesEightBandsAndCompleteReasonInvariant() throws {
+        let incompleteBands = Array(bands().dropLast())
+        let invalidPresent = state(bands: incompleteBands)
+        let complete = state(complete: true, partialReason: "stale")
+
+        #expect(!invalidPresent.present)
+        #expect(complete.partialReason == nil)
+        #expect(
+            bands().map(\.filterRole) == [
+                .highPass,
+                .lowShelf,
+                .parametric1,
+                .parametric2,
+                .parametric3,
+                .parametric4,
+                .highShelf,
+                .lowPass,
+            ]
+        )
+
+        let encoded = try JSONEncoder().encode(
+            state(complete: false, partialReason: "readback incomplete")
+        )
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object["bands"] = Array(try #require(object["bands"] as? [[String: Any]]).dropLast())
+        object["present"] = true
+        object["complete"] = true
+        object["partialReason"] = "stale"
+
+        let decoded = try JSONDecoder().decode(
+            ChannelEQState.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+        #expect(!decoded.present)
+        #expect(decoded.partialReason == nil)
+    }
+
+    @Test func adr013FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR013_CHANNEL_EQ"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr013ChannelEQ)
+    }
+
+    private func state(
+        present: Bool = true,
+        bands: [ChannelEQBandState]? = nil,
+        complete: Bool = true,
+        partialReason: String? = nil
+    ) -> ChannelEQState {
+        ChannelEQState(
+            insertRef: TargetReference(rawValue: "ins_test"),
+            present: present,
+            bands: bands ?? self.bands(),
+            masterGainDb: 0,
+            complete: complete,
+            partialReason: partialReason
+        )
+    }
+
+    private func bands() -> [ChannelEQBandState] {
+        [
+            band(1, .highPass, frequencyHz: 40, gainOrSlope: 12, q: 1),
+            band(2, .lowShelf, frequencyHz: 100, gainOrSlope: 0, q: 1),
+            band(3, .parametric1, frequencyHz: 250, gainOrSlope: 0, q: 1),
+            band(4, .parametric2, frequencyHz: 500, gainOrSlope: 0, q: 1),
+            band(5, .parametric3, frequencyHz: 1_000, gainOrSlope: 0, q: 1),
+            band(6, .parametric4, frequencyHz: 3_000, gainOrSlope: 0, q: 1),
+            band(7, .highShelf, frequencyHz: 8_000, gainOrSlope: 0, q: 1),
+            band(8, .lowPass, frequencyHz: 16_000, gainOrSlope: 12, q: 1),
+        ]
+    }
+
+    private func band(
+        _ number: Int,
+        _ role: EQBandRole,
+        frequencyHz: Double,
+        gainOrSlope: Double,
+        q: Double,
+        enabled: Bool = true
+    ) -> ChannelEQBandState {
+        ChannelEQBandState(
+            band: number,
+            filterRole: role,
+            frequencyHz: frequencyHz,
+            gainOrSlope: gainOrSlope,
+            q: q,
+            enabled: enabled
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,7 +40,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | --- | --- | --- | --- | --- |
 | ADR-011 | Full Verified Compressor Control | D | `In Implementation` | [#299](https://github.com/MongLong0214/logic-pro-mcp/issues/299) |
 | ADR-012 | Spectral Analysis and EQ Recommendation | D | `In Implementation` | [#300](https://github.com/MongLong0214/logic-pro-mcp/issues/300) |
-| ADR-013 | Verified Channel EQ Band Control | D | `Proposed` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
+| ADR-013 | Verified Channel EQ Band Control | D | `In Implementation` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
 | ADR-015 | Piano Roll Data-level Transform | D | `Proposed` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
 | ADR-016 | Smart Tempo and Tempo-map Control | D | `Proposed` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
@@ -132,6 +132,14 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Pure models** — `SpectralAnalysisResult` (bands, resonances, source classification, confidence, `complete`/`partialReason`), an `AnalysisJob` state machine (`queued → decoding → analyzing → completed | failed | cancelled`) that accepts only valid forward transitions (backtracking / skipping → rejected), and a pure `compareSpectra` band-delta comparison.
 - 11 deterministic synthetic tests (low-confidence / unknown-source / incomplete → no-safe-recommendation, high-confidence-resonance → advisory cuts, recommendations-always-advisory-never-applied, job-state forward-only + reject-backtrack/skip, spectra comparison, complete-drops-partial-reason, confidence-in-unit-interval, flag-default-off).
 - Deferred (honest scope): the real FFT / audio-feature extraction from managed artifacts, the async job execution, the MCP surface (`analyze_spectrum` / `compare_spectra` / `recommend_eq` / job control), and any EQ apply-back (ADR-013). Those need real audio and are not claimed here.
+
+### ADR-013 — Verified Channel EQ Band Control (`In Implementation`)
+- 8-band channel-EQ state model + pure band-write preflight only, behind `FeatureFlags.adr013ChannelEQ` (default off), with no runtime path (no EQ is driven).
+- **State model** — `ChannelEQState` (present, 8 `ChannelEQBandState` bands with role / frequency / gain-or-slope / Q, master gain, `complete`/`partialReason`); band role is fixed by census, not by UI label alone; a `present` EQ carries exactly 8 bands and a complete state carries no partial reason.
+- **Write-safety preflight (honesty core)** — `validateBandWrite` returns a list of rejections and performs no write: **`eqAbsent` when the channel has no EQ** (a band write is refused until an explicit `insert_verified` adds the EQ), band-out-of-range (1–8), frequency/gain/Q out-of-range, `staleTarget` on epoch mismatch, and `coordinateOnlyPlaneNotPublic` — the `EQWritePlane` priority is C4 control-surface › qualified AX Controls › coordinate-only, and the **coordinate-only plane can never be a public verified write**.
+- **Saga eligibility** — eligible only when a full 8-band before-snapshot (present + complete) and a verified restore both exist; an absent or incomplete snapshot is never eligible. Plus a pure before/after band-parameter comparison.
+- 9 deterministic synthetic tests (absent-EQ-rejects-band-write, coordinate-only-never-public, band/parameter ranges fail closed, stale-epoch-rejects, valid-write-passes-preflight, saga-requires-full-snapshot+restore, comparison, 8-band/complete invariants, flag-default-off).
+- Deferred (honest scope): the Mackie C4 control-surface adapter, the qualified AX Controls-view write/readback, the Doctor `verified_channel_eq` capability check, the MCP surface (`get_channel_eq_state_verified` / `set_channel_eq_band_verified` / …), and applying ADR-012 recommendations. Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. 8-band channel-EQ state model + pure band-write preflight, behind `LOGIC_MCP_ADR013_CHANNEL_EQ` (default off), no runtime path.

- **Honesty core:** `validateBandWrite` returns rejections and performs no write — **`eqAbsent` when the channel has no EQ** (band write refused until an explicit `insert_verified`), band-range (1–8), freq/gain/Q ranges, `staleTarget`, and `coordinateOnlyPlaneNotPublic` (EQWritePlane C4 › qualified AX › coordinate-only; **coordinate-only can never be a public verified write**).
- **Saga eligibility:** only with a full 8-band before-snapshot (present+complete) + verified restore; absent/incomplete never eligible. Plus before/after comparison.
- 9 deterministic tests; full suite **2445 tests, 0 failures** (two compiler-level issues in the generated diff — a default-parameter instance member and a helper-name collision with ADR-011 — were caught in review and fixed).

**Deferred:** C4 adapter, AX Controls write/readback, Doctor check, MCP surface, applying ADR-012 recommendations — need real Logic.

Refs #301, #308.