### PR TITLE
fix(adr-005/prd-003): finalizeTrace preserves the original result; read-only zero-write census covers all specs (#288)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -290,7 +290,7 @@ extension OperationTraceDispatching {
         traceID: TraceID?
     ) async -> CallTool.Result {
         guard let traceID else { return result }
-        guard case .text(let raw, _, _) = result.content.first else {
+        guard case .text(let raw, let annotations, let meta) = result.content.first else {
             await OperationTraceStore.shared.record(
                 traceID,
                 phase: .verificationCompleted,
@@ -319,6 +319,18 @@ extension OperationTraceDispatching {
 
         let merged = HonestContract.addExtras(["trace_id": traceID.rawValue], into: raw)
         guard merged != raw else { return result }
-        return toolTextResult(merged, isError: result.isError == true)
+        // Injecting trace_id must not silently rewrite the rest of the result the
+        // dispatcher already built: rebuilding via `toolTextResult` dropped block 0's
+        // annotations/_meta, every later content block, the result-level _meta, and
+        // coerced a nil `isError` into `false`. Reconstruct in place instead —
+        // only block 0's text changes. Mirrors `TargetRefResolution.addEvidence`.
+        var content = result.content
+        content[0] = .text(text: merged, annotations: annotations, _meta: meta)
+        return CallTool.Result(
+            content: content,
+            structuredContent: structuredContentValue(fromToolText: merged),
+            isError: result.isError,
+            _meta: result._meta
+        )
     }
 }

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -38,6 +38,44 @@ private actor OperationTraceCoverageChannel: Channel {
     }
 }
 
+/// Answers State A so every read-only op runs its SUCCESS path. The refusing
+/// mock above short-circuits each op at its first channel hop — which is
+/// precisely why it can never prove where `writeBoundaryCrossed` is (or is
+/// not) recorded. The read-only inverse gate uses this permissive probe
+/// instead, so an op that wrongly recorded a write boundary on its happy path
+/// is actually reached.
+private actor OperationTraceReadOnlyProbeChannel: Channel {
+    nonisolated let id: ChannelID
+
+    init(id: ChannelID) {
+        self.id = id
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace read-only probe")
+    }
+}
+
+/// Counts `recordWriteBoundary` calls independently of the trace store. This
+/// is the load-bearing part of the zero-write census: `recordWriteBoundary`
+/// fires the `onWriteBoundary` hook BEFORE its `guard let traceID` early
+/// return, so a read-only op that crosses a write boundary is caught here even
+/// though it starts no trace and therefore leaves the store empty.
+private actor WriteBoundaryProbe {
+    private(set) var count = 0
+
+    func record() {
+        count += 1
+    }
+}
+
 private struct OperationTraceCoverageFixtures {
     let projectPath: String
     let outputRoot: String
@@ -130,41 +168,114 @@ extension OperationTraceTests {
         await OperationTraceStore.shared.clear()
     }
 
-    @Test func OperationTraceCoverageReadOnlyCommandsRemainTraceFree() async throws {
+    /// ADR-005 zero-write census (inverse gate). Read-only ops start no trace
+    /// by design, so the contract is an ABSENCE: for EVERY read-only registry
+    /// spec — not a hand-picked sample — invoking the real bound handler must
+    /// record no trace and cross no write boundary. Two independent assertions,
+    /// because neither alone is sufficient: the store-empty check proves no
+    /// trace was started, and the `onWriteBoundary` probe proves no write
+    /// boundary was crossed even in the (correct) absence of a trace, which a
+    /// store-only check is structurally blind to.
+    ///
+    /// Side-effect safety mirrors the executable dispatch census: every channel
+    /// is a probe, the project lifecycle executor is stubbed through the
+    /// dependencies seam, and the support-bundle exporter throws. Ops whose
+    /// read path needs live AX return errors through the probe channels — the
+    /// contract under test is trace/write-boundary absence, not success.
+    @Test func OperationTraceCoverageEveryReadOnlyRegistrySpecIsTraceAndWriteFree() async throws {
         let previous = replaceOperationTraceCoverageFlag(with: "1")
         defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
 
+        let projectRoot = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectRoot)
+            try? FileManager.default.removeItem(at: outputRoot)
+        }
+        let project = try makeLogicxProject(in: projectRoot, named: "Trace ReadOnly")
+        let resources = project.appendingPathComponent("Resources", isDirectory: true)
+        let alternative = project.appendingPathComponent("Alternatives/000", isDirectory: true)
+        try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: alternative, withIntermediateDirectories: true)
+        try Data().write(to: resources.appendingPathComponent("ProjectInformation.plist"))
+        try Data().write(to: alternative.appendingPathComponent("ProjectData"))
+        let midiFile = try SMFWriter.temporaryMIDIFile()
+        try Data([0x4D, 0x54, 0x68, 0x64]).write(to: midiFile.fileURL)
+        defer { SMFWriter.cleanupTemporaryMIDIFile(midiFile) }
+
         let fixtures = OperationTraceCoverageFixtures(
-            projectPath: "/tmp/trace-coverage.logicx",
-            outputRoot: "/tmp",
-            midiPath: "/tmp/trace-coverage.mid"
+            projectPath: project.path,
+            outputRoot: outputRoot.path,
+            midiPath: midiFile.fileURL.path
         )
         let router = ChannelRouter()
         for channelID in ChannelID.allCases {
-            await router.register(OperationTraceCoverageChannel(id: channelID))
+            await router.register(OperationTraceReadOnlyProbeChannel(id: channelID))
         }
         let cache = StateCache()
-        let readOnlyIDs: [OperationID] = [
-            .audioAnalyzeFile,
-            .pluginsGetInventory,
-            .projectIsRunning,
-            .midiListPorts,
-            .tracksResolvePath,
-        ]
+        let dependencies = HandlerDependencies(
+            router: router,
+            cache: cache,
+            targetRegistry: TargetRegistry(),
+            poller: StatePoller(
+                axChannel: AccessibilityChannel(),
+                cache: cache,
+                runtime: .fastTest
+            ),
+            dialogPresent: { false },
+            supportBundleExporter: { _, _ in
+                throw NSError(domain: "operation-trace-read-only-census", code: 1)
+            },
+            projectLifecycleExecute: { _ in
+                ProjectDispatcher.LifecycleExecution(
+                    executionError: nil,
+                    timedOut: false,
+                    terminationStatus: 0,
+                    stderrOutput: ""
+                )
+            }
+        )
 
-        for operationID in readOnlyIDs {
-            let spec = try #require(OperationRegistry.specs.first { $0.id == operationID })
-            #expect(spec.mutability == .readOnly)
+        let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
+        let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
+        #expect(OperationRegistry.specs.count == 107)
+        #expect(readOnlySpecs.count == 21)
+        // Mutability is total: the mutating census (86) and this inverse gate
+        // (21) together account for every registered spec, so a new operation
+        // cannot land outside both gates.
+        #expect(readOnlySpecs.count + mutatingSpecs.count == OperationRegistry.specs.count)
+
+        for spec in readOnlySpecs {
+            let handler = try #require(
+                OperationHandlerRegistry.handler(for: spec.id),
+                Comment(rawValue: "\(spec.id.rawValue) has no bound handler")
+            )
             await OperationTraceStore.shared.clear()
-            _ = await dispatchOperationTraceCoverageSpec(
-                spec,
-                params: operationTraceCoverageParams(for: operationID, fixtures: fixtures),
-                router: router,
-                cache: cache
+            let boundaryProbe = WriteBoundaryProbe()
+            _ = await OperationTraceParentBoundary.$onWriteBoundary.withValue({
+                await boundaryProbe.record()
+            }) {
+                await handler(
+                    dependencies,
+                    operationTraceCoverageParams(for: spec.id, fixtures: fixtures)
+                )
+            }
+
+            let boundaryCount = await boundaryProbe.count
+            #expect(
+                boundaryCount == 0,
+                Comment(rawValue: "Read-only command crossed a write boundary: \(spec.id.rawValue)")
+            )
+            let traces = await OperationTraceStore.shared.recent(limit: 128)
+            #expect(
+                traces.isEmpty,
+                Comment(rawValue: "Read-only command traced: \(spec.tool.rawValue).\(spec.command)")
             )
             #expect(
-                await OperationTraceStore.shared.recent(limit: 128).isEmpty,
-                "Read-only command traced: \(spec.tool.rawValue).\(spec.command)"
+                !traces.contains { trace in
+                    trace.events.contains { $0.phase == .writeBoundaryCrossed }
+                },
+                Comment(rawValue: "Read-only command recorded writeBoundaryCrossed: \(spec.id.rawValue)")
             )
         }
 

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -731,3 +731,122 @@ extension OperationTraceTests {
         })
     }
 }
