### PR TITLE
feat(adr-001): executable qualification runner + attestation + release promotion gate (#284)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,26 @@ jobs:
         # .testFormulaInstallPathsMatchRepoAndReleaseStaging.
         run: bash Scripts/release-verify-formula-install-paths.sh
 
+      - name: Qualify and verify promotion
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          binary_sha256="$(shasum -a 256 LogicProMCP | awk '{print $1}')"
+          ./LogicProMCP --qualify \
+            --out release-qualification-attestation.json \
+            --release-version "$RELEASE_VERSION" \
+            --variant desktop \
+            --locale en \
+            --profile core \
+            --cache cold
+          ./LogicProMCP --verify-promotion \
+            --attestation release-qualification-attestation.json \
+            --release-version "$RELEASE_VERSION" \
+            --expected-binary-sha256 "$binary_sha256" \
+            --required-artifacts LogicProMCP,evidence-manifest.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -23,6 +23,9 @@ enum MainEntrypoint {
         approvalStoreFactory: () -> any ManualValidationStoring = { ManualValidationStore() },
         doctorRuntime: SetupDoctor.Runtime = .production,
         lifecycleRuntime: SetupLifecycle.Runtime = .production,
+        qualificationCommand: ([String]) async -> QualificationCommandResult = { arguments in
+            await QualificationRunner().run(arguments: arguments)
+        },
         // Injected so doctor's color/TTY gating is pinnable in tests (AC-5.4).
         isStdoutTTY: () -> Bool = { isatty(STDOUT_FILENO) != 0 },
         doctorEnvironment: [String: String] = ProcessInfo.processInfo.environment,
@@ -50,6 +53,14 @@ enum MainEntrypoint {
         if hasFlag("--help", or: "-h", in: arguments) {
             writeStdout(usageText + "\n")
             return 0
+        }
+
+        if let command = arguments.dropFirst().first,
+           command == "--qualify" || command == "--verify-promotion" {
+            let result = await qualificationCommand(arguments)
+            if !result.stdout.isEmpty { writeStdout(result.stdout) }
+            if !result.stderr.isEmpty { writeStderr(result.stderr) }
+            return result.exitCode
         }
 
         let approvalStore = approvalStoreFactory()
@@ -255,6 +266,10 @@ enum MainEntrypoint {
           LogicProMCP <install|update|uninstall> --dry-run [--json]
                                                Print a read-only lifecycle plan and exit
           LogicProMCP --check-permissions      Print macOS permission status and exit (non-zero if not ready)
+          LogicProMCP --qualify --out <attestation.json> [--cases <cases.json>] [--release-version <version>] [--variant <desktop|creator>] [--locale <en|ko>] [--profile <core|full>] [--cache <cold|warm>]
+                                               Run deterministic structural qualification and write an attestation
+          LogicProMCP --verify-promotion --attestation <attestation.json> --release-version <version> --expected-binary-sha256 <hex> [--required-artifacts <path,...>]
+                                               Evaluate the release promotion gate and emit a JSON decision
           LogicProMCP --list-approvals         List manual channel approvals and exit
           LogicProMCP --approve-channel <MIDIKeyCommands|Scripter> [--approval-note <note>]
                                                Record a manual channel approval and exit

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -1,0 +1,622 @@
+import Foundation
+
+struct QualificationCommandResult: Sendable {
+    let exitCode: Int
+    let stdout: String
+    let stderr: String
+}
+
+struct QualificationRunner: Sendable {
+    struct Runtime: Sendable {
+        let executableURL: @Sendable () throws -> URL
+        let environment: @Sendable () -> [String: String]
+        let now: @Sendable () -> Date
+        let serverVersion: @Sendable () -> String
+        let specs: @Sendable () -> [OperationSpec]
+        let registryValidationErrors: @Sendable () -> [String]
+        let handlerValidationErrors: @Sendable () -> [String]
+        let handlerExists: @Sendable (String, String) -> Bool
+
+        static let production = Runtime(
+            executableURL: { try QualificationRunner.currentExecutableURL() },
+            environment: { ProcessInfo.processInfo.environment },
+            now: Date.init,
+            serverVersion: { ServerConfig.serverVersion },
+            specs: { OperationRegistry.specs },
+            registryValidationErrors: { OperationRegistry.validationErrors() },
+            handlerValidationErrors: { OperationHandlerRegistry.validationErrors() },
+            handlerExists: { tool, command in
+                OperationHandlerRegistry.bindings.contains {
+                    $0.tool == tool && $0.command == command
+                }
+            }
+        )
+    }
+
+    private struct QualifyOptions {
+        let outputURL: URL
+        let externalCasesURL: URL?
+        let releaseVersion: String
+        let variant: LogicVariant
+        let locale: QualificationLocale
+        let profile: SetupProfile
+        let cache: CacheState
+    }
+
+    private struct VerifyOptions {
+        let attestationURL: URL
+        let releaseVersion: String
+        let expectedBinarySHA256: String
+        let requiredArtifacts: Set<String>
+    }
+
+    private struct VerificationOutput: Codable {
+        struct Rejection: Codable {
+            let reason: String
+            let caseID: String?
+            let key: String?
+            let name: String?
+            let expected: String?
+            let actual: String?
+        }
+
+        let promotable: Bool
+        let rejections: [Rejection]
+    }
+
+    private struct CaseEvidence: Codable {
+        let schema: String
+        let caseID: String
+        let operationID: String
+        let tool: String
+        let command: String
+        let registrySpecFound: Bool
+        let handlerBound: Bool
+        let traceStarted: Bool
+        let traceCompleted: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case caseID = "case_id"
+            case operationID = "operation_id"
+            case tool
+            case command
+            case registrySpecFound = "registry_spec_found"
+            case handlerBound = "handler_bound"
+            case traceStarted = "trace_started"
+            case traceCompleted = "trace_completed"
+        }
+    }
+
+    private struct EvidenceManifest: Codable {
+        struct Entry: Codable {
+            let path: String
+            let sha256: String
+        }
+
+        let schema: String
+        let files: [Entry]
+    }
+
+    private enum RunnerError: Error, CustomStringConvertible {
+        case invalidArguments(String)
+        case missingOption(String)
+        case invalidOption(String, String)
+        case releaseVersionMismatch(expected: String, actual: String)
+        case executableUnavailable
+
+        var description: String {
+            switch self {
+            case .invalidArguments(let detail): detail
+            case .missingOption(let option): "Missing required option: \(option)"
+            case .invalidOption(let option, let value): "Invalid value for \(option): \(value)"
+            case .releaseVersionMismatch(let expected, let actual):
+                "Release version does not match this binary: expected \(expected), got \(actual)"
+            case .executableUnavailable: "Unable to resolve the running executable"
+            }
+        }
+    }
+
+    private let runtime: Runtime
+
+    init(runtime: Runtime = .production) {
+        self.runtime = runtime
+    }
+
+    func run(arguments: [String]) async -> QualificationCommandResult {
+        do {
+            switch arguments.dropFirst().first {
+            case "--qualify":
+                let options = try parseQualifyOptions(Array(arguments.dropFirst(2)))
+                try await qualify(options)
+                return QualificationCommandResult(exitCode: 0, stdout: "", stderr: "")
+            case "--verify-promotion":
+                return try verify(parseVerifyOptions(Array(arguments.dropFirst(2))))
+            default:
+                throw RunnerError.invalidArguments("Expected --qualify or --verify-promotion")
+            }
+        } catch {
+            return failure(String(describing: error))
+        }
+    }
+
+    static func currentExecutableURL() throws -> URL {
+        if let executableURL = Bundle.main.executableURL {
+            return executableURL.resolvingSymlinksInPath()
+        }
+        guard let argument = CommandLine.arguments.first, !argument.isEmpty else {
+            throw RunnerError.executableUnavailable
+        }
+        let url = URL(
+            fileURLWithPath: argument,
+            relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        )
+        return url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private func qualify(_ options: QualifyOptions) async throws {
+        guard options.outputURL.lastPathComponent.caseInsensitiveCompare(Self.manifestFilename)
+            != .orderedSame
+        else {
+            throw RunnerError.invalidOption("--out", options.outputURL.path)
+        }
+        let embeddedVersion = runtime.serverVersion()
+        if options.releaseVersion != "unknown",
+           Self.normalizedVersion(options.releaseVersion) != Self.normalizedVersion(embeddedVersion)
+        {
+            throw RunnerError.releaseVersionMismatch(
+                expected: embeddedVersion,
+                actual: options.releaseVersion
+            )
+        }
+        let startedAt = runtime.now()
+        let executableData = try Data(contentsOf: runtime.executableURL(), options: .mappedIfSafe)
+        let binarySHA256 = SupportBundleBuilder.sha256(executableData)
+        let outputDirectory = options.outputURL.deletingLastPathComponent()
+        let evidenceDirectory = outputDirectory.appendingPathComponent("evidence", isDirectory: true)
+        try FileManager.default.createDirectory(at: evidenceDirectory, withIntermediateDirectories: true)
+
+        let specs = runtime.specs().sorted { $0.id.rawValue < $1.id.rawValue }
+        let registryErrors = runtime.registryValidationErrors()
+        let handlerErrors = runtime.handlerValidationErrors()
+        let traceStore = OperationTraceStore(
+            maximumTraceCount: max(OperationTraceStore.defaultMaximumTraceCount, specs.count + 4),
+            maximumBytes: OperationTraceStore.defaultMaximumBytes
+        )
+        var cases: [QualificationCase] = []
+        var manifestEntries: [EvidenceManifest.Entry] = []
+
+        for spec in specs {
+            let matchingSpecs = specs.filter {
+                $0.id == spec.id
+                    && $0.tool == spec.tool
+                    && $0.command == spec.command
+            }
+            let registrySpecFound = matchingSpecs.count == 1 && registryErrors.isEmpty
+            let handlerBound = runtime.handlerExists(spec.tool.rawValue, spec.command)
+                && handlerErrors.isEmpty
+            let traceID = await traceStore.start(operationID: spec.id.rawValue)
+            let traceStarted = await traceStore.trace(traceID) != nil
+            await traceStore.complete(traceID)
+            let traceCompleted = await traceStore.trace(traceID)?.completedAt != nil
+            let passed = registrySpecFound && handlerBound && traceStarted && traceCompleted
+            let relativePath = "evidence/operation-\(spec.id.rawValue).json"
+            let evidence = CaseEvidence(
+                schema: "qualification-case-evidence/v1",
+                caseID: "in-process/\(spec.id.rawValue)",
+                operationID: spec.id.rawValue,
+                tool: spec.tool.rawValue,
+                command: spec.command,
+                registrySpecFound: registrySpecFound,
+                handlerBound: handlerBound,
+                traceStarted: traceStarted,
+                traceCompleted: traceCompleted
+            )
+            let evidenceData = try Self.encoded(evidence)
+            try evidenceData.write(
+                to: outputDirectory.appendingPathComponent(relativePath),
+                options: .atomic
+            )
+            manifestEntries.append(.init(
+                path: relativePath,
+                sha256: SupportBundleBuilder.sha256(evidenceData)
+            ))
+            cases.append(QualificationCase(
+                id: evidence.caseID,
+                status: passed ? .passed : .failed,
+                tool: spec.tool.rawValue,
+                command: spec.command,
+                traceID: traceID.rawValue,
+                verified: passed,
+                evidenceFiles: [relativePath]
+            ))
+        }
+
+        let operationCasesPassed = cases.allSatisfy {
+            $0.status == .passed && $0.verified && !$0.evidenceFiles.isEmpty
+        }
+        for axis in QualificationAxis.requiredCombinations {
+            let axisKey = "\(axis.variant.rawValue)/\(axis.locale.rawValue)/\(options.profile.rawValue)/\(options.cache.rawValue)"
+            let traceID = await traceStore.start(operationID: "qualification.\(axisKey)")
+            let traceStarted = await traceStore.trace(traceID) != nil
+            await traceStore.complete(traceID)
+            let traceCompleted = await traceStore.trace(traceID)?.completedAt != nil
+            let passed = operationCasesPassed && traceStarted && traceCompleted
+            let caseID = "\(axisKey)/empty"
+            let relativePath = "evidence/axis-\(axisKey.replacingOccurrences(of: "/", with: "-")).json"
+            let evidence = CaseEvidence(
+                schema: "qualification-case-evidence/v1",
+                caseID: caseID,
+                operationID: "qualification.\(axisKey)",
+                tool: "qualification",
+                command: "registry_handler_trace",
+                registrySpecFound: operationCasesPassed,
+                handlerBound: operationCasesPassed,
+                traceStarted: traceStarted,
+                traceCompleted: traceCompleted
+            )
+            let evidenceData = try Self.encoded(evidence)
+            try evidenceData.write(
+                to: outputDirectory.appendingPathComponent(relativePath),
+                options: .atomic
+            )
+            manifestEntries.append(.init(
+                path: relativePath,
+                sha256: SupportBundleBuilder.sha256(evidenceData)
+            ))
+            cases.append(QualificationCase(
+                id: caseID,
+                status: passed ? .passed : .failed,
+                tool: evidence.tool,
+                command: evidence.command,
+                traceID: traceID.rawValue,
+                verified: passed,
+                evidenceFiles: [relativePath]
+            ))
+        }
+
+        if let externalCasesURL = options.externalCasesURL {
+            let externalCases = try JSONDecoder().decode(
+                [QualificationCase].self,
+                from: Data(contentsOf: externalCasesURL)
+            )
+            let internalEvidencePaths = Set(manifestEntries.map(\.path))
+            let externalEvidencePaths = Set(externalCases.flatMap(\.evidenceFiles))
+                .subtracting(internalEvidencePaths)
+            for relativePath in externalEvidencePaths.sorted() {
+                let evidenceData = try Self.validatedEvidenceData(
+                    relativePath: relativePath,
+                    outputDirectory: outputDirectory
+                )
+                manifestEntries.append(.init(
+                    path: relativePath,
+                    sha256: SupportBundleBuilder.sha256(evidenceData)
+                ))
+            }
+            cases.append(contentsOf: externalCases)
+        }
+
+        manifestEntries.sort { $0.path < $1.path }
+        let manifest = EvidenceManifest(
+            schema: "qualification-evidence-manifest/v1",
+            files: manifestEntries
+        )
+        let manifestData = try Self.encoded(manifest)
+        try manifestData.write(
+            to: outputDirectory.appendingPathComponent(Self.manifestFilename),
+            options: .atomic
+        )
+
+        let attestation = ReleaseQualificationAttestation(
+            schema: "release-qualification-attestation/v1",
+            serverVersion: options.releaseVersion,
+            commitSHA: runtime.environment()["GIT_COMMIT"] ?? "unknown",
+            binarySHA256: binarySHA256,
+            logicVariant: options.variant,
+            logicVersion: "unknown",
+            locale: options.locale,
+            profile: options.profile,
+            startedAt: startedAt,
+            completedAt: runtime.now(),
+            total: cases.count,
+            passed: cases.filter { $0.status == .passed }.count,
+            failed: cases.filter { $0.status == .failed }.count,
+            waived: cases.filter { $0.status == .waived }.count,
+            cases: cases,
+            waivers: [],
+            evidenceManifestSHA256: SupportBundleBuilder.sha256(manifestData)
+        )
+        try Self.attestationData(attestation, cache: options.cache).write(
+            to: options.outputURL,
+            options: .atomic
+        )
+    }
+
+    private func parseQualifyOptions(_ arguments: [String]) throws -> QualifyOptions {
+        let values = try Self.optionValues(arguments, allowed: [
+            "--out", "--cases", "--release-version", "--variant", "--locale", "--profile", "--cache",
+        ])
+        guard let output = values["--out"] else { throw RunnerError.missingOption("--out") }
+        let environment = runtime.environment()
+        let variant = try Self.parseVariant(values["--variant"] ?? "desktop")
+        let locale = try Self.parseLocale(values["--locale"] ?? "en")
+        let profile = try Self.parseEnum(SetupProfile.self, values["--profile"] ?? "core", option: "--profile")
+        let cache = try Self.parseEnum(CacheState.self, values["--cache"] ?? "cold", option: "--cache")
+        return QualifyOptions(
+            outputURL: URL(fileURLWithPath: output),
+            externalCasesURL: values["--cases"].map(URL.init(fileURLWithPath:)),
+            releaseVersion: values["--release-version"] ?? environment["RELEASE_VERSION"] ?? "unknown",
+            variant: variant,
+            locale: locale,
+            profile: profile,
+            cache: cache
+        )
+    }
+
+    private func verify(_ options: VerifyOptions) throws -> QualificationCommandResult {
+        let attestation = try JSONDecoder().decode(
+            ReleaseQualificationAttestation.self,
+            from: Data(contentsOf: options.attestationURL)
+        )
+        let directory = options.attestationURL.deletingLastPathComponent()
+        let manifestArtifact = Self.manifestFilename
+        let requiredArtifacts = options.requiredArtifacts.union([manifestArtifact])
+        var presentArtifacts = Set(requiredArtifacts.filter { artifact in
+            let url = artifact.hasPrefix("/")
+                ? URL(fileURLWithPath: artifact)
+                : directory.appendingPathComponent(artifact)
+            return Self.isReadableRegularFile(url)
+        })
+        if !Self.evidenceIsIntact(attestation: attestation, directory: directory) {
+            presentArtifacts.remove(manifestArtifact)
+        }
+        let decision = PromotionGate().evaluate(
+            attestation: attestation,
+            releaseVersion: options.releaseVersion,
+            expectedBinarySHA256: options.expectedBinarySHA256,
+            presentArtifacts: presentArtifacts,
+            requiredArtifacts: requiredArtifacts
+        )
+        let currentExecutableData = try Data(
+            contentsOf: runtime.executableURL(),
+            options: .mappedIfSafe
+        )
+        let currentExecutableSHA256 = SupportBundleBuilder.sha256(currentExecutableData)
+        var rejections = decision.rejections
+        if currentExecutableSHA256 != options.expectedBinarySHA256 {
+            let replacementRejection = PromotionRejectionReason.binarySHAMismatch(
+                expected: options.expectedBinarySHA256,
+                actual: currentExecutableSHA256
+            )
+            if !rejections.contains(replacementRejection) {
+                rejections.append(replacementRejection)
+            }
+        }
+        let output = VerificationOutput(
+            promotable: rejections.isEmpty,
+            rejections: rejections.map(Self.output)
+        )
+        guard let json = String(data: try Self.encoded(output), encoding: .utf8) else {
+            throw RunnerError.invalidArguments("Unable to encode promotion decision")
+        }
+        return QualificationCommandResult(
+            exitCode: rejections.isEmpty ? 0 : 1,
+            stdout: json + "\n",
+            stderr: ""
+        )
+    }
+
+    private func parseVerifyOptions(_ arguments: [String]) throws -> VerifyOptions {
+        let values = try Self.optionValues(arguments, allowed: [
+            "--attestation", "--release-version", "--expected-binary-sha256", "--required-artifacts",
+        ])
+        guard let attestation = values["--attestation"] else {
+            throw RunnerError.missingOption("--attestation")
+        }
+        guard let releaseVersion = values["--release-version"] else {
+            throw RunnerError.missingOption("--release-version")
+        }
+        guard let expectedBinarySHA256 = values["--expected-binary-sha256"] else {
+            throw RunnerError.missingOption("--expected-binary-sha256")
+        }
+        let requiredArtifacts = Set(
+            (values["--required-artifacts"] ?? "")
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+        return VerifyOptions(
+            attestationURL: URL(fileURLWithPath: attestation),
+            releaseVersion: releaseVersion,
+            expectedBinarySHA256: expectedBinarySHA256,
+            requiredArtifacts: requiredArtifacts
+        )
+    }
+
+    private static func output(_ reason: PromotionRejectionReason) -> VerificationOutput.Rejection {
+        switch reason {
+        case .requiredCaseFailed(let caseID):
+            VerificationOutput.Rejection(
+                reason: "requiredCaseFailed", caseID: caseID, key: nil,
+                name: nil, expected: nil, actual: nil
+            )
+        case .requiredCombinationNotQualified(let key):
+            VerificationOutput.Rejection(
+                reason: "requiredCombinationNotQualified", caseID: nil, key: key,
+                name: nil, expected: nil, actual: nil
+            )
+        case .missingArtifact(let name):
+            VerificationOutput.Rejection(
+                reason: "missingArtifact", caseID: nil, key: nil,
+                name: name, expected: nil, actual: nil
+            )
+        case .binarySHAMismatch(let expected, let actual):
+            VerificationOutput.Rejection(
+                reason: "binarySHAMismatch", caseID: nil, key: nil,
+                name: nil, expected: expected, actual: actual
+            )
+        case .expiredWaiver(let caseID):
+            VerificationOutput.Rejection(
+                reason: "expiredWaiver", caseID: caseID, key: nil,
+                name: nil, expected: nil, actual: nil
+            )
+        case .releaseVersionMismatch(let expected, let actual):
+            VerificationOutput.Rejection(
+                reason: "releaseVersionMismatch", caseID: nil, key: nil,
+                name: nil, expected: expected, actual: actual
+            )
+        }
+    }
+
+    private static func optionValues(
+        _ arguments: [String],
+        allowed: Set<String>
+    ) throws -> [String: String] {
+        var values: [String: String] = [:]
+        var index = 0
+        while index < arguments.count {
+            let option = arguments[index]
+            guard allowed.contains(option) else { throw RunnerError.invalidArguments("Unknown option: \(option)") }
+            guard arguments.indices.contains(index + 1) else { throw RunnerError.missingOption(option) }
+            guard values[option] == nil else { throw RunnerError.invalidArguments("Duplicate option: \(option)") }
+            values[option] = arguments[index + 1]
+            index += 2
+        }
+        return values
+    }
+
+    private static func parseVariant(_ value: String) throws -> LogicVariant {
+        switch value {
+        case "desktop": .desktop
+        case "creator": .creatorStudio
+        default: throw RunnerError.invalidOption("--variant", value)
+        }
+    }
+
+    private static func parseLocale(_ value: String) throws -> QualificationLocale {
+        switch value {
+        case "en": .enUS
+        case "ko": .koKR
+        default: throw RunnerError.invalidOption("--locale", value)
+        }
+    }
+
+    private static func parseEnum<T: RawRepresentable>(
+        _ type: T.Type,
+        _ value: String,
+        option: String
+    ) throws -> T where T.RawValue == String {
+        guard let parsed = T(rawValue: value) else { throw RunnerError.invalidOption(option, value) }
+        return parsed
+    }
+
+    private static let manifestFilename = "evidence-manifest.json"
+
+    private static func normalizedVersion(_ version: String) -> Substring {
+        version.first == "v" || version.first == "V" ? version.dropFirst() : version[...]
+    }
+
+    private static func validatedEvidenceData(
+        relativePath: String,
+        outputDirectory: URL
+    ) throws -> Data {
+        guard let url = safeEvidenceURL(relativePath: relativePath, outputDirectory: outputDirectory),
+              isReadableRegularFile(url)
+        else {
+            throw RunnerError.invalidArguments("Invalid or unreadable evidence file: \(relativePath)")
+        }
+        return try Data(contentsOf: url, options: .mappedIfSafe)
+    }
+
+    private static func evidenceIsIntact(
+        attestation: ReleaseQualificationAttestation,
+        directory: URL
+    ) -> Bool {
+        let manifestURL = directory.appendingPathComponent(manifestFilename)
+        guard isReadableRegularFile(manifestURL),
+              let manifestData = try? Data(contentsOf: manifestURL, options: .mappedIfSafe),
+              SupportBundleBuilder.sha256(manifestData) == attestation.evidenceManifestSHA256,
+              let manifest = try? JSONDecoder().decode(EvidenceManifest.self, from: manifestData),
+              manifest.schema == "qualification-evidence-manifest/v1"
+        else {
+            return false
+        }
+
+        let expectedPaths = Set(attestation.cases.flatMap(\.evidenceFiles))
+        let manifestPaths = manifest.files.map(\.path)
+        guard Set(manifestPaths).count == manifestPaths.count,
+              Set(manifestPaths) == expectedPaths
+        else {
+            return false
+        }
+
+        for entry in manifest.files {
+            guard let evidenceData = try? validatedEvidenceData(
+                relativePath: entry.path,
+                outputDirectory: directory
+            ), SupportBundleBuilder.sha256(evidenceData) == entry.sha256 else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func safeEvidenceURL(
+        relativePath: String,
+        outputDirectory: URL
+    ) -> URL? {
+        guard !relativePath.isEmpty,
+              !relativePath.hasPrefix("/"),
+              !relativePath.split(separator: "/", omittingEmptySubsequences: false).contains(".."),
+              relativePath.caseInsensitiveCompare(manifestFilename) != .orderedSame
+        else {
+            return nil
+        }
+        let directory = outputDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = directory.appendingPathComponent(relativePath).standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath()
+        guard resolved.path.hasPrefix(directory.path + "/"),
+              candidate.path == resolved.path
+        else {
+            return nil
+        }
+        return candidate
+    }
+
+    private static func isReadableRegularFile(_ url: URL) -> Bool {
+        guard FileManager.default.isReadableFile(atPath: url.path),
+              let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              let isRegularFile = values.isRegularFile,
+              let isSymbolicLink = values.isSymbolicLink
+        else {
+            return false
+        }
+        return isRegularFile && !isSymbolicLink
+    }
+
+    private static func encoded<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(value)
+    }
+
+    private static func attestationData(
+        _ attestation: ReleaseQualificationAttestation,
+        cache: CacheState
+    ) throws -> Data {
+        var object = try JSONSerialization.jsonObject(with: encoded(attestation)) as? [String: Any] ?? [:]
+        object["cache"] = cache.rawValue
+        return try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+
+    private func failure(_ detail: String) -> QualificationCommandResult {
+        QualificationCommandResult(
+            exitCode: 1,
+            stdout: "",
+            stderr: "Qualification failed: \(detail)\n"
+        )
+    }
+}

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -1,0 +1,552 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-001 qualification runner", .serialized)
+struct QualificationRunnerTests {
+    @Test func runnerRecordsExactExecutableSHAAndCodableSchema() async throws {
+        let fixture = try Fixture(specs: Array(OperationRegistry.specs.prefix(1)))
+        defer { fixture.remove() }
+
+        let result = await fixture.runner.run(arguments: [
+            "LogicProMCP", "--qualify",
+            "--out", fixture.attestationURL.path,
+            "--release-version", "1.2.3",
+            "--variant", "creator",
+            "--locale", "ko",
+            "--profile", "full",
+            "--cache", "warm",
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stderr.isEmpty)
+        let data = try Data(contentsOf: fixture.attestationURL)
+        let attestation = try JSONDecoder().decode(ReleaseQualificationAttestation.self, from: data)
+        let roundTripped = try JSONDecoder().decode(
+            ReleaseQualificationAttestation.self,
+            from: JSONEncoder().encode(attestation)
+        )
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(attestation == roundTripped)
+        #expect(attestation.schema == "release-qualification-attestation/v1")
+        #expect(attestation.serverVersion == "1.2.3")
+        #expect(attestation.commitSHA == fixture.commitSHA)
+        #expect(attestation.binarySHA256 == SupportBundleBuilder.sha256(fixture.executableData))
+        #expect(attestation.logicVariant == .creatorStudio)
+        #expect(attestation.locale == .koKR)
+        #expect(attestation.profile == .full)
+        #expect(json["cache"] as? String == "warm")
+        #expect(attestation.waivers.isEmpty)
+        #expect(attestation.total == 5)
+        #expect(attestation.total == attestation.cases.count)
+        let aggregateIDs = attestation.cases
+            .filter { !$0.id.hasPrefix("in-process/") }
+            .map(\.id)
+        #expect(aggregateIDs.allSatisfy { $0.contains("/full/warm/") })
+        let requiredIDs = Set(QualificationAxis.requiredCombinations.map { "\($0.key)/empty" })
+        #expect(requiredIDs.isDisjoint(with: aggregateIDs))
+    }
+
+    @Test func inProcessCasesMatchRegistryHandlersAndTraces() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+
+        let result = await fixture.runner.run(arguments: [
+            "LogicProMCP", "--qualify",
+            "--out", fixture.attestationURL.path,
+            "--release-version", "1.2.3",
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stderr.isEmpty)
+        let attestation = try JSONDecoder().decode(
+            ReleaseQualificationAttestation.self,
+            from: Data(contentsOf: fixture.attestationURL)
+        )
+        let operationCases = attestation.cases.filter { $0.id.hasPrefix("in-process/") }
+        let aggregateCases = attestation.cases.filter { !$0.id.hasPrefix("in-process/") }
+        let expectedOperations = Set(OperationRegistry.specs.map(\.id.rawValue))
+        let actualOperations = Set(operationCases.map { String($0.id.dropFirst("in-process/".count)) })
+
+        #expect(operationCases.count == OperationRegistry.specs.count)
+        #expect(actualOperations == expectedOperations, "missing operation cases: \(expectedOperations.subtracting(actualOperations).sorted())")
+        #expect(aggregateCases.map(\.id) == QualificationAxis.requiredCombinations.map { "\($0.key)/empty" })
+        #expect(attestation.cases.map(\.id).count == Set(attestation.cases.map(\.id)).count)
+        #expect(attestation.passed == attestation.total)
+        #expect(attestation.failed == 0)
+
+        for qualificationCase in operationCases {
+            let spec = try #require(OperationRegistry.spec(
+                tool: qualificationCase.tool,
+                command: qualificationCase.command
+            ))
+            #expect(qualificationCase.id == "in-process/\(spec.id.rawValue)")
+            #expect(OperationHandlerRegistry.handler(tool: qualificationCase.tool, command: qualificationCase.command) != nil)
+            #expect(qualificationCase.status == .passed)
+            #expect(qualificationCase.verified)
+            #expect(TraceID.isValid(qualificationCase.traceID))
+            let evidencePath = try #require(qualificationCase.evidenceFiles.first)
+            let evidenceURL = fixture.directory.appendingPathComponent(evidencePath)
+            let evidence = try #require(
+                JSONSerialization.jsonObject(with: Data(contentsOf: evidenceURL)) as? [String: Any]
+            )
+            #expect(evidence["registry_spec_found"] as? Bool ?? false)
+            #expect(evidence["handler_bound"] as? Bool ?? false)
+            #expect(evidence["trace_started"] as? Bool ?? false)
+        }
+
+        #expect(FileManager.default.fileExists(atPath: fixture.manifestURL.path))
+        let manifestData = try Data(contentsOf: fixture.manifestURL)
+        #expect(attestation.evidenceManifestSHA256 == SupportBundleBuilder.sha256(manifestData))
+    }
+
+    @Test func externalCasesAreInjectedWithoutTransformation() async throws {
+        let fixture = try Fixture(specs: Array(OperationRegistry.specs.prefix(1)))
+        defer { fixture.remove() }
+        let external = QualificationCase(
+            id: "external/live-case",
+            status: .passed,
+            tool: "logic_system",
+            command: "health",
+            traceID: "lpmcp_00000000-0000-0000-0000-000000000000",
+            verified: true,
+            evidenceFiles: ["external/live-case.json"]
+        )
+        let externalEvidenceURL = fixture.directory.appendingPathComponent("external/live-case.json")
+        try FileManager.default.createDirectory(
+            at: externalEvidenceURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("external evidence".utf8).write(to: externalEvidenceURL)
+        try JSONEncoder().encode([external]).write(to: fixture.externalCasesURL)
+
+        let result = await fixture.runner.run(arguments: [
+            "LogicProMCP", "--qualify",
+            "--out", fixture.attestationURL.path,
+            "--cases", fixture.externalCasesURL.path,
+            "--release-version", "1.2.3",
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stderr.isEmpty)
+        let attestation = try JSONDecoder().decode(
+            ReleaseQualificationAttestation.self,
+            from: Data(contentsOf: fixture.attestationURL)
+        )
+        #expect(attestation.cases.last == external)
+        #expect(attestation.total == 6)
+    }
+
+    @Test func sameSHAApprovesWithExitZero() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+
+        let result = await fixture.verify(expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData))
+        let json = try Self.resultObject(result)
+        let promotable = try #require(json["promotable"] as? Bool)
+        let rejections = try #require(json["rejections"] as? [[String: Any]])
+
+        #expect(result.exitCode == 0)
+        #expect(promotable)
+        #expect(rejections.isEmpty)
+    }
+
+    @Test func differentPublishedSHARejects() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+
+        let result = await fixture.verify(expectedSHA256: String(repeating: "b", count: 64))
+        let json = try Self.resultObject(result)
+        let promotable = try #require(json["promotable"] as? Bool)
+
+        #expect(result.exitCode != 0)
+        #expect(!promotable)
+        #expect(Self.rejectionReasons(json).contains("binarySHAMismatch"))
+    }
+
+    @Test func releaseVersionMismatchRejectsThroughCLI() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+
+        let result = await fixture.verify(
+            releaseVersion: "1.2.4",
+            expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData)
+        )
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("releaseVersionMismatch"))
+    }
+
+    @Test func missingRequiredArtifactRejectsThroughCLI() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+
+        let result = await fixture.verify(
+            expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData),
+            requiredArtifacts: "missing-artifact.json"
+        )
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("missingArtifact"))
+    }
+
+    @Test func expiredWaiverRejectsThroughCLI() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        let original = try await fixture.qualify()
+        try fixture.writeAttestation(original, waivers: [QualificationWaiver(
+            caseID: "optional-case",
+            reasonCode: "known-limitation",
+            owningIssue: "#284",
+            userImpact: "Optional capability unavailable",
+            affectedCapability: "optional-capability",
+            affectsDefaultProfile: false,
+            expiryVersion: "1.2.3",
+            releaseNoteVisible: true
+        )])
+
+        let result = await fixture.verify(expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData))
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("expiredWaiver"))
+    }
+
+    @Test func verificationEmitsEveryApplicableRejection() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        let original = try await fixture.qualify()
+        var cases = original.cases
+        let aggregateIndex = try #require(cases.firstIndex {
+            $0.id == "\(QualificationAxis.requiredCombinations[0].key)/empty"
+        })
+        let first = cases[aggregateIndex]
+        cases[aggregateIndex] = QualificationCase(
+            id: first.id,
+            status: .failed,
+            tool: first.tool,
+            command: first.command,
+            traceID: first.traceID,
+            verified: false,
+            evidenceFiles: first.evidenceFiles
+        )
+        let changed = fixture.copy(
+            original,
+            serverVersion: "1.2.2",
+            binarySHA256: String(repeating: "a", count: 64),
+            cases: cases,
+            waivers: [QualificationWaiver(
+                caseID: "optional-case",
+                reasonCode: "known-limitation",
+                owningIssue: "#284",
+                userImpact: "Optional capability unavailable",
+                affectedCapability: "optional-capability",
+                affectsDefaultProfile: false,
+                expiryVersion: "1.2.3",
+                releaseNoteVisible: true
+            )]
+        )
+        try JSONEncoder().encode(changed).write(to: fixture.attestationURL)
+
+        let result = await fixture.verify(
+            releaseVersion: "1.2.3",
+            expectedSHA256: String(repeating: "b", count: 64),
+            requiredArtifacts: "missing-artifact.json"
+        )
+        let reasons = Self.rejectionReasons(try Self.resultObject(result))
+
+        #expect(result.exitCode != 0)
+        #expect(reasons.contains("requiredCaseFailed"))
+        #expect(reasons.contains("binarySHAMismatch"))
+        #expect(reasons.contains("missingArtifact"))
+        #expect(reasons.contains("expiredWaiver"))
+        #expect(reasons.contains("releaseVersionMismatch"))
+    }
+
+    @Test func rebuildAfterQualificationRejects() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+        let qualifiedSHA256 = SupportBundleBuilder.sha256(fixture.executableData)
+        try Data("rebuilt-after-qualification".utf8).write(to: fixture.executableURL)
+
+        let result = await fixture.verify(expectedSHA256: qualifiedSHA256)
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("binarySHAMismatch"))
+    }
+
+    @Test func releaseVersionDifferentFromBinaryRejectsQualification() async throws {
+        let fixture = try Fixture(specs: Array(OperationRegistry.specs.prefix(1)))
+        defer { fixture.remove() }
+
+        let result = await fixture.runner.run(arguments: [
+            "LogicProMCP", "--qualify",
+            "--out", fixture.attestationURL.path,
+            "--release-version", "9.9.9",
+        ])
+
+        #expect(result.exitCode != 0)
+        #expect(!FileManager.default.fileExists(atPath: fixture.attestationURL.path))
+    }
+
+    @Test func vPrefixedReleaseTagMatchesBinaryVersion() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+
+        let qualification = await fixture.runner.run(arguments: [
+            "LogicProMCP", "--qualify",
+            "--out", fixture.attestationURL.path,
+            "--release-version", "v1.2.3",
+        ])
+        let verification = await fixture.verify(
+            releaseVersion: "v1.2.3",
+            expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData)
+        )
+
+        #expect(qualification.exitCode == 0)
+        #expect(verification.exitCode == 0)
+    }
+
+    @Test func tamperedEvidenceRejectsPromotion() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        let attestation = try await fixture.qualify()
+        let evidencePath = try #require(attestation.cases.first?.evidenceFiles.first)
+        try Data("tampered evidence".utf8).write(
+            to: fixture.directory.appendingPathComponent(evidencePath),
+            options: .atomic
+        )
+
+        let result = await fixture.verify(expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData))
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("missingArtifact"))
+    }
+
+    @Test func tamperedManifestRejectsPromotion() async throws {
+        let fixture = try Fixture(specs: OperationRegistry.specs)
+        defer { fixture.remove() }
+        _ = try await fixture.qualify()
+        try Data("tampered manifest".utf8).write(to: fixture.manifestURL, options: .atomic)
+
+        let result = await fixture.verify(expectedSHA256: SupportBundleBuilder.sha256(fixture.executableData))
+
+        #expect(result.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(result)).contains("missingArtifact"))
+    }
+
+    @Test func reservedManifestOutputPathRejectsQualification() async throws {
+        let fixture = try Fixture(specs: Array(OperationRegistry.specs.prefix(1)))
+        defer { fixture.remove() }
+
+        for filename in ["evidence-manifest.json", "EVIDENCE-MANIFEST.JSON"] {
+            let outputURL = fixture.directory.appendingPathComponent(filename)
+            let result = await fixture.runner.run(arguments: [
+                "LogicProMCP", "--qualify",
+                "--out", outputURL.path,
+                "--release-version", "1.2.3",
+            ])
+
+            #expect(result.exitCode != 0)
+            #expect(!FileManager.default.fileExists(atPath: outputURL.path))
+        }
+    }
+
+    @Test func mainEntrypointRoutesQualificationBeforeSideEffects() async {
+        for (subcommand, expectedExitCode) in [("--qualify", 0), ("--verify-promotion", 1)] {
+            var receivedArguments: [String] = []
+            var stdout = ""
+            var stderr = ""
+            let result = await MainEntrypoint.run(
+                arguments: ["LogicProMCP", subcommand, "--sentinel", "value"],
+                permissionCheck: {
+                    Issue.record("Permission check must not run for \(subcommand)")
+                    return .init(accessibility: false, automationLogicPro: false)
+                },
+                serverFactory: {
+                    Issue.record("Server must not start for \(subcommand)")
+                    return MockQualificationServer()
+                },
+                approvalStoreFactory: {
+                    Issue.record("Approval store must not be created for \(subcommand)")
+                    return ManualValidationStore()
+                },
+                qualificationCommand: { arguments in
+                    receivedArguments = arguments
+                    return QualificationCommandResult(
+                        exitCode: expectedExitCode,
+                        stdout: "{\"subcommand\":\"\(subcommand)\"}\n",
+                        stderr: "qualification-stderr\n"
+                    )
+                },
+                writeStdout: { stdout += $0 },
+                writeStderr: { stderr += $0 }
+            )
+
+            #expect(result == expectedExitCode)
+            #expect(receivedArguments == ["LogicProMCP", subcommand, "--sentinel", "value"])
+            #expect(stdout == "{\"subcommand\":\"\(subcommand)\"}\n")
+            #expect(stderr == "qualification-stderr\n")
+        }
+    }
+
+    @Test func helpListsQualificationSubcommands() async {
+        var stdout = ""
+        let result = await MainEntrypoint.run(
+            arguments: ["LogicProMCP", "--help"],
+            serverFactory: {
+                Issue.record("Server must not start for --help")
+                return MockQualificationServer()
+            },
+            writeStdout: { stdout += $0 },
+            writeStderr: { _ in }
+        )
+
+        #expect(result == 0)
+        #expect(stdout.contains("--qualify --out <attestation.json>"))
+        #expect(stdout.contains("--verify-promotion --attestation <attestation.json>"))
+        #expect(stdout.contains("--expected-binary-sha256 <hex>"))
+    }
+
+    @Test func releaseWorkflowQualifiesFinalBinaryBeforePublication() throws {
+        let workflow = try scriptContents(".github/workflows/release.yml")
+        let package = try #require(workflow.range(of: "name: Package"))
+        let formula = try #require(workflow.range(of: "name: Verify Formula install paths against tarball"))
+        let gate = try #require(workflow.range(of: "name: Qualify and verify promotion"))
+        let release = try #require(workflow.range(of: "name: Create GitHub Release"))
+        let gateText = String(workflow[gate.lowerBound..<release.lowerBound])
+
+        #expect(package.lowerBound < gate.lowerBound)
+        #expect(formula.lowerBound < gate.lowerBound)
+        #expect(gate.lowerBound < release.lowerBound)
+        #expect(gateText.contains("shasum -a 256 LogicProMCP"))
+        #expect(gateText.contains("./LogicProMCP --qualify"))
+        #expect(gateText.contains("--out release-qualification-attestation.json"))
+        #expect(gateText.contains("./LogicProMCP --verify-promotion"))
+        #expect(gateText.contains("--expected-binary-sha256 \"$binary_sha256\""))
+        #expect(gateText.contains("--release-version \"$RELEASE_VERSION\""))
+        #expect(!gateText.contains("swift build"))
+        #expect(workflow.contains("tags:"))
+        #expect(workflow.contains("validate-install:"))
+        #expect(workflow.contains("needs: build"))
+    }
+
+    private static func resultObject(_ result: QualificationCommandResult) throws -> [String: Any] {
+        let data = try #require(result.stdout.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func rejectionReasons(_ json: [String: Any]) -> Set<String> {
+        let rejections = json["rejections"] as? [[String: Any]] ?? []
+        return Set(rejections.compactMap { $0["reason"] as? String })
+    }
+
+    private actor MockQualificationServer: ServerStarting {
+        func start() async throws {}
+        func stop() async {}
+    }
+
+    private final class Fixture: @unchecked Sendable {
+        let directory: URL
+        let executableURL: URL
+        let executableData = Data("qualification-binary-fixture".utf8)
+        let attestationURL: URL
+        let manifestURL: URL
+        let externalCasesURL: URL
+        let commitSHA = String(repeating: "c", count: 40)
+        let runner: QualificationRunner
+
+        init(specs: [OperationSpec], binaryVersion: String = "1.2.3") throws {
+            directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("qualification-runner-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            executableURL = directory.appendingPathComponent("LogicProMCP")
+            attestationURL = directory.appendingPathComponent("attestation.json")
+            manifestURL = directory.appendingPathComponent("evidence-manifest.json")
+            externalCasesURL = directory.appendingPathComponent("cases.json")
+            try executableData.write(to: executableURL)
+            runner = QualificationRunner(runtime: .init(
+                executableURL: { [executableURL] in executableURL },
+                environment: { [commitSHA] in ["GIT_COMMIT": commitSHA] },
+                now: { Date(timeIntervalSince1970: 1_000) },
+                serverVersion: { binaryVersion },
+                specs: { specs },
+                registryValidationErrors: { OperationRegistry.validationErrors() },
+                handlerValidationErrors: { OperationHandlerRegistry.validationErrors() },
+                handlerExists: { OperationHandlerRegistry.handler(tool: $0, command: $1) != nil }
+            ))
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        func qualify() async throws -> ReleaseQualificationAttestation {
+            let result = await runner.run(arguments: [
+                "LogicProMCP", "--qualify",
+                "--out", attestationURL.path,
+                "--release-version", "1.2.3",
+            ])
+            #expect(result.exitCode == 0)
+            return try JSONDecoder().decode(
+                ReleaseQualificationAttestation.self,
+                from: Data(contentsOf: attestationURL)
+            )
+        }
+
+        func verify(
+            releaseVersion: String = "1.2.3",
+            expectedSHA256: String,
+            requiredArtifacts: String = "LogicProMCP,evidence-manifest.json"
+        ) async -> QualificationCommandResult {
+            await runner.run(arguments: [
+                "LogicProMCP", "--verify-promotion",
+                "--attestation", attestationURL.path,
+                "--release-version", releaseVersion,
+                "--expected-binary-sha256", expectedSHA256,
+                "--required-artifacts", requiredArtifacts,
+            ])
+        }
+
+        func writeAttestation(
+            _ original: ReleaseQualificationAttestation,
+            waivers: [QualificationWaiver]
+        ) throws {
+            try JSONEncoder().encode(copy(original, waivers: waivers)).write(to: attestationURL)
+        }
+
+        func copy(
+            _ original: ReleaseQualificationAttestation,
+            serverVersion: String? = nil,
+            binarySHA256: String? = nil,
+            cases: [QualificationCase]? = nil,
+            waivers: [QualificationWaiver]? = nil
+        ) -> ReleaseQualificationAttestation {
+            let copiedCases = cases ?? original.cases
+            return ReleaseQualificationAttestation(
+                schema: original.schema,
+                serverVersion: serverVersion ?? original.serverVersion,
+                commitSHA: original.commitSHA,
+                binarySHA256: binarySHA256 ?? original.binarySHA256,
+                logicVariant: original.logicVariant,
+                logicVersion: original.logicVersion,
+                locale: original.locale,
+                profile: original.profile,
+                startedAt: original.startedAt,
+                completedAt: original.completedAt,
+                total: copiedCases.count,
+                passed: copiedCases.filter { $0.status == .passed }.count,
+                failed: copiedCases.filter { $0.status == .failed }.count,
+                waived: copiedCases.filter { $0.status == .waived }.count,
+                cases: copiedCases,
+                waivers: waivers ?? original.waivers,
+                evidenceManifestSHA256: original.evidenceManifestSHA256
+            )
+        }
+    }
+}


### PR DESCRIPTION
## ADR-001 (#284, part of #308) — executable qualification runner + attestation + release promotion gate

Closes ADR-001's runner + CI-enforcement gap. The pure `PromotionGate` + attestation/`QualificationCase`/`QualificationWaiver` value types (matching #284's schema) already existed and are **unchanged**; this adds the two missing pieces: a runner that *produces* an attestation bound to the exact artifact, and a release gate that *enforces* it.

