### PR TITLE
feat(adr-018): verified third-party host-parameter control pure core (#306)

### DIFF
--- a/Sources/LogicProMCP/HostParameters/HostParameterGate.swift
+++ b/Sources/LogicProMCP/HostParameters/HostParameterGate.swift
@@ -1,0 +1,81 @@
+func isManifestValid(
+    _ manifest: PluginCapabilityManifest,
+    currentBuildFingerprint: String,
+    currentUISignature: String
+) -> Bool {
+    manifest.buildFingerprint == currentBuildFingerprint
+        && manifest.uiSignatureFingerprint == currentUISignature
+}
+
+func publicParameters(
+    _ manifest: PluginCapabilityManifest,
+    currentBuildFingerprint: String,
+    currentUISignature: String
+) -> [GenericPluginParameter] {
+    guard manifest.approved,
+          isManifestValid(
+              manifest,
+              currentBuildFingerprint: currentBuildFingerprint,
+              currentUISignature: currentUISignature
+          ),
+          manifest.provider.canHostVerifiedWrite
+    else {
+        return []
+    }
+    return manifest.parameters.filter { $0.valueKind != .unsupported }
+}
+
+enum HostWriteRejection: Equatable, Sendable {
+    case manifestNotApproved
+    case manifestInvalidated(reason: String)
+    case providerNotHostVerified
+    case unsupportedParameter(TargetReference)
+}
+
+func validateHostWrite(
+    manifest: PluginCapabilityManifest,
+    parameterRef: TargetReference,
+    currentBuildFingerprint: String,
+    currentUISignature: String
+) -> [HostWriteRejection] {
+    var rejections: [HostWriteRejection] = []
+    if !manifest.approved {
+        rejections.append(.manifestNotApproved)
+    }
+
+    var invalidationReasons: [String] = []
+    if manifest.buildFingerprint != currentBuildFingerprint {
+        invalidationReasons.append("build_fingerprint_changed")
+    }
+    if manifest.uiSignatureFingerprint != currentUISignature {
+        invalidationReasons.append("ui_signature_changed")
+    }
+    if !invalidationReasons.isEmpty {
+        rejections.append(.manifestInvalidated(reason: invalidationReasons.joined(separator: ",")))
+    }
+
+    if !manifest.provider.canHostVerifiedWrite {
+        rejections.append(.providerNotHostVerified)
+    }
+    let valueKind = manifest.parameters.first {
+        $0.parameterRef == parameterRef
+    }?.valueKind
+    if valueKind == nil || valueKind == .unsupported {
+        rejections.append(.unsupportedParameter(parameterRef))
+    }
+    return rejections
+}
+
+func sagaEligibility(
+    fullParameterSnapshotPresent: Bool,
+    verifiedInverseSnapshotPresent: Bool
+) -> (eligible: Bool, missing: [String]) {
+    var missing: [String] = []
+    if !fullParameterSnapshotPresent {
+        missing.append("full_parameter_snapshot")
+    }
+    if !verifiedInverseSnapshotPresent {
+        missing.append("verified_inverse_snapshot")
+    }
+    return (eligible: missing.isEmpty, missing: missing)
+}

--- a/Sources/LogicProMCP/HostParameters/HostParameterPlane.swift
+++ b/Sources/LogicProMCP/HostParameters/HostParameterPlane.swift
@@ -1,0 +1,22 @@
+enum PluginParameterProvider: Int, Codable, Comparable, Sendable {
+    case mcuC4PluginEdit = 0
+    case controlsViewAX = 1
+    case separateAUInstance = 2
+    case pixelGUI = 3
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+extension PluginParameterProvider {
+    var canHostVerifiedWrite: Bool {
+        self == .mcuC4PluginEdit || self == .controlsViewAX
+    }
+}
+
+func preferredHostPlane(
+    available: Set<PluginParameterProvider>
+) -> PluginParameterProvider? {
+    available.min()
+}

--- a/Sources/LogicProMCP/HostParameters/PluginCapabilityManifest.swift
+++ b/Sources/LogicProMCP/HostParameters/PluginCapabilityManifest.swift
@@ -1,0 +1,23 @@
+enum GenericParameterValueKind: String, Codable, Sendable {
+    case exactWriteReadback
+    case normalizedReadbackOnly
+    case unsupported
+}
+
+struct GenericPluginParameter: Codable, Equatable, Sendable {
+    let parameterRef: TargetReference
+    let name: String
+    let valueKind: GenericParameterValueKind
+    let page: Int
+    let index: Int
+}
+
+struct PluginCapabilityManifest: Codable, Equatable, Sendable {
+    let provider: PluginParameterProvider
+    let pluginName: String
+    let buildFingerprint: String
+    let uiSignatureFingerprint: String
+    let parameters: [GenericPluginParameter]
+    let approved: Bool
+    let manifestFingerprint: String
+}

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -76,4 +76,8 @@ enum FeatureFlags: Sendable {
     static var adr017FlexPitch: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR017_FLEX_PITCH"] == "1"
     }
+
+    static var adr018HostParams: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR018_HOST_PARAMS"] == "1"
+    }
 }

