### PR TITLE
fix(adr-003/prd-002): executable dispatch truth — registry-derived sets + typed-contract census (#286)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -3,7 +3,7 @@ import MCP
 
 struct AudioDispatcher {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = ["analyze_file"]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicAudio)
 
     /// Non-absolute marker assigned to outputRoot when the caller sent a present-but-malformed
     /// output_root. validatedURL rejects it (does not begin with "/") so confinement fails

--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-struct AudioDispatcher {
+struct AudioDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
     static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicAudio)
 
@@ -37,10 +37,7 @@ struct AudioDispatcher {
             )
 
         default:
-            return toolTextResult(
-                "Unknown audio command: \(command). Available: analyze_file",
-                isError: true
-            )
+            return Self.unhandledCommandResult(command, label: "audio")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -215,6 +215,30 @@ protocol OperationTraceDispatching {
 }
 
 extension OperationTraceDispatching {
+    /// Typed fallthrough for a REGISTERED command that reached this
+    /// dispatcher without a matching switch case. Unregistered commands never
+    /// get here (the server rejects them before dispatch), so this envelope
+    /// firing means registry↔dispatch drift; the executable dispatch census
+    /// asserts it never fires for any registered operation. The hint keeps
+    /// the human-readable phrasing (and the registry-derived command list);
+    /// the error code is the machine contract.
+    static func unhandledCommandResult(_ command: String, label: String) -> CallTool.Result {
+        let available = OperationRegistry.specs
+            .filter { $0.tool.rawValue == tool.name }
+            .map(\.command)
+            .joined(separator: ", ")
+        return toolTextResult(
+            HonestContract.encodeStateC(
+                error: .unhandledRegisteredCommand,
+                hint: "Unknown \(label) command: \(command). Available: \(available)",
+                extras: ["tool": tool.name, "command": command]
+            ),
+            isError: true
+        )
+    }
+}
+
+extension OperationTraceDispatching {
     static func startTraceIfEnabled(command: String) async -> TraceID? {
         guard FeatureFlags.adr005OperationTrace,
               let spec = OperationRegistry.spec(tool: tool.name, command: command),

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -97,10 +97,7 @@ struct EditDispatcher: OperationTraceDispatching {
             )
 
         default:
-            return toolTextResult(
-                "Unknown edit command: \(command). Available: undo, redo, cut, copy, paste, delete, select_all, split, join, quantize, bounce_in_place, normalize, duplicate, toggle_step_input",
-                isError: true
-            )
+            return Self.unhandledCommandResult(command, label: "edit")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -3,10 +3,7 @@ import MCP
 
 struct EditDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
-        "quantize", "bounce_in_place", "normalize", "duplicate", "toggle_step_input",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicEdit)
 
     private enum EditRoute {
         case regular(String)

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -336,10 +336,7 @@ struct MIDIDispatcher: OperationTraceDispatching {
             return await finalizeTrace(result, traceID: traceID)
 
         default:
-            return toolTextResult(
-                "Unknown MIDI command: \(command). Available: send_note, send_chord, send_cc, send_program_change, send_pitch_bend, send_aftertouch, send_sysex, play_sequence, import_file, list_ports, create_virtual_port, step_input, mmc_play, mmc_stop, mmc_record, mmc_locate",
-                isError: true
-            )
+            return Self.unhandledCommandResult(command, label: "MIDI")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -3,12 +3,7 @@ import MCP
 
 struct MIDIDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "send_note", "send_chord", "send_cc", "send_program_change", "send_pitch_bend",
-        "send_aftertouch", "send_sysex", "play_sequence", "import_file", "list_ports",
-        "create_virtual_port", "step_input", "mmc_play", "mmc_stop", "mmc_record",
-        "mmc_locate",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicMidi)
 
     private static let maxSysExBytes = 1024
     private static let maxSysExTextCharacters = maxSysExBytes * 5

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -3,9 +3,7 @@ import MCP
 
 struct MixerDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "set_volume", "set_pan", "set_master_volume", "set_plugin_param", "insert_plugin",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicMixer)
     static let notExposedCommands: Set<String> = [
         "set_send", "set_output", "set_input", "toggle_eq", "reset_strip", "bypass_plugin",
     ]

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -311,10 +311,7 @@ struct MixerDispatcher: OperationTraceDispatching {
             return await finalizeTrace(result, traceID: traceID)
 
         default:
-            return toolInvalidParamsResult(
-                "Unknown mixer command: \(command). Available: set_volume, set_pan, set_master_volume, set_plugin_param, insert_plugin",
-                extras: ["operation": "mixer.\(command)"]
-            )
+            return Self.unhandledCommandResult(command, label: "mixer")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -3,10 +3,7 @@ import MCP
 
 struct NavigateDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "goto_bar", "goto_marker", "create_marker", "delete_marker", "rename_marker",
-        "zoom_to_fit", "set_zoom", "toggle_view",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicNavigate)
 
     static let tool = Tool(
         name: "logic_navigate",

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -307,10 +307,7 @@ struct NavigateDispatcher: OperationTraceDispatching {
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
-            return toolInvalidParamsResult(
-                "Unknown navigate command: \(command). Available: goto_bar, goto_marker, create_marker, delete_marker, rename_marker, zoom_to_fit, set_zoom, toggle_view",
-                extras: ["operation": "nav.\(command)"]
-            )
+            return Self.unhandledCommandResult(command, label: "navigate")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -37,9 +37,7 @@ final class VerifiedOpGate: @unchecked Sendable {
 /// AX result.
 struct PluginsDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "get_inventory", "set_param_verified", "insert_verified",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicPlugins)
 
     static let tool = commandTool(
         name: "logic_plugins",

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -198,10 +198,7 @@ struct PluginsDispatcher: OperationTraceDispatching {
             )
 
         default:
-            return toolTextResult(
-                "Unknown plugins command: \(command). Available: get_inventory, set_param_verified, insert_verified",
-                isError: true
-            )
+            return Self.unhandledCommandResult(command, label: "plugins")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -493,10 +493,7 @@ struct ProjectDispatcher: OperationTraceDispatching {
             return await finalizeTrace(result, traceID: traceID)
 
         default:
-            return toolInvalidParamsResult(
-                "Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, is_running, launch, quit, get_regions, export_plan, export_run, export_resume, audit, cleanup_plan, cleanup_apply",
-                extras: ["operation": "project.\(command)"]
-            )
+            return Self.unhandledCommandResult(command, label: "project")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -3,11 +3,7 @@ import MCP
 
 struct ProjectDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "new", "open", "save", "save_as", "close", "bounce", "is_running", "launch", "quit",
-        "get_regions", "export_plan", "export_run", "export_resume", "audit", "cleanup_plan",
-        "cleanup_apply",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicProject)
 
     struct LifecycleExecution: Sendable {
         let executionError: String?

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -837,16 +837,7 @@ struct SystemDispatcher: OperationTraceDispatching {
     }
 
     private static func unknownCommandResult(_ command: String) -> CallTool.Result {
-        // ADR-003: the available-command list is registry-derived (registry
-        // order), so a new logic_system operation can never be missing here.
-        let available = OperationRegistry.specs
-            .filter { $0.tool == .logicSystem }
-            .map(\.command)
-            .joined(separator: ", ")
-        return toolTextResult(
-            "Unknown system command: \(command). Available: \(available)",
-            isError: true
-        )
+        unhandledCommandResult(command, label: "system")
     }
 
     private static func handleTraceCommand(

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -5,11 +5,7 @@ import MCP
 
 struct SystemDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "health", "permissions", "refresh_cache", "export_support_bundle", "help",
-        "list_recent_traces", "get_trace", "clear_traces",
-        "saga_preflight", "saga_execute", "saga_status", "saga_cancel",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicSystem)
 
     typealias SupportBundleExporter = @Sendable (
         URL,

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -780,10 +780,7 @@ struct TrackDispatcher: OperationTraceDispatching {
             return toolTextResult(result)
 
         default:
-            return toolInvalidParamsResult(
-                "Unknown track command: \(command). Available: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets",
-                extras: ["operation": "track.\(command)"]
-            )
+            return Self.unhandledCommandResult(command, label: "track")
         }
     }
 

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -3,12 +3,7 @@ import MCP
 
 struct TrackDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "select", "create_audio", "create_instrument", "create_drummer",
-        "create_external_midi", "delete", "duplicate", "rename", "mute", "solo", "arm",
-        "arm_only", "record_sequence", "set_automation", "set_instrument", "list_library",
-        "scan_library", "resolve_path", "scan_plugin_presets",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicTracks)
     static let notExposedCommands: Set<String> = ["set_color"]
     // The legacy direct alias stays explicit but is never exposed through MCP fallback.
     static let directOnlyCommands: Set<String> = ["library"]

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -3,11 +3,7 @@ import MCP
 
 struct TransportDispatcher: OperationTraceDispatching {
     // Keeps dispatcher cases auditable against the registry so fallback cannot bypass strict validation.
-    static let handledCommands: Set<String> = [
-        "play", "stop", "record", "pause", "rewind", "fast_forward", "toggle_cycle",
-        "toggle_metronome", "set_tempo", "goto_position", "set_cycle_range",
-        "toggle_count_in", "toggle_autopunch",
-    ]
+    static let handledCommands: Set<String> = OperationRegistry.commands(for: .logicTransport)
 
     static let tool = Tool(
         name: "logic_transport",

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -239,10 +239,7 @@ struct TransportDispatcher: OperationTraceDispatching {
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
-            return toolTextResult(
-                "Unknown transport command: \(command). Available: play, stop, record, pause, rewind, fast_forward, toggle_cycle, toggle_metronome, set_tempo, goto_position, set_cycle_range, toggle_count_in, toggle_autopunch",
-                isError: true
-            )
+            return Self.unhandledCommandResult(command, label: "transport")
         }
     }
 

--- a/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
@@ -9,6 +9,11 @@ struct HandlerDependencies: Sendable {
     let supportBundleExporter: SystemDispatcher.SupportBundleExporter?
     let sagaJournal: SagaJournal
     let mutationGate: LogicMutationGate?
+    /// Explicit seam for the project lifecycle AppleScript executor.
+    /// `nil` = production osascript path. Tests (notably the executable
+    /// dispatch census) inject a stub so exercising `launch`/`quit` cases
+    /// can never touch the real app lifecycle.
+    let projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)?
 
     init(
         router: ChannelRouter,
@@ -18,7 +23,8 @@ struct HandlerDependencies: Sendable {
         dialogPresent: @escaping @Sendable () -> Bool,
         supportBundleExporter: SystemDispatcher.SupportBundleExporter?,
         sagaJournal: SagaJournal = SagaJournal(),
-        mutationGate: LogicMutationGate? = nil
+        mutationGate: LogicMutationGate? = nil,
+        projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)? = nil
     ) {
         self.router = router
         self.cache = cache
@@ -28,6 +34,7 @@ struct HandlerDependencies: Sendable {
         self.supportBundleExporter = supportBundleExporter
         self.sagaJournal = sagaJournal
         self.mutationGate = mutationGate
+        self.projectLifecycleExecute = projectLifecycleExecute
     }
 }
 
@@ -272,7 +279,18 @@ enum OperationHandlerRegistry {
             }
         case .logicProject:
             return { dependencies, params in
-                await ProjectDispatcher.handle(
+                if let lifecycle = dependencies.projectLifecycleExecute {
+                    return await ProjectDispatcher.handle(
+                        command: command,
+                        params: params,
+                        router: dependencies.router,
+                        cache: dependencies.cache,
+                        targetRegistry: dependencies.targetRegistry,
+                        executeLifecycleScript: lifecycle,
+                        dialogPresent: dependencies.dialogPresent
+                    )
+                }
+                return await ProjectDispatcher.handle(
                     command: command,
                     params: params,
                     router: dependencies.router,

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -779,6 +779,15 @@ enum OperationRegistry {
         )
     }
 
+    /// ADR-003/PRD-002: the registry is the single source of a tool's command
+    /// set — dispatchers derive their handled-command sets from here instead
+    /// of hand-maintaining parallel lists that can drift from the specs.
+    /// Executable dispatch truth (every command reaches a real switch case)
+    /// is proven separately by the dispatch census test.
+    static func commands(for tool: ToolID) -> Set<String> {
+        Set(specs.filter { $0.tool == tool }.map(\.command))
+    }
+
     /// Lifecycle transitions swap the whole open-project world; the project
     /// dispatcher's invalidate-on-success derives from this declaration.
     /// Typed helper (not inline) to keep the large `specs` literal within the

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -178,6 +178,12 @@ enum HonestContract {
         /// can tell a typo'd category apart from a missing required argument,
         /// and so an unknown category never silently returns full help. #219.
         case unknownCategory = "unknown_category"
+        /// A REGISTERED command reached a dispatcher without a matching
+        /// switch case — registry↔dispatch drift. Unregistered commands are
+        /// rejected at the server layer and never produce this; the
+        /// executable dispatch census asserts it never fires for any
+        /// registered operation.
+        case unhandledRegisteredCommand = "unhandled_registered_command"
         case supportBundleExportFailed = "support_bundle_export_failed"
         case sagaInProgress = "saga_in_progress"
         case idempotencyKeyConflict = "idempotency_key_conflict"

--- a/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
+++ b/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// Records every routed operation and answers State A so no census call can
+/// reach a real channel or produce a side effect.
+private actor CensusProbeChannel: Channel {
+    nonisolated let id: ChannelID
+
+    init(id: ChannelID) {
+        self.id = id
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "dispatch census probe")
+    }
+}
+
+@Suite("Executable dispatch census", .serialized)
+struct OperationDispatchCensusTests {
+    /// PRD-002: every registered operation must reach a REAL dispatcher
+    /// switch case. Set comparisons cannot prove that — a hand-written or
+    /// derived command set can claim commands the switch never handles, and
+    /// the strict-parameter census rejects at the server layer BEFORE
+    /// dispatch, so it cannot catch a missing case either. This census
+    /// invokes the actual bound handler for every spec and fails if any
+    /// command falls through to a dispatcher's unknown-command envelope
+    /// ("Unknown <tool> command: …"). Side-effect safety: every channel is a
+    /// probe, the project lifecycle executor is stubbed through the
+    /// dependencies seam, and the support-bundle exporter throws.
+    @Test func everyRegisteredOperationReachesARealDispatchCase() async throws {
+        let router = ChannelRouter()
+        for id in ChannelID.allCases {
+            await router.register(CensusProbeChannel(id: id))
+        }
+        let cache = StateCache()
+        let dependencies = HandlerDependencies(
+            router: router,
+            cache: cache,
+            targetRegistry: TargetRegistry(),
+            poller: StatePoller(
+                axChannel: AccessibilityChannel(),
+                cache: cache,
+                runtime: .fastTest
+            ),
+            dialogPresent: { false },
+            supportBundleExporter: { _, _ in
+                throw NSError(domain: "dispatch-census", code: 1)
+            },
+            projectLifecycleExecute: { _ in
+                ProjectDispatcher.LifecycleExecution(
+                    executionError: nil,
+                    timedOut: false,
+                    terminationStatus: 0,
+                    stderrOutput: ""
+                )
+            }
+        )
+
+        for spec in OperationRegistry.specs {
+            let handler = try #require(
+                OperationHandlerRegistry.handler(for: spec.id),
+                Comment(rawValue: "\(spec.id.rawValue) has no bound handler")
+            )
+            let result = await handler(dependencies, [:])
+            guard case .text(let text, _, _) = result.content.first else {
+                continue
+            }
+            let fellThrough = text.contains("Unknown ") && text.contains(" command: ")
+            #expect(
+                !fellThrough,
+                Comment(rawValue: "\(spec.id.rawValue) fell through to the unknown-command envelope: \(text.prefix(120))")
+            )
+        }
+    }
+
+    /// The derived handled-command sets are definitionally registry-equal —
+    /// pinned so a future hand-written override reintroducing drift fails.
+    @Test func handledCommandSetsAreRegistryDerived() {
+        let expectations: [(ToolID, Set<String>)] = [
+            (.logicTransport, TransportDispatcher.handledCommands),
+            (.logicMixer, MixerDispatcher.handledCommands),
+            (.logicNavigate, NavigateDispatcher.handledCommands),
+            (.logicAudio, AudioDispatcher.handledCommands),
+            (.logicSystem, SystemDispatcher.handledCommands),
+            (.logicPlugins, PluginsDispatcher.handledCommands),
+            (.logicEdit, EditDispatcher.handledCommands),
+            (.logicProject, ProjectDispatcher.handledCommands),
+            (.logicMidi, MIDIDispatcher.handledCommands),
+            (.logicTracks, TrackDispatcher.handledCommands),
+        ]
+        for (tool, handled) in expectations {
+            #expect(
+                handled == OperationRegistry.commands(for: tool),
+                Comment(rawValue: tool.rawValue)
+            )
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
+++ b/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
@@ -71,15 +71,52 @@ struct OperationDispatchCensusTests {
                 Comment(rawValue: "\(spec.id.rawValue) has no bound handler")
             )
             let result = await handler(dependencies, [:])
-            guard case .text(let text, _, _) = result.content.first else {
+            // Fail closed on content shape: a dispatch outcome must be
+            // inspectable text — an empty or non-text response would
+            // otherwise be a silent census pass.
+            let first = try #require(
+                result.content.first,
+                Comment(rawValue: "\(spec.id.rawValue) returned empty content")
+            )
+            guard case .text(let text, _, _) = first else {
+                #expect(
+                    Bool(false),
+                    Comment(rawValue: "\(spec.id.rawValue) returned non-text first content")
+                )
                 continue
             }
-            let fellThrough = text.contains("Unknown ") && text.contains(" command: ")
+            // Typed contract, not prose matching: a registered command that
+            // reaches a dispatcher without a matching switch case produces
+            // the shared unhandled_registered_command State-C envelope.
+            let body = (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
+            let fellThrough = body?["error"] as? String
+                == HonestContract.FailureError.unhandledRegisteredCommand.rawValue
             #expect(
                 !fellThrough,
-                Comment(rawValue: "\(spec.id.rawValue) fell through to the unknown-command envelope: \(text.prefix(120))")
+                Comment(rawValue: "\(spec.id.rawValue) fell through to the unhandled-command envelope: \(text.prefix(120))")
             )
         }
+    }
+
+    /// The typed fallthrough envelope itself is discriminating: an
+    /// out-of-registry command through a dispatcher default arm produces
+    /// exactly the unhandled_registered_command code the census scans for.
+    @Test func fallthroughEnvelopeCarriesTypedCode() throws {
+        let result = TransportDispatcher.unhandledCommandResult(
+            "no_such_command", label: "transport"
+        )
+        guard case .text(let text, _, _) = result.content.first else {
+            #expect(Bool(false), "fallthrough must be text")
+            return
+        }
+        let body = try #require(
+            (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
+        )
+        #expect(body["error"] as? String == "unhandled_registered_command")
+        #expect(result.isError == true)
+        let hint = try #require(body["hint"] as? String)
+        #expect(hint.contains("Unknown transport command: no_such_command"))
+        #expect(hint.contains("play"))
     }
 
     /// The derived handled-command sets are definitionally registry-equal —


### PR DESCRIPTION
## Summary

Corrective PR for the reopened #286. An independent debt re-audit found the dispatch-parity story weaker than the ADR-003 receipt claimed: hand-written `handledCommands` sets were the parity source, the handler-existence census was structurally vacuous (the factory switches on the tool, so a missing command case is undetectable), and the strict-parameter census rejects at the server layer **before** dispatch so it can't catch a missing case either.

- **All ten `handledCommands` sets are registry-derived** (`OperationRegistry.commands(for:)`); a pinning test forbids hand-written lists returning.
- **Executable dispatch census**: every registered operation is invoked through its actual bound handler; a missing dispatcher switch case fails CI. Side-effect-free by construction: probe channels on every `ChannelID`, a new explicit `HandlerDependencies.projectLifecycleExecute` seam (tests stub the project lifecycle executor so `launch`/`quit` can never reach real osascript; `nil` = unchanged production path), and a throwing support-bundle exporter stub.
- **Typed fallthrough contract** (adversarial-gate hardening): all ten dispatcher default arms now emit a shared State-C envelope with `error: unhandled_registered_command` (hint keeps the human phrasing + a registry-derived command list). The census discriminates on the **code**, not prose, and fails closed on empty/non-text content. Production note: genuinely unknown commands are rejected at the server layer before dispatch — these arms fire only on registry↔dispatch drift.
- Honest census scope: with empty params it proves no registered command falls through; per-arm logic coverage remains the strict-parameter census's job.

## Verification
Full suite `--no-parallel`: **2,839 passed**; adversarial gate re-run PROCEED after fixes; merged with main (`45d2b76`).