### PR TITLE
fix(adr-004/prd-004): saga decisions read the live surface with per-op tolerance — never the cache (#287)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -228,7 +228,13 @@ struct SystemDispatcher: OperationTraceDispatching {
         // reorder. nil by default (saga surface tests stay deterministic);
         // production dispatch supplies the real reader.
         liveTrackName: (@Sendable (Int) -> String?)? = nil,
-        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil,
+        // LPMCP-PRD-004 — independent live AX reads for saga before-state,
+        // verification, and compensation proof. nil by default so unit call
+        // sites stay deterministic; that default is `.unavailable`, i.e. the
+        // saga fails closed at before-state capture rather than reading the
+        // stale-able cache mirror. Production dispatch supplies `.production`.
+        sagaLiveReadback: SagaLiveReadback? = nil
     ) async -> CallTool.Result {
         switch command {
         case "list_recent_traces", "get_trace", "clear_traces":
@@ -438,6 +444,7 @@ struct SystemDispatcher: OperationTraceDispatching {
                 cache: cache,
                 targetRegistry: targetRegistry,
                 dialogPresent: dialogPresent,
+                liveReadback: sagaLiveReadback ?? .unavailable,
                 liveTrackName: liveTrackName,
                 liveTrackNames: liveTrackNames
             )
@@ -547,6 +554,7 @@ struct SystemDispatcher: OperationTraceDispatching {
                     cache: cache,
                     targetRegistry: targetRegistry,
                     dialogPresent: dialogPresent,
+                    liveReadback: sagaLiveReadback ?? .unavailable,
                     liveTrackName: liveTrackName,
                     liveTrackNames: liveTrackNames
                 )

--- a/Sources/LogicProMCP/Saga/MutationSaga.swift
+++ b/Sources/LogicProMCP/Saga/MutationSaga.swift
@@ -46,9 +46,70 @@ struct StepResult: Codable, Equatable, Sendable {
     let detail: String
 }
 
+/// Which live AX primitive produced a saga observation. These are the SAME
+/// primitives the dispatchers use for their State-A verification — the saga
+/// reads the surface, never the cache mirror.
+enum SagaReadSource: String, Codable, Equatable, Sendable {
+    case axTrackHeaderFader = "ax_track_header_fader"
+    case axTrackHeaderPan = "ax_track_header_pan"
+    case axTrackName = "ax_track_name"
+    case axTrackToggle = "ax_track_toggle"
+
+    /// Short label for the human summary string.
+    var label: String {
+        switch self {
+        case .axTrackHeaderFader: "header_fader"
+        case .axTrackHeaderPan: "header_pan"
+        case .axTrackName: "track_name"
+        case .axTrackToggle: "track_toggle"
+        }
+    }
+}
+
+/// LPMCP-PRD-004: every saga observation is an INDEPENDENT live read. The enum
+/// has exactly one case on purpose — there is no legal cache-sourced saga
+/// observation, so no `state_cache` provenance can be constructed.
+enum SagaProvenance: String, Codable, Equatable, Sendable {
+    case liveIndependent = "live_independent"
+}
+
+/// Structured provenance for one saga observation. Serialized into the journal
+/// so an operator can audit WHERE a rollback value came from.
+struct SagaReadEvidence: Codable, Equatable, Sendable {
+    let readSource: SagaReadSource
+    let provenance: SagaProvenance
+    let trackIndex: Int
+    let field: String
+    let observed: Value
+    let sampledAt: String
+
+    /// Human summary, e.g. `ax_live tracks[3].volume (header_fader)`.
+    var summary: String {
+        "ax_live tracks[\(trackIndex)].\(field) (\(readSource.label))"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case readSource = "read_source"
+        case provenance
+        case trackIndex = "track_index"
+        case field
+        case observed
+        case sampledAt = "sampled_at"
+    }
+}
+
 struct ObservedState: Codable, Equatable, Sendable {
     let value: Value
     let evidence: String
+    var read: SagaReadEvidence?
+}
+
+extension ObservedState {
+    /// Build an observation from a live read — the value, the human summary,
+    /// and the structured provenance always agree because they share one source.
+    init(read: SagaReadEvidence) {
+        self.init(value: read.observed, evidence: read.summary, read: read)
+    }
 }
 
 protocol SagaStepExecutor: Sendable {
@@ -65,6 +126,10 @@ enum VerificationDisposition: String, Codable, Equatable, Sendable {
 struct VerificationEvidence: Codable, Equatable, Sendable {
     let disposition: VerificationDisposition
     let readback: ObservedState?
+    /// How the disposition was decided (comparator/epsilon/desired/observed/
+    /// delta). Absent when no comparison ran — e.g. a pre-write State C, where
+    /// `notApplied` follows from the write never crossing the boundary.
+    var comparison: SagaComparisonEvidence?
 }
 
 enum CompensationDisposition: String, Codable, Equatable, Sendable {
@@ -78,6 +143,9 @@ struct CompensationEvidence: Codable, Equatable, Sendable {
     let disposition: CompensationDisposition
     let executionResult: StepResult?
     let readback: ObservedState?
+    /// Live readback vs the captured live before-state, within the operation's
+    /// epsilon. Absent when no inverse was dispatched.
+    var comparison: SagaComparisonEvidence?
 }
 
 struct CompensationJournalRecord: Codable, Equatable, Sendable {
@@ -143,18 +211,55 @@ actor MutationSaga {
         let tool: ToolID
         let command: String
         let valueParameter: String
+        /// LPMCP-PRD-004: how an observed live value is compared to an expected
+        /// one for THIS operation. Declared next to the inverse contract so a
+        /// future allowlist entry cannot be added without deciding it.
+        let tolerance: SagaTolerance
     }
 
+    /// Epsilon rationale (absolute, on the operation's normalized range):
+    /// - rename: a name is a discrete string — `"A"` and `"A "` are different
+    ///   tracks to the operator, so exact.
+    /// - mute/solo/arm: booleans have no near-miss.
+    /// - volume (0...1, eps 0.01): the AX header fader is exposed in ~10-raw-unit
+    ///   detents, so a verified write lands on the nearest representable level,
+    ///   not the requested double.
+    /// - pan (-1...1, eps 0.05): the same detent quantization over a range twice
+    ///   as wide, and the pan control is coarser still.
     private static let reversibleDefinitions: [OperationID: ReversibleDefinition] = [
-        .tracksRename: ReversibleDefinition(tool: .logicTracks, command: "rename", valueParameter: "name"),
-        .mixerSetVolume: ReversibleDefinition(tool: .logicMixer, command: "set_volume", valueParameter: "value"),
-        .mixerSetPan: ReversibleDefinition(tool: .logicMixer, command: "set_pan", valueParameter: "value"),
-        .tracksMute: ReversibleDefinition(tool: .logicTracks, command: "mute", valueParameter: "enabled"),
-        .tracksSolo: ReversibleDefinition(tool: .logicTracks, command: "solo", valueParameter: "enabled"),
-        .tracksArm: ReversibleDefinition(tool: .logicTracks, command: "arm", valueParameter: "enabled"),
+        .tracksRename: ReversibleDefinition(
+            tool: .logicTracks, command: "rename", valueParameter: "name",
+            tolerance: .exact
+        ),
+        .mixerSetVolume: ReversibleDefinition(
+            tool: .logicMixer, command: "set_volume", valueParameter: "value",
+            tolerance: .absoluteEpsilon(0.01)
+        ),
+        .mixerSetPan: ReversibleDefinition(
+            tool: .logicMixer, command: "set_pan", valueParameter: "value",
+            tolerance: .absoluteEpsilon(0.05)
+        ),
+        .tracksMute: ReversibleDefinition(
+            tool: .logicTracks, command: "mute", valueParameter: "enabled",
+            tolerance: .exact
+        ),
+        .tracksSolo: ReversibleDefinition(
+            tool: .logicTracks, command: "solo", valueParameter: "enabled",
+            tolerance: .exact
+        ),
+        .tracksArm: ReversibleDefinition(
+            tool: .logicTracks, command: "arm", valueParameter: "enabled",
+            tolerance: .exact
+        ),
     ]
 
     nonisolated static let reversibleOperationIDs: Set<OperationID> = Set(reversibleDefinitions.keys)
+
+    /// The declared comparison contract for `operationID`, or nil when the
+    /// operation is not saga-reversible.
+    nonisolated static func tolerance(for operationID: OperationID) -> SagaTolerance? {
+        reversibleDefinitions[operationID]?.tolerance
+    }
 
     private let targetRegistry: TargetRegistry
     private let enabled: Bool
@@ -388,14 +493,19 @@ actor MutationSaga {
             switch executionResult.state {
             case .stateA:
                 let readback = await executor.readState(step)
-                let disposition = classify(
+                let disposition = classifyVerifiedWrite(
                     readback,
                     desiredValue: desiredValue,
-                    beforeState: beforeState
+                    operationID: step.operationID
                 )
                 outcome.journal[index].verificationEvidence = VerificationEvidence(
                     disposition: disposition,
-                    readback: readback
+                    readback: readback,
+                    comparison: SagaValueComparator.evidence(
+                        observed: readback?.value,
+                        desired: desiredValue,
+                        op: step.operationID
+                    )
                 )
                 if disposition == .applied {
                     appliedIndices.append(index)
@@ -429,11 +539,17 @@ actor MutationSaga {
                 let disposition = classify(
                     readback,
                     desiredValue: desiredValue,
-                    beforeState: beforeState
+                    beforeState: beforeState,
+                    operationID: step.operationID
                 )
                 outcome.journal[index].verificationEvidence = VerificationEvidence(
                     disposition: disposition,
-                    readback: readback
+                    readback: readback,
+                    comparison: SagaValueComparator.evidence(
+                        observed: readback?.value,
+                        desired: desiredValue,
+                        op: step.operationID
+                    )
                 )
                 if disposition == .applied { appliedIndices.append(index) }
                 if disposition != .applied {
@@ -458,11 +574,17 @@ actor MutationSaga {
                     let disposition = classify(
                         readback,
                         desiredValue: desiredValue,
-                        beforeState: beforeState
+                        beforeState: beforeState,
+                        operationID: step.operationID
                     )
                     outcome.journal[index].verificationEvidence = VerificationEvidence(
                         disposition: disposition,
-                        readback: readback
+                        readback: readback,
+                        comparison: SagaValueComparator.evidence(
+                            observed: readback?.value,
+                            desired: desiredValue,
+                            op: step.operationID
+                        )
                     )
                     if disposition == .applied { appliedIndices.append(index) }
                     if disposition != .applied {
@@ -584,8 +706,17 @@ actor MutationSaga {
 
             let compensationResult = await executor.run(inverse)
             let readback = await executor.readState(inverse)
+            // LPMCP-PRD-004: the restore target is the LIVE before-state
+            // captured at step time, and the proof is an independent live
+            // readback compared within the operation's epsilon — a quantized
+            // fader that restores to 0.249 has restored 0.25.
+            let comparison = SagaValueComparator.evidence(
+                observed: readback?.value,
+                desired: beforeState.value,
+                op: inverse.operationID
+            )
             let disposition: CompensationDisposition
-            if readback?.value == beforeState.value {
+            if comparison.equal {
                 disposition = .verified
                 verifiedCount += 1
             } else if readback == nil && compensationResult.writeBoundaryCrossed {
@@ -597,7 +728,8 @@ actor MutationSaga {
             outcome.journal[index].compensationEvidence = CompensationEvidence(
                 disposition: disposition,
                 executionResult: compensationResult,
-                readback: readback
+                readback: readback,
+                comparison: comparison
             )
             sessions[outcome.idempotencyKey] = outcome
         }
@@ -614,14 +746,52 @@ actor MutationSaga {
         return outcome
     }
 
+    /// State-B/C reconciliation: the write path could NOT verify itself, so the
+    /// saga decides from an independent live read, compared within the
+    /// operation's declared epsilon.
     private func classify(
         _ readback: ObservedState?,
         desiredValue: Value,
-        beforeState: ObservedState
+        beforeState: ObservedState,
+        operationID: OperationID
     ) -> VerificationDisposition {
-        if readback?.value == desiredValue { return .applied }
-        if readback?.value == beforeState.value { return .notApplied }
+        guard let readback else { return .unknown }
+        if SagaValueComparator.equals(
+            observed: readback.value,
+            expected: desiredValue,
+            op: operationID
+        ) {
+            return .applied
+        }
+        if SagaValueComparator.equals(
+            observed: readback.value,
+            expected: beforeState.value,
+            op: operationID
+        ) {
+            return .notApplied
+        }
         return .unknown
+    }
+
+    /// State A means the DISPATCHER already verified the write against the live
+    /// AX surface at the moment it landed. LPMCP-PRD-004: re-deciding that from
+    /// a second, later read is strictly worse information — a concurrent
+    /// operator nudge, or plain quantization under the old exact `==`, would
+    /// downgrade a verified write to `notApplied` and roll back a change that
+    /// actually applied. So a State-A step is `applied`. A corroborating live
+    /// read is optional evidence that can only escalate to `unknown` (drift we
+    /// cannot explain), never demote to `notApplied`.
+    private func classifyVerifiedWrite(
+        _ readback: ObservedState?,
+        desiredValue: Value,
+        operationID: OperationID
+    ) -> VerificationDisposition {
+        guard let readback else { return .applied }
+        return SagaValueComparator.equals(
+            observed: readback.value,
+            expected: desiredValue,
+            op: operationID
+        ) ? .applied : .unknown
     }
 
     private func markReconciliation(outcome: inout SagaOutcome) {

--- a/Sources/LogicProMCP/Saga/MutationSaga.swift
+++ b/Sources/LogicProMCP/Saga/MutationSaga.swift
@@ -710,6 +710,13 @@ actor MutationSaga {
             // captured at step time, and the proof is an independent live
             // readback compared within the operation's epsilon — a quantized
             // fader that restores to 0.249 has restored 0.25.
+            //
+            // No ambiguous zone here (unlike `classify`): this asks ONE
+            // question — is the surface back at the before-state? — and
+            // compares against the before-state alone. Where the desired value
+            // sits within epsilon of the before-state, the two are the same
+            // value under the declared tolerance, so no second hypothesis
+            // competes and no different action could follow from one.
             let comparison = SagaValueComparator.evidence(
                 observed: readback?.value,
                 desired: beforeState.value,
@@ -749,6 +756,17 @@ actor MutationSaga {
     /// State-B/C reconciliation: the write path could NOT verify itself, so the
     /// saga decides from an independent live read, compared within the
     /// operation's declared epsilon.
+    ///
+    /// THE AMBIGUOUS ZONE: an epsilon-tolerant comparison — unlike the exact `==`
+    /// it replaced — can match the readback against BOTH the desired value and
+    /// the before-state at once, whenever `|desired - before| <= epsilon`. A pan
+    /// step from -1.0 to -0.96 (eps 0.05) whose write failed leaves the surface
+    /// at -1.0, and -1.0 matches the desired -0.96 within epsilon. Checking
+    /// desired first would call that failed write `applied` — a false success
+    /// with no compensation. The two hypotheses (it landed / it never landed)
+    /// are indistinguishable from this read, so the honest disposition is
+    /// `unknown`: the operator is told we cannot tell, and the plan reconciles
+    /// as uncertain instead of claiming a success it did not observe.
     private func classify(
         _ readback: ObservedState?,
         desiredValue: Value,
@@ -756,21 +774,20 @@ actor MutationSaga {
         operationID: OperationID
     ) -> VerificationDisposition {
         guard let readback else { return .unknown }
-        if SagaValueComparator.equals(
+        let matchesDesired = SagaValueComparator.equals(
             observed: readback.value,
             expected: desiredValue,
             op: operationID
-        ) {
-            return .applied
-        }
-        if SagaValueComparator.equals(
+        )
+        let matchesBefore = SagaValueComparator.equals(
             observed: readback.value,
             expected: beforeState.value,
             op: operationID
-        ) {
-            return .notApplied
+        )
+        if matchesDesired {
+            return matchesBefore ? .unknown : .applied
         }
-        return .unknown
+        return matchesBefore ? .notApplied : .unknown
     }
 
     /// State A means the DISPATCHER already verified the write against the live

--- a/Sources/LogicProMCP/Saga/SagaExecution.swift
+++ b/Sources/LogicProMCP/Saga/SagaExecution.swift
@@ -1,4 +1,83 @@
+import ApplicationServices
+import Foundation
 import MCP
+
+/// The track-header toggle a saga step addresses.
+enum SagaToggleField: String, Sendable {
+    case mute
+    case solo
+    case arm
+}
+
+/// LPMCP-PRD-004 — independent LIVE read seams for saga decisions.
+///
+/// The saga used to source its before-state, verification readback, and
+/// compensation proof from `StateCache`. The cache is a poller-refreshed
+/// MIRROR: it can be stale by a poll interval, and it is refreshed by the very
+/// write the saga is trying to judge. A stale mirror means the saga can capture
+/// the WRONG before-state and then "restore" a value the operator never had —
+/// a rollback that is itself a mutation.
+///
+/// Every reader here calls the SAME AX primitive the corresponding dispatcher
+/// uses for its State-A verification, and every one returns `nil` rather than a
+/// fabricated default when the surface is unreadable — an unreadable fader must
+/// become `unknown`, never `0.0`.
+struct SagaLiveReadback: Sendable {
+    let readTrackName: @Sendable (Int) async -> String?
+    let readTrackVolume: @Sendable (Int) async -> Double?
+    let readTrackPan: @Sendable (Int) async -> Double?
+    let readTrackToggle: @Sendable (Int, SagaToggleField) async -> Bool?
+
+    /// Fail-closed seam: every read is unavailable, so every saga decision
+    /// resolves to `unknown` and every plan rejects at before-state capture.
+    /// A construction site that forgets the real reader loses the saga — it
+    /// does NOT silently fall back to a cache value.
+    static let unavailable = SagaLiveReadback(
+        readTrackName: { _ in nil },
+        readTrackVolume: { _ in nil },
+        readTrackPan: { _ in nil },
+        readTrackToggle: { _, _ in nil }
+    )
+}
+
+extension SagaLiveReadback {
+    /// Production seam. Each reader mirrors a dispatcher's State-A verification
+    /// primitive exactly:
+    /// - name: `AXLogicProElements.trackName(at:)` — the same live-identity-gated
+    ///   read the ADR-002 F5 mutation-boundary check uses.
+    /// - volume/pan: the header fader/pan slider + the same contract mapping
+    ///   `AccessibilityChannel.defaultSetMixerValue` reads back through.
+    /// - toggles: the M/S/R checkbox AXValue that
+    ///   `AccessibilityChannel.defaultSetTrackToggle` verifies against.
+    static let production = SagaLiveReadback(
+        readTrackName: { index in
+            AXLogicProElements.trackName(at: index)
+        },
+        readTrackVolume: { index in
+            guard let fader = AXLogicProElements.findTrackHeaderVolumeFader(at: index) else {
+                return nil
+            }
+            return AXValueExtractors.extractLogicMixerFaderValue(fader)
+        },
+        readTrackPan: { index in
+            guard let slider = AXLogicProElements.findTrackHeaderPanControl(at: index),
+                  let range = AXValueExtractors.extractSliderRange(slider),
+                  range.max > range.min else {
+                return nil
+            }
+            return AXValueExtractors.headerPanContract(slider, range: range)
+        },
+        readTrackToggle: { index, field in
+            let button: AXUIElement? = switch field {
+            case .mute: AXLogicProElements.findTrackMuteButton(trackIndex: index)
+            case .solo: AXLogicProElements.findTrackSoloButton(trackIndex: index)
+            case .arm: AXLogicProElements.findTrackArmButton(trackIndex: index)
+            }
+            guard let button else { return nil }
+            return AXValueExtractors.extractButtonState(button)
+        }
+    )
+}
 
 struct ProductionSagaStepExecutor: SagaStepExecutor {
     private static let allowlist: Set<OperationID> = [
@@ -11,30 +90,46 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
     ]
 
     private let router: ChannelRouter
+    // LPMCP-PRD-004: the cache is threaded to the DISPATCHERS (the write path's
+    // own resolution and the resource mirror they refresh) — it is never read
+    // for a saga decision. `readState` uses `liveReadback` only.
     private let cache: StateCache
     private let targetRegistry: TargetRegistry
     private let dialogPresent: @Sendable () -> Bool
+    /// LPMCP-PRD-004 — live AX reads for saga before-state / verification /
+    /// compensation proof. Explicit and non-optional: a saga that cannot read
+    /// the live surface must fail closed loudly, so callers name their seam
+    /// (`.production`, `.unavailable`, or a fake) at the construction site.
+    private let liveReadback: SagaLiveReadback
     // ADR-002 F5 — live AX track-header reader, threaded to the dispatchers so
     // saga-replayed / compensated track/mixer target_ref mutations fail closed
     // on an out-of-band reorder. nil by default (saga tests stay deterministic);
     // production construction supplies the real reader.
     private let liveTrackName: (@Sendable (Int) -> String?)?
     private let liveTrackNames: (@Sendable () -> [Int: String]?)?
+    /// Evidence timestamp source. Injectable so evidence assertions stay
+    /// deterministic; `sampled_at` is provenance metadata and never an input to
+    /// a saga decision.
+    private let now: @Sendable () -> Date
 
     init(
         router: ChannelRouter,
         cache: StateCache,
         targetRegistry: TargetRegistry,
         dialogPresent: @escaping @Sendable () -> Bool,
+        liveReadback: SagaLiveReadback,
         liveTrackName: (@Sendable (Int) -> String?)? = nil,
-        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.router = router
         self.cache = cache
         self.targetRegistry = targetRegistry
         self.dialogPresent = dialogPresent
+        self.liveReadback = liveReadback
         self.liveTrackName = liveTrackName
         self.liveTrackNames = liveTrackNames
+        self.now = now
     }
 
     func run(_ step: SagaStep) async -> StepResult {
@@ -149,6 +244,10 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
         return Self.mapResponse(response, operationID: step.operationID)
     }
 
+    /// LPMCP-PRD-004: every value returned here is an INDEPENDENT live AX read.
+    /// There is deliberately no cache fallback — a surface we cannot read
+    /// returns nil, which the engine treats as `unknown` (fail-closed), rather
+    /// than a mirror value that could be stale by a poll interval.
     func readState(_ step: SagaStep) async -> ObservedState? {
         guard Self.allowlist.contains(step.operationID),
               let targetRef = step.targetRef,
@@ -158,9 +257,15 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
             return nil
         }
 
-        let tracks = await cache.getTracks()
-        guard let track = tracks.first(where: { $0.id == binding.descriptor.trackIndex }),
-              TargetDescriptor(trackIndex: track.id, trackName: track.name).fingerprint
+        let index = binding.descriptor.trackIndex
+        // Per-step identity fingerprint gate, unchanged in shape but now
+        // LIVE-sourced: the cache name it used to compare could agree with the
+        // binding while the live track at `index` was a different track after
+        // an out-of-band reorder — the gate would pass and the saga would read
+        // (and later restore) the wrong track. `trackName(at:)` is itself
+        // live-identity-gated and returns nil for an unreadable header.
+        guard let liveName = await liveReadback.readTrackName(index),
+              TargetDescriptor(trackIndex: index, trackName: liveName).fingerprint
                 == binding.observedFingerprint
         else {
             return nil
@@ -168,32 +273,49 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
 
         let value: Value
         let field: String
+        let readSource: SagaReadSource
         switch step.operationID {
         case .tracksRename:
-            value = .string(track.name)
+            value = .string(liveName)
             field = "name"
+            readSource = .axTrackName
         case .mixerSetVolume:
-            value = .double(track.volume)
+            guard let volume = await liveReadback.readTrackVolume(index) else { return nil }
+            value = .double(volume)
             field = "volume"
+            readSource = .axTrackHeaderFader
         case .mixerSetPan:
-            value = .double(track.pan)
+            guard let pan = await liveReadback.readTrackPan(index) else { return nil }
+            value = .double(pan)
             field = "pan"
+            readSource = .axTrackHeaderPan
         case .tracksMute:
-            value = .bool(track.isMuted)
+            guard let muted = await liveReadback.readTrackToggle(index, .mute) else { return nil }
+            value = .bool(muted)
             field = "isMuted"
+            readSource = .axTrackToggle
         case .tracksSolo:
-            value = .bool(track.isSoloed)
+            guard let soloed = await liveReadback.readTrackToggle(index, .solo) else { return nil }
+            value = .bool(soloed)
             field = "isSoloed"
+            readSource = .axTrackToggle
         case .tracksArm:
-            value = .bool(track.isArmed)
+            guard let armed = await liveReadback.readTrackToggle(index, .arm) else { return nil }
+            value = .bool(armed)
             field = "isArmed"
+            readSource = .axTrackToggle
         default:
             return nil
         }
-        return ObservedState(
-            value: value,
-            evidence: "state_cache tracks[\(track.id)].\(field)"
-        )
+
+        return ObservedState(read: SagaReadEvidence(
+            readSource: readSource,
+            provenance: .liveIndependent,
+            trackIndex: index,
+            field: field,
+            observed: value,
+            sampledAt: ISO8601DateFormatter.cacheFormatter.string(from: now())
+        ))
     }
 
     private static func mapResponse(

--- a/Sources/LogicProMCP/Saga/SagaJournal.swift
+++ b/Sources/LogicProMCP/Saga/SagaJournal.swift
@@ -555,10 +555,14 @@ enum SagaWire {
                 } else {
                     readback = NSNull()
                 }
-                evidence["verification"] = [
+                var verificationObject: [String: Any] = [
                     "disposition": verification.disposition.rawValue,
                     "readback": readback,
                 ]
+                if let comparison = verification.comparison {
+                    verificationObject["comparison"] = comparisonObject(comparison)
+                }
+                evidence["verification"] = verificationObject
             }
             object["evidence"] = evidence
             if let compensation = record.compensationEvidence {
@@ -568,10 +572,14 @@ enum SagaWire {
                 } else {
                     readback = NSNull()
                 }
-                object["compensation"] = [
+                var compensationRecord: [String: Any] = [
                     "disposition": compensation.disposition.rawValue,
                     "readback": readback,
                 ]
+                if let comparison = compensation.comparison {
+                    compensationRecord["comparison"] = comparisonObject(comparison)
+                }
+                object["compensation"] = compensationRecord
             }
             return object
         }
@@ -581,11 +589,15 @@ enum SagaWire {
         let evidence: [[String: Any]] = outcome.journal.compactMap { record in
             guard let compensation = record.compensationEvidence,
                   let readback = compensation.readback else { return nil }
-            return [
+            var object: [String: Any] = [
                 "step_index": record.stepIndex,
                 "disposition": compensation.disposition.rawValue,
                 "readback": observedState(readback),
             ]
+            if let comparison = compensation.comparison {
+                object["comparison"] = comparisonObject(comparison)
+            }
+            return object
         }
         let verifiedCount = outcome.journal.filter {
             $0.compensationEvidence?.disposition == .verified
@@ -627,8 +639,40 @@ enum SagaWire {
         }
     }
 
+    /// LPMCP-PRD-004: saga observations carry structured provenance so an
+    /// operator can audit WHERE a rollback value came from — not just a prose
+    /// string. `evidence` stays the human summary (`ax_live tracks[3].volume
+    /// (header_fader)`).
     private static func observedState(_ state: ObservedState) -> [String: Any] {
-        ["value": foundationValue(state.value), "evidence": state.evidence]
+        var object: [String: Any] = [
+            "value": foundationValue(state.value),
+            "evidence": state.evidence,
+        ]
+        guard let read = state.read else { return object }
+        object["read_source"] = read.readSource.rawValue
+        object["provenance"] = read.provenance.rawValue
+        object["track_index"] = read.trackIndex
+        object["field"] = read.field
+        object["observed"] = foundationValue(read.observed)
+        object["sampled_at"] = read.sampledAt
+        return object
+    }
+
+    /// How a disposition was decided: comparator, epsilon, desired, observed,
+    /// delta. Absent keys mean "not applicable" (no epsilon for an exact
+    /// comparator; no delta for a string/bool field).
+    private static func comparisonObject(
+        _ comparison: SagaComparisonEvidence
+    ) -> [String: Any] {
+        var object: [String: Any] = [
+            "comparator": comparison.comparator.rawValue,
+            "equal": comparison.equal,
+        ]
+        if let epsilon = comparison.epsilon { object["epsilon"] = epsilon }
+        if let desired = comparison.desired { object["desired"] = foundationValue(desired) }
+        if let observed = comparison.observed { object["observed"] = foundationValue(observed) }
+        if let delta = comparison.delta { object["delta"] = delta }
+        return object
     }
 
     private static func foundationValue(_ value: Value) -> Any {

--- a/Sources/LogicProMCP/Saga/SagaValueComparator.swift
+++ b/Sources/LogicProMCP/Saga/SagaValueComparator.swift
@@ -1,0 +1,122 @@
+import Foundation
+import MCP
+
+/// How a saga decides that an observed value matches an expected one.
+///
+/// LPMCP-PRD-004: saga classification used to be EXACT `==` on doubles that
+/// Logic only exposes to AX in quantized detents (the mixer fader moves in
+/// ~10-raw-unit steps). A verified write of `0.7` reads back as `0.699…`, and
+/// exact equality then called it `notApplied` — a false rollback of a write
+/// that actually landed. Comparison is therefore per-operation: exact where the
+/// domain is discrete (strings, bools), absolute-epsilon where the surface
+/// quantizes (volume, pan).
+enum SagaComparator: String, Codable, Equatable, Sendable {
+    case exact
+    case absoluteEpsilon = "abs_eps"
+}
+
+/// The comparison contract for one operation.
+///
+/// The epsilon is ABSOLUTE, never relative: both quantized fields are already
+/// normalized (volume 0...1, pan -1...1), so a relative epsilon would shrink to
+/// nothing near zero — exactly where a pan detent still spans 0.05 — and a
+/// centred pan could never verify.
+struct SagaTolerance: Codable, Equatable, Sendable {
+    let comparator: SagaComparator
+    let epsilon: Double?
+
+    static let exact = SagaTolerance(comparator: .exact, epsilon: nil)
+
+    static func absoluteEpsilon(_ epsilon: Double) -> SagaTolerance {
+        SagaTolerance(comparator: .absoluteEpsilon, epsilon: epsilon)
+    }
+}
+
+/// Serialized proof of HOW a saga decision was reached, so an operator reading
+/// the journal can tell an epsilon-tolerated match from an exact one.
+struct SagaComparisonEvidence: Codable, Equatable, Sendable {
+    let comparator: SagaComparator
+    let epsilon: Double?
+    let desired: Value?
+    let observed: Value?
+    let delta: Double?
+    let equal: Bool
+}
+
+/// The single decision point for saga value equality.
+///
+/// Used by State-B/C classification and compensation verification ONLY. A
+/// State-A step is already live-verified by the dispatcher and is NOT
+/// re-decided here (see `MutationSaga.classifyVerifiedWrite`).
+enum SagaValueComparator {
+    /// The declared tolerance for `op`. Unknown operations fall back to
+    /// `exact` — fail-closed: an operation nobody declared a tolerance for
+    /// must not silently inherit a permissive epsilon.
+    static func tolerance(for op: OperationID) -> SagaTolerance {
+        MutationSaga.tolerance(for: op) ?? .exact
+    }
+
+    static func equals(observed: Value, expected: Value, op: OperationID) -> Bool {
+        let tolerance = tolerance(for: op)
+        switch tolerance.comparator {
+        case .exact:
+            return observed == expected
+        case .absoluteEpsilon:
+            // Fail closed on a missing epsilon or a non-numeric value: a
+            // quantized field that arrives as a string/bool is a contract
+            // violation, not a match.
+            guard let epsilon = tolerance.epsilon,
+                  let observedNumber = numeric(observed),
+                  let expectedNumber = numeric(expected),
+                  observedNumber.isFinite,
+                  expectedNumber.isFinite else {
+                return false
+            }
+            return abs(observedNumber - expectedNumber) <= epsilon
+        }
+    }
+
+    /// Absolute difference between two numeric values, or nil when either side
+    /// is absent/non-numeric (string and bool fields have no meaningful delta).
+    static func delta(observed: Value?, expected: Value?) -> Double? {
+        guard let observed,
+              let expected,
+              let observedNumber = numeric(observed),
+              let expectedNumber = numeric(expected),
+              observedNumber.isFinite,
+              expectedNumber.isFinite else {
+            return nil
+        }
+        return abs(observedNumber - expectedNumber)
+    }
+
+    static func evidence(
+        observed: Value?,
+        desired: Value?,
+        op: OperationID
+    ) -> SagaComparisonEvidence {
+        let tolerance = tolerance(for: op)
+        let equal: Bool
+        if let observed, let desired {
+            equal = equals(observed: observed, expected: desired, op: op)
+        } else {
+            equal = false
+        }
+        return SagaComparisonEvidence(
+            comparator: tolerance.comparator,
+            epsilon: tolerance.epsilon,
+            desired: desired,
+            observed: observed,
+            delta: delta(observed: observed, expected: desired),
+            equal: equal
+        )
+    }
+
+    private static func numeric(_ value: Value) -> Double? {
+        switch value {
+        case .double(let double): double
+        case .int(let int): Double(int)
+        default: nil
+        }
+    }
+}

--- a/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
@@ -255,7 +255,10 @@ enum OperationHandlerRegistry {
                     // track-header reader so saga-replayed target_ref track/mixer
                     // steps fail closed on an out-of-band reorder.
                     liveTrackName: { AXLogicProElements.trackName(at: $0) },
-                    liveTrackNames: { AXLogicProElements.trackNames() }
+                    liveTrackNames: { AXLogicProElements.trackNames() },
+                    // LPMCP-PRD-004 — saga before-state/verification/compensation
+                    // read the live AX surface, never the cache mirror.
+                    sagaLiveReadback: .production
                 )
             }
         case .logicPlugins:

--- a/Tests/LogicProMCPTests/SagaExecutionTests.swift
+++ b/Tests/LogicProMCPTests/SagaExecutionTests.swift
@@ -25,6 +25,7 @@ private actor SagaRecordingChannel: Channel {
     nonisolated let id: ChannelID = .accessibility
 
     private let cache: StateCache
+    private let surface: SagaLiveTrackSurface
     private let failureAt: Int?
     private let failureCode: String
     private let failureWriteAttempted: Bool?
@@ -34,6 +35,7 @@ private actor SagaRecordingChannel: Channel {
 
     init(
         cache: StateCache,
+        surface: SagaLiveTrackSurface,
         failureAt: Int? = nil,
         failureCode: String = "invalid_params",
         failureWriteAttempted: Bool? = nil,
@@ -41,6 +43,7 @@ private actor SagaRecordingChannel: Channel {
         failureSuccess: Bool = false
     ) {
         self.cache = cache
+        self.surface = surface
         self.failureAt = failureAt
         self.failureCode = failureCode
         self.failureWriteAttempted = failureWriteAttempted
@@ -72,27 +75,36 @@ private actor SagaRecordingChannel: Channel {
         guard let rawIndex = params["index"], let index = Int(rawIndex) else {
             return .error(HonestContract.encodeStateC(error: .invalidParams))
         }
+        // A write lands on the LIVE surface (what Logic actually holds) and is
+        // mirrored into the cache, exactly as production's refreshAfterWrite
+        // eventually would. Tests that need a stale mirror desync them by hand.
         switch operation {
         case "track.rename":
             guard let name = params["name"] else {
                 return .error(HonestContract.encodeStateC(error: .invalidParams))
             }
+            surface.update(index) { $0.name = name }
             await cache.updateTrack(at: index) { $0.name = name }
         case "mixer.set_volume":
             guard let raw = params["volume"], let value = Double(raw) else {
                 return .error(HonestContract.encodeStateC(error: .invalidParams))
             }
+            surface.update(index) { $0.volume = value }
             await cache.updateTrack(at: index) { $0.volume = value }
         case "mixer.set_pan":
             guard let raw = params["pan"], let value = Double(raw) else {
                 return .error(HonestContract.encodeStateC(error: .invalidParams))
             }
+            surface.update(index) { $0.pan = value }
             await cache.updateTrack(at: index) { $0.pan = value }
         case "track.set_mute":
+            surface.update(index) { $0.isMuted = params["enabled"] == "true" }
             await cache.updateTrack(at: index) { $0.isMuted = params["enabled"] == "true" }
         case "track.set_solo":
+            surface.update(index) { $0.isSoloed = params["enabled"] == "true" }
             await cache.updateTrack(at: index) { $0.isSoloed = params["enabled"] == "true" }
         case "track.set_arm":
+            surface.update(index) { $0.isArmed = params["enabled"] == "true" }
             await cache.updateTrack(at: index) { $0.isArmed = params["enabled"] == "true" }
         default:
             return .error(HonestContract.encodeStateC(error: .commandNotExposed))
@@ -109,6 +121,26 @@ private actor SagaRecordingChannel: Channel {
     }
 }
 
+/// Fails the rename step AFTER its write boundary so the preceding volume
+/// step's compensation runs — while leaving the live-read seams under test
+/// entirely untouched.
+private struct RenameFailingExecutor: SagaStepExecutor {
+    let base: ProductionSagaStepExecutor
+
+    func run(_ step: SagaStep) async -> StepResult {
+        guard step.operationID == .tracksRename else { return await base.run(step) }
+        return StepResult(
+            state: .stateC,
+            writeBoundaryCrossed: true,
+            detail: "tracks.rename: error=ax_write_failed"
+        )
+    }
+
+    func readState(_ step: SagaStep) async -> ObservedState? {
+        await base.readState(step)
+    }
+}
+
 @Suite("Production saga execution", .serialized)
 struct SagaExecutionTests {
     private struct Scenario: Sendable {
@@ -122,6 +154,7 @@ struct SagaExecutionTests {
         let executor: ProductionSagaStepExecutor
         let channel: SagaRecordingChannel
         let cache: StateCache
+        let surface: SagaLiveTrackSurface
         let registry: TargetRegistry
         let target: TargetReference
     }
@@ -134,19 +167,19 @@ struct SagaExecutionTests {
         failureSuccess: Bool = false,
         dialogPresent: @escaping @Sendable () -> Bool = { false }
     ) async -> Fixture {
+        let track = TrackState(
+            id: 0,
+            name: "Bass",
+            type: .audio,
+            isMuted: false,
+            isSoloed: true,
+            isArmed: false,
+            volume: 0.25,
+            pan: -0.5
+        )
         let cache = StateCache()
-        await cache.updateTracks([
-            TrackState(
-                id: 0,
-                name: "Bass",
-                type: .audio,
-                isMuted: false,
-                isSoloed: true,
-                isArmed: false,
-                volume: 0.25,
-                pan: -0.5
-            ),
-        ])
+        await cache.updateTracks([track])
+        let surface = SagaLiveTrackSurface([track])
         let registry = TargetRegistry()
         let descriptor = TargetDescriptor(trackIndex: 0, trackName: "Bass")
         let target = await registry.bind(
@@ -156,6 +189,7 @@ struct SagaExecutionTests {
         )
         let channel = SagaRecordingChannel(
             cache: cache,
+            surface: surface,
             failureAt: failureAt,
             failureCode: failureCode,
             failureWriteAttempted: failureWriteAttempted,
@@ -169,10 +203,12 @@ struct SagaExecutionTests {
                 router: router,
                 cache: cache,
                 targetRegistry: registry,
-                dialogPresent: dialogPresent
+                dialogPresent: dialogPresent,
+                liveReadback: surface.readback
             ),
             channel: channel,
             cache: cache,
+            surface: surface,
             registry: registry,
             target: target
         )
@@ -184,42 +220,42 @@ struct SagaExecutionTests {
             Scenario(
                 before: .string("Bass"),
                 desired: .string("Lead"),
-                evidence: "state_cache tracks[0].name",
+                evidence: "ax_live tracks[0].name (track_name)",
                 channelOperation: "track.rename"
             )
         case .mixerSetVolume:
             Scenario(
                 before: .double(0.25),
                 desired: .double(0.75),
-                evidence: "state_cache tracks[0].volume",
+                evidence: "ax_live tracks[0].volume (header_fader)",
                 channelOperation: "mixer.set_volume"
             )
         case .mixerSetPan:
             Scenario(
                 before: .double(-0.5),
                 desired: .double(0.5),
-                evidence: "state_cache tracks[0].pan",
+                evidence: "ax_live tracks[0].pan (header_pan)",
                 channelOperation: "mixer.set_pan"
             )
         case .tracksMute:
             Scenario(
                 before: .bool(false),
                 desired: .bool(true),
-                evidence: "state_cache tracks[0].isMuted",
+                evidence: "ax_live tracks[0].isMuted (track_toggle)",
                 channelOperation: "track.set_mute"
             )
         case .tracksSolo:
             Scenario(
                 before: .bool(true),
                 desired: .bool(false),
-                evidence: "state_cache tracks[0].isSoloed",
+                evidence: "ax_live tracks[0].isSoloed (track_toggle)",
                 channelOperation: "track.set_solo"
             )
         case .tracksArm:
             Scenario(
                 before: .bool(false),
                 desired: .bool(true),
-                evidence: "state_cache tracks[0].isArmed",
+                evidence: "ax_live tracks[0].isArmed (track_toggle)",
                 channelOperation: "track.set_arm"
             )
         default:
@@ -440,11 +476,13 @@ struct SagaExecutionTests {
 
     @Test("before-state capture is all-or-nothing")
     func captureBeforeStateReturnsEmptyWhenAnyStepCannotBeRead() async {
-        let cache = StateCache()
-        await cache.updateTracks([
+        let tracks = [
             TrackState(id: 0, name: "Bass", type: .audio, volume: 0.25),
             TrackState(id: 1, name: "Keys", type: .softwareInstrument, pan: -0.25),
-        ])
+        ]
+        let cache = StateCache()
+        await cache.updateTracks(tracks)
+        let surface = SagaLiveTrackSurface(tracks)
         let registry = TargetRegistry()
         let staleDescriptor = TargetDescriptor(trackIndex: 1, trackName: "Keys")
         let stale = await registry.bind(
@@ -459,14 +497,15 @@ struct SagaExecutionTests {
             descriptor: validDescriptor,
             fingerprint: validDescriptor.fingerprint
         )
-        let channel = SagaRecordingChannel(cache: cache)
+        let channel = SagaRecordingChannel(cache: cache, surface: surface)
         let router = ChannelRouter()
         await router.register(channel)
         let executor = ProductionSagaStepExecutor(
             router: router,
             cache: cache,
             targetRegistry: registry,
-            dialogPresent: { false }
+            dialogPresent: { false },
+            liveReadback: surface.readback
         )
 
         let validPlan = SagaPlan(
@@ -490,16 +529,106 @@ struct SagaExecutionTests {
         #expect(await executor.captureBeforeState(plan: invalidPlan).isEmpty)
     }
 
+    /// LPMCP-PRD-004 (the debt itself). The cache is a poller mirror; it can be
+    /// stale by a poll interval. Pre-fix, `readState` read it — so a saga whose
+    /// mirror still said 0.25 while the operator had already moved the fader to
+    /// 0.80 would capture 0.25 as the before-state and, on rollback, "restore"
+    /// a value the operator never had. That is a rollback that is itself a
+    /// destructive mutation. The before-state must come from the live surface.
+    @Test("stale cache never sources the before-state a rollback restores")
+    func staleCacheNeverSourcesBeforeState() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let fixture = await makeFixture()
+            // Live truth diverges from the mirror: the operator moved the
+            // fader out-of-band and the poller has not caught up.
+            fixture.surface.update(0) { $0.volume = 0.80 }
+            #expect(await fixture.cache.getTracks().first?.volume == 0.25)
+
+            let before = await fixture.executor.readState(
+                step(.mixerSetVolume, target: fixture.target, value: .double(0.5))
+            )
+            #expect(before?.value == .double(0.80))
+            #expect(before?.value != .double(0.25))
+            #expect(before?.read?.provenance == .liveIndependent)
+            #expect(before?.read?.readSource == .axTrackHeaderFader)
+
+            // And end-to-end: the compensation restores the LIVE 0.80, not the
+            // cached 0.25.
+            let plan = SagaPlan(
+                steps: [
+                    step(.mixerSetVolume, target: fixture.target, value: .double(0.5)),
+                    step(.tracksRename, target: fixture.target, value: .string("Nope")),
+                ],
+                idempotencyKey: "stale-cache-before-state"
+            )
+            let outcome = await MutationSaga(
+                targetRegistry: fixture.registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            ).execute(plan, executor: RenameFailingExecutor(base: fixture.executor))
+
+            #expect(outcome.journal[0].beforeState?.value == .double(0.80))
+            #expect(outcome.journal[0].compensationEvidence?.disposition == .verified)
+            #expect(fixture.surface.snapshot(0)?.volume == 0.80)
+        }
+    }
+
+    /// LPMCP-PRD-004: saga evidence must name a live, independent read — and
+    /// must never claim the cache. `state_cache` appearing anywhere in a saga
+    /// journal is the bug this debt closed.
+    @Test("saga evidence is live-provenanced and never cache-provenanced")
+    func sagaEvidenceIsLiveProvenanced() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let fixture = await makeFixture()
+            let observed = try #require(await fixture.executor.readState(
+                step(.mixerSetVolume, target: fixture.target, value: .double(0.5))
+            ))
+            #expect(observed.evidence == "ax_live tracks[0].volume (header_fader)")
+            #expect(!observed.evidence.contains("state_cache"))
+
+            let read = try #require(observed.read)
+            #expect(read.provenance.rawValue == "live_independent")
+            #expect(read.readSource.rawValue == "ax_track_header_fader")
+            #expect(read.trackIndex == 0)
+            #expect(read.field == "volume")
+            #expect(read.observed == .double(0.25))
+            #expect(!read.sampledAt.isEmpty)
+        }
+    }
+
+    /// The live seam is the ONLY source: with the seam unavailable there is no
+    /// cache fallback to quietly answer from, even though the cache is
+    /// populated and the binding resolves.
+    @Test("unreadable live surface fails closed instead of falling back to cache")
+    func unreadableLiveSurfaceFailsClosed() async {
+        await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let fixture = await makeFixture()
+            let blindExecutor = ProductionSagaStepExecutor(
+                router: ChannelRouter(),
+                cache: fixture.cache,
+                targetRegistry: fixture.registry,
+                dialogPresent: { false },
+                liveReadback: .unavailable
+            )
+            #expect(await fixture.cache.getTracks().first?.volume == 0.25)
+            #expect(await blindExecutor.readState(
+                step(.mixerSetVolume, target: fixture.target, value: .double(0.5))
+            ) == nil)
+        }
+    }
+
     @Test("engine compensates every applied prefix in reverse")
     func mutationSagaFailurePositionMatrix() async {
         await FeatureFlags.withAdr002TargetRefForTests(true) {
             for failureAt in 1...3 {
-                let cache = StateCache()
-                await cache.updateTracks([
+                let tracks = [
                     TrackState(id: 0, name: "Lead", type: .audio),
                     TrackState(id: 1, name: "Pad", type: .softwareInstrument, volume: 0.2),
                     TrackState(id: 2, name: "FX", type: .audio, pan: 0),
-                ])
+                ]
+                let cache = StateCache()
+                await cache.updateTracks(tracks)
+                let surface = SagaLiveTrackSurface(tracks)
                 let registry = TargetRegistry()
                 var targets: [TargetReference] = []
                 for track in await cache.getTracks() {
@@ -510,14 +639,19 @@ struct SagaExecutionTests {
                         fingerprint: descriptor.fingerprint
                     ))
                 }
-                let channel = SagaRecordingChannel(cache: cache, failureAt: failureAt)
+                let channel = SagaRecordingChannel(
+                    cache: cache,
+                    surface: surface,
+                    failureAt: failureAt
+                )
                 let router = ChannelRouter()
                 await router.register(channel)
                 let executor = ProductionSagaStepExecutor(
                     router: router,
                     cache: cache,
                     targetRegistry: registry,
-                    dialogPresent: { false }
+                    dialogPresent: { false },
+                    liveReadback: surface.readback
                 )
                 let plan = SagaPlan(
                     steps: [
@@ -550,10 +684,11 @@ struct SagaExecutionTests {
                 }
                 #expect(operations == expectedOperations, "failure position \(failureAt)")
 
-                let tracks = await cache.getTracks()
-                #expect(tracks[0].name == "Lead", "failure position \(failureAt)")
-                #expect(tracks[1].volume == 0.2, "failure position \(failureAt)")
-                #expect(tracks[2].pan == 0, "failure position \(failureAt)")
+                // Assert on the LIVE surface: it, not the cache mirror, is what
+                // the operator's Logic actually holds after compensation.
+                #expect(surface.snapshot(0)?.name == "Lead", "failure position \(failureAt)")
+                #expect(surface.snapshot(1)?.volume == 0.2, "failure position \(failureAt)")
+                #expect(surface.snapshot(2)?.pan == 0, "failure position \(failureAt)")
                 for index in 0..<failureAt - 1 {
                     #expect(
                         outcome.journal[index].compensationEvidence?.disposition == .verified,

--- a/Tests/LogicProMCPTests/SagaLiveTrackSurfaceFake.swift
+++ b/Tests/LogicProMCPTests/SagaLiveTrackSurfaceFake.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import LogicProMCP
+
+/// Models the LIVE Logic surface that the saga's AX read seams observe —
+/// deliberately SEPARATE from `StateCache`.
+///
+/// LPMCP-PRD-004: the cache is a poller-refreshed mirror and can disagree with
+/// what Logic actually holds. Keeping the two distinct in tests is what makes
+/// "the saga never sources a decision from the cache" assertable: a test can
+/// desync them and watch which one the saga believes.
+final class SagaLiveTrackSurface: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tracks: [Int: TrackState]
+    private var reads = 0
+
+    init(_ tracks: [TrackState]) {
+        self.tracks = Dictionary(uniqueKeysWithValues: tracks.map { ($0.id, $0) })
+    }
+
+    func snapshot(_ index: Int) -> TrackState? {
+        lock.lock()
+        defer { lock.unlock() }
+        return tracks[index]
+    }
+
+    func update(_ index: Int, _ mutate: (inout TrackState) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var track = tracks[index] else { return }
+        mutate(&track)
+        tracks[index] = track
+    }
+
+    func readCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads
+    }
+
+    private func noteRead() {
+        lock.lock()
+        reads += 1
+        lock.unlock()
+    }
+
+    /// The live-read seam the executor consumes. An absent track reads as nil
+    /// on every field — the fail-closed case, never a fabricated default.
+    var readback: SagaLiveReadback {
+        SagaLiveReadback(
+            readTrackName: { [self] index in
+                noteRead()
+                return snapshot(index)?.name
+            },
+            readTrackVolume: { [self] index in
+                noteRead()
+                return snapshot(index)?.volume
+            },
+            readTrackPan: { [self] index in
+                noteRead()
+                return snapshot(index)?.pan
+            },
+            readTrackToggle: { [self] index, field in
+                noteRead()
+                guard let track = snapshot(index) else { return nil }
+                return switch field {
+                case .mute: track.isMuted
+                case .solo: track.isSoloed
+                case .arm: track.isArmed
+                }
+            }
+        )
+    }
+}

--- a/Tests/LogicProMCPTests/SagaSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/SagaSurfaceTests.swift
@@ -6,19 +6,24 @@ import Testing
 private actor SagaSurfaceWriteProbeChannel: Channel {
     nonisolated let id: ChannelID = .accessibility
     private let cache: StateCache
+    private let surface: SagaLiveTrackSurface?
     private let failureCalls: Set<Int>
-    private let updatesCache: Bool
+    /// Whether a write actually lands. `false` models a write Logic silently
+    /// ignored: neither the live surface nor the cache moves.
+    private let updatesState: Bool
     private var calls: [(operation: String, params: [String: String])] = []
     private var boundarySeenAtFirstDispatch = false
 
     init(
         cache: StateCache = StateCache(),
+        surface: SagaLiveTrackSurface? = nil,
         failureCalls: Set<Int> = [],
-        updatesCache: Bool = true
+        updatesState: Bool = true
     ) {
         self.cache = cache
+        self.surface = surface
         self.failureCalls = failureCalls
-        self.updatesCache = updatesCache
+        self.updatesState = updatesState
     }
 
     func start() async throws {}
@@ -45,12 +50,18 @@ private actor SagaSurfaceWriteProbeChannel: Channel {
             guard let name = params["name"] else {
                 return .error(HonestContract.encodeStateC(error: .invalidParams))
             }
-            if updatesCache { await cache.updateTrack(at: index) { $0.name = name } }
+            if updatesState {
+                surface?.update(index) { $0.name = name }
+                await cache.updateTrack(at: index) { $0.name = name }
+            }
         case "mixer.set_volume":
             guard let rawValue = params["volume"], let value = Double(rawValue) else {
                 return .error(HonestContract.encodeStateC(error: .invalidParams))
             }
-            if updatesCache { await cache.updateTrack(at: index) { $0.volume = value } }
+            if updatesState {
+                surface?.update(index) { $0.volume = value }
+                await cache.updateTrack(at: index) { $0.volume = value }
+            }
         default:
             return .error(HonestContract.encodeStateC(error: .commandNotExposed))
         }
@@ -106,6 +117,12 @@ private actor BlockingSagaRefreshProbe {
     }
 }
 
+private actor SagaRefreshCounter {
+    private var calls = 0
+    func note() { calls += 1 }
+    func count() -> Int { calls }
+}
+
 private actor SagaPhaseBarrier {
     private var entered = false
     private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
@@ -136,6 +153,8 @@ struct SagaSurfaceTests {
     private struct Fixture: Sendable {
         let router: ChannelRouter
         let cache: StateCache
+        /// The live AX surface the saga reads — distinct from `cache`.
+        let surface: SagaLiveTrackSurface
         let targetRegistry: TargetRegistry
         let journal: SagaJournal
         let channel: SagaSurfaceWriteProbeChannel
@@ -187,10 +206,13 @@ struct SagaSurfaceTests {
         )
     }
 
+    /// `populateState` seeds BOTH the live surface and the cache mirror. An
+    /// empty live surface is what makes a before-state unavailable now — the
+    /// cache is no longer a saga read source at all.
     private func makeFixture(
         failureCalls: Set<Int> = [],
-        populateCache: Bool = true,
-        updatesCache: Bool = true,
+        populateState: Bool = true,
+        updatesState: Bool = true,
         journal: SagaJournal = SagaJournal()
     ) async -> Fixture {
         let cache = StateCache()
@@ -198,7 +220,8 @@ struct SagaSurfaceTests {
             TrackState(id: 0, name: "Bass", type: .audio, volume: 0.25),
             TrackState(id: 1, name: "Keys", type: .softwareInstrument, volume: 0.2),
         ]
-        if populateCache { await cache.updateTracks(tracks) }
+        if populateState { await cache.updateTracks(tracks) }
+        let surface = SagaLiveTrackSurface(populateState ? tracks : [])
         let targetRegistry = TargetRegistry()
         var targets: [TargetReference] = []
         for track in tracks {
@@ -211,14 +234,16 @@ struct SagaSurfaceTests {
         }
         let channel = SagaSurfaceWriteProbeChannel(
             cache: cache,
+            surface: surface,
             failureCalls: failureCalls,
-            updatesCache: updatesCache
+            updatesState: updatesState
         )
         let router = ChannelRouter()
         await router.register(channel)
         return Fixture(
             router: router,
             cache: cache,
+            surface: surface,
             targetRegistry: targetRegistry,
             journal: journal,
             channel: channel,
@@ -289,7 +314,8 @@ struct SagaSurfaceTests {
             sagaJournal: fixture.journal,
             mutationGate: mutationGate,
             sagaAfterJournalBegin: sagaAfterJournalBegin,
-            sagaRefreshAfterWrite: sagaRefreshAfterWrite
+            sagaRefreshAfterWrite: sagaRefreshAfterWrite,
+            sagaLiveReadback: fixture.surface.readback
         )
     }
 
@@ -539,7 +565,7 @@ struct SagaSurfaceTests {
             #expect(readyAvailability.allSatisfy { ($0["available"] as? Bool)! })
             #expect(await ready.channel.writeCount() == 0)
 
-            let unavailable = await makeFixture(populateCache: false)
+            let unavailable = await makeFixture(populateState: false)
             let unavailableResult = await dispatch(
                 command: "saga_preflight",
                 params: plan(idempotencyKey: "preflight-unavailable", steps: [
@@ -593,7 +619,36 @@ struct SagaSurfaceTests {
                 #expect(stepResult["state"] as? String == "A")
                 #expect(verification["disposition"] as? String == "applied")
                 #expect(!(try #require(readback["evidence"] as? String)).isEmpty)
+
+                // LPMCP-PRD-004: every serialized saga observation names an
+                // independent LIVE read, structurally — not just in prose.
+                let before = try #require(evidence["before_state"] as? [String: Any])
+                for observation in [before, readback] {
+                    let summary = try #require(observation["evidence"] as? String)
+                    #expect(summary.hasPrefix("ax_live "))
+                    #expect(!summary.contains("state_cache"))
+                    #expect(observation["provenance"] as? String == "live_independent")
+                    #expect(observation["track_index"] is NSNumber)
+                    #expect(!(try #require(observation["read_source"] as? String)).isEmpty)
+                    #expect(!(try #require(observation["field"] as? String)).isEmpty)
+                    #expect(!(try #require(observation["sampled_at"] as? String)).isEmpty)
+                }
+
+                // ...and the comparator that decided it is on the wire.
+                let comparison = try #require(verification["comparison"] as? [String: Any])
+                let comparator = try #require(comparison["comparator"] as? String)
+                #expect(["exact", "abs_eps"].contains(comparator))
+                #expect(try #require(comparison["equal"] as? Bool))
             }
+
+            // The whole envelope must never claim a cache provenance anywhere.
+            guard case .text(let rawBody, _, _) = result.content.first else {
+                Issue.record("expected text tool result")
+                return
+            }
+            #expect(!rawBody.contains("state_cache"))
+            #expect(rawBody.contains("ax_live"))
+            #expect(rawBody.contains("live_independent"))
             let volumeEvidence = try #require(steps[1]["evidence"] as? [String: Any])
             let volumeVerification = try #require(
                 volumeEvidence["verification"] as? [String: Any]
@@ -609,10 +664,21 @@ struct SagaSurfaceTests {
         }
     }
 
-    @Test("surface refreshes observed state after a verified channel write")
-    func executeRefreshesBeforeEngineVerification() async throws {
+    /// LPMCP-PRD-004 — the debt, at the public surface. `refreshAfterWrite` is a
+    /// RESOURCE-cache mitigation and nothing more: it must never be able to
+    /// manufacture a saga verification.
+    ///
+    /// Here the write does NOT land (the live fader stays 0.2) but the refresh
+    /// writes the desired 0.75 into the cache mirror. Pre-fix, the saga read
+    /// that cache, saw its own refresh echoed back, and reported a clean State A
+    /// for a write that never happened — the cache verifying the cache. Now the
+    /// saga reads the live surface, sees 0.2 against a desired 0.75, and reports
+    /// drift instead of a false success.
+    @Test("refreshAfterWrite cannot manufacture a saga verification")
+    func refreshAfterWriteCannotManufactureVerification() async throws {
         try await withSagaFeatures {
-            let fixture = await makeFixture(updatesCache: false)
+            let fixture = await makeFixture(updatesState: false)
+            let refreshed = SagaRefreshCounter()
             let result = try resultObject(await dispatch(
                 command: "saga_execute",
                 params: plan(idempotencyKey: "refresh-before-verify", steps: [
@@ -625,12 +691,28 @@ struct SagaSurfaceTests {
                 ]),
                 fixture: fixture,
                 sagaRefreshAfterWrite: {
+                    await refreshed.note()
                     await fixture.cache.updateTrack(at: 1) { $0.volume = 0.75 }
                 }
             ))
 
-            #expect(result["state"] as? String == "A")
+            // refreshAfterWrite still runs on the write path (it stays as the
+            // resource-cache mitigation it was always meant to be)...
+            #expect(await refreshed.count() == 1)
+            #expect(await fixture.cache.getTracks()[1].volume == 0.75)
             #expect(await fixture.channel.writeCount() == 1)
+
+            // ...but it did NOT buy a State A. The live fader never moved.
+            #expect(result["state"] as? String != "A")
+            #expect(fixture.surface.snapshot(1)?.volume == 0.2)
+
+            let steps = try #require(result["steps"] as? [[String: Any]])
+            let evidence = try #require(steps.first?["evidence"] as? [String: Any])
+            let verification = try #require(evidence["verification"] as? [String: Any])
+            #expect(verification["disposition"] as? String == "unknown")
+            let readback = try #require(verification["readback"] as? [String: Any])
+            #expect(readback["provenance"] as? String == "live_independent")
+            #expect(readback["value"] as? Double == 0.2)
         }
     }
 
@@ -712,7 +794,7 @@ struct SagaSurfaceTests {
     @Test("execute classifies unavailable before-state separately from malformed input")
     func executeUnavailableBeforeStateIsReadbackUnavailable() async throws {
         try await withSagaFeatures {
-            let fixture = await makeFixture(populateCache: false)
+            let fixture = await makeFixture(populateState: false)
             let result = try resultObject(await dispatch(
                 command: "saga_execute",
                 params: plan(idempotencyKey: "execute-no-before", steps: [
@@ -1084,7 +1166,7 @@ struct SagaSurfaceTests {
     @Test("cancellation racing rejected preflight reaches a verified terminal record")
     func sagaCancellationAtRejectedPreflightDoesNotRemainPending() async throws {
         try await withSagaFeatures {
-            let fixture = await makeFixture(populateCache: false)
+            let fixture = await makeFixture(populateState: false)
             let barrier = SagaPhaseBarrier()
             let params = plan(idempotencyKey: "cancel-preflight-refusal", steps: [
                 step(

--- a/Tests/LogicProMCPTests/SagaValueComparatorTests.swift
+++ b/Tests/LogicProMCPTests/SagaValueComparatorTests.swift
@@ -1,0 +1,363 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// Drives one saga step to a chosen write-path state with a chosen live
+/// readback, so classification can be asserted in isolation. The first read is
+/// the before-state; every later read is the post-write readback.
+private actor StubReadbackExecutor: SagaStepExecutor {
+    private let before: Value
+    private let readback: Value?
+    private let result: StepResult
+    private var reads = 0
+
+    init(before: Value, readback: Value?, result: StepResult) {
+        self.before = before
+        self.readback = readback
+        self.result = result
+    }
+
+    func run(_ step: SagaStep) async -> StepResult { result }
+
+    func readState(_ step: SagaStep) async -> ObservedState? {
+        reads += 1
+        let value: Value? = reads == 1 ? before : readback
+        guard let value else { return nil }
+        return ObservedState(read: SagaReadEvidence(
+            readSource: .axTrackHeaderFader,
+            provenance: .liveIndependent,
+            trackIndex: 0,
+            field: "value",
+            observed: value,
+            sampledAt: "2026-07-17T00:00:00.000Z"
+        ))
+    }
+}
+
+@Suite("Saga value comparator", .serialized)
+struct SagaValueComparatorTests {
+    private func bind(_ registry: TargetRegistry, index: Int, name: String) async -> TargetReference {
+        let descriptor = TargetDescriptor(trackIndex: index, trackName: name)
+        return await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+    }
+
+    private func step(
+        _ operationID: OperationID,
+        target: TargetReference,
+        value: Value
+    ) -> SagaStep {
+        let valueParameter: String = switch operationID {
+        case .tracksRename: "name"
+        case .tracksMute, .tracksSolo, .tracksArm: "enabled"
+        default: "value"
+        }
+        return SagaStep(
+            operationID: operationID,
+            targetRef: target,
+            params: [valueParameter: value],
+            expectedInverse: SagaExpectedInverse(
+                operationID: operationID,
+                valueParameter: valueParameter
+            )
+        )
+    }
+
+    /// Runs a single-step plan and returns its verification disposition.
+    private func disposition(
+        _ operationID: OperationID,
+        desired: Value,
+        before: Value,
+        readback: Value?,
+        state: StepResultState,
+        key: String
+    ) async -> VerificationDisposition? {
+        let registry = TargetRegistry()
+        let target = await bind(registry, index: 0, name: "Bass")
+        let executor = StubReadbackExecutor(
+            before: before,
+            readback: readback,
+            result: StepResult(
+                state: state,
+                writeBoundaryCrossed: true,
+                detail: "stub \(state.rawValue)"
+            )
+        )
+        let outcome = await MutationSaga(
+            targetRegistry: registry,
+            enabled: true,
+            routeAvailable: { _ in true }
+        ).execute(
+            SagaPlan(
+                steps: [step(operationID, target: target, value: desired)],
+                idempotencyKey: key
+            ),
+            executor: executor
+        )
+        return outcome.journal.first?.verificationEvidence?.disposition
+    }
+
+    // MARK: - Unit: the comparator itself
+
+    /// The debt's core defect: EXACT `==` on a value the AX surface quantizes.
+    /// Logic exposes the header fader in ~10-raw-unit detents, so a verified
+    /// write of 0.7 reads back 0.699 — exact equality called that `notApplied`.
+    ///
+    /// NOTE ON THE BOUNDARY: the rule is the ratified `abs(a-b) <= 0.01`,
+    /// applied literally. A value EXACTLY one epsilon away is deliberately not
+    /// asserted here in either direction — in binary floating point
+    /// `abs(0.71 - 0.7)` is `0.010000000000000009`, so the exact-boundary
+    /// outcome is an artifact of decimal-literal representation rather than a
+    /// decided contract. Asserting it would enshrine the artifact. Real
+    /// readbacks (0.699…) sit well inside the tolerance; see the report note.
+    @Test("volume tolerates the surface's quantization within 0.01")
+    func volumeToleratesQuantization() {
+        #expect(SagaValueComparator.equals(
+            observed: .double(0.699), expected: .double(0.7), op: .mixerSetVolume
+        ))
+        #expect(SagaValueComparator.equals(
+            observed: .double(0.705), expected: .double(0.7), op: .mixerSetVolume
+        ))
+        #expect(SagaValueComparator.equals(
+            observed: .double(0.695), expected: .double(0.7), op: .mixerSetVolume
+        ))
+        // Clear of the boundary in both directions: a real mismatch.
+        #expect(!SagaValueComparator.equals(
+            observed: .double(0.68), expected: .double(0.7), op: .mixerSetVolume
+        ))
+        #expect(!SagaValueComparator.equals(
+            observed: .double(0.72), expected: .double(0.7), op: .mixerSetVolume
+        ))
+    }
+
+    @Test("pan tolerates 0.05 on its -1...1 range")
+    func panToleratesItsWiderDetent() {
+        #expect(SagaValueComparator.equals(
+            observed: .double(0.46), expected: .double(0.5), op: .mixerSetPan
+        ))
+        #expect(!SagaValueComparator.equals(
+            observed: .double(0.40), expected: .double(0.5), op: .mixerSetPan
+        ))
+    }
+
+    /// A name is discrete: a trailing space is a different track name to the
+    /// operator, and no epsilon may absorb it.
+    @Test("rename compares exactly — a trailing space is not a match")
+    func renameIsExact() {
+        #expect(SagaValueComparator.equals(
+            observed: .string("A"), expected: .string("A"), op: .tracksRename
+        ))
+        #expect(!SagaValueComparator.equals(
+            observed: .string("A "), expected: .string("A"), op: .tracksRename
+        ))
+        #expect(SagaValueComparator.tolerance(for: .tracksRename).comparator == .exact)
+        #expect(SagaValueComparator.tolerance(for: .tracksRename).epsilon == nil)
+    }
+
+    @Test("toggles compare exactly")
+    func togglesAreExact() {
+        for op in [OperationID.tracksMute, .tracksSolo, .tracksArm] {
+            #expect(SagaValueComparator.tolerance(for: op).comparator == .exact)
+            #expect(SagaValueComparator.equals(
+                observed: .bool(true), expected: .bool(true), op: op
+            ))
+            #expect(!SagaValueComparator.equals(
+                observed: .bool(false), expected: .bool(true), op: op
+            ))
+        }
+    }
+
+    /// Epsilon is absolute on a normalized range — a relative epsilon would
+    /// collapse to zero at pan center, where a detent still spans 0.05.
+    @Test("epsilon is absolute, not relative")
+    func epsilonIsAbsolute() {
+        #expect(SagaValueComparator.equals(
+            observed: .double(0.04), expected: .double(0.0), op: .mixerSetPan
+        ))
+        #expect(SagaValueComparator.tolerance(for: .mixerSetVolume).epsilon == 0.01)
+        #expect(SagaValueComparator.tolerance(for: .mixerSetPan).epsilon == 0.05)
+    }
+
+    /// A quantized field arriving as a non-numeric is a contract violation, not
+    /// a near-miss — it must not be tolerated into a match.
+    @Test("epsilon comparison fails closed on non-numeric or unknown operations")
+    func epsilonFailsClosedOnNonNumeric() {
+        #expect(!SagaValueComparator.equals(
+            observed: .string("0.7"), expected: .double(0.7), op: .mixerSetVolume
+        ))
+        #expect(!SagaValueComparator.equals(
+            observed: .bool(true), expected: .double(1.0), op: .mixerSetVolume
+        ))
+        // An operation with no declared tolerance falls back to exact.
+        #expect(SagaValueComparator.tolerance(for: .transportPlay).comparator == .exact)
+    }
+
+    @Test("comparison evidence records comparator, epsilon, and delta")
+    func comparisonEvidenceIsComplete() {
+        let evidence = SagaValueComparator.evidence(
+            observed: .double(0.699), desired: .double(0.7), op: .mixerSetVolume
+        )
+        #expect(evidence.comparator == .absoluteEpsilon)
+        #expect(evidence.comparator.rawValue == "abs_eps")
+        #expect(evidence.epsilon == 0.01)
+        #expect(evidence.desired == .double(0.7))
+        #expect(evidence.observed == .double(0.699))
+        #expect(evidence.equal)
+        let delta = try? #require(evidence.delta)
+        #expect(abs((delta ?? 1) - 0.001) < 1e-9)
+
+        // Exact comparators carry no epsilon, and string fields carry no delta.
+        let exact = SagaValueComparator.evidence(
+            observed: .string("A "), desired: .string("A"), op: .tracksRename
+        )
+        #expect(exact.comparator == .exact)
+        #expect(exact.epsilon == nil)
+        #expect(exact.delta == nil)
+        #expect(!exact.equal)
+    }
+
+    // MARK: - Engine: classification through the comparator
+
+    /// The headline regression: a State-B write whose live readback is one
+    /// detent off the request is APPLIED, not `notApplied`. Pre-fix, exact `==`
+    /// classified it `notApplied` and rolled back a write that had landed.
+    @Test("volume 0.7 written, live readback 0.699 classifies applied")
+    func quantizedVolumeReadbackClassifiesApplied() async {
+        #expect(await disposition(
+            .mixerSetVolume,
+            desired: .double(0.7),
+            before: .double(0.25),
+            readback: .double(0.699),
+            state: .stateB,
+            key: "volume-quantized-applied"
+        ) == .applied)
+    }
+
+    @Test("pan 0.5 readback 0.46 applies; 0.40 is beyond epsilon and did not apply")
+    func panEpsilonDiscriminates() async {
+        #expect(await disposition(
+            .mixerSetPan,
+            desired: .double(0.5),
+            before: .double(0.40),
+            readback: .double(0.46),
+            state: .stateB,
+            key: "pan-within-eps"
+        ) == .applied)
+
+        // Beyond epsilon AND equal to the before-state → the write did not land.
+        #expect(await disposition(
+            .mixerSetPan,
+            desired: .double(0.5),
+            before: .double(0.40),
+            readback: .double(0.40),
+            state: .stateB,
+            key: "pan-beyond-eps"
+        ) == .notApplied)
+    }
+
+    /// LPMCP-PRD-004: State A means the dispatcher ALREADY verified the write
+    /// against the live surface. A later corroborating read that disagrees is
+    /// drift we cannot explain — `unknown`. Demoting it to `notApplied` would
+    /// roll back a verified write (the compensate-storm this closes).
+    @Test("State A with a drifting corroborating read is unknown, never notApplied")
+    func stateADriftIsUnknownNotNotApplied() async {
+        let drifted = await disposition(
+            .mixerSetVolume,
+            desired: .double(0.7),
+            before: .double(0.25),
+            readback: .double(0.40),
+            state: .stateA,
+            key: "state-a-drift"
+        )
+        #expect(drifted == .unknown)
+        #expect(drifted != .notApplied)
+
+        // Drift all the way back to the before-state is STILL unknown under
+        // State-A trust — the exact case the old `==` classified notApplied.
+        let backToBefore = await disposition(
+            .mixerSetVolume,
+            desired: .double(0.7),
+            before: .double(0.25),
+            readback: .double(0.25),
+            state: .stateA,
+            key: "state-a-drift-to-before"
+        )
+        #expect(backToBefore == .unknown)
+        #expect(backToBefore != .notApplied)
+    }
+
+    /// State-A trust does not depend on a corroborating read being available:
+    /// the dispatcher's own live verification is sufficient.
+    @Test("State A without a corroborating read stays applied")
+    func stateAWithoutCorroborationStaysApplied() async {
+        #expect(await disposition(
+            .mixerSetVolume,
+            desired: .double(0.7),
+            before: .double(0.25),
+            readback: nil,
+            state: .stateA,
+            key: "state-a-no-corroboration"
+        ) == .applied)
+    }
+
+    /// State A + a corroborating read within epsilon is the ordinary path.
+    @Test("State A with a quantized corroborating read stays applied")
+    func stateAWithQuantizedCorroborationStaysApplied() async {
+        #expect(await disposition(
+            .mixerSetVolume,
+            desired: .double(0.7),
+            before: .double(0.25),
+            readback: .double(0.699),
+            state: .stateA,
+            key: "state-a-quantized"
+        ) == .applied)
+    }
+
+    /// A State-B rename whose readback differs only by a trailing space did NOT
+    /// apply — no epsilon exists to absorb it.
+    @Test("rename readback with a trailing space does not classify applied")
+    func renameTrailingSpaceIsNotApplied() async {
+        let result = await disposition(
+            .tracksRename,
+            desired: .string("A"),
+            before: .string("Bass"),
+            readback: .string("A "),
+            state: .stateB,
+            key: "rename-trailing-space"
+        )
+        #expect(result != .applied)
+        #expect(result == .unknown)
+    }
+
+    @Test("verification evidence carries the comparator that decided it")
+    func verificationEvidenceCarriesComparator() async throws {
+        let registry = TargetRegistry()
+        let target = await bind(registry, index: 0, name: "Bass")
+        let executor = StubReadbackExecutor(
+            before: .double(0.25),
+            readback: .double(0.699),
+            result: StepResult(state: .stateB, writeBoundaryCrossed: true, detail: "stub B")
+        )
+        let outcome = await MutationSaga(
+            targetRegistry: registry,
+            enabled: true,
+            routeAvailable: { _ in true }
+        ).execute(
+            SagaPlan(
+                steps: [step(.mixerSetVolume, target: target, value: .double(0.7))],
+                idempotencyKey: "verification-comparator-evidence"
+            ),
+            executor: executor
+        )
+        let comparison = try #require(outcome.journal.first?.verificationEvidence?.comparison)
+        #expect(comparison.comparator == .absoluteEpsilon)
+        #expect(comparison.epsilon == 0.01)
+        #expect(comparison.desired == .double(0.7))
+        #expect(comparison.observed == .double(0.699))
+        #expect(comparison.equal)
+    }
+}

--- a/Tests/LogicProMCPTests/SagaValueComparatorTests.swift
+++ b/Tests/LogicProMCPTests/SagaValueComparatorTests.swift
@@ -333,6 +333,107 @@ struct SagaValueComparatorTests {
         #expect(result == .unknown)
     }
 
+    // MARK: - Engine: the ambiguous epsilon zone
+
+    /// The epsilon that fixed the false-rollback opened a mirrored hole: when
+    /// `|desired - before| <= epsilon`, a readback matches BOTH. Here the write
+    /// FAILED (State B) and the surface never moved off -1.0 — but -1.0 is
+    /// within the pan epsilon (0.05) of the desired -0.96. Checking desired
+    /// first called that `applied`: a false success on a failed write, with no
+    /// compensation. Exact `==` never had this failure.
+    @Test("pan write that failed inside the epsilon zone is unknown, never applied")
+    func ambiguousPanZoneIsUnknownNotApplied() async {
+        let result = await disposition(
+            .mixerSetPan,
+            desired: .double(-0.96),
+            before: .double(-1.0),
+            readback: .double(-1.0),
+            state: .stateB,
+            key: "pan-ambiguous-zone"
+        )
+        #expect(result == .unknown)
+        #expect(result != .applied)
+    }
+
+    /// The ambiguous zone must reconcile as UNCERTAIN, not as a success. Pre-fix
+    /// the step was booked `applied`, compensation "restored" a surface that had
+    /// never moved, and the plan reported `fullyCompensated` — a clean-rollback
+    /// claim built on a write nobody observed land.
+    @Test("ambiguous-zone plan reconciles as rollbackUncertain, not a clean rollback")
+    func ambiguousZonePlanIsRollbackUncertain() async throws {
+        let registry = TargetRegistry()
+        let target = await bind(registry, index: 0, name: "Bass")
+        let executor = StubReadbackExecutor(
+            before: .double(-1.0),
+            readback: .double(-1.0),
+            result: StepResult(state: .stateB, writeBoundaryCrossed: true, detail: "stub B")
+        )
+        let outcome = await MutationSaga(
+            targetRegistry: registry,
+            enabled: true,
+            routeAvailable: { _ in true }
+        ).execute(
+            SagaPlan(
+                steps: [step(.mixerSetPan, target: target, value: .double(-0.96))],
+                idempotencyKey: "pan-ambiguous-zone-outcome"
+            ),
+            executor: executor
+        )
+        #expect(outcome.state == .rollbackUncertain)
+        #expect(outcome.state != .fullyCompensated)
+        #expect(!outcome.complete)
+        #expect(outcome.stateHistory.contains(.reconciling))
+        let record = try #require(outcome.journal.first)
+        #expect(record.verificationEvidence?.disposition == .unknown)
+        #expect(record.compensationEvidence?.disposition == .uncertain)
+    }
+
+    /// The same hole on the volume epsilon (0.01), on an analog step an operator
+    /// would plausibly request: 0.70 → 0.705 is a real request, and a failed
+    /// write leaves a readback that matches the desired within epsilon.
+    @Test("volume write that failed inside the epsilon zone is unknown, never applied")
+    func ambiguousVolumeZoneIsUnknownNotApplied() async {
+        let result = await disposition(
+            .mixerSetVolume,
+            desired: .double(0.705),
+            before: .double(0.70),
+            readback: .double(0.70),
+            state: .stateB,
+            key: "volume-ambiguous-zone"
+        )
+        #expect(result == .unknown)
+        #expect(result != .applied)
+    }
+
+    /// Control: outside the ambiguous zone a failed write still reads as the
+    /// before-state and is unambiguously `notApplied` — the fix must not turn
+    /// every failed write into `unknown`.
+    @Test("failed write outside the epsilon zone still classifies notApplied")
+    func unambiguousFailedWriteStaysNotApplied() async {
+        #expect(await disposition(
+            .mixerSetVolume,
+            desired: .double(0.8),
+            before: .double(0.2),
+            readback: .double(0.2),
+            state: .stateB,
+            key: "volume-unambiguous-not-applied"
+        ) == .notApplied)
+    }
+
+    /// Control: a write the surface DID take, far from the before-state, has no
+    /// ambiguity to resolve and stays `applied`.
+    @Test("landed write outside the epsilon zone still classifies applied")
+    func unambiguousLandedWriteStaysApplied() async {
+        #expect(await disposition(
+            .mixerSetVolume,
+            desired: .double(0.8),
+            before: .double(0.2),
+            readback: .double(0.8),
+            state: .stateB,
+            key: "volume-unambiguous-applied"
+        ) == .applied)
+    }
+
     @Test("verification evidence carries the comparator that decided it")
     func verificationEvidenceCarriesComparator() async throws {
         let registry = TargetRegistry()


### PR DESCRIPTION
## Summary

Debt **LPMCP-PRD-004** (P1, ADR-004 #287): saga before-state, verification readback, and State-B/C reconciliation read `StateCache` — a poller-refreshed mirror that can be stale by a poll interval and is refreshed by the very write under judgment — and values compared with **exact equality** on quantized doubles. A stale mirror meant the saga could capture the wrong before-state and then "restore" a value the operator never had; exact equality meant a correct write (0.7 → detent 0.699) classified as not-applied and triggered compensation storms.

**Commit 1 — live readback + tolerant comparison (adversarially ratified design):**
- `SagaLiveReadback` seams: per-family live reads calling the **same AX primitives the dispatchers use for their own State-A verification** (track name / header fader / pan control / M-S-R toggles). Non-optional on the production executor; `SystemDispatcher` defaults to `.unavailable` (all reads nil) so a construction site that forgets the seam **fails closed at before-state capture** — it can never silently fall back to a cache value. Zero cache reads remain in `SagaExecution`; readers return honest Optionals, never the fabricated `0.0` an unreadable fader used to produce.
- `SagaValueComparator` with per-op tolerance declared in `reversibleDefinitions`: rename/toggles exact; volume `abs ≤ 0.01` (0…1); pan `abs ≤ 0.05` (−1…1); unknown-op exact and non-numeric-under-epsilon both fail closed.
- **State-A trust**: a step whose write path already live-verified State A is applied without re-classification by exact equality; a corroborating live read disagreeing beyond tolerance yields `unknown` (drift), never `notApplied`.
- Structured evidence provenance (`read_source`, `provenance: live_independent`, `track_index`, `field`, `sampled_at`, plus `comparator/epsilon/desired/observed/delta`); the saga envelope can never contain `state_cache`.
- The one legacy test that **encoded the debt** (refresh pushing the desired value into the cache, then asserting State A — the cache verifying the cache) is inverted to assert honest drift.
- Comparator + State-A trust are mutation-verified: reverting to exact equality turns 8 assertions red.

**Commit 2 — ambiguous-epsilon-zone fix (implementation gate P1):**
With tolerance, a **failed** write whose desired value sits within epsilon of the before-state read back as before, matched desired within epsilon, and classified `.applied` — the plan then emitted `fullyCompensated` with a verified compensation receipt for a write nobody observed land. The shared classify now orders both matches: both-match ⇒ `unknown` (honest reconciliation), desired-only ⇒ `applied`, before-only ⇒ `notApplied`. Compensation-verify needs no change (single-hypothesis comparison — documented in-code). RED-proof captured; out-of-zone controls green pre- and post-fix.

Accepted scope (gate-documented): pan ε 0.05 is detent physics, flagged for measured tightening after live soak (never silent loosening); State-A-trust + later compensation is intentional last-writer-wins; a journal evidence field for the before-match (so `comparison.equal` reads coherently in the ambiguous zone) is tracked as a follow-up.

## Verification
Full suite `--no-parallel`: **2,875 passed**. Focused saga suites 72/72 (67 + 5 ambiguity/control tests); census/coverage suites unaffected (8/8). Live `fully_compensated` proof on real Logic remains with the live batch (ADR-004 receipt residual).
