### PR TITLE
fix(adr-005/prd-015): durable append-only audit receipt for trace deletion (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -814,6 +814,74 @@ struct SystemDispatcher: OperationTraceDispatching {
             .standardizedFileURL
     }
 
+    /// PRD-015 (ADR-005 #288): the directory the `clear_traces` audit receipt is
+    /// written under, OUTSIDE the in-process trace store it records the clearing
+    /// of. Overridable for tests via a DEBUG-only environment hook (never
+    /// honored in a release binary, mirroring `supportBundleRoot`) so the
+    /// fail-closed / append-only behavior is provable against a temp root.
+    static var auditLogRoot: URL {
+        #if DEBUG
+        if let override = ProcessInfo.processInfo
+            .environment["LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"],
+            !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true).standardizedFileURL
+        }
+        #endif
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/LogicProMCP/audit", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    /// PRD-015 receipt schema tag. Bumped only on a breaking field change so a
+    /// consumer can branch on the version rather than sniff individual keys.
+    static let traceClearReceiptSchema = "logic_pro_mcp_trace_clear_receipt.v1"
+
+    /// The append-only audit log the `clear_traces` receipt is appended to.
+    static var traceClearReceiptURL: URL {
+        auditLogRoot.appendingPathComponent("trace-clear.log", isDirectory: false)
+    }
+
+    private enum TraceClearReceiptError: Error {
+        case encodingFailed
+        case openFailed(errno: Int32)
+        case writeFailed
+    }
+
+    /// PRD-015: append ONE JSON line recording a successful trace clear to the
+    /// durable audit log. The receipt survives the store clear (it lives outside
+    /// it) and carries counts/timestamps ONLY — never trace contents, paths, or
+    /// params — so the log itself leaks nothing about the cleared evidence.
+    /// Opened `O_APPEND` (never truncated); intermediate directories are created
+    /// fail-closed (a create/append error propagates so the caller refuses the
+    /// clear). Returns the receipt file path for the response body.
+    private static func appendTraceClearReceipt(clearedTraceCount: Int) throws -> String {
+        let root = auditLogRoot
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let receiptURL = traceClearReceiptURL
+        // Counts + timestamps ONLY. `authorization` records the boundary that
+        // sanctioned the clear so a future operator-approval integration can
+        // slot in without a schema bump. No path/param/trace content ever.
+        let receipt: [String: Any] = [
+            "schema": traceClearReceiptSchema,
+            "cleared_at": ISO8601DateFormatter.cacheFormatter.string(from: Date()),
+            "cleared_trace_count": clearedTraceCount,
+            "authorization": "mcp_confirmed_param",
+            "server_version": ServerConfig.serverVersion,
+            "pid": Int(ProcessInfo.processInfo.processIdentifier),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw TraceClearReceiptError.encodingFailed
+        }
+        let bytes = Array((line + "\n").utf8)
+        let fd = open(receiptURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        guard fd >= 0 else { throw TraceClearReceiptError.openFailed(errno: errno) }
+        defer { close(fd) }
+        let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+        guard written == bytes.count else { throw TraceClearReceiptError.writeFailed }
+        return receiptURL.path
+    }
+
     /// Resolves a caller-requested bundle directory strictly inside the
     /// support-bundle root, or nil. Relative subpaths resolve against the
     /// root; absolute paths must already be under it. `..` is collapsed by
@@ -1061,8 +1129,36 @@ struct SystemDispatcher: OperationTraceDispatching {
                     isError: true
                 )
             }
+            // PRD-015 (ADR-005 #288): the authorization boundary for this
+            // destructive op stays `confirmed:true` — this is a LOCAL,
+            // single-user MCP server, so the durable boundary is (a) the
+            // registry's l2 confirmation gate checked above and (b) an
+            // append-only audit receipt written OUTSIDE the cleared store,
+            // below. `authorization` is recorded in the receipt so a future
+            // operator-approval integration slots in without a schema change.
+            //
+            // Fail closed: capture the count, then write the receipt BEFORE
+            // clearing. If the receipt cannot be written the store is left
+            // intact and a typed State C is returned — never destroy evidence
+            // without a surviving durable record of the clear.
+            let clearedTraceCount = await OperationTraceStore.shared.recent(limit: .max).count
+            let receiptPath: String
+            do {
+                receiptPath = try appendTraceClearReceipt(clearedTraceCount: clearedTraceCount)
+            } catch {
+                return toolStateCResult(
+                    .traceClearReceiptFailed,
+                    hint: "clear_traces refused: the durable audit receipt could not be written; "
+                        + "the trace store was left intact. Fix the audit-log location and retry.",
+                    extras: ["write_attempted": false]
+                )
+            }
             await OperationTraceStore.shared.clear()