+
+/// Renders a three-state `Bool?` as a distinct non-Optional token. `#expect` on
+/// an `Optional<Bool>` compared to a `nil`/`true`/`false` literal is one of this
+/// repo's known DEAD assertion forms — it passes regardless of the actual value.
+/// Projecting to `String` first keeps the comparison live and makes the failure
+/// message name the state that leaked.
+private func describeThreeStateFlag(_ value: Bool?) -> String {
+    guard let value else { return "nil" }
+    return value ? "true" : "false"
+}
+
+/// LPMCP-PRD-003 residual: `finalizeTrace` injects `trace_id` into the first
+/// text block, and that injection must be surgical. It previously rebuilt the
+/// whole result through `toolTextResult(merged, isError:)`, which silently
+/// discarded block 0's annotations/`_meta`, every later content block, the
+/// result-level `_meta`, and flattened a nil `isError` to `false`.
+extension OperationTraceTests {
+    private static let preservedAnnotations = Resource.Annotations(
+        audience: [.assistant],
+        priority: 0.5,
+        lastModified: "2026-07-17T00:00:00Z"
+    )
+
+    private static let preservedBlockMeta = Metadata(
+        additionalFields: ["block_meta": .string("preserved")]
+    )
+
+    private static let preservedResultMeta = Metadata(
+        additionalFields: ["result_meta": .string("preserved")]
+    )
+
+    /// A multi-block State-A result carrying annotations and `_meta` on both
+    /// block 0 and the result itself. Only block 0's JSON may change.
+    private static func preservationFixture(isError: Bool?) -> CallTool.Result {
+        let raw = HonestContract.encodeStateA(extras: ["operation": "transport.play"])
+        return CallTool.Result(
+            content: [
+                .text(
+                    text: raw,
+                    annotations: preservedAnnotations,
+                    _meta: preservedBlockMeta
+                ),
+                .image(
+                    data: "aW1hZ2U=",
+                    mimeType: "image/png",
+                    annotations: nil,
+                    _meta: nil
+                ),
+            ],
+            structuredContent: structuredContentValue(fromToolText: raw),
+            isError: isError,
+            _meta: preservedResultMeta
+        )
+    }
+
+    private func assertTracePreservesResult(isError: Bool?) async throws {
+        let traceID = await OperationTraceStore.shared.start(
+            operationID: OperationID.transportPlay.rawValue
+        )
+        let original = Self.preservationFixture(isError: isError)
+        let finalized = await TransportDispatcher.finalizeTrace(original, traceID: traceID)
+
+        // isError is a THREE-state field: nil must survive as nil, never coerce
+        // to false. Compare through a non-Optional projection — `#expect` on an
+        // `Optional<Bool>` compared against `nil`/`true`/`false` expands to a
+        // DEAD check that passes even when the values differ (proven here: the
+        // pre-fix `isError: false` rebuild did not trip `== nil`).
+        #expect(
+            describeThreeStateFlag(finalized.isError) == describeThreeStateFlag(isError),
+            "isError must carry through verbatim (three-state: nil/true/false)"
+        )
+
+        // Block 0: trace_id merged in, annotations/_meta carried through.
+        // #require, not #expect: a dropped block would otherwise trap on the
+        // index below and kill the whole test process instead of failing.
+        try #require(finalized.content.count == 2, "later content blocks must survive")
+        guard case .text(let mergedText, let annotations, let meta) = finalized.content[0] else {
+            #expect(Bool(false), "block 0 must remain text")
+            return
+        }
+        let body = try #require(
+            (try? JSONSerialization.jsonObject(with: Data(mergedText.utf8))) as? [String: Any]
+        )
+        #expect(body["trace_id"] as? String == traceID.rawValue)
+        #expect(body["state"] as? String == "A")
+        #expect(body["operation"] as? String == "transport.play")
+        #expect(annotations == Self.preservedAnnotations, "block 0 annotations dropped")
+        #expect(meta == Self.preservedBlockMeta, "block 0 _meta dropped")
+
+        // Block 1 is untouched — only block 0 is text-merged.
+        #expect(finalized.content[1] == original.content[1], "second content block mutated")
+
+        // Result-level _meta survives; structuredContent tracks the merged JSON
+        // so it cannot desync from block 0's text.
+        #expect(finalized._meta == Self.preservedResultMeta, "result _meta dropped")
+        #expect(finalized.structuredContent == structuredContentValue(fromToolText: mergedText))
+        let structured = try #require(finalized.structuredContent)
+        #expect(structured.objectValue?["trace_id"]?.stringValue == traceID.rawValue)
+
+        await OperationTraceStore.shared.clear()
+    }
+
+    @Test func finalizeTracePreservesResultWhenIsErrorIsNil() async throws {
+        try await assertTracePreservesResult(isError: nil)
+    }
+
+    @Test func finalizeTracePreservesResultWhenIsErrorIsFalse() async throws {
+        try await assertTracePreservesResult(isError: false)
+    }
+
+    /// isError == true with a State-A body is deliberately contradictory: it
+    /// pins that finalizeTrace carries isError through verbatim rather than
+    /// re-deriving it from the envelope. (`addExtras` refuses success:false
+    /// bodies, so a State-C body would early-return before the rebuild and
+    /// never exercise this path.)
+    @Test func finalizeTracePreservesResultWhenIsErrorIsTrue() async throws {
+        try await assertTracePreservesResult(isError: true)
+    }
+}


