### PR TITLE
feat(adr-016): smart tempo + tempo-map control surface pure core (#304)

### DIFF
--- a/Sources/LogicProMCP/SmartTempo/TempoMap.swift
+++ b/Sources/LogicProMCP/SmartTempo/TempoMap.swift
@@ -1,0 +1,51 @@
+enum ProjectTempoMode: String, Codable, CaseIterable, Equatable, Sendable {
+    case keep
+    case adapt
+    case autoMatch
+}
+
+struct TempoMapEvent: Codable, Equatable, Sendable {
+    let tick: Int64
+    let bpm: Double
+}
+
+struct TempoMapSnapshot: Codable, Equatable, Sendable {
+    let events: [TempoMapEvent]
+    let timeSignatures: [TimeSignatureEvent]
+    let ppq: Int
+    let complete: Bool
+    let partialReason: String?
+
+    init(
+        events: [TempoMapEvent],
+        timeSignatures: [TimeSignatureEvent],
+        ppq: Int,
+        complete: Bool,
+        partialReason: String?
+    ) {
+        self.events = events
+        self.timeSignatures = timeSignatures
+        self.ppq = ppq
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            events: try values.decode([TempoMapEvent].self, forKey: .events),
+            timeSignatures: try values.decode([TimeSignatureEvent].self, forKey: .timeSignatures),
+            ppq: try values.decode(Int.self, forKey: .ppq),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason)
+        )
+    }
+}
+
+struct SmartTempoState: Codable, Equatable, Sendable {
+    let mode: ProjectTempoMode
+    let analysisAvailable: Bool
+    let mapPresent: Bool
+    let complete: Bool
+    let partialReason: String?
+}

--- a/Sources/LogicProMCP/SmartTempo/TempoMapMutationGate.swift
+++ b/Sources/LogicProMCP/SmartTempo/TempoMapMutationGate.swift
@@ -1,0 +1,43 @@
+enum TempoMutationRejection: Equatable, Sendable {
+    case snapshotIncomplete
+    case invalidTempoMap
+    case noCheckpoint
+    case restoreNotVerified
+}
+
+func tempoMapDiff(
+    before: TempoMapSnapshot,
+    after: TempoMapSnapshot
+) -> (addedOrChanged: [TempoMapEvent], removed: [TempoMapEvent]) {
+    let addedOrChanged = after.events.filter { event in
+        guard let previous = before.events.first(where: { $0.tick == event.tick }) else {
+            return true
+        }
+        return previous != event
+    }
+    let removed = before.events.filter { event in
+        !after.events.contains(where: { $0.tick == event.tick })
+    }
+    return (addedOrChanged, removed)
+}
+
+func tempoMapSagaEligibility(
+    beforeCheckpoint: TempoMapSnapshot?,
+    restoreVerified: Bool
+) -> [TempoMutationRejection] {
+    var rejections: [TempoMutationRejection] = []
+    if let beforeCheckpoint {
+        if !beforeCheckpoint.complete {
+            rejections.append(.snapshotIncomplete)
+        }
+        if !isValidTempoMap(beforeCheckpoint) {
+            rejections.append(.invalidTempoMap)
+        }
+    } else {
+        rejections.append(.noCheckpoint)
+    }
+    if !restoreVerified {
+        rejections.append(.restoreNotVerified)
+    }
+    return rejections
+}

