### PR TITLE
fix(adr-005/prd-014): trace availability from feature policy; no-op clear never claims success (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [Unreleased]
+
+### Changed — BREAKING (honesty contract)
+
+- **Release promotion is fail-closed until real per-operation qualification evidence exists.** The 106 blanket operation waivers were removed as invalid; `PromotionGate` rejects every uncovered operation, and the release workflow verifies the exact artifact through a pinned independent verifier bound to the released commit. No release can promote until the coverage program (#373) lands evidence.
+- **Flag-off `clear_traces` no longer claims success.** With operation tracing disabled, a confirmed `clear_traces` returns a typed State C (`error: trace_disabled`, `write_attempted: false`) instead of `success: true` — a no-op never surfaces as success. Cleanup flows that called `clear_traces` unconditionally under the default configuration must treat this outcome as the expected disabled response.
+- **Trace operation availability is generated from the feature policy.** `list_recent_traces`, `get_trace`, and `clear_traces` advertise `default_install` only when tracing is enabled for the process; otherwise they advertise `experimental` in the operation catalog. Promotion requirements are unaffected (all registered operations remain required).
+- **Saga preflight rejects three more plan classes before step 1**: unavailable routes, confirmation-requiring steps (the saga wire carries no confirmation flow), and plans whose modeled duration cannot fit the saga-execute deadline budget.
+- **`saga_cancel` is a real two-phase cancellation**: State B `saga_cancellation_pending` until the unwind is journaled; terminal State A only after compensation readback verifies restoration; compensation failure surfaces as State B `saga_reconciliation_required` with the stored outcome.
+
+### Added
+
+- All 13 declared operation-trace phases now record at live seams (input validation, mutation-gate pair, route evaluation, channel bracket, target resolution, verification polls, compensation start), with saga child traces correlated to their parent via `parent_trace_id`.
+- A registered command that reaches a dispatcher without a matching switch case now produces a typed `unhandled_registered_command` State C envelope (previously prose); genuinely unknown commands are still rejected at the server layer before dispatch.
+
+---
+
 ## [3.11.0] — 2026-07-10
 
 Minor release for Doctor readiness, native UI routing fixes, and the full-surface QA bug batch after v3.10.0. The public MCP surface remains **10 tools / 18 resources / 11 templates**.

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -937,11 +937,18 @@ struct SystemDispatcher: OperationTraceDispatching {
                 }
             }
             guard FeatureFlags.adr005OperationTrace else {
-                return toolTextResult(HonestContract.jsonString([
-                    "note": "trace_disabled",
-                    "success": true,
-                    "trace_disabled": true,
-                ]))
+                // PRD-014: a no-op clear must never claim success — tracing
+                // is disabled, nothing was cleared, and the catalog advertises
+                // these operations as experimental in this configuration.
+                return toolTextResult(
+                    HonestContract.encodeStateC(
+                        error: .traceDisabled,
+                        hint: "Operation tracing is disabled; nothing was cleared. "
+                            + "Enable LOGIC_MCP_ADR005_OPERATION_TRACE=1 to record and manage traces.",
+                        extras: ["trace_disabled": true, "write_attempted": false]
+                    ),
+                    isError: true
+                )
             }
             await OperationTraceStore.shared.clear()
             return toolTextResult(HonestContract.jsonString(["success": true]))

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -537,7 +537,9 @@ enum OperationRegistry {
             verification: entry.4,
             retry: .neverAutomatic,
             deadline: entry.3,
-            availability: .defaultInstall,
+            availability: Self.traceOperationIDs.contains(entry.0)
+                ? traceAvailability(traceEnabled: traceEnabledAtRegistryBuild)
+                : .defaultInstall,
             allowedParams: allowedParams(for: entry.0, commandSpecific: entry.5),
             capability: CapabilityID(rawValue: entry.0.rawValue)
         )
@@ -786,6 +788,25 @@ enum OperationRegistry {
     /// is proven separately by the dispatch census test.
     static func commands(for tool: ToolID) -> Set<String> {
         Set(specs.filter { $0.tool == tool }.map(\.command))
+    }
+
+    /// PRD-014: the three trace operations are flag-gated at runtime, so
+    /// their advertised availability is GENERATED from the feature policy —
+    /// `defaultInstall` only when tracing is actually on for this process
+    /// (the flag is environment-derived and process-constant), otherwise
+    /// `experimental`. A hardcoded `defaultInstall` contradicted the catalog.
+    static let traceOperationIDs: Set<OperationID> = [
+        .systemListRecentTraces, .systemGetTrace, .systemClearTraces,
+    ]
+
+    /// The flag value the registry actually consulted when the static specs
+    /// were built (environment-derived, process-constant in production; in
+    /// tests the first registry access decides it). Exposed so the derivation
+    /// can be asserted self-consistently regardless of test ordering.
+    static let traceEnabledAtRegistryBuild = FeatureFlags.adr005OperationTrace
+
+    static func traceAvailability(traceEnabled: Bool) -> AvailabilityPolicy {
+        traceEnabled ? .defaultInstall : .experimental
     }
 
     /// Lifecycle transitions swap the whole open-project world; the project

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -184,6 +184,9 @@ enum HonestContract {
         /// executable dispatch census asserts it never fires for any
         /// registered operation.
         case unhandledRegisteredCommand = "unhandled_registered_command"
+        /// PRD-014: trace management requested while operation tracing is
+        /// disabled — a no-op must never surface as success.
+        case traceDisabled = "trace_disabled"
         case supportBundleExportFailed = "support_bundle_export_failed"
         case sagaInProgress = "saga_in_progress"
         case idempotencyKeyConflict = "idempotency_key_conflict"

--- a/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
+++ b/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
@@ -119,6 +119,26 @@ struct OperationDispatchCensusTests {
         #expect(hint.contains("play"))
     }
 
+    /// PRD-014: trace-operation availability is GENERATED from the feature
+    /// policy — both branches of the pure derivation, plus the registry's
+    /// actual value matching this process's flag state (the flag is
+    /// environment-derived and process-constant, so the static registry
+    /// value is decided exactly once and must agree with it).
+    @Test func traceAvailabilityIsGeneratedFromFeaturePolicy() {
+        #expect(OperationRegistry.traceAvailability(traceEnabled: true) == .defaultInstall)
+        #expect(OperationRegistry.traceAvailability(traceEnabled: false) == .experimental)
+        let expected = OperationRegistry.traceAvailability(
+            traceEnabled: OperationRegistry.traceEnabledAtRegistryBuild
+        )
+        for id in OperationRegistry.traceOperationIDs {
+            let spec = OperationRegistry.specs.first { $0.id == id }
+            #expect(spec?.availability == expected, Comment(rawValue: id.rawValue))
+        }
+        // Non-trace system ops stay unconditionally defaultInstall.
+        let health = OperationRegistry.specs.first { $0.id == .systemHealth }
+        #expect(health?.availability == .defaultInstall)
+    }
+
     /// The derived handled-command sets are definitionally registry-equal —
     /// pinned so a future hand-written override reintroducing drift fails.
     @Test func handledCommandSetsAreRegistryDerived() {

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -410,7 +410,16 @@ struct OperationRegistryTests {
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)
-            #expect(spec.availability == .defaultInstall)
+            // PRD-014: trace-op availability is generated from the feature
+            // policy (defaultInstall only when tracing was enabled when the
+            // registry was built); everything else stays defaultInstall.
+            #expect(spec.availability == (
+                OperationRegistry.traceOperationIDs.contains(id)
+                    ? OperationRegistry.traceAvailability(
+                        traceEnabled: OperationRegistry.traceEnabledAtRegistryBuild
+                    )
+                    : .defaultInstall
+            ))
             #expect(spec.capability.rawValue == entry.id)
         }
     }
