### PR TITLE
feat(adr-005): privacy-safe local support bundle + leakage-scan gate (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -2,7 +2,11 @@ import Foundation
 import CoreGraphics
 import MCP
 
-struct SystemDispatcher {
+struct SystemDispatcher: OperationTraceDispatching {
+    typealias SupportBundleExporter = @Sendable (
+        URL,
+        @Sendable () async -> Void
+    ) async throws -> SupportBundleBuilder.Result
     private struct HealthResponse: Encodable {
         struct MCUSection: Encodable {
             let connected: Bool
@@ -130,10 +134,11 @@ struct SystemDispatcher {
         name: "logic_system",
         description: """
             Diagnostics and help for the Logic Pro MCP server. \
-            Commands: health, permissions, refresh_cache, help. \
+            Commands: health, permissions, refresh_cache, export_support_bundle, help. \
             Params by command: \
             help -> { category: String } (returns full param docs for a dispatcher); \
             refresh_cache -> {} (force AX re-poll); \
+            export_support_bundle -> { dir?: String } (local files only; never uploaded); \
             Others -> {}
             """,
         inputSchema: .object([
@@ -157,7 +162,8 @@ struct SystemDispatcher {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
-        poller: StatePoller? = nil
+        poller: StatePoller? = nil,
+        supportBundleExporter: SupportBundleExporter? = nil
     ) async -> CallTool.Result {
         if FeatureFlags.adr005OperationTrace,
            let traceResult = await handleTraceCommand(command: command, params: params) {
@@ -251,6 +257,54 @@ struct SystemDispatcher {
             }
             return toolTextResult("State refresh triggered. Cache will be updated on next poll cycle.")
 
+        case "export_support_bundle":
+            let createdAt = Date()
+            let directory: URL
+            if let raw = params["dir"] {
+                guard let path = raw.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !path.isEmpty,
+                      path.hasPrefix("/") else {
+                    return toolInvalidParamsResult("export_support_bundle 'dir' must be an absolute path")
+                }
+                directory = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+            } else {
+                directory = defaultSupportBundleDirectory(createdAt: createdAt)
+            }
+            let traceID = await startTraceIfEnabled(command: command)
+            do {
+                let result: SupportBundleBuilder.Result
+                if let supportBundleExporter {
+                    result = try await supportBundleExporter(directory) {
+                        await recordWriteBoundary(traceID)
+                    }
+                } else {
+                    result = try await exportSupportBundle(
+                        to: directory,
+                        createdAt: createdAt,
+                        router: router,
+                        onFirstWrite: { await recordWriteBoundary(traceID) }
+                    )
+                }
+                return await finalizeTrace(
+                    toolTextResult(HonestContract.encodeStateA(extras: [
+                        "bundle_path": result.directory.path,
+                        "files": result.files.map { ["name": $0.name, "sha256": $0.sha256] },
+                    ])),
+                    traceID: traceID
+                )
+            } catch {
+                return await finalizeTrace(
+                    toolTextResult(
+                        HonestContract.encodeStateC(
+                            error: .supportBundleExportFailed,
+                            hint: "Support bundle could not be written to the requested local directory"
+                        ),
+                        isError: true
+                    ),
+                    traceID: traceID
+                )
+            }
+
         case "help":
             // #219: an unknown category used to fall through to full help with
             // isError:false, hiding client typos. An absent category still means
@@ -278,9 +332,69 @@ struct SystemDispatcher {
         }
     }
 
+    private static func defaultSupportBundleDirectory(createdAt: Date) -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/LogicProMCP/support-bundles", isDirectory: true)
+            .appendingPathComponent(
+                "\(formatter.string(from: createdAt))-\(UUID().uuidString.lowercased())",
+                isDirectory: true
+            )
+    }
+
+    private static func exportSupportBundle(
+        to directory: URL,
+        createdAt: Date,
+        router: ChannelRouter,
+        onFirstWrite: @escaping @Sendable () async -> Void
+    ) async throws -> SupportBundleBuilder.Result {
+        let approvalStore = ManualValidationStore()
+        let approvals = await approvalStore.list()
+        let manualStoreHealth = await approvalStore.health()
+        let doctor = try await SupportBundleBuilder.runBlocking {
+            SetupDoctor.generate(
+                arguments: [CommandLine.arguments.first ?? "LogicProMCP", "doctor", "--json"],
+                permissionStatus: PermissionChecker.check(),
+                approvals: approvals,
+                manualStoreHealth: manualStoreHealth
+            )
+        }
+        let channels = await router.healthReport().sorted { $0.key.rawValue < $1.key.rawValue }.map {
+            SupportBundleBuilder.ChannelMetadata(
+                id: $0.key.rawValue,
+                available: $0.value.available,
+                ready: $0.value.ready,
+                verificationStatus: $0.value.verificationStatus.rawValue
+            )
+        }
+        let process = ProcessUtils.currentProcessMetrics()
+        let target = LogicProTarget.current
+        let input = SupportBundleBuilder.Input(
+            createdAt: createdAt,
+            serverVersion: ServerConfig.serverVersion,
+            serverCommit: "unknown",
+            logic: .init(
+                version: ProcessUtils.logicProVersion() ?? "unknown",
+                variant: target.variantLabel,
+                locale: Locale.current.identifier
+            ),
+            qualificationReference: "not_available",
+            traces: await OperationTraceStore.shared.recent(limit: .max),
+            doctorReport: doctor,
+            metadata: .init(
+                process: .init(uptimeSec: process.uptimeSec, memoryMb: process.memoryMB),
+                channels: channels
+            )
+        )
+        return try await SupportBundleBuilder().build(input, at: directory, onFirstWrite: onFirstWrite)
+    }
+
     private static func unknownCommandResult(_ command: String) -> CallTool.Result {
         toolTextResult(
-            "Unknown system command: \(command). Available: health, permissions, refresh_cache, help",
+            "Unknown system command: \(command). Available: health, permissions, refresh_cache, export_support_bundle, help",
             isError: true
         )
     }
@@ -544,6 +658,7 @@ struct SystemDispatcher {
                   health            -> {} — Channel status + cache info
                   permissions       -> {} — macOS permission status
                   refresh_cache     -> {} — Force AX re-poll
+                  export_support_bundle -> { dir?: String } — Write privacy-safe local diagnostics; never upload
                   help              -> { category: String } — Param docs per category
 
                 Categories: transport, tracks, mixer, midi, edit, navigate, project, audio, plugins, system

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -361,7 +361,10 @@ actor LogicProServer {
 
     // MARK: - Tool Registration (10 dispatchers)
 
-    func makeHandlers(dialogPresent: @escaping @Sendable () -> Bool = { false }) -> LogicProServerHandlers {
+    func makeHandlers(
+        dialogPresent: @escaping @Sendable () -> Bool = { false },
+        supportBundleExporter: SystemDispatcher.SupportBundleExporter? = nil
+    ) -> LogicProServerHandlers {
         let router = self.router
         let cache = self.cache
         let poller = self.poller
@@ -428,7 +431,14 @@ actor LogicProServer {
                     case "logic_audio":
                         return AudioDispatcher.handle(command: command, params: cmdParams)
                     case "logic_system":
-                        return await SystemDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, poller: poller)
+                        return await SystemDispatcher.handle(
+                            command: command,
+                            params: cmdParams,
+                            router: router,
+                            cache: cache,
+                            poller: poller,
+                            supportBundleExporter: supportBundleExporter
+                        )
                     case "logic_plugins":
                         return await PluginsDispatcher.handle(
                             command: command,

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -29,6 +29,7 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case systemHealth = "system.health"
     case systemPermissions = "system.permissions"
     case systemRefreshCache = "system.refresh_cache"
+    case systemExportSupportBundle = "system.export_support_bundle"
     case systemHelp = "system.help"
     case pluginsGetInventory = "plugins.get_inventory"
     case pluginsSetParamVerified = "plugins.set_param_verified"
@@ -213,7 +214,8 @@ enum OperationRegistry {
             "audio.analyze_file",
         ],
         ToolID.logicSystem.rawValue: [
-            "system.health", "system.permissions", "system.refresh_cache", "system.help",
+            "system.health", "system.permissions", "system.refresh_cache",
+            "system.export_support_bundle", "system.help",
         ],
         ToolID.logicPlugins.rawValue: [
             "plugins.get_inventory", "plugins.set_param_verified", "plugins.insert_verified",
@@ -264,7 +266,7 @@ enum OperationRegistry {
             "analyze_file",
         ],
         ToolID.logicSystem.rawValue: [
-            "health", "permissions", "refresh_cache", "help",
+            "health", "permissions", "refresh_cache", "export_support_bundle", "help",
         ],
         ToolID.logicPlugins.rawValue: [
             "get_inventory", "set_param_verified", "insert_verified",
@@ -383,11 +385,12 @@ enum OperationRegistry {
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
     } + ([
-        (.systemHealth, "health", Mutability.readOnly),
-        (.systemPermissions, "permissions", Mutability.readOnly),
-        (.systemRefreshCache, "refresh_cache", Mutability.readOnly),
-        (.systemHelp, "help", Mutability.readOnly),
-    ] as [(OperationID, String, Mutability)]).map { entry in
+        (.systemHealth, "health", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+        (.systemPermissions, "permissions", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+        (.systemRefreshCache, "refresh_cache", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+        (.systemExportSupportBundle, "export_support_bundle", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired),
+        (.systemHelp, "help", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none),
+    ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy)]).map { entry in
         OperationSpec(
             id: entry.0,
             tool: .logicSystem,
@@ -395,9 +398,9 @@ enum OperationRegistry {
             mutability: entry.2,
             confirmation: .none,
             target: .none,
-            verification: .none,
+            verification: entry.4,
             retry: .neverAutomatic,
-            deadline: .short,
+            deadline: entry.3,
             availability: .defaultInstall,
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -61,6 +61,14 @@ actor OperationTraceStore {
     static let shared = OperationTraceStore()
     static let defaultMaximumTraceCount = 128
     static let defaultMaximumBytes = 8 * 1024 * 1024
+    static let attributePrivacyClasses: [String: TracePrivacyClass] = [
+        "operation_id": .publicDiagnostic,
+        "command": .publicDiagnostic,
+        "target_ref": .publicDiagnostic,
+        "project_path_hash": .hashed,
+        "readback_state": .publicDiagnostic,
+        "error_code": .publicDiagnostic,
+    ]
 
     let maximumTraceCount: Int
     let maximumBytes: Int
@@ -176,18 +184,10 @@ actor OperationTraceStore {
     private static func filteredAttributes(
         _ attributes: [String: String]
     ) -> (values: [String: String], privacyClasses: [String: TracePrivacyClass]) {
-        let classes: [String: TracePrivacyClass] = [
-            "operation_id": .publicDiagnostic,
-            "command": .publicDiagnostic,
-            "target_ref": .publicDiagnostic,
-            "project_path_hash": .hashed,
-            "readback_state": .publicDiagnostic,
-            "error_code": .publicDiagnostic,
-        ]
         var values: [String: String] = [:]
         var privacyClasses: [String: TracePrivacyClass] = [:]
         for (key, value) in attributes {
-            guard let privacyClass = classes[key] else { continue }
+            guard let privacyClass = attributePrivacyClasses[key] else { continue }
             values[key] = value
             privacyClasses[key] = privacyClass
         }

--- a/Sources/LogicProMCP/Server/SupportBundle.swift
+++ b/Sources/LogicProMCP/Server/SupportBundle.swift
@@ -1,0 +1,558 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+struct SupportBundleBuilder: Sendable {
+    private static let blockingQueue = DispatchQueue(
+        label: "logic-pro-mcp.support-bundle.blocking",
+        qos: .utility,
+        attributes: .concurrent
+    )
+    static let jsonFileNames = [
+        "doctor.json",
+        "manifest.json",
+        "metadata.json",
+        "redaction_report.json",
+        "traces.json",
+    ]
+    static let fileNames = jsonFileNames + ["SHA256SUMS"]
+
+    struct LogicMetadata: Codable, Sendable {
+        let version: String
+        let variant: String
+        let locale: String
+    }
+
+    struct ProcessMetadata: Codable, Sendable {
+        let uptimeSec: Int
+        let memoryMb: Double
+
+        enum CodingKeys: String, CodingKey {
+            case uptimeSec = "uptime_sec"
+            case memoryMb = "memory_mb"
+        }
+    }
+
+    struct ChannelMetadata: Codable, Sendable {
+        let id: String
+        let available: Bool
+        let ready: Bool
+        let verificationStatus: String
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case available
+            case ready
+            case verificationStatus = "verification_status"
+        }
+    }
+
+    struct Metadata: Codable, Sendable {
+        let process: ProcessMetadata
+        let channels: [ChannelMetadata]
+    }
+
+    struct Input: Sendable {
+        let createdAt: Date
+        let serverVersion: String
+        let serverCommit: String
+        let logic: LogicMetadata
+        let qualificationReference: String
+        let traces: [OperationTrace]
+        let doctorReport: SetupDoctor.Report
+        let metadata: Metadata
+    }
+
+    struct FileDigest: Codable, Sendable, Equatable {
+        let name: String
+        let sha256: String
+    }
+
+    struct Result: Sendable, Equatable {
+        let directory: URL
+        let files: [FileDigest]
+    }
+
+    struct Assembly: Sendable {
+        let files: [String: Data]
+    }
+
+    func build(
+        _ input: Input,
+        at directory: URL,
+        onFirstWrite: @Sendable () async -> Void = {}
+    ) async throws -> Result {
+        try await write(assemble(input), to: directory, onFirstWrite: onFirstWrite)
+    }
+
+    func assemble(_ input: Input) throws -> Assembly {
+        let traceOutput = exportTraces(input.traces)
+        let doctorOutput = exportDoctor(input.doctorReport)
+        let manifest = Manifest(
+            schema: "logic_pro_mcp_support_bundle.v1",
+            createdAt: input.createdAt,
+            serverVersion: safeDiagnostic(input.serverVersion),
+            serverCommit: safeDiagnostic(input.serverCommit),
+            logic: .init(
+                version: safeDiagnostic(input.logic.version),
+                variant: safeDiagnostic(input.logic.variant),
+                locale: safeDiagnostic(input.logic.locale)
+            ),
+            qualificationReference: safeDiagnostic(input.qualificationReference),
+            files: Self.fileNames.sorted()
+        )
+        let summaries = [
+            RedactionSummary(file: "manifest.json", privacyClasses: [.publicDiagnostic], droppedKeyCount: 0),
+            RedactionSummary(file: "traces.json", privacyClasses: traceOutput.privacyClasses, droppedKeyCount: traceOutput.droppedKeyCount),
+            RedactionSummary(
+                file: "doctor.json",
+                privacyClasses: doctorOutput.privacyClasses,
+                droppedKeyCount: doctorOutput.droppedKeyCount
+            ),
+            RedactionSummary(file: "metadata.json", privacyClasses: [.publicDiagnostic], droppedKeyCount: 0),
+            RedactionSummary(file: "redaction_report.json", privacyClasses: [.publicDiagnostic], droppedKeyCount: 0),
+            RedactionSummary(file: "SHA256SUMS", privacyClasses: [.publicDiagnostic], droppedKeyCount: 0),
+        ]
+
+        var files: [String: Data] = [
+            "manifest.json": try jsonData(manifest),
+            "traces.json": try jsonData(TraceFile(schema: "logic_pro_mcp_operation_traces.v1", traces: traceOutput.traces)),
+            "doctor.json": try jsonData(doctorOutput.report),
+            "metadata.json": try jsonData(input.metadata),
+            "redaction_report.json": try jsonData(RedactionReport(
+                schema: "logic_pro_mcp_support_bundle_redaction.v1",
+                files: summaries
+            )),
+        ]
+        let sums = try Self.jsonFileNames.map { name in
+            guard let data = files[name] else { throw CocoaError(.fileNoSuchFile) }
+            return "\(Self.sha256(data))  \(name)"
+        }
+            .joined(separator: "\n") + "\n"
+        files["SHA256SUMS"] = Data(sums.utf8)
+        return Assembly(files: files)
+    }
+
+    func write(
+        _ assembly: Assembly,
+        to directory: URL,
+        onFirstWrite: @Sendable () async -> Void = {}
+    ) async throws -> Result {
+        try Self.requireAbsent(directory)
+        await onFirstWrite()
+        return try await Self.runBlocking {
+            try Self.requireAbsent(directory)
+            let fileManager = FileManager.default
+            let parent = directory.deletingLastPathComponent()
+            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+            let staging = parent.appendingPathComponent(
+                ".\(directory.lastPathComponent).tmp-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try Self.createExclusiveDirectory(staging)
+            var moved = false
+            defer {
+                if !moved { try? fileManager.removeItem(at: staging) }
+            }
+            for name in Self.fileNames.sorted() {
+                guard let data = assembly.files[name] else { throw CocoaError(.fileNoSuchFile) }
+                let url = staging.appendingPathComponent(name)
+                try data.write(to: url, options: .atomic)
+                try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            }
+            try Self.verify(assembly, at: staging)
+            try Self.publishExclusively(staging, to: directory)
+            moved = true
+            do {
+                let readback = try Self.readback(at: directory)
+                for file in readback {
+                    guard let source = assembly.files[file.name] else {
+                        throw CocoaError(.fileNoSuchFile)
+                    }
+                    guard file.sha256 == Self.sha256(source) else {
+                        throw CocoaError(.fileReadCorruptFile)
+                    }
+                }
+                return Result(directory: directory, files: readback)
+            } catch {
+                try? fileManager.removeItem(at: directory)
+                throw error
+            }
+        }
+    }
+
+    static func runBlocking<T: Sendable>(
+        _ operation: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            blockingQueue.async {
+                do {
+                    continuation.resume(returning: try operation())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func exportTraces(_ traces: [OperationTrace]) -> TraceOutput {
+        var droppedKeyCount = 0
+        var appliedClasses: Set<TracePrivacyClass> = []
+        let exported = traces.map { trace in
+            TraceRecord(
+                traceID: trace.traceID.rawValue,
+                operationID: safeDiagnostic(trace.operationID),
+                events: trace.events.map { event in
+                    var attributes: [String: String] = [:]
+                    var classes: [String: String] = [:]
+                    for (key, value) in event.attributes {
+                        if let declared = event.privacyClasses[key] { appliedClasses.insert(declared) }
+                        guard let declared = event.privacyClasses[key],
+                              OperationTraceStore.attributePrivacyClasses[key] == declared else {
+                            droppedKeyCount += 1
+                            continue
+                        }
+                        switch declared {
+                        case .publicDiagnostic:
+                            attributes[key] = safeDiagnostic(value)
+                        case .hashed:
+                            attributes[key] = Self.sha256(Data(value.utf8))
+                        case .presenceOnly:
+                            attributes[key] = "present"
+                        case .secret:
+                            droppedKeyCount += 1
+                            continue
+                        }
+                        classes[key] = declared.rawValue
+                    }
+                    return TraceEventRecord(
+                        phase: event.phase.rawValue,
+                        timestamp: String(describing: event.timestamp),
+                        attributes: attributes,
+                        privacyClasses: classes
+                    )
+                }
+            )
+        }
+        return TraceOutput(
+            traces: exported,
+            privacyClasses: appliedClasses.sorted { $0.rawValue < $1.rawValue },
+            droppedKeyCount: droppedKeyCount
+        )
+    }
+
+    private func exportDoctor(_ report: SetupDoctor.Report) -> DoctorOutput {
+        var droppedKeyCount = 0
+        let checks = report.checks.map { check in
+            var evidence: [String: String] = [:]
+            for (key, value) in check.evidence {
+                guard !isSensitiveLabel(key), !containsSecretMarker(value) else {
+                    droppedKeyCount += 1
+                    continue
+                }
+                evidence[safeIdentifier(key)] = "present"
+            }
+            return DoctorCheck(
+                id: safeIdentifier(check.id),
+                domain: safeIdentifier(check.domain),
+                status: check.status,
+                summary: "Check \(safeIdentifier(check.id)): \(check.status.rawValue)",
+                evidence: evidence,
+                remediation: .init(
+                    type: check.remediation.type,
+                    value: check.remediation.value.isEmpty ? "" : "present"
+                ),
+                category: check.category,
+                severity: check.severity,
+                durationMs: check.durationMs,
+                blockedBy: check.blockedBy.map(safeIdentifier),
+                skipReason: check.skipReason,
+                optional: check.optional
+            )
+        }
+        var capabilities: [String: DoctorCapability] = [:]
+        for (key, capability) in report.capabilities {
+            capabilities[safeIdentifier(key)] = .init(
+                status: capability.status,
+                checks: capability.checks.map(safeIdentifier),
+                liveVerification: capability.liveVerification == nil ? nil : "present"
+            )
+        }
+        let privacyClasses: [TracePrivacyClass] = droppedKeyCount == 0
+            ? [.publicDiagnostic, .presenceOnly]
+            : [.publicDiagnostic, .presenceOnly, .secret]
+        return DoctorOutput(
+            report: .init(
+                schema: safeIdentifier(report.schema),
+                status: report.status,
+                version: safeIdentifier(report.version),
+                installSource: report.installSource,
+                checks: checks,
+                summary: report.summary,
+                headline: "Doctor status: \(report.status.rawValue)",
+                fixPlan: report.fixPlan.map(safeIdentifier),
+                doctorProfile: report.doctorProfile,
+                doctorProfileBasis: report.doctorProfileBasis.isEmpty ? "" : "present",
+                clientProfile: report.clientProfile,
+                clientProfileBasis: report.clientProfileBasis.isEmpty ? "" : "present",
+                capabilities: capabilities
+            ),
+            privacyClasses: privacyClasses,
+            droppedKeyCount: droppedKeyCount
+        )
+    }
+
+    private func jsonData<T: Encodable>(_ value: T) throws -> Data {
+        Data(try encodeJSONStrict(value).utf8)
+    }
+
+    private func safeDiagnostic(_ value: String) -> String {
+        if ["sk-", "ghp_", "Bearer "].contains(where: value.contains) { return "redacted" }
+        return value.replacingOccurrences(
+            of: FileManager.default.homeDirectoryForCurrentUser.path,
+            with: "~"
+        )
+    }
+
+    private func safeIdentifier(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._+-"))
+        guard !value.isEmpty,
+              value.unicodeScalars.allSatisfy(allowed.contains),
+              !isSensitive(value) else {
+            return "redacted"
+        }
+        return value
+    }
+
+    private func isSensitive(_ value: String) -> Bool {
+        isSensitiveLabel(value) || containsSecretMarker(value)
+            || value.lowercased().contains("/users/")
+    }
+
+    private func isSensitiveLabel(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return ["token", "secret", "password", "api_key", "apikey", "authorization"].contains {
+            lower.contains($0)
+        }
+    }
+
+    private func containsSecretMarker(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return ["sk-", "ghp_", "bearer ", "api_key=", "apikey=", "password=", "secret=", "token="].contains {
+            lower.contains($0)
+        }
+    }
+
+    private static func requireAbsent(_ directory: URL) throws {
+        var info = stat()
+        let result = directory.path.withCString { lstat($0, &info) }
+        if result == 0 { throw CocoaError(.fileWriteFileExists) }
+        guard errno == ENOENT else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private static func createExclusiveDirectory(_ directory: URL) throws {
+        let result = directory.path.withCString { mkdir($0, S_IRWXU) }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private static func publishExclusively(_ source: URL, to destination: URL) throws {
+        let result = source.path.withCString { sourcePath in
+            destination.path.withCString { destinationPath in
+                renameatx_np(
+                    AT_FDCWD,
+                    sourcePath,
+                    AT_FDCWD,
+                    destinationPath,
+                    UInt32(RENAME_EXCL)
+                )
+            }
+        }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private static func verify(_ assembly: Assembly, at directory: URL) throws {
+        for file in try readback(at: directory) {
+            guard let source = assembly.files[file.name] else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            guard file.sha256 == sha256(source) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+        }
+    }
+
+    private static func readback(at directory: URL) throws -> [FileDigest] {
+        try fileNames.sorted().map { name in
+            FileDigest(
+                name: name,
+                sha256: sha256(try Data(contentsOf: directory.appendingPathComponent(name)))
+            )
+        }
+    }
+}
+
+private extension SupportBundleBuilder {
+    struct DoctorReport: Encodable {
+        let schema: String
+        let status: SetupDoctor.ReportStatus
+        let version: String
+        let installSource: SetupDoctor.InstallSource
+        let checks: [DoctorCheck]
+        let summary: SetupDoctor.Summary
+        let headline: String
+        let fixPlan: [String]
+        let doctorProfile: SetupDoctor.DoctorProfile
+        let doctorProfileBasis: String
+        let clientProfile: SetupDoctor.ClientProfile
+        let clientProfileBasis: String
+        let capabilities: [String: DoctorCapability]
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case status
+            case version
+            case installSource = "install_source"
+            case checks
+            case summary
+            case headline
+            case fixPlan = "fix_plan"
+            case doctorProfile = "doctor_profile"
+            case doctorProfileBasis = "doctor_profile_basis"
+            case clientProfile = "client_profile"
+            case clientProfileBasis = "client_profile_basis"
+            case capabilities
+        }
+    }
+
+    struct DoctorCheck: Encodable {
+        let id: String
+        let domain: String
+        let status: SetupDoctor.CheckStatus
+        let summary: String
+        let evidence: [String: String]
+        let remediation: SetupRemediation
+        let category: SetupDoctor.Category
+        let severity: SetupDoctor.Severity
+        let durationMs: Double
+        let blockedBy: String?
+        let skipReason: SetupDoctor.DoctorSkipReason?
+        let optional: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case domain
+            case status
+            case summary
+            case evidence
+            case remediation
+            case category
+            case severity
+            case durationMs = "duration_ms"
+            case blockedBy = "blocked_by"
+            case skipReason = "skip_reason"
+            case optional
+        }
+    }
+
+    struct DoctorCapability: Encodable {
+        let status: SetupDoctor.CapabilityStatus
+        let checks: [String]
+        let liveVerification: String?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case checks
+            case liveVerification = "live_verification"
+        }
+    }
+
+    struct DoctorOutput {
+        let report: DoctorReport
+        let privacyClasses: [TracePrivacyClass]
+        let droppedKeyCount: Int
+    }
+
+    struct Manifest: Encodable {
+        let schema: String
+        let createdAt: Date
+        let serverVersion: String
+        let serverCommit: String
+        let logic: LogicMetadata
+        let qualificationReference: String
+        let files: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case createdAt = "created_at"
+            case serverVersion = "server_version"
+            case serverCommit = "server_commit"
+            case logic
+            case qualificationReference = "qualification_reference"
+            case files
+        }
+    }
+
+    struct TraceEventRecord: Encodable {
+        let phase: String
+        let timestamp: String
+        let attributes: [String: String]
+        let privacyClasses: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case phase
+            case timestamp
+            case attributes
+            case privacyClasses = "privacy_classes"
+        }
+    }
+
+    struct TraceRecord: Encodable {
+        let traceID: String
+        let operationID: String
+        let events: [TraceEventRecord]
+
+        enum CodingKeys: String, CodingKey {
+            case traceID = "trace_id"
+            case operationID = "operation_id"
+            case events
+        }
+    }
+
+    struct TraceFile: Encodable {
+        let schema: String
+        let traces: [TraceRecord]
+    }
+
+    struct TraceOutput {
+        let traces: [TraceRecord]
+        let privacyClasses: [TracePrivacyClass]
+        let droppedKeyCount: Int
+    }
+
+    struct RedactionSummary: Encodable {
+        let file: String
+        let privacyClasses: [TracePrivacyClass]
+        let droppedKeyCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case file
+            case privacyClasses = "privacy_classes"
+            case droppedKeyCount = "dropped_key_count"
+        }
+    }
+
+    struct RedactionReport: Encodable {
+        let schema: String
+        let files: [RedactionSummary]
+    }
+}

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -173,6 +173,7 @@ enum HonestContract {
         /// can tell a typo'd category apart from a missing required argument,
         /// and so an unknown category never silently returns full help. #219.
         case unknownCategory = "unknown_category"
+        case supportBundleExportFailed = "support_bundle_export_failed"
     }
 
     // MARK: - Encoding primitives
@@ -351,6 +352,7 @@ enum HonestContract {
         // category. (help doesn't route through the fallback chain; listed for
         // classification consistency.)
         FailureError.unknownCategory.rawValue,
+        FailureError.supportBundleExportFailed.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -546,7 +546,7 @@ enum WorkflowSkillCatalog {
             "audit", "cleanup_plan", "cleanup_apply", "launch", "quit",
         ],
         "logic_system": [
-            "health", "permissions", "refresh_cache", "help",
+            "health", "permissions", "refresh_cache", "export_support_bundle", "help",
         ],
         "logic_audio": [
             "analyze_file",

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -25,6 +25,8 @@ struct HCGlobalInvariantTests {
     private struct Fixtures {
         let existingProjectPath: String
         let saveAsProjectPath: String
+        let supportBundlePath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hc-support-bundle-\(UUID().uuidString)").path
     }
 
     private static let hcInvariantAllowlist: Set<String> = [
@@ -301,6 +303,8 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_project", command: "bounce", params: ["confirmed": .bool(true)], operation: "project.bounce", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_project", command: "cleanup_apply", params: ["step_id": .string("rename_duplicate_kick_0_1"), "confirmed": .bool(true), "names": .string("Kick L,Kick R")], operation: "project.cleanup_apply", destinations: [], invariant: .minimumV1),
 
+            RouteCase(tool: "logic_system", command: "export_support_bundle", params: ["dir": .string(fixtures.supportBundlePath)], operation: "system.export_support_bundle", destinations: [], invariant: .minimumV1),
+
             RouteCase(tool: "logic_plugins", command: "set_param_verified", params: ["track": .int(0), "insert": .int(0), "plugin": .string("logic.stock.gain"), "param": .string("gain_db"), "value": .double(0), "unit": .string("dB"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.set_param_verified", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_plugins", command: "insert_verified", params: ["track": .int(0), "insert": .int(0), "plugin": .string("Gain"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.insert_verified", destinations: [], invariant: .minimumV1),
         ]
@@ -443,6 +447,19 @@ struct HCGlobalInvariantTests {
                 router: router,
                 cache: cache,
                 cleanupAuditFileReader: Self.headlessAuditFileReader
+            )
+        case "logic_system":
+            return await SystemDispatcher.handle(
+                command: routeCase.command,
+                params: routeCase.params,
+                router: router,
+                cache: cache,
+                supportBundleExporter: { directory, onFirstWrite in
+                    await onFirstWrite()
+                    return .init(directory: directory, files: [
+                        .init(name: "manifest.json", sha256: String(repeating: "a", count: 64)),
+                    ])
+                }
             )
         case "logic_plugins":
             return await PluginsDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache)

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 99)
+        #expect(OperationRegistry.specs.count == 100)
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -83,9 +83,9 @@ struct OperationRegistryCoverageTests {
             .tracksSetInstrument,
         ]
 
-        #expect(mutating.count == 83)
+        #expect(mutating.count == 84)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
-        #expect(targetless.count == 70)
+        #expect(targetless.count == 71)
         #expect(targetBearingIDs.count + targetless.count == mutating.count)
         #expect(OperationRegistry.specs
             .filter { $0.mutability == .readOnly }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -51,7 +51,7 @@ struct OperationRegistryTests {
         "rename_marker": .unsupported,
     ]
 
-    private static let smallToolCount = 8 // logic_audio(1) + logic_system(4) + logic_plugins(3)
+    private static let smallToolCount = 9 // logic_audio(1) + logic_system(5) + logic_plugins(3)
     private static let expectedRegistryCount =
         commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
             + editCommands.count + projectCommands.count + midiCommands.count + trackCommands.count
@@ -356,6 +356,7 @@ struct OperationRegistryTests {
         ("logic_system", "system.permissions", "permissions", .readOnly, .short, .none),
         ("logic_system", "system.refresh_cache", "refresh_cache", .readOnly, .short, .none),
         ("logic_system", "system.help", "help", .readOnly, .short, .none),
+        ("logic_system", "system.export_support_bundle", "export_support_bundle", .mutating, .medium, .readbackRequired),
         ("logic_plugins", "plugins.get_inventory", "get_inventory", .readOnly, .short, .none),
         ("logic_plugins", "plugins.set_param_verified", "set_param_verified", .mutating, .medium, .readbackRequired),
         ("logic_plugins", "plugins.insert_verified", "insert_verified", .mutating, .medium, .readbackRequired),

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -91,8 +91,8 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 99)
-        #expect(mutatingSpecs.count == 83)
+        #expect(OperationRegistry.specs.count == 100)
+        #expect(mutatingSpecs.count == 84)
 
         for spec in mutatingSpecs {
             await OperationTraceStore.shared.clear()
@@ -252,7 +252,13 @@ private func dispatchOperationTraceCoverageSpec(
             command: spec.command,
             params: params,
             router: router,
-            cache: cache
+            cache: cache,
+            supportBundleExporter: { directory, onFirstWrite in
+                await onFirstWrite()
+                return .init(directory: directory, files: [
+                    .init(name: "manifest.json", sha256: String(repeating: "a", count: 64)),
+                ])
+            }
         )
     case .logicPlugins:
         return await PluginsDispatcher.handle(
@@ -309,6 +315,9 @@ private func operationTraceCoverageParams(
     fixtures: OperationTraceCoverageFixtures
 ) -> [String: Value] {
     switch operationID {
+    case .systemExportSupportBundle:
+        return ["dir": .string(URL(fileURLWithPath: fixtures.outputRoot)
+            .appendingPathComponent("support-bundle").path)]
     case .transportSetTempo:
         return ["tempo": .double(120)]
     case .transportGotoPosition:

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -312,7 +312,7 @@ struct OperationTraceTests {
             #expect(result.isError == true)
             #expect(
                 sharedToolText(result)
-                    == "Unknown system command: \(command). Available: health, permissions, refresh_cache, help"
+                    == "Unknown system command: \(command). Available: health, permissions, refresh_cache, export_support_bundle, help"
             )
         }
     }

--- a/Tests/LogicProMCPTests/SupportBundleTests.swift
+++ b/Tests/LogicProMCPTests/SupportBundleTests.swift
@@ -1,0 +1,385 @@
+import CryptoKit
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-005 support bundle", .serialized)
+struct SupportBundleTests {
+    @Test("bundle is complete, readback-verifiable, and privacy safe")
+    func completePrivacySafeBundle() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-support-bundle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: output) }
+
+        let privatePath = "/Users/private/Library/secret.logicx"
+        let envValue = "ULW_ENV_VALUE_7d2c2b09"
+        let doctorValue = "ULW_DOCTOR_VALUE_081c0e7a"
+        let trace = OperationTrace(
+            traceID: TraceID(rawValue: "lpmcp_00000000-0000-0000-0000-000000000001"),
+            operationID: OperationID.transportPlay.rawValue,
+            startedAt: .now,
+            events: [
+                TraceEvent(
+                    phase: .requestReceived,
+                    timestamp: .now,
+                    attributes: [
+                        "operation_id": OperationID.transportPlay.rawValue,
+                        "command": "play",
+                        "project_path_hash": privatePath,
+                        "prompt": "sk-private-prompt",
+                        "token": "ghp_private-token",
+                        "environment": envValue,
+                        "private_path": "Bearer private-token \(privatePath)",
+                    ],
+                    privacyClasses: [
+                        "operation_id": .publicDiagnostic,
+                        "command": .publicDiagnostic,
+                        "project_path_hash": .hashed,
+                        "prompt": .secret,
+                        "token": .secret,
+                        "environment": .secret,
+                        "private_path": .publicDiagnostic,
+                    ]
+                ),
+            ],
+            completedAt: .now
+        )
+        let input = SupportBundleBuilder.Input(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            serverVersion: "3.11.0",
+            serverCommit: "unknown",
+            logic: .init(version: "12.3", variant: "desktop", locale: "en_US"),
+            qualificationReference: "not_available",
+            traces: [trace],
+            doctorReport: Self.hostileDoctorReport(privateValue: doctorValue),
+            metadata: .init(
+                process: .init(uptimeSec: 42, memoryMb: 64.5),
+                channels: [
+                    .init(
+                        id: "accessibility",
+                        available: true,
+                        ready: true,
+                        verificationStatus: "verified"
+                    ),
+                ]
+            )
+        )
+
+        let result = try await SupportBundleBuilder().build(input, at: output)
+        let expectedFiles = Set([
+            "manifest.json", "traces.json", "doctor.json", "metadata.json",
+            "redaction_report.json", "SHA256SUMS",
+        ])
+        let actualFiles = Set(try FileManager.default.contentsOfDirectory(atPath: output.path))
+        #expect(actualFiles == expectedFiles)
+        #expect(Set(result.files.map(\.name)) == expectedFiles)
+
+        let manifest = try Self.jsonObject(output.appendingPathComponent("manifest.json"))
+        #expect(manifest["schema"] as? String == "logic_pro_mcp_support_bundle.v1")
+        #expect(manifest["created_at"] as? String == "2023-11-14T22:13:20.000Z")
+        #expect(Set(manifest["files"] as? [String] ?? []) == expectedFiles)
+        #expect(manifest["server_commit"] as? String == "unknown")
+        #expect(manifest["qualification_reference"] as? String == "not_available")
+
+        let checksumLines = try String(
+            contentsOf: output.appendingPathComponent("SHA256SUMS"),
+            encoding: .utf8
+        ).split(separator: "\n").map(String.init)
+        #expect(checksumLines.count == expectedFiles.count - 1)
+        for line in checksumLines {
+            let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+            #expect(parts.count == 2)
+            guard parts.count == 2 else { continue }
+            let expectedDigest = String(parts[0])
+            let name = String(parts[1])
+            let data = try Data(contentsOf: output.appendingPathComponent(name))
+            #expect(expectedDigest == Self.sha256(data))
+        }
+        for file in result.files {
+            let data = try Data(contentsOf: output.appendingPathComponent(file.name))
+            #expect(file.sha256 == Self.sha256(data))
+        }
+
+        let allText = try expectedFiles.sorted().map {
+            try String(contentsOf: output.appendingPathComponent($0), encoding: .utf8)
+        }.joined(separator: "\n")
+        for forbidden in ["/Users/", "sk-", "ghp_", "Bearer ", envValue, doctorValue] {
+            #expect(!allText.contains(forbidden), "bundle leaked forbidden marker: \(forbidden)")
+        }
+
+        let traces = try Self.jsonObject(output.appendingPathComponent("traces.json"))
+        let exportedTraces = try #require(traces["traces"] as? [[String: Any]])
+        let events = try #require(exportedTraces.first?["events"] as? [[String: Any]])
+        let attributes = try #require(events.first?["attributes"] as? [String: String])
+        #expect(Set(attributes.keys) == ["operation_id", "command", "project_path_hash"])
+        #expect(attributes["project_path_hash"] == Self.sha256(Data(privatePath.utf8)))
+
+        let report = try Self.jsonObject(output.appendingPathComponent("redaction_report.json"))
+        let summaries = try #require(report["files"] as? [[String: Any]])
+        let traceSummary = try #require(summaries.first { $0["file"] as? String == "traces.json" })
+        #expect((traceSummary["dropped_key_count"] as? Int ?? 0) == 4)
+        #expect(Set(traceSummary["privacy_classes"] as? [String] ?? []) == [
+            TracePrivacyClass.publicDiagnostic.rawValue,
+            TracePrivacyClass.hashed.rawValue,
+            TracePrivacyClass.secret.rawValue,
+        ])
+        let doctorSummary = try #require(summaries.first { $0["file"] as? String == "doctor.json" })
+        #expect((doctorSummary["dropped_key_count"] as? Int ?? 0) == 1)
+
+        let doctor = try Self.jsonObject(output.appendingPathComponent("doctor.json"))
+        let doctorChecks = try #require(doctor["checks"] as? [[String: Any]])
+        let doctorEvidence = try #require(doctorChecks.first?["evidence"] as? [String: String])
+        #expect(doctorEvidence["dialog_title"] == "present")
+        #expect(doctorEvidence["path"] == "present")
+        #expect(doctorEvidence["token"] == nil)
+    }
+
+    @Test("existing output directories are refused without changing caller files")
+    func refusesExistingOutputDirectory() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-existing-support-\(UUID().uuidString)")
+        let link = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-linked-support-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: link)
+            try? FileManager.default.removeItem(at: output)
+        }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: false)
+        let marker = output.appendingPathComponent("keep.me")
+        try Data("caller-owned".utf8).write(to: marker)
+        let assembly = SupportBundleBuilder.Assembly(files: Dictionary(
+            uniqueKeysWithValues: SupportBundleBuilder.fileNames.map { ($0, Data($0.utf8)) }
+        ))
+
+        await #expect(throws: Error.self) {
+            try await SupportBundleBuilder().write(assembly, to: output)
+        }
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "caller-owned")
+        #expect(try FileManager.default.contentsOfDirectory(atPath: output.path) == ["keep.me"])
+
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: output)
+        await #expect(throws: Error.self) {
+            try await SupportBundleBuilder().write(assembly, to: link)
+        }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: output.path) == ["keep.me"])
+    }
+
+    @Test("concurrent publishers cannot replace an already published bundle")
+    func concurrentPublishIsExclusive() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-racing-support-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: output) }
+        let assembly = SupportBundleBuilder.Assembly(files: Dictionary(
+            uniqueKeysWithValues: SupportBundleBuilder.fileNames.map { ($0, Data($0.utf8)) }
+        ))
+
+        let successes = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<2 {
+                group.addTask {
+                    do {
+                        _ = try await SupportBundleBuilder().write(assembly, to: output)
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            var values: [Bool] = []
+            for await value in group { values.append(value) }
+            return values
+        }
+
+        #expect(successes.filter { $0 }.count == 1)
+        #expect(Set(try FileManager.default.contentsOfDirectory(atPath: output.path))
+            == Set(SupportBundleBuilder.fileNames))
+    }
+
+    @Test("system command returns typed State A/C and records the write boundary")
+    func systemCommandContractAndTrace() async throws {
+        let flag = "LOGIC_MCP_ADR005_OPERATION_TRACE"
+        let previous = getenv(flag).map { String(cString: $0) }
+        setenv(flag, "1", 1)
+        defer {
+            if let previous { setenv(flag, previous, 1) } else { unsetenv(flag) }
+        }
+        await OperationTraceStore.shared.clear()
+
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-support-command-\(UUID().uuidString)")
+        let success = await SystemDispatcher.handle(
+            command: "export_support_bundle",
+            params: ["dir": .string(output.path)],
+            router: ChannelRouter(),
+            cache: StateCache(),
+            supportBundleExporter: { directory, onFirstWrite in
+                await onFirstWrite()
+                return .init(
+                    directory: directory,
+                    files: [.init(name: "manifest.json", sha256: String(repeating: "a", count: 64))]
+                )
+            }
+        )
+        let successObject = try #require(sharedJSONObject(sharedToolText(success)))
+        #expect(successObject["state"] as? String == "A")
+        #expect(successObject["bundle_path"] as? String == output.path)
+        let files = try #require(successObject["files"] as? [[String: String]])
+        #expect(files == [["name": "manifest.json", "sha256": String(repeating: "a", count: 64)]])
+        let traceID = try #require(successObject["trace_id"] as? String)
+        let trace = try #require(await OperationTraceStore.shared.trace(.init(rawValue: traceID)))
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+        ])
+
+        let failure = await SystemDispatcher.handle(
+            command: "export_support_bundle",
+            params: ["dir": .string(output.path)],
+            router: ChannelRouter(),
+            cache: StateCache(),
+            supportBundleExporter: { _, _ in throw CocoaError(.fileWriteNoPermission) }
+        )
+        let failureObject = try #require(sharedJSONObject(sharedToolText(failure)))
+        #expect(failure.isError == true)
+        #expect(failureObject["state"] as? String == "C")
+        #expect(failureObject["error"] as? String == "support_bundle_export_failed")
+
+        let defaultPath = await SystemDispatcher.handle(
+            command: "export_support_bundle",
+            params: [:],
+            router: ChannelRouter(),
+            cache: StateCache(),
+            supportBundleExporter: { directory, onFirstWrite in
+                await onFirstWrite()
+                return .init(directory: directory, files: [])
+            }
+        )
+        let defaultObject = try #require(sharedJSONObject(sharedToolText(defaultPath)))
+        #expect((defaultObject["bundle_path"] as? String)?.contains(
+            "/Library/Logs/LogicProMCP/support-bundles/"
+        ) == true)
+    }
+
+    @Test("public MCP handler exports locally without starting Logic")
+    func publicHandlerExport() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logic-pro-mcp-public-support-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: output) }
+        let input = SupportBundleBuilder.Input(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            serverVersion: ServerConfig.serverVersion,
+            serverCommit: "unknown",
+            logic: .init(version: "unknown", variant: "unknown", locale: "en_US"),
+            qualificationReference: "not_available",
+            traces: [],
+            doctorReport: Self.doctorReport,
+            metadata: .init(process: .init(uptimeSec: 1, memoryMb: 1), channels: [])
+        )
+        let server = LogicProServer()
+        let handlers = await server.makeHandlers(supportBundleExporter: { directory, onFirstWrite in
+            try await SupportBundleBuilder().build(input, at: directory, onFirstWrite: onFirstWrite)
+        })
+        let result = await handlers.callTool(CallTool.Parameters(
+            name: "logic_system",
+            arguments: [
+                "command": .string("export_support_bundle"),
+                "params": .object(["dir": .string(output.path)]),
+            ]
+        ))
+        let object = try #require(sharedJSONObject(sharedToolText(result)))
+        #expect(object["state"] as? String == "A")
+        #expect(Set(try FileManager.default.contentsOfDirectory(atPath: output.path))
+            == Set(SupportBundleBuilder.fileNames))
+
+        let invalid = await handlers.callTool(CallTool.Parameters(
+            name: "logic_system",
+            arguments: [
+                "command": .string("export_support_bundle"),
+                "params": .object(["dir": .string("relative/path")]),
+            ]
+        ))
+        #expect(invalid.isError == true)
+        #expect(sharedJSONObject(sharedToolText(invalid))?["error"] as? String == "invalid_params")
+    }
+
+    private static let doctorReport = SetupDoctor.Report(
+        schema: SetupDoctor.schema,
+        status: .ok,
+        version: "3.11.0",
+        installSource: .sourceBuild,
+        checks: [],
+        summary: .init(
+            total: 0,
+            passed: 0,
+            failed: 0,
+            warnings: 0,
+            manual: 0,
+            skipped: 0,
+            durationMs: 0
+        ),
+        headline: "Ready",
+        fixPlan: [],
+        doctorProfile: .core,
+        doctorProfileBasis: "test",
+        clientProfile: .terminal,
+        clientProfileBasis: "test",
+        capabilities: [:]
+    )
+
+    private static func hostileDoctorReport(privateValue: String) -> SetupDoctor.Report {
+        SetupDoctor.Report(
+            schema: SetupDoctor.schema,
+            status: .degraded,
+            version: "3.11.0",
+            installSource: .sourceBuild,
+            checks: [
+                .init(
+                    id: "logic.blocking_dialog",
+                    domain: "logic",
+                    status: .warn,
+                    summary: "Bearer \(privateValue)",
+                    evidence: [
+                        "dialog_title": privateValue,
+                        "path": "/Users/private/\(privateValue)",
+                        "token": "sk-doctor-secret",
+                    ],
+                    remediation: .init(
+                        type: .command,
+                        value: "chmod /Users/private/\(privateValue) ghp_doctor"
+                    ),
+                    category: .runtime,
+                    severity: .warning,
+                    durationMs: 1,
+                    blockedBy: nil,
+                    skipReason: nil,
+                    optional: false
+                ),
+            ],
+            summary: .init(
+                total: 1,
+                passed: 0,
+                failed: 0,
+                warnings: 1,
+                manual: 0,
+                skipped: 0,
+                durationMs: 1
+            ),
+            headline: "Bearer \(privateValue)",
+            fixPlan: ["logic.blocking_dialog"],
+            doctorProfile: .core,
+            doctorProfileBasis: privateValue,
+            clientProfile: .terminal,
+            clientProfileBasis: privateValue,
+            capabilities: [:]
+        )
+    }
+
+    private static func jsonObject(_ url: URL) throws -> [String: Any] {
+        try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        )
+    }
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -608,6 +608,7 @@ struct WorkflowCommandCensusTests {
             #expect(project.contains(command),
                     "logic_project.\(command) executes in the dispatcher + is documented in API.md but is missing from the census")
         }
+        #expect(WorkflowSkillCatalog.publicCommands["logic_system"]?.contains("export_support_bundle") == true)
     }
 }
 


### PR DESCRIPTION
## ADR-005 (#288, part of #308) — privacy-safe local support bundle + leakage-scan gate

Completes ADR-005's remaining roadmap scope: "manifest, traces, Doctor report, server/Logic metadata, redaction report, SHA256SUMS; never auto-upload" + "privacy-class registry and CI fixtures that scan bundles for leakage".

### Change
- `logic_system export_support_bundle { dir?: String }` → local-only bundle: `manifest.json`, `traces.json` (privacy-allowlisted via the existing `TracePrivacyClass` registry), `doctor.json`, `metadata.json`, `redaction_report.json` (honest drop counts), `SHA256SUMS`. **No network code paths.** State A only after re-reading written files and verifying hashes (independent readback); relative dir fails closed (typed State C).
- **Triple-gate registration** (the gates built in #354/#356/#357 forced every step): OperationRegistry spec (`system.export_support_bundle`, mutating, `TargetPolicy.none`), census, trace wiring (mutating gate count 83 → 84).
- Leakage-scan tests: synthetic poisoned traces prove `/Users/` paths, `sk-`/`ghp_`/`Bearer ` secrets, and env sentinels never reach the bundle.

### Verification
- Unit: `SupportBundle|OperationTrace|OperationRegistry` **75/75**; census + mutation completeness 8/8.
- **Live (real Logic 12.3)**: exported a real bundle — **State A + trace_id**, 6 files, **SHA256SUMS verified 5/5 on disk**, independent leakage scan of all contents: **0 hits**.

Refs #308.
