### PR TITLE
feat(adr-003): bind one runtime handler per operation spec + startup invariant (#286)

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -370,6 +370,14 @@ actor LogicProServer {
         let poller = self.poller
         let mutationGate = self.mutationGate
         let targetRegistry = self.targetRegistry
+        let handlerDependencies = HandlerDependencies(
+            router: router,
+            cache: cache,
+            targetRegistry: targetRegistry,
+            poller: poller,
+            dialogPresent: dialogPresent,
+            supportBundleExporter: supportBundleExporter
+        )
 
         return LogicProServerHandlers(
             listTools: { _ in
@@ -393,63 +401,19 @@ actor LogicProServer {
                 // normal op can never false-trip (verified across the full live
                 // surface); only a genuine hang is bounded.
                 return await Self.runWithDeadline(tool: name, command: command, mutationGate: mutationGate) {
-                    switch name {
-                    case "logic_transport":
-                        return await TransportDispatcher.handle(
-                            command: command,
-                            params: cmdParams,
-                            router: router,
-                            cache: cache,
-                            dialogPresent: dialogPresent
-                        )
-                    case "logic_tracks":
-                        return await TrackDispatcher.handle(
-                            command: command,
-                            params: cmdParams,
-                            router: router,
-                            cache: cache,
-                            targetRegistry: targetRegistry,
-                            dialogPresent: dialogPresent
-                        )
-                    case "logic_mixer":
-                        return await MixerDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache, targetRegistry: targetRegistry)
-                    case "logic_midi":
-                        return await MIDIDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                    case "logic_edit":
-                        return await EditDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                    case "logic_navigate":
-                        return await NavigateDispatcher.handle(command: command, params: cmdParams, router: router, cache: cache)
-                    case "logic_project":
-                        return await ProjectDispatcher.handle(
-                            command: command,
-                            params: cmdParams,
-                            router: router,
-                            cache: cache,
-                            targetRegistry: targetRegistry,
-                            dialogPresent: dialogPresent
-                        )
-                    case "logic_audio":
-                        return AudioDispatcher.handle(command: command, params: cmdParams)
-                    case "logic_system":
-                        return await SystemDispatcher.handle(
-                            command: command,
-                            params: cmdParams,
-                            router: router,
-                            cache: cache,
-                            poller: poller,
-                            supportBundleExporter: supportBundleExporter
-                        )
-                    case "logic_plugins":
-                        return await PluginsDispatcher.handle(
-                            command: command,
-                            params: cmdParams,
-                            router: router,
-                            cache: cache,
-                            targetRegistry: targetRegistry
-                        )
-                    default:
-                        return toolTextResult("Unknown tool: \(name)", isError: true)
+                    guard let handler = OperationHandlerRegistry.handler(
+                        tool: name,
+                        command: command
+                    ) else {
+                        guard let fallback = OperationHandlerRegistry.fallbackHandler(
+                            tool: name,
+                            command: command
+                        ) else {
+                            return toolTextResult("Unknown tool: \(name)", isError: true)
+                        }
+                        return await fallback(handlerDependencies, cmdParams)
                     }
+                    return await handler(handlerDependencies, cmdParams)
                 }
             },
             listResources: { _ in
@@ -811,8 +775,8 @@ actor LogicProServer {
     ///    present command whose command-specific params are missing (e.g.
     ///    `set_tempo` with no `tempo`) still dispatches and returns the
     ///    dispatcher's typed domain `invalid_params` State C.
-    /// Single source of truth for the wire behavior; the dispatch switch's
-    /// `default: "Unknown tool"` branch remains only as unreachable defense.
+    /// Single source of truth for the wire behavior; the registry route's
+    /// `"Unknown tool"` result remains only as unreachable defense.
     static func toolCallProtocolError(name: String, arguments: [String: Value]?) -> MCPError? {
         guard ServerCatalog.toolNames.contains(name) else {
             return .invalidParams("Unknown tool: \(name)")
@@ -888,6 +852,7 @@ actor LogicProServer {
     }
 
     func start() async throws {
+        OperationHandlerRegistry.validate()
         if let cleanupStartupArtifacts = runtimeOverrides?.cleanupStartupArtifacts {
             cleanupStartupArtifacts()
         } else {
@@ -924,6 +889,7 @@ actor LogicProServer {
     }
 
     func startProtocolProbe(transport: any Transport) async throws {
+        OperationHandlerRegistry.validate()
         await registerTools()
         await registerResources()
         await registerPrompts()

--- a/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
@@ -1,0 +1,230 @@
+import MCP
+
+struct HandlerDependencies: Sendable {
+    let router: ChannelRouter
+    let cache: StateCache
+    let targetRegistry: TargetRegistry
+    let poller: StatePoller
+    let dialogPresent: @Sendable () -> Bool
+    let supportBundleExporter: SystemDispatcher.SupportBundleExporter?
+}
+
+typealias OperationHandler = @Sendable (
+    HandlerDependencies,
+    [String: Value]
+) async -> CallTool.Result
+
+enum OperationHandlerRegistry {
+    struct Binding: Sendable {
+        let id: OperationID
+        let tool: String
+        let command: String
+        let handler: OperationHandler
+    }
+
+    private struct Key: Hashable, Sendable {
+        let tool: String
+        let command: String
+
+        var description: String { "\(tool):\(command)" }
+    }
+
+    static let bindings: [Binding] = OperationRegistry.specs.map { spec in
+        Binding(
+            id: spec.id,
+            tool: spec.tool.rawValue,
+            command: spec.command,
+            handler: makeHandler(tool: spec.tool, command: spec.command)
+        )
+    }
+
+    private static let handlersByID = bindings.reduce(into: [OperationID: OperationHandler]()) {
+        $0[$1.id] = $1.handler
+    }
+
+    private static let handlersByKey = bindings.reduce(into: [Key: OperationHandler]()) {
+        $0[Key(tool: $1.tool, command: $1.command)] = $1.handler
+    }
+
+    private static let validated: Void = {
+        let errors = validationErrors()
+        guard errors.isEmpty else {
+            fatalError("Operation handler registry invariant failed:\n\(errors.joined(separator: "\n"))")
+        }
+    }()
+
+    static func handler(for operationID: OperationID) -> OperationHandler? {
+        validate()
+        return handlersByID[operationID]
+    }
+
+    static func handler(tool: String, command: String) -> OperationHandler? {
+        validate()
+        return handlersByKey[Key(tool: tool, command: command)]
+    }
+
+    static func fallbackHandler(tool: String, command: String) -> OperationHandler? {
+        validate()
+        guard let toolID = ToolID(rawValue: tool) else { return nil }
+        return makeHandler(tool: toolID, command: command)
+    }
+
+    static func validate() {
+        _ = validated
+    }
+
+    static func validationErrors() -> [String] {
+        var errors = OperationRegistry.validationErrors().map { "operation spec: \($0)" }
+        let specs = OperationRegistry.specs
+        let specIDs = Set(specs.map(\.id))
+        let bindingIDs = bindings.map(\.id)
+        let handlerIDs = Set(bindingIDs)
+        let specKeys = Set(specs.map { Key(tool: $0.tool.rawValue, command: $0.command) })
+        let bindingKeys = bindings.map { Key(tool: $0.tool, command: $0.command) }
+        let handlerKeys = Set(bindingKeys)
+
+        if bindings.count != specs.count {
+            errors.append("binding count: expected \(specs.count), got \(bindings.count)")
+        }
+
+        let duplicateIDs = Dictionary(grouping: bindingIDs, by: { $0 })
+            .filter { $0.value.count > 1 }
+            .keys.map(\.rawValue).sorted()
+        if !duplicateIDs.isEmpty {
+            errors.append("duplicate handler IDs: \(duplicateIDs.joined(separator: ", "))")
+        }
+
+        let duplicateKeys = Dictionary(grouping: bindingKeys, by: { $0 })
+            .filter { $0.value.count > 1 }
+            .keys.map(\.description).sorted()
+        if !duplicateKeys.isEmpty {
+            errors.append("duplicate handler keys: \(duplicateKeys.joined(separator: ", "))")
+        }
+
+        let missingIDs = specIDs.subtracting(handlerIDs).map(\.rawValue).sorted()
+        if !missingIDs.isEmpty {
+            errors.append("missing handler IDs: \(missingIDs.joined(separator: ", "))")
+        }
+        let orphanIDs = handlerIDs.subtracting(specIDs).map(\.rawValue).sorted()
+        if !orphanIDs.isEmpty {
+            errors.append("orphan handler IDs: \(orphanIDs.joined(separator: ", "))")
+        }
+
+        let missingKeys = specKeys.subtracting(handlerKeys).map(\.description).sorted()
+        if !missingKeys.isEmpty {
+            errors.append("missing handler keys: \(missingKeys.joined(separator: ", "))")
+        }
+        let orphanKeys = handlerKeys.subtracting(specKeys).map(\.description).sorted()
+        if !orphanKeys.isEmpty {
+            errors.append("orphan handler keys: \(orphanKeys.joined(separator: ", "))")
+        }
+
+        if handlersByID.count != bindings.count {
+            errors.append("operation ID table count: expected \(bindings.count), got \(handlersByID.count)")
+        }
+        if handlersByKey.count != bindings.count {
+            errors.append("tool-command table count: expected \(bindings.count), got \(handlersByKey.count)")
+        }
+
+        return errors
+    }
+
+    private static func makeHandler(tool: ToolID, command: String) -> OperationHandler {
+        switch tool {
+        case .logicTransport:
+            return { dependencies, params in
+                await TransportDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    dialogPresent: dependencies.dialogPresent
+                )
+            }
+        case .logicMixer:
+            return { dependencies, params in
+                await MixerDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry
+                )
+            }
+        case .logicNavigate:
+            return { dependencies, params in
+                await NavigateDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache
+                )
+            }
+        case .logicAudio:
+            return { _, params in
+                AudioDispatcher.handle(command: command, params: params)
+            }
+        case .logicSystem:
+            return { dependencies, params in
+                await SystemDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    poller: dependencies.poller,
+                    supportBundleExporter: dependencies.supportBundleExporter
+                )
+            }
+        case .logicPlugins:
+            return { dependencies, params in
+                await PluginsDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry
+                )
+            }
+        case .logicEdit:
+            return { dependencies, params in
+                await EditDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache
+                )
+            }
+        case .logicProject:
+            return { dependencies, params in
+                await ProjectDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry,
+                    dialogPresent: dependencies.dialogPresent
+                )
+            }
+        case .logicMidi:
+            return { dependencies, params in
+                await MIDIDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache
+                )
+            }
+        case .logicTracks:
+            return { dependencies, params in
+                await TrackDispatcher.handle(
+                    command: command,
+                    params: params,
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry,
+                    dialogPresent: dependencies.dialogPresent
+                )
+            }
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+@Suite("Operation handler bindings", .serialized)
+struct OperationHandlerBindingTests {
+    private static func dependencies() -> HandlerDependencies {
+        let cache = StateCache()
+        return HandlerDependencies(
+            router: ChannelRouter(),
+            cache: cache,
+            targetRegistry: TargetRegistry(),
+            poller: StatePoller(
+                axChannel: AccessibilityChannel(),
+                cache: cache,
+                runtime: .fastTest
+            ),
+            dialogPresent: { false },
+            supportBundleExporter: nil
+        )
+    }
+
+    private static func bytes(_ result: CallTool.Result) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(result)
+    }
+
+    private static func object(_ result: CallTool.Result) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: bytes(result)) as? [String: Any])
+    }
+
+    @Test("registry exactly binds every operation spec once")
+    func registryMatchesOperationSpecs() throws {
+        let specs = OperationRegistry.specs
+        let bindings = OperationHandlerRegistry.bindings
+        let specIDs = Set(specs.map(\.id))
+        let bindingIDs = bindings.map(\.id)
+        let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
+        let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
+
+        #expect(specs.count == 100)
+        #expect(bindings.count == specs.count)
+        #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
+        #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")
+        #expect(Set(bindingIDs) == specIDs, "missing or orphan handler IDs")
+        #expect(Set(bindingKeys) == specKeys, "missing or orphan handler keys")
+        #expect(OperationHandlerRegistry.validationErrors().isEmpty)
+
+        OperationHandlerRegistry.validate()
+        for spec in specs {
+            #expect(OperationHandlerRegistry.handler(for: spec.id) != nil)
+            #expect(OperationHandlerRegistry.handler(
+                tool: spec.tool.rawValue,
+                command: spec.command
+            ) != nil)
+        }
+    }
+
+    @Test("representative registry handlers are byte-identical to direct dispatch")
+    func representativeHandlersMatchDirectDispatchers() async throws {
+        let dependencies = Self.dependencies()
+        await dependencies.router.register(MockChannel(id: .coreMIDI))
+        await dependencies.router.register(MockChannel(id: .accessibility))
+        let cases: [(OperationID, [String: Value], CallTool.Result)] = [
+            (
+                .midiListPorts,
+                [:],
+                await MIDIDispatcher.handle(
+                    command: "list_ports",
+                    params: [:],
+                    router: dependencies.router,
+                    cache: dependencies.cache
+                )
+            ),
+            (
+                .tracksListLibrary,
+                [:],
+                await TrackDispatcher.handle(
+                    command: "list_library",
+                    params: [:],
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry,
+                    dialogPresent: dependencies.dialogPresent
+                )
+            ),
+            (
+                .pluginsGetInventory,
+                ["track": .int(0)],
+                await PluginsDispatcher.handle(
+                    command: "get_inventory",
+                    params: ["track": .int(0)],
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    targetRegistry: dependencies.targetRegistry
+                )
+            ),
+            (
+                .systemExportSupportBundle,
+                ["dir": .string("relative")],
+                await SystemDispatcher.handle(
+                    command: "export_support_bundle",
+                    params: ["dir": .string("relative")],
+                    router: dependencies.router,
+                    cache: dependencies.cache,
+                    poller: dependencies.poller,
+                    supportBundleExporter: dependencies.supportBundleExporter
+                )
+            ),
+        ]
+
+        for (operationID, params, direct) in cases {
+            let handler = try #require(OperationHandlerRegistry.handler(for: operationID))
+            let throughRegistry = await handler(dependencies, params)
+            #expect(throughRegistry == direct)
+            #expect(try Self.bytes(throughRegistry) == Self.bytes(direct))
+        }
+    }
+
+    @Test("unregistered server command preserves dispatcher bytes")
+    func unregisteredCommandPreservesDispatcherUnknownResponse() async throws {
+        let command = "__operation_handler_binding_unknown__"
+        let server = LogicProServer()
+        let handlers = await server.makeHandlers()
+        let throughServer = await handlers.callTool(.init(
+            name: TrackDispatcher.tool.name,
+            arguments: ["command": .string(command)]
+        ))
+        let dependencies = Self.dependencies()
+        let direct = await TrackDispatcher.handle(
+            command: command,
+            params: [:],
+            router: dependencies.router,
+            cache: dependencies.cache,
+            targetRegistry: dependencies.targetRegistry,
+            dialogPresent: dependencies.dialogPresent
+        )
+
+        #expect(OperationHandlerRegistry.handler(
+            tool: TrackDispatcher.tool.name,
+            command: command
+        ) == nil)
+        #expect(throughServer == direct)
+        #expect(try Self.bytes(throughServer) == Self.bytes(direct))
+
+        let unknownTool = await handlers.callTool(.init(
+            name: "logic_unknown",
+            arguments: ["command": .string("noop")]
+        ))
+        let directUnknownTool = toolTextResult("Unknown tool: logic_unknown", isError: true)
+        #expect(unknownTool == directUnknownTool)
+        #expect(try Self.bytes(unknownTool) == Self.bytes(directUnknownTool))
+    }
+
+    @Test("MCP protocol preserves registered and unregistered dispatcher results")
+    func protocolRoutePreservesDispatcherResults() async throws {
+        let server = LogicProServer()
+        let transport = MCPProtocolProbeTransport()
+        try await server.startProtocolProbe(transport: transport)
+        defer { Task { await server.stopProtocolProbe() } }
+
+        await transport.queueJSON(probeInitializeFrame(id: 1))
+        _ = try await waitForProbeResponse(transport, id: 1)
+
+        let dependencies = Self.dependencies()
+        let registeredDirect = await TransportDispatcher.handle(
+            command: "set_tempo",
+            params: [:],
+            router: dependencies.router,
+            cache: dependencies.cache,
+            dialogPresent: dependencies.dialogPresent
+        )
+        await transport.queueJSON(probeToolCallFrame(
+            id: 2,
+            name: TransportDispatcher.tool.name,
+            command: "set_tempo"
+        ))
+        let registeredResponse = try await waitForProbeResponse(transport, id: 2)
+        let registeredResult = try #require(registeredResponse["result"] as? [String: Any])
+        #expect(try canonicalJSONObjectData(registeredResult)
+            == canonicalJSONObjectData(Self.object(registeredDirect)))
+
+        let unknownCommand = "__operation_handler_protocol_unknown__"
+        let unknownDirect = await TrackDispatcher.handle(
+            command: unknownCommand,
+            params: [:],
+            router: dependencies.router,
+            cache: dependencies.cache,
+            targetRegistry: dependencies.targetRegistry,
+            dialogPresent: dependencies.dialogPresent
+        )
+        await transport.queueJSON(probeToolCallFrame(
+            id: 3,
+            name: TrackDispatcher.tool.name,
+            command: unknownCommand
+        ))
+        let unknownResponse = try await waitForProbeResponse(transport, id: 3)
+        let unknownResult = try #require(unknownResponse["result"] as? [String: Any])
+        #expect(try canonicalJSONObjectData(unknownResult)
+            == canonicalJSONObjectData(Self.object(unknownDirect)))
+    }
+}


