### PR TITLE
test(adr-003): permanent 100% operation-spec coverage + legacy-map equivalence gate (#286)

### DIFF
--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import LogicProMCP
+
+@Suite("OperationRegistry coverage")
+struct OperationRegistryCoverageTests {
+    private static func operationKey(tool: String, command: String) -> String {
+        "\(tool).\(command)"
+    }
+
+    private static var publicOperations: Set<String> {
+        Set(WorkflowSkillCatalog.publicCommands.flatMap { tool, commands in
+            commands.map { operationKey(tool: tool, command: $0) }
+        })
+    }
+
+    private static var registeredOperations: Set<String> {
+        Set(OperationRegistry.specs.map {
+            operationKey(tool: $0.tool.rawValue, command: $0.command)
+        })
+    }
+
+    @Test("registry exactly covers every public command")
+    func registryExactlyCoversEveryPublicCommand() {
+        let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
+        let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
+
+        #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
+        #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
+        #expect(missing.isEmpty, "missing specs: \(missing)")
+        #expect(orphans.isEmpty, "orphan specs: \(orphans)")
+        #expect(OperationRegistry.validationErrors().isEmpty)
+    }
+
+    @Test("registry mutability and deadlines equal flag-off legacy values for every public command")
+    func registryValuesEqualFlagOffLegacyValues() throws {
+        let registryMutations = Set(OperationRegistry.specs
+            .filter { $0.mutability == Mutability.`mutating` }
+            .map { Self.operationKey(tool: $0.tool.rawValue, command: $0.command) })
+        let legacyMutations = Set(LogicProServer.mutatingCommandsByTool.flatMap { tool, commands in
+            commands.map { Self.operationKey(tool: tool, command: $0) }
+        })
+        #expect(registryMutations == legacyMutations)
+
+        #expect(!FeatureFlags.adr003OperationRegistry)
+        for tool in WorkflowSkillCatalog.publicCommands.keys.sorted() {
+            #expect(!LogicProServer.usesOperationRegistry(tool: tool))
+            for command in WorkflowSkillCatalog.publicCommands[tool, default: []].sorted() {
+                let spec = try #require(OperationRegistry.spec(tool: tool, command: command))
+                let legacyMutating = LogicProServer.mutatingCommandsByTool[tool, default: []]
+                    .contains(command)
+                let registryDeadline = try #require(
+                    OperationRegistry.deadlineSeconds(tool: tool, command: command)
+                )
+
+                #expect((spec.mutability == Mutability.`mutating`) == legacyMutating)
+                #expect(registryDeadline == LogicProServer.commandDeadlineSeconds(
+                    tool: tool,
+                    command: command
+                ))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ADR-003 Stage 1 (#286, part of #308) — permanent 100%-coverage + legacy-equivalence gate

Investigation (this PR's finding): the registry **already carries an `OperationSpec` for all 99 public (tool, command) pairs** — what was missing is an **enforcement gate** that keeps it that way and proves the registry equals the legacy manual maps it will eventually replace.

### Change (tests only — zero source change)
New `Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift`:
- **Exact coverage**: census derived live from `WorkflowSkillCatalog.publicCommands` (99 commands, 10 tools) ↔ `OperationRegistry.specs` — missing 0, orphans 0, `validationErrors()` empty, tool key-set equality. Adding a command without a spec (or a spec without a command) now fails CI permanently.
- **Legacy equivalence** (flag-off truth): for every public command, registry `mutability` == `LogicProServer.mutatingCommandsByTool` membership and registry deadline == `LogicProServer.commandDeadlineSeconds` (short 80 / medium 9 / long 10). 0 mismatches. This de-risks Stage 2 (flipping registry to single-source and deleting the legacy maps): any future divergence is caught at PR time.
- Flag default-off + `usesOperationRegistry` false per tool asserted.

Census: 99 specs (83 mutating / 16 read-only). `swift build` green; `OperationRegistry` filter 51/51; census suite 5/5.

Stage 2 (legacy-map removal / single-source flip) is a separate follow-up, now gated by this equivalence proof.

Refs #308.
