### PR TITLE
feat(adr-002): resolve target_ref across all track/mixer/plugin mutations (#285)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -6,6 +6,13 @@ import MCP
 /// `index` on mutating track commands where falling through to track 0
 /// would edit the wrong track on a malformed caller request.
 func intParamOrNil(_ params: [String: Value], _ keys: String...) -> Int? {
+    intParamOrNil(params, keys: keys)
+}
+
+/// Array-keyed companion to the variadic `intParamOrNil`, so callers that build
+/// their alias list dynamically (e.g. the ADR-002 `target_ref` resolver) share
+/// the exact same coercion + alias-conflict semantics.
+func intParamOrNil(_ params: [String: Value], keys: [String]) -> Int? {
     var selected: Int?
     for key in keys {
         guard let raw = params[key] else { continue }

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -4,7 +4,7 @@ import MCP
 struct MixerDispatcher {
     static let tool = commandTool(
         name: "logic_mixer",
-        description: "Mixer actions in Logic Pro. Commands: set_volume, set_pan, set_master_volume, set_plugin_param, insert_plugin. BREAKING since v3.3.0: every mutating command requires explicit `track` (Int ≥ 0) — pre-v3.3.0 missing `track` defaulted to 0 and silently mutated the first track; this now returns an error. Params: set_volume -> { track: Int (required, ≥ 0), value: Float (0.0..1.0) } verified against the visible mixer strip via AX readback; set_pan -> { track: Int (required, ≥ 0), value: Float (-1.0..1.0) } verified against the visible mixer strip via AX readback; set_master_volume -> { value: Float (0.0..1.0) } — the master fader has no AX track-header equivalent, so MCU echo is the ONLY readback: State A only when a fresh echo lands, otherwise honest State B echo_timeout with readback_source:mcu_echo + a surface_limitation note (non-deterministic, not a recoverable failure); set_plugin_param -> { track: Int (required, ≥ 0), insert: Int (required, currently only 0), param: Int (required, ≥ 0), value: Float (required) } on the selected track via Scripter; insert_plugin -> { track: Int, slot: Int, plugin_name: Gain|Compressor|Channel EQ, confirmed: true } via AX mixer slot with readback.",
+        description: "Mixer actions in Logic Pro. Commands: set_volume, set_pan, set_master_volume, set_plugin_param, insert_plugin. BREAKING since v3.3.0: every mutating command requires explicit `track` (Int ≥ 0) — pre-v3.3.0 missing `track` defaulted to 0 and silently mutated the first track; this now returns an error. Params: set_volume -> { track: Int (required, ≥ 0), value: Float (0.0..1.0) } verified against the visible mixer strip via AX readback; set_pan -> { track: Int (required, ≥ 0), value: Float (-1.0..1.0) } verified against the visible mixer strip via AX readback; set_master_volume -> { value: Float (0.0..1.0) } — the master fader has no AX track-header equivalent, so MCU echo is the ONLY readback: State A only when a fresh echo lands, otherwise honest State B echo_timeout with readback_source:mcu_echo + a surface_limitation note (non-deterministic, not a recoverable failure); set_plugin_param -> { track: Int (required, ≥ 0), insert: Int (required, currently only 0), param: Int (required, ≥ 0), value: Float (required) } on the selected track via Scripter; insert_plugin -> { track: Int, slot: Int, plugin_name: Gain|Compressor|Channel EQ, confirmed: true } via AX mixer slot with readback. ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_volume and set_pan ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) that resolves to the addressed track's mixer strip in place of the explicit track/index; when both target_ref and track/index are supplied they must agree or the op fails closed (stale_target_reference); with the flag off target_ref is ignored and the explicit track/index remains required.",
         commandDescription: "Mixer command to execute"
     )
 
@@ -12,7 +12,8 @@ struct MixerDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        targetRegistry: TargetRegistry? = nil
     ) async -> CallTool.Result {
         switch command {
         case "set_volume":
@@ -20,10 +21,24 @@ struct MixerDispatcher {
             // missing `track` to 0, so a malformed caller silently mutated
             // the first track's fader. Mixer writes are not undoable from
             // the operator's seat — missing/invalid target now fails closed.
-            guard let index = intParamOrNil(params, "track", "index"), index >= 0 else {
-                return toolInvalidParamsResult(
+            // ADR-002: with the flag on, a target_ref resolves to the track
+            // whose (trackIndex-keyed) mixer strip is addressed; flag off →
+            // explicit track/index required (byte-identical to prior behaviour).
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "mixer.set_volume",
+                indexKeys: ["track", "index"],
+                invalidIndexResult: toolInvalidParamsResult(
                     "set_volume requires explicit 'track' or non-conflicting 'index' (Int >= 0)"
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             guard let volume = doubleParamOrNil(params, "value", "volume") else {
                 return toolInvalidParamsResult(
@@ -45,10 +60,24 @@ struct MixerDispatcher {
 
         case "set_pan":
             // RB-1.a — same fail-closed treatment as set_volume.
-            guard let index = intParamOrNil(params, "track", "index"), index >= 0 else {
-                return toolInvalidParamsResult(
+            // ADR-002: target_ref (flag on) resolves to the addressed track's
+            // (trackIndex-keyed) mixer strip; flag off → explicit track/index
+            // required (byte-identical to prior behaviour).
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "mixer.set_pan",
+                indexKeys: ["track", "index"],
+                invalidIndexResult: toolInvalidParamsResult(
                     "set_pan requires explicit 'track' or non-conflicting 'index' (Int >= 0)"
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             guard let pan = doubleParamOrNil(params, "value", "pan") else {
                 return toolInvalidParamsResult(

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -38,7 +38,7 @@ final class VerifiedOpGate: @unchecked Sendable {
 struct PluginsDispatcher {
     static let tool = commandTool(
         name: "logic_plugins",
-        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required) }. mode confirmed_live is not supported in Release 1 (State C unsupported_mode).",
+        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required) }. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_param_verified ALSO accepts a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) that resolves the host track in place of the explicit track; when both target_ref and track are supplied they must agree or the op fails closed (stale_target_reference); with the flag off target_ref is ignored and the explicit track remains required.",
         commandDescription: "Verified plugin command to execute"
     )
 
@@ -64,8 +64,32 @@ struct PluginsDispatcher {
 
         case "set_param_verified":
             return await runVerified(operation: "plugin.set_param_verified") {
-                await routedTextResult(router, operation: "plugin.set_param_verified",
-                                       params: verifiedWriteParams(params))
+                var writeParams = verifiedWriteParams(params)
+                // ADR-002: with the flag on, a target_ref resolves the host track
+                // (verified plugin writes are trackIndex-keyed) and overrides the
+                // forwarded `track`; a stale/wrong-kind ref fails closed BEFORE any
+                // AX write. Flag off or no target_ref → params are forwarded
+                // unchanged and the channel performs its own HC v2 track
+                // validation (byte-identical to prior behaviour).
+                if FeatureFlags.adr002TargetRef, params["target_ref"] != nil {
+                    switch await TargetRefResolver.resolveMutationIndex(
+                        params,
+                        targetRegistry: targetRegistry,
+                        cache: cache,
+                        operation: "logic_plugins.set_param_verified",
+                        indexKeys: ["track"],
+                        invalidIndexResult: toolInvalidParamsResult(
+                            "set_param_verified requires explicit 'track' (Int >= 0)"
+                        )
+                    ) {
+                    case .success(let resolved):
+                        writeParams["track"] = String(resolved.index)
+                    case .failure(let result):
+                        return result
+                    }
+                }
+                return await routedTextResult(router, operation: "plugin.set_param_verified",
+                                              params: writeParams)
             }
 
         case "insert_verified":

--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -1,0 +1,106 @@
+import Foundation
+import MCP
+
+/// ADR-002 (#285, part of #308): shared session-stable `target_ref` → track
+/// index resolver for track / mixer / plugin mutations.
+///
+/// Extracted verbatim from `logic_tracks rename`'s original inline logic so that
+/// every index-keyed mutation can ALSO accept an opaque `trk_…` reference behind
+/// `FeatureFlags.adr002TargetRef`, while the flag-off / no-`target_ref` path
+/// stays byte-identical to the prior explicit-index behaviour.
+enum TargetRefResolver {
+    /// A resolved mutation target: the concrete track index plus — when the
+    /// caller supplied a valid `target_ref` — the reference that produced it, so
+    /// the dispatcher can echo `track_ref` back (as `rename` does).
+    struct Resolved {
+        let index: Int
+        let reference: TargetReference?
+    }
+
+    /// Resolution outcome. A dedicated enum (rather than `Swift.Result`) because
+    /// the failure payload is a `CallTool.Result` envelope, which is not an
+    /// `Error`. `.failure` carries the fully-formed fail-closed tool result the
+    /// dispatcher returns verbatim.
+    enum Outcome {
+        case success(Resolved)
+        case failure(CallTool.Result)
+    }
+
+    /// Resolve the target track index for a mutation.
+    ///
+    /// Flag ON **and** `target_ref` present:
+    ///   1. Trim the raw reference; require non-empty + a live `TargetRegistry`.
+    ///   2. `resolve` it and require `binding.kind == requiredKind`.
+    ///   3. Optional cross-check: if an explicit index alias (`indexKeys`) is
+    ///      ALSO present it must be ≥ 0 and equal the bound track index.
+    ///   4. Drift check: the live cache must still hold a track at the bound
+    ///      index whose fingerprint matches the one observed at bind time.
+    ///   Any failure fails closed with `staleTargetReferenceResult` — never a
+    ///   wrong-target mutation.
+    ///
+    /// Flag OFF **or** no `target_ref`: require an explicit non-negative index
+    /// from `indexKeys`; on missing/malformed/negative return the caller's own
+    /// `invalidIndexResult` (an autoclosure, so the exact prior error shape is
+    /// preserved byte-for-byte and only built when actually needed).
+    static func resolveMutationIndex(
+        _ params: [String: Value],
+        targetRegistry: TargetRegistry?,
+        cache: StateCache,
+        operation: String,
+        indexKeys: [String] = ["index", "track"],
+        requiredKind: TargetKind = .track,
+        invalidIndexResult: @autoclosure () -> CallTool.Result
+    ) async -> Outcome {
+        if FeatureFlags.adr002TargetRef, params["target_ref"] != nil {
+            let rawReference = params["target_ref"]?.stringValue?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let rawReference,
+                  !rawReference.isEmpty,
+                  let targetRegistry,
+                  let binding = await targetRegistry.resolve(TargetReference(rawValue: rawReference)),
+                  binding.kind == requiredKind
+            else {
+                return .failure(staleTargetReferenceResult(rawReference, operation: operation))
+            }
+
+            if indexKeys.contains(where: { params[$0] != nil }) {
+                guard let requestedIndex = intParamOrNil(params, keys: indexKeys),
+                      requestedIndex >= 0,
+                      requestedIndex == binding.descriptor.trackIndex
+                else {
+                    return .failure(staleTargetReferenceResult(rawReference, operation: operation))
+                }
+            }
+
+            let tracks = await cache.getTracks()
+            guard let track = tracks.first(where: { $0.id == binding.descriptor.trackIndex }),
+                  TargetDescriptor(trackIndex: track.id, trackName: track.name).fingerprint
+                    == binding.observedFingerprint
+            else {
+                return .failure(staleTargetReferenceResult(rawReference, operation: operation))
+            }
+            return .success(Resolved(index: binding.descriptor.trackIndex, reference: binding.reference))
+        }
+
+        guard let requestedIndex = intParamOrNil(params, keys: indexKeys), requestedIndex >= 0 else {
+            return .failure(invalidIndexResult())
+        }
+        return .success(Resolved(index: requestedIndex, reference: nil))
+    }
+
+    /// Fail-closed State C for a `target_ref` that is missing/malformed, no longer
+    /// in the registry (session / project-epoch / topology drift), a wrong-kind
+    /// binding, or that no longer identifies the requested current track. Mirrors
+    /// the exact shape `logic_tracks rename` has always emitted, with `operation`
+    /// parameterised so each surface reports its own op.
+    static func staleTargetReferenceResult(_ rawReference: String?, operation: String) -> CallTool.Result {
+        toolStateCResult(
+            .staleTargetReference,
+            hint: "target_ref is stale or does not identify the requested current track",
+            extras: [
+                "operation": operation,
+                "target_ref": rawReference ?? "",
+            ]
+        )
+    }
+}

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -6,7 +6,7 @@ struct TrackDispatcher {
 
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, when LOGIC_MCP_ADR002_TARGET_REF=1, { name: String, target_ref: String, index?: Int }; when the flag is off target_ref is ignored and index remains required; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, when LOGIC_MCP_ADR002_TARGET_REF=1, { name: String, target_ref: String, index?: Int }; when the flag is off target_ref is ignored and index remains required; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim|off }; set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); with the flag off target_ref is ignored and the explicit index remains required.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -33,6 +33,31 @@ struct TrackDispatcher {
             // `index` is supplied but not a valid non-negative integer, fail
             // closed — silently falling back to track 0 on a malformed
             // request would corrupt the wrong track.
+            // ADR-002: when the flag is on and a target_ref is supplied, resolve
+            // it to the current track index (fail-closed on stale/wrong-kind);
+            // flag off or no target_ref falls through to the byte-identical
+            // index/name flow below.
+            if FeatureFlags.adr002TargetRef, params["target_ref"] != nil {
+                switch await TargetRefResolver.resolveMutationIndex(
+                    params,
+                    targetRegistry: targetRegistry,
+                    cache: cache,
+                    operation: "track.select",
+                    invalidIndexResult: toolInvalidParamsResult(
+                        "select requires 'index' or 'name' param",
+                        extras: ["operation": "track.select"]
+                    )
+                ) {
+                case .success(let resolved):
+                    let result = await router.route(
+                        operation: "track.select",
+                        params: ["index": String(resolved.index)]
+                    )
+                    return toolTextResult(result)
+                case .failure(let result):
+                    return result
+                }
+            }
             if params["index"] != nil || params["track"] != nil {
                 guard let index = intParamOrNil(params, "index", "track") else {
                     return toolInvalidParamsResult(
@@ -85,11 +110,21 @@ struct TrackDispatcher {
             return toolTextResult(result)
 
         case "delete":
-            guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-                return toolInvalidParamsResult(
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.delete",
+                invalidIndexResult: toolInvalidParamsResult(
                     "delete requires explicit 'index' (Int ≥ 0)",
                     extras: ["operation": "track.delete"]
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             let selectResult = await router.route(
                 operation: "track.select",
@@ -126,11 +161,21 @@ struct TrackDispatcher {
             return toolTextResult(result)
 
         case "duplicate":
-            guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-                return toolInvalidParamsResult(
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.duplicate",
+                invalidIndexResult: toolInvalidParamsResult(
                     "duplicate requires explicit 'index' (Int ≥ 0)",
                     extras: ["operation": "track.duplicate"]
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             let selectResult = await router.route(
                 operation: "track.select",
@@ -168,45 +213,21 @@ struct TrackDispatcher {
         case "rename":
             let index: Int
             let resolvedReference: TargetReference?
-            if FeatureFlags.adr002TargetRef, params["target_ref"] != nil {
-                let rawReference = params["target_ref"]?.stringValue?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                guard let rawReference,
-                      !rawReference.isEmpty,
-                      let targetRegistry,
-                      let binding = await targetRegistry.resolve(TargetReference(rawValue: rawReference)),
-                      binding.kind == .track
-                else {
-                    return staleTargetReferenceResult(rawReference)
-                }
-
-                if params["index"] != nil || params["track"] != nil {
-                    guard let requestedIndex = intParamOrNil(params, "index", "track"),
-                          requestedIndex >= 0,
-                          requestedIndex == binding.descriptor.trackIndex
-                    else {
-                        return staleTargetReferenceResult(rawReference)
-                    }
-                }
-
-                let tracks = await cache.getTracks()
-                guard let track = tracks.first(where: { $0.id == binding.descriptor.trackIndex }),
-                      TargetDescriptor(trackIndex: track.id, trackName: track.name).fingerprint
-                        == binding.observedFingerprint
-                else {
-                    return staleTargetReferenceResult(rawReference)
-                }
-                index = binding.descriptor.trackIndex
-                resolvedReference = binding.reference
-            } else {
-                guard let requestedIndex = intParamOrNil(params, "index", "track"), requestedIndex >= 0 else {
-                    return toolInvalidParamsResult(
-                        "rename requires explicit 'index' (Int ≥ 0)",
-                        extras: ["operation": "track.rename"]
-                    )
-                }
-                index = requestedIndex
-                resolvedReference = nil
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: toolInvalidParamsResult(
+                    "rename requires explicit 'index' (Int ≥ 0)",
+                    extras: ["operation": "track.rename"]
+                )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+                resolvedReference = resolved.reference
+            case .failure(let result):
+                return result
             }
             let name = stringParam(params, "name")
             guard !name.isEmpty else {
@@ -271,6 +292,8 @@ struct TrackDispatcher {
                 operation: "track.set_mute",
                 params: params,
                 router: router,
+                cache: cache,
+                targetRegistry: targetRegistry,
                 traceID: traceID
             )
             return await finalizeTrace(result, traceID: traceID)
@@ -282,6 +305,8 @@ struct TrackDispatcher {
                 operation: "track.set_solo",
                 params: params,
                 router: router,
+                cache: cache,
+                targetRegistry: targetRegistry,
                 traceID: traceID
             )
             return await finalizeTrace(result, traceID: traceID)
@@ -293,6 +318,8 @@ struct TrackDispatcher {
                 operation: "track.set_arm",
                 params: params,
                 router: router,
+                cache: cache,
+                targetRegistry: targetRegistry,
                 traceID: traceID
             )
             return await finalizeTrace(result, traceID: traceID)
@@ -305,11 +332,21 @@ struct TrackDispatcher {
             return result
 
         case "arm_only":
-            guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-                return toolInvalidParamsResult(
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.arm_only",
+                invalidIndexResult: toolInvalidParamsResult(
                     "arm_only requires explicit 'index' (Int ≥ 0)",
                     extras: ["operation": "track.arm_only"]
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             let tracks = await cache.getTracks()
             var disarmed: [Int] = []
@@ -413,11 +450,21 @@ struct TrackDispatcher {
             return notExposedCommandResult(operation: "track.set_color")
 
         case "set_automation":
-            guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-                return toolInvalidParamsResult(
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.set_automation",
+                invalidIndexResult: toolInvalidParamsResult(
                     "set_automation requires explicit 'index' (Int ≥ 0)",
                     extras: ["operation": "track.set_automation"]
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             guard params["mode"] != nil else {
                 return toolInvalidParamsResult(
@@ -440,11 +487,22 @@ struct TrackDispatcher {
             return toolTextResult(result)
 
         case "set_instrument":
-            guard let index = intParamOrNil(params, "index"), index >= 0 else {
-                return toolInvalidParamsResult(
+            let index: Int
+            switch await TargetRefResolver.resolveMutationIndex(
+                params,
+                targetRegistry: targetRegistry,
+                cache: cache,
+                operation: "track.set_instrument",
+                indexKeys: ["index"],
+                invalidIndexResult: toolInvalidParamsResult(
                     "set_instrument requires explicit 'index' (Int ≥ 0)",
                     extras: ["operation": "track.set_instrument"]
                 )
+            ) {
+            case .success(let resolved):
+                index = resolved.index
+            case .failure(let result):
+                return result
             }
             let category = stringParam(params, "category")
             let preset = stringParam(params, "preset")
@@ -553,13 +611,25 @@ struct TrackDispatcher {
         operation: String,
         params: [String: Value],
         router: ChannelRouter,
+        cache: StateCache,
+        targetRegistry: TargetRegistry?,
         traceID: TraceID? = nil
     ) async -> CallTool.Result {
-        guard let index = intParamOrNil(params, "index", "track"), index >= 0 else {
-            return toolInvalidParamsResult(
+        let index: Int
+        switch await TargetRefResolver.resolveMutationIndex(
+            params,
+            targetRegistry: targetRegistry,
+            cache: cache,
+            operation: operation,
+            invalidIndexResult: toolInvalidParamsResult(
                 "\(command) requires explicit 'index' (Int ≥ 0)",
                 extras: ["operation": operation]
             )
+        ) {
+        case .success(let resolved):
+            index = resolved.index
+        case .failure(let result):
+            return result
         }
         let enabled: Bool
         if params["enabled"] != nil {
@@ -644,17 +714,6 @@ struct TrackDispatcher {
         let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
         guard merged != raw else { return result }
         return toolTextResult(merged, isError: result.isError == true)
-    }
-
-    private static func staleTargetReferenceResult(_ rawReference: String?) -> CallTool.Result {
-        toolStateCResult(
-            .staleTargetReference,
-            hint: "target_ref is stale or does not identify the requested current track",
-            extras: [
-                "operation": "track.rename",
-                "target_ref": rawReference ?? "",
-            ]
-        )
     }
 
     private static func modalGuardedTrackOperation(for command: String) -> String? {

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -409,7 +409,7 @@ actor LogicProServer {
                             dialogPresent: dialogPresent
                         )
                     case "logic_mixer":
-                        return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
+                        return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, targetRegistry: targetRegistry)
                     case "logic_midi":
                         return await MIDIDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
                     case "logic_edit":

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -1,0 +1,715 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+// ADR-002 (#285, part of #308): `target_ref` resolution extended from
+// `logic_tracks rename` to ALL track / mixer / plugin mutations behind
+// `FeatureFlags.adr002TargetRef`. These synthetic, deterministic tests lock in:
+//   * the shared `TargetRefResolver` resolution + fail-closed matrix,
+//   * per-command-family wiring (flag-on resolves the correct index),
+//   * flag-off byte-identity (target_ref ignored, explicit index required),
+//   * the #308 wrong-target negative guarantees (never a wrong-target mutation).
+
+private actor RecordingChannel: Channel {
+    nonisolated let id: ChannelID
+    private let succeeds: Bool
+    private(set) var executedOps: [(String, [String: String])] = []
+
+    init(id: ChannelID, succeeds: Bool = true) {
+        self.id = id
+        self.succeeds = succeeds
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        guard succeeds else { return .error("synthetic failure") }
+        return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "target-ref recording channel")
+    }
+}
+
+@Suite(.serialized)
+struct TargetRefResolutionTests {
+    // Every op touched here has `.accessibility` first in its routing chain
+    // except track.set_automation (.mcu) and track.duplicate (.midiKeyCommands),
+    // so recorders on this union observe every routed write.
+    private static let recorderIDs: [ChannelID] =
+        [.accessibility, .mcu, .midiKeyCommands, .cgEvent, .scripter]
+
+    private func makeRouter(succeeds: Bool = true) async -> (ChannelRouter, [RecordingChannel]) {
+        let channels = Self.recorderIDs.map { RecordingChannel(id: $0, succeeds: succeeds) }
+        let router = ChannelRouter()
+        for channel in channels { await router.register(channel) }
+        return (router, channels)
+    }
+
+    private func allOps(_ channels: [RecordingChannel]) async -> [(String, [String: String])] {
+        var out: [(String, [String: String])] = []
+        for channel in channels { out.append(contentsOf: await channel.executedOps) }
+        return out
+    }
+
+    private func opParams(
+        _ channels: [RecordingChannel],
+        _ operation: String
+    ) async -> [String: String]? {
+        await allOps(channels).first(where: { $0.0 == operation })?.1
+    }
+
+    private func boundTrack(
+        index: Int = 2,
+        name: String = "Bass"
+    ) async -> (TargetRegistry, StateCache, TargetReference) {
+        let registry = TargetRegistry()
+        let descriptor = TargetDescriptor(trackIndex: index, trackName: name)
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        let cache = StateCache()
+        await cache.updateTracks([
+            TrackState(id: 0, name: "Kick", type: .audio),
+            TrackState(id: 1, name: "Snare", type: .audio),
+            TrackState(id: index, name: name, type: .audio),
+        ])
+        return (registry, cache, reference)
+    }
+
+    private func errorCode(_ result: CallTool.Result) -> String? {
+        sharedJSONObject(sharedToolText(result))?["error"] as? String
+    }
+
+    private func dummyInvalid() -> CallTool.Result {
+        toolInvalidParamsResult("resolver-test: explicit index required")
+    }
+
+    // MARK: - Resolver unit: positive resolution
+
+    @Test
+    func testResolverFlagOnValidReferenceResolvesIndexAndEchoesReference() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .success(let resolved) = outcome else {
+                Issue.record("expected success")
+                return
+            }
+            #expect(resolved.index == 2)
+            #expect(resolved.reference == reference)
+        }
+    }
+
+    @Test
+    func testResolverFlagOnNoTargetRefUsesExplicitIndex() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, _) = await boundTrack()
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["index": .int(3)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.delete",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .success(let resolved) = outcome else {
+                Issue.record("expected success")
+                return
+            }
+            #expect(resolved.index == 3)
+            #expect(resolved.reference == nil)
+        }
+    }
+
+    @Test
+    func testResolverMatchingCrossCheckSucceeds() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue), "index": .int(2)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .success(let resolved) = outcome else {
+                Issue.record("expected success")
+                return
+            }
+            #expect(resolved.index == 2)
+            #expect(resolved.reference == reference)
+        }
+    }
+
+    // MARK: - Resolver unit: flag-off byte-identity
+
+    @Test
+    func testResolverFlagOffIgnoresTargetRefAndUsesIndex() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue), "index": .int(5)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.delete",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .success(let resolved) = outcome else {
+                Issue.record("expected success")
+                return
+            }
+            #expect(resolved.index == 5)
+            #expect(resolved.reference == nil)
+        }
+    }
+
+    @Test
+    func testResolverFlagOffTargetRefWithoutIndexFailsInvalidParams() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack()
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.delete",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "invalid_params")
+        }
+    }
+
+    // MARK: - Resolver unit: wrong-target negatives (#308 done-bar)
+
+    @Test
+    func testResolverStaleReferenceFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack()
+            await registry.bumpTopologyGeneration()
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "stale_target_reference")
+        }
+    }
+
+    @Test
+    func testResolverEmptyAndUnknownReferenceFailClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, _) = await boundTrack()
+            for raw in ["   ", "", "trk_not_a_real_reference"] {
+                let outcome = await TargetRefResolver.resolveMutationIndex(
+                    ["target_ref": .string(raw)],
+                    targetRegistry: registry,
+                    cache: cache,
+                    operation: "track.rename",
+                    invalidIndexResult: dummyInvalid()
+                )
+                guard case .failure(let result) = outcome else {
+                    Issue.record("expected failure for '\(raw)'")
+                    continue
+                }
+                #expect(errorCode(result) == "stale_target_reference")
+            }
+        }
+    }
+
+    @Test
+    func testResolverWrongKindBindingFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = TargetDescriptor(trackIndex: 2, trackName: "Bass")
+            // A non-track binding (mixer strip) must not satisfy a .track resolve.
+            let mixReference = await registry.bind(
+                kind: .mixerStrip,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+            let cache = StateCache()
+            await cache.updateTracks([TrackState(id: 2, name: "Bass", type: .audio)])
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(mixReference.rawValue)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                requiredKind: .track,
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "stale_target_reference")
+        }
+    }
+
+    @Test
+    func testResolverMismatchedIndexCrossCheckFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue), "index": .int(1)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "stale_target_reference")
+        }
+    }
+
+    @Test
+    func testResolverNegativeCrossCheckIndexFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue), "index": .int(-1)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "stale_target_reference")
+        }
+    }
+
+    @Test
+    func testResolverDriftedFingerprintFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let registry = TargetRegistry()
+            let descriptor = TargetDescriptor(trackIndex: 2, trackName: "Bass")
+            let reference = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+            // The live track at index 2 was renamed out from under the ref.
+            let cache = StateCache()
+            await cache.updateTracks([TrackState(id: 2, name: "Lead Synth", type: .audio)])
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["target_ref": .string(reference.rawValue)],
+                targetRegistry: registry,
+                cache: cache,
+                operation: "track.rename",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "stale_target_reference")
+        }
+    }
+
+    @Test
+    func testResolverFlagOffNegativeIndexFailsInvalidParams() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let outcome = await TargetRefResolver.resolveMutationIndex(
+                ["index": .int(-1)],
+                targetRegistry: nil,
+                cache: StateCache(),
+                operation: "track.delete",
+                invalidIndexResult: dummyInvalid()
+            )
+            guard case .failure(let result) = outcome else {
+                Issue.record("expected failure")
+                return
+            }
+            #expect(errorCode(result) == "invalid_params")
+        }
+    }
+
+    // MARK: - Track dispatcher wiring (flag on resolves; flag off byte-identical)
+
+    @Test
+    func testTrackSelectFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "select",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.select") == ["index": "2"])
+        }
+    }
+
+    @Test
+    func testTrackSelectFlagOffIgnoresTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "select",
+                params: ["index": .int(1), "target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            // target_ref (which points at 2) is ignored; explicit index 1 wins.
+            #expect(await opParams(channels, "track.select") == ["index": "1"])
+        }
+    }
+
+    @Test
+    func testTrackSelectFlagOnStaleReferenceFailsClosedNoWrite() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            await registry.bumpTopologyGeneration()
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "select",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "stale_target_reference")
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+
+    @Test
+    func testTrackDeleteFlagOnStaleReferenceFailsClosedBeforeSelectSideEffect() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            await registry.bumpProjectEpoch()
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "delete",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "stale_target_reference")
+            // The pre-delete track.select side effect must NOT have fired.
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+
+    @Test
+    func testTrackDeleteFlagOnResolvesTargetRefToSelectIndex() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "delete",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.select") == ["index": "2"])
+            #expect(await allOps(channels).contains(where: { $0.0 == "track.delete" }))
+        }
+    }
+
+    @Test
+    func testTrackDuplicateFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "duplicate",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.select") == ["index": "2"])
+            #expect(await allOps(channels).contains(where: { $0.0 == "track.duplicate" }))
+        }
+    }
+
+    @Test
+    func testTrackMuteFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "mute",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.set_mute") == ["index": "2", "enabled": "true"])
+        }
+    }
+
+    @Test
+    func testTrackMuteFlagOffRequiresIndex() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "mute",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "invalid_params")
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+
+    @Test
+    func testTrackArmOnlyFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "arm_only",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.set_arm") == ["index": "2", "enabled": "true"])
+        }
+    }
+
+    @Test
+    func testTrackSetAutomationFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "set_automation",
+                params: ["target_ref": .string(reference.rawValue), "mode": .string("read")],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.set_automation") == ["index": "2", "mode": "read"])
+        }
+    }
+
+    @Test
+    func testTrackSetInstrumentFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "set_instrument",
+                params: ["target_ref": .string(reference.rawValue), "path": .string("/x.patch")],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "track.set_instrument") == ["index": "2", "path": "/x.patch"])
+        }
+    }
+
+    @Test
+    func testTrackRenameFlagOnResolvesTargetRefAndEchoesTrackRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: ["target_ref": .string(reference.rawValue), "name": .string("Sub Bass")],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] as? String == reference.rawValue)
+            #expect(await opParams(channels, "track.rename") == ["index": "2", "name": "Sub Bass"])
+        }
+    }
+
+    // MARK: - Mixer dispatcher wiring
+
+    @Test
+    func testMixerSetVolumeFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await MixerDispatcher.handle(
+                command: "set_volume",
+                params: ["target_ref": .string(reference.rawValue), "value": .double(0.5)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "mixer.set_volume") == ["index": "2", "volume": "0.5"])
+        }
+    }
+
+    @Test
+    func testMixerSetVolumeFlagOffIgnoresTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await MixerDispatcher.handle(
+                command: "set_volume",
+                params: [
+                    "track": .int(1),
+                    "value": .double(0.5),
+                    "target_ref": .string(reference.rawValue),
+                ],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "mixer.set_volume") == ["index": "1", "volume": "0.5"])
+        }
+    }
+
+    @Test
+    func testMixerSetPanFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await MixerDispatcher.handle(
+                command: "set_pan",
+                params: ["target_ref": .string(reference.rawValue), "value": .double(-0.25)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "mixer.set_pan") == ["index": "2", "pan": "-0.25"])
+        }
+    }
+
+    @Test
+    func testMixerSetVolumeFlagOnStaleReferenceFailsClosedNoWrite() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            await registry.bumpTopologyGeneration()
+            let (router, channels) = await makeRouter()
+            let result = await MixerDispatcher.handle(
+                command: "set_volume",
+                params: ["target_ref": .string(reference.rawValue), "value": .double(0.5)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "stale_target_reference")
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+
+    // MARK: - Plugin dispatcher wiring
+
+    private func verifiedParams(track: Int?, targetRef: String?) -> [String: Value] {
+        var params: [String: Value] = [
+            "insert": .int(0),
+            "plugin": .string("logic.stock.gain"),
+            "param": .string("gain_db"),
+            "value": .double(0.5),
+            "unit": .string("db"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string("/tmp/project.logicx"),
+        ]
+        if let track { params["track"] = .int(track) }
+        if let targetRef { params["target_ref"] = .string(targetRef) }
+        return params
+    }
+
+    @Test
+    func testPluginSetParamVerifiedFlagOnResolvesTargetRef() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await PluginsDispatcher.handle(
+                command: "set_param_verified",
+                params: verifiedParams(track: nil, targetRef: reference.rawValue),
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            #expect(await opParams(channels, "plugin.set_param_verified")?["track"] == "2")
+        }
+    }
+
+    @Test
+    func testPluginSetParamVerifiedFlagOffForwardsTrackUnchanged() async {
+        await FeatureFlags.withAdr002TargetRefForTests(false) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            let (router, channels) = await makeRouter()
+            let result = await PluginsDispatcher.handle(
+                command: "set_param_verified",
+                params: verifiedParams(track: 3, targetRef: reference.rawValue),
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == false)
+            // target_ref (pointing at 2) is ignored; explicit track 3 forwarded.
+            #expect(await opParams(channels, "plugin.set_param_verified")?["track"] == "3")
+        }
+    }
+
+    @Test
+    func testPluginSetParamVerifiedFlagOnStaleReferenceFailsClosedNoWrite() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2)
+            await registry.bumpProjectEpoch()
+            let (router, channels) = await makeRouter()
+            let result = await PluginsDispatcher.handle(
+                command: "set_param_verified",
+                params: verifiedParams(track: nil, targetRef: reference.rawValue),
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "stale_target_reference")
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## ADR-002 (#285, part of #308) — resolve `target_ref` across all track/mixer/plugin mutations