-            return toolTextResult(HonestContract.jsonString(["success": true]))
+            return toolTextResult(HonestContract.jsonString([
+                "success": true,
+                "receipt_path": receiptPath,
+                "cleared_trace_count": clearedTraceCount,
+            ]))
 
         default:
             return nil

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -845,30 +845,67 @@ struct SystemDispatcher: OperationTraceDispatching {
         case encodingFailed
         case openFailed(errno: Int32)
         case writeFailed
+        /// The audit directory resolved OUTSIDE its intended parent (symlink
+        /// planted for the final component) — the receipt must never be
+        /// diverted out of the containment root, so the clear is refused.
+        case auditDirectoryEscaped
     }
 
-    /// PRD-015: append ONE JSON line recording a successful trace clear to the
-    /// durable audit log. The receipt survives the store clear (it lives outside
-    /// it) and carries counts/timestamps ONLY — never trace contents, paths, or
-    /// params — so the log itself leaks nothing about the cleared evidence.
-    /// Opened `O_APPEND` (never truncated); intermediate directories are created
-    /// fail-closed (a create/append error propagates so the caller refuses the
-    /// clear). Returns the receipt file path for the response body.
-    private static func appendTraceClearReceipt(clearedTraceCount: Int) throws -> String {
-        let root = auditLogRoot
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        let receiptURL = traceClearReceiptURL
-        // Counts + timestamps ONLY. `authorization` records the boundary that
-        // sanctioned the clear so a future operator-approval integration can
-        // slot in without a schema bump. No path/param/trace content ever.
-        let receipt: [String: Any] = [
+    /// PRD-015 receipt fields — counts + timestamps ONLY, never trace contents,
+    /// paths, or params, so the log itself leaks nothing about the evidence it
+    /// records the destruction of. `authorization` records the boundary that
+    /// sanctioned the clear so a future operator-approval integration can slot
+    /// in without a schema bump.
+    ///
+    /// `trace_count_at_receipt` is deliberately named for what it can honestly
+    /// promise: the count SNAPSHOT taken when this line was written, one actor
+    /// hop before the store was drained. When `actualClearedCount` is supplied
+    /// the line is an amendment (see `appendTraceClearAmendment`) and carries
+    /// the drain's true number alongside the snapshot it corrects. Schema stays
+    /// `.v1`: both fields are additive and the tag brands the record shape, so
+    /// a consumer branching on it keeps parsing every line.
+    private static func traceClearReceiptFields(
+        traceCountAtReceipt: Int,
+        actualClearedCount: Int? = nil
+    ) -> [String: Any] {
+        var receipt: [String: Any] = [
             "schema": traceClearReceiptSchema,
             "cleared_at": ISO8601DateFormatter.cacheFormatter.string(from: Date()),
-            "cleared_trace_count": clearedTraceCount,
+            "trace_count_at_receipt": traceCountAtReceipt,
             "authorization": "mcp_confirmed_param",
             "server_version": ServerConfig.serverVersion,
             "pid": Int(ProcessInfo.processInfo.processIdentifier),
         ]
+        if let actualClearedCount {
+            receipt["amends"] = true
+            receipt["actual_cleared_count"] = actualClearedCount
+        }
+        return receipt
+    }
+
+    /// PRD-015: append ONE JSON line to the durable audit log. The line survives
+    /// the store clear (it lives outside it). Opened `O_APPEND` (never
+    /// truncated); the directory is created and containment-checked fail-closed
+    /// (any error propagates so the caller refuses the clear). Returns the
+    /// receipt file path for the response body.
+    ///
+    /// Unbounded append is ACCEPTED, not an oversight. Each line is a fixed,
+    /// receipt-sized record and `clear_traces` is an l2-confirmed operator
+    /// action, so the log grows with human-scale invocation frequency, not with
+    /// traffic. Rotation/pruning is deliberately out of scope: a rotator that
+    /// can delete receipt lines is itself an evidence-destruction surface —
+    /// precisely the failure mode this receipt exists to close.
+    private static func appendTraceClearAuditLine(_ receipt: [String: Any]) throws -> String {
+        let root = auditLogRoot
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        // The directory now EXISTS, so re-resolve it through realpath BEFORE
+        // any write: a symlink planted for the audit dir would otherwise divert
+        // the receipt — and with it the whole evidence trail — outside the
+        // intended root, which is indistinguishable from having no receipt.
+        guard auditDirectoryIsContained(root) else {
+            throw TraceClearReceiptError.auditDirectoryEscaped
+        }
+        let receiptURL = traceClearReceiptURL
         let data = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
         guard let line = String(data: data, encoding: .utf8) else {
             throw TraceClearReceiptError.encodingFailed
@@ -880,6 +917,49 @@ struct SystemDispatcher: OperationTraceDispatching {
         let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
         guard written == bytes.count else { throw TraceClearReceiptError.writeFailed }
         return receiptURL.path
+    }
+
+    /// PRD-015: record a trace clear, written BEFORE the store is drained so a
+    /// clear can never destroy evidence without a surviving durable record.
+    private static func appendTraceClearReceipt(traceCountAtReceipt: Int) throws -> String {
+        try appendTraceClearAuditLine(
+            traceClearReceiptFields(traceCountAtReceipt: traceCountAtReceipt)
+        )
+    }
+
+    /// PRD-015: amend an already-durable receipt whose snapshot count the atomic
+    /// drain then contradicted. The first line is NEVER rewritten — the log
+    /// tells the truth by growing, never by editing history, which is the only
+    /// form of honesty an append-only audit trail can offer. The amendment is
+    /// self-describing (`amends:true` + `actual_cleared_count`) so a consumer
+    /// reading lines in order lands on the true count without ambiguity.
+    @discardableResult
+    static func appendTraceClearAmendment(
+        traceCountAtReceipt: Int,
+        actualClearedCount: Int
+    ) throws -> String {
+        try appendTraceClearAuditLine(
+            traceClearReceiptFields(
+                traceCountAtReceipt: traceCountAtReceipt,
+                actualClearedCount: actualClearedCount
+            )
+        )
+    }
+
+    /// PRD-015 symlink hardening: the audit directory must resolve INSIDE its
+    /// intended parent — production `~/Library/Logs/LogicProMCP`, or the
+    /// DEBUG override root's parent when the test hook is set. Mirrors the
+    /// support-bundle containment check (`createdBundleDirectoryIsContained`):
+    /// realpath BOTH sides, then require the directory to resolve strictly
+    /// under the parent. Because `realpath` follows the final component while
+    /// the parent is resolved independently, a symlink planted for the audit
+    /// dir resolves outside the parent and is caught. Fail-closed when either
+    /// side cannot be canonicalized — an unresolved path is never contained.
+    static func auditDirectoryIsContained(_ directory: URL) -> Bool {
+        guard let parentPath = realpathResolvedPath(directory.deletingLastPathComponent()),
+              let resolved = realpathResolvedPath(directory) else { return false }
+        return resolved.hasPrefix(parentPath + "/")
+            && !resolved.split(separator: "/").contains("..")
     }
 
     /// Resolves a caller-requested bundle directory strictly inside the
@@ -1137,27 +1217,56 @@ struct SystemDispatcher: OperationTraceDispatching {
             // below. `authorization` is recorded in the receipt so a future
             // operator-approval integration slots in without a schema change.
             //
-            // Fail closed: capture the count, then write the receipt BEFORE
+            // Fail closed: snapshot the count, then write the receipt BEFORE
             // clearing. If the receipt cannot be written the store is left
             // intact and a typed State C is returned — never destroy evidence
             // without a surviving durable record of the clear.
-            let clearedTraceCount = await OperationTraceStore.shared.recent(limit: .max).count
+            //
+            // The snapshot and the drain are two actor hops with file IO
+            // between them, so a trace started in that window would make the
+            // receipt's count wrong. The ordering is NOT relaxed to fix that
+            // (receipt-before-destruction is the whole guarantee); instead the
+            // drain is atomic and reports what it ACTUALLY removed, and any
+            // divergence is amended with a second append-only line below.
+            let countAtReceipt = await OperationTraceStore.shared.traceCount
             let receiptPath: String
             do {
-                receiptPath = try appendTraceClearReceipt(clearedTraceCount: clearedTraceCount)
+                receiptPath = try appendTraceClearReceipt(traceCountAtReceipt: countAtReceipt)
             } catch {
                 return toolStateCResult(
                     .traceClearReceiptFailed,
                     hint: "clear_traces refused: the durable audit receipt could not be written; "
                         + "the trace store was left intact. Fix the audit-log location and retry.",
-                    extras: ["write_attempted": false]
+                    // The receipt write WAS attempted (and failed); what the
+                    // caller needs to know is that the STORE is untouched.
+                    extras: ["store_cleared": false]
                 )
             }
-            await OperationTraceStore.shared.clear()
+            let actualCleared = await OperationTraceStore.shared.clearReturningCount()
+            if actualCleared != countAtReceipt {
+                // The receipt is already durable and is never rewritten. If the
+                // amendment itself cannot be written the clear has ALREADY
+                // happened, so State C would be a lie — report the true count
+                // and leave a warning rather than claim nothing was cleared.
+                do {
+                    try appendTraceClearAmendment(
+                        traceCountAtReceipt: countAtReceipt,
+                        actualClearedCount: actualCleared
+                    )
+                } catch {
+                    Log.warn(
+                        "clear_traces receipt amendment could not be appended: the durable "
+                            + "receipt records \(countAtReceipt) trace(s) at snapshot but "
+                            + "\(actualCleared) were actually cleared",
+                        subsystem: .server
+                    )
+                }
+            }
             return toolTextResult(HonestContract.jsonString([
                 "success": true,
                 "receipt_path": receiptPath,
-                "cleared_trace_count": clearedTraceCount,
+                // The drain's true number, not the earlier snapshot.
+                "cleared_trace_count": actualCleared,
             ]))
 
         default:

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -203,11 +203,29 @@ actor OperationTraceStore {
         return order.reversed().prefix(count).compactMap { traces[$0] }
     }
 
-    func clear() {
+    /// Number of traces currently retained. `recent()` materializes the whole
+    /// trace list just to count it; callers that only need the size take this.
+    var traceCount: Int {
+        traces.count
+    }
+
+    /// PRD-015: atomically drain every retained trace and report how many were
+    /// ACTUALLY removed. A count sampled in one actor call and a `clear()` in
+    /// another straddle a suspension point, so a trace started in between makes
+    /// the separately-sampled number a lie. Draining and counting in a SINGLE
+    /// actor call closes that window: the returned number is exactly what this
+    /// call destroyed, and nothing else can interleave.
+    func clearReturningCount() -> Int {
+        let removed = traces.count
         traces.removeAll(keepingCapacity: true)
         order.removeAll(keepingCapacity: true)
         byteCounts.removeAll(keepingCapacity: true)
         totalBytes = 0
+        return removed
+    }
+
+    func clear() {
+        _ = clearReturningCount()
     }
 
     private func replace(_ trace: OperationTrace) {

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -188,6 +188,14 @@ enum HonestContract {
         /// disabled — a no-op must never surface as success.
         case traceDisabled = "trace_disabled"
         case supportBundleExportFailed = "support_bundle_export_failed"
+        /// PRD-015 (ADR-005 #288): `clear_traces` could not write its durable,
+        /// append-only audit receipt (directory-create or append error), so the
+        /// clear was REFUSED and the in-process trace store left intact —
+        /// destroying evidence without a surviving receipt is the failure mode
+        /// this debt closes. Terminal: no fallback channel or retry can create a
+        /// filesystem path the operator's environment denies; the caller must
+        /// fix the audit-log location.
+        case traceClearReceiptFailed = "trace_clear_receipt_failed"
         case sagaInProgress = "saga_in_progress"
         case idempotencyKeyConflict = "idempotency_key_conflict"
         case sagaJournalCapacityExceeded = "saga_journal_capacity_exceeded"
@@ -372,6 +380,10 @@ enum HonestContract {
         // classification consistency.)
         FailureError.unknownCategory.rawValue,
         FailureError.supportBundleExportFailed.rawValue,
+        // PRD-015: a trace-clear receipt-write failure is terminal — no channel
+        // or retry can create a path the operator's environment denies; the
+        // store is left intact and the caller must fix the audit-log location.
+        FailureError.traceClearReceiptFailed.rawValue,
         FailureError.idempotencyKeyConflict.rawValue,
         FailureError.sagaJournalCapacityExceeded.rawValue,
     ]

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -55,12 +55,22 @@ struct OperationCatalogTests {
         let key = "LOGIC_MCP_ADR005_OPERATION_TRACE"
         let previous = getenv(key).map { String(cString: $0) }
         setenv(key, "1", 1)
+        // PRD-015: contain the clear_traces audit receipt under a temp root so
+        // the successful clear exercised by this suite never writes to the real
+        // user Logs directory.
+        let auditKey = "LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"
+        let previousAudit = getenv(auditKey).map { String(cString: $0) }
+        let auditRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpmcp-prd015-catalog-\(UUID().uuidString)", isDirectory: true)
+        setenv(auditKey, auditRoot.path, 1)
         defer {
             if let previous {
                 setenv(key, previous, 1)
             } else {
                 unsetenv(key)
             }
+            if let previousAudit { setenv(auditKey, previousAudit, 1) } else { unsetenv(auditKey) }
+            try? FileManager.default.removeItem(at: auditRoot)
         }
         return try await operation()
     }

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -335,6 +335,17 @@ struct OperationTraceTests {
     @Test func OperationTraceSystemLifecycle() async throws {
         let previous = replaceOperationTraceFlag(with: "1")
         defer { _ = replaceOperationTraceFlag(with: previous) }
+        // PRD-015: contain the clear_traces audit receipt under a temp root so
+        // the successful clear below never writes to the real user Logs dir.
+        let auditKey = "LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"
+        let previousAudit = getenv(auditKey).map { String(cString: $0) }
+        let auditRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpmcp-prd015-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        setenv(auditKey, auditRoot.path, 1)
+        defer {
+            if let previousAudit { setenv(auditKey, previousAudit, 1) } else { unsetenv(auditKey) }
+            try? FileManager.default.removeItem(at: auditRoot)
+        }
         await OperationTraceStore.shared.clear()
 
         let id = await OperationTraceStore.shared.start(operationID: OperationID.transportPlay.rawValue)

--- a/Tests/LogicProMCPTests/TraceClearAuditTests.swift
+++ b/Tests/LogicProMCPTests/TraceClearAuditTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// PRD-015 (ADR-005 #288): `clear_traces` destroys the in-process trace
+/// evidence store, so every SUCCESSFUL clear must leave a durable, append-only
+/// audit receipt OUTSIDE the cleared store, and a receipt that cannot be
+/// written must fail closed (nothing cleared). These tests pin that contract.
+@Suite("PRD-015 clear_traces audit receipt", .serialized)
+struct TraceClearAuditTests {
+    private static let flagKey = "LOGIC_MCP_ADR005_OPERATION_TRACE"
+    private static let auditKey = "LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"
+
+    /// Sets the ADR-005 flag + the DEBUG-only audit-root override to `auditRoot`,
+    /// runs `body`, then restores both env vars. `auditRoot` may point at a
+    /// deliberately-unwritable path to exercise the fail-closed branch.
+    private func withEnv<R>(
+        flagOn: Bool,
+        auditRoot: URL,
+        _ body: () async throws -> R
+    ) async rethrows -> R {
+        let prevFlag = getenv(Self.flagKey).map { String(cString: $0) }
+        let prevAudit = getenv(Self.auditKey).map { String(cString: $0) }
+        setenv(Self.flagKey, flagOn ? "1" : "0", 1)
+        setenv(Self.auditKey, auditRoot.path, 1)
+        defer {
+            if let prevFlag { setenv(Self.flagKey, prevFlag, 1) } else { unsetenv(Self.flagKey) }
+            if let prevAudit { setenv(Self.auditKey, prevAudit, 1) } else { unsetenv(Self.auditKey) }
+        }
+        return try await body()
+    }
+
+    private func tempRoot(_ label: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpmcp-prd015-\(label)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// Seed `n` completed traces directly into the shared store. `start()` is not
+    /// flag-gated, so this works even when the ADR-005 flag is off.
+    private func seedTraces(_ n: Int) async {
+        for i in 0..<n {
+            let id = await OperationTraceStore.shared.start(operationID: "test.prd015.seed.\(i)")
+            await OperationTraceStore.shared.complete(id)
+        }
+    }
+
+    private func clearTraces(confirmed: Bool = true) async -> CallTool.Result {
+        await SystemDispatcher.handle(
+            command: "clear_traces",
+            params: confirmed ? ["confirmed": .bool(true)] : [:],
+            router: ChannelRouter(),
+            cache: StateCache()
+        )
+    }
+
+    private func nonEmptyLines(ofFileAt path: String) throws -> [String] {
+        let contents = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+        return contents.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    @Test("successful confirmed clear writes a durable receipt and empties the store")
+    func successfulClearWritesReceipt() async throws {
+        let root = tempRoot("success")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(3)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            #expect(result.isError != true)
+            let success = try #require(body["success"] as? Bool)
+            #expect(success)
+            #expect(try #require(body["cleared_trace_count"] as? Int) == 3)
+            let receiptPath = try #require(body["receipt_path"] as? String)
+            #expect(receiptPath.hasSuffix("/trace-clear.log"))
+
+            // The receipt file EXISTS, holds exactly one new line, and parses as
+            // JSON carrying the schema fields.
+            #expect(FileManager.default.fileExists(atPath: receiptPath))
+            let lines = try nonEmptyLines(ofFileAt: receiptPath)
+            #expect(lines.count == 1)
+            let receipt = try #require(sharedJSONObject(lines[0]))
+            #expect(try #require(receipt["schema"] as? String)
+                == SystemDispatcher.traceClearReceiptSchema)
+            #expect(try #require(receipt["cleared_trace_count"] as? Int) == 3)
+
+            // Store is now empty.
+            #expect(await OperationTraceStore.shared.recent(limit: 128).isEmpty)
+        }
+    }
+
+    @Test("two consecutive clears append two lines without truncating")
+    func twoClearsAppendTwoLines() async throws {
+        let root = tempRoot("append")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+            let first = await clearTraces()
+            #expect(first.isError != true)
+
+            await seedTraces(1)
+            let second = await clearTraces()
+            #expect(second.isError != true)
+
+            let receiptPath = try #require(
+                sharedJSONObject(sharedToolText(second))?["receipt_path"] as? String
+            )
+            let lines = try nonEmptyLines(ofFileAt: receiptPath)
+            // Append-only: the first receipt survived the second clear.
+            #expect(lines.count == 2)
+            let firstReceipt = try #require(sharedJSONObject(lines[0]))
+            let secondReceipt = try #require(sharedJSONObject(lines[1]))
+            #expect(try #require(firstReceipt["schema"] as? String)
+                == SystemDispatcher.traceClearReceiptSchema)
+            #expect(try #require(secondReceipt["schema"] as? String)
+                == SystemDispatcher.traceClearReceiptSchema)
+            #expect(try #require(firstReceipt["cleared_trace_count"] as? Int) == 2)
+            #expect(try #require(secondReceipt["cleared_trace_count"] as? Int) == 1)
+        }
+    }
+
+    @Test("receipt-unwritable clear fails closed and leaves the store intact")
+    func receiptUnwritableFailsClosed() async throws {
+        // The deepest existing prefix of the audit root is a regular FILE, so
+        // directory creation for the audit root fails → the clear is refused.
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpmcp-prd015-file-\(UUID().uuidString)")
+        try Data("not-a-directory".utf8).write(to: file)
+        let rootUnderFile = file.appendingPathComponent("audit", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        try await withEnv(flagOn: true, auditRoot: rootUnderFile) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(isError)
+            #expect(try #require(body["state"] as? String) == "C")
+            #expect(try #require(body["error"] as? String) == "trace_clear_receipt_failed")
+            let writeAttempted = try #require(body["write_attempted"] as? Bool)
+            #expect(!writeAttempted)
+
+            // Fail-closed: nothing was cleared.
+            #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
+            // No receipt file materialized.
+            let receiptPath = rootUnderFile.appendingPathComponent("trace-clear.log").path
+            #expect(!FileManager.default.fileExists(atPath: receiptPath))
+        }
+    }
+
+    @Test("receipt content is counts/timestamps only — exact key set, no user paths")
+    func receiptPrivacyExactKeySet() async throws {
+        let root = tempRoot("privacy")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(1)
+
+            let result = await clearTraces()
+            let receiptPath = try #require(
+                sharedJSONObject(sharedToolText(result))?["receipt_path"] as? String
+            )
+            let lines = try nonEmptyLines(ofFileAt: receiptPath)
+            #expect(lines.count == 1)
+            let line = lines[0]
+
+            // Privacy: the receipt line carries no absolute user path.
+            #expect(!line.contains("/Users/"))
+
+            let receipt = try #require(sharedJSONObject(line))
+            #expect(Set(receipt.keys) == [
+                "schema", "cleared_at", "cleared_trace_count",
+                "authorization", "server_version", "pid",
+            ])
+            #expect(try #require(receipt["schema"] as? String)
+                == "logic_pro_mcp_trace_clear_receipt.v1")
+            #expect(try #require(receipt["authorization"] as? String) == "mcp_confirmed_param")
+            #expect(try #require(receipt["server_version"] as? String) == ServerConfig.serverVersion)
+            _ = try #require(receipt["cleared_at"] as? String)
+            #expect(try #require(receipt["cleared_trace_count"] as? Int) == 1)
+            #expect(try #require(receipt["pid"] as? Int) > 0)
+        }
+    }
+
+    @Test("flag-off clear is a typed no-op with no receipt written")
+    func flagOffClearWritesNoReceipt() async throws {
+        let root = tempRoot("flagoff")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: false, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(isError)
+            #expect(try #require(body["state"] as? String) == "C")
+            #expect(try #require(body["error"] as? String) == "trace_disabled")
+            let writeAttempted = try #require(body["write_attempted"] as? Bool)
+            #expect(!writeAttempted)
+
+            // Store intact — a no-op never clears.
+            #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
+            // A no-op never writes a receipt.
+            let receiptPath = root.appendingPathComponent("trace-clear.log").path
+            #expect(!FileManager.default.fileExists(atPath: receiptPath))
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/TraceClearAuditTests.swift
+++ b/Tests/LogicProMCPTests/TraceClearAuditTests.swift
@@ -84,7 +84,10 @@ struct TraceClearAuditTests {
             let receipt = try #require(sharedJSONObject(lines[0]))
             #expect(try #require(receipt["schema"] as? String)
                 == SystemDispatcher.traceClearReceiptSchema)
-            #expect(try #require(receipt["cleared_trace_count"] as? Int) == 3)
+            // The receipt records the pre-drain SNAPSHOT; with no concurrent
+            // trace start it matches the count the drain then reported.
+            #expect(try #require(receipt["trace_count_at_receipt"] as? Int) == 3)
+            #expect(receipt["amends"] == nil)
 
             // Store is now empty.
             #expect(await OperationTraceStore.shared.recent(limit: 128).isEmpty)
@@ -117,8 +120,8 @@ struct TraceClearAuditTests {
                 == SystemDispatcher.traceClearReceiptSchema)
             #expect(try #require(secondReceipt["schema"] as? String)
                 == SystemDispatcher.traceClearReceiptSchema)
-            #expect(try #require(firstReceipt["cleared_trace_count"] as? Int) == 2)
-            #expect(try #require(secondReceipt["cleared_trace_count"] as? Int) == 1)
+            #expect(try #require(firstReceipt["trace_count_at_receipt"] as? Int) == 2)
+            #expect(try #require(secondReceipt["trace_count_at_receipt"] as? Int) == 1)
         }
     }
 
