### PR TITLE
feat(adr-005): 100% mutation trace coverage via registry-driven wiring + permanent gate (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -204,3 +204,65 @@ func blockingLogicDialogResult(
         isError: true
     )
 }
+
+protocol OperationTraceDispatching {
+    static var tool: Tool { get }
+}
+
+extension OperationTraceDispatching {
+    static func startTraceIfEnabled(command: String) async -> TraceID? {
+        guard FeatureFlags.adr005OperationTrace,
+              let spec = OperationRegistry.spec(tool: tool.name, command: command),
+              spec.mutability == Mutability.`mutating` else {
+            return nil
+        }
+        let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
+        await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+            "operation_id": spec.id.rawValue,
+            "command": command,
+        ])
+        return id
+    }
+
+    static func recordWriteBoundary(_ traceID: TraceID?) async {
+        guard let traceID else { return }
+        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
+    }
+
+    static func finalizeTrace(
+        _ result: CallTool.Result,
+        traceID: TraceID?
+    ) async -> CallTool.Result {
+        guard let traceID else { return result }
+        guard case .text(let raw, _, _) = result.content.first else {
+            await OperationTraceStore.shared.record(
+                traceID,
+                phase: .verificationCompleted,
+                attributes: ["readback_state": result.isError == true ? "C" : "A"]
+            )
+            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+            await OperationTraceStore.shared.complete(traceID)
+            return result
+        }
+
+        let object = decodedJSONObject(raw)
+        var attributes = [
+            "readback_state": object?["state"] as? String
+                ?? (result.isError == true ? "C" : "A"),
+        ]
+        if let errorCode = object?["error"] as? String {
+            attributes["error_code"] = errorCode
+        }
+        await OperationTraceStore.shared.record(
+            traceID,
+            phase: .verificationCompleted,
+            attributes: attributes
+        )
+        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(traceID)
+
+        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
+        guard merged != raw else { return result }
+        return toolTextResult(merged, isError: result.isError == true)
+    }
+}

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct EditDispatcher {
+struct EditDispatcher: OperationTraceDispatching {
     private enum EditRoute {
         case regular(String)
         case unverifiedIsError(String)
@@ -65,7 +65,9 @@ struct EditDispatcher {
             guard let route = routedCommands[command] else {
                 return toolTextResult("Internal edit route missing for \(command)", isError: true)
             }
-            return await routeEditCommand(route, router: router)
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await routeEditCommand(route, router: router, traceID: traceID)
+            return await finalizeTrace(result, traceID: traceID)
 
         case "quantize":
             guard params["value"] != nil || params["grid"] != nil else {
@@ -80,11 +82,16 @@ struct EditDispatcher {
                     isError: true
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "edit.quantize",
                 params: ["value": value]
             )
-            return toolTextResultTreatingUnverifiedAsError(result)
+            return await finalizeTrace(
+                toolTextResultTreatingUnverifiedAsError(result),
+                traceID: traceID
+            )
 
         default:
             return toolTextResult(
@@ -96,8 +103,10 @@ struct EditDispatcher {
 
     private static func routeEditCommand(
         _ route: EditRoute,
-        router: ChannelRouter
+        router: ChannelRouter,
+        traceID: TraceID?
     ) async -> CallTool.Result {
+        await recordWriteBoundary(traceID)
         switch route {
         case .regular(let operation):
             return await routedTextResult(router, operation: operation)

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct MIDIDispatcher {
+struct MIDIDispatcher: OperationTraceDispatching {
     private static let maxSysExBytes = 1024
     private static let maxSysExTextCharacters = maxSysExBytes * 5
 
@@ -35,6 +35,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_note",
                 params: params,
                 additionalParams: [
@@ -62,6 +63,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_chord",
                 params: params,
                 additionalParams: [
@@ -102,9 +104,12 @@ struct MIDIDispatcher {
                 return toolInvalidParamsResult(msg.message)
             case .success(let port):
                 let opKey = port == "midi" ? "midi.play_sequence" : "midi.play_sequence.\(port)"
-                return await routedTextResult(router, operation: opKey, params: [
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
+                let result = await routedTextResult(router, operation: opKey, params: [
                     "notes": notes,
                 ])
+                return await finalizeTrace(result, traceID: traceID)
             }
 
         case "send_cc":
@@ -119,6 +124,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_cc",
                 params: params,
                 additionalParams: [
@@ -135,6 +141,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_program_change",
                 params: params,
                 additionalParams: [
@@ -150,6 +157,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_pitch_bend",
                 params: params,
                 additionalParams: [
@@ -165,6 +173,7 @@ struct MIDIDispatcher {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             return await dispatchSendOp(
+                command: command,
                 baseOp: "midi.send_aftertouch",
                 params: params,
                 additionalParams: [
@@ -186,7 +195,10 @@ struct MIDIDispatcher {
             case .success(let parsed): data = parsed
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
-            return await routedTextResult(router, operation: "midi.send_sysex", params: ["data": data])
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "midi.send_sysex", params: ["data": data])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "import_file":
             if let reject = rejectIfPortPresent(params, command: command) {
@@ -197,17 +209,23 @@ struct MIDIDispatcher {
             case .success(let parsed): path = parsed
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
-            return await routedTextResult(router, operation: "midi.import_file", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "midi.import_file", params: [
                 "path": path,
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "create_virtual_port":
             if let reject = rejectIfPortPresent(params, command: command) {
                 return reject
             }
-            return await routedTextResult(router, operation: "midi.create_virtual_port", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "midi.create_virtual_port", params: [
                 "name": stringParam(params, "name", default: "Virtual Port"),
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "list_ports":
             if let reject = rejectIfPortPresent(params, command: command) {
@@ -219,19 +237,28 @@ struct MIDIDispatcher {
             if let reject = rejectIfPortPresent(params, command: command) {
                 return reject
             }
-            return await routedTextResult(router, operation: "mmc.play")
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mmc.play")
+            return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_stop":
             if let reject = rejectIfPortPresent(params, command: command) {
                 return reject
             }
-            return await routedTextResult(router, operation: "mmc.stop")
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mmc.stop")
+            return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_record":
             if let reject = rejectIfPortPresent(params, command: command) {
                 return reject
             }
-            return await routedTextResult(router, operation: "mmc.record_strobe")
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mmc.record_strobe")
+            return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_locate":
             if let reject = rejectIfPortPresent(params, command: command) {
@@ -256,23 +283,29 @@ struct MIDIDispatcher {
                 // returned the raw channel State B and could only ever report
                 // `verified:false` — it never confirmed the playhead landed.
                 let position = "\(bar).1.1.1"
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "transport.goto_position",
                     params: ["position": position]
                 )
-                return await TransportDispatcher.finalizeGotoPositionResult(
+                let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                     result,
                     requestedPosition: position,
                     router: router,
                     cache: cache
                 )
+                return await finalizeTrace(finalized, traceID: traceID)
             }
             guard let time = params["time"]?.stringValue, isValidSMPTE(time) else {
                 return toolInvalidParamsResult("mmc_locate 'time' must be HH:MM:SS:FF")
             }
-            return await routedTextResult(router, operation: "mmc.locate", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mmc.locate", params: [
                 "time": time,
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "step_input":
             if let reject = rejectIfPortPresent(params, command: command) {
@@ -291,10 +324,13 @@ struct MIDIDispatcher {
             case .success(let parsed): duration = parsed
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
-            return await routedTextResult(router, operation: "midi.step_input", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "midi.step_input", params: [
                 "note": String(note),
                 "duration": duration,
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         default:
             return toolTextResult(
@@ -314,6 +350,7 @@ struct MIDIDispatcher {
     /// this helper because its per-event channels live inside the notes string;
     /// it inlines just the `validatePort` half above.
     private static func dispatchSendOp(
+        command: String,
         baseOp: String,
         params: [String: Value],
         additionalParams: [String: String],
@@ -330,7 +367,10 @@ struct MIDIDispatcher {
                 let opKey = port == "midi" ? baseOp : "\(baseOp).\(port)"
                 var allParams = additionalParams
                 allParams["channel"] = String(wireChannel)
-                return await routedTextResult(router, operation: opKey, params: allParams)
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
+                let result = await routedTextResult(router, operation: opKey, params: allParams)
+                return await finalizeTrace(result, traceID: traceID)
             }
         }
     }

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct MixerDispatcher {
+struct MixerDispatcher: OperationTraceDispatching {
     static let tool = commandTool(
         name: "logic_mixer",
         description: "Mixer actions in Logic Pro. Commands: set_volume, set_pan, set_master_volume, set_plugin_param, insert_plugin. BREAKING since v3.3.0: every mutating command requires explicit `track` (Int ≥ 0) — pre-v3.3.0 missing `track` defaulted to 0 and silently mutated the first track; this now returns an error. Params: set_volume -> { track: Int (required, ≥ 0), value: Float (0.0..1.0) } verified against the visible mixer strip via AX readback; set_pan -> { track: Int (required, ≥ 0), value: Float (-1.0..1.0) } verified against the visible mixer strip via AX readback; set_master_volume -> { value: Float (0.0..1.0) } — the master fader has no AX track-header equivalent, so MCU echo is the ONLY readback: State A only when a fresh echo lands, otherwise honest State B echo_timeout with readback_source:mcu_echo + a surface_limitation note (non-deterministic, not a recoverable failure); set_plugin_param -> { track: Int (required, ≥ 0), insert: Int (required, currently only 0), param: Int (required, ≥ 0), value: Float (required) } on the selected track via Scripter; insert_plugin -> { track: Int, slot: Int, plugin_name: Gain|Compressor|Channel EQ, confirmed: true } via AX mixer slot with readback. ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_volume and set_pan ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) that resolves to the addressed track's mixer strip in place of the explicit track/index; when both target_ref and track/index are supplied they must agree or the op fails closed (stale_target_reference); with the flag off target_ref is ignored and the explicit track/index remains required.",
@@ -120,9 +120,12 @@ struct MixerDispatcher {
                     "set_master_volume 'value' must be in 0.0..1.0 (got \(volume))"
                 )
             }
-            return await routedTextResult(router, operation: "mixer.set_master_volume", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "mixer.set_master_volume", params: [
                 "volume": String(volume),
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "toggle_eq":
             return notExposedCommandResult(operation: "mixer.toggle_eq")
@@ -159,11 +162,14 @@ struct MixerDispatcher {
             case .invalid(let hint):
                 return toolInvalidParamsResult("insert_plugin \(hint)")
             }
-            return await routedTextResult(router, operation: "plugin.insert", params: [
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
+            let result = await routedTextResult(router, operation: "plugin.insert", params: [
                 "track": String(track),
                 "slot": String(slot),
                 "plugin_name": spec.canonicalName,
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         case "bypass_plugin":
             // Still removed from the public surface: no verified AX/MCU
@@ -220,15 +226,20 @@ struct MixerDispatcher {
                     "set_plugin_param 'param' must be 0...17 (Scripter CC range); got \(paramIndex)"
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let selectResult = await router.route(
                 operation: "track.select",
                 params: ["index": String(track)]
             )
             guard selectResult.isSuccess else {
-                return toolTextResult(selectResult.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(selectResult.message, isError: true),
+                    traceID: traceID
+                )
             }
             guard channelResultIsVerified(selectResult) else {
-                return toolStateCResult(
+                return await finalizeTrace(toolStateCResult(
                     .readbackMismatch,
                     hint: "set_plugin_param refused: track \(track) selection unverified (State B). Cannot safely write plugin parameter to an unverified selected track.",
                     extras: [
@@ -236,14 +247,15 @@ struct MixerDispatcher {
                         "requested_track": track,
                         "select_response": selectResult.message,
                     ]
-                )
+                ), traceID: traceID)
             }
-            return await routedTextResult(router, operation: "plugin.set_param", params: [
+            let result = await routedTextResult(router, operation: "plugin.set_param", params: [
                 "track": String(track),
                 "insert": String(insert),
                 "param": String(paramIndex),
                 "value": String(value),
             ])
+            return await finalizeTrace(result, traceID: traceID)
 
         default:
             return toolInvalidParamsResult(
@@ -253,63 +265,4 @@ struct MixerDispatcher {
         }
     }
 
-    private static func startTraceIfEnabled(command: String) async -> TraceID? {
-        guard FeatureFlags.adr005OperationTrace,
-              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
-            return nil
-        }
-        switch spec.id {
-        case .mixerSetVolume, .mixerSetPan:
-            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
-            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
-                "operation_id": spec.id.rawValue,
-                "command": command,
-            ])
-            return id
-        default:
-            return nil
-        }
-    }
-
-    private static func recordWriteBoundary(_ traceID: TraceID?) async {
-        guard let traceID else { return }
-        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
-    }
-
-    private static func finalizeTrace(
-        _ result: CallTool.Result,
-        traceID: TraceID?
-    ) async -> CallTool.Result {
-        guard let traceID else { return result }
-        guard case .text(let raw, _, _) = result.content.first else {
-            await OperationTraceStore.shared.record(
-                traceID,
-                phase: .verificationCompleted,
-                attributes: ["readback_state": result.isError == true ? "C" : "A"]
-            )
-            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-            await OperationTraceStore.shared.complete(traceID)
-            return result
-        }
-
-        let object = decodedJSONObject(raw)
-        var attributes = [
-            "readback_state": object?["state"] as? String
-                ?? (result.isError == true ? "C" : "A"),
-        ]
-        if let errorCode = object?["error"] as? String {
-            attributes["error_code"] = errorCode
-        }
-        await OperationTraceStore.shared.record(
-            traceID,
-            phase: .verificationCompleted,
-            attributes: attributes
-        )
-        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-        await OperationTraceStore.shared.complete(traceID)
-
-        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
-        guard merged != raw else { return result }
-        return toolTextResult(merged, isError: result.isError == true)
-    }
 }

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct NavigateDispatcher {
+struct NavigateDispatcher: OperationTraceDispatching {
     static let tool = Tool(
         name: "logic_navigate",
         description: "Navigation and markers in Logic Pro. Commands: goto_bar, goto_marker, create_marker, delete_marker, rename_marker, zoom_to_fit, set_zoom, toggle_view. UNSUPPORTED: rename_marker is NOT implemented — there is no verified AX write path on Logic 12.x, so it always fails closed with State C error=not_implemented; to rename, delete_marker the target then create_marker with the new name. BREAKING since v3.3.0: delete_marker / rename_marker require explicit `index` (Int ≥ 0) — pre-v3.3.0 missing `index` defaulted to 0 and silently mutated marker 0; rename_marker now also rejects empty `name`. Params: goto_bar -> { bar: Int }; goto_marker -> { index: Int } or { name: String }; create_marker -> { name: String }; rename_marker -> { index: Int (required, ≥ 0), name: String (required, non-empty) } (not implemented: returns not_implemented); delete_marker -> { index: Int (required, ≥ 0) }; set_zoom -> { level: String } (in|out|fit); toggle_view -> { view: String } (mixer|piano_roll|score|step_editor|library|inspector|automation).",
@@ -31,16 +31,19 @@ struct NavigateDispatcher {
                     "goto_bar 'bar' must be in 1..9999 (got \(bar))"
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "transport.goto_position",
                 params: ["position": "\(bar).1.1.1"]
             )
-            return await TransportDispatcher.finalizeGotoPositionResult(
+            let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                 result,
                 requestedPosition: "\(bar).1.1.1",
                 router: router,
                 cache: cache
             )
+            return await finalizeTrace(finalized, traceID: traceID)
 
         case "goto_marker":
             // v3.1.10 (boomer P1-1) — resolve the target marker from cache and
@@ -53,6 +56,8 @@ struct NavigateDispatcher {
             //
             let markers = await cache.getMarkers()
             func routeMarkerTarget(_ target: MarkerState) async -> CallTool.Result {
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 var result = await router.route(
                     operation: "transport.goto_position",
                     params: ["position": target.position]
@@ -65,12 +70,13 @@ struct NavigateDispatcher {
                     )
                     result = result.isSuccess ? .success(merged) : .error(merged)
                 }
-                return await TransportDispatcher.finalizeGotoPositionResult(
+                let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                     result,
                     requestedPosition: target.position,
                     router: router,
                     cache: cache
                 )
+                return await finalizeTrace(finalized, traceID: traceID)
             }
             // H-2 (2026-05-08 enterprise review): pre-fix the cache-cold
             // index-based path fell back to `nav.goto_marker` (CC 38), which
@@ -138,11 +144,14 @@ struct NavigateDispatcher {
                     extras: ["operation": "nav.create_marker"]
                 )
             }
-            return await finalizeCreateMarkerResult(
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await finalizeCreateMarkerResult(
                 requestedName: providedName.isEmpty ? nil : providedName,
                 router: router,
-                cache: cache
+                cache: cache,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "delete_marker":
             // RB-1.b (2026-05-08 enterprise review): pre-fix `intParam(default: 0)`
@@ -155,11 +164,13 @@ struct NavigateDispatcher {
                     extras: ["operation": "nav.delete_marker"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "nav.delete_marker",
                 params: ["index": String(index)]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "rename_marker":
             // RB-1.b — same fail-closed treatment for index, plus reject empty
@@ -177,15 +188,22 @@ struct NavigateDispatcher {
                     extras: ["operation": "nav.rename_marker"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "nav.rename_marker",
                 params: ["index": String(index), "name": name]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "zoom_to_fit":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "nav.zoom_to_fit")
-            return toolTextResultTreatingUnverifiedAsError(result)
+            return await finalizeTrace(
+                toolTextResultTreatingUnverifiedAsError(result),
+                traceID: traceID
+            )
 
         case "set_zoom":
             // Accept both `level` (docs) and `direction` (common caller term) —
@@ -200,20 +218,35 @@ struct NavigateDispatcher {
             let level = stringParam(params, "level", "direction", default: "fit")
             switch level {
             case "in":
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "nav.set_zoom_level",
                     params: ["level": "8"]
                 )
-                return toolTextResultTreatingUnverifiedAsError(result)
+                return await finalizeTrace(
+                    toolTextResultTreatingUnverifiedAsError(result),
+                    traceID: traceID
+                )
             case "out":
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "nav.set_zoom_level",
                     params: ["level": "2"]
                 )
-                return toolTextResultTreatingUnverifiedAsError(result)
+                return await finalizeTrace(
+                    toolTextResultTreatingUnverifiedAsError(result),
+                    traceID: traceID
+                )
             case "fit":
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(operation: "nav.zoom_to_fit")
-                return toolTextResultTreatingUnverifiedAsError(result)
+                return await finalizeTrace(
+                    toolTextResultTreatingUnverifiedAsError(result),
+                    traceID: traceID
+                )
             default:
                 guard let numericLevel = Int(level),
                       (1...10).contains(numericLevel) else {
@@ -221,11 +254,16 @@ struct NavigateDispatcher {
                         "set_zoom 'level' must be one of: in, out, fit, or integer 1..10"
                     )
                 }
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "nav.set_zoom_level",
                     params: ["level": String(numericLevel)]
                 )
-                return toolTextResultTreatingUnverifiedAsError(result)
+                return await finalizeTrace(
+                    toolTextResultTreatingUnverifiedAsError(result),
+                    traceID: traceID
+                )
             }
 
         case "toggle_view":
@@ -250,8 +288,10 @@ struct NavigateDispatcher {
                     extras: ["operation": "nav.toggle_view"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: operation)
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
             return toolInvalidParamsResult(
@@ -264,7 +304,8 @@ struct NavigateDispatcher {
     private static func finalizeCreateMarkerResult(
         requestedName: String?,
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        traceID: TraceID?
     ) async -> CallTool.Result {
         // audit P1 #8: snapshot the marker list BEFORE the mutating route so the
         // count-delta verify reflects the +1 this create adds. Pre-fix both the
@@ -272,6 +313,7 @@ struct NavigateDispatcher {
         // counts were equal on success → every verified-by-readback create fell
         // to the State-B readback-mismatch path. Still fail-closed: a nil/short
         // readback below returns State B.
+        await recordWriteBoundary(traceID)
         let openResult = await router.route(operation: "nav.open_marker_list")
         guard openResult.isSuccess else {
             return toolTextResult(openResult)

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -35,7 +35,7 @@ final class VerifiedOpGate: @unchecked Sendable {
 /// AX-only verified operations (`plugin.*`). Verified ops never fall back
 /// (router chain is `[.accessibility]` alone) so a State C is always the honest
 /// AX result.
-struct PluginsDispatcher {
+struct PluginsDispatcher: OperationTraceDispatching {
     static let tool = commandTool(
         name: "logic_plugins",
         description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required) }. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_param_verified ALSO accepts a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) that resolves the host track in place of the explicit track; when both target_ref and track are supplied they must agree or the op fails closed (stale_target_reference); with the flag off target_ref is ignored and the explicit track remains required.",
@@ -63,7 +63,8 @@ struct PluginsDispatcher {
             return await routedTextResult(router, operation: "plugin.get_inventory", params: inventoryParams)
 
         case "set_param_verified":
-            return await runVerified(operation: "plugin.set_param_verified") {
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await runVerified(operation: "plugin.set_param_verified") {
                 var writeParams = verifiedWriteParams(params)
                 // ADR-002: with the flag on, a target_ref resolves the host track
                 // (verified plugin writes are trackIndex-keyed) and overrides the
@@ -88,12 +89,16 @@ struct PluginsDispatcher {
                         return result
                     }
                 }
+                await recordWriteBoundary(traceID)
                 return await routedTextResult(router, operation: "plugin.set_param_verified",
                                               params: writeParams)
             }
+            return await finalizeTrace(result, traceID: traceID)
 
         case "insert_verified":
-            return await runVerified(operation: "plugin.insert_verified") {
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await runVerified(operation: "plugin.insert_verified") {
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "plugin.insert_verified",
                     params: insertVerifiedParams(params)
@@ -103,6 +108,7 @@ struct PluginsDispatcher {
                 }
                 return toolTextResult(result)
             }
+            return await finalizeTrace(result, traceID: traceID)
 
         default:
             return toolTextResult(

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct ProjectDispatcher {
+struct ProjectDispatcher: OperationTraceDispatching {
     struct LifecycleExecution: Sendable {
         let executionError: String?
         let timedOut: Bool
@@ -108,25 +108,42 @@ struct ProjectDispatcher {
                     extras: ["operation": "project.\(command)"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.\(command)")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.\(command)"),
+                    traceID: traceID
+                )
             }
-            let run: ProjectExportExecutor.RunResult
-            switch strictBoolParam(params, "confirmed") {
-            case .invalid(let hint):
+            let confirmation = strictBoolParam(params, "confirmed")
+            if case .invalid(let hint) = confirmation {
                 audit(command, phase: .rejected, reason: "invalid confirmed")
-                return toolInvalidParamsResult(
+                return await finalizeTrace(toolInvalidParamsResult(
                     "\(command) \(hint)",
                     extras: ["operation": "project.\(command)"]
-                )
+                ), traceID: traceID)
+            }
+            let existingFirstWrite = exportOptions.onFirstWrite
+            var tracedExportOptions = exportOptions
+            tracedExportOptions.onFirstWrite = {
+                await existingFirstWrite()
+                await recordWriteBoundary(traceID)
+            }
+            let run: ProjectExportExecutor.RunResult
+            switch confirmation {
+            case .invalid:
+                return await finalizeTrace(toolInvalidParamsResult(
+                    "\(command) 'confirmed' must be a literal boolean true or false",
+                    extras: ["operation": "project.\(command)"]
+                ), traceID: traceID)
             case .missing, .value(false):
                 audit(command, phase: .confirmationRequired)
                 run = await ProjectExportExecutor.run(
                     params: params,
                     router: router,
                     resume: command == "export_resume",
-                    options: exportOptions
+                    options: tracedExportOptions
                 )
             case .value(true):
                 audit(command, phase: .executed)
@@ -134,7 +151,7 @@ struct ProjectDispatcher {
                     params: params,
                     router: router,
                     resume: command == "export_resume",
-                    options: exportOptions
+                    options: tracedExportOptions
                 )
             }
             // Lifecycle cache invalidation: a guarded run opens projects, so the
@@ -149,20 +166,28 @@ struct ProjectDispatcher {
                 // wire so a client never reads a failed/blocked run as success.
                 let body = try encodeJSONStrict(run, compact: true)
                 let isError = run.status == "failed" || run.status == "confirmation_required"
-                return toolTextResult(body, isError: isError)
+                return await finalizeTrace(
+                    toolTextResult(body, isError: isError),
+                    traceID: traceID
+                )
             } catch {
-                return toolTextResult(
+                return await finalizeTrace(toolTextResult(
                     "{\"success\":false,\"error\":\"\(command) encode failed: \(jsonStringEscape(error.localizedDescription))\"}",
                     isError: true
-                )
+                ), traceID: traceID)
             }
 
         case "new":
+            let traceID = await startTraceIfEnabled(command: command)
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.new")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.new"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "project.new")
             // v3.1.2 (P0-3) — clear cache on lifecycle success so the next
             // resource read / name-based routing decision sees the fresh
@@ -174,7 +199,7 @@ struct ProjectDispatcher {
             // mutation-free on actor state — safe to call on every success
             // even if the poller would have caught up eventually.
             await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "open":
             let path = stringParam(params, "path")
@@ -192,37 +217,49 @@ struct ProjectDispatcher {
                     extras: ["operation": "project.open"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
             let confirmation = destructiveConfirmation(for: command)
-            if let error = confirmation.error { return error }
+            if let error = confirmation.error {
+                return await finalizeTrace(error, traceID: traceID)
+            }
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
-                return toolTextResult(response)
+                return await finalizeTrace(toolTextResult(response), traceID: traceID)
             }
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.open")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.open"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "project.open",
                 params: ["path": path]
             )
             // v3.1.2 (P0-3) — same cache stale-after-lifecycle bug as `new`.
             await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "save":
+            let traceID = await startTraceIfEnabled(command: command)
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.save")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.save"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
             // #110: save is an export/bounce prerequisite. The read-back
             // verification lives in the AppleScript channel (the reliable
             // writer, now tried first) so it stays DI-testable like save_as;
             // the dispatcher just routes + surfaces the channel's HC verdict.
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "project.save")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "save_as":
             let path = stringParam(params, "path")
@@ -240,22 +277,29 @@ struct ProjectDispatcher {
                     extras: ["operation": "project.save_as"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
             let confirmation = destructiveConfirmation(for: command)
-            if let error = confirmation.error { return error }
+            if let error = confirmation.error {
+                return await finalizeTrace(error, traceID: traceID)
+            }
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
-                return toolTextResult(response)
+                return await finalizeTrace(toolTextResult(response), traceID: traceID)
             }
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.save_as")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.save_as"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "project.save_as",
                 params: ["path": path]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "close":
             let savingRaw = stringParam(params, "saving", default: "yes")
@@ -267,17 +311,24 @@ struct ProjectDispatcher {
                     extras: ["operation": "project.close"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
             let confirmation = destructiveConfirmation(for: command)
-            if let error = confirmation.error { return error }
+            if let error = confirmation.error {
+                return await finalizeTrace(error, traceID: traceID)
+            }
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
-                return toolTextResult(response)
+                return await finalizeTrace(toolTextResult(response), traceID: traceID)
             }
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.close")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.close"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "project.close",
                 params: ["saving": saving]
@@ -286,27 +337,34 @@ struct ProjectDispatcher {
             // with the just-closed tracks/regions/markers. Clear so resource
             // reads honestly reflect "no project" until the next open.
             await invalidateOnSuccess(result, cache: cache, targetRegistry: targetRegistry)
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "bounce":
+            let traceID = await startTraceIfEnabled(command: command)
             let confirmation = destructiveConfirmation(for: command)
-            if let error = confirmation.error { return error }
+            if let error = confirmation.error {
+                return await finalizeTrace(error, traceID: traceID)
+            }
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
-                return toolTextResult(response)
+                return await finalizeTrace(toolTextResult(response), traceID: traceID)
             }
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.bounce")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.bounce"),
+                    traceID: traceID
+                )
             }
             let preflight = await ProjectSessionAudit.buildAudit(cache: cache)
             if let block = bouncePreflightBlock(preflight) {
                 audit(command, phase: .rejected, reason: "export readiness blocked")
-                return block
+                return await finalizeTrace(block, traceID: traceID)
             }
             audit(command, phase: .executed)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "project.bounce")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "is_running":
             return toolTextResult(isLogicProRunning() ? "true" : "false")
@@ -344,58 +402,81 @@ struct ProjectDispatcher {
             }
 
         case "cleanup_apply":
+            let traceID = await startTraceIfEnabled(command: command)
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.cleanup_apply")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.cleanup_apply"),
+                    traceID: traceID
+                )
             }
-            return await handleCleanupApply(
+            let result = await handleCleanupApply(
                 params: params,
                 router: router,
                 cache: cache,
-                auditFileReader: cleanupAuditFileReader
+                auditFileReader: cleanupAuditFileReader,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "launch":
+            let traceID = await startTraceIfEnabled(command: command)
             if isLogicProRunning() {
                 audit(command, phase: .rejected, reason: "already running")
-                return toolTextResult("Logic Pro is already running")
+                return await finalizeTrace(
+                    toolTextResult("Logic Pro is already running"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
-            return await runLifecycleScript(
+            let result = await runLifecycleScript(
                 script: LogicProTarget.appleScriptTarget().activateByBundleID,
                 successMessage: "Logic Pro launched",
                 expectedRunning: true,
                 actionLabel: "launch",
                 execute: executeLifecycleScript,
                 isLogicProRunning: isLogicProRunning,
-                sleep: sleep
+                sleep: sleep,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         case "quit":
+            let traceID = await startTraceIfEnabled(command: command)
             let confirmation = destructiveConfirmation(for: command)
-            if let error = confirmation.error { return error }
+            if let error = confirmation.error {
+                return await finalizeTrace(error, traceID: traceID)
+            }
             if !confirmation.confirmed, let response = DestructivePolicy.confirmationResponse(command: command) {
                 audit(command, phase: .confirmationRequired)
-                return toolTextResult(response)
+                return await finalizeTrace(toolTextResult(response), traceID: traceID)
             }
             if !isLogicProRunning() {
                 audit(command, phase: .rejected, reason: "not running")
-                return toolTextResult("Logic Pro is not running")
+                return await finalizeTrace(
+                    toolTextResult("Logic Pro is not running"),
+                    traceID: traceID
+                )
             }
             if dialogPresent() {
                 audit(command, phase: .rejected, reason: "blocking dialog")
-                return blockingLogicDialogResult(operation: "project.quit")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "project.quit"),
+                    traceID: traceID
+                )
             }
             audit(command, phase: .executed)
-            return await runLifecycleScript(
+            let result = await runLifecycleScript(
                 script: LogicProTarget.appleScriptTarget().quitByBundleID,
                 successMessage: "Logic Pro quit",
                 expectedRunning: false,
                 actionLabel: "quit",
                 execute: executeLifecycleScript,
                 isLogicProRunning: isLogicProRunning,
-                sleep: sleep
+                sleep: sleep,
+                traceID: traceID
             )
+            return await finalizeTrace(result, traceID: traceID)
 
         default:
             return toolInvalidParamsResult(
@@ -436,7 +517,8 @@ struct ProjectDispatcher {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
-        auditFileReader: LogicProjectFileReader.Runtime = .production
+        auditFileReader: LogicProjectFileReader.Runtime = .production,
+        traceID: TraceID? = nil
     ) async -> CallTool.Result {
         let stepID = stringParam(params, "step_id", "stepId")
         guard !stepID.isEmpty else {
@@ -545,7 +627,8 @@ struct ProjectDispatcher {
                 step,
                 params: params,
                 router: router,
-                cache: cache
+                cache: cache,
+                traceID: traceID
             )
         default:
             audit(command, phase: .rejected, reason: "no executable path")
@@ -566,7 +649,8 @@ struct ProjectDispatcher {
         _ step: ProjectSessionAudit.CleanupPlanStep,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        traceID: TraceID?
     ) async -> CallTool.Result {
         let targets = cleanupApplyTargetIndices(step.targetIdentifier)
         guard !targets.isEmpty else {
@@ -597,6 +681,7 @@ struct ProjectDispatcher {
         }
 
         var renamed: [[String: Any]] = []
+        await recordWriteBoundary(traceID)
         for (target, newName) in zip(targets, names) {
             let result = await TrackDispatcher.handle(
                 command: "rename",
@@ -848,8 +933,10 @@ struct ProjectDispatcher {
         actionLabel: String,
         execute: (String) async -> LifecycleExecution,
         isLogicProRunning: () -> Bool,
-        sleep: (UInt64) async -> Void
+        sleep: (UInt64) async -> Void,
+        traceID: TraceID?
     ) async -> CallTool.Result {
+        await recordWriteBoundary(traceID)
         let execution = await execute(script)
         if let executionError = execution.executionError {
             return toolTextResult("Failed to \(actionLabel) Logic Pro: \(executionError)", isError: true)

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
@@ -18,6 +18,7 @@ extension TrackDispatcher {
         params: [String: MCP.Value],
         router: ChannelRouter,
         cache: StateCache,
+        traceID: TraceID? = nil,
         trackHeaderCount: @escaping @Sendable () -> Int = { AXLogicProElements.allTrackHeaders().count },
         trackNameAt: @escaping @Sendable (Int) -> String? = { AXLogicProElements.trackName(at: $0) },
         readRegions: @escaping @Sendable () -> RecordSequenceRegionReadback = {
@@ -158,6 +159,7 @@ extension TrackDispatcher {
         // above), so the goto-dialog is enabled on any non-empty project,
         // and on an empty project the playhead is already at bar 1 and the
         // slider fallback succeeds trivially.
+        await recordWriteBoundary(traceID)
         let gotoResult = await router.route(
             operation: "transport.goto_position",
             params: ["bar": "1"]

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct TrackDispatcher {
+struct TrackDispatcher: OperationTraceDispatching {
     private static let maxTrackNameLength = 128
 
     static let tool = Tool(
@@ -24,7 +24,11 @@ struct TrackDispatcher {
         dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
         if let operation = modalGuardedTrackOperation(for: command), dialogPresent() {
-            return blockingLogicDialogResult(operation: operation)
+            let traceID = await startTraceIfEnabled(command: command)
+            return await finalizeTrace(
+                blockingLogicDialogResult(operation: operation),
+                traceID: traceID
+            )
         }
 
         switch command {
@@ -49,11 +53,13 @@ struct TrackDispatcher {
                     )
                 ) {
                 case .success(let resolved):
+                    let traceID = await startTraceIfEnabled(command: command)
+                    await recordWriteBoundary(traceID)
                     let result = await router.route(
                         operation: "track.select",
                         params: ["index": String(resolved.index)]
                     )
-                    return toolTextResult(result)
+                    return await finalizeTrace(toolTextResult(result), traceID: traceID)
                 case .failure(let result):
                     return result
                 }
@@ -71,21 +77,25 @@ struct TrackDispatcher {
                         extras: ["operation": "track.select"]
                     )
                 }
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "track.select",
                     params: ["index": String(index)]
                 )
-                return toolTextResult(result)
+                return await finalizeTrace(toolTextResult(result), traceID: traceID)
             }
             let name = stringParam(params, "name")
             if !name.isEmpty {
                 let tracks = await cache.getTracks()
                 if let track = tracks.first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
+                    let traceID = await startTraceIfEnabled(command: command)
+                    await recordWriteBoundary(traceID)
                     let result = await router.route(
                         operation: "track.select",
                         params: ["index": String(track.id)]
                     )
-                    return toolTextResult(result)
+                    return await finalizeTrace(toolTextResult(result), traceID: traceID)
                 }
                 return toolStateCResult(
                     .elementNotFound,
@@ -100,14 +110,19 @@ struct TrackDispatcher {
 
         case "create_audio", "create_instrument", "create_drummer", "create_external_midi":
             // 4 byte-identical bodies; the channel op is always "track.<command>".
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "track.\(command)")
             if result.isSuccess, !channelSuccessIsVerified(result) {
-                return toolTextResult(result.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(result.message, isError: true),
+                    traceID: traceID
+                )
             }
             if FeatureFlags.adr002TargetRef, result.isSuccess {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "delete":
             let index: Int
@@ -126,12 +141,17 @@ struct TrackDispatcher {
             case .failure(let result):
                 return result
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let selectResult = await router.route(
                 operation: "track.select",
                 params: ["index": String(index)]
             )
             guard selectResult.isSuccess else {
-                return toolTextResult(selectResult.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(selectResult.message, isError: true),
+                    traceID: traceID
+                )
             }
             // v3.1.2 P1-5 — `track.select` can return State B (`verified:false`,
             // e.g. `reason:"retry_exhausted"` or `"readback_mismatch"`) while
@@ -144,7 +164,7 @@ struct TrackDispatcher {
             // require the caller to re-issue selection (or accept that the
             // selection is uncertain and abort).
             guard channelResultIsVerified(selectResult) else {
-                return toolStateCResult(
+                return await finalizeTrace(toolStateCResult(
                     .readbackMismatch,
                     hint: "track.delete refused: track \(index) selection unverified (State B). Cannot safely delete unverified target — re-select or fix Logic Pro AX state and retry.",
                     extras: [
@@ -152,13 +172,13 @@ struct TrackDispatcher {
                         "requested_index": index,
                         "select_response": selectResult.message,
                     ]
-                )
+                ), traceID: traceID)
             }
             let result = await router.route(operation: "track.delete")
             if FeatureFlags.adr002TargetRef, result.isSuccess {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "duplicate":
             let index: Int
@@ -177,12 +197,17 @@ struct TrackDispatcher {
             case .failure(let result):
                 return result
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let selectResult = await router.route(
                 operation: "track.select",
                 params: ["index": String(index)]
             )
             guard selectResult.isSuccess else {
-                return toolTextResult(selectResult.message, isError: true)
+                return await finalizeTrace(
+                    toolTextResult(selectResult.message, isError: true),
+                    traceID: traceID
+                )
             }
             // RB-1.c (2026-05-08 enterprise review): mirror the State-B
             // refusal gate that `delete` already enforces. `track.select`
@@ -194,7 +219,7 @@ struct TrackDispatcher {
             // and confusing the caller's mental model. Refuse and require
             // the caller to re-issue selection.
             guard channelResultIsVerified(selectResult) else {
-                return toolStateCResult(
+                return await finalizeTrace(toolStateCResult(
                     .readbackMismatch,
                     hint: "track.duplicate refused: track \(index) selection unverified (State B). Cannot safely duplicate unverified target — re-select or fix Logic Pro AX state and retry.",
                     extras: [
@@ -202,13 +227,13 @@ struct TrackDispatcher {
                         "requested_index": index,
                         "select_response": selectResult.message,
                     ]
-                )
+                ), traceID: traceID)
             }
             let result = await router.route(operation: "track.duplicate")
             if FeatureFlags.adr002TargetRef, result.isSuccess {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "rename":
             let index: Int
@@ -361,11 +386,17 @@ struct TrackDispatcher {
             return await finalizeTrace(result, traceID: traceID)
 
         case "record_sequence":
-            let result = await handleRecordSequenceSMF(params: params, router: router, cache: cache)
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await handleRecordSequenceSMF(
+                params: params,
+                router: router,
+                cache: cache,
+                traceID: traceID
+            )
             if FeatureFlags.adr002TargetRef, result.isError != true {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return result
+            return await finalizeTrace(result, traceID: traceID)
 
         case "arm_only":
             let index: Int
@@ -385,6 +416,8 @@ struct TrackDispatcher {
                 return result
             }
             let tracks = await cache.getTracks()
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             var disarmed: [Int] = []
             var unverifiedDisarm: [Int] = []
             var failedDisarm: [Int] = []
@@ -418,11 +451,11 @@ struct TrackDispatcher {
                     unverifiedDisarm: unverifiedDisarm,
                     failedDisarm: failedDisarm
                 )
-                return toolStateCResult(
+                return await finalizeTrace(toolStateCResult(
                     .axWriteFailed,
                     hint: "arm_only failed: target arm rejected — \(armResult.message)",
                     extras: extras
-                )
+                ), traceID: traceID)
             }
             if !trackToggleResultIsVerified(armResult) {
                 let extras = armOnlyExtras(
@@ -434,9 +467,9 @@ struct TrackDispatcher {
                     unverifiedDisarm: unverifiedDisarm,
                     failedDisarm: failedDisarm
                 )
-                return toolTextResult(.success(
+                return await finalizeTrace(toolTextResult(.success(
                     HonestContract.encodeStateB(reason: armOnlyUncertainReason(from: armResult), extras: extras)
-                ))
+                )), traceID: traceID)
             }
             if !failedDisarm.isEmpty {
                 let extras = armOnlyExtras(
@@ -448,11 +481,11 @@ struct TrackDispatcher {
                     unverifiedDisarm: unverifiedDisarm,
                     failedDisarm: failedDisarm
                 )
-                return toolStateCResult(
+                return await finalizeTrace(toolStateCResult(
                     .axWriteFailed,
                     hint: "arm_only failed: disarm rejected",
                     extras: extras
-                )
+                ), traceID: traceID)
             }
             if !unverifiedDisarm.isEmpty {
                 let extras = armOnlyExtras(
@@ -464,11 +497,11 @@ struct TrackDispatcher {
                     unverifiedDisarm: unverifiedDisarm,
                     failedDisarm: failedDisarm
                 )
-                return toolTextResult(.success(
+                return await finalizeTrace(toolTextResult(.success(
                     HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras)
-                ))
+                )), traceID: traceID)
             }
-            return toolTextResult(.success(
+            return await finalizeTrace(toolTextResult(.success(
                 HonestContract.encodeStateA(
                     extras: armOnlyExtras(
                         targetIndex: index,
@@ -480,7 +513,7 @@ struct TrackDispatcher {
                         failedDisarm: []
                     )
                 )
-            ))
+            )), traceID: traceID)
 
         case "set_color":
             return notExposedCommandResult(operation: "track.set_color")
@@ -516,11 +549,13 @@ struct TrackDispatcher {
                     extras: ["operation": "track.set_automation"]
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "track.set_automation",
                 params: ["index": String(index), "mode": mode]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "set_instrument":
             let index: Int
@@ -553,9 +588,14 @@ struct TrackDispatcher {
             if !path.isEmpty { routeParams["path"] = path }
             if !category.isEmpty { routeParams["category"] = category }
             if !preset.isEmpty { routeParams["preset"] = preset }
+            let traceID = await startTraceIfEnabled(command: command)
             if dialogPresent() {
-                return blockingLogicDialogResult(operation: "track.set_instrument")
+                return await finalizeTrace(
+                    blockingLogicDialogResult(operation: "track.set_instrument"),
+                    traceID: traceID
+                )
             }
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "track.set_instrument",
                 params: routeParams
@@ -568,7 +608,7 @@ struct TrackDispatcher {
             // no-op rebind), and any other guess could mask an external rename. So we
             // honestly defer: an auto-rename here fails the next same-ref op closed,
             // which is correct — the server cannot cheaply prove the new identity.
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "resolve_path":
             let path = stringParam(params, "path")
@@ -698,66 +738,6 @@ struct TrackDispatcher {
             return toolTextResult(result.message, isError: true)
         }
         return toolTextResult(result)
-    }
-
-    private static func startTraceIfEnabled(command: String) async -> TraceID? {
-        guard FeatureFlags.adr005OperationTrace,
-              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
-            return nil
-        }
-        switch spec.id {
-        case .tracksRename, .tracksMute, .tracksSolo, .tracksArm:
-            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
-            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
-                "operation_id": spec.id.rawValue,
-                "command": command,
-            ])
-            return id
-        default:
-            return nil
-        }
-    }
-
-    private static func recordWriteBoundary(_ traceID: TraceID?) async {
-        guard let traceID else { return }
-        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
-    }
-
-    private static func finalizeTrace(
-        _ result: CallTool.Result,
-        traceID: TraceID?
-    ) async -> CallTool.Result {
-        guard let traceID else { return result }
-        guard case .text(let raw, _, _) = result.content.first else {
-            await OperationTraceStore.shared.record(
-                traceID,
-                phase: .verificationCompleted,
-                attributes: ["readback_state": result.isError == true ? "C" : "A"]
-            )
-            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-            await OperationTraceStore.shared.complete(traceID)
-            return result
-        }
-
-        let object = decodedJSONObject(raw)
-        var attributes = [
-            "readback_state": object?["state"] as? String
-                ?? (result.isError == true ? "C" : "A"),
-        ]
-        if let errorCode = object?["error"] as? String {
-            attributes["error_code"] = errorCode
-        }
-        await OperationTraceStore.shared.record(
-            traceID,
-            phase: .verificationCompleted,
-            attributes: attributes
-        )
-        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-        await OperationTraceStore.shared.complete(traceID)
-
-        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
-        guard merged != raw else { return result }
-        return toolTextResult(merged, isError: result.isError == true)
     }
 
     private static func modalGuardedTrackOperation(for command: String) -> String? {

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct TransportDispatcher {
+struct TransportDispatcher: OperationTraceDispatching {
     static let tool = Tool(
         name: "logic_transport",
         description: "Control Logic Pro transport. Commands: play, stop, record, pause, rewind, fast_forward, toggle_cycle, toggle_metronome, set_tempo, goto_position, set_cycle_range, toggle_count_in, toggle_autopunch. Params: set_tempo -> { tempo: Float } (5.0-999.0); goto_position -> { bar: Int (1..9999) } or { position: String } where String is bar.beat.sub.tick (e.g. \"9.1.1.1\") or HH:MM:SS:FF SMPTE (e.g. \"00:00:08:12\"); set_cycle_range -> { start: Int, end: Int } (UNSUPPORTED/best-effort: Logic 12.x exposes no numeric cycle-locator fields, so this fails closed with State C not_implemented and CANNOT verify a write); others -> {}.",
@@ -16,8 +16,8 @@ struct TransportDispatcher {
         sleep: @escaping (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
         dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> CallTool.Result {
-        let traceID = await startTraceIfEnabled(command: command)
         if let operation = modalGuardedTransportOperation(for: command), dialogPresent() {
+            let traceID = await startTraceIfEnabled(command: command)
             return await finalizeTrace(
                 blockingLogicDialogResult(operation: operation),
                 traceID: traceID
@@ -26,6 +26,7 @@ struct TransportDispatcher {
 
         switch command {
         case "play":
+            let traceID = await startTraceIfEnabled(command: command)
             let result = await handleVerifiedTransportCommand(
                 action: .play,
                 router: router,
@@ -35,6 +36,7 @@ struct TransportDispatcher {
             return await finalizeTrace(result, traceID: traceID)
 
         case "stop":
+            let traceID = await startTraceIfEnabled(command: command)
             let result = await verifiedStopResult(
                 router: router,
                 cache: cache,
@@ -44,6 +46,7 @@ struct TransportDispatcher {
             return await finalizeTrace(result, traceID: traceID)
 
         case "record":
+            let traceID = await startTraceIfEnabled(command: command)
             let result = await handleVerifiedTransportCommand(
                 action: .record,
                 router: router,
@@ -53,6 +56,7 @@ struct TransportDispatcher {
             return await finalizeTrace(result, traceID: traceID)
 
         case "pause":
+            let traceID = await startTraceIfEnabled(command: command)
             let result = await verifiedPauseResult(
                 router: router,
                 cache: cache,
@@ -62,34 +66,47 @@ struct TransportDispatcher {
             return await finalizeTrace(result, traceID: traceID)
 
         case "rewind":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.rewind")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "fast_forward":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.fast_forward")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_cycle":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.toggle_cycle")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_metronome":
+            let traceID = await startTraceIfEnabled(command: command)
             let beforeTransport = await liveTransportState(router: router, cache: cache)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.toggle_metronome")
-            return await finalizeToggleMetronomeResult(
+            let finalized = await finalizeToggleMetronomeResult(
                 result,
                 beforeTransport: beforeTransport,
                 router: router,
                 cache: cache
             )
+            return await finalizeTrace(finalized, traceID: traceID)
 
         case "toggle_count_in":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.toggle_count_in")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_autopunch":
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(operation: "transport.toggle_autopunch")
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "set_tempo":
             guard params["tempo"] != nil || params["bpm"] != nil else {
@@ -110,11 +127,13 @@ struct TransportDispatcher {
                         "set_tempo 'tempo' must be in 5..999 (got \(tempo))"
                     )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "transport.set_tempo",
                 params: ["bpm": String(tempo)]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "goto_position":
             // Reject unknown keys before falling back to defaults. Prior to
@@ -147,16 +166,19 @@ struct TransportDispatcher {
                         "goto_position 'bar' must be in 1..9999 (got \(bar))"
                     )
                 }
+                let traceID = await startTraceIfEnabled(command: command)
+                await recordWriteBoundary(traceID)
                 let result = await router.route(
                     operation: "transport.goto_position",
                     params: ["position": "\(bar).1.1.1"]
                 )
-                return await finalizeGotoPositionResult(
+                let finalized = await finalizeGotoPositionResult(
                     result,
                     requestedPosition: "\(bar).1.1.1",
                     router: router,
                     cache: cache
                 )
+                return await finalizeTrace(finalized, traceID: traceID)
             }
             let time = stringParam(params, "position", default: "1.1.1.1")
             // Validate position format before routing. Accept:
@@ -167,16 +189,19 @@ struct TransportDispatcher {
                     "goto_position 'position' must be bar.beat.sub.tick (e.g. 1.1.1.1) or HH:MM:SS:FF (got '\(time)')"
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "transport.goto_position",
                 params: ["position": time]
             )
-            return await finalizeGotoPositionResult(
+            let finalized = await finalizeGotoPositionResult(
                 result,
                 requestedPosition: time,
                 router: router,
                 cache: cache
             )
+            return await finalizeTrace(finalized, traceID: traceID)
 
         case "set_cycle_range":
             guard params["start"] != nil, params["end"] != nil else {
@@ -202,11 +227,13 @@ struct TransportDispatcher {
                     "set_cycle_range 'start' (\(start)) must be <= 'end' (\(end))"
                 )
             }
+            let traceID = await startTraceIfEnabled(command: command)
+            await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "transport.set_cycle_range",
                 params: ["start": "\(start).1.1.1", "end": "\(end).1.1.1"]
             )
-            return toolTextResult(result)
+            return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
             return toolTextResult(
@@ -214,66 +241,6 @@ struct TransportDispatcher {
                 isError: true
             )
         }
-    }
-
-    private static func startTraceIfEnabled(command: String) async -> TraceID? {
-        guard FeatureFlags.adr005OperationTrace,
-              let spec = OperationRegistry.spec(tool: tool.name, command: command) else {
-            return nil
-        }
-        switch spec.id {
-        case .transportPlay, .transportStop, .transportRecord, .transportPause:
-            let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
-            await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
-                "operation_id": spec.id.rawValue,
-                "command": command,
-            ])
-            return id
-        default:
-            return nil
-        }
-    }
-
-    private static func recordWriteBoundary(_ traceID: TraceID?) async {
-        guard let traceID else { return }
-        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
-    }
-
-    private static func finalizeTrace(
-        _ result: CallTool.Result,
-        traceID: TraceID?
-    ) async -> CallTool.Result {
-        guard let traceID else { return result }
-        guard case .text(let raw, _, _) = result.content.first else {
-            await OperationTraceStore.shared.record(
-                traceID,
-                phase: .verificationCompleted,
-                attributes: ["readback_state": result.isError == true ? "C" : "A"]
-            )
-            await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-            await OperationTraceStore.shared.complete(traceID)
-            return result
-        }
-
-        let object = decodedJSONObject(raw)
-        var attributes = [
-            "readback_state": object?["state"] as? String
-                ?? (result.isError == true ? "C" : "A"),
-        ]
-        if let errorCode = object?["error"] as? String {
-            attributes["error_code"] = errorCode
-        }
-        await OperationTraceStore.shared.record(
-            traceID,
-            phase: .verificationCompleted,
-            attributes: attributes
-        )
-        await OperationTraceStore.shared.record(traceID, phase: .resultEmitted)
-        await OperationTraceStore.shared.complete(traceID)
-
-        let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
-        guard merged != raw else { return result }
-        return toolTextResult(merged, isError: result.isError == true)
     }
 
     private static func modalGuardedTransportOperation(for command: String) -> String? {

--- a/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
@@ -75,6 +75,7 @@ enum ProjectExportExecutor {
         var pollAttempts: Int
         var pollIntervalNanos: UInt64
         var sleep: @Sendable (UInt64) async -> Void
+        var onFirstWrite: @Sendable () async -> Void = {}
         /// Minimum sane duration (seconds) for a produced artifact. A bounce that
         /// yields a sub-tick file is treated as not-verified (State B).
         var minimumDurationSeconds: Double
@@ -144,13 +145,15 @@ enum ProjectExportExecutor {
             return confirmationRequiredRun(plan: plan, resume: resume)
         }
 
+        let firstWriteNotifier = FirstWriteNotifier(action: options.onFirstWrite)
         var runProjects: [RunProject] = []
         for project in plan.projects {
             let runProject = await execute(
                 project: project,
                 plan: plan,
                 router: router,
-                options: options
+                options: options,
+                firstWriteNotifier: firstWriteNotifier
             )
             runProjects.append(runProject)
         }
@@ -164,7 +167,8 @@ enum ProjectExportExecutor {
         project: ProjectExportPlanProject,
         plan: ProjectExportPlan,
         router: ChannelRouter,
-        options: Options
+        options: Options,
+        firstWriteNotifier: FirstWriteNotifier
     ) async -> RunProject {
         // A degraded/invalid project (bad path, intra-plan collision, would-
         // overwrite under fail_if_exists) never gets opened — every artifact
@@ -228,6 +232,7 @@ enum ProjectExportExecutor {
         }
 
         // (3a) Open the project (existing open path through the router).
+        await firstWriteNotifier.notify()
         let openResult = await router.route(
             operation: "project.open",
             params: ["path": project.projectPath]
@@ -303,5 +308,20 @@ enum ProjectExportExecutor {
             opened: true,
             artifacts: arts
         )
+    }
+
+    private actor FirstWriteNotifier {
+        private let action: @Sendable () async -> Void
+        private var notified = false
+
+        init(action: @escaping @Sendable () async -> Void) {
+            self.action = action
+        }
+
+        func notify() async {
+            guard !notified else { return }
+            notified = true
+            await action()
+        }
     }
 }

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -1,0 +1,426 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+private let operationTraceCoverageFlagKey = "LOGIC_MCP_ADR005_OPERATION_TRACE"
+
+private func replaceOperationTraceCoverageFlag(with value: String?) -> String? {
+    let previous = getenv(operationTraceCoverageFlagKey).map { String(cString: $0) }
+    if let value {
+        setenv(operationTraceCoverageFlagKey, value, 1)
+    } else {
+        unsetenv(operationTraceCoverageFlagKey)
+    }
+    return previous
+}
+
+private actor OperationTraceCoverageChannel: Channel {
+    nonisolated let id: ChannelID
+
+    init(id: ChannelID) {
+        self.id = id
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        .error(HonestContract.encodeStateC(
+            error: .axWriteFailed,
+            hint: "Operation trace coverage mock refused \(operation)",
+            extras: ["operation": operation]
+        ))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace coverage mock")
+    }
+}
+
+private struct OperationTraceCoverageFixtures {
+    let projectPath: String
+    let outputRoot: String
+    let midiPath: String
+}
+
+private let operationTraceCoverageFileReader = LogicProjectFileReader.Runtime(
+    currentDocumentPath: { nil },
+    now: Date.init,
+    readPlistData: { _ in nil },
+    mtime: { _ in nil },
+    sleep: { _ in }
+)
+
+extension OperationTraceTests {
+    @Test func OperationTraceCoverageAllRegistryMutations() async throws {
+        let previous = replaceOperationTraceCoverageFlag(with: "1")
+        defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
+
+        let projectRoot = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectRoot)
+            try? FileManager.default.removeItem(at: outputRoot)
+        }
+        let project = try makeLogicxProject(in: projectRoot, named: "Trace Coverage")
+        let resources = project.appendingPathComponent("Resources", isDirectory: true)
+        let alternative = project.appendingPathComponent("Alternatives/000", isDirectory: true)
+        try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: alternative, withIntermediateDirectories: true)
+        try Data().write(to: resources.appendingPathComponent("ProjectInformation.plist"))
+        try Data().write(to: alternative.appendingPathComponent("ProjectData"))
+        let midiFile = try SMFWriter.temporaryMIDIFile()
+        try Data([0x4D, 0x54, 0x68, 0x64]).write(to: midiFile.fileURL)
+        defer { SMFWriter.cleanupTemporaryMIDIFile(midiFile) }
+
+        let fixtures = OperationTraceCoverageFixtures(
+            projectPath: project.path,
+            outputRoot: outputRoot.path,
+            midiPath: midiFile.fileURL.path
+        )
+        let router = ChannelRouter()
+        for channelID in ChannelID.allCases {
+            await router.register(OperationTraceCoverageChannel(id: channelID))
+        }
+        let cache = StateCache()
+        await cache.updateMarkers([
+            MarkerState(id: 0, name: "Coverage Marker", position: "1.1.1.1", positionSource: .parser),
+        ])
+
+        let mutatingSpecs = OperationRegistry.specs.filter {
+            $0.mutability == Mutability.`mutating`
+        }
+        #expect(OperationRegistry.specs.count == 99)
+        #expect(mutatingSpecs.count == 83)
+
+        for spec in mutatingSpecs {
+            await OperationTraceStore.shared.clear()
+            _ = await dispatchOperationTraceCoverageSpec(
+                spec,
+                params: operationTraceCoverageParams(for: spec.id, fixtures: fixtures),
+                router: router,
+                cache: cache
+            )
+
+            let matchingTrace = await OperationTraceStore.shared.recent(limit: 128)
+                .first { $0.operationID == spec.id.rawValue }
+            #expect(matchingTrace != nil, "Missing trace for \(spec.tool.rawValue).\(spec.command)")
+            if let matchingTrace {
+                #expect(
+                    matchingTrace.events.contains { $0.phase == .requestReceived },
+                    "Missing request.received for \(spec.id.rawValue)"
+                )
+                #expect(
+                    matchingTrace.events.contains { $0.phase == .resultEmitted },
+                    "Missing result.emitted for \(spec.id.rawValue)"
+                )
+                #expect(matchingTrace.completedAt != nil, "Incomplete trace for \(spec.id.rawValue)")
+            }
+        }
+
+        await OperationTraceStore.shared.clear()
+    }
+
+    @Test func OperationTraceCoverageReadOnlyCommandsRemainTraceFree() async throws {
+        let previous = replaceOperationTraceCoverageFlag(with: "1")
+        defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
+
+        let fixtures = OperationTraceCoverageFixtures(
+            projectPath: "/tmp/trace-coverage.logicx",
+            outputRoot: "/tmp",
+            midiPath: "/tmp/trace-coverage.mid"
+        )
+        let router = ChannelRouter()
+        for channelID in ChannelID.allCases {
+            await router.register(OperationTraceCoverageChannel(id: channelID))
+        }
+        let cache = StateCache()
+        let readOnlyIDs: [OperationID] = [
+            .audioAnalyzeFile,
+            .pluginsGetInventory,
+            .projectIsRunning,
+            .midiListPorts,
+            .tracksResolvePath,
+        ]
+
+        for operationID in readOnlyIDs {
+            let spec = try #require(OperationRegistry.specs.first { $0.id == operationID })
+            #expect(spec.mutability == .readOnly)
+            await OperationTraceStore.shared.clear()
+            _ = await dispatchOperationTraceCoverageSpec(
+                spec,
+                params: operationTraceCoverageParams(for: operationID, fixtures: fixtures),
+                router: router,
+                cache: cache
+            )
+            #expect(
+                await OperationTraceStore.shared.recent(limit: 128).isEmpty,
+                "Read-only command traced: \(spec.tool.rawValue).\(spec.command)"
+            )
+        }
+
+        await OperationTraceStore.shared.clear()
+    }
+
+    @Test func OperationTraceCoverageProjectBlockingDialogsTraceWithoutBoundary() async throws {
+        let previous = replaceOperationTraceCoverageFlag(with: "1")
+        defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
+
+        let projectRoot = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectRoot)
+            try? FileManager.default.removeItem(at: outputRoot)
+        }
+        let project = try makeLogicxProject(in: projectRoot, named: "Trace Blocking")
+        let exportParams: [String: Value] = [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+            "confirmed": .bool(true),
+        ]
+        let cases: [(command: String, params: [String: Value])] = [
+            ("new", [:]),
+            ("save", [:]),
+            ("export_run", exportParams),
+            ("export_resume", exportParams),
+        ]
+
+        for testCase in cases {
+            await OperationTraceStore.shared.clear()
+            _ = await ProjectDispatcher.handle(
+                command: testCase.command,
+                params: testCase.params,
+                router: ChannelRouter(),
+                cache: StateCache(),
+                dialogPresent: { true },
+                cleanupAuditFileReader: operationTraceCoverageFileReader,
+                exportOptions: fastOptions(identity: { nil })
+            )
+
+            let operationID = try #require(
+                OperationRegistry.spec(tool: ProjectDispatcher.tool.name, command: testCase.command)?.id
+            )
+            let trace = try #require(
+                await OperationTraceStore.shared.recent(limit: 8)
+                    .first { $0.operationID == operationID.rawValue }
+            )
+            #expect(trace.events.contains { $0.phase == .requestReceived })
+            #expect(!trace.events.contains { $0.phase == .writeBoundaryCrossed })
+            #expect(trace.events.contains { $0.phase == .resultEmitted })
+            #expect(trace.completedAt != nil)
+        }
+
+        await OperationTraceStore.shared.clear()
+    }
+}
+
+private func dispatchOperationTraceCoverageSpec(
+    _ spec: OperationSpec,
+    params: [String: Value],
+    router: ChannelRouter,
+    cache: StateCache
+) async -> CallTool.Result {
+    switch spec.tool {
+    case .logicTransport:
+        return await TransportDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache,
+            sleep: { _ in }
+        )
+    case .logicMixer:
+        return await MixerDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicNavigate:
+        return await NavigateDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicAudio:
+        return AudioDispatcher.handle(command: spec.command, params: params)
+    case .logicSystem:
+        return await SystemDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicPlugins:
+        return await PluginsDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicEdit:
+        return await EditDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicProject:
+        return await ProjectDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache,
+            isLogicProRunning: { spec.command == "quit" },
+            executeLifecycleScript: { _ in
+                ProjectDispatcher.LifecycleExecution(
+                    executionError: "operation trace coverage mock",
+                    timedOut: false,
+                    terminationStatus: 1,
+                    stderrOutput: ""
+                )
+            },
+            sleep: { _ in },
+            cleanupAuditFileReader: operationTraceCoverageFileReader,
+            exportOptions: fastOptions(identity: { nil })
+        )
+    case .logicMidi:
+        return await MIDIDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    case .logicTracks:
+        return await TrackDispatcher.handle(
+            command: spec.command,
+            params: params,
+            router: router,
+            cache: cache
+        )
+    }
+}
+
+private func operationTraceCoverageParams(
+    for operationID: OperationID,
+    fixtures: OperationTraceCoverageFixtures
+) -> [String: Value] {
+    switch operationID {
+    case .transportSetTempo:
+        return ["tempo": .double(120)]
+    case .transportGotoPosition:
+        return ["bar": .int(1)]
+    case .transportSetCycleRange:
+        return ["start": .int(1), "end": .int(2)]
+    case .mixerSetVolume:
+        return ["track": .int(0), "value": .double(0.5)]
+    case .mixerSetPan:
+        return ["track": .int(0), "value": .double(0)]
+    case .mixerSetMasterVolume:
+        return ["value": .double(0.5)]
+    case .mixerSetPluginParam:
+        return ["track": .int(0), "insert": .int(0), "param": .int(0), "value": .double(0.5)]
+    case .mixerInsertPlugin:
+        return [
+            "track": .int(0), "slot": .int(0), "plugin_name": .string("Gain"),
+            "confirmed": .bool(true),
+        ]
+    case .navigateGotoBar:
+        return ["bar": .int(1)]
+    case .navigateGotoMarker, .navigateDeleteMarker:
+        return ["index": .int(0)]
+    case .navigateCreateMarker:
+        return ["name": .string("Coverage Marker")]
+    case .navigateRenameMarker:
+        return ["index": .int(0), "name": .string("Coverage Marker")]
+    case .navigateSetZoom:
+        return ["level": .string("fit")]
+    case .navigateToggleView:
+        return ["view": .string("mixer")]
+    case .pluginsGetInventory:
+        return ["track": .int(0)]
+    case .pluginsSetParamVerified:
+        return [
+            "track": .int(0), "insert": .int(0), "plugin": .string("logic.stock.gain"),
+            "param": .string("gain_db"), "value": .double(0), "unit": .string("dB"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string(fixtures.projectPath),
+        ]
+    case .pluginsInsertVerified:
+        return [
+            "track": .int(0), "insert": .int(0), "plugin": .string("Gain"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string(fixtures.projectPath),
+        ]
+    case .editQuantize:
+        return ["value": .string("1/16")]
+    case .projectOpen:
+        return ["path": .string(fixtures.projectPath), "confirmed": .bool(true)]
+    case .projectSaveAs:
+        return [
+            "path": .string(URL(fileURLWithPath: fixtures.outputRoot)
+                .appendingPathComponent("Trace Coverage.logicx").path),
+            "confirmed": .bool(true),
+        ]
+    case .projectClose:
+        return ["saving": .string("no"), "confirmed": .bool(true)]
+    case .projectBounce:
+        return ["confirmed": .bool(false)]
+    case .projectQuit:
+        return ["confirmed": .bool(true)]
+    case .projectExportRun, .projectExportResume:
+        return [
+            "projects": .array([.string(fixtures.projectPath)]),
+            "output_root": .string(fixtures.outputRoot),
+            "artifacts": .array([.string("bounce")]),
+            "confirmed": .bool(false),
+        ]
+    case .projectCleanupApply:
+        return ["step_id": .string("coverage-step"), "confirmed": .bool(true)]
+    case .midiSendNote:
+        return ["note": .int(60), "velocity": .int(100), "duration_ms": .int(100)]
+    case .midiSendChord:
+        return ["notes": .string("60,64,67"), "velocity": .int(100), "duration_ms": .int(100)]
+    case .midiSendCC:
+        return ["controller": .int(1), "value": .int(64)]
+    case .midiSendProgramChange:
+        return ["program": .int(1)]
+    case .midiSendPitchBend:
+        return ["value": .int(0)]
+    case .midiSendAftertouch:
+        return ["value": .int(64)]
+    case .midiSendSysEx:
+        return ["bytes": .array([.int(0xF0), .int(0x01), .int(0xF7)])]
+    case .midiPlaySequence:
+        return ["notes": .string("60,0,100")]
+    case .midiImportFile:
+        return ["path": .string(fixtures.midiPath)]
+    case .midiCreateVirtualPort:
+        return ["name": .string("Trace Coverage")]
+    case .midiStepInput:
+        return ["note": .int(60), "duration": .string("1/16")]
+    case .midiMMCLocate:
+        return ["bar": .int(1)]
+    case .tracksSelect, .tracksDelete, .tracksDuplicate, .tracksArmOnly:
+        return ["index": .int(0)]
+    case .tracksRename:
+        return ["index": .int(0), "name": .string("Trace Coverage")]
+    case .tracksMute, .tracksSolo, .tracksArm:
+        return ["index": .int(0), "enabled": .bool(true)]
+    case .tracksRecordSequence:
+        return ["notes": .string("60,0,100")]
+    case .tracksSetAutomation:
+        return ["index": .int(0), "mode": .string("read")]
+    case .tracksSetInstrument:
+        return ["index": .int(0), "path": .string("Pianos/Trace Coverage.patch")]
+    case .tracksResolvePath:
+        return ["path": .string("Pianos/Trace Coverage.patch")]
+    case .audioAnalyzeFile:
+        return ["path": .string("/tmp/trace-coverage-missing.wav")]
+    default:
+        return [:]
+    }
+}


### PR DESCRIPTION
## ADR-005 (#288, part of #308) — 100% mutation trace coverage + permanent registry-driven gate

Trace coverage was ~10/83 mutating commands (Track/Mixer/Transport subsets) with the trace helpers copy-pasted as private statics in two dispatchers. This PR completes the ADR-005 done-bar: **83/83 registry-mutating commands traced**, helpers unified, and a permanent gate that keeps it that way.

### Change
- **Helper unification** — `OperationTraceDispatching` protocol extension in `DispatcherSupport`; `startTraceIfEnabled` now derives mutability from the **OperationRegistry spec** (registry-driven; correctness pinned by the ADR-003 equivalence gate merged in #354). Read-only commands never start a trace; every mutating command does. Duplicated private helpers removed.
- **Newly wired**: Edit (14), Project (11), MIDI (15), Navigate (8), Plugins (2); completions in Transport (13), Mixer (5), Tracks (15 incl. record_sequence). Audio/System have no mutating registry commands. `write_boundary.crossed` recorded once, immediately before the first call that can change Logic/UI state; confirmation/modal/no-op paths trace without a boundary event.
- **Permanent gate** — `OperationTraceCoverageTests` dispatches ALL 83 registry-derived mutating specs (asserts 99 specs / 83 mutating counts) and requires a completed trace with `request.received` + `result.emitted` per spec; read-only negative spot-checks; Project modal State C paths assert trace-without-boundary. Adding a mutating command without trace wiring now fails CI.
- Flag-off (`LOGIC_MCP_ADR005_OPERATION_TRACE` unset) byte-identical: `startTraceIfEnabled` returns nil.

### Verification
- Unit: gate 3/3; OperationTrace 17/17; OperationRegistry 49/49; broad dispatcher filter **785/785** (excluding the known environmentally-hanging installer test).
- **Live (real Logic 12.3, flag on)**: newly-wired `navigate.create_marker` (State A) and `midi.send_cc` (State B) both carry `trace_id`; `get_trace` shows the full `request.received → write_boundary.crossed → verification.completed → result.emitted` chain; read-only `health` carries no trace_id; **flag OFF → no trace_id** (control).

Refs #308. Builds on #353/#355 (branch stacked; delta-only vs main).