--- a/Tests/LogicProMCPTests/HostParameterTests.swift
+++ b/Tests/LogicProMCPTests/HostParameterTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-018 host parameters")
+struct HostParameterTests {
+    @Test func onlyLogicHostedPlanesCanVerifyWrites() {
+        #expect(PluginParameterProvider.mcuC4PluginEdit.canHostVerifiedWrite)
+        #expect(PluginParameterProvider.controlsViewAX.canHostVerifiedWrite)
+        #expect(!PluginParameterProvider.separateAUInstance.canHostVerifiedWrite)
+        #expect(!PluginParameterProvider.pixelGUI.canHostVerifiedWrite)
+    }
+
+    @Test func preferredPlaneUsesProviderPriority() {
+        #expect(preferredHostPlane(available: []) == nil)
+        #expect(
+            preferredHostPlane(available: [.pixelGUI, .controlsViewAX, .separateAUInstance])
+                == .controlsViewAX
+        )
+        #expect(
+            preferredHostPlane(available: [.pixelGUI, .mcuC4PluginEdit, .controlsViewAX])
+                == .mcuC4PluginEdit
+        )
+    }
+
+    @Test func fingerprintChangesInvalidateManifestAndHideParameters() {
+        let parameter = makeParameter("ins_gain", .exactWriteReadback)
+        let subject = makeManifest(
+            provider: .mcuC4PluginEdit,
+            approved: true,
+            parameters: [parameter]
+        )
+
+        #expect(
+            isManifestValid(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            )
+        )
+        #expect(
+            !isManifestValid(
+                subject,
+                currentBuildFingerprint: "build-2",
+                currentUISignature: "ui-1"
+            )
+        )
+        #expect(
+            !isManifestValid(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-2"
+            )
+        )
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-2",
+                currentUISignature: "ui-1"
+            ).isEmpty
+        )
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-2"
+            ).isEmpty
+        )
+    }
+
+    @Test func unapprovedManifestFailsClosed() {
+        let parameter = makeParameter("ins_gain", .exactWriteReadback)
+        let subject = makeManifest(
+            provider: .mcuC4PluginEdit,
+            approved: false,
+            parameters: [parameter]
+        )
+
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ).isEmpty
+        )
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: parameter.parameterRef,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [.manifestNotApproved]
+        )
+    }
+
+    @Test func unsupportedParameterIsHiddenAndRejected() {
+        let supported = makeParameter("ins_gain", .exactWriteReadback)
+        let unsupported = makeParameter("ins_unknown", .unsupported)
+        let subject = makeManifest(
+            provider: .controlsViewAX,
+            approved: true,
+            parameters: [supported, unsupported]
+        )
+
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [supported]
+        )
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: unsupported.parameterRef,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [.unsupportedParameter(unsupported.parameterRef)]
+        )
+    }
+
+    @Test func nonHostedProviderCannotExposeOrValidateWrite() {
+        let parameter = makeParameter("ins_gain", .exactWriteReadback)
+        let subject = makeManifest(
+            provider: .separateAUInstance,
+            approved: true,
+            parameters: [parameter]
+        )
+
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ).isEmpty
+        )
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: parameter.parameterRef,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [.providerNotHostVerified]
+        )
+    }
+
+    @Test func approvedValidHostVerifiedParameterPasses() {
+        let parameter = makeParameter("ins_gain", .exactWriteReadback)
+        let subject = makeManifest(
+            provider: .mcuC4PluginEdit,
+            approved: true,
+            parameters: [parameter]
+        )
+
+        #expect(
+            publicParameters(
+                subject,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [parameter]
+        )
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: parameter.parameterRef,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ).isEmpty
+        )
+    }
+
+    @Test func invalidWriteReportsDeterministicFingerprintReasons() {
+        let parameter = makeParameter("ins_gain", .exactWriteReadback)
+        let subject = makeManifest(
+            provider: .mcuC4PluginEdit,
+            approved: true,
+            parameters: [parameter]
+        )
+
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: parameter.parameterRef,
+                currentBuildFingerprint: "build-2",
+                currentUISignature: "ui-2"
+            ) == [.manifestInvalidated(
+                reason: "build_fingerprint_changed,ui_signature_changed"
+            )]
+        )
+    }
+
+    @Test func sagaRequiresFullAndVerifiedInverseSnapshots() {
+        let eligible = sagaEligibility(
+            fullParameterSnapshotPresent: true,
+            verifiedInverseSnapshotPresent: true
+        )
+        #expect(eligible.eligible)
+        #expect(eligible.missing.isEmpty)
+
+        #expect(
+            sagaEligibility(
+                fullParameterSnapshotPresent: false,
+                verifiedInverseSnapshotPresent: true
+            ).missing == ["full_parameter_snapshot"]
+        )
+        #expect(
+            sagaEligibility(
+                fullParameterSnapshotPresent: true,
+                verifiedInverseSnapshotPresent: false
+            ).missing == ["verified_inverse_snapshot"]
+        )
+        let neither = sagaEligibility(
+            fullParameterSnapshotPresent: false,
+            verifiedInverseSnapshotPresent: false
+        )
+        #expect(!neither.eligible)
+        #expect(neither.missing == ["full_parameter_snapshot", "verified_inverse_snapshot"])
+    }
+
+    @Test func manifestCodableRoundTrips() throws {
+        let subject = makeManifest(
+            provider: .controlsViewAX,
+            approved: true,
+            parameters: [
+                makeParameter("ins_gain", .exactWriteReadback),
+                makeParameter("ins_mix", .normalizedReadbackOnly),
+                makeParameter("ins_unknown", .unsupported),
+            ]
+        )
+
+        let encoded = try JSONEncoder().encode(subject)
+        #expect(try JSONDecoder().decode(PluginCapabilityManifest.self, from: encoded) == subject)
+    }
+
+    @Test func adr018FeatureFlagDefaultsToFalse() {
+        let key = "LOGIC_MCP_ADR018_HOST_PARAMS"
+        let previous = ProcessInfo.processInfo.environment[key]
+        unsetenv(key)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        #expect(!FeatureFlags.adr018HostParams)
+    }
+
+    private func makeParameter(
+        _ rawReference: String,
+        _ valueKind: GenericParameterValueKind
+    ) -> GenericPluginParameter {
+        GenericPluginParameter(
+            parameterRef: TargetReference(rawValue: rawReference),
+            name: rawReference,
+            valueKind: valueKind,
+            page: 0,
+            index: 0
+        )
+    }
+
+    private func makeManifest(
+        provider: PluginParameterProvider,
+        approved: Bool,
+        parameters: [GenericPluginParameter]
+    ) -> PluginCapabilityManifest {
+        PluginCapabilityManifest(
+            provider: provider,
+            pluginName: "Synthetic Plug-in",
+            buildFingerprint: "build-1",
+            uiSignatureFingerprint: "ui-1",
+            parameters: parameters,
+            approved: approved,
+            manifestFingerprint: "manifest-1"
+        )
+    }
+}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,7 +45,7 @@ The three kernel ADRs — ADR-002, ADR-003, ADR-005 — are now `In Implementati
 | ADR-015 | Piano Roll Data-level Transform | D | `In Implementation` | [#303](https://github.com/MongLong0214/logic-pro-mcp/issues/303) |
 | ADR-016 | Smart Tempo and Tempo-map Control | D | `In Implementation` | [#304](https://github.com/MongLong0214/logic-pro-mcp/issues/304) |
 | ADR-017 | Flex Pitch Inspection and Verified Editing | D | `In Implementation` | [#305](https://github.com/MongLong0214/logic-pro-mcp/issues/305) |
-| ADR-018 | Verified Third-party Host-Parameter Control | D | `Proposed` | [#306](https://github.com/MongLong0214/logic-pro-mcp/issues/306) |
+| ADR-018 | Verified Third-party Host-Parameter Control | D | `In Implementation` | [#306](https://github.com/MongLong0214/logic-pro-mcp/issues/306) |
 
 ## Implementation status
 
@@ -163,6 +163,13 @@ Kernel pilots merged to `main`, all behind default-off feature flags (zero runti
 - **Public-edit gate (honesty core)** — `editEligibility` returns `experimental(reasons:)` unless every condition holds, and `publicEditableReferences` is therefore **empty without live dual evidence**. It fails closed on an incomplete snapshot, a stale snapshot, a stale note reference, a reference that does not belong to the snapshot, a non-finite / out-of-range monophonic confidence or threshold, a **polyphonic** signal (confidence below threshold), or **fewer than two independent evidence planes** (`provenance == .none` or `dualEvidenceCount < 2`). Only a monophonic, complete, current, dual-evidence-backed reference is `publicEligible`.
 - 11 deterministic synthetic tests (dual-evidence-required, polyphonic-experimental, incomplete-experimental, stale-reference-detected, reference-must-belong-to-snapshot, invalid-confidence/threshold-fail-closed, fully-qualified-synthetic-eligible, reference-validity-uses-only-analysis-generation, complete-clears-partial-reason, Codable round-trip, flag-default-off).
 - Deferred (honest scope): the live Flex Pitch inspection/edit, the `FlexPitchProvider` implementations (Create-MIDI-Track-from-Flex plane A plus an ADR-014 independent readback), and the MCP surface (`enable_flex_pitch_verified` / `set_flex_pitch_note_verified` / …). Those need real Logic and are not claimed here.
+
+### ADR-018 — Verified Third-Party Host-Parameter Control (`In Implementation`)
+- Host-parameter provider-plane model + capability manifest + a pure host-write gate only, behind `FeatureFlags.adr018HostParams` (default off), with no runtime path. This is host-exposed automatable parameter control, **not** arbitrary GUI automation.
+- **Honesty core (`canHostVerifiedWrite`)** — the provider planes are, in priority order, `mcuC4PluginEdit` › `controlsViewAX` › `separateAUInstance` › `pixelGUI`; only the first two can be a host-verified write. A **separate `AUParameterTree` / AU instance is never host-verifiable** (the MCP server is not the host attached to Logic's live AU instance, so mutating a separate instance would not change the project's insert), and **pixel/coordinate GUI automation is never host-verifiable** (unsafe across plug-in updates / scaling / skins / locale).
+- **Manifest lifecycle** — a `PluginCapabilityManifest` (provider, per-parameter `GenericPluginParameter` with a value kind, build + UI-signature fingerprints, approval flag) whose parameters are exposed only when the manifest is **approved AND still valid**; a changed build or UI-signature fingerprint **auto-invalidates** the manifest (empty public parameters), an unapproved manifest fails closed, and an `unsupported` value kind is hidden and rejected. Saga eligibility requires a full parameter snapshot **and** a verified inverse snapshot.
+- 11 deterministic synthetic tests (only-Logic-hosted-planes-verify, non-hosted-provider-cannot-expose/validate, fingerprint-invalidation, unapproved-fails-closed, unsupported-hidden/rejected, approved-valid-passes, deterministic rejection reasons, saga-requires-full+verified-inverse, provider priority, Codable round-trip, flag-default-off).
+- Deferred (honest scope): the live MCU/C4 Plug-in-Edit and Controls-view AX parameter enumeration/write/readback, live manifest creation + third-party plug-in qualification, and the MCP surface (`approve_plugin_manifest` / …). Those need real Logic and are not claimed here.
 
 ### Release qualification
 - Strict live E2E suite (`LOGIC_PRO_MCP_STRICT_LIVE=1`, real Logic Pro, fresh-session bootstrap) is green on `main`.


### PR DESCRIPTION
Final Category D pure core. Host-parameter provider-plane model + capability manifest + pure host-write gate, behind `LOGIC_MCP_ADR018_HOST_PARAMS` (default off), no runtime path. **Host-exposed automatable parameter control, NOT arbitrary GUI automation.**

- **Honesty core (`canHostVerifiedWrite`):** planes mcuC4PluginEdit › controlsViewAX › separateAUInstance › pixelGUI; only the first two verify. A **separate AU instance / `AUParameterTree` is never host-verifiable** (MCP server isn't the host of Logic's live AU → mutating a separate instance wouldn't change the project insert); **pixel/coordinate GUI never host-verifiable**.
- **Manifest lifecycle:** parameters exposed only when approved AND valid; changed build/UI fingerprint **auto-invalidates**; unapproved fails closed; unsupported value kind hidden+rejected; saga needs full snapshot + verified inverse.
- 11 deterministic tests; full suite **2498 tests, 0 failures**.

**Deferred:** live MCU/C4 + Controls-view AX write/readback, manifest creation + third-party qualification, MCP surface — need real Logic.

Refs #306, #308. **This completes all 18 ADR pure cores (ADR-001–018).**