@@ -142,8 +145,12 @@ struct TraceClearAuditTests {
             #expect(isError)
             #expect(try #require(body["state"] as? String) == "C")
             #expect(try #require(body["error"] as? String) == "trace_clear_receipt_failed")
-            let writeAttempted = try #require(body["write_attempted"] as? Bool)
-            #expect(!writeAttempted)
+            // The receipt write WAS attempted here, so `write_attempted:false`
+            // would be a lie; the honest signal is that the STORE is intact.
+            let storeCleared = try #require(body["store_cleared"] as? Bool)
+            #expect(!storeCleared)
+            #expect(body["write_attempted"] == nil)
+            #expect(try #require(body["hint"] as? String).contains("left intact"))
 
             // Fail-closed: nothing was cleared.
             #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
@@ -174,7 +181,7 @@ struct TraceClearAuditTests {
 
             let receipt = try #require(sharedJSONObject(line))
             #expect(Set(receipt.keys) == [
-                "schema", "cleared_at", "cleared_trace_count",
+                "schema", "cleared_at", "trace_count_at_receipt",
                 "authorization", "server_version", "pid",
             ])
             #expect(try #require(receipt["schema"] as? String)
@@ -182,8 +189,105 @@ struct TraceClearAuditTests {
             #expect(try #require(receipt["authorization"] as? String) == "mcp_confirmed_param")
             #expect(try #require(receipt["server_version"] as? String) == ServerConfig.serverVersion)
             _ = try #require(receipt["cleared_at"] as? String)
-            #expect(try #require(receipt["cleared_trace_count"] as? Int) == 1)
+            #expect(try #require(receipt["trace_count_at_receipt"] as? Int) == 1)
             #expect(try #require(receipt["pid"] as? Int) > 0)
+        }
+    }
+
+    @Test("clearReturningCount drains atomically and reports the true count")
+    func clearReturningCountReportsTrueDrainedCount() async {
+        await OperationTraceStore.shared.clear()
+        await seedTraces(2)
+        // Traces added after the first batch are drained by the SAME call —
+        // the returned number is what this call actually removed, never a
+        // count sampled at some earlier moment.
+        await seedTraces(1)
+        #expect(await OperationTraceStore.shared.traceCount == 3)
+
+        #expect(await OperationTraceStore.shared.clearReturningCount() == 3)
+        #expect(await OperationTraceStore.shared.traceCount == 0)
+        // Draining an already-empty store honestly reports zero.
+        #expect(await OperationTraceStore.shared.clearReturningCount() == 0)
+    }
+
+    @Test("a count divergence appends an amendment line without rewriting the receipt")
+    func amendmentLineAppendsWithoutRewritingReceipt() async throws {
+        let root = tempRoot("amend")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+            let result = await clearTraces()
+            #expect(result.isError != true)
+            let receiptPath = try #require(
+                sharedJSONObject(sharedToolText(result))?["receipt_path"] as? String
+            )
+            let receiptLineBefore = try #require(nonEmptyLines(ofFileAt: receiptPath).first)
+
+            // The amendment WRITER is the unit under test: interleaving a real
+            // trace start between the dispatcher's snapshot and its atomic
+            // drain would be a race, and a race is not a deterministic test.
+            try SystemDispatcher.appendTraceClearAmendment(
+                traceCountAtReceipt: 2,
+                actualClearedCount: 3
+            )
+
+            let lines = try nonEmptyLines(ofFileAt: receiptPath)
+            #expect(lines.count == 2)
+            // Append-only: the original receipt line is byte-for-byte intact.
+            #expect(try #require(lines.first) == receiptLineBefore)
+
+            let amendmentLine = try #require(lines.last)
+            let amendment = try #require(sharedJSONObject(amendmentLine))
+            #expect(try #require(amendment["schema"] as? String)
+                == SystemDispatcher.traceClearReceiptSchema)
+            let amends = try #require(amendment["amends"] as? Bool)
+            #expect(amends)
+            // Both the corrected number and the snapshot it corrects.
+            #expect(try #require(amendment["actual_cleared_count"] as? Int) == 3)
+            #expect(try #require(amendment["trace_count_at_receipt"] as? Int) == 2)
+        }
+    }
+
+    @Test("audit dir symlinked outside its intended parent fails closed")
+    func auditDirSymlinkEscapeFailsClosed() async throws {
+        // Layout: <base>/logs/audit is a SYMLINK to <base>/outside, a real
+        // directory outside the intended parent <base>/logs. Directory
+        // creation therefore SUCCEEDS — only the post-create realpath
+        // containment check can catch the escape.
+        let base = tempRoot("symlink")
+        let intendedParent = base.appendingPathComponent("logs", isDirectory: true)
+        let outside = base.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: intendedParent, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let auditRoot = intendedParent.appendingPathComponent("audit", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: auditRoot, withDestinationURL: outside)
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        // The containment check itself refuses, independent of whatever
+        // `createDirectory` chooses to do with a symlink-to-existing-dir.
+        #expect(!SystemDispatcher.auditDirectoryIsContained(auditRoot))
+
+        try await withEnv(flagOn: true, auditRoot: auditRoot) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(isError)
+            #expect(try #require(body["state"] as? String) == "C")
+            #expect(try #require(body["error"] as? String) == "trace_clear_receipt_failed")
+            let storeCleared = try #require(body["store_cleared"] as? Bool)
+            #expect(!storeCleared)
+
+            // Fail-closed: the store survived the refused clear.
+            #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
+            // Nothing was appended at the symlink TARGET — the receipt never
+            // escaped the intended parent.
+            #expect(!FileManager.default.fileExists(
+                atPath: outside.appendingPathComponent("trace-clear.log").path
+            ))
         }
     }
 


