### PR TITLE
feat(adr-005): all 13 trace phases live — context wiring, saga correlation, poll/compensation visibility (#288)

### DIFF
--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -111,6 +111,12 @@ actor ChannelRouter {
             return .success("No channel required for \(operation)")
         }
 
+        // ADR-005: no-op unless an active mutation trace registered in this
+        // task's context (flag on + mutating op).
+        await OperationTraceContext.record(.routeEvaluated, attributes: [
+            "chain": chain.map(\.rawValue).joined(separator: ","),
+        ])
+
         var lastError: String = "No channels available"
         let isBypass = Self.bypassReadinessOps.contains(operation)
 
@@ -152,7 +158,14 @@ actor ChannelRouter {
                 continue
             }
 
+            await OperationTraceContext.record(.channelStarted, attributes: [
+                "channel": channelID.rawValue,
+            ])
             let result = await channel.execute(operation: operation, params: params)
+            await OperationTraceContext.record(.channelCompleted, attributes: [
+                "channel": channelID.rawValue,
+                "outcome": result.isSuccess ? "success" : "error",
+            ])
             switch result {
             case .success:
                 Log.debug("\(operation) succeeded via \(channelID.rawValue)", subsystem: "router")

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -628,6 +628,11 @@ actor MCUChannel: Channel {
             if let axReadback = self.axReadback {
                 for attempt in 0..<10 {
                     observedMode = await axReadback.readAutomationMode(track)
+                    // ADR-005: every verification poll attempt is a traced
+                    // phase (no-op without an active mutation trace).
+                    await OperationTraceContext.record(.verificationPoll, attributes: [
+                        "outcome": observedMode == requestedMode ? "matched" : "pending",
+                    ])
                     if observedMode == requestedMode { break }
                     if attempt < 9 { try? await Task.sleep(nanoseconds: 50_000_000) }
                 }

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -222,10 +222,34 @@ extension OperationTraceDispatching {
             return nil
         }
         let id = await OperationTraceStore.shared.start(operationID: spec.id.rawValue)
-        await OperationTraceStore.shared.record(id, phase: .requestReceived, attributes: [
+        var requestAttributes = [
             "operation_id": spec.id.rawValue,
             "command": command,
-        ])
+        ]
+        let context = OperationTraceContext.current
+        if let parent = context?.parentTraceID {
+            requestAttributes["parent_trace_id"] = parent.rawValue
+        }
+        await OperationTraceStore.shared.record(
+            id, phase: .requestReceived, attributes: requestAttributes
+        )
+        // Reaching dispatch means server-side strict parameter validation
+        // already accepted the call (rejections never start a trace).
+        await OperationTraceStore.shared.record(id, phase: .inputValidated)
+        // The server's mutation gate is try-acquire: there is no queueing
+        // wait, so both gate phases record at registration with honest
+        // zero-wait semantics.
+        if context?.mutationGateAcquired == true {
+            await OperationTraceStore.shared.record(
+                id, phase: .mutationGateWaitStarted,
+                attributes: ["gate_mode": "try_acquire"]
+            )
+            await OperationTraceStore.shared.record(
+                id, phase: .mutationGateAcquired,
+                attributes: ["gate_mode": "try_acquire"]
+            )
+        }
+        context?.register(id)
         return id
     }
 

--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -142,6 +142,12 @@ enum TargetRefResolver {
             ) {
                 return .failure(liveIdentityFailure)
             }
+            // ADR-005: a stable-reference resolution that survived every
+            // continuity/fingerprint/live-identity guard is a traced phase.
+            await OperationTraceContext.record(.targetResolved, attributes: [
+                "target_ref": binding.reference.rawValue,
+                "outcome": "resolved",
+            ])
             return .success(Resolved(
                 index: binding.descriptor.trackIndex,
                 reference: binding.reference,

--- a/Sources/LogicProMCP/Saga/MutationSaga.swift
+++ b/Sources/LogicProMCP/Saga/MutationSaga.swift
@@ -491,6 +491,12 @@ actor MutationSaga {
         executor: Executor,
         outcome initialOutcome: SagaOutcome
     ) async -> SagaOutcome {
+        // ADR-005: compensation begin is visible on the PARENT saga trace
+        // (the step scopes below carry parent_trace_id for the inverse
+        // dispatches themselves).
+        await OperationTraceContext.record(.compensationStarted, attributes: [
+            "outcome": rollbackIsUncertain ? "rollback_uncertain" : "partially_applied",
+        ])
         var outcome = initialOutcome
         if outcome.state != .partiallyApplied && outcome.state != .reconciling {
             advance(.partiallyApplied, outcome: &outcome)

--- a/Sources/LogicProMCP/Saga/SagaExecution.swift
+++ b/Sources/LogicProMCP/Saga/SagaExecution.swift
@@ -38,6 +38,19 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
     }
 
     func run(_ step: SagaStep) async -> StepResult {
+        // ADR-005: each saga step dispatch gets a NESTED trace context
+        // carrying the parent saga trace ID — without it a child's trace
+        // start would clobber the parent's registration in the shared box,
+        // and child traces would be uncorrelated orphans.
+        let parentTraceID = OperationTraceContext.current?.traceID
+        return await OperationTraceContext.$current.withValue(
+            OperationTraceContext(parentTraceID: parentTraceID)
+        ) {
+            await runInChildTraceScope(step)
+        }
+    }
+
+    private func runInChildTraceScope(_ step: SagaStep) async -> StepResult {
         guard Self.allowlist.contains(step.operationID) else {
             return StepResult(
                 state: .stateC,

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -666,8 +666,17 @@ actor LogicProServer {
         return await withCheckedContinuation { continuation in
             let race = DeadlineRace()
             let timeoutHandle = DeadlineTimeoutHandle()
+            // ADR-005: the trace context scope must open INSIDE the detached
+            // task — Task.detached severs TaskLocal inheritance, so a scope
+            // opened in the caller would be invisible to the dispatcher and
+            // every seam below it.
+            let traceContext = OperationTraceContext(
+                mutationGateAcquired: heldClaim != nil
+            )
             let workTask = Task.detached(priority: .userInitiated) {
-                let result = await work()
+                let result = await OperationTraceContext.$current.withValue(traceContext) {
+                    await work()
+                }
                 if let heldClaim { heldMutationGate?.release(heldClaim) }
                 let didWin = race.resume(continuation, returning: result)
                 if didWin {

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -4,6 +4,56 @@ enum OperationTraceParentBoundary {
     @TaskLocal static var onWriteBoundary: (@Sendable () async -> Void)?
 }
 
+/// ADR-005: task-scoped carrier that lets deep seams (router, channels,
+/// verification polls, saga) record onto the active operation trace without
+/// threading a TraceID through every signature. The server opens one scope
+/// per tool call (inside the deadline task — `Task.detached` severs TaskLocal
+/// inheritance, so the scope must live within the detached work); the
+/// dispatcher's trace start registers into it. Saga child dispatches open a
+/// nested scope with a fresh box carrying the parent's trace ID so child
+/// traces correlate instead of clobbering the parent registration.
+final class OperationTraceContext: @unchecked Sendable {
+    @TaskLocal static var current: OperationTraceContext?
+
+    private let lock = NSLock()
+    private var registeredTraceID: TraceID?
+
+    /// Parent saga trace, set when this box scopes a saga child dispatch.
+    let parentTraceID: TraceID?
+    /// The server's mutation gate is try-acquire (no queueing wait); true when
+    /// a claim was held for this call, letting the trace record the gate
+    /// phases with honest zero-wait semantics.
+    let mutationGateAcquired: Bool
+
+    init(parentTraceID: TraceID? = nil, mutationGateAcquired: Bool = false) {
+        self.parentTraceID = parentTraceID
+        self.mutationGateAcquired = mutationGateAcquired
+    }
+
+    var traceID: TraceID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return registeredTraceID
+    }
+
+    func register(_ id: TraceID) {
+        lock.lock()
+        defer { lock.unlock() }
+        registeredTraceID = id
+    }
+
+    /// Record a phase on the active trace, if one is registered in the current
+    /// task's context. Deep seams call this without knowing whether tracing is
+    /// enabled — no registered trace (flag off / read-only op) means no-op.
+    static func record(
+        _ phase: TracePhase,
+        attributes: [String: String] = [:]
+    ) async {
+        guard let id = current?.traceID else { return }
+        await OperationTraceStore.shared.record(id, phase: phase, attributes: attributes)
+    }
+}
+
 struct TraceID: RawRepresentable, Codable, Sendable, Hashable, CustomStringConvertible {
     let rawValue: String
 
@@ -72,6 +122,12 @@ actor OperationTraceStore {
         "project_path_hash": .hashed,
         "readback_state": .publicDiagnostic,
         "error_code": .publicDiagnostic,
+        // ADR-005 phase wiring — all runtime-structural, never user content.
+        "channel": .publicDiagnostic,
+        "chain": .publicDiagnostic,
+        "outcome": .publicDiagnostic,
+        "parent_trace_id": .publicDiagnostic,
+        "gate_mode": .publicDiagnostic,
     ]
 
     let maximumTraceCount: Int

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -164,13 +164,142 @@ struct OperationTraceTests {
         #expect(result.isError == false)
         #expect(trace.operationID == OperationID.transportPlay.rawValue)
         #expect(trace.events.map(\.phase) == [
-            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+            .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,
+            .resultEmitted,
         ])
-        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.events[3].attributes["readback_state"] == "A")
         #expect(trace.completedAt != nil)
         #expect(await channel.executedOperations == [
             "transport.get_state", "transport.play", "transport.get_state",
         ])
+    }
+
+    /// ADR-005 phase wiring: under the server's trace-context scope (as
+    /// runWithDeadline opens it inside the deadline task), a verified mutation
+    /// records the full phase sequence — input validation, the try-acquire
+    /// gate pair, route evaluation, and the channel bracket — exactly once
+    /// each and all attributes stay within the privacy allowlist.
+    @Test func OperationTraceServerScopedFullSequence() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTransportChannel(states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+        ])
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let context = OperationTraceContext(mutationGateAcquired: true)
+        let result = await OperationTraceContext.$current.withValue(context) {
+            await TransportDispatcher.handle(
+                command: "play",
+                params: [:],
+                router: router,
+                cache: StateCache(),
+                sleep: { _ in }
+            )
+        }
+
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
+        #expect(context.traceID?.rawValue == rawID)
+        // transport.play performs three routed calls — the pre-state probe,
+        // the mutation itself (write boundary recorded just before it), and
+        // the verification readback — and every one is visible on the trace.
+        #expect(trace.events.map(\.phase) == [
+            .requestReceived, .inputValidated,
+            .mutationGateWaitStarted, .mutationGateAcquired,
+            .routeEvaluated, .channelStarted, .channelCompleted,
+            .writeBoundaryCrossed,
+            .routeEvaluated, .channelStarted, .channelCompleted,
+            .routeEvaluated, .channelStarted, .channelCompleted,
+            .verificationCompleted, .resultEmitted,
+        ])
+        let route = try #require(trace.events.first { $0.phase == .routeEvaluated })
+        #expect(route.attributes["chain"]?.contains("accessibility") == true)
+        let completed = try #require(trace.events.first { $0.phase == .channelCompleted })
+        #expect(completed.attributes["outcome"] == "success")
+        #expect(trace.events.allSatisfy { event in
+            Set(event.attributes.keys).isSubset(of: Set(
+                OperationTraceStore.attributePrivacyClasses.keys
+            ))
+        })
+    }
+
+    /// Saga-child correlation: a context carrying a parent trace ID stamps
+    /// `parent_trace_id` onto the child's request event.
+    @Test func OperationTraceChildCarriesParentTraceID() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let parentID = await OperationTraceStore.shared.start(
+            operationID: OperationID.systemSagaExecute.rawValue
+        )
+        let channel = OperationTraceTransportChannel(states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+        ])
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let childContext = OperationTraceContext(parentTraceID: parentID)
+        let result = await OperationTraceContext.$current.withValue(childContext) {
+            await TransportDispatcher.handle(
+                command: "play",
+                params: [:],
+                router: router,
+                cache: StateCache(),
+                sleep: { _ in }
+            )
+        }
+
+        let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
+        let rawID = try #require(resultObject["trace_id"] as? String)
+        let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
+        #expect(rawID != parentID.rawValue)
+        let request = try #require(trace.events.first { $0.phase == .requestReceived })
+        #expect(request.attributes["parent_trace_id"] == parentID.rawValue)
+    }
+
+    /// TaskLocal isolation: two concurrent scoped dispatches register into
+    /// their own contexts — no cross-contamination of trace IDs.
+    @Test func OperationTraceConcurrentContextsStayIsolated() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        @Sendable func dispatchOnce() async throws -> (context: OperationTraceContext, traceID: String) {
+            let channel = OperationTraceTransportChannel(states: [
+                #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+                #"{"isPlaying":true,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            ])
+            let router = ChannelRouter()
+            await router.register(channel)
+            let context = OperationTraceContext(mutationGateAcquired: true)
+            let result = await OperationTraceContext.$current.withValue(context) {
+                await TransportDispatcher.handle(
+                    command: "play",
+                    params: [:],
+                    router: router,
+                    cache: StateCache(),
+                    sleep: { _ in }
+                )
+            }
+            let object = try #require(sharedJSONObject(sharedToolText(result)))
+            let rawID = try #require(object["trace_id"] as? String)
+            return (context, rawID)
+        }
+
+        async let first = dispatchOnce()
+        async let second = dispatchOnce()
+        let (a, b) = try await (first, second)
+        #expect(a.traceID != b.traceID)
+        #expect(a.context.traceID?.rawValue == a.traceID)
+        #expect(b.context.traceID?.rawValue == b.traceID)
     }
 
     @Test func OperationTraceTransportNoWrite() async throws {
@@ -197,9 +326,9 @@ struct OperationTraceTests {
         let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
         #expect(!trace.events.map(\.phase).contains(.writeBoundaryCrossed))
         #expect(trace.events.map(\.phase) == [
-            .requestReceived, .verificationCompleted, .resultEmitted,
+            .requestReceived, .inputValidated, .verificationCompleted, .resultEmitted,
         ])
-        #expect(trace.events[1].attributes["readback_state"] == "A")
+        #expect(trace.events[2].attributes["readback_state"] == "A")
         #expect(await channel.executedOperations == ["transport.get_state"])
     }
 
