### PR TITLE
fix: make modal reconciler locale-aware (ko + en) via AXLocalePolicy (#350)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -176,6 +176,36 @@ enum AXLocalePolicy {
         rationale: "Dialog dismissal fallback; no success state is inferred from this click."
     )
 
+    /// #346/#350: the mandatory New Track sheet's only exit ("Create"). The modal
+    /// reconciler clicks it to un-wedge Logic, then verifies via track-count
+    /// readback — the click itself gates no State-A success. KO live-confirmed
+    /// (Logic 12.3: `생성`).
+    static let createButton = LabelSet(
+        canonical: "Create",
+        variants: ["생성"],
+        rationale: "Mandatory New Track sheet's only exit; reconciler-clicked, then verified by track-count readback. KO live-confirmed (Logic 12.3)."
+    )
+
+    /// #346/#350: `AXDescription` that identifies the mandatory New Track sheet.
+    /// One of two signals (with disabled-Cancel) the reconciler uses to classify
+    /// the sheet; read-only classifier. KO live-confirmed (Logic 12.3: `새로운 트랙`).
+    static let newTrackSheetDescription = LabelSet(
+        canonical: "New Track",
+        variants: ["새로운 트랙"],
+        rationale: "Identifies the mandatory New Track sheet by AXDescription (with disabled-Cancel); read-only classifier. KO live-confirmed (Logic 12.3)."
+    )
+
+    /// #346/#350: primary destructive button on the "delete channel strips that
+    /// are assigned to tracks!" confirm sheet. KO variant is UNVERIFIED (no live
+    /// capture), so `variants` stays empty; KO detection degrades to the
+    /// structural `Delete `-prefix check plus the Return default-button fallback
+    /// (fail-closed — a wrong-title guess is never fabricated).
+    static let deleteTracksPrimaryButton = LabelSet(
+        canonical: "Delete Tracks and Content",
+        variants: [],
+        rationale: "Primary destructive button on the delete-channel-strips confirm sheet; reconciler-clicked with a Return fallback. KO UNVERIFIED → variants empty (fail-closed structural + Return fallback)."
+    )
+
     static let saveConfirmationButton = LabelSet(
         canonical: "Save",
         variants: ["저장", "OK", "확인"],

--- a/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
+++ b/Sources/LogicProMCP/Accessibility/ModalReconciliation.swift
@@ -50,6 +50,13 @@ enum ModalReconciliation {
         let topLevelAlertButtonCount: Int
         /// The single button's title (empty when none/ambiguous).
         let topLevelAlertPrimaryButton: String
+        /// #350: the ACTUAL localized on-screen titles the reader resolved for
+        /// the sheet buttons (e.g. `생성` / `Create`, `취소` / `Cancel`, the primary
+        /// delete title), so the executor clicks the real title rather than a
+        /// hardcoded English one. Empty when the corresponding button is absent.
+        let createButtonTitle: String
+        let cancelButtonTitle: String
+        let deletePrimaryTitle: String
     }
 
     /// The sanctioned reconciliation action for a classified modal.
@@ -69,23 +76,23 @@ enum ModalReconciliation {
         case failClosed(String)
     }
 
-    /// Logic's own `AXDescription` on the mandatory New Track sheet. Either this
-    /// OR the disabled-Cancel signal is sufficient to identify the sheet.
-    static let newTrackSheetDescription = "New Track"
-
     /// Classify the current modal from its observable signals. Precedence: a
     /// main-window sheet (the strongest blocker) outranks a top-level alert,
     /// which outranks a stray menu. The mandatory New Track sheet is
     /// disambiguated from an ordinary cancelable sheet by its DISABLED Cancel (or
-    /// the "New Track" description) — the `createButtonPresent` conjunct keeps a
+    /// the New Track description) — the `createButtonPresent` conjunct keeps a
     /// delete-confirm sheet that happens to disable Cancel from being misread as
-    /// a New Track sheet. A top-level alert is only acknowledged when it has
-    /// EXACTLY ONE button; two+ buttons is a lossy CHOICE and fails closed.
+    /// a New Track sheet. Both signals are locale-aware (#350): the description is
+    /// matched against `AXLocalePolicy.newTrackSheetDescription` (EN + KO), and
+    /// `createButtonPresent`/`cancelButtonPresent` are resolved by the reader
+    /// against the localized button LabelSets. A top-level alert is only
+    /// acknowledged when it has EXACTLY ONE button; two+ buttons is a lossy CHOICE
+    /// and fails closed.
     static func classify(_ s: ModalSignals) -> BlockingModalKind {
         if s.sheetPresent {
             let isMandatoryNewTrack =
                 (s.createButtonPresent && s.cancelButtonPresent && !s.cancelButtonEnabled)
-                || s.sheetDescription == newTrackSheetDescription
+                || AXLocalePolicy.newTrackSheetDescription.matches(s.sheetDescription, mode: .exact)
             if isMandatoryNewTrack {
                 return .mandatoryNewTrack
             }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -105,37 +105,54 @@ extension AccessibilityChannel {
                 strayMenuOpen: detectStrayMenuOpen(runtime: runtime),
                 topLevelAlertPresent: alert.present,
                 topLevelAlertButtonCount: alert.buttonCount,
-                topLevelAlertPrimaryButton: alert.primaryButton
+                topLevelAlertPrimaryButton: alert.primaryButton,
+                createButtonTitle: "",
+                cancelButtonTitle: "",
+                deletePrimaryTitle: ""
             )
         }
 
         let description = (AXHelpers.getAttribute(sheet, kAXDescriptionAttribute, runtime: runtime.ax) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let buttons = AXHelpers.findAllDescendants(
+        // #350: resolve each button's on-screen label ONCE, then match locale-
+        // aware against the AXLocalePolicy LabelSets (EN + KO) so Korean Logic's
+        // 생성 / 취소 / 새로운 트랙 sheet is recognized, not just the English literals.
+        // The captured labels are threaded to the executor so it clicks the REAL
+        // localized title rather than a hardcoded English string.
+        let labeled = AXHelpers.findAllDescendants(
             of: sheet, role: kAXButtonRole as String, maxDepth: 6, runtime: runtime.ax
-        )
+        ).map { (element: $0, label: buttonLabel($0, runtime: runtime.ax)) }
 
-        let createPresent = buttons.contains { buttonLabel($0, runtime: runtime.ax) == "Create" }
-        let cancelButton = buttons.first { buttonLabel($0, runtime: runtime.ax) == "Cancel" }
+        let createButton = labeled.first { AXLocalePolicy.createButton.matches($0.label, mode: .exact) }
+        let cancelButton = labeled.first { AXLocalePolicy.cancelButton.matches($0.label, mode: .exact) }
+        // Delete-confirm primary: localized LabelSet (EN only today) OR the
+        // structural English `Delete ` prefix. The KO title is unverified, so KO
+        // delete-confirm detection degrades to fail-closed + the Return fallback.
+        let deleteButton = labeled.first {
+            AXLocalePolicy.deleteTracksPrimaryButton.matches($0.label, mode: .exact)
+                || $0.label.hasPrefix("Delete ")
+        }
         // Fail-closed default: an unreadable enabled state is treated as ENABLED
         // so a normal cancelable sheet is never mistaken for the mandatory one
         // (which would auto-click "Create" — a side effect we must not guess).
         let cancelEnabled: Bool = cancelButton
-            .flatMap { AXHelpers.getAttribute($0, kAXEnabledAttribute, runtime: runtime.ax) as Bool? }
+            .flatMap { AXHelpers.getAttribute($0.element, kAXEnabledAttribute, runtime: runtime.ax) as Bool? }
             ?? true
-        let deletePresent = buttons.contains { buttonLabel($0, runtime: runtime.ax).hasPrefix("Delete ") }
 
         return ModalReconciliation.ModalSignals(
             sheetPresent: true,
             sheetDescription: description,
-            createButtonPresent: createPresent,
+            createButtonPresent: createButton != nil,
             cancelButtonPresent: cancelButton != nil,
             cancelButtonEnabled: cancelEnabled,
-            deleteConfirmButtonPresent: deletePresent,
+            deleteConfirmButtonPresent: deleteButton != nil,
             strayMenuOpen: false,
             topLevelAlertPresent: false,
             topLevelAlertButtonCount: 0,
-            topLevelAlertPrimaryButton: ""
+            topLevelAlertPrimaryButton: "",
+            createButtonTitle: createButton?.label ?? "",
+            cancelButtonTitle: cancelButton?.label ?? "",
+            deletePrimaryTitle: deleteButton?.label ?? ""
         )
     }
 
@@ -203,9 +220,9 @@ extension AccessibilityChannel {
         case .noAction, .failClosed:
             return false
         case .clickCreate:
-            return await clickNewTrackCreateButton()
+            return await clickNewTrackCreateButton(createTitle: signals.createButtonTitle)
         case .confirmDelete:
-            return await confirmDeleteTracksSheet()
+            return await confirmDeleteTracksSheet(deleteTitle: signals.deletePrimaryTitle)
         case .acknowledgeAlert:
             return await acknowledgeTopLevelAlert(primaryButton: signals.topLevelAlertPrimaryButton)
         case .escapeMenu:
@@ -213,14 +230,16 @@ extension AccessibilityChannel {
         }
     }
 
-    /// Click the mandatory New Track sheet's only exit. This exact addressing is
-    /// the live-verified recovery — Escape/Cancel are inert on this sheet.
-    private static func clickNewTrackCreateButton() async -> Bool {
+    /// Click the mandatory New Track sheet's only exit (`Create` / `생성`). The
+    /// title is the localized on-screen label the reader resolved (#350), so this
+    /// works on Korean Logic; Escape/Cancel are inert on this sheet.
+    private static func clickNewTrackCreateButton(createTitle: String) async -> Bool {
         let target = LogicProTarget.appleScriptTarget()
+        let escapedTitle = AppleScriptSafety.escapeForScript(createTitle)
         let script = """
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
-                click button "Create" of group 1 of sheet 1 of window 1
+                click button "\(escapedTitle)" of group 1 of sheet 1 of window 1
             end tell
         end tell
         return "clicked"
@@ -229,19 +248,22 @@ extension AccessibilityChannel {
     }
 
     /// Confirm the delete-channel-strips sheet by its primary destructive button,
-    /// falling back to the sheet's default button (Return) when the exact title
-    /// is not matched (e.g. a localized build).
-    private static func confirmDeleteTracksSheet() async -> Bool {
+    /// clicking the localized title the reader resolved (#350). Falls back to the
+    /// sheet's default button (Return) when the title is absent/unmatched — which
+    /// also covers the KO path (the KO delete title is unverified, so no variant).
+    private static func confirmDeleteTracksSheet(deleteTitle: String) async -> Bool {
         let target = LogicProTarget.appleScriptTarget()
+        let escapedTitle = AppleScriptSafety.escapeForScript(deleteTitle)
         let script = """
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
-                click button "Delete Tracks and Content" of sheet 1 of window 1
+                click button "\(escapedTitle)" of sheet 1 of window 1
             end tell
         end tell
         return "clicked"
         """
-        if await AppleScriptChannel.executeAppleScript(script).isSuccess {
+        if !deleteTitle.isEmpty,
+           await AppleScriptChannel.executeAppleScript(script).isSuccess {
             return true
         }
         // Fall back to the default button — the primary delete action is the

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -17,7 +17,10 @@ private func makeSignals(
     strayMenuOpen: Bool = false,
     topLevelAlertPresent: Bool = false,
     topLevelAlertButtonCount: Int = 0,
-    topLevelAlertPrimaryButton: String = ""
+    topLevelAlertPrimaryButton: String = "",
+    createButtonTitle: String = "",
+    cancelButtonTitle: String = "",
+    deletePrimaryTitle: String = ""
 ) -> ModalReconciliation.ModalSignals {
     ModalReconciliation.ModalSignals(
         sheetPresent: sheetPresent,
@@ -29,7 +32,10 @@ private func makeSignals(
         strayMenuOpen: strayMenuOpen,
         topLevelAlertPresent: topLevelAlertPresent,
         topLevelAlertButtonCount: topLevelAlertButtonCount,
-        topLevelAlertPrimaryButton: topLevelAlertPrimaryButton
+        topLevelAlertPrimaryButton: topLevelAlertPrimaryButton,
+        createButtonTitle: createButtonTitle,
+        cancelButtonTitle: cancelButtonTitle,
+        deletePrimaryTitle: deletePrimaryTitle
     )
 }
 
@@ -301,4 +307,72 @@ private func makeSignals(
         #expect(!ModalReconciliation.preflightShouldPerform(kind: .unknownSheet, clearMandatoryNewTrack: clear))
         #expect(!ModalReconciliation.preflightShouldPerform(kind: .none, clearMandatoryNewTrack: clear))
     }
+}
+
+// MARK: - locale-aware classification (#350, Korean Logic)
+
+@Test func testClassifyKoreanMandatoryNewTrackViaDisabledCancel() {
+    // Logic 12.3 ko: 생성 / 취소(disabled) / desc 새로운 트랙. Must classify as the
+    // mandatory New Track sheet just like English, not fall to .unknownSheet.
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "새로운 트랙",
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: false,
+        createButtonTitle: "생성",
+        cancelButtonTitle: "취소"
+    )
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+@Test func testClassifyKoreanNewTrackViaDescriptionOnly() {
+    // The localized description alone (새로운 트랙) identifies the sheet, even if
+    // the disabled-Cancel signal were unreadable.
+    let signals = makeSignals(sheetPresent: true, sheetDescription: "새로운 트랙")
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+@Test func testClassifyKoreanCancelableSheetIsNotMandatory() {
+    // Korean sheet with 취소 ENABLED and a non-New-Track description must NOT be
+    // misclassified as mandatory (no auto-Create) — it is an unknown sheet.
+    let signals = makeSignals(
+        sheetPresent: true,
+        sheetDescription: "다른 시트",
+        createButtonPresent: true,
+        cancelButtonPresent: true,
+        cancelButtonEnabled: true,
+        createButtonTitle: "생성",
+        cancelButtonTitle: "취소"
+    )
+    #expect(ModalReconciliation.classify(signals) == .unknownSheet)
+}
+
+@Test func testClassifyEnglishNewTrackDescriptionStillMatches() {
+    // English description path still works after the LabelSet migration.
+    let signals = makeSignals(sheetPresent: true, sheetDescription: "New Track")
+    #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+}
+
+// MARK: - AXLocalePolicy LabelSets added for the reconciler (#350)
+
+@Test func testCreateButtonLabelSetMatchesEnAndKo() {
+    #expect(AXLocalePolicy.createButton.matches("Create"))
+    #expect(AXLocalePolicy.createButton.matches("생성"))
+    #expect(!AXLocalePolicy.createButton.matches("취소"))
+    #expect(!AXLocalePolicy.createButton.matches("Delete"))
+}
+
+@Test func testNewTrackSheetDescriptionLabelSetMatchesEnAndKo() {
+    #expect(AXLocalePolicy.newTrackSheetDescription.matches("New Track"))
+    #expect(AXLocalePolicy.newTrackSheetDescription.matches("새로운 트랙"))
+    #expect(!AXLocalePolicy.newTrackSheetDescription.matches("Some Other Sheet"))
+    // Diacritic-SENSITIVE: an accented English variant must NOT match.
+    #expect(!AXLocalePolicy.newTrackSheetDescription.matches("Nèw Track"))
+}
+
+@Test func testDeleteTracksPrimaryButtonLabelSetEnglishOnly() {
+    #expect(AXLocalePolicy.deleteTracksPrimaryButton.matches("Delete Tracks and Content"))
+    // KO variant intentionally absent (unverified) — must not match a guess.
+    #expect(!AXLocalePolicy.deleteTracksPrimaryButton.matches("트랙 및 콘텐츠 삭제"))
 }


### PR DESCRIPTION
## Fixes #350 — modal-wedge reconciler was English-label-only

Follow-up to #346/#347/#348. The reconciler matched English button titles (`Create`/`Cancel`/`Delete `) and description (`New Track`) literally, so on **non-English (Korean) Logic** (`생성`/`취소`/`새로운 트랙`) `classify` returned `.unknownSheet` → no reconciliation → **Korean Logic still wedged**. The maintainer's system is `ko-KR`. Caught by live en/ko qualification.

### Fix — locale-aware via AXLocalePolicy
- 3 new `LabelSet`s: `createButton` (Create/생성), `newTrackSheetDescription` (New Track/새로운 트랙), `deleteTracksPrimaryButton` (Delete Tracks and Content; KO variant TBD); reused `cancelButton` (Cancel/취소). `.exact` matching — case-insensitive, **diacritic-sensitive**.
- `readModalSignals` resolves each button/description via the LabelSets and **captures the actual on-screen titles**; the executor clicks the **captured localized title** (생성/Create), not a hardcoded string. `deleteConfirmButtonPresent` = LabelSet match OR the structural `"Delete "` prefix.
- Additive, no flag. KO delete-confirm labels not yet captured → that path degrades to fail-closed + `sendReturnKey` default-button fallback (safe, never a fabricated guess). The New Track sheet (the live-captured #350 case) is fully KO-aware.

### Verification
- **Unit**: `ModalReconciliation` **35/35** (28 + 7 locale); `LocalePolicy` 25/25; **221/221** across Modal/Locale/Track; no regressions.
- **Live (real Logic 12.3, both locales)**: delete-to-zero mandatory New Track sheet → detected + auto-Created (`reconciled=mandatory_new_track`, `new_track_dialog_auto_confirmed=true`), **no wedge** — confirmed in **Korean** (생성/새로운 트랙) AND **English** (no regression).

Refs #308.