--- a/Sources/LogicProMCP/SmartTempo/TempoMath.swift
+++ b/Sources/LogicProMCP/SmartTempo/TempoMath.swift
@@ -1,0 +1,65 @@
+func isValidTempoMap(_ snapshot: TempoMapSnapshot) -> Bool {
+    guard snapshot.ppq > 0,
+          let first = snapshot.events.first,
+          first.tick == 0 else {
+        return false
+    }
+
+    for (index, event) in snapshot.events.enumerated() {
+        guard event.bpm.isFinite, event.bpm > 0 else { return false }
+        if index > 0, event.tick <= snapshot.events[index - 1].tick {
+            return false
+        }
+    }
+    return true
+}
+
+func secondsAtTick(_ tick: Int64, map: TempoMapSnapshot) -> Double? {
+    guard tick >= 0, isValidTempoMap(map), var current = map.events.first else {
+        return nil
+    }
+
+    var seconds = 0.0
+    for next in map.events.dropFirst() {
+        if tick <= next.tick {
+            return seconds + secondsBetweenTicks(tick - current.tick, event: current, ppq: map.ppq)
+        }
+        seconds += secondsBetweenTicks(next.tick - current.tick, event: current, ppq: map.ppq)
+        current = next
+    }
+    return seconds + secondsBetweenTicks(tick - current.tick, event: current, ppq: map.ppq)
+}
+
+func tickAtSeconds(_ seconds: Double, map: TempoMapSnapshot) -> Int64? {
+    guard seconds.isFinite,
+          seconds >= 0,
+          isValidTempoMap(map),
+          var current = map.events.first else {
+        return nil
+    }
+
+    var elapsed = 0.0
+    for next in map.events.dropFirst() {
+        let segmentSeconds = secondsBetweenTicks(next.tick - current.tick, event: current, ppq: map.ppq)
+        if seconds <= elapsed + segmentSeconds {
+            return interpolatedTick(
+                seconds: seconds - elapsed,
+                event: current,
+                ppq: map.ppq
+            )
+        }
+        elapsed += segmentSeconds
+        current = next
+    }
+    return interpolatedTick(seconds: seconds - elapsed, event: current, ppq: map.ppq)
+}
+
+private func secondsBetweenTicks(_ ticks: Int64, event: TempoMapEvent, ppq: Int) -> Double {
+    Double(ticks) / Double(ppq) * 60 / event.bpm
+}
+
+private func interpolatedTick(seconds: Double, event: TempoMapEvent, ppq: Int) -> Int64? {
+    let tick = Double(event.tick) + seconds * event.bpm * Double(ppq) / 60
+    guard tick.isFinite else { return nil }
+    return Int64(exactly: tick.rounded())
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -68,4 +68,8 @@ enum FeatureFlags: Sendable {
     static var adr015PianoRoll: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR015_PIANO_ROLL"] == "1"
     }
+
+    static var adr016SmartTempo: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR016_SMART_TEMPO"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/TempoMapTests.swift
+++ b/Tests/LogicProMCPTests/TempoMapTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-016 Tempo Map")
+struct TempoMapTests {
+    @Test func constantTempoConvertsOneBarToTwoSeconds() throws {
+        let map = snapshot(events: [event(0, 120)])
+
+        #expect(try #require(secondsAtTick(1_920, map: map)) == 2)
+    }
+
+    @Test func variableTempoUsesPiecewiseIntegration() throws {
+        let map = snapshot(events: [event(0, 120), event(480, 60)])
+
+        #expect(try #require(secondsAtTick(480, map: map)) == 0.5)
+        #expect(try #require(secondsAtTick(960, map: map)) == 1.5)
+        #expect(try #require(secondsAtTick(1_440, map: map)) == 2.5)
+    }
+
+    @Test func beatTimeRoundTripsAreStable() throws {
+        let map = snapshot(events: [event(0, 120), event(480, 90), event(1_200, 72)])
+
+        for tick in [Int64(0), 1, 479, 480, 481, 960, 1_200, 1_921] {
+            let seconds = try #require(secondsAtTick(tick, map: map))
+            #expect(tickAtSeconds(seconds, map: map) == tick)
+        }
+    }
+
+    @Test func invalidMapsAndQueriesFailClosed() {
+        let reversed = snapshot(events: [event(0, 120), event(480, 90), event(240, 60)])
+        let duplicate = snapshot(events: [event(0, 120), event(0, 60)])
+        let nonzeroStart = snapshot(events: [event(1, 120)])
+        let zeroBPM = snapshot(events: [event(0, 0)])
+        let infiniteBPM = snapshot(events: [event(0, .infinity)])
+        let invalidPPQ = snapshot(events: [event(0, 120)], ppq: 0)
+
+        for map in [reversed, duplicate, nonzeroStart, zeroBPM, infiniteBPM, invalidPPQ] {
+            #expect(!isValidTempoMap(map))
+            #expect(secondsAtTick(480, map: map) == nil)
+            #expect(tickAtSeconds(1, map: map) == nil)
+        }
+        #expect(secondsAtTick(-1, map: snapshot()) == nil)
+        #expect(tickAtSeconds(-1, map: snapshot()) == nil)
+        #expect(tickAtSeconds(.infinity, map: snapshot()) == nil)
+    }
+
+    @Test func sagaRequiresCompleteValidCheckpointAndVerifiedRestore() {
+        let valid = snapshot()
+        let incomplete = snapshot(complete: false, partialReason: "tempo readback unavailable")
+        let invalid = snapshot(events: [event(0, -1)])
+
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: nil, restoreVerified: true) == [
+            .noCheckpoint,
+        ])
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: incomplete, restoreVerified: true) == [
+            .snapshotIncomplete,
+        ])
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: invalid, restoreVerified: true) == [
+            .invalidTempoMap,
+        ])
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: valid, restoreVerified: false) == [
+            .restoreNotVerified,
+        ])
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: valid, restoreVerified: true).isEmpty)
+    }
+
+    @Test func incompleteInvalidCheckpointAccumulatesHonestRejections() {
+        let checkpoint = snapshot(
+            events: [event(0, -1)],
+            complete: false,
+            partialReason: "partial project tempo readback"
+        )
+
+        #expect(tempoMapSagaEligibility(beforeCheckpoint: checkpoint, restoreVerified: false) == [
+            .snapshotIncomplete,
+            .invalidTempoMap,
+            .restoreNotVerified,
+        ])
+    }
+
+    @Test func tempoMapDiffReportsChangesAndRemovalsByTick() {
+        let before = snapshot(events: [event(0, 120), event(480, 90), event(960, 80)])
+        let after = snapshot(events: [event(0, 120), event(480, 60), event(1_440, 100)])
+        let diff = tempoMapDiff(before: before, after: after)
+
+        #expect(diff.addedOrChanged == [event(480, 60), event(1_440, 100)])
+        #expect(diff.removed == [event(960, 80)])
+    }
+
+    @Test func completeSnapshotAlwaysClearsPartialReason() throws {
+        let initialized = snapshot(complete: true, partialReason: "stale reason")
+        let encoded = Data(
+            #"{"events":[{"tick":0,"bpm":120}],"timeSignatures":[],"ppq":480,"complete":true,"partialReason":"stale reason"}"#.utf8
+        )
+        let decoded = try JSONDecoder().decode(TempoMapSnapshot.self, from: encoded)
+
+        #expect(initialized.partialReason == nil)
+        #expect(decoded.partialReason == nil)
+    }
+
+    @Test func projectModeAndReadOnlyStateRoundTrip() throws {
+        let modes: [ProjectTempoMode] = [.keep, .adapt, .autoMatch]
+        let state = SmartTempoState(
+            mode: .autoMatch,
+            analysisAvailable: true,
+            mapPresent: true,
+            complete: false,
+            partialReason: "region readback not independently qualified"
+        )
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        #expect(try decoder.decode([ProjectTempoMode].self, from: encoder.encode(modes)) == modes)
+        #expect(try decoder.decode(SmartTempoState.self, from: encoder.encode(state)) == state)
+        #expect(!state.complete)
+    }
+
+    @Test func adr016FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR016_SMART_TEMPO"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr016SmartTempo)
+    }
+
+    private func snapshot(
+        events: [TempoMapEvent] = [TempoMapEvent(tick: 0, bpm: 120)],
+        ppq: Int = 480,
+        complete: Bool = true,
+        partialReason: String? = nil
+    ) -> TempoMapSnapshot {
+        TempoMapSnapshot(
+            events: events,
+            timeSignatures: [TimeSignatureEvent(tick: 0, numerator: 4, denominator: 4)],
+            ppq: ppq,
+            complete: complete,
+            partialReason: partialReason
+        )
+    }
+
+    private func event(_ tick: Int64, _ bpm: Double) -> TempoMapEvent {
+        TempoMapEvent(tick: tick, bpm: bpm)
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,7 +43,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-013 | Verified Channel EQ Band Control | D | `In Implementation` | [#301](https://github.com/MongLong0214/logic-pro-mcp/issues/301) |
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
 | ADR-015 | Piano Roll Data-level Transform | D | `In Implementation` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
-| ADR-016 | Smart Tempo and Tempo-map Control | D | `Proposed` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
+| ADR-016 | Smart Tempo and Tempo-map Control | D | `In Implementation` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
 | ADR-017 | Flex Pitch Inspection and Verified Editing | D | `Proposed` | [#305](https://github.com/MongLong0214/logic-pro-mcp/issues/305) |
 | ADR-018 | Verified Third-party Host-Parameter Control | D | `Proposed` | [#306](https://github.com/MongLong0214/logic-pro-mcp/issues/306) |
 
@@ -148,6 +148,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Verification (patch ordering)** — `verifyTransform` returns State A **only** when the post-write snapshot is `complete`, has the same region ref, shows the expected generation transition, and its note set is an **exact multiset match** of the predicted canonical result; an incomplete snapshot, a wrong generation, or any unexpected event is `stateBUnverified` / `mismatch` — a partial or pixel-drag result can never be State A. Compensation restores the exact before-snapshot (not a blind inverse).
 - 15 deterministic synthetic tests (transform clamps, humanize-seed-determinism, incomplete-before → no plan, stale-apply rejection, region-mismatch, exact-multiset → State A, incomplete/wrong-generation/region-mismatch → never State A, multiset-mismatch reporting, compensation restores before-snapshot, flag-default-off).
 - Deferred (honest scope): the live note selection / edit against Logic, the live before/after snapshot reads (which themselves depend on an ADR-014/ADR-010 provider being qualified), and the MCP surface (`plan_region_transform` / `apply_region_transform_verified` / …). Those need real Logic and are not claimed here.
+
+### ADR-016 — Smart Tempo and Tempo-Map Control (`In Implementation`)
+- Tempo-map data model + pure beat↔time math + a mutation-eligibility gate only, behind `FeatureFlags.adr016SmartTempo` (default off), with no runtime path. `set_tempo` is a single-BPM setter and is explicitly **not** Smart Tempo.
+- **Pure variable-tempo beat↔time math** — `secondsAtTick` / `tickAtSeconds` do a piecewise integration across a variable tempo map (each segment a constant BPM), verified round-trip-stable and with no wall-clock / RNG. `isValidTempoMap` fails closed on a non-zero-start / non-monotonic / non-positive-BPM / non-positive-PPQ map (and the conversions return `nil` for an invalid map).
+- **Read-only state + honesty gate** — a `TempoMapSnapshot` (events + time signatures, `complete`/`partialReason`) and a read-only `SmartTempoState`; project-wide mode/map mutation is only saga-eligible when a **complete, valid before-checkpoint and a verified restore both exist** — an incomplete/invalid checkpoint or an unverified restore accumulates honest rejections, so `Adapt`-style automatic application cannot be claimed without independent readback + rollback qualification.
+- 10 deterministic synthetic tests (constant-tempo one-bar → 2s, variable-tempo piecewise integration, beat↔time round-trip, invalid-map fail-closed, saga-requires-complete-valid-checkpoint + verified-restore, honest rejection accumulation, tempo-map diff, complete-clears-partial-reason, mode/state round-trip, flag-default-off). Reuses the ADR-010 `TimeSignatureEvent`.
+- Deferred (honest scope): live Smart Tempo analysis jobs, the live tempo-map read/write, the high-risk `Adapt` project-tempo mutation, and the MCP surface (`set_project_tempo_mode_verified` / `apply_tempo_map_verified` / …). Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. Tempo-map data model + pure beat↔time math + mutation-eligibility gate, behind `LOGIC_MCP_ADR016_SMART_TEMPO` (default off), no runtime path. `set_tempo` is a single-BPM setter and is **not** Smart Tempo.

- **Pure variable-tempo math:** `secondsAtTick`/`tickAtSeconds` piecewise integration (constant-BPM segments), round-trip stable, no clock/RNG. `isValidTempoMap` fails closed on non-zero-start / non-monotonic / non-positive-BPM/PPQ.
- **Honesty gate:** mode/map mutation is saga-eligible **only** with a complete valid before-checkpoint + verified restore; otherwise honest rejections accumulate — `Adapt` automatic application cannot be claimed without independent readback + rollback qualification.
- 10 deterministic tests; full suite **2470 tests, 0 failures**. Reuses ADR-010 `TimeSignatureEvent`.

**Deferred:** live Smart Tempo analysis, live tempo-map read/write, the high-risk `Adapt` mutation, MCP surface — need real Logic.

Refs #304, #308.