### PR DESCRIPTION
## ADR-003 (#286, part of #308) — one runtime handler per operation spec + startup invariant

Completes G1's handler-binding requirement: "Every public operation has exactly one typed `OperationSpec` and exactly one runtime handler."

### Change
- New `OperationHandlerRegistry`: a typed `(tool, command) → OperationHandler` table derived from `OperationRegistry.specs` (no hand list), with `HandlerDependencies` bundling the server's router/cache/targetRegistry/poller/dialogPresent/supportBundleExporter. Dispatcher switches remain the handler implementations — bound once, per spec.
- `LogicProServer` tool routing swapped from a hand-written tool switch to registry lookup (net −58 lines in the switch body). Unregistered command / unknown tool responses preserve the exact prior shapes (per-tool "Unknown … command" hints).
- **Startup invariant**: `validate()` fail-fast (fatalError) on missing handler / handler-without-spec / duplicates. CI test pins **100/100 bindings** (census includes the new `system.export_support_bundle`), 0 duplicates, 0 orphans.
- Byte-identity proofs: full `CallTool.Result` byte comparison for MIDI/tracks/plugins/system paths (registry-routed vs direct dispatcher), plus in-memory MCP registered/unregistered frame equality.
- Prepares ADR-004: `handler(for: OperationID)` is the saga executor's entry point.

### Verification
- Unit: designated filter **558/558**; binding tests 4/4; my re-run `OperationHandlerBinding|OperationRegistry` **57/57**.
- **Live (real Logic 12.3, registry-routed)**: full scenario qualification **21/21, 0 violations**; resource reads OK; unknown-command shape byte-preserved.

Refs #308. Follows #354/#358 (registry sole authority).