@@ -621,7 +630,16 @@ struct OperationRegistryTests {
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)
-            #expect(spec.availability == .defaultInstall)
+            // PRD-014: trace-op availability is generated from the feature
+            // policy (defaultInstall only when tracing was enabled when the
+            // registry was built); everything else stays defaultInstall.
+            #expect(spec.availability == (
+                OperationRegistry.traceOperationIDs.contains(id)
+                    ? OperationRegistry.traceAvailability(
+                        traceEnabled: OperationRegistry.traceEnabledAtRegistryBuild
+                    )
+                    : .defaultInstall
+            ))
             #expect(spec.capability.rawValue == entry.id)
         }
     }
@@ -849,7 +867,16 @@ struct OperationRegistryTests {
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)
-            #expect(spec.availability == .defaultInstall)
+            // PRD-014: trace-op availability is generated from the feature
+            // policy (defaultInstall only when tracing was enabled when the
+            // registry was built); everything else stays defaultInstall.
+            #expect(spec.availability == (
+                OperationRegistry.traceOperationIDs.contains(id)
+                    ? OperationRegistry.traceAvailability(
+                        traceEnabled: OperationRegistry.traceEnabledAtRegistryBuild
+                    )
+                    : .defaultInstall
+            ))
             #expect(spec.capability.rawValue == entry.id)
         }
     }
