### PR TITLE
fix(adr-002): target_ref survives verified server-performed rename (#353)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -268,6 +268,18 @@ struct TrackDispatcher {
                 )
             }
             if let resolvedReference {
+                // ADR-002 (#353): this verified rename ran THROUGH `resolvedReference`
+                // and changed the track's name — the exact field the drift check
+                // hashes — so rebind the ref in place. The causal chain (server-issued,
+                // read-back-verified rename via this ref) proves identity, letting the
+                // SAME ref keep addressing the track across its own rename. We are past
+                // the `verified == false` guard above, so only State A rebinds; State
+                // B/C (unverified/failed) never do. External (non-server) renames stay
+                // fail-closed via the unchanged drift check — see `TargetRegistry.rebind`.
+                await targetRegistry?.rebind(
+                    resolvedReference,
+                    to: TargetDescriptor(trackIndex: index, trackName: name)
+                )
                 if var payload = decodedJSONObject(result.message) {
                     payload["track_ref"] = resolvedReference.rawValue
                     return await finalizeTrace(
@@ -524,6 +536,14 @@ struct TrackDispatcher {
                 operation: "track.set_instrument",
                 params: routeParams
             )
+            // ADR-002 (#353): unlike `rename`, set_instrument does NOT rebind the
+            // target_ref. Loading a patch CAN make Logic auto-rename the track, but
+            // this path neither reads back the track's NEW name nor refreshes the
+            // cache — the success read-back confirms the loaded PRESET, not the track
+            // name. Re-reading the cache here would only yield the pre-op name (a
+            // no-op rebind), and any other guess could mask an external rename. So we
+            // honestly defer: an auto-rename here fails the next same-ref op closed,
+            // which is correct — the server cannot cheaply prove the new identity.
             return toolTextResult(result)
 
         case "resolve_path":

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -268,6 +268,30 @@ struct TrackDispatcher {
                 )
             }
             if let resolvedReference {
+                // AX readback verified this rename, so `name` is ground truth.
+                // Commit it before rebind to close the stale-cache window; the
+                // poller confirms the same value on its next cycle. A poller
+                // write between get/update may clobber other fields for one
+                // cycle, but the following poll self-heals them.
+                var tracks = await cache.getTracks()
+                if tracks.indices.contains(index) {
+                    let track = tracks[index]
+                    tracks[index] = TrackState(
+                        id: track.id,
+                        name: name,
+                        type: track.type,
+                        isMuted: track.isMuted,
+                        isSoloed: track.isSoloed,
+                        isArmed: track.isArmed,
+                        isSelected: track.isSelected,
+                        volume: track.volume,
+                        pan: track.pan,
+                        automationMode: track.automationMode,
+                        color: track.color,
+                        placeholder: track.placeholder
+                    )
+                    await cache.updateTracks(tracks)
+                }
                 // ADR-002 (#353): this verified rename ran THROUGH `resolvedReference`
                 // and changed the track's name — the exact field the drift check
                 // hashes — so rebind the ref in place. The causal chain (server-issued,

--- a/Sources/LogicProMCP/State/TargetReference.swift
+++ b/Sources/LogicProMCP/State/TargetReference.swift
@@ -98,6 +98,42 @@ actor TargetRegistry {
         return binding
     }
 
+    /// Rebind an existing `target_ref` to a new descriptor after the SERVER
+    /// ITSELF verifiably changed the referenced track's identity fingerprint —
+    /// currently a `logic_tracks rename` performed through this very ref and
+    /// confirmed by read-back (State A). The causal chain (this server issued
+    /// the verified mutation via this reference) proves the binding still names
+    /// the same track, so we update it in place instead of letting the
+    /// name-fingerprint drift check invalidate a track that was renamed via its
+    /// own ref.
+    ///
+    /// Validity gates match `resolve` (session / project-epoch /
+    /// topology-generation): an unknown or already-stale reference is a no-op —
+    /// a stale binding is NEVER resurrected. The rebound binding preserves
+    /// `reference`, `kind`, `serverSessionID`, `projectEpoch`,
+    /// `topologyGeneration`, and `createdAt`, adopting only the new `descriptor`
+    /// with `observedFingerprint = descriptor.fingerprint`.
+    ///
+    /// Deliberately server-only: user-initiated (non-server) renames, and any
+    /// topology change made directly in Logic's UI, are NOT rebound — the server
+    /// cannot prove it caused those, so the drift check MUST keep invalidating
+    /// them (fail-closed). Dropping the track name from the fingerprint instead
+    /// would forfeit that external-change protection; hence rebind-on-proof, not
+    /// a thinner fingerprint.
+    func rebind(_ reference: TargetReference, to descriptor: TargetDescriptor) {
+        guard let existing = resolve(reference) else { return }
+        bindings[reference] = TargetBinding(
+            reference: existing.reference,
+            kind: existing.kind,
+            serverSessionID: existing.serverSessionID,
+            projectEpoch: existing.projectEpoch,
+            topologyGeneration: existing.topologyGeneration,
+            descriptor: descriptor,
+            observedFingerprint: descriptor.fingerprint,
+            createdAt: existing.createdAt
+        )
+    }
+
     func bumpProjectEpoch() {
         projectEpoch += 1
         bindings.removeAll(keepingCapacity: true)

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -12,13 +12,20 @@ import Testing
 //   * the #308 wrong-target negative guarantees (never a wrong-target mutation).
 
 private actor RecordingChannel: Channel {
+    // #353: `.stateB` returns a `verified:false` success so a rename's dispatcher
+    // guard treats it as unverified (State B). Default `.stateA` keeps every other
+    // test byte-identical.
+    enum Envelope: Sendable { case stateA, stateB }
+
     nonisolated let id: ChannelID
     private let succeeds: Bool
+    private let envelope: Envelope
     private(set) var executedOps: [(String, [String: String])] = []
 
-    init(id: ChannelID, succeeds: Bool = true) {
+    init(id: ChannelID, succeeds: Bool = true, envelope: Envelope = .stateA) {
         self.id = id
         self.succeeds = succeeds
+        self.envelope = envelope
     }
 
     func start() async throws {}
@@ -27,7 +34,15 @@ private actor RecordingChannel: Channel {
     func execute(operation: String, params: [String: String]) async -> ChannelResult {
         executedOps.append((operation, params))
         guard succeeds else { return .error("synthetic failure") }
-        return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+        switch envelope {
+        case .stateA:
+            return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+        case .stateB:
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackMismatch,
+                extras: ["operation": operation]
+            ))
+        }
     }
 
     func healthCheck() async -> ChannelHealth {
@@ -711,5 +726,165 @@ struct TargetRefResolutionTests {
             #expect(errorCode(result) == "stale_target_reference")
             #expect(await allOps(channels).isEmpty)
         }
+    }
+
+    // MARK: - #353: rebind target_ref on verified server-performed rename
+
+    /// The core regression: renaming a track THROUGH its own target_ref must not
+    /// invalidate that ref. Pre-#353 the drift check saw the new live name and
+    /// failed the next same-ref op closed; the verified-success rebind keeps it.
+    @Test
+    func testRenameViaRefThenSecondOpViaSameRefResolves() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            let (renameRouter, _) = await makeRouter()
+            let renameResult = await TrackDispatcher.handle(
+                command: "rename",
+                params: ["target_ref": .string(reference.rawValue), "name": .string("Sub Bass")],
+                router: renameRouter,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(renameResult.isError == false)
+
+            // Live cache now reflects Logic's applied rename — exactly the change
+            // that used to invalidate the ref.
+            await cache.updateTracks([
+                TrackState(id: 0, name: "Kick", type: .audio),
+                TrackState(id: 1, name: "Snare", type: .audio),
+                TrackState(id: 2, name: "Sub Bass", type: .audio),
+            ])
+
+            let (selectRouter, selectChannels) = await makeRouter()
+            let secondOp = await TrackDispatcher.handle(
+                command: "select",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: selectRouter,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(secondOp.isError == false)
+            #expect(await opParams(selectChannels, "track.select") == ["index": "2"])
+        }
+    }
+
+    /// Regression guard for the intended fail-closed behaviour: a rename made
+    /// DIRECTLY in Logic's UI (no server op, no rebind) still invalidates the
+    /// ref — the server cannot prove it caused the change.
+    @Test
+    func testExternalRenameWithoutServerOpStillFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            // User renamed the track in Logic; the cache caught up but no server
+            // op / rebind ever ran.
+            await cache.updateTracks([
+                TrackState(id: 0, name: "Kick", type: .audio),
+                TrackState(id: 1, name: "Snare", type: .audio),
+                TrackState(id: 2, name: "Renamed In Logic", type: .audio),
+            ])
+            let (router, channels) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "select",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(result.isError == true)
+            #expect(errorCode(result) == "stale_target_reference")
+            #expect(await allOps(channels).isEmpty)
+        }
+    }
+
+    /// A State B (unverified) rename must NOT rebind — identity is not proven.
+    /// Once the cache reflects the (unverified) new name, the ref fails closed.
+    @Test
+    func testRenameStateBUnverifiedDoesNotRebind() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
+            let router = ChannelRouter()
+            await router.register(RecordingChannel(id: .accessibility, envelope: .stateB))
+            let renameResult = await TrackDispatcher.handle(
+                command: "rename",
+                params: ["target_ref": .string(reference.rawValue), "name": .string("Sub Bass")],
+                router: router,
+                cache: cache,
+                targetRegistry: registry
+            )
+            // State B (verified:false) rename surfaces as an error.
+            #expect(renameResult.isError == true)
+
+            await cache.updateTracks([
+                TrackState(id: 0, name: "Kick", type: .audio),
+                TrackState(id: 1, name: "Snare", type: .audio),
+                TrackState(id: 2, name: "Sub Bass", type: .audio),
+            ])
+            let (selectRouter, selectChannels) = await makeRouter()
+            let secondOp = await TrackDispatcher.handle(
+                command: "select",
+                params: ["target_ref": .string(reference.rawValue)],
+                router: selectRouter,
+                cache: cache,
+                targetRegistry: registry
+            )
+            #expect(secondOp.isError == true)
+            #expect(errorCode(secondOp) == "stale_target_reference")
+            #expect(await allOps(selectChannels).isEmpty)
+        }
+    }
+
+    // MARK: - #353: TargetRegistry.rebind unit
+
+    @Test
+    func testRebindUnknownReferenceIsNoOp() async {
+        let registry = TargetRegistry()
+        let unknown = TargetReference(rawValue: "trk_\(UUID().uuidString)")
+        await registry.rebind(unknown, to: TargetDescriptor(trackIndex: 5, trackName: "Ghost"))
+        // No binding existed, so none was created — never resurrected.
+        #expect(await registry.resolve(unknown) == nil)
+    }
+
+    @Test
+    func testRebindStaleReferenceIsNoOp() async {
+        let registry = TargetRegistry()
+        let descriptor = TargetDescriptor(trackIndex: 2, trackName: "Bass")
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        await registry.bumpTopologyGeneration()  // binding is now stale/removed
+        await registry.rebind(reference, to: TargetDescriptor(trackIndex: 2, trackName: "Sub Bass"))
+        // A stale reference must not be rebound back to life.
+        #expect(await registry.resolve(reference) == nil)
+    }
+
+    @Test
+    func testRebindPreservesIdentityFieldsAndUpdatesDescriptor() async {
+        let registry = TargetRegistry()
+        let old = TargetDescriptor(trackIndex: 2, trackName: "Bass")
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: old,
+            fingerprint: old.fingerprint
+        )
+        let epochBefore = await registry.currentProjectEpoch
+        let generationBefore = await registry.currentTopologyGeneration
+
+        let new = TargetDescriptor(trackIndex: 2, trackName: "Sub Bass")
+        await registry.rebind(reference, to: new)
+
+        guard let binding = await registry.resolve(reference) else {
+            Issue.record("expected the rebound reference to still resolve")
+            return
+        }
+        // Descriptor + fingerprint adopt the new identity...
+        #expect(binding.descriptor == new)
+        #expect(binding.observedFingerprint == new.fingerprint)
+        // ...while reference / kind / epoch / topology-generation are preserved.
+        #expect(binding.reference == reference)
+        #expect(binding.kind == .track)
+        #expect(binding.projectEpoch == epochBefore)
+        #expect(binding.topologyGeneration == generationBefore)
     }
 }

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -746,14 +746,8 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(renameResult.isError == false)
-
-            // Live cache now reflects Logic's applied rename — exactly the change
-            // that used to invalidate the ref.
-            await cache.updateTracks([
-                TrackState(id: 0, name: "Kick", type: .audio),
-                TrackState(id: 1, name: "Snare", type: .audio),
-                TrackState(id: 2, name: "Sub Bass", type: .audio),
-            ])
+            #expect((await registry.resolve(reference))!.descriptor.trackName == "Sub Bass")
+            #expect((await cache.getTracks())[2].name == "Sub Bass")
 
             let (selectRouter, selectChannels) = await makeRouter()
             let secondOp = await TrackDispatcher.handle(
@@ -765,6 +759,22 @@ struct TargetRefResolutionTests {
             )
             #expect(secondOp.isError == false)
             #expect(await opParams(selectChannels, "track.select") == ["index": "2"])
+        }
+    }
+
+    @Test
+    func testRenameViaIndexDoesNotUpdateCache() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let (_, cache, _) = await boundTrack(index: 2, name: "Bass")
+            let (router, _) = await makeRouter()
+            let result = await TrackDispatcher.handle(
+                command: "rename",
+                params: ["index": .int(2), "name": .string("Sub Bass")],
+                router: router,
+                cache: cache
+            )
+            #expect(result.isError == false)
+            #expect((await cache.getTracks())[2].name == "Bass")
         }
     }
 