@@ -447,9 +576,10 @@ extension OperationTraceTests {
         #expect(result.isError == false)
         #expect(trace.operationID == operationID.rawValue)
         #expect(trace.events.map(\.phase) == [
-            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+            .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,
+            .resultEmitted,
         ])
-        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.events[3].attributes["readback_state"] == "A")
         #expect(trace.completedAt != nil)
         #expect(await channel.executedOperations == [operationID.rawValue])
 
@@ -567,9 +697,10 @@ extension OperationTraceTests {
         #expect(result.isError == false)
         #expect(trace.operationID == operationID.rawValue)
         #expect(trace.events.map(\.phase) == [
-            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+            .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,
+            .resultEmitted,
         ])
-        #expect(trace.events[2].attributes["readback_state"] == "A")
+        #expect(trace.events[3].attributes["readback_state"] == "A")
         #expect(trace.completedAt != nil)
         #expect(await channel.executedOperations == [operation])
 

--- a/Tests/LogicProMCPTests/SupportBundleTests.swift
+++ b/Tests/LogicProMCPTests/SupportBundleTests.swift
@@ -228,7 +228,8 @@ struct SupportBundleTests {
         let traceID = try #require(successObject["trace_id"] as? String)
         let trace = try #require(await OperationTraceStore.shared.trace(.init(rawValue: traceID)))
         #expect(trace.events.map(\.phase) == [
-            .requestReceived, .writeBoundaryCrossed, .verificationCompleted, .resultEmitted,
+            .requestReceived, .inputValidated, .writeBoundaryCrossed,
+            .verificationCompleted, .resultEmitted,
         ])
 
         let failure = await SystemDispatcher.handle(


### PR DESCRIPTION
## Summary

The ADR-005 receipt audit found **9 of 13 declared `TracePhase` cases were dead scaffolding** — recorded nowhere — and saga child traces were uncorrelated orphans. This lands the wiring in two commits:

**Increment A — `OperationTraceContext` + input/gate/route/channel phases**
- A task-scoped TaskLocal carrier lets deep seams record onto the active mutation trace without threading TraceIDs through signatures. The scope opens **inside** `runWithDeadline`'s detached deadline task (`Task.detached` severs TaskLocal inheritance — a caller-side scope would be invisible below).
- `inputValidated` records at trace start; the try-acquire mutation gate records `mutationGateWaitStarted`/`mutationGateAcquired` with honest zero-wait semantics when a claim was held.
- `ChannelRouter` records `routeEvaluated` (chain) and a `channelStarted`/`channelCompleted` bracket per attempted channel — the pre-state probe, the mutation write, and the verification readback each become visible triplets.
- New privacy-allowlisted attributes: `channel`, `chain`, `outcome`, `parent_trace_id`, `gate_mode`.

**Increment B — saga correlation + remaining phases**
- `SagaExecution.run` wraps each step dispatch in a **nested** context carrying the parent saga trace ID — children stamp `parent_trace_id` instead of clobbering the parent registration.
- `MutationSaga.compensate` records `compensationStarted` on the parent trace; `TargetRefResolution` records `targetResolved` after every continuity guard passes; the MCU automation verification loop records `verificationPoll` per attempt.

**Every one of the 13 declared phases now has at least one live recording site.**

## Tests
Server-scoped full-sequence pin (16 events for a verified `transport.play`), parent-correlation stamp, concurrent TaskLocal isolation, updated exact-array pins (+`inputValidated`). Full suite `--no-parallel`: **2,832 passed**. (Filtered *parallel* runs can race on the shared trace store across suites — CI runs `--no-parallel`.)

## Honest deferrals (tracked for the ADR-005 receipt)
Saga end-to-end correlation test (the mechanism is pinned by the explicit-parent test), trace overhead measurement, the bundle leak-scan fixture corpus, and live write-boundary placement evidence.