### PR DESCRIPTION
## Summary

Two audit residuals on the trace layer (debt LPMCP-PRD-003):

**1. `finalizeTrace` preserves the original result.** Injecting `trace_id` rebuilt the result via `toolTextResult`, dropping block-0 annotations/`_meta`, every later content block, result-level `_meta`, and coercing a nil `isError` to false. It now reconstructs: only block 0's text is replaced by the merged JSON (annotations/`_meta` kept), later blocks and result metadata kept verbatim, `isError` preserved three-state. `structuredContent` is recomputed from the merged JSON so it cannot desync from the text now carrying `trace_id`. RED-proof: reverting drops the second content block and flips `isError` nil→false.

**2. Read-only zero-write census generalized 5 → all 21 read-only specs.** The old gate covered 5 hand-picked IDs through a test-local switch with a refusing mock — which short-circuits before any write boundary, the audit's exact complaint. The gate now iterates **every read-only registry spec through its real bound handler** with State-A-answering probe channels and asserts both no trace created **and** a write-boundary TaskLocal probe count of zero; `21 + 86 == 107` is pinned so no future operation escapes both censuses. Injecting a boundary into a read-only op fails only the probe assertion — proving the store-empty check alone was structurally blind to traceless boundaries.

Testing footnote (repo-wide relevance): `#expect(optionalBool == nil)` is silently dead, like `== true/false` — three-state assertions use a describing helper; index access is guarded by `#require` (a trapped index kills the whole test process).

## Verification
Full suite `--no-parallel`: **2,878 passed**; focused trace/census/dispatcher suites 154/154; merged with main (PRD-004 live-readback).