### PR TITLE
feat(adr-002): explicit target policies + uniform target_ref evidence echo (#285)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -25,6 +25,7 @@ struct MixerDispatcher: OperationTraceDispatching {
             // whose (trackIndex-keyed) mixer strip is addressed; flag off →
             // explicit track/index required (byte-identical to prior behaviour).
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -37,6 +38,7 @@ struct MixerDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -52,10 +54,13 @@ struct MixerDispatcher: OperationTraceDispatching {
             }
             let traceID = await startTraceIfEnabled(command: command)
             await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mixer.set_volume", params: [
-                "index": String(index),
-                "volume": String(volume),
-            ])
+            let result = TargetRefResolver.addEvidence(
+                resolvedReference,
+                to: await routedTextResult(router, operation: "mixer.set_volume", params: [
+                    "index": String(index),
+                    "volume": String(volume),
+                ])
+            )
             return await finalizeTrace(result, traceID: traceID)
 
         case "set_pan":
@@ -64,6 +69,7 @@ struct MixerDispatcher: OperationTraceDispatching {
             // (trackIndex-keyed) mixer strip; flag off → explicit track/index
             // required (byte-identical to prior behaviour).
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -76,6 +82,7 @@ struct MixerDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -91,10 +98,13 @@ struct MixerDispatcher: OperationTraceDispatching {
             }
             let traceID = await startTraceIfEnabled(command: command)
             await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mixer.set_pan", params: [
-                "index": String(index),
-                "pan": String(pan),
-            ])
+            let result = TargetRefResolver.addEvidence(
+                resolvedReference,
+                to: await routedTextResult(router, operation: "mixer.set_pan", params: [
+                    "index": String(index),
+                    "pan": String(pan),
+                ])
+            )
             return await finalizeTrace(result, traceID: traceID)
 
         case "set_send":

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -64,6 +64,7 @@ struct PluginsDispatcher: OperationTraceDispatching {
 
         case "set_param_verified":
             let traceID = await startTraceIfEnabled(command: command)
+            var resolvedReference: TargetReference?
             let result = await runVerified(operation: "plugin.set_param_verified") {
                 var writeParams = verifiedWriteParams(params)
                 // ADR-002: with the flag on, a target_ref resolves the host track
@@ -85,6 +86,7 @@ struct PluginsDispatcher: OperationTraceDispatching {
                     ) {
                     case .success(let resolved):
                         writeParams["track"] = String(resolved.index)
+                        resolvedReference = resolved.reference
                     case .failure(let result):
                         return result
                     }
@@ -93,7 +95,10 @@ struct PluginsDispatcher: OperationTraceDispatching {
                 return await routedTextResult(router, operation: "plugin.set_param_verified",
                                               params: writeParams)
             }
-            return await finalizeTrace(result, traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: result),
+                traceID: traceID
+            )
 
         case "insert_verified":
             let traceID = await startTraceIfEnabled(command: command)

--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -90,9 +90,13 @@ enum TargetRefResolver {
 
     /// Echo the causal reference only on a verified State A response. Nil
     /// references are the legacy index/flag-off path and remain byte-identical.
+    /// `legacyTrackRefAlias` additionally emits the pre-uniform `track_ref` key —
+    /// rename shipped that echo first, so it keeps the alias for backward
+    /// compatibility (G8); new consumers should read `target_ref`.
     static func addEvidence(
         _ reference: TargetReference?,
-        to result: CallTool.Result
+        to result: CallTool.Result,
+        legacyTrackRefAlias: Bool = false
     ) -> CallTool.Result {
         guard let reference,
               case .text(let rawJSON, let annotations, let meta) = result.content.first,
@@ -100,8 +104,12 @@ enum TargetRefResolver {
             return result
         }
 
+        var evidence: [String: Any] = ["target_ref": reference.rawValue]
+        if legacyTrackRefAlias {
+            evidence["track_ref"] = reference.rawValue
+        }
         let echoed = HonestContract.addExtras(
-            ["target_ref": reference.rawValue],
+            evidence,
             into: rawJSON
         )
         guard echoed != rawJSON else { return result }

--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -11,8 +11,8 @@ import MCP
 enum TargetRefResolver {
     /// A resolved mutation target: the concrete track index plus — when the
     /// caller supplied a valid `target_ref` — the reference that produced it, so
-    /// the dispatcher can echo `track_ref` back (as `rename` does).
-    struct Resolved {
+    /// the dispatcher can echo `target_ref` evidence on verified success.
+    struct Resolved: Sendable {
         let index: Int
         let reference: TargetReference?
     }
@@ -86,6 +86,34 @@ enum TargetRefResolver {
             return .failure(invalidIndexResult())
         }
         return .success(Resolved(index: requestedIndex, reference: nil))
+    }
+
+    /// Echo the causal reference only on a verified State A response. Nil
+    /// references are the legacy index/flag-off path and remain byte-identical.
+    static func addEvidence(
+        _ reference: TargetReference?,
+        to result: CallTool.Result
+    ) -> CallTool.Result {
+        guard let reference,
+              case .text(let rawJSON, let annotations, let meta) = result.content.first,
+              decodedJSONObject(rawJSON)?["state"] as? String == "A" else {
+            return result
+        }
+
+        let echoed = HonestContract.addExtras(
+            ["target_ref": reference.rawValue],
+            into: rawJSON
+        )
+        guard echoed != rawJSON else { return result }
+
+        var content = result.content
+        content[0] = .text(text: echoed, annotations: annotations, _meta: meta)
+        return CallTool.Result(
+            content: content,
+            structuredContent: structuredContentValue(fromToolText: echoed),
+            isError: result.isError,
+            _meta: result._meta
+        )
     }
 
     /// Fail-closed State C for a `target_ref` that is missing/malformed, no longer

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -59,7 +59,10 @@ struct TrackDispatcher: OperationTraceDispatching {
                         operation: "track.select",
                         params: ["index": String(resolved.index)]
                     )
-                    return await finalizeTrace(toolTextResult(result), traceID: traceID)
+                    return await finalizeTrace(
+                        TargetRefResolver.addEvidence(resolved.reference, to: toolTextResult(result)),
+                        traceID: traceID
+                    )
                 case .failure(let result):
                     return result
                 }
@@ -126,6 +129,7 @@ struct TrackDispatcher: OperationTraceDispatching {
 
         case "delete":
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -138,6 +142,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -178,10 +183,14 @@ struct TrackDispatcher: OperationTraceDispatching {
             if FeatureFlags.adr002TargetRef, result.isSuccess {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return await finalizeTrace(toolTextResult(result), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                traceID: traceID
+            )
 
         case "duplicate":
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -194,6 +203,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -233,7 +243,10 @@ struct TrackDispatcher: OperationTraceDispatching {
             if FeatureFlags.adr002TargetRef, result.isSuccess {
                 await targetRegistry?.bumpTopologyGeneration()
             }
-            return await finalizeTrace(toolTextResult(result), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                traceID: traceID
+            )
 
         case "rename":
             let index: Int
@@ -329,22 +342,11 @@ struct TrackDispatcher: OperationTraceDispatching {
                     resolvedReference,
                     to: TargetDescriptor(trackIndex: index, trackName: name)
                 )
-                if var payload = decodedJSONObject(result.message) {
-                    payload["track_ref"] = resolvedReference.rawValue
-                    return await finalizeTrace(
-                        toolTextResult(HonestContract.jsonString(payload)),
-                        traceID: traceID
-                    )
-                }
-                return await finalizeTrace(
-                    toolTextResult(HonestContract.encodeStateA(extras: [
-                        "operation": "track.rename",
-                        "track_ref": resolvedReference.rawValue,
-                    ])),
-                    traceID: traceID
-                )
             }
-            return await finalizeTrace(toolTextResult(result), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                traceID: traceID
+            )
 
         case "mute":
             let traceID = await startTraceIfEnabled(command: command)
@@ -400,6 +402,7 @@ struct TrackDispatcher: OperationTraceDispatching {
 
         case "arm_only":
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -412,6 +415,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -501,25 +505,32 @@ struct TrackDispatcher: OperationTraceDispatching {
                     HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras)
                 )), traceID: traceID)
             }
-            return await finalizeTrace(toolTextResult(.success(
-                HonestContract.encodeStateA(
-                    extras: armOnlyExtras(
-                        targetIndex: index,
-                        armResult: armResult,
-                        armedSuccess: true,
-                        verified: true,
-                        disarmed: disarmed,
-                        unverifiedDisarm: [],
-                        failedDisarm: []
-                    )
-                )
-            )), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(
+                    resolvedReference,
+                    to: toolTextResult(.success(
+                        HonestContract.encodeStateA(
+                            extras: armOnlyExtras(
+                                targetIndex: index,
+                                armResult: armResult,
+                                armedSuccess: true,
+                                verified: true,
+                                disarmed: disarmed,
+                                unverifiedDisarm: [],
+                                failedDisarm: []
+                            )
+                        )
+                    ))
+                ),
+                traceID: traceID
+            )
 
         case "set_color":
             return notExposedCommandResult(operation: "track.set_color")
 
         case "set_automation":
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -532,6 +543,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -555,10 +567,14 @@ struct TrackDispatcher: OperationTraceDispatching {
                 operation: "track.set_automation",
                 params: ["index": String(index), "mode": mode]
             )
-            return await finalizeTrace(toolTextResult(result), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                traceID: traceID
+            )
 
         case "set_instrument":
             let index: Int
+            let resolvedReference: TargetReference?
             switch await TargetRefResolver.resolveMutationIndex(
                 params,
                 targetRegistry: targetRegistry,
@@ -572,6 +588,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
             case .success(let resolved):
                 index = resolved.index
+                resolvedReference = resolved.reference
             case .failure(let result):
                 return result
             }
@@ -608,7 +625,10 @@ struct TrackDispatcher: OperationTraceDispatching {
             // no-op rebind), and any other guess could mask an external rename. So we
             // honestly defer: an auto-rename here fails the next same-ref op closed,
             // which is correct — the server cannot cheaply prove the new identity.
-            return await finalizeTrace(toolTextResult(result), traceID: traceID)
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                traceID: traceID
+            )
 
         case "resolve_path":
             let path = stringParam(params, "path")
@@ -700,6 +720,7 @@ struct TrackDispatcher: OperationTraceDispatching {
         traceID: TraceID? = nil
     ) async -> CallTool.Result {
         let index: Int
+        let resolvedReference: TargetReference?
         switch await TargetRefResolver.resolveMutationIndex(
             params,
             targetRegistry: targetRegistry,
@@ -712,6 +733,7 @@ struct TrackDispatcher: OperationTraceDispatching {
         ) {
         case .success(let resolved):
             index = resolved.index
+            resolvedReference = resolved.reference
         case .failure(let result):
             return result
         }
@@ -737,7 +759,7 @@ struct TrackDispatcher: OperationTraceDispatching {
         if result.isSuccess, !trackToggleResultIsVerified(result) {
             return toolTextResult(result.message, isError: true)
         }
-        return toolTextResult(result)
+        return TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result))
     }
 
     private static func modalGuardedTrackOperation(for command: String) -> String? {

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -344,7 +344,13 @@ struct TrackDispatcher: OperationTraceDispatching {
                 )
             }
             return await finalizeTrace(
-                TargetRefResolver.addEvidence(resolvedReference, to: toolTextResult(result)),
+                // legacyTrackRefAlias: rename shipped the `track_ref` echo before the
+                // uniform `target_ref` evidence key existed — keep both (G8 compat).
+                TargetRefResolver.addEvidence(
+                    resolvedReference,
+                    to: toolTextResult(result),
+                    legacyTrackRefAlias: true
+                ),
                 traceID: traceID
             )
 

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -324,19 +324,19 @@ enum OperationRegistry {
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     } + ([
-        (.mixerSetVolume, "set_volume", .none),
-        (.mixerSetPan, "set_pan", .none),
-        (.mixerSetMasterVolume, "set_master_volume", .none),
-        (.mixerSetPluginParam, "set_plugin_param", .none),
-        (.mixerInsertPlugin, "insert_plugin", .l2),
-    ] as [(OperationID, String, ConfirmationPolicy)]).map { entry in
+        (.mixerSetVolume, "set_volume", .none, TargetPolicy.requiresStableTarget),
+        (.mixerSetPan, "set_pan", .none, .requiresStableTarget),
+        (.mixerSetMasterVolume, "set_master_volume", .none, .none),
+        (.mixerSetPluginParam, "set_plugin_param", .none, .none),
+        (.mixerInsertPlugin, "insert_plugin", .l2, .none),
+    ] as [(OperationID, String, ConfirmationPolicy, TargetPolicy)]).map { entry in
         OperationSpec(
             id: entry.0,
             tool: .logicMixer,
             command: entry.1,
             mutability: Mutability.`mutating`,
             confirmation: entry.2,
-            target: .none,
+            target: entry.3,
             verification: .readbackRequired,
             retry: .neverAutomatic,
             deadline: .short,
@@ -402,17 +402,17 @@ enum OperationRegistry {
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     } + ([
-        (.pluginsGetInventory, "get_inventory", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
-        (.pluginsSetParamVerified, "set_param_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
-        (.pluginsInsertVerified, "insert_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
-    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy)]).map { entry in
+        (.pluginsGetInventory, "get_inventory", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.none),
+        (.pluginsSetParamVerified, "set_param_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.pluginsInsertVerified, "insert_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.none),
+    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy, TargetPolicy)]).map { entry in
         OperationSpec(
             id: entry.0,
             tool: .logicPlugins,
             command: entry.1,
             mutability: entry.2,
             confirmation: .none,
-            target: .none,
+            target: entry.5,
             verification: entry.4,
             retry: .neverAutomatic,
             deadline: entry.3,
@@ -511,33 +511,33 @@ enum OperationRegistry {
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     } + ([
-        (.tracksSelect, "select", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksCreateAudio, "create_audio", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksCreateInstrument, "create_instrument", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksCreateDrummer, "create_drummer", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksCreateExternalMIDI, "create_external_midi", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksDelete, "delete", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksDuplicate, "duplicate", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
-        (.tracksRename, "rename", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksMute, "mute", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksSolo, "solo", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksArm, "arm", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksArmOnly, "arm_only", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired),
-        (.tracksRecordSequence, "record_sequence", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired),
-        (.tracksSetAutomation, "set_automation", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none),
-        (.tracksSetInstrument, "set_instrument", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
-        (.tracksListLibrary, "list_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none),
-        (.tracksScanLibrary, "scan_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none),
-        (.tracksResolvePath, "resolve_path", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
-        (.tracksScanPluginPresets, "scan_plugin_presets", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none),
-    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy)]).map { entry in
+        (.tracksSelect, "select", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksCreateAudio, "create_audio", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none),
+        (.tracksCreateInstrument, "create_instrument", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none),
+        (.tracksCreateDrummer, "create_drummer", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none),
+        (.tracksCreateExternalMIDI, "create_external_midi", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none),
+        (.tracksDelete, "delete", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksDuplicate, "duplicate", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.requiresStableTarget),
+        (.tracksRename, "rename", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksMute, "mute", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksSolo, "solo", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksArm, "arm", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksArmOnly, "arm_only", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksRecordSequence, "record_sequence", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired, TargetPolicy.none),
+        (.tracksSetAutomation, "set_automation", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.requiresStableTarget),
+        (.tracksSetInstrument, "set_instrument", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget),
+        (.tracksListLibrary, "list_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none),
+        (.tracksScanLibrary, "scan_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none),
+        (.tracksResolvePath, "resolve_path", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.none),
+        (.tracksScanPluginPresets, "scan_plugin_presets", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none),
+    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy, TargetPolicy)]).map { entry in
         OperationSpec(
             id: entry.0,
             tool: .logicTracks,
             command: entry.1,
             mutability: entry.2,
             confirmation: .none,
-            target: .none,
+            target: entry.5,
             verification: entry.4,
             retry: .neverAutomatic,
             deadline: entry.3,

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -60,4 +60,36 @@ struct OperationRegistryCoverageTests {
             }
         }
     }
+
+    @Test("unclassified mutation targets = 0")
+    func everyMutationHasAnExplicitTargetPolicy() {
+        let mutating = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
+        let targetBearingIDs = Set(mutating
+            .filter { $0.target == .requiresStableTarget }
+            .map(\.id))
+        let targetless = mutating.filter { $0.target == .none }
+        let expectedTargetBearingIDs: Set<OperationID> = [
+            .mixerSetVolume,
+            .mixerSetPan,
+            .pluginsSetParamVerified,
+            .tracksSelect,
+            .tracksDelete,
+            .tracksDuplicate,
+            .tracksRename,
+            .tracksMute,
+            .tracksSolo,
+            .tracksArm,
+            .tracksArmOnly,
+            .tracksSetAutomation,
+            .tracksSetInstrument,
+        ]
+
+        #expect(mutating.count == 83)
+        #expect(targetBearingIDs == expectedTargetBearingIDs)
+        #expect(targetless.count == 70)
+        #expect(targetBearingIDs.count + targetless.count == mutating.count)
+        #expect(OperationRegistry.specs
+            .filter { $0.mutability == .readOnly }
+            .allSatisfy { $0.target == .none })
+    }
 }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -183,6 +183,7 @@ struct OperationRegistryTests {
     @Test("all mixer metadata matches current runtime truth")
     func mixerMetadata() throws {
         let mixerSpecs = OperationRegistry.specs.filter { $0.tool == .logicMixer }
+        let targetBearingCommands: Set<String> = ["set_volume", "set_pan"]
         #expect(Set(Self.mixerCommands.map(\.1)) == Set(mixerSpecs.map(\.command)))
 
         for (id, command) in Self.mixerCommands {
@@ -192,7 +193,7 @@ struct OperationRegistryTests {
             #expect(spec.command == command)
             #expect(spec.mutability == Mutability.`mutating`)
             #expect(spec.confirmation == (command == "insert_plugin" ? .l2 : .none))
-            #expect(spec.target == .none)
+            #expect(spec.target == (targetBearingCommands.contains(command) ? .requiresStableTarget : .none))
             #expect(spec.verification == .readbackRequired)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == .short)
@@ -439,7 +440,7 @@ struct OperationRegistryTests {
             #expect(spec.command == entry.command)
             #expect(spec.mutability == entry.mutability)
             #expect(spec.confirmation == .none)
-            #expect(spec.target == .none)
+            #expect(spec.target == (id == .pluginsSetParamVerified ? .requiresStableTarget : .none))
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)
@@ -963,6 +964,10 @@ struct OperationRegistryTests {
     @Test("all tracks metadata matches dispatcher and channel truth")
     func tracksMetadata() throws {
         let tool = try #require(ToolID(rawValue: "logic_tracks"))
+        let targetBearingCommands: Set<String> = [
+            "select", "delete", "duplicate", "rename", "mute", "solo", "arm", "arm_only",
+            "set_automation", "set_instrument",
+        ]
 
         for entry in Self.trackCommands {
             let id = try #require(OperationID(rawValue: entry.id))
@@ -972,7 +977,7 @@ struct OperationRegistryTests {
             #expect(spec.command == entry.command)
             #expect(spec.mutability == entry.mutability)
             #expect(spec.confirmation == .none)
-            #expect(spec.target == .none)
+            #expect(spec.target == (targetBearingCommands.contains(entry.command) ? .requiresStableTarget : .none))
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -589,7 +589,9 @@ struct TargetRefResolutionTests {
             )
             #expect(result.isError == false)
             #expect(echoedTargetRef(result) == reference.rawValue)
-            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] == nil)
+            // rename keeps its pre-uniform `track_ref` alias (G8 backward compat);
+            // the other 12 mutations emit only the uniform `target_ref` key.
+            #expect(sharedJSONObject(sharedToolText(result))!["track_ref"] as! String == reference.rawValue)
             #expect(await opParams(channels, "track.rename") == ["index": "2", "name": "Sub Bass"])
         }
     }

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -102,6 +102,10 @@ struct TargetRefResolutionTests {
         sharedJSONObject(sharedToolText(result))?["error"] as? String
     }
 
+    private func echoedTargetRef(_ result: CallTool.Result) -> String? {
+        sharedJSONObject(sharedToolText(result))?["target_ref"] as? String
+    }
+
     private func dummyInvalid() -> CallTool.Result {
         toolInvalidParamsResult("resolver-test: explicit index required")
     }
@@ -380,6 +384,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
         }
     }
@@ -397,6 +402,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == nil)
             // target_ref (which points at 2) is ignored; explicit index 1 wins.
             #expect(await opParams(channels, "track.select") == ["index": "1"])
         }
@@ -454,6 +460,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
             #expect(await allOps(channels).contains(where: { $0.0 == "track.delete" }))
         }
@@ -472,6 +479,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
             #expect(await allOps(channels).contains(where: { $0.0 == "track.duplicate" }))
         }
@@ -490,6 +498,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_mute") == ["index": "2", "enabled": "true"])
         }
     }
@@ -525,6 +534,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_arm") == ["index": "2", "enabled": "true"])
         }
     }
@@ -542,6 +552,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_automation") == ["index": "2", "mode": "read"])
         }
     }