`target_ref` (session-stable opaque `trk_…` reference) was resolved only by `logic_tracks rename`. This extends it to **all 13 index-keyed mutations**, behind the existing `FeatureFlags.adr002TargetRef` — additive, flag-gated, **flag-off byte-identical**.

### Change
- New shared resolver `TargetRefResolver.resolveMutationIndex(...)` (`Dispatchers/TargetRefResolution.swift`), extracted verbatim from rename's inline logic: resolve → `.track` kind gate → optional index cross-check → live-cache fingerprint drift check → fail-closed via `staleTargetReferenceResult` (never a wrong-target mutation). Flag-off / no-`target_ref` preserves each caller's exact prior `invalid_params` shape (autoclosure).
- Adopted by **logic_tracks** (select, delete, duplicate, rename, mute, solo, arm, arm_only, set_automation, set_instrument), **logic_mixer** (set_volume, set_pan → resolve track → trackIndex-keyed strip), **logic_plugins** (set_param_verified → resolve host track). All three dispatchers reach `targetRegistry` (no parallel registry).

### Wrong-target negative matrix (#308 002 done-bar) — all typed fail-closed, no write
stale ref / malformed / empty / wrong-kind / target_ref+mismatching index / negative cross-check / drifted fingerprint → State C `stale_target_reference`. flag-off variants byte-identical.

### Verification
- `swift build` GREEN; filtered gate `swift test --no-parallel --filter "TargetRef|Track|Mixer|Plugin"` **505 tests, 0 failures** (incl. 31 new + rename regression guard); +214 more across other dispatchers, 0 failures.
- (Full `swift test --no-parallel` wedges on this machine's documented install-script/AppleScript environmental hang — CI + filtered runs are authoritative; 0 failures recorded.)
- Live qualification (CTO): target_ref resolves + fail-closes across all commands on real Logic — see PR checks.

### Honest notes
- `logic_plugins set_param_verified` stale-ref reuses `staleTargetReferenceResult` (HC v1 State C) per the reuse constraint; fully typed + fail-closed. No `track_ref` echo added to the newly-extended commands (rename keeps its existing echo) to avoid response-shape changes.

Refs #308.