### PR DESCRIPTION
## Summary

Debt PRD-015 (P1): a confirmed `clear_traces` destroyed the in-process trace evidence store with no durable record surviving the clear.

**Receipt (commit 1):** every successful clear first appends one JSON line to `~/Library/Logs/LogicProMCP/audit/trace-clear.log` (O_APPEND, never truncated): schema `logic_pro_mcp_trace_clear_receipt.v1`, `cleared_at`, count, `authorization: mcp_confirmed_param`, `server_version`, `pid` — counts/timestamps only, never trace contents or paths. **Receipt-write failure fails closed**: typed State C `trace_clear_receipt_failed` (terminal), store left intact — evidence is never destroyed without its receipt. Success body returns `receipt_path` + `cleared_trace_count`. The audit-root override is DEBUG-only.

**Adversarial hardening (commit 2):** the gate flagged count dishonesty (count and clear straddled an actor suspension point) — the store now **drains atomically** (`clearReturningCount()` reports what it actually removed), the receipt carries the honest `trace_count_at_receipt`, and a divergence appends one **amendment line** (`amends:true`, `actual_cleared_count`) — the first line is never rewritten. Failure extras disambiguated to `store_cleared:false`; the audit directory is realpath-verified against its intended parent before any append (symlinked final component → fail closed; guard **mutation-probed** — neutering it makes the symlink test fail with the clear succeeding). Unbounded-append acceptance documented: a rotator that can delete lines is itself the evidence-destruction surface this receipt closes.

Authorization deliberately remains the registry's l2 `confirmed` gate (local single-user server); the receipt records the authorization source so future operator-approval integration slots in.

## Verification
Full suite `--no-parallel`: **2,853 passed**; focused TraceClear/OperationTrace/SupportBundle 36/36; merged with main (`834c25b`).