@@ -559,12 +570,13 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_instrument") == ["index": "2", "path": "/x.patch"])
         }
     }
 
     @Test
-    func testTrackRenameFlagOnResolvesTargetRefAndEchoesTrackRef() async {
+    func testTrackRenameFlagOnResolvesTargetRefAndEchoesTargetRef() async {
         await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
@@ -576,7 +588,8 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
-            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] as? String == reference.rawValue)
+            #expect(echoedTargetRef(result) == reference.rawValue)
+            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] == nil)
             #expect(await opParams(channels, "track.rename") == ["index": "2", "name": "Sub Bass"])
         }
     }
@@ -596,6 +609,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "mixer.set_volume") == ["index": "2", "volume": "0.5"])
         }
     }
@@ -617,6 +631,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == nil)
             #expect(await opParams(channels, "mixer.set_volume") == ["index": "1", "volume": "0.5"])
         }
     }
@@ -634,6 +649,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "mixer.set_pan") == ["index": "2", "pan": "-0.25"])
         }
     }
@@ -687,6 +703,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "plugin.set_param_verified")?["track"] == "2")
         }
     }
@@ -704,6 +721,7 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == nil)
             // target_ref (pointing at 2) is ignored; explicit track 3 forwarded.
             #expect(await opParams(channels, "plugin.set_param_verified")?["track"] == "3")
         }
