### PR TITLE
feat(adr-017): flex pitch inspection + verified editing pure core (#305)

### DIFF
--- a/Sources/LogicProMCP/FlexPitch/FlexPitchEditGate.swift
+++ b/Sources/LogicProMCP/FlexPitch/FlexPitchEditGate.swift
@@ -1,0 +1,66 @@
+enum FlexEditEligibility: Equatable, Sendable {
+    case publicEligible
+    case experimental(reasons: [String])
+}
+
+func editEligibility(
+    snapshot: FlexPitchSnapshot,
+    ref: FlexPitchNoteReference,
+    currentAnalysisGeneration: UInt64,
+    dualEvidenceCount: Int,
+    monophonicThreshold: Double = 0.9
+) -> FlexEditEligibility {
+    var reasons: [String] = []
+    if !snapshot.complete {
+        reasons.append("snapshot incomplete")
+    }
+    if snapshot.analysisGeneration != currentAnalysisGeneration {
+        reasons.append("stale snapshot")
+    }
+    if !isReferenceCurrent(ref, currentAnalysisGeneration: currentAnalysisGeneration) {
+        reasons.append("stale note reference")
+    }
+    if !snapshot.notes.contains(where: { $0.reference == ref }) {
+        reasons.append("note reference does not belong to snapshot")
+    }
+
+    // Fail closed on non-finite / out-of-range confidence or threshold, and only
+    // compare the two when both are in range (an out-of-range value is its own,
+    // distinct rejection rather than a silent threshold comparison).
+    let confidenceInRange = snapshot.monophonicConfidence.isFinite
+        && (0 ... 1).contains(snapshot.monophonicConfidence)
+    let thresholdInRange = monophonicThreshold.isFinite
+        && (0 ... 1).contains(monophonicThreshold)
+    if !confidenceInRange {
+        reasons.append("monophonic confidence outside 0...1")
+    }
+    if !thresholdInRange {
+        reasons.append("monophonic threshold outside 0...1")
+    }
+    if confidenceInRange, thresholdInRange, snapshot.monophonicConfidence < monophonicThreshold {
+        reasons.append("monophonic confidence below threshold")
+    }
+
+    if snapshot.provenance == .none || dualEvidenceCount < 2 {
+        reasons.append("dual evidence required")
+    }
+    return reasons.isEmpty ? .publicEligible : .experimental(reasons: reasons)
+}
+
+func publicEditableReferences(
+    snapshot: FlexPitchSnapshot,
+    currentAnalysisGeneration: UInt64,
+    dualEvidenceCount: Int
+) -> [FlexPitchNoteReference] {
+    snapshot.notes.compactMap { note in
+        guard editEligibility(
+            snapshot: snapshot,
+            ref: note.reference,
+            currentAnalysisGeneration: currentAnalysisGeneration,
+            dualEvidenceCount: dualEvidenceCount
+        ) == .publicEligible else {
+            return nil
+        }
+        return note.reference
+    }
+}

--- a/Sources/LogicProMCP/FlexPitch/FlexPitchModel.swift
+++ b/Sources/LogicProMCP/FlexPitch/FlexPitchModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct FlexPitchNoteReference: Codable, Hashable, Sendable {
+    let regionRef: TargetReference
+    let analysisGeneration: UInt64
+    let noteOrdinal: Int
+    let startTick: Int64
+    let durationTicks: Int64
+    let coarsePitch: Int
+    let pitchCurveFingerprint: String
+}
+
+struct FlexPitchNote: Codable, Equatable, Sendable {
+    let reference: FlexPitchNoteReference
+    let cents: Double
+    let gainDb: Double
+}
+
+enum FlexProvenance: String, Codable, Equatable, Sendable {
+    case midiTrackFromFlexPlusReadback
+    case none
+}
+
+struct FlexPitchSnapshot: Codable, Equatable, Sendable {
+    let regionRef: TargetReference
+    let analysisGeneration: UInt64
+    let monophonicConfidence: Double
+    let notes: [FlexPitchNote]
+    let provenance: FlexProvenance
+    let complete: Bool
+    let partialReason: String?
+
+    init(
+        regionRef: TargetReference,
+        analysisGeneration: UInt64,
+        monophonicConfidence: Double,
+        notes: [FlexPitchNote],
+        provenance: FlexProvenance,
+        complete: Bool,
+        partialReason: String?
+    ) {
+        self.regionRef = regionRef
+        self.analysisGeneration = analysisGeneration
+        self.monophonicConfidence = monophonicConfidence
+        self.notes = notes
+        self.provenance = provenance
+        self.complete = complete
+        self.partialReason = complete ? nil : partialReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            regionRef: try values.decode(TargetReference.self, forKey: .regionRef),
+            analysisGeneration: try values.decode(UInt64.self, forKey: .analysisGeneration),
+            monophonicConfidence: try values.decode(Double.self, forKey: .monophonicConfidence),
+            notes: try values.decode([FlexPitchNote].self, forKey: .notes),
+            provenance: try values.decode(FlexProvenance.self, forKey: .provenance),
+            complete: try values.decode(Bool.self, forKey: .complete),
+            partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason)
+        )
+    }
+}