### Two CLI subcommands (`Sources/LogicProMCP/Qualification/QualificationRunner.swift` + `MainEntrypoint.swift`)
- **`--qualify --out <att.json>`** `[--release-version --variant --locale --profile --cache]`: hashes THIS running binary (`Bundle.main.executableURL` / argv[0]) into `binarySHA256` (the same-artifact anchor), runs deterministic in-process structural cases (registry spec + handler binding + trace start per op), writes the attestation JSON. Live-Logic matrix cases inject via `--cases` (follow-up live runner).
- **`--verify-promotion --attestation --release-version --expected-binary-sha256 [--required-artifacts]`**: calls `PromotionGate.evaluate`, prints all rejection reasons, **exits non-zero on any rejection**; exit 0 only when promotable.

### Release gate (`.github/workflows/release.yml`)
In the tag-triggered build job, **after Package, before Create GitHub Release**: hash the published binary → `--qualify` that exact artifact → `--verify-promotion` enforcing `expected-binary-sha256 == published sha` and `release-version == tag`. Any rejection fails the job → **publication blocked**. Runs on the real release path (not just PR CI — #183 lesson).

### Verification
- Unit: `Qualification|PromotionGate` **38/38**.
- **CLI self-test (built release binary)**: valid same-artifact under release conditions (artifacts present, sha+version match) → **promotable:true, exit 0** (does NOT break valid releases); tampered/re-signed Mach-O (sha mismatch) → exit 1; version mismatch / missing artifact → exit 1.

Refs #308. Honest scope: structural (CI-runnable) cases now; the live-Logic same-artifact matrix is the follow-up live runner (feeds `--cases`), part of Stage 8 GA qualification.