@@ -979,7 +1006,16 @@ struct OperationRegistryTests {
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)
-            #expect(spec.availability == .defaultInstall)
+            // PRD-014: trace-op availability is generated from the feature
+            // policy (defaultInstall only when tracing was enabled when the
+            // registry was built); everything else stays defaultInstall.
+            #expect(spec.availability == (
+                OperationRegistry.traceOperationIDs.contains(id)
+                    ? OperationRegistry.traceAvailability(
+                        traceEnabled: OperationRegistry.traceEnabledAtRegistryBuild
+                    )
+                    : .defaultInstall
+            ))
             #expect(spec.capability.rawValue == entry.id)
         }
     }

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -470,6 +470,8 @@ struct OperationTraceTests {
             #expect(sharedJSONObject(sharedToolText(unconfirmed))?["error"] as? String == "invalid_params")
             #expect(await OperationTraceStore.shared.trace(traceID) != nil)
 
+            // PRD-014: a flag-off clear is a NO-OP and must never claim
+            // success — typed State C, write_attempted:false, store intact.
             let cleared = await SystemDispatcher.handle(
                 command: "clear_traces",
                 params: ["confirmed": .bool(true)],
@@ -477,9 +479,12 @@ struct OperationTraceTests {
                 cache: cache
             )
             let clearedBody = sharedJSONObject(sharedToolText(cleared)) ?? [:]
-            #expect(cleared.isError != true)
-            #expect(clearedBody["success"] as? Bool == true)
-            #expect(clearedBody["note"] as? String == "trace_disabled")
+            #expect(cleared.isError == true)
+            #expect(clearedBody["state"] as? String == "C")
+            #expect(clearedBody["error"] as? String == "trace_disabled")
+            #expect(clearedBody["trace_disabled"] as? Bool == true)
+            #expect(clearedBody["write_attempted"] as? Bool == false)
+            #expect(clearedBody["success"] as? Bool != true)
             #expect(await OperationTraceStore.shared.trace(traceID) != nil)
         }
         await OperationTraceStore.shared.clear()


### PR DESCRIPTION
## Summary

Debt PRD-014: the three trace operations advertised `default_install` while tracing is default-off, and a confirmed flag-off `clear_traces` returned `success:true` despite clearing nothing.

- **Availability generated from the feature policy**: the registry consults the tracing flag at build (environment-derived, process-constant) — `default_install` when tracing is on, `experimental` when off. The consulted value is exposed (`traceEnabledAtRegistryBuild`) so tests assert the derivation self-consistently regardless of suite ordering; the pure derivation is covered on both branches. Non-trace operations unaffected.
- **Flag-off `clear_traces` is a typed State C** (`error: trace_disabled`, `write_attempted: false`) — a no-op never surfaces as success; the contract test pins the honest shape and that the store stays intact.
- CHANGELOG gains an `[Unreleased]` section documenting this and the program's other honesty-contract behavior changes.

## Adversarial gate — PROCEED-WITH-FIXES, addressed
- Qualification-path safety verified: the qualification transport spawns the candidate with tracing **enabled**, so the qualification flow never sees the flag-off State C; probe outcomes already tolerate typed errors.
- No consumer filters required-operation sets by availability (grep-verified) — `experimental` labeling is honest catalog truth, not a promotion loophole (all registered ops remain required).
- The flag-off clear contract break is documented in the changelog (deliberate: mutate-when-disabled ≠ success; reads keep their diagnostic disabled-note shapes).
- Static-vs-live flag divergence impossible in production (env is process-constant; dispatch re-reads the same env).

Remaining PRD-014 scope for the live batch: exact-binary surface check of both flag states.

## Verification
Full suite `--no-parallel`: **2,840 passed**; merged with main (`ab568ad`).