@@ -774,6 +792,7 @@ struct TargetRefResolutionTests {
                 cache: cache
             )
             #expect(result.isError == false)
+            #expect(echoedTargetRef(result) == nil)
             #expect((await cache.getTracks())[2].name == "Bass")
         }
     }

--- a/Tests/LogicProMCPTests/TargetRegistryTests.swift
+++ b/Tests/LogicProMCPTests/TargetRegistryTests.swift
@@ -240,7 +240,11 @@ struct TargetRegistryTests {
             )
 
             #expect(result.isError == false)
-            #expect(sharedJSONObject(sharedToolText(result))?["track_ref"] as? String == reference.rawValue)
+            // rename keeps its pre-uniform `track_ref` echo (G8 backward compat)
+            // AND carries the uniform `target_ref` evidence key.
+            let payload = sharedJSONObject(sharedToolText(result))!
+            #expect(payload["track_ref"] as! String == reference.rawValue)
+            #expect(payload["target_ref"] as! String == reference.rawValue)
             let operations = await channel.executedOps
             #expect(operations.count == 1)
             #expect(operations.first?.0 == "track.rename")


### PR DESCRIPTION
## ADR-002 (#285, part of #308) — explicit target policies + uniform `target_ref` evidence echo

Completes the two remaining kernel-scope ADR-002 items from the #308 roadmap (Train A item 2):

### 1. Explicit `TargetPolicy` on every mutating spec + permanent invariant
Every mutating `OperationSpec` now declares its target policy: `requiresStableTarget` on the 13 index/`target_ref`-keyed track/mixer/plugin mutations; `.none` on targetless/global mutations (transport/project/navigate/midi/edit — these will be consumed by ADR-004 preflight's project/process-continuity check). New permanent gate test: **unclassified mutation targets = 0**, with the exact expected target-bearing ID set pinned — adding a mutating command without a target policy now fails CI.

### 2. Uniform G2 evidence echo
`TargetRefResolver.addEvidence(_:to:)` appends `"target_ref": <resolved ref>` to a **State A** response **only** when the mutation was resolved via a valid `target_ref` (`Resolved.reference` non-nil), reusing `HonestContract.addExtras`. Applied across all 13 target-bearing mutations (11 call sites; toggle commands share a path). Index-keyed and flag-off paths are **byte-identical** (nil reference short-circuits before any JSON work).

### Verification
- Unit: `TargetRefResolution|OperationRegistry` filters **90/90**; build green.
- **Live (real Logic 12.3, flag on)**: full same-ref chain across 7 command families — valid ref resolves (State A/B honest), **State A responses carry the `target_ref` echo** (G2), stale/bogus refs fail closed — **18/18, 0 failures**.

Implementation completed; the interrupted wrapper state was audited and verified before commit.

Refs #308. Builds on #352/#355 (resolution) and #356 (trace).