### PR TITLE
fix: reconcile stray blocking modals before track creation (#348)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
+++ b/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
@@ -126,4 +126,27 @@ enum ModalReconciliation {
             return .noAction
         }
     }
+
+    /// Whether a PREFLIGHT reconciliation should actually PERFORM the action for
+    /// `kind`. Preflight only auto-clears non-destructive blockers: a single-
+    /// button informational alert and a stray menu ALWAYS; the mandatory New
+    /// Track sheet ONLY when `clearMandatoryNewTrack` is true. The create path
+    /// passes `false` so preflight never clicks "Create" — `createTrackViaMenu`
+    /// opens and confirms its own New Track dialog, and auto-Creating here too
+    /// would DOUBLE-CREATE. deleteConfirm / unknownSheet / none never act at
+    /// preflight (fail closed — never confirm an unrequested delete or dismiss a
+    /// sheet that could be a Save prompt).
+    static func preflightShouldPerform(
+        kind: BlockingModalKind,
+        clearMandatoryNewTrack: Bool
+    ) -> Bool {
+        switch kind {
+        case .informationalAlert, .strayMenu:
+            return true
+        case .mandatoryNewTrack:
+            return clearMandatoryNewTrack
+        case .deleteConfirm, .unknownSheet, .none:
+            return false
+        }
+    }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -28,33 +28,52 @@ extension AccessibilityChannel {
         isDeleteContext: Bool,
         runtime: AXLogicProElements.Runtime = .production
     ) async -> ModalReconcileOutcome {
-        await reconcile(isDeleteContext: isDeleteContext, preflight: false, runtime: runtime)
+        await reconcile(
+            isDeleteContext: isDeleteContext,
+            preflight: false,
+            clearMandatoryNewTrack: true,
+            runtime: runtime
+        )
     }
 
-    /// Reconcile a blocking modal BEFORE starting an operation. Only auto-clears
-    /// the mandatory New Track sheet, a single-button informational alert, and a
-    /// stray open menu; a deleteConfirm / unknownSheet is reported but NOT acted
-    /// on (we never confirm a delete the caller did not request, nor dismiss a
-    /// sheet/dialog that could be a Save prompt).
+    /// Reconcile a blocking modal BEFORE starting an operation. Auto-clears a
+    /// single-button informational alert and a stray open menu; the mandatory
+    /// New Track sheet is auto-cleared ONLY when `clearMandatoryNewTrack` is true
+    /// (the default). The CREATE path passes `false` so preflight never clicks
+    /// "Create" — `createTrackViaMenu` opens/confirms its own New Track dialog,
+    /// and doing both would double-create. A deleteConfirm / unknownSheet is
+    /// reported but NOT acted on (we never confirm a delete the caller did not
+    /// request, nor dismiss a sheet/dialog that could be a Save prompt).
     static func reconcilePreflight(
+        clearMandatoryNewTrack: Bool = true,
         runtime: AXLogicProElements.Runtime = .production
     ) async -> ModalReconcileOutcome {
-        await reconcile(isDeleteContext: false, preflight: true, runtime: runtime)
+        await reconcile(
+            isDeleteContext: false,
+            preflight: true,
+            clearMandatoryNewTrack: clearMandatoryNewTrack,
+            runtime: runtime
+        )
     }
 
     private static func reconcile(
         isDeleteContext: Bool,
         preflight: Bool,
+        clearMandatoryNewTrack: Bool,
         runtime: AXLogicProElements.Runtime
     ) async -> ModalReconcileOutcome {
         let signals = readModalSignals(runtime: runtime)
         let kind = ModalReconciliation.classify(signals)
         let decision = ModalReconciliation.decide(kind: kind, isDeleteContext: isDeleteContext)
 
-        // Preflight only auto-clears the mandatory New Track sheet, a single-
-        // button informational alert, and a stray menu; everything else is
-        // reported without a side effect.
-        if preflight, kind != .mandatoryNewTrack, kind != .informationalAlert, kind != .strayMenu {
+        // At preflight, only the non-destructive blockers are auto-cleared (and
+        // the mandatory New Track sheet only when `clearMandatoryNewTrack`); the
+        // scoping policy is the pure `preflightShouldPerform`.
+        if preflight,
+           !ModalReconciliation.preflightShouldPerform(
+                kind: kind,
+                clearMandatoryNewTrack: clearMandatoryNewTrack
+           ) {
             return ModalReconcileOutcome(kind: kind, decision: decision, performed: false)
         }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -444,6 +444,15 @@ extension AccessibilityChannel {
             return .error("No document open for track creation")
         }
 
+        // #348: clear a stray blocking modal BEFORE driving the Track menu — a
+        // single-OK top-level alert (audio-interface warning on fresh-document /
+        // first-track creation) otherwise wedges the create. Scoped with
+        // `clearMandatoryNewTrack: false` so preflight NEVER clicks "Create": the
+        // New-Track-dialog confirmation below (`sendReturnKey`) owns that, and
+        // doing both would double-create. Acknowledges alerts + escapes stray
+        // menus only; a no-op AX read when nothing is blocking.
+        let reconcileOutcome = await reconcilePreflight(clearMandatoryNewTrack: false, runtime: runtime)
+
         let beforeTracks = observedTrackStates(runtime: runtime)
         let beforeCount = beforeTracks.count
 
@@ -477,6 +486,7 @@ extension AccessibilityChannel {
             expectedTrackType: expectedTrackType,
             beforeTracks: beforeTracks,
             dialogConfirmationAttempted: dialogConfirmationAttempted,
+            reconcileOutcome: reconcileOutcome,
             runtime: runtime
         )
     }
@@ -502,12 +512,13 @@ extension AccessibilityChannel {
         expectedTrackType: TrackType,
         beforeTracks: [TrackState],
         dialogConfirmationAttempted: Bool,
+        reconcileOutcome: ModalReconcileOutcome,
         runtime: AXLogicProElements.Runtime
     ) async -> ChannelResult {
         let beforeCount = beforeTracks.count
         var lastObservedCount = beforeCount
 
-        let extras: [String: Any] = [
+        var extras: [String: Any] = [
             "menu_clicked": title,
             "track_count_before": beforeCount,
             "requested_delta": 1,
@@ -516,6 +527,15 @@ extension AccessibilityChannel {
             "track_type_verification_source": "menu_clicked",
             "verification_source": "track_count_delta"
         ]
+        // #348: note any pre-create reconciliation (alert acknowledged / stray
+        // menu escaped). No-op when nothing was blocking, so the clean create
+        // path stays byte-identical.
+        mergeReconcileExtras(
+            &extras,
+            kind: reconcileOutcome.kind,
+            action: reconcileActionLabel(reconcileOutcome.decision),
+            newTrackAutoConfirmed: false
+        )
 
         for attempt in 0..<4 {
             let currentTracks = observedTrackStates(runtime: runtime)

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -269,3 +269,36 @@ private func makeSignals(
     #expect(ModalReconciliation.decide(kind: .informationalAlert, isDeleteContext: true) == .acknowledgeAlert)
     #expect(ModalReconciliation.decide(kind: .informationalAlert, isDeleteContext: false) == .acknowledgeAlert)
 }
+
+// MARK: - create-path preflight scope (#348)
+
+@Test func testPreflightCreateScopeDoesNotClickCreateForMandatoryNewTrack() {
+    // DOUBLE-CREATE GUARD: in create scope the mandatory New Track sheet still
+    // DECIDES clickCreate, but preflight must NOT PERFORM it — createTrackViaMenu
+    // opens/confirms its own dialog, so acting here would create two tracks.
+    #expect(ModalReconciliation.decide(kind: .mandatoryNewTrack, isDeleteContext: false) == .clickCreate)
+    #expect(!ModalReconciliation.preflightShouldPerform(kind: .mandatoryNewTrack, clearMandatoryNewTrack: false))
+}
+
+@Test func testPreflightDefaultScopeClearsMandatoryNewTrack() {
+    // Default scope (any other caller) still auto-clears the mandatory sheet.
+    #expect(ModalReconciliation.preflightShouldPerform(kind: .mandatoryNewTrack, clearMandatoryNewTrack: true))
+}
+
+@Test func testPreflightCreateScopeStillAcknowledgesAlert() {
+    #expect(ModalReconciliation.decide(kind: .informationalAlert, isDeleteContext: false) == .acknowledgeAlert)
+    #expect(ModalReconciliation.preflightShouldPerform(kind: .informationalAlert, clearMandatoryNewTrack: false))
+}
+
+@Test func testPreflightCreateScopeStillEscapesStrayMenu() {
+    #expect(ModalReconciliation.decide(kind: .strayMenu, isDeleteContext: false) == .escapeMenu)
+    #expect(ModalReconciliation.preflightShouldPerform(kind: .strayMenu, clearMandatoryNewTrack: false))
+}
+
+@Test func testPreflightNeverActsOnDeleteConfirmUnknownOrNone() {
+    for clear in [true, false] {
+        #expect(!ModalReconciliation.preflightShouldPerform(kind: .deleteConfirm, clearMandatoryNewTrack: clear))
+        #expect(!ModalReconciliation.preflightShouldPerform(kind: .unknownSheet, clearMandatoryNewTrack: clear))
+        #expect(!ModalReconciliation.preflightShouldPerform(kind: .none, clearMandatoryNewTrack: clear))
+    }
+}


### PR DESCRIPTION
## Fixes #348 — extend modal reconciliation to the track-create path

Follow-up to #346/#347. The blocking-modal reconciler was wired into DELETE (`reconcileAfterMutation`) but not CREATE, so a single-OK top-level alert (Logic's audio-interface warning on fresh-document / first-track creation) still wedged `create_instrument` (`fresh_track_ui_not_ready` in strict-live E2E).

### Fix — narrow create-scoped preflight
`createTrackViaMenu` now calls `reconcilePreflight(clearMandatoryNewTrack: false)` once, **before** driving the Track menu. New pure policy `preflightShouldPerform(kind:clearMandatoryNewTrack:)`:
- `informationalAlert` → acknowledge, `strayMenu` → escape (always)
- `mandatoryNewTrack` → **NOT performed at create preflight** (report only) — the create flow's own `sendReturnKey` New-Track-dialog confirmation stays the sole creator, so there is **no double-create**
- `deleteConfirm` / `unknownSheet` / `none` → never act (fail closed)

Additive: when nothing is blocking, the preflight is a no-op AX read and `mergeReconcileExtras(kind: .none)` adds nothing — the clean create path is byte-identical. `reconcileAfterMutation` (delete) passes `clearMandatoryNewTrack: true`, so delete behavior is unchanged.

### Verification
- **Unit**: `ModalReconciliation` **28/28** (23 + 5 create-scope); `Track|ModalReconciliation` **189/189**; `AccessibilityChannel` 74/74; no regressions.
- **Live (real Logic 12.3)**: normal `create_instrument` → State A `verified:true` (no regression); clean path carries no reconcile noise; a stray open menu before create is **detected + escaped by the preflight** (`reconciled_modal_kind=stray_menu`) with create still succeeding and no menu left open.

Refs #308.