### PR DESCRIPTION
## Fixes #353 — target_ref survives its own verified rename (ADR-002 kernel)

An ADR-002 `target_ref`'s identity fingerprint embeds the track name, so renaming a track **through its own ref** invalidated that ref (`stale_target_reference` on the next same-ref op). Live-reproduced on Logic 12.3.

### Fix (2 commits)
1. **rebind-on-proof** — `TargetRegistry.rebind(_:to:)` (reuses `resolve`'s validity gates; unknown/stale refs are never resurrected; identity fields preserved). The rename dispatcher rebinds **only** after the mutation succeeds AND passes the `verified == false` guard (State A, AX-readback-proven). The name deliberately **stays** in the drift check: UI-side topology changes are only caught by the name fingerprint (server-side ops bump `topologyGeneration`; external ones don't), so thinning the fingerprint would forfeit external-change protection. External renames stay fail-closed. `set_instrument` rebind honestly deferred (its readback proves the preset, not the track name).
2. **cache-sync at the rename commit** — live instrumentation showed a ~2-3s race: the rebound binding carried the new name while `StateCache` still held the old one until the poller caught up (t≤1.2s stale, t=3.5s same-ref recovery). Since the AX readback already proved the new name, the dispatcher now writes it into the cache (`getTracks` → replace name at index → `updateTracks`) immediately before rebinding — binding and cache stay consistent with no window.

### Verification
- Unit: `TargetRefResolution` **38/38** (31 + 7; the prior regression test *masked* the race by manually updating the mock cache — now it asserts the dispatcher's own synchronous cache write + immediate same-ref follow-up; index-path rename proven to NOT touch the cache; one optional-chained `#expect` hardened to force-unwrap per the repo dead-assertion footgun). `TargetRegistry` 12/12.
- **Live (real Logic 12.3)**: `rename → mute → rename → set_volume → solo` through the **same ref back-to-back with zero delay** — all **State A verified**; bogus ref control still `stale_target_reference`.

Refs #285 #308. Follows #352.
