### PR TITLE
feat(adr-015): piano roll data-level transform engine pure core (#303)

### DIFF
--- a/Sources/LogicProMCP/PianoRoll/MIDITransform.swift
+++ b/Sources/LogicProMCP/PianoRoll/MIDITransform.swift
@@ -1,0 +1,160 @@
+enum QuantizeGrid: String, Codable, Sendable {
+    case thirtySecond
+    case sixteenth
+    case eighth
+    case quarter
+    case half
+    case whole
+
+    func ticks(ppq: Int) -> Int64 {
+        guard ppq > 0 else { return 0 }
+        let base = Int64(ppq)
+        switch self {
+        case .thirtySecond:
+            return max(1, base / 8)
+        case .sixteenth:
+            return max(1, base / 4)
+        case .eighth:
+            return max(1, base / 2)
+        case .quarter:
+            return base
+        case .half:
+            let result = base.multipliedReportingOverflow(by: 2)
+            return result.overflow ? 0 : result.partialValue
+        case .whole:
+            let result = base.multipliedReportingOverflow(by: 4)
+            return result.overflow ? 0 : result.partialValue
+        }
+    }
+}
+
+enum MIDITransform: Codable, Equatable, Sendable {
+    case transpose(semitones: Int)
+    case setVelocity(Int)
+    case scaleVelocity(factor: Double, pivot: Int)
+    case quantize(grid: QuantizeGrid, strength: Double, swing: Double)
+    case humanize(timingTicks: Int, velocity: Int, seed: UInt64)
+}
+
+func applyTransform(
+    _ transform: MIDITransform,
+    to notes: [MIDINoteEvent],
+    ppq: Int
+) -> [MIDINoteEvent] {
+    switch transform {
+    case .transpose(let semitones):
+        return notes.map { note in
+            let (pitch, overflow) = Int(note.pitch).addingReportingOverflow(semitones)
+            return replacing(note, pitch: midiPitch(overflow ? semitones.signum() * 128 : pitch))
+        }
+    case .setVelocity(let velocity):
+        return notes.map { replacing($0, velocity: midiVelocity(velocity)) }
+    case .scaleVelocity(let factor, let pivot):
+        guard factor.isFinite else { return notes }
+        return notes.map { note in
+            let scaled = Double(pivot) + (Double(note.velocity) - Double(pivot)) * factor
+            guard scaled.isFinite else { return note }
+            return replacing(note, velocity: midiVelocity(Int(scaled.rounded())))
+        }
+    case .quantize(let grid, let strength, let swing):
+        return quantized(notes, grid: grid, strength: strength, swing: swing, ppq: ppq)
+    case .humanize(let timingTicks, let velocity, let seed):
+        return notes.enumerated().map { index, note in
+            let timing = symmetricOffset(
+                limit: timingTicks,
+                random: deterministicWord(seed: seed, index: index, lane: 0)
+            )
+            let velocityOffset = symmetricOffset(
+                limit: velocity,
+                random: deterministicWord(seed: seed, index: index, lane: 1)
+            )
+            let (shiftedStart, overflow) = note.startTicks.addingReportingOverflow(timing)
+            let start = overflow ? (timing < 0 ? 0 : Int64.max) : max(0, shiftedStart)
+            return replacing(
+                note,
+                startTicks: start,
+                velocity: midiVelocity(Int(note.velocity) + Int(velocityOffset))
+            )
+        }
+    }
+}
+
+private func quantized(
+    _ notes: [MIDINoteEvent],
+    grid: QuantizeGrid,
+    strength: Double,
+    swing: Double,
+    ppq: Int
+) -> [MIDINoteEvent] {
+    let gridTicks = grid.ticks(ppq: ppq)
+    guard gridTicks > 0 else { return notes }
+    let appliedStrength = strength.isFinite ? min(max(strength, 0), 1) : 0
+    let appliedSwing = swing.isFinite ? min(max(swing, -1), 1) : 0
+
+    return notes.map { note in
+        let gridIndex = roundedQuotient(note.startTicks, divisor: gridTicks)
+        let (baseTarget, baseOverflow) = gridIndex.multipliedReportingOverflow(by: gridTicks)
+        guard !baseOverflow else { return note }
+
+        let swingOffset = gridIndex % 2 == 0
+            ? 0
+            : roundedInt64(Double(gridTicks) * appliedSwing / 2)
+        let (swungTarget, swingOverflow) = baseTarget.addingReportingOverflow(swingOffset)
+        guard !swingOverflow else { return note }
+
+        let interpolated = Double(note.startTicks)
+            + (Double(swungTarget) - Double(note.startTicks)) * appliedStrength
+        return replacing(note, startTicks: roundedInt64(interpolated))
+    }
+}
+
+private func roundedQuotient(_ value: Int64, divisor: Int64) -> Int64 {
+    let quotient = value / divisor
+    let remainder = value % divisor
+    let threshold = divisor / 2 + divisor % 2
+    guard abs(remainder) >= threshold else { return quotient }
+    return quotient + (value >= 0 ? 1 : -1)
+}
+
+private func roundedInt64(_ value: Double) -> Int64 {
+    guard value.isFinite else { return 0 }
+    if value >= Double(Int64.max) { return Int64.max }
+    if value <= Double(Int64.min) { return Int64.min }
+    return Int64(value.rounded())
+}
+
+private func deterministicWord(seed: UInt64, index: Int, lane: UInt64) -> UInt64 {
+    var word = seed &+ UInt64(index) &* 0x9E37_79B9_7F4A_7C15 &+ lane
+    word = (word ^ (word >> 30)) &* 0xBF58_476D_1CE4_E5B9
+    word = (word ^ (word >> 27)) &* 0x94D0_49BB_1331_11EB
+    return word ^ (word >> 31)
+}
+
+private func symmetricOffset(limit: Int, random: UInt64) -> Int64 {
+    let magnitude = min(UInt64(limit.magnitude), UInt64(Int64.max / 2))
+    guard magnitude > 0 else { return 0 }
+    return Int64(random % (magnitude * 2 + 1)) - Int64(magnitude)
+}
+
+private func midiPitch(_ value: Int) -> UInt8 {
+    UInt8(min(max(value, 0), 127))
+}
+
+private func midiVelocity(_ value: Int) -> UInt8 {
+    UInt8(min(max(value, 1), 127))
+}
+
+private func replacing(
+    _ note: MIDINoteEvent,
+    pitch: UInt8? = nil,
+    startTicks: Int64? = nil,
+    velocity: UInt8? = nil
+) -> MIDINoteEvent {
+    MIDINoteEvent(
+        pitch: pitch ?? note.pitch,
+        startTicks: startTicks ?? note.startTicks,
+        durationTicks: note.durationTicks,
+        velocity: velocity ?? note.velocity,
+        channel: note.channel
+    )
+}

--- a/Sources/LogicProMCP/PianoRoll/RegionTransformPlan.swift
+++ b/Sources/LogicProMCP/PianoRoll/RegionTransformPlan.swift
@@ -1,0 +1,51 @@
+struct RegionTransformPlan: Sendable {
+    let regionRef: MIDIRegionReference
+    let boundGeneration: UInt64
+    let transform: MIDITransform
+    let beforeSnapshot: MIDIRegionNoteSnapshot
+    let predictedAfter: [MIDINoteEvent]
+}
+
+func planTransform(
+    region: MIDIRegionReference,
+    transform: MIDITransform,
+    beforeSnapshot: MIDIRegionNoteSnapshot,
+    ppq: Int
+) -> RegionTransformPlan? {
+    guard beforeSnapshot.complete, beforeSnapshot.regionReference == region else { return nil }
+    return RegionTransformPlan(
+        regionRef: region,
+        boundGeneration: beforeSnapshot.projectEpoch,
+        transform: transform,
+        beforeSnapshot: beforeSnapshot,
+        predictedAfter: applyTransform(transform, to: beforeSnapshot.notes, ppq: ppq)
+    )
+}
+
+enum PlanApplyRejection: Equatable, Sendable {
+    case staleGeneration(bound: UInt64, current: UInt64)
+    case snapshotIncomplete
+    case regionMismatch
+}
+
+func validateApply(
+    plan: RegionTransformPlan,
+    currentGeneration: UInt64,
+    currentRegion: MIDIRegionReference
+) -> [PlanApplyRejection] {
+    var rejections: [PlanApplyRejection] = []
+    if currentGeneration != plan.boundGeneration {
+        rejections.append(
+            .staleGeneration(bound: plan.boundGeneration, current: currentGeneration)
+        )
+    }
+    if !plan.beforeSnapshot.complete {
+        rejections.append(.snapshotIncomplete)
+    }
+    if currentRegion != plan.regionRef
+        || plan.beforeSnapshot.regionReference != plan.regionRef
+    {
+        rejections.append(.regionMismatch)
+    }
+    return rejections
+}

--- a/Sources/LogicProMCP/PianoRoll/TransformVerification.swift
+++ b/Sources/LogicProMCP/PianoRoll/TransformVerification.swift
@@ -1,0 +1,49 @@
+enum TransformVerdict: Equatable, Sendable {
+    case stateA
+    case stateBUnverified(reason: String)
+    case mismatch(unexpected: [MIDINoteEvent])
+}
+
+func verifyTransform(
+    plan: RegionTransformPlan,
+    observedAfter: MIDIRegionNoteSnapshot
+) -> TransformVerdict {
+    guard observedAfter.complete else {
+        return .stateBUnverified(
+            reason: observedAfter.partialReason ?? "Post-write MIDI snapshot is incomplete"
+        )
+    }
+    guard observedAfter.regionReference == plan.regionRef else {
+        return .stateBUnverified(reason: "Post-write region does not match the transform plan")
+    }
+    let (expectedGeneration, overflow) = plan.boundGeneration.addingReportingOverflow(1)
+    guard !overflow, observedAfter.projectEpoch == expectedGeneration else {
+        return .stateBUnverified(reason: "Post-write generation transition is not verified")
+    }
+
+    let expected = sortedNotes(plan.predictedAfter)
+    let observed = sortedNotes(observedAfter.notes)
+    guard observed != expected else { return .stateA }
+
+    var unmatchedExpected = expected
+    let unexpected = observed.filter { note in
+        guard let index = unmatchedExpected.firstIndex(of: note) else { return true }
+        unmatchedExpected.remove(at: index)
+        return false
+    }
+    return .mismatch(unexpected: unexpected)
+}
+
+func compensationNotes(plan: RegionTransformPlan) -> [MIDINoteEvent] {
+    plan.beforeSnapshot.notes
+}
+
+private func sortedNotes(_ notes: [MIDINoteEvent]) -> [MIDINoteEvent] {
+    notes.sorted { lhs, rhs in
+        if lhs.pitch != rhs.pitch { return lhs.pitch < rhs.pitch }
+        if lhs.startTicks != rhs.startTicks { return lhs.startTicks < rhs.startTicks }
+        if lhs.durationTicks != rhs.durationTicks { return lhs.durationTicks < rhs.durationTicks }
+        if lhs.velocity != rhs.velocity { return lhs.velocity < rhs.velocity }
+        return lhs.channel < rhs.channel
+    }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -64,4 +64,8 @@ enum FeatureFlags: Sendable {
     static var adr013ChannelEQ: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR013_CHANNEL_EQ"] == "1"
     }
+
+    static var adr015PianoRoll: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR015_PIANO_ROLL"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/PianoRollTransformTests.swift
+++ b/Tests/LogicProMCPTests/PianoRollTransformTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-015 Piano Roll Transform")
+struct PianoRollTransformTests {
+    @Test func transposeClampsPitch() {
+        let notes = [note(pitch: 1), note(pitch: 120)]
+
+        #expect(applyTransform(.transpose(semitones: -12), to: notes, ppq: 480) == [
+            note(pitch: 0),
+            note(pitch: 108),
+        ])
+        #expect(applyTransform(.transpose(semitones: 12), to: notes, ppq: 480) == [
+            note(pitch: 13),
+            note(pitch: 127),
+        ])
+    }
+
+    @Test func setVelocityClampsToMidiRange() {
+        let notes = [note(pitch: 60, velocity: 40), note(pitch: 64, velocity: 100)]
+
+        #expect(applyTransform(.setVelocity(0), to: notes, ppq: 480).map(\.velocity) == [1, 1])
+        #expect(applyTransform(.setVelocity(200), to: notes, ppq: 480).map(\.velocity) == [127, 127])
+    }
+
+    @Test func scaleVelocityUsesPivotAndClamps() {
+        let notes = [
+            note(pitch: 60, velocity: 1),
+            note(pitch: 62, velocity: 80),
+            note(pitch: 64, velocity: 127),
+        ]
+
+        #expect(
+            applyTransform(
+                .scaleVelocity(factor: 2, pivot: 64),
+                to: notes,
+                ppq: 480
+            ).map(\.velocity) == [1, 96, 127]
+        )
+    }
+
+    @Test func quantizeAppliesGridStrengthAndSwing() {
+        let notes = [note(pitch: 60, start: 350)]
+
+        #expect(QuantizeGrid.sixteenth.ticks(ppq: 480) == 120)
+        #expect(
+            applyTransform(
+                .quantize(grid: .eighth, strength: 0.5, swing: 0.5),
+                to: notes,
+                ppq: 480
+            ) == [note(pitch: 60, start: 325)]
+        )
+    }
+
+    @Test func humanizeIsSeedDeterministic() {
+        let notes = [
+            note(pitch: 60, start: 100, velocity: 30),
+            note(pitch: 62, start: 200, velocity: 70),
+            note(pitch: 64, start: 300, velocity: 120),
+        ]
+        let transform = MIDITransform.humanize(timingTicks: 40, velocity: 20, seed: 42)
+
+        let first = applyTransform(transform, to: notes, ppq: 480)
+        let second = applyTransform(transform, to: notes, ppq: 480)
+        let differentSeed = applyTransform(
+            .humanize(timingTicks: 40, velocity: 20, seed: 43),
+            to: notes,
+            ppq: 480
+        )
+
+        #expect(first == second)
+        #expect(first != differentSeed)
+    }
+
+    @Test func incompleteBeforeSnapshotCannotProducePlan() {
+        #expect(
+            planTransform(
+                region: region(),
+                transform: .transpose(semitones: 2),
+                beforeSnapshot: snapshot(complete: false),
+                ppq: 480
+            ) == nil
+        )
+    }
+
+    @Test func planBindsGenerationAndRejectsStaleApply() throws {
+        let target = region()
+        let plan = try #require(
+            planTransform(
+                region: target,
+                transform: .transpose(semitones: 2),
+                beforeSnapshot: snapshot(region: target, generation: 7, notes: [note(pitch: 60)]),
+                ppq: 480
+            )
+        )
+
+        #expect(plan.boundGeneration == 7)
+        #expect(plan.predictedAfter == [note(pitch: 62)])
+        #expect(
+            validateApply(plan: plan, currentGeneration: 8, currentRegion: target) == [
+                .staleGeneration(bound: 7, current: 8),
+            ]
+        )
+        #expect(validateApply(plan: plan, currentGeneration: 7, currentRegion: target).isEmpty)
+    }
+
+    @Test func applyValidationRejectsRegionMismatch() throws {
+        let target = region(index: 0)
+        let plan = try #require(
+            planTransform(
+                region: target,
+                transform: .setVelocity(90),
+                beforeSnapshot: snapshot(region: target),
+                ppq: 480
+            )
+        )
+
+        #expect(
+            validateApply(
+                plan: plan,
+                currentGeneration: plan.boundGeneration,
+                currentRegion: region(index: 1)
+            ) == [.regionMismatch]
+        )
+    }
+
+    @Test func exactCompleteNextGenerationMultisetIsStateA() throws {
+        let target = region()
+        let duplicate = note(pitch: 60, start: 120)
+        let other = note(pitch: 64, start: 0)
+        let plan = try #require(
+            planTransform(
+                region: target,
+                transform: .transpose(semitones: 0),
+                beforeSnapshot: snapshot(
+                    region: target,
+                    generation: 10,
+                    notes: [duplicate, duplicate, other]
+                ),
+                ppq: 480
+            )
+        )
+        let observed = snapshot(
+            region: target,
+            generation: 11,
+            notes: [other, duplicate, duplicate]
+        )
+
+        #expect(verifyTransform(plan: plan, observedAfter: observed) == .stateA)
+    }
+
+    @Test func incompleteObservedSnapshotIsNeverStateA() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            complete: false,
+            notes: plan.predictedAfter
+        )
+
+        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+            Issue.record("An incomplete post-write snapshot must never be State A")
+            return
+        }
+    }
+
+    @Test func unexpectedGenerationIsNeverStateA() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration,
+            notes: plan.predictedAfter
+        )
+
+        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+            Issue.record("State A requires the expected generation transition")
+            return
+        }
+    }
+
+    @Test func observedRegionMismatchIsNeverStateA() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: region(index: 1),
+            generation: plan.boundGeneration + 1,
+            notes: plan.predictedAfter
+        )
+
+        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+            Issue.record("State A requires the same region reference")
+            return
+        }
+    }
+
+    @Test func multisetMismatchReportsUnexpectedEvents() throws {
+        let expected = note(pitch: 60)
+        let unexpected = note(pitch: 67)
+        let plan = try #require(
+            planTransform(
+                region: region(),
+                transform: .transpose(semitones: 0),
+                beforeSnapshot: snapshot(notes: [expected, expected]),
+                ppq: 480
+            )
+        )
+        let observed = snapshot(
+            generation: plan.boundGeneration + 1,
+            notes: [expected, unexpected]
+        )
+
+        #expect(
+            verifyTransform(plan: plan, observedAfter: observed) == .mismatch(
+                unexpected: [unexpected]
+            )
+        )
+    }
+
+    @Test func compensationRestoresExactBeforeSnapshot() throws {
+        let before = [note(pitch: 60, start: 20), note(pitch: 60, start: 20)]
+        let plan = try #require(
+            planTransform(
+                region: region(),
+                transform: .humanize(timingTicks: 10, velocity: 4, seed: 9),
+                beforeSnapshot: snapshot(notes: before),
+                ppq: 480
+            )
+        )
+
+        #expect(compensationNotes(plan: plan) == before)
+    }
+
+    @Test func adr015FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR015_PIANO_ROLL"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr015PianoRoll)
+    }
+
+    private func makePlan() -> RegionTransformPlan? {
+        planTransform(
+            region: region(),
+            transform: .transpose(semitones: 2),
+            beforeSnapshot: snapshot(notes: [note(pitch: 60)]),
+            ppq: 480
+        )
+    }
+
+    private func region(index: Int = 0) -> MIDIRegionReference {
+        MIDIRegionReference(
+            targetRef: TargetReference(rawValue: "trk_test"),
+            regionIndex: index
+        )
+    }
+
+    private func snapshot(
+        region: MIDIRegionReference? = nil,
+        generation: UInt64 = 1,
+        complete: Bool = true,
+        notes: [MIDINoteEvent] = []
+    ) -> MIDIRegionNoteSnapshot {
+        MIDIRegionNoteSnapshot(
+            regionReference: region ?? self.region(),
+            projectEpoch: generation,
+            complete: complete,
+            partialReason: complete ? nil : "synthetic incomplete snapshot",
+            provenance: .eventListAX,
+            ppq: 480,
+            notes: notes,
+            tempoMap: [],
+            timeSignatures: []
+        )
+    }
+
+    private func note(
+        pitch: UInt8,
+        start: Int64 = 0,
+        duration: Int64 = 120,
+        velocity: UInt8 = 100,
+        channel: UInt8 = 0
+    ) -> MIDINoteEvent {
+        MIDINoteEvent(
+            pitch: pitch,
+            startTicks: start,
+            durationTicks: duration,
+            velocity: velocity,
+            channel: channel
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,7 +42,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-012 | Spectral Analysis and EQ Recommendation | D | `In Implementation` | [#300](https://github.com/MongLong0214/logic-pro-mcp/issues/300) |
 | ADR-013 | Verified Channel EQ Band Control | D | `In Implementation` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
-| ADR-015 | Piano Roll Data-level Transform | D | `Proposed` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
+| ADR-015 | Piano Roll Data-level Transform | D | `In Implementation` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
 | ADR-016 | Smart Tempo and Tempo-map Control | D | `Proposed` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
 | ADR-017 | Flex Pitch Inspection and Verified Editing | D | `Proposed` | [#305](https://github.com/MongLong0214/logic-pro-mcp/issues/305) |
 | ADR-018 | Verified Third-party Host-Parameter Control | D | `Proposed` | [#306](https://github.com/MongLong0214/logic-pro-mcp/issues/306) |
@@ -140,6 +140,14 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Saga eligibility** — eligible only when a full 8-band before-snapshot (present + complete) and a verified restore both exist; an absent or incomplete snapshot is never eligible. Plus a pure before/after band-parameter comparison.
 - 9 deterministic synthetic tests (absent-EQ-rejects-band-write, coordinate-only-never-public, band/parameter ranges fail closed, stale-epoch-rejects, valid-write-passes-preflight, saga-requires-full-snapshot+restore, comparison, 8-band/complete invariants, flag-default-off).
 - Deferred (honest scope): the Mackie C4 control-surface adapter, the qualified AX Controls-view write/readback, the Doctor `verified_channel_eq` capability check, the MCP surface (`get_channel_eq_state_verified` / `set_channel_eq_band_verified` / …), and applying ADR-012 recommendations. Those need real Logic and are not claimed here.
+
+### ADR-015 — Piano Roll Data-Level Transform (`In Implementation`)
+- Pure MIDI transform engine + plan/verify/compensate logic only, behind `FeatureFlags.adr015PianoRoll` (default off), with no runtime path. Operates on the ADR-010 note **data model**, not on graphic note dragging.
+- **Deterministic transform engine** — `MIDITransform` (`transpose` / `setVelocity` / `scaleVelocity` / `quantize(grid, strength, swing)` / `humanize(seed)`) applied as pure data transforms over `[MIDINoteEvent]` with pitch/velocity clamping; `humanize` is **seed-deterministic** (no wall clock / RNG).
+- **Plan-generation binding** — a `RegionTransformPlan` binds to the before-snapshot's generation; `planTransform` refuses an incomplete before-snapshot, and `validateApply` **rejects a stale plan** (`staleGeneration` when the region's generation moved, `regionMismatch`, `snapshotIncomplete`).
+- **Verification (patch ordering)** — `verifyTransform` returns State A **only** when the post-write snapshot is `complete`, has the same region ref, shows the expected generation transition, and its note set is an **exact multiset match** of the predicted canonical result; an incomplete snapshot, a wrong generation, or any unexpected event is `stateBUnverified` / `mismatch` — a partial or pixel-drag result can never be State A. Compensation restores the exact before-snapshot (not a blind inverse).
+- 15 deterministic synthetic tests (transform clamps, humanize-seed-determinism, incomplete-before → no plan, stale-apply rejection, region-mismatch, exact-multiset → State A, incomplete/wrong-generation/region-mismatch → never State A, multiset-mismatch reporting, compensation restores before-snapshot, flag-default-off).
+- Deferred (honest scope): the live note selection / edit against Logic, the live before/after snapshot reads (which themselves depend on an ADR-014/ADR-010 provider being qualified), and the MCP surface (`plan_region_transform` / `apply_region_transform_verified` / …). Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. Pure MIDI transform engine + plan/verify/compensate logic, behind `LOGIC_MCP_ADR015_PIANO_ROLL` (default off), no runtime path. Operates on the ADR-010 note **data model**, not graphic dragging.

- **Deterministic transforms:** transpose/setVelocity/scaleVelocity/quantize/humanize over `[MIDINoteEvent]` with clamping; humanize is **seed-deterministic** (no clock/RNG).
- **Plan-generation binding:** `validateApply` **rejects a stale plan** (`staleGeneration`/`regionMismatch`/`snapshotIncomplete`); `planTransform` refuses an incomplete before-snapshot.
- **Verification:** State A **only** on a complete post-write snapshot, same region, expected generation transition, and an **exact note-multiset match**; incomplete/wrong-generation/unexpected → never State A. Compensation restores the exact before-snapshot.
- 15 deterministic tests; full suite **2460 tests, 0 failures**. Reuses ADR-010 note model.

**Deferred:** live note selection/edit, live snapshot reads (need a qualified ADR-014/010 provider), MCP surface — need real Logic.

Refs #303, #308.