### PR TITLE
fix: reconcile blocking Logic modals (mandatory New Track / delete-confirm / top-level alert) + close stray Navigate menu (#346)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
+++ b/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
@@ -22,6 +22,10 @@ enum ModalReconciliation {
         case mandatoryNewTrack
         /// "delete channel strips that are assigned to tracks!" confirmation.
         case deleteConfirm
+        /// A top-level informational `AXDialog` alert (NOT a main-window sheet)
+        /// with EXACTLY ONE button — safe to acknowledge. A 2+ button dialog is
+        /// a CHOICE and is classified `.unknownSheet` instead (fail closed).
+        case informationalAlert
         /// A menu bar menu left open (no sheet present).
         case strayMenu
         /// A sheet is up that we do not recognise — never blindly dismissed.
@@ -38,6 +42,14 @@ enum ModalReconciliation {
         let cancelButtonEnabled: Bool
         let deleteConfirmButtonPresent: Bool
         let strayMenuOpen: Bool
+        /// A top-level `AXDialog` alert window (NOT a main-window sheet) is up.
+        /// Only populated on the no-sheet branch, so a sheet always outranks it.
+        let topLevelAlertPresent: Bool
+        /// Number of titled buttons on that alert — the safety discriminator:
+        /// exactly one ⇒ informational (acknowledge); two+ ⇒ a choice (fail closed).
+        let topLevelAlertButtonCount: Int
+        /// The single button's title (empty when none/ambiguous).
+        let topLevelAlertPrimaryButton: String
     }
 
     /// The sanctioned reconciliation action for a classified modal.
@@ -47,6 +59,9 @@ enum ModalReconciliation {
         case clickCreate
         /// Confirm the delete-channel-strips sheet (primary delete button).
         case confirmDelete
+        /// Acknowledge a single-button top-level informational alert (click its
+        /// only button). Safe in any context — one button means no lossy choice.
+        case acknowledgeAlert
         /// Send Escape to close a stray open menu.
         case escapeMenu
         /// Refuse to act — report the reason; NEVER blindly dismiss a modal we
@@ -58,12 +73,14 @@ enum ModalReconciliation {
     /// OR the disabled-Cancel signal is sufficient to identify the sheet.
     static let newTrackSheetDescription = "New Track"
 
-    /// Classify the current modal from its observable signals. A present sheet
-    /// always wins over a stray menu (a sheet is the stronger blocker), and the
-    /// mandatory New Track sheet is disambiguated from an ordinary cancelable
-    /// sheet by its DISABLED Cancel (or the "New Track" description) — the
-    /// `createButtonPresent` conjunct keeps a delete-confirm sheet that happens
-    /// to disable Cancel from being misread as a New Track sheet.
+    /// Classify the current modal from its observable signals. Precedence: a
+    /// main-window sheet (the strongest blocker) outranks a top-level alert,
+    /// which outranks a stray menu. The mandatory New Track sheet is
+    /// disambiguated from an ordinary cancelable sheet by its DISABLED Cancel (or
+    /// the "New Track" description) — the `createButtonPresent` conjunct keeps a
+    /// delete-confirm sheet that happens to disable Cancel from being misread as
+    /// a New Track sheet. A top-level alert is only acknowledged when it has
+    /// EXACTLY ONE button; two+ buttons is a lossy CHOICE and fails closed.
     static func classify(_ s: ModalSignals) -> BlockingModalKind {
         if s.sheetPresent {
             let isMandatoryNewTrack =
@@ -76,6 +93,12 @@ enum ModalReconciliation {
                 return .deleteConfirm
             }
             return .unknownSheet
+        }
+        if s.topLevelAlertPresent {
+            // Exactly one button ⇒ informational (safe to acknowledge). Anything
+            // else (0 ambiguous, or 2+ = a choice like Save/Don't Save/Cancel) is
+            // never guessed — fail closed as an unknown sheet.
+            return s.topLevelAlertButtonCount == 1 ? .informationalAlert : .unknownSheet
         }
         if s.strayMenuOpen {
             return .strayMenu
@@ -93,6 +116,8 @@ enum ModalReconciliation {
             return .clickCreate
         case .deleteConfirm:
             return isDeleteContext ? .confirmDelete : .failClosed("unexpected delete-confirm sheet")
+        case .informationalAlert:
+            return .acknowledgeAlert
         case .strayMenu:
             return .escapeMenu
         case .unknownSheet:

--- a/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
+++ b/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Pure, side-effect-free decision core for reconciling the blocking modals a
+/// Logic Pro operation can trigger but never reconcile (#346), leaving Logic
+/// permanently wedged. The live AX reader (`AccessibilityChannel+ModalReconcile`)
+/// gathers observable signals into `ModalSignals`; `classify` maps them to a
+/// `BlockingModalKind`; `decide` maps a kind + call context to a sanctioned
+/// `ModalReconcileDecision`. No AX calls live here, so the full truth table is
+/// unit-testable without a live Logic session.
+///
+/// The three live triggers (one class): the mandatory "Create New Track" sheet
+/// (Cancel DISABLED, Escape inert — the ONLY exit is "Create") that Logic
+/// auto-presents on delete-to-zero / fresh bootstrap; the "delete channel strips
+/// that are assigned to tracks!" confirmation on channel-strip track delete; and
+/// a Navigate menu left open on a marker-op error.
+enum ModalReconciliation {
+
+    /// Which blocking modal (if any) Logic is currently presenting.
+    enum BlockingModalKind: Equatable, Sendable {
+        case none
+        /// Mandatory "New Track" sheet — Cancel disabled, only "Create" exits.
+        case mandatoryNewTrack
+        /// "delete channel strips that are assigned to tracks!" confirmation.
+        case deleteConfirm
+        /// A menu bar menu left open (no sheet present).
+        case strayMenu
+        /// A sheet is up that we do not recognise — never blindly dismissed.
+        case unknownSheet
+    }
+
+    /// Observable signals read from the main window's sheet (+ menu bar). Pure
+    /// inputs to `classify`, so the classifier stays fully deterministic.
+    struct ModalSignals: Equatable, Sendable {
+        let sheetPresent: Bool
+        let sheetDescription: String
+        let createButtonPresent: Bool
+        let cancelButtonPresent: Bool
+        let cancelButtonEnabled: Bool
+        let deleteConfirmButtonPresent: Bool
+        let strayMenuOpen: Bool
+    }
+
+    /// The sanctioned reconciliation action for a classified modal.
+    enum ModalReconcileDecision: Equatable, Sendable {
+        case noAction
+        /// Click the mandatory New Track sheet's only exit ("Create").
+        case clickCreate
+        /// Confirm the delete-channel-strips sheet (primary delete button).
+        case confirmDelete
+        /// Send Escape to close a stray open menu.
+        case escapeMenu
+        /// Refuse to act — report the reason; NEVER blindly dismiss a modal we
+        /// do not understand (a "Save changes?" prompt could lose data).
+        case failClosed(String)
+    }
+
+    /// Logic's own `AXDescription` on the mandatory New Track sheet. Either this
+    /// OR the disabled-Cancel signal is sufficient to identify the sheet.
+    static let newTrackSheetDescription = "New Track"
+
+    /// Classify the current modal from its observable signals. A present sheet
+    /// always wins over a stray menu (a sheet is the stronger blocker), and the
+    /// mandatory New Track sheet is disambiguated from an ordinary cancelable
+    /// sheet by its DISABLED Cancel (or the "New Track" description) — the
+    /// `createButtonPresent` conjunct keeps a delete-confirm sheet that happens
+    /// to disable Cancel from being misread as a New Track sheet.
+    static func classify(_ s: ModalSignals) -> BlockingModalKind {
+        if s.sheetPresent {
+            let isMandatoryNewTrack =
+                (s.createButtonPresent && s.cancelButtonPresent && !s.cancelButtonEnabled)
+                || s.sheetDescription == newTrackSheetDescription
+            if isMandatoryNewTrack {
+                return .mandatoryNewTrack
+            }
+            if s.deleteConfirmButtonPresent {
+                return .deleteConfirm
+            }
+            return .unknownSheet
+        }
+        if s.strayMenuOpen {
+            return .strayMenu
+        }
+        return .none
+    }
+
+    /// Map a classified modal + call context to a sanctioned action. The
+    /// delete-confirm sheet is only confirmed inside a delete context; an
+    /// unexpected one — or any unknown sheet — fails closed rather than being
+    /// dismissed blindly.
+    static func decide(kind: BlockingModalKind, isDeleteContext: Bool) -> ModalReconcileDecision {
+        switch kind {
+        case .mandatoryNewTrack:
+            return .clickCreate
+        case .deleteConfirm:
+            return isDeleteContext ? .confirmDelete : .failClosed("unexpected delete-confirm sheet")
+        case .strayMenu:
+            return .escapeMenu
+        case .unknownSheet:
+            return .failClosed("unexpected blocking sheet")
+        case .none:
+            return .noAction
+        }
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
@@ -147,15 +147,30 @@ extension AccessibilityChannel {
                 if exists menu bar item "Navigate" of menu bar 1 then
                     click menu bar item "Navigate" of menu bar 1
                     delay 0.1
-                    set targetItem to menu item "\(englishItem)" of menu 1 of menu bar item "Navigate" of menu bar 1
-                    if enabled of targetItem is false then error "menu item disabled"
-                    click targetItem
+                    -- #346: once the menu is open, ANY failure (item missing on a
+                    -- wrong locale, or disabled) must Escape it before erroring so
+                    -- the Navigate menu is never left open (wedging Logic).
+                    try
+                        set targetItem to menu item "\(englishItem)" of menu 1 of menu bar item "Navigate" of menu bar 1
+                        if enabled of targetItem is false then error "menu item disabled"
+                        click targetItem
+                    on error errMsg
+                        key code 53
+                        delay 0.1
+                        error errMsg
+                    end try
                 else
                     click menu bar item "탐색" of menu bar 1
                     delay 0.1
-                    set targetItem to menu item "\(koreanItem)" of menu 1 of menu bar item "탐색" of menu bar 1
-                    if enabled of targetItem is false then error "menu item disabled"
-                    click targetItem
+                    try
+                        set targetItem to menu item "\(koreanItem)" of menu 1 of menu bar item "탐색" of menu bar 1
+                        if enabled of targetItem is false then error "menu item disabled"
+                        click targetItem
+                    on error errMsg
+                        key code 53
+                        delay 0.1
+                        error errMsg
+                    end try
                 end if
             end tell
         end tell

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -1,0 +1,256 @@
+import ApplicationServices
+import Foundation
+
+/// #346 — live AX reader + executor for the pure `ModalReconciliation` core.
+/// Reads the MAIN WINDOW's sheet (native AX; `dialogPresent` scans only
+/// top-level windows and MISSES a main-window sheet) into `ModalSignals`,
+/// classifies + decides via the pure core, and performs the sanctioned recovery
+/// (click "Create" / confirm delete / Escape a stray menu). Unknown sheets fail
+/// closed — never blindly dismissed.
+extension AccessibilityChannel {
+
+    /// Outcome of one reconciliation pass, surfaced as honest extras by callers.
+    struct ModalReconcileOutcome: Sendable, Equatable {
+        let kind: ModalReconciliation.BlockingModalKind
+        let decision: ModalReconciliation.ModalReconcileDecision
+        let performed: Bool
+
+        static let none = ModalReconcileOutcome(kind: .none, decision: .noAction, performed: false)
+    }
+
+    // MARK: - Public entry points
+
+    /// Reconcile a blocking modal left by a just-completed mutation. Performs
+    /// every actionable decision (clickCreate / confirmDelete / escapeMenu);
+    /// fail-closed and no-action never touch the UI. `isDeleteContext` authorises
+    /// confirming a delete-channel-strips sheet.
+    static func reconcileAfterMutation(
+        isDeleteContext: Bool,
+        runtime: AXLogicProElements.Runtime = .production
+    ) async -> ModalReconcileOutcome {
+        await reconcile(isDeleteContext: isDeleteContext, preflight: false, runtime: runtime)
+    }
+
+    /// Reconcile a blocking modal BEFORE starting an operation. Only auto-clears
+    /// the mandatory New Track sheet and a stray open menu; a deleteConfirm /
+    /// unknownSheet is reported but NOT acted on (we never confirm a delete the
+    /// caller did not request, nor dismiss a sheet that could be a Save prompt).
+    static func reconcilePreflight(
+        runtime: AXLogicProElements.Runtime = .production
+    ) async -> ModalReconcileOutcome {
+        await reconcile(isDeleteContext: false, preflight: true, runtime: runtime)
+    }
+
+    private static func reconcile(
+        isDeleteContext: Bool,
+        preflight: Bool,
+        runtime: AXLogicProElements.Runtime
+    ) async -> ModalReconcileOutcome {
+        let signals = readModalSignals(runtime: runtime)
+        let kind = ModalReconciliation.classify(signals)
+        let decision = ModalReconciliation.decide(kind: kind, isDeleteContext: isDeleteContext)
+
+        // Preflight only auto-clears the mandatory New Track sheet + a stray
+        // menu; everything else is reported without a side effect.
+        if preflight, kind != .mandatoryNewTrack, kind != .strayMenu {
+            return ModalReconcileOutcome(kind: kind, decision: decision, performed: false)
+        }
+
+        let performed = await perform(decision, runtime: runtime)
+        return ModalReconcileOutcome(kind: kind, decision: decision, performed: performed)
+    }
+
+    // MARK: - Signal reader
+
+    /// Read the main window's sheet into `ModalSignals`. When no sheet is
+    /// present the only remaining blocker we reconcile is a stray open menu.
+    static func readModalSignals(
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ModalReconciliation.ModalSignals {
+        guard let window = AXLogicProElements.mainWindow(runtime: runtime),
+              let sheet = firstSheet(in: window, runtime: runtime.ax) else {
+            return ModalReconciliation.ModalSignals(
+                sheetPresent: false,
+                sheetDescription: "",
+                createButtonPresent: false,
+                cancelButtonPresent: false,
+                cancelButtonEnabled: false,
+                deleteConfirmButtonPresent: false,
+                strayMenuOpen: detectStrayMenuOpen(runtime: runtime)
+            )
+        }
+
+        let description = (AXHelpers.getAttribute(sheet, kAXDescriptionAttribute, runtime: runtime.ax) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let buttons = AXHelpers.findAllDescendants(
+            of: sheet, role: kAXButtonRole as String, maxDepth: 6, runtime: runtime.ax
+        )
+
+        let createPresent = buttons.contains { buttonLabel($0, runtime: runtime.ax) == "Create" }
+        let cancelButton = buttons.first { buttonLabel($0, runtime: runtime.ax) == "Cancel" }
+        // Fail-closed default: an unreadable enabled state is treated as ENABLED
+        // so a normal cancelable sheet is never mistaken for the mandatory one
+        // (which would auto-click "Create" — a side effect we must not guess).
+        let cancelEnabled: Bool = cancelButton
+            .flatMap { AXHelpers.getAttribute($0, kAXEnabledAttribute, runtime: runtime.ax) as Bool? }
+            ?? true
+        let deletePresent = buttons.contains { buttonLabel($0, runtime: runtime.ax).hasPrefix("Delete ") }
+
+        return ModalReconciliation.ModalSignals(
+            sheetPresent: true,
+            sheetDescription: description,
+            createButtonPresent: createPresent,
+            cancelButtonPresent: cancelButton != nil,
+            cancelButtonEnabled: cancelEnabled,
+            deleteConfirmButtonPresent: deletePresent,
+            strayMenuOpen: false
+        )
+    }
+
+    /// The main window's first attached sheet. Real AX exposes an open sheet via
+    /// the window's `AXSheets` attribute (the `kAXSheetsAttribute` constant is not
+    /// vended by ApplicationServices, so the raw name is used) AND as a descendant
+    /// with role `AXSheet`; the role scan is the resilient fallback.
+    private static func firstSheet(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        if let sheets: [AXUIElement] = AXHelpers.getAttribute(window, "AXSheets", runtime: runtime),
+           let sheet = sheets.first {
+            return sheet
+        }
+        return AXHelpers.findDescendant(
+            of: window, role: kAXSheetRole as String, maxDepth: 4, runtime: runtime
+        )
+    }
+
+    /// A button's visible label — `AXTitle` first (what AppleScript `button "X"`
+    /// matches), falling back to `AXDescription` for buttons that only expose the
+    /// description.
+    private static func buttonLabel(_ button: AXUIElement, runtime: AXHelpers.Runtime) -> String {
+        (AXHelpers.getTitle(button, runtime: runtime)
+            ?? AXHelpers.getDescription(button, runtime: runtime)
+            ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Best-effort detection of a menu bar menu left open: a menu bar item whose
+    /// menu is showing reports `AXSelected == true`. Conservative — only true on
+    /// a positively-observed selected item, so a spurious Escape is never sent.
+    private static func detectStrayMenuOpen(runtime: AXLogicProElements.Runtime) -> Bool {
+        guard let menuBar = AXLogicProElements.getMenuBar(runtime: runtime) else { return false }
+        return AXHelpers.getChildren(menuBar, runtime: runtime.ax).contains { item in
+            (AXHelpers.getAttribute(item, kAXSelectedAttribute, runtime: runtime.ax) as Bool?) == true
+        }
+    }
+
+    // MARK: - Executor
+
+    private static func perform(
+        _ decision: ModalReconciliation.ModalReconcileDecision,
+        runtime: AXLogicProElements.Runtime
+    ) async -> Bool {
+        switch decision {
+        case .noAction, .failClosed:
+            return false
+        case .clickCreate:
+            return await clickNewTrackCreateButton()
+        case .confirmDelete:
+            return await confirmDeleteTracksSheet()
+        case .escapeMenu:
+            return await sendEscapeKey()
+        }
+    }
+
+    /// Click the mandatory New Track sheet's only exit. This exact addressing is
+    /// the live-verified recovery — Escape/Cancel are inert on this sheet.
+    private static func clickNewTrackCreateButton() async -> Bool {
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                click button "Create" of group 1 of sheet 1 of window 1
+            end tell
+        end tell
+        return "clicked"
+        """
+        return await AppleScriptChannel.executeAppleScript(script).isSuccess
+    }
+
+    /// Confirm the delete-channel-strips sheet by its primary destructive button,
+    /// falling back to the sheet's default button (Return) when the exact title
+    /// is not matched (e.g. a localized build).
+    private static func confirmDeleteTracksSheet() async -> Bool {
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                click button "Delete Tracks and Content" of sheet 1 of window 1
+            end tell
+        end tell
+        return "clicked"
+        """
+        if await AppleScriptChannel.executeAppleScript(script).isSuccess {
+            return true
+        }
+        // Fall back to the default button — the primary delete action is the
+        // sheet's default, so Return commits it.
+        sendReturnKey()
+        return true
+    }
+
+    /// Send Escape (key code 53) to close a stray open menu.
+    private static func sendEscapeKey() async -> Bool {
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                key code 53
+            end tell
+        end tell
+        return "escaped"
+        """
+        return await AppleScriptChannel.executeAppleScript(script).isSuccess
+    }
+
+    // MARK: - Extras labels
+
+    /// Stable wire label for the reconciled modal kind (merged into op extras).
+    static func reconcileKindLabel(_ kind: ModalReconciliation.BlockingModalKind) -> String {
+        switch kind {
+        case .none: return "none"
+        case .mandatoryNewTrack: return "mandatory_new_track"
+        case .deleteConfirm: return "delete_confirm"
+        case .strayMenu: return "stray_menu"
+        case .unknownSheet: return "unknown_sheet"
+        }
+    }
+
+    /// Stable wire label for the reconciliation action taken (merged into extras).
+    static func reconcileActionLabel(_ decision: ModalReconciliation.ModalReconcileDecision) -> String {
+        switch decision {
+        case .noAction: return "none"
+        case .clickCreate: return "click_create"
+        case .confirmDelete: return "confirm_delete"
+        case .escapeMenu: return "escape_menu"
+        case .failClosed: return "fail_closed"
+        }
+    }
+
+    /// Merge reconciliation provenance into an op's extras — only when a modal
+    /// was actually observed, so the common (no-sheet) path stays noise-free.
+    /// `new_track_dialog_auto_confirmed` is present only when the mandatory New
+    /// Track sheet's "Create" was auto-clicked.
+    static func mergeReconcileExtras(
+        _ extras: inout [String: Any],
+        kind: ModalReconciliation.BlockingModalKind,
+        action: String,
+        newTrackAutoConfirmed: Bool
+    ) {
+        guard kind != .none else { return }
+        extras["reconciled_modal_kind"] = reconcileKindLabel(kind)
+        extras["reconciled_action"] = action
+        if newTrackAutoConfirmed {
+            extras["new_track_dialog_auto_confirmed"] = true
+        }
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -32,9 +32,10 @@ extension AccessibilityChannel {
     }
 
     /// Reconcile a blocking modal BEFORE starting an operation. Only auto-clears
-    /// the mandatory New Track sheet and a stray open menu; a deleteConfirm /
-    /// unknownSheet is reported but NOT acted on (we never confirm a delete the
-    /// caller did not request, nor dismiss a sheet that could be a Save prompt).
+    /// the mandatory New Track sheet, a single-button informational alert, and a
+    /// stray open menu; a deleteConfirm / unknownSheet is reported but NOT acted
+    /// on (we never confirm a delete the caller did not request, nor dismiss a
+    /// sheet/dialog that could be a Save prompt).
     static func reconcilePreflight(
         runtime: AXLogicProElements.Runtime = .production
     ) async -> ModalReconcileOutcome {
@@ -50,13 +51,14 @@ extension AccessibilityChannel {
         let kind = ModalReconciliation.classify(signals)
         let decision = ModalReconciliation.decide(kind: kind, isDeleteContext: isDeleteContext)
 
-        // Preflight only auto-clears the mandatory New Track sheet + a stray
-        // menu; everything else is reported without a side effect.
-        if preflight, kind != .mandatoryNewTrack, kind != .strayMenu {
+        // Preflight only auto-clears the mandatory New Track sheet, a single-
+        // button informational alert, and a stray menu; everything else is
+        // reported without a side effect.
+        if preflight, kind != .mandatoryNewTrack, kind != .informationalAlert, kind != .strayMenu {
             return ModalReconcileOutcome(kind: kind, decision: decision, performed: false)
         }
 
-        let performed = await perform(decision, runtime: runtime)
+        let performed = await perform(decision, signals: signals, runtime: runtime)
         return ModalReconcileOutcome(kind: kind, decision: decision, performed: performed)
     }
 
@@ -69,6 +71,11 @@ extension AccessibilityChannel {
     ) -> ModalReconciliation.ModalSignals {
         guard let window = AXLogicProElements.mainWindow(runtime: runtime),
               let sheet = firstSheet(in: window, runtime: runtime.ax) else {
+            // No main-window sheet: the remaining blockers are a top-level
+            // informational alert (safe only when single-button) and a stray
+            // open menu. Alert signals are populated ONLY here, so any sheet
+            // above still outranks a top-level alert.
+            let alert = topLevelAlertSignals(runtime: runtime)
             return ModalReconciliation.ModalSignals(
                 sheetPresent: false,
                 sheetDescription: "",
@@ -76,7 +83,10 @@ extension AccessibilityChannel {
                 cancelButtonPresent: false,
                 cancelButtonEnabled: false,
                 deleteConfirmButtonPresent: false,
-                strayMenuOpen: detectStrayMenuOpen(runtime: runtime)
+                strayMenuOpen: detectStrayMenuOpen(runtime: runtime),
+                topLevelAlertPresent: alert.present,
+                topLevelAlertButtonCount: alert.buttonCount,
+                topLevelAlertPrimaryButton: alert.primaryButton
             )
         }
 
@@ -103,8 +113,28 @@ extension AccessibilityChannel {
             cancelButtonPresent: cancelButton != nil,
             cancelButtonEnabled: cancelEnabled,
             deleteConfirmButtonPresent: deletePresent,
-            strayMenuOpen: false
+            strayMenuOpen: false,
+            topLevelAlertPresent: false,
+            topLevelAlertButtonCount: 0,
+            topLevelAlertPrimaryButton: ""
         )
+    }
+
+    /// Detect a TOP-LEVEL informational `AXDialog` alert (NOT a main-window
+    /// sheet). Reuses `blockingDialogInfo` — which already scans top-level
+    /// windows, excludes plugin-editor / keyboard-layout overlays, and returns
+    /// the dialog's titled buttons — so the single-button safety gate applies to
+    /// its `buttonTitles.count`. Restricted to the `AXDialog` subrole so it stays
+    /// consistent with the executor's verified `subrole is "AXDialog"` targeting
+    /// (an `AXSystemDialog` we could not dismiss is deliberately not claimed).
+    private static func topLevelAlertSignals(
+        runtime: AXLogicProElements.Runtime
+    ) -> (present: Bool, buttonCount: Int, primaryButton: String) {
+        guard let info = AXLogicProElements.blockingDialogInfo(runtime: runtime),
+              info.role == (kAXDialogSubrole as String) else {
+            return (false, 0, "")
+        }
+        return (true, info.buttonTitles.count, info.buttonTitles.first ?? "")
     }
 
     /// The main window's first attached sheet. Real AX exposes an open sheet via
@@ -147,6 +177,7 @@ extension AccessibilityChannel {
 
     private static func perform(
         _ decision: ModalReconciliation.ModalReconcileDecision,
+        signals: ModalReconciliation.ModalSignals,
         runtime: AXLogicProElements.Runtime
     ) async -> Bool {
         switch decision {
@@ -156,6 +187,8 @@ extension AccessibilityChannel {
             return await clickNewTrackCreateButton()
         case .confirmDelete:
             return await confirmDeleteTracksSheet()
+        case .acknowledgeAlert:
+            return await acknowledgeTopLevelAlert(primaryButton: signals.topLevelAlertPrimaryButton)
         case .escapeMenu:
             return await sendEscapeKey()
         }
@@ -198,6 +231,28 @@ extension AccessibilityChannel {
         return true
     }
 
+    /// Acknowledge a single-button top-level informational alert (the classifier
+    /// has already gated this to EXACTLY ONE button). Clicks the named button on
+    /// the first `AXDialog` window, falling back to that dialog's first button.
+    private static func acknowledgeTopLevelAlert(primaryButton: String) async -> Bool {
+        let target = LogicProTarget.appleScriptTarget()
+        let escapedButton = AppleScriptSafety.escapeForScript(primaryButton)
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                set alertWindow to first window whose subrole is "AXDialog"
+                try
+                    click button "\(escapedButton)" of alertWindow
+                on error
+                    click button 1 of alertWindow
+                end try
+            end tell
+        end tell
+        return "acknowledged"
+        """
+        return await AppleScriptChannel.executeAppleScript(script).isSuccess
+    }
+
     /// Send Escape (key code 53) to close a stray open menu.
     private static func sendEscapeKey() async -> Bool {
         let target = LogicProTarget.appleScriptTarget()
@@ -220,6 +275,7 @@ extension AccessibilityChannel {
         case .none: return "none"
         case .mandatoryNewTrack: return "mandatory_new_track"
         case .deleteConfirm: return "delete_confirm"
+        case .informationalAlert: return "informational_alert"
         case .strayMenu: return "stray_menu"
         case .unknownSheet: return "unknown_sheet"
         }
@@ -231,6 +287,7 @@ extension AccessibilityChannel {
         case .noAction: return "none"
         case .clickCreate: return "click_create"
         case .confirmDelete: return "confirm_delete"
+        case .acknowledgeAlert: return "acknowledge_alert"
         case .escapeMenu: return "escape_menu"
         case .failClosed: return "fail_closed"
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -483,7 +483,9 @@ extension AccessibilityChannel {
 
     /// Send Return key via CGEvent — used to auto-confirm Logic 12's
     /// "New Track" dialog (which is sometimes opaque to AX tree).
-    private static func sendReturnKey() {
+    // internal (not private): reused by the +ModalReconcile extension as the
+    // delete-confirm sheet's default-button fallback (#346).
+    static func sendReturnKey() {
         guard let src = CGEventSource(stateID: .hidSystemState) else { return }
         let returnVK: CGKeyCode = 0x24
         if let down = CGEvent(keyboardEventSource: src, virtualKey: returnVK, keyDown: true) {
@@ -623,36 +625,70 @@ extension AccessibilityChannel {
             (try? JSONSerialization.jsonObject(with: Data(click.message.utf8))) as? [String: String]
         )?["menu_clicked"] ?? "Delete Track / 트랙 삭제"
 
-        let extras: [String: Any] = [
+        var extras: [String: Any] = [
             "menu_clicked": menuClicked,
             "track_count_before": beforeCount,
             "requested_delta": -1
         ]
 
+        // #346: a channel-strip delete raises a "delete channel strips…" confirm
+        // sheet, and a delete that empties the project raises the mandatory New
+        // Track sheet (Cancel disabled, Escape inert) — both wedge Logic until
+        // reconciled. Reconcile each poll round (a cheap AX read that no-ops when
+        // no sheet is up) and note the outcome. Reconciliation is ADDITIVE: State
+        // A below still requires a real decrement, so auto-Creating a replacement
+        // track on delete-to-zero correctly stays an honest State B rather than a
+        // fabricated success.
+        var reconcileKind = ModalReconciliation.BlockingModalKind.none
+        var reconcileAction = "none"
+        var newTrackAutoConfirmed = false
+
         var lastObservedCount = beforeCount
         for attempt in 0..<4 {
             try? await Task.sleep(nanoseconds: 250_000_000)
+
+            // Bound the mandatory-New-Track auto-Create to exactly once — it is
+            // the terminal sheet, so stop reconciling after it fires.
+            if !newTrackAutoConfirmed {
+                let outcome = await reconcileAfterMutation(isDeleteContext: true, runtime: runtime)
+                if outcome.kind != .none {
+                    reconcileKind = outcome.kind
+                    reconcileAction = reconcileActionLabel(outcome.decision)
+                    if outcome.kind == .mandatoryNewTrack && outcome.performed {
+                        newTrackAutoConfirmed = true
+                    }
+                }
+            }
+
             let currentCount = AXLogicProElements.allTrackHeaders(runtime: runtime).count
             lastObservedCount = currentCount
             if currentCount < beforeCount {
-                let merged = extras.merging([
-                    "track_count_after": currentCount,
-                    "observed_delta": currentCount - beforeCount
-                ]) { _, new in new }
-                return .success(HonestContract.encodeStateA(extras: merged))
+                extras["track_count_after"] = currentCount
+                extras["observed_delta"] = currentCount - beforeCount
+                mergeReconcileExtras(
+                    &extras,
+                    kind: reconcileKind,
+                    action: reconcileAction,
+                    newTrackAutoConfirmed: newTrackAutoConfirmed
+                )
+                return .success(HonestContract.encodeStateA(extras: extras))
             }
             if attempt < 3 {
                 try? await Task.sleep(nanoseconds: 750_000_000)
             }
         }
 
-        let merged = extras.merging([
-            "track_count_after": lastObservedCount,
-            "observed_delta": lastObservedCount - beforeCount
-        ]) { _, new in new }
+        extras["track_count_after"] = lastObservedCount
+        extras["observed_delta"] = lastObservedCount - beforeCount
+        mergeReconcileExtras(
+            &extras,
+            kind: reconcileKind,
+            action: reconcileAction,
+            newTrackAutoConfirmed: newTrackAutoConfirmed
+        )
         return .success(HonestContract.encodeStateB(
             reason: .retryExhausted,
-            extras: merged
+            extras: extras
         ))
     }
 

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -14,7 +14,10 @@ private func makeSignals(
     cancelButtonPresent: Bool = false,
     cancelButtonEnabled: Bool = true,
     deleteConfirmButtonPresent: Bool = false,
-    strayMenuOpen: Bool = false
+    strayMenuOpen: Bool = false,
+    topLevelAlertPresent: Bool = false,
+    topLevelAlertButtonCount: Int = 0,
+    topLevelAlertPrimaryButton: String = ""
 ) -> ModalReconciliation.ModalSignals {
     ModalReconciliation.ModalSignals(
         sheetPresent: sheetPresent,
@@ -23,7 +26,10 @@ private func makeSignals(
         cancelButtonPresent: cancelButtonPresent,
         cancelButtonEnabled: cancelButtonEnabled,
         deleteConfirmButtonPresent: deleteConfirmButtonPresent,
-        strayMenuOpen: strayMenuOpen
+        strayMenuOpen: strayMenuOpen,
+        topLevelAlertPresent: topLevelAlertPresent,
+        topLevelAlertButtonCount: topLevelAlertButtonCount,
+        topLevelAlertPrimaryButton: topLevelAlertPrimaryButton
     )
 }
 
@@ -188,4 +194,78 @@ private func makeSignals(
     let kind = ModalReconciliation.classify(signals)
     #expect(kind == .deleteConfirm)
     #expect(ModalReconciliation.decide(kind: kind, isDeleteContext: true) == .confirmDelete)
+}
+
+// MARK: - top-level informational alerts (#346 increment 2)
+
+@Test func testSingleButtonTopLevelAlertIsAcknowledged() {
+    // Live shape: top-level AXDialog "alert" with a single "OK" button.
+    let signals = makeSignals(
+        sheetPresent: false,
+        topLevelAlertPresent: true,
+        topLevelAlertButtonCount: 1,
+        topLevelAlertPrimaryButton: "OK"
+    )
+    let kind = ModalReconciliation.classify(signals)
+    #expect(kind == .informationalAlert)
+    #expect(ModalReconciliation.decide(kind: kind, isDeleteContext: false) == .acknowledgeAlert)
+    #expect(ModalReconciliation.decide(kind: kind, isDeleteContext: true) == .acknowledgeAlert)
+}
+
+@Test func testTwoButtonTopLevelDialogIsNeverAcknowledged() {
+    // DATA-LOSS SAFETY GUARD: a 2+ button dialog is a CHOICE (e.g. Save /
+    // Don't Save / Cancel) and must NEVER be auto-dismissed — classify to
+    // unknownSheet, decide to failClosed, and assert it is not acknowledged.
+    let signals = makeSignals(
+        sheetPresent: false,
+        topLevelAlertPresent: true,
+        topLevelAlertButtonCount: 2,
+        topLevelAlertPrimaryButton: "Save"
+    )
+    let kind = ModalReconciliation.classify(signals)
+    #expect(kind == .unknownSheet)
+    let decision = ModalReconciliation.decide(kind: kind, isDeleteContext: false)
+    #expect(decision == .failClosed("unexpected blocking sheet"))
+    #expect(decision != .acknowledgeAlert)
+}
+
+@Test func testZeroButtonTopLevelAlertFailsClosed() {
+    // Present but no identifiable single button ⇒ cannot safely acknowledge.
+    let signals = makeSignals(
+        sheetPresent: false,
+        topLevelAlertPresent: true,
+        topLevelAlertButtonCount: 0
+    )
+    #expect(ModalReconciliation.classify(signals) == .unknownSheet)
+}
+
+@Test func testMainWindowSheetOutranksTopLevelAlert() {
+    // Both present ⇒ the main-window sheet wins (sheet is the stronger blocker).
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "New Track",
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false,
+        topLevelAlertPresent: true,
+        topLevelAlertButtonCount: 1,
+        topLevelAlertPrimaryButton: "OK"
+    )
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+@Test func testTopLevelAlertOutranksStrayMenu() {
+    let signals = makeSignals(
+        sheetPresent: false,
+        strayMenuOpen: true,
+        topLevelAlertPresent: true,
+        topLevelAlertButtonCount: 1,
+        topLevelAlertPrimaryButton: "OK"
+    )
+    #expect(ModalReconciliation.classify(signals) == .informationalAlert)
+}
+
+@Test func testDecideInformationalAlertAcknowledgesInAnyContext() {
+    #expect(ModalReconciliation.decide(kind: .informationalAlert, isDeleteContext: true) == .acknowledgeAlert)
+    #expect(ModalReconciliation.decide(kind: .informationalAlert, isDeleteContext: false) == .acknowledgeAlert)
 }

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// #346 — exhaustive, deterministic truth table for the pure modal-reconciliation
+// core (classify + decide). No AX / live Logic; the live reader + executor are
+// verified separately. Enum `==` comparisons below are non-optional Bool
+// expressions (NOT the dead `#expect(optionalBool == true)` pattern).
+
+private func makeSignals(
+    sheetPresent: Bool = false,
+    sheetDescription: String = "",
+    createButtonPresent: Bool = false,
+    cancelButtonPresent: Bool = false,
+    cancelButtonEnabled: Bool = true,
+    deleteConfirmButtonPresent: Bool = false,
+    strayMenuOpen: Bool = false
+) -> ModalReconciliation.ModalSignals {
+    ModalReconciliation.ModalSignals(
+        sheetPresent: sheetPresent,
+        sheetDescription: sheetDescription,
+        createButtonPresent: createButtonPresent,
+        cancelButtonPresent: cancelButtonPresent,
+        cancelButtonEnabled: cancelButtonEnabled,
+        deleteConfirmButtonPresent: deleteConfirmButtonPresent,
+        strayMenuOpen: strayMenuOpen
+    )
+}
+
+// MARK: - classify
+
+@Test func testClassifyMandatoryNewTrackViaDisabledCancel() {
+    // Live shape: Create enabled, Cancel present-but-disabled (Escape inert).
+    let signals = makeSignals(
+        sheetPresent: true,
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false
+    )
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+@Test func testClassifyMandatoryNewTrackViaDescription() {
+    // Description alone identifies the sheet even if button state is unreadable.
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "New Track"
+    )
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+@Test func testClassifyDeleteConfirm() {
+    let signals = makeSignals(
+        sheetPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: true,
+        deleteConfirmButtonPresent: true
+    )
+    #expect(ModalReconciliation.classify(signals) == .deleteConfirm)
+}
+
+@Test func testClassifyStrayMenu() {
+    let signals = makeSignals(sheetPresent: false, strayMenuOpen: true)
+    #expect(ModalReconciliation.classify(signals) == .strayMenu)
+}
+
+@Test func testClassifyUnknownSheet() {
+    // A sheet with none of the recognised signals — never auto-dismissed.
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "Some Other Sheet",
+        createButtonPresent: false,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: true
+    )
+    #expect(ModalReconciliation.classify(signals) == .unknownSheet)
+}
+
+@Test func testClassifyNone() {
+    #expect(ModalReconciliation.classify(makeSignals()) == .none)
+}
+
+@Test func testClassifySheetWinsOverStrayMenu() {
+    // A present sheet is the stronger blocker even if a menu also reads open.
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "New Track",
+        strayMenuOpen: true
+    )
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+// MARK: - discriminator: disabled Cancel is the mandatory-sheet signal
+
+@Test func testDisabledCancelIsTheMandatoryDiscriminator() {
+    // Two sheets identical except Cancel's enabled state (and no "New Track"
+    // description): disabled Cancel => mandatory; enabled Cancel => ordinary
+    // cancelable sheet (unknown, fail-closed) — never auto-Created.
+    let mandatory = makeSignals(
+        sheetPresent: true,
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false
+    )
+    let ordinary = makeSignals(
+        sheetPresent: true,
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: true
+    )
+    #expect(ModalReconciliation.classify(mandatory) == .mandatoryNewTrack)
+    #expect(ModalReconciliation.classify(ordinary) == .unknownSheet)
+}
+
+@Test func testDeleteConfirmWithDisabledCancelIsNotMisreadAsNewTrack() {
+    // A delete-confirm sheet has NO Create button, so a disabled Cancel must not
+    // promote it to mandatoryNewTrack (the createButtonPresent conjunct guards).
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "Delete channel strips",
+        createButtonPresent: false,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false,
+        deleteConfirmButtonPresent: true
+    )
+    #expect(ModalReconciliation.classify(signals) == .deleteConfirm)
+}
+
+// MARK: - decide
+
+@Test func testDecideMandatoryNewTrackAlwaysClicksCreate() {
+    #expect(ModalReconciliation.decide(kind: .mandatoryNewTrack, isDeleteContext: true) == .clickCreate)
+    #expect(ModalReconciliation.decide(kind: .mandatoryNewTrack, isDeleteContext: false) == .clickCreate)
+}
+
+@Test func testDecideDeleteConfirmInDeleteContext() {
+    #expect(ModalReconciliation.decide(kind: .deleteConfirm, isDeleteContext: true) == .confirmDelete)
+}
+
+@Test func testDecideDeleteConfirmOutsideDeleteContextFailsClosed() {
+    let decision = ModalReconciliation.decide(kind: .deleteConfirm, isDeleteContext: false)
+    #expect(decision == .failClosed("unexpected delete-confirm sheet"))
+    // Must NOT confirm a delete the caller did not request.
+    #expect(decision != .confirmDelete)
+}
+
+@Test func testDecideStrayMenuEscapes() {
+    #expect(ModalReconciliation.decide(kind: .strayMenu, isDeleteContext: false) == .escapeMenu)
+}
+
+@Test func testDecideUnknownSheetFailsClosedAndIsNotDismissed() {
+    let decision = ModalReconciliation.decide(kind: .unknownSheet, isDeleteContext: true)
+    #expect(decision == .failClosed("unexpected blocking sheet"))
+    // A "Save changes?" could lose data — assert we never auto-dismiss/act.
+    #expect(decision != .clickCreate)
+    #expect(decision != .confirmDelete)
+    #expect(decision != .escapeMenu)
+    #expect(decision != .noAction)
+}
+
+@Test func testDecideNoneIsNoAction() {
+    #expect(ModalReconciliation.decide(kind: .none, isDeleteContext: true) == .noAction)
+    #expect(ModalReconciliation.decide(kind: .none, isDeleteContext: false) == .noAction)
+}
+
+// MARK: - end-to-end pipeline (classify -> decide)
+
+@Test func testPipelineNewTrackSheetAutoCreates() {
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "New Track",
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false
+    )
+    let kind = ModalReconciliation.classify(signals)
+    #expect(kind == .mandatoryNewTrack)
+    #expect(ModalReconciliation.decide(kind: kind, isDeleteContext: true) == .clickCreate)
+}
+
+@Test func testPipelineDeleteConfirmConfirmsInDeleteContext() {
+    let signals = makeSignals(
+        sheetPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: true,
+        deleteConfirmButtonPresent: true
+    )
+    let kind = ModalReconciliation.classify(signals)
+    #expect(kind == .deleteConfirm)
+    #expect(ModalReconciliation.decide(kind: kind, isDeleteContext: true) == .confirmDelete)
+}


### PR DESCRIPTION
## Fixes #346 — Logic wedge on unhandled blocking modals

### Root cause (confirmed live on Logic Pro 12.3)
Logic operations trigger blocking modal sheets / open menus that the server never reconciled, leaving Logic **permanently wedged** and cascading into the strict-live `fresh_track_unavailable` cluster. Three triggers, one class (no post-operation modal/menu reconciliation):

1. **Mandatory "Create New Track" sheet with `Cancel` DISABLED** — Logic auto-presents it on a fresh-project bootstrap (and can appear at delete-to-zero). Escape/Cancel are inert; the *only* exit is the `Create` button. No handler → permanent wedge. (Live AX dump: `AXSheet` desc `New Track`, `AXButton "Create" enabled=true`, `AXButton "Cancel" enabled=false`.)
2. **"delete channel strips that are assigned to tracks!" confirmation** on channel-strip track delete — `defaultDeleteTrack` had zero sheet handling.
3. **Navigate menu left open** on a marker-op error (`Markers.swift` had no Escape cleanup).
4. **Top-level informational `AXDialog` alert** (single OK button, e.g. Logic's "The previously selected audio interface is not available." warning) — a top-level window, not a main-window sheet, so it evaded even sheet-level detection.

### Fix
- **`ModalReconciliation.swift`** — pure, Sendable, AX-free decision core (`classify` + `decide`). Never blindly dismisses an unrecognized sheet (a "Save changes?" could lose data) — it fails closed. Disabled-Cancel (or the `New Track` description) discriminates the mandatory sheet from an ordinary cancelable one.
- **`AccessibilityChannel+ModalReconcile.swift`** — live AX reader/executor. Reads the **main-window sheet** (`dialogPresent` only scans top-level windows and misses it), classifies, and performs the sanctioned recovery (`clickCreate` / `confirmDelete` / `escapeMenu`). Fail-closed default: an unreadable Cancel-enabled state is treated as *enabled*, so a normal sheet is never mistaken for the mandatory one (no spurious auto-Create).
- **`defaultDeleteTrack`** — reconciles each poll round. **Additive**: State A still requires a real count decrement, so a delete-to-zero that auto-Creates a replacement track stays an honest State B with `reconciled_modal_kind` / `reconciled_action` / `new_track_dialog_auto_confirmed` — never a fabricated success.
- **`Markers.swift`** — Escape (`key code 53`) on ANY error after the Navigate menu opens (both English + Korean branches); the menu is never left open. Success path unchanged.
- **Single-button top-level alerts** (2nd commit) — the reader also detects a top-level `AXDialog` (reusing `blockingDialogInfo`, no-sheet branch so a sheet always outranks it). A dialog with **exactly one** button → `informationalAlert` → acknowledge (click it). A **2+ button** dialog is a lossy CHOICE (Save / Don't Save / Cancel) → `unknownSheet` → **fail closed, never auto-dismissed** (explicitly tested).

Always-on bug fix (no feature flag). Two commits: reconciler + delete/marker wiring, then the alert class.

### Verification
- **Unit**: `ModalReconciliationTests` **23/23** (17 + 6 alert-class, incl. the data-loss-safety guard `testTwoButtonTopLevelDialogIsNeverAcknowledged`); no regressions (Track 166 / Marker 60 / Accessibility 106).
- **Live (real Logic 12.3, tmux transport)**: delete-to-zero → the mandatory New Track sheet is **detected + auto-Created** (`reconciled=mandatory_new_track`, `new_track_dialog_auto_confirmed=true`) as an honest **State B** (no net decrement — Logic mandates a track), **`sheets=0`, no wedge**; no wedge across 40+ deletes; markers leave no open menu; server responsive.
- **Strict live E2E** (`STRICT_LIVE=1`, fresh bootstrap + 378 checks): the entire `fresh_track_unavailable` wedge cluster (7 failures pre-fix) is **GONE**; §17b Fresh Record Modal Guard (fresh document + fresh track) green; Logic running + server responsive at end. Residual failures across runs were environmental only — §13/§18 concurrent-stress/perf under load (all cleared on a lower-load re-run), and an intermittent Logic audio-interface alert during the Python fresh-bootstrap (harness-side; tracked separately). None in this fix's code paths.

Refs #308.