--- a/Sources/LogicProMCP/FlexPitch/FlexPitchRefValidity.swift
+++ b/Sources/LogicProMCP/FlexPitch/FlexPitchRefValidity.swift
@@ -1,0 +1,13 @@
+func isReferenceCurrent(
+    _ ref: FlexPitchNoteReference,
+    currentAnalysisGeneration: UInt64
+) -> Bool {
+    ref.analysisGeneration == currentAnalysisGeneration
+}
+
+func staleReferences(
+    _ refs: [FlexPitchNoteReference],
+    currentAnalysisGeneration: UInt64
+) -> [FlexPitchNoteReference] {
+    refs.filter { !isReferenceCurrent($0, currentAnalysisGeneration: currentAnalysisGeneration) }
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -72,4 +72,8 @@ enum FeatureFlags: Sendable {
     static var adr016SmartTempo: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR016_SMART_TEMPO"] == "1"
     }
+
+    static var adr017FlexPitch: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR017_FLEX_PITCH"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/FlexPitchTests.swift
+++ b/Tests/LogicProMCPTests/FlexPitchTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-017 Flex Pitch")
+struct FlexPitchTests {
+    @Test func editRequiresQualifiedProvenanceAndDualEvidence() {
+        let unqualified = makeFlexSnapshot(provenance: .none)
+        let qualified = makeFlexSnapshot(provenance: .midiTrackFromFlexPlusReadback)
+        let reference = unqualified.notes[0].reference
+
+        #expect(
+            editEligibility(
+                snapshot: unqualified,
+                ref: reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .experimental(reasons: ["dual evidence required"])
+        )
+        #expect(
+            editEligibility(
+                snapshot: qualified,
+                ref: qualified.notes[0].reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 1
+            ) == .experimental(reasons: ["dual evidence required"])
+        )
+        #expect(
+            publicEditableReferences(
+                snapshot: unqualified,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 0
+            ).isEmpty
+        )
+    }
+
+    @Test func polyphonicConfidenceIsExperimental() {
+        let snapshot = makeFlexSnapshot(confidence: 0.89)
+
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: snapshot.notes[0].reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .experimental(reasons: ["monophonic confidence below threshold"])
+        )
+    }
+
+    @Test func incompleteSnapshotIsExperimental() {
+        let snapshot = makeFlexSnapshot(complete: false)
+
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: snapshot.notes[0].reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .experimental(reasons: ["snapshot incomplete"])
+        )
+    }
+
+    @Test func staleReferencesAreExperimentalAndDetected() {
+        let stale = makeFlexReference(generation: 6, ordinal: 0)
+        let fresh = makeFlexReference(generation: 7, ordinal: 1)
+        let snapshot = makeFlexSnapshot(generation: 6, references: [stale])
+
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: stale,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .experimental(reasons: ["stale snapshot", "stale note reference"])
+        )
+        #expect(staleReferences([fresh, stale], currentAnalysisGeneration: 7) == [stale])
+    }
+
+    @Test func referenceMustBelongToCurrentSnapshot() {
+        let snapshot = makeFlexSnapshot()
+        let otherRegion = FlexPitchNoteReference(
+            regionRef: TargetReference(rawValue: "trk_other"),
+            analysisGeneration: 7,
+            noteOrdinal: 0,
+            startTick: 0,
+            durationTicks: 120,
+            coarsePitch: 60,
+            pitchCurveFingerprint: "curve_0"
+        )
+
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: otherRegion,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .experimental(reasons: ["note reference does not belong to snapshot"])
+        )
+    }
+
+    @Test func invalidConfidenceAndThresholdFailClosed() {
+        for confidence in [Double.nan, -.infinity, .infinity, -0.01, 1.01] {
+            let snapshot = makeFlexSnapshot(confidence: confidence)
+            #expect(
+                editEligibility(
+                    snapshot: snapshot,
+                    ref: snapshot.notes[0].reference,
+                    currentAnalysisGeneration: 7,
+                    dualEvidenceCount: 2
+                ) == .experimental(reasons: ["monophonic confidence outside 0...1"])
+            )
+        }
+
+        let snapshot = makeFlexSnapshot()
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: snapshot.notes[0].reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2,
+                monophonicThreshold: .nan
+            ) == .experimental(reasons: ["monophonic threshold outside 0...1"])
+        )
+    }
+
+    @Test func fullyQualifiedSyntheticReferenceIsPublicEligible() {
+        let snapshot = makeFlexSnapshot()
+
+        #expect(
+            editEligibility(
+                snapshot: snapshot,
+                ref: snapshot.notes[0].reference,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == .publicEligible
+        )
+        #expect(
+            publicEditableReferences(
+                snapshot: snapshot,
+                currentAnalysisGeneration: 7,
+                dualEvidenceCount: 2
+            ) == snapshot.notes.map(\.reference)
+        )
+    }
+
+    @Test func referenceValidityUsesOnlyAnalysisGeneration() {
+        let reference = makeFlexReference(generation: 7)
+
+        #expect(isReferenceCurrent(reference, currentAnalysisGeneration: 7))
+        #expect(!isReferenceCurrent(reference, currentAnalysisGeneration: 8))
+    }
+
+    @Test func completeSnapshotAlwaysClearsPartialReason() throws {
+        let initialized = makeFlexSnapshot(complete: true, partialReason: "stale reason")
+        let encoded = Data(
+            #"{"regionRef":{"rawValue":"trk_test"},"analysisGeneration":7,"monophonicConfidence":0.95,"notes":[],"provenance":"none","complete":true,"partialReason":"stale reason"}"#.utf8
+        )
+        let decoded = try JSONDecoder().decode(FlexPitchSnapshot.self, from: encoded)
+
+        #expect(initialized.partialReason == nil)
+        #expect(decoded.partialReason == nil)
+    }
+
+    @Test func snapshotCodableRoundTrips() throws {
+        let snapshot = makeFlexSnapshot(complete: false, partialReason: "synthetic partial")
+        let encoded = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(FlexPitchSnapshot.self, from: encoded)
+
+        #expect(decoded == snapshot)
+    }
+
+    @Test func adr017FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR017_FLEX_PITCH"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr017FlexPitch)
+    }
+}
+
+private func makeFlexReference(
+    generation: UInt64 = 7,
+    ordinal: Int = 0
+) -> FlexPitchNoteReference {
+    FlexPitchNoteReference(
+        regionRef: TargetReference(rawValue: "trk_test"),
+        analysisGeneration: generation,
+        noteOrdinal: ordinal,
+        startTick: Int64(ordinal * 120),
+        durationTicks: 120,
+        coarsePitch: 60 + ordinal,
+        pitchCurveFingerprint: "curve_\(ordinal)"
+    )
+}
+
+private func makeFlexSnapshot(
+    confidence: Double = 0.95,
+    complete: Bool = true,
+    partialReason: String? = nil,
+    provenance: FlexProvenance = .midiTrackFromFlexPlusReadback,
+    generation: UInt64 = 7,
+    references: [FlexPitchNoteReference]? = nil
+) -> FlexPitchSnapshot {
+    let noteReferences = references ?? [makeFlexReference(generation: generation)]
+    return FlexPitchSnapshot(
+        regionRef: TargetReference(rawValue: "trk_test"),
+        analysisGeneration: generation,
+        monophonicConfidence: confidence,
+        notes: noteReferences.map { FlexPitchNote(reference: $0, cents: 12.5, gainDb: -1) },
+        provenance: provenance,
+        complete: complete,
+        partialReason: partialReason ?? (complete ? nil : "synthetic incomplete snapshot")
+    )
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,7 +44,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-014 | Independent MIDI Event Readback | D | `Proposed` | [#302](https://github.com/MongLong0214/logic-pro-mcp/issues/302) |
 | ADR-015 | Piano Roll Data-level Transform | D | `In Implementation` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
 | ADR-016 | Smart Tempo and Tempo-map Control | D | `In Implementation` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
-| ADR-017 | Flex Pitch Inspection and Verified Editing | D | `Proposed` | [#305](https://github.com/MongLong0214/logic-pro-mcp/issues/305) |
+| ADR-017 | Flex Pitch Inspection and Verified Editing | D | `In Implementation` | [#305](https://github.com/MongLong0214/logic-pro-mcp/issues/305) |
 | ADR-018 | Verified Third-party Host-Parameter Control | D | `Proposed` | [#306](https://github.com/MongLong0214/logic-pro-mcp/issues/306) |
 
 ## Implementation status
@@ -155,6 +155,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Read-only state + honesty gate** — a `TempoMapSnapshot` (events + time signatures, `complete`/`partialReason`) and a read-only `SmartTempoState`; project-wide mode/map mutation is only saga-eligible when a **complete, valid before-checkpoint and a verified restore both exist** — an incomplete/invalid checkpoint or an unverified restore accumulates honest rejections, so `Adapt`-style automatic application cannot be claimed without independent readback + rollback qualification.
 - 10 deterministic synthetic tests (constant-tempo one-bar → 2s, variable-tempo piecewise integration, beat↔time round-trip, invalid-map fail-closed, saga-requires-complete-valid-checkpoint + verified-restore, honest rejection accumulation, tempo-map diff, complete-clears-partial-reason, mode/state round-trip, flag-default-off). Reuses the ADR-010 `TimeSignatureEvent`.
 - Deferred (honest scope): live Smart Tempo analysis jobs, the live tempo-map read/write, the high-risk `Adapt` project-tempo mutation, and the MCP surface (`set_project_tempo_mode_verified` / `apply_tempo_map_verified` / …). Those need real Logic and are not claimed here.
+
+### ADR-017 — Flex Pitch Inspection and Verified Editing (`In Implementation`)
+- Flex-pitch target-identity model + a read-only inspection snapshot + a public-edit eligibility gate only, behind `FeatureFlags.adr017FlexPitch` (default off), with no runtime path. This is one of the highest-risk automation surfaces (graphical UI, unstable note identity), so the gate is deliberately conservative.
+- **Target identity + stale detection** — `FlexPitchNoteReference` binds region ref + analysis generation + note ordinal + start/duration + coarse pitch + pitch-curve fingerprint; `isReferenceCurrent` treats a reference as current **only** when its analysis generation matches the live one (a Flex re-analysis / split / merge / region edit bumps the generation and expires old references), and `staleReferences` enumerates the expired ones.
+- **Public-edit gate (honesty core)** — `editEligibility` returns `experimental(reasons:)` unless every condition holds, and `publicEditableReferences` is therefore **empty without live dual evidence**. It fails closed on an incomplete snapshot, a stale snapshot, a stale note reference, a reference that does not belong to the snapshot, a non-finite / out-of-range monophonic confidence or threshold, a **polyphonic** signal (confidence below threshold), or **fewer than two independent evidence planes** (`provenance == .none` or `dualEvidenceCount < 2`). Only a monophonic, complete, current, dual-evidence-backed reference is `publicEligible`.
+- 11 deterministic synthetic tests (dual-evidence-required, polyphonic-experimental, incomplete-experimental, stale-reference-detected, reference-must-belong-to-snapshot, invalid-confidence/threshold-fail-closed, fully-qualified-synthetic-eligible, reference-validity-uses-only-analysis-generation, complete-clears-partial-reason, Codable round-trip, flag-default-off).
+- Deferred (honest scope): the live Flex Pitch inspection/edit, the `FlexPitchProvider` implementations (Create-MIDI-Track-from-Flex plane A plus an ADR-014 independent readback), and the MCP surface (`enable_flex_pitch_verified` / `set_flex_pitch_note_verified` / …). Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Category D increment. Flex-pitch target-identity model + read-only inspection snapshot + public-edit eligibility gate, behind `LOGIC_MCP_ADR017_FLEX_PITCH` (default off), no runtime path. Highest-risk surface → conservative gate.

- **Target identity + stale detection:** `FlexPitchNoteReference` (region ref + analysis generation + ordinal + pitch-curve fingerprint); `isReferenceCurrent` current only on matching analysis generation (re-analysis/split/merge expires refs).
- **Public-edit gate (honesty core):** `publicEditableReferences` is **empty without live dual evidence** — fails closed on incomplete/stale snapshot, stale/foreign reference, out-of-range confidence/threshold, **polyphonic** signal, or **< 2 independent evidence planes**. Only monophonic + complete + current + dual-evidence → `publicEligible`.
- 11 deterministic tests; full suite **2481 tests, 0 failures**. (CTO review enhanced the impl to match the stricter honesty checks the tests encode.)

**Deferred:** live inspection/edit, `FlexPitchProvider` implementations, MCP surface — need real Logic.

Refs #305, #308.