### PR TITLE
qualification: #373 Phase A — semantic oracles for the 20-op read-only surface

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -285,8 +285,16 @@ enum QualificationSemanticReadbackValidator {
     ) -> Bool? {
         switch OperationID(rawValue: operationID) {
         case .systemHealth:
+            // Bespoke: full typed-payload equality against the independent read.
             return healthMatches(responseData, readbackData)
-        default:
+        case .some(let id):
+            // #373 Phase A: the read-only surface is covered by the data-driven
+            // oracle table. Only an operation with no oracle at all falls
+            // through to nil, which the runner honestly records as
+            // protocolSmoke rather than passing it.
+            guard let oracle = SemanticOracleTable.byOperationID[id] else { return nil }
+            return oracle.evaluate(responseData: responseData, readbackData: readbackData)
+        case .none:
             return nil
         }
     }

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1,0 +1,613 @@
+import Foundation
+
+// #373 Phase A — the oracle table.
+//
+// Every entry was derived by reading the operation's dispatcher handler and
+// pinning what that handler ACTUALLY emits. Comments cite the handler so a
+// future shape change is reconciled here rather than silently passing.
+//
+// Census invariant (meta-tested): the table's keys are exactly the registry's
+// read-only specs whose availability is not `.unsupported`, minus
+// `system.health` which keeps its bespoke full-payload equality validator.
+//
+// ── KNOWN GAPS (Phase A ships with these open; carried as Phase B debt) ──────
+//
+// 1. FIXTURE↔HANDLER DRIFT HAS NO AUTOMATIC GUARD. Every oracle here was
+//    derived by READING its dispatcher, and the payloads in
+//    SemanticOracleFixtures were hand-written to match. Nothing mechanically
+//    binds the two: if a handler changes a key tomorrow, the fixture keeps the
+//    old shape, the oracle keeps passing the stale fixture, and CI stays green
+//    while the live surface has drifted. Phase B should close this by emitting
+//    golden samples from the handlers' own encode paths, or by landing the
+//    live-run drift catcher. Until then, treat green fixtures as evidence the
+//    ORACLE LOGIC works — not as evidence the shapes are current.
+//
+// 2. SIX OPERATIONS CANNOT REACH `passed` UNDER THE CURRENT PROBE PARAMS. The
+//    runner classifies on `isError` before any oracle runs, and these probes
+//    are typed refusals by construction: project.export_plan,
+//    plugins.get_inventory, tracks.resolve_path (empty params → invalid_params),
+//    audio.analyze_file (empty params → unsafe_path), system.clear_traces
+//    (probed `confirmed:false` on purpose, so qualification never destroys
+//    diagnostic evidence), system.saga_status (probed with a key no record
+//    exists for). Their oracles pin the real success contract and are unit- and
+//    mutation-tested, but a live run cannot exercise them. Phase B: give these
+//    probes qualifying params (a fixture project, a real track index, a seeded
+//    saga) rather than weaken the oracles.
+//
+// 3. THREE MORE ARE ENVIRONMENT-CONDITIONAL live: project.get_regions,
+//    tracks.list_library and tracks.scan_plugin_presets need Logic running with
+//    (respectively) an arrange viewport, an open Library panel, and a focused
+//    plugin window.
+//
+// 4. midi.list_ports' cross-check is a SAME-HANDLER ECHO, not an independent
+//    readback — see its oracle's reason. No independent MIDI probe exists yet.
+
+enum SemanticOracleTable {
+    /// `system.health` is excluded: it has a bespoke validator that compares the
+    /// entire typed `HealthResult` against the independent readback — a
+    /// stronger check than any constraint list, and the only op whose readback
+    /// resource returns the identical payload by construction.
+    static let bespokeOperationIDs: Set<OperationID> = [.systemHealth]
+
+    /// The read-only surface this table must cover, derived from the registry
+    /// (the registry is truth — never a hand-maintained name list).
+    static var coveredSpecIDs: Set<OperationID> {
+        Set(
+            OperationRegistry.specs
+                .filter { $0.mutability == .readOnly && $0.availability != .unsupported }
+                .map(\.id)
+        )
+        .subtracting(bespokeOperationIDs)
+    }
+
+    static let all: [OperationOracle] = [
+        systemPermissions,
+        systemRefreshCache,
+        systemHelp,
+        systemListRecentTraces,
+        systemGetTrace,
+        systemClearTraces,
+        systemSagaPreflight,
+        systemSagaStatus,
+        pluginsGetInventory,
+        projectIsRunning,
+        projectGetRegions,
+        projectExportPlan,
+        projectAudit,
+        projectCleanupPlan,
+        audioAnalyzeFile,
+        midiListPorts,
+        tracksListLibrary,
+        tracksScanLibrary,
+        tracksResolvePath,
+        tracksScanPluginPresets,
+    ]
+
+    static let byOperationID: [OperationID: OperationOracle] = Dictionary(
+        uniqueKeysWithValues: all.map { ($0.operationID, $0) }
+    )
+
+    /// Escape-hatch tax.
+    ///
+    /// DEVIATION from the ratified design, reported rather than improvised: the
+    /// ratified budget was "≤5 of the set may be .custom". Against the real
+    /// handler shapes that budget is infeasible — SEVEN read-only operations
+    /// cannot carry any declarative VALUE constraint:
+    ///
+    ///   * prose bodies, no key to bind to:
+    ///       system.permissions, system.refresh_cache, system.help
+    ///   * bare-scalar body, no key to bind to:
+    ///       project.is_running
+    ///   * JSON with zero constant-valued fields:
+    ///       midi.list_ports, tracks.list_library, tracks.resolve_path
+    ///
+    /// The root cause is a gap in the constraint data model, not laziness: a
+    /// constraint binds to ONE payload and has no cross-check case, and there is
+    /// no implication case. For these seven the only honest checks ARE
+    /// cross-checks and conditionals. Forcing them under a numeric cap would
+    /// have produced tautological oracles (`enumMember` over a field a
+    /// `typedField` already types) — checkbox oracles of exactly the kind this
+    /// ticket exists to forbid.
+    ///
+    /// So the cap is replaced by something stricter than "≤5": an explicit
+    /// allowlist. A new `.custom` oracle cannot appear without editing this set,
+    /// which is the review gate the budget was reaching for.
+    ///
+    /// Phase B recommendation: add `.crossCheck` and `.implies` constraint cases;
+    /// midi.list_ports, tracks.list_library, tracks.resolve_path and
+    /// project.is_running all become declarative, taking the hatch back to the
+    /// three irreducible prose bodies.
+    static let sanctionedCustomOperationIDs: Set<OperationID> = [
+        .systemPermissions,
+        .systemRefreshCache,
+        .systemHelp,
+        .projectIsRunning,
+        .midiListPorts,
+        .tracksListLibrary,
+        .tracksResolvePath,
+    ]
+
+    static var customOracles: [OperationOracle] { all.filter { $0.strength == .custom } }
+
+    // MARK: - system
+
+    // SystemDispatcher `case "permissions"` → toolTextResult(status.summary).
+    // PermissionChecker.summary is human-readable prose, one line per
+    // permission, each ending in a state label.
+    static let systemPermissions = OperationOracle(
+        custom: .systemPermissions,
+        reason: """
+            The handler returns PermissionChecker.summary — human-readable prose, \
+            not JSON. There is no key-addressable field for a declarative \
+            constraint to bind to, so the four required permission lines and \
+            their legal state labels are asserted in the closure.
+            """
+    ) { responseData, _ in
+        guard let text = String(data: responseData, encoding: .utf8) else { return false }
+        let requiredPrefixes = [
+            "Accessibility: ",
+            "Automation (Logic Pro): ",
+            "Automation (System Events): ",
+            "PostEvent (CGEvent): ",
+        ]
+        // The closed set of line remainders PermissionChecker.summary can emit:
+        // State.summaryLabel's three values, plus the one hardcoded variant the
+        // Automation (Logic Pro) notVerifiable branch appends. Matched EXACTLY —
+        // a prefix match would accept "granted_evil" or "NOT GRANTEDish" and
+        // wave through a label this code has never seen.
+        let legalLabels: Set<String> = [
+            "granted",
+            "NOT GRANTED",
+            "NOT VERIFIABLE",
+            "NOT VERIFIABLE (Logic Pro not running)",
+        ]
+        let lines = text.split(separator: "\n").map(String.init)
+        return requiredPrefixes.allSatisfy { prefix in
+            guard let line = lines.first(where: { $0.hasPrefix(prefix) }) else { return false }
+            return legalLabels.contains(String(line.dropFirst(prefix.count)))
+        }
+    }
+
+    // SystemDispatcher `case "refresh_cache"` → one of exactly two sentences,
+    // depending on whether an AX fallback poller is attached.
+    static let systemRefreshCache = OperationOracle(
+        custom: .systemRefreshCache,
+        reason: """
+            The handler returns a bare prose sentence, not JSON. The legal \
+            bodies are a closed two-element set, but with no JSON key to bind \
+            an enumMember constraint to, the set is enumerated in the closure.
+            """
+    ) { responseData, _ in
+        guard let text = String(data: responseData, encoding: .utf8) else { return false }
+        let legalBodies = [
+            "State refresh completed via AX fallback poller.",
+            "State refresh triggered. Cache will be updated on next poll cycle.",
+        ]
+        return legalBodies.contains(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    // SystemDispatcher `case "help"` → Self.helpText(for: category). The
+    // qualification probe passes category "system" (QualificationTransport
+    // .probeParams), so the body must be the logic_system section — not the
+    // full help, and not another dispatcher's section.
+    static let systemHelp = OperationOracle(
+        custom: .systemHelp,
+        reason: """
+            The handler returns a formatted help document, not JSON. The check \
+            that matters — that the probe's `category:"system"` was honoured and \
+            the section documents the real logic_system surface — is a prose \
+            assertion no key-addressable constraint can express.
+            """
+    ) { responseData, _ in
+        guard let text = String(data: responseData, encoding: .utf8) else { return false }
+        // Honouring `category:"system"` means the SYSTEM section, not full help.
+        guard text.hasPrefix("logic_system commands:") else { return false }
+        // The section must document the system commands the registry exposes.
+        let requiredCommands = [
+            "health", "permissions", "refresh_cache", "list_recent_traces",
+            "get_trace", "clear_traces", "saga_preflight", "saga_execute",
+            "saga_status", "saga_cancel", "help",
+        ]
+        guard requiredCommands.allSatisfy({ text.contains("\n  \($0)") || text.contains("  \($0) ") })
+        else {
+            return false
+        }
+        // The category enumeration must list every accepted help category.
+        return text.contains("Categories: transport, tracks, mixer, midi, edit, "
+            + "navigate, project, audio, plugins, system")
+    }
+
+    // SystemDispatcher `case "list_recent_traces"` →
+    // {"traces":[{trace_id, operation_id, phase_count, readback_state?}]}.
+    // The qualification drive seeds exactly one saga_execute trace before this
+    // probe runs, so the list cannot be empty and its entries cannot be hollow:
+    // a trace claiming zero phases is a lie about what was recorded.
+    static let systemListRecentTraces = OperationOracle(
+        .systemListRecentTraces,
+        strength: .shapeAndDomain,
+        constraints: [
+            .typedField(key: "traces", type: .array),
+            .nonEmptyArray(key: "traces"),
+            .typedField(key: "traces.0.trace_id", type: .string),
+            .typedField(key: "traces.0.operation_id", type: .string),
+            .numericRange(key: "traces.0.phase_count", min: 1, max: 100_000),
+        ]
+    )
+
+    // SystemDispatcher `case "get_trace"` →
+    // {"trace_id", "operation_id", "events":[{phase, timestamp, attributes}]}.
+    // The probe always reads back the trace the drive seeded, and the drive
+    // seeds it via system.saga_execute (QualificationTransport asserts
+    // `$0.operationID == OperationID.systemSagaExecute.rawValue`), so the
+    // operation_id is exactly pinnable — this oracle catches a handler that
+    // returns SOME trace rather than the requested one.
+    static let systemGetTrace = OperationOracle(
+        .systemGetTrace,
+        strength: .shapeAndDomain,
+        constraints: [
+            .typedField(key: "trace_id", type: .string),
+            .valueEquals(key: "operation_id", expected: .string(OperationID.systemSagaExecute.rawValue)),
+            .nonEmptyArray(key: "events"),
+            .enumMember(key: "events.0.phase", allowed: TracePhase.allCases.map(\.rawValue)),
+        ]
+    )
+
+    // SystemDispatcher `case "clear_traces"` success →
+    // {"success":true, "receipt_path":String, "cleared_trace_count":Int}.
+    // NOTE: unreachable under the current probe, which sends `confirmed:false`
+    // on purpose so qualification never destroys diagnostic evidence. That
+    // yields a typed State C and the runner classifies on isError before the
+    // oracle is consulted. The oracle still pins the success contract so a
+    // future confirmed probe (or a handler regression) is checked.
+    static let systemClearTraces = OperationOracle(
+        .systemClearTraces,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "success", expected: .bool(true)),
+            .typedField(key: "receipt_path", type: .string),
+            .numericRange(key: "cleared_trace_count", min: 0, max: 100_000),
+        ]
+    )
+
+    // SystemDispatcher `case "saga_preflight"` → SagaWire.sessionFields +
+    // {"ok", "issues", "before_state_availability", "writes_performed": 0}.
+    // writes_performed == 0 is the load-bearing honesty claim: a preflight that
+    // wrote anything is a contract violation regardless of what it reports.
+    static let systemSagaPreflight = OperationOracle(
+        .systemSagaPreflight,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "writes_performed", expected: .number(0)),
+            .valueEquals(key: "journal_scope", expected: .string("session")),
+            .valueEquals(
+                key: "journal_persistence",
+                expected: .string("cleared_on_server_session_end")
+            ),
+            .valueEquals(key: "journal_survives_process_restart", expected: .bool(false)),
+            .typedField(key: "ok", type: .bool),
+            .typedField(key: "issues", type: .array),
+        ]
+    )
+
+    // SystemDispatcher `case "saga_status"` success → sessionFields +
+    // {"idempotency_key", "record": {"status", ...}}.
+    // NOTE: unreachable under the current probe, which asks for the key
+    // "qualification-read-probe" that no probe ever creates a record for; the
+    // handler answers elementNotFound (State C, isError) and the runner
+    // classifies before the oracle runs. The oracle pins the success contract.
+    static let systemSagaStatus = OperationOracle(
+        .systemSagaStatus,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "journal_scope", expected: .string("session")),
+            .valueEquals(key: "journal_survives_process_restart", expected: .bool(false)),
+            .typedField(key: "idempotency_key", type: .string),
+            .enumMember(
+                key: "record.status",
+                allowed: ["in_progress", "cancellation_requested", "cancelled", "completed"]
+            ),
+        ]
+    )
+
+    // MARK: - plugins
+
+    // AccessibilityChannel+VerifiedPlugins `defaultGetPluginInventory` success →
+    // HC v2 envelope + {track, plugins_source, plugins, complete, ...}.
+    // NOTE: unreachable under the current probe, which sends empty params; the
+    // handler requires `track` and answers a typed HC v2 invalid_params State C.
+    static let pluginsGetInventory = OperationOracle(
+        .pluginsGetInventory,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "hc_schema", expected: .number(2)),
+            // State A ONLY. State B is an honest `readback_unavailable` — the
+            // handler is telling us it could not see the insert chain, and its
+            // extras omit `plugins` entirely. Two reasons this must not qualify:
+            //   1. Semantics: a qualification `passed` means the operation was
+            //      SEMANTICALLY VERIFIED. State B is by construction unverified;
+            //      passing it would launder "I couldn't check" into "checked".
+            //   2. Consistency: allowing {A,B} while requiring a typed `plugins`
+            //      array would false-FAIL every honest State B, since B omits it.
+            // Resolved strict rather than loose: pin A, keep the plugins array.
+            .valueEquals(key: "state", expected: .string("A")),
+            .numericRange(key: "track", min: 0, max: 10_000),
+            .typedField(key: "plugins", type: .array),
+        ]
+    )
+
+    // MARK: - project
+
+    // ProjectDispatcher `case "is_running"` →
+    // toolTextResult(isLogicProRunning() ? "true" : "false").
+    static let projectIsRunning = OperationOracle(
+        custom: .projectIsRunning,
+        reason: """
+            The whole body is a bare scalar literal — `true` or `false` — with \
+            no key to address. A constraint on the root key path could only \
+            restate "is a boolean", which the JSON type already implies; that \
+            is a presence check wearing a value constraint's clothes. The real \
+            contract is byte-exact: exactly one of two literals, so prose, an \
+            envelope, a quoted "true", or `True` are all caught.
+            """
+    ) { responseData, _ in
+        guard let text = String(data: responseData, encoding: .utf8) else { return false }
+        return ["true", "false"].contains(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    // AccessibilityChannel+Regions `defaultGetRegions` → RegionInventoryPayload.
+    // complete/scope/reason are hardcoded honesty disclaimers: this read only
+    // ever sees the visible arrange viewport, and it must never claim otherwise.
+    static let projectGetRegions = OperationOracle(
+        .projectGetRegions,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "complete", expected: .bool(false)),
+            .valueEquals(key: "scope", expected: .string("visible_arrange_area")),
+            .valueEquals(key: "reason", expected: .string("logic_ax_viewport_only")),
+            .numericRange(key: "returned_count", min: 0, max: 100_000),
+            .typedField(key: "regions", type: .array),
+        ]
+    )
+
+    // ProjectExportPlannerModels `ProjectExportPlan` CodingKeys.
+    // NOTE: unreachable under the current probe (empty params; the planner
+    // requires `projects`/`project`/`path` and answers invalid_params).
+    // execution_mode/next_safe_action are the plan's dry-run guarantees.
+    static let projectExportPlan = OperationOracle(
+        .projectExportPlan,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schema", expected: .string("logic_pro_mcp_export_manifest.v1")),
+            .valueEquals(key: "execution_mode", expected: .string("dry_run_only")),
+            .valueEquals(key: "next_safe_action", expected: .string("review_export_plan")),
+            .enumMember(key: "status", allowed: ["planned", "degraded"]),
+            .numericRange(key: "project_count", min: 0, max: 100_000),
+            .typedField(key: "projects", type: .array),
+        ]
+    )
+
+    // ProjectSessionAudit `AuditReport`. read_only:true is hardcoded and
+    // load-bearing: the audit promises it touched nothing.
+    static let projectAudit = OperationOracle(
+        .projectAudit,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schema", expected: .string("logic_pro_mcp_project_audit.v1")),
+            .valueEquals(key: "read_only", expected: .bool(true)),
+            .enumMember(key: "status", allowed: ["ok", "degraded", "failed"]),
+            .numericRange(key: "project.track_count", min: 0, max: 10_000),
+            .typedField(key: "findings", type: .array),
+            .typedField(key: "evidence", type: .object),
+        ]
+    )
+
+    // ProjectSessionAudit `CleanupPlanReport`. source_audit_schema binds the
+    // plan to the audit schema it was derived from; requires_plan_confirmation
+    // is the hardcoded promise that a plan is never self-applying.
+    static let projectCleanupPlan = OperationOracle(
+        .projectCleanupPlan,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(
+                key: "schema",
+                expected: .string("logic_pro_mcp_project_cleanup_plan.v1")
+            ),
+            .valueEquals(
+                key: "source_audit_schema",
+                expected: .string("logic_pro_mcp_project_audit.v1")
+            ),
+            .valueEquals(key: "read_only", expected: .bool(true)),
+            .valueEquals(key: "requires_plan_confirmation", expected: .bool(true)),
+            .enumMember(key: "status", allowed: ["ok", "degraded", "failed"]),
+            .typedField(key: "steps", type: .array),
+        ]
+    )
+
+    // MARK: - audio
+
+    // AudioAnalyzer.Result CodingKeys. NOTE: unreachable under the current
+    // probe (empty params → unsafe_path failure body), but the oracle pins the
+    // real success contract.
+    static let audioAnalyzeFile = OperationOracle(
+        .audioAnalyzeFile,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schema", expected: .string("logic_pro_mcp_audio_analysis.v1")),
+            // {pass, warn} only — NOT fail. AudioDispatcher sets
+            // `isError: result.verification.status == .fail`, so a fail body
+            // always arrives with isError and the runner classifies it
+            // notQualified before this oracle is consulted. Accepting "fail"
+            // could therefore only ever launder a failed analysis into a
+            // semantic pass; a `warn` is a completed measurement with caveats,
+            // a `fail` is not a measurement at all.
+            .enumMember(key: "verification.status", allowed: ["pass", "warn"]),
+            .typedField(key: "verification.reasons", type: .array),
+            .typedField(key: "exists", type: .bool),
+            .numericRange(key: "duration_seconds", min: 0, max: 86_400),
+            .numericRange(key: "sample_rate", min: 0, max: 768_000),
+            .numericRange(key: "channel_count", min: 0, max: 512),
+            // dBFS is a negative-or-zero log scale; a positive peak from this
+            // analyzer would mean the measurement, not the file, is wrong.
+            .numericRange(key: "peak_dbfs", min: -200, max: 0),
+            .numericRange(key: "silence_ratio", min: 0, max: 1),
+        ]
+    )
+
+    // MARK: - midi
+
+    // CoreMIDIChannel `listMIDIPortsJSON` → {"sources":[String],
+    // "destinations":[String]}. The `logic://midi/ports` resource routes the
+    // SAME midi.list_ports operation and serves the channel's message verbatim
+    // (ResourceHandlers+StateReaders), so response and readback are equal by
+    // construction — the strongest available check for a body with no constants.
+    static let midiListPorts = OperationOracle(
+        custom: .midiListPorts,
+        reason: """
+            The body has no constant-valued field (both keys are \
+            environment-dependent string arrays), so no declarative VALUE \
+            constraint exists, and the constraint model cannot bind two \
+            payloads at once. HONEST SCOPE OF THIS CHECK: the readback resource \
+            re-invokes the SAME midi.list_ports handler and serves its message \
+            verbatim, so agreement proves same-handler echo and transport \
+            consistency — it is NOT an independent readback and must not be \
+            read as one. It still catches truncation, reordering, and \
+            serialization damage between the two reads. No truly independent \
+            MIDI probe exists today; Phase B may add a CoreMIDI-direct probe to \
+            make this a real cross-check.
+            """
+    ) { responseData, readbackData in
+        guard let response = JSONInspector.parse(responseData) as? [String: Any],
+              let readback = JSONInspector.parse(readbackData) as? [String: Any] else {
+            return false
+        }
+        // A degraded resource read answers {"message":…} or {"error":…}; that is
+        // not an independent confirmation of the port lists.
+        guard let responseSources = response["sources"] as? [String],
+              let responseDestinations = response["destinations"] as? [String],
+              let readbackSources = readback["sources"] as? [String],
+              let readbackDestinations = readback["destinations"] as? [String] else {
+            return false
+        }
+        return responseSources == readbackSources
+            && responseDestinations == readbackDestinations
+    }
+
+    // MARK: - tracks
+
+    // LibraryAccessor.Inventory → {categories, presetsByCategory,
+    // currentCategory?, currentPreset?}. The `logic://library/inventory`
+    // resource wraps the cached scan in a T7 envelope under "data".
+    static let tracksListLibrary = OperationOracle(
+        custom: .tracksListLibrary,
+        reason: """
+            LibraryAccessor.Inventory has no constant-valued field — all four \
+            keys are environment-dependent — so no declarative VALUE constraint \
+            exists. The load-bearing check is the internal consistency of the \
+            inventory (every advertised category must actually carry a preset \
+            list) plus agreement with the independent inventory resource read, \
+            neither of which the constraint model can express.
+            """
+    ) { responseData, readbackData in
+        guard let response = JSONInspector.parse(responseData) as? [String: Any],
+              let categories = response["categories"] as? [String],
+              let presetsByCategory = response["presetsByCategory"] as? [String: Any] else {
+            return false
+        }
+        // A zero-category inventory would make the checks below vacuously true
+        // (`[].allSatisfy` is true, and two empty sets always agree). "I read
+        // nothing and it was all consistent" is not a semantic pass.
+        guard !categories.isEmpty else { return false }
+        // An inventory that advertises a category it cannot enumerate presets
+        // for is lying about what it read — and the preset list must actually
+        // be a list of preset names, not merely some value under that key.
+        guard categories.allSatisfy({ presetsByCategory[$0] as? [String] != nil }) else {
+            return false
+        }
+        // Fail closed on the readback. A degraded resource read ({"error":…},
+        // a cache miss {"cached":false,…}, or a non-object body) carries no
+        // inventory to compare against — and an internal-consistency-only pass
+        // would report `readback.verified == true` on evidence that contributed
+        // nothing. Without a usable independent read there is no semantic
+        // verification to claim.
+        guard let readback = JSONInspector.parse(readbackData) as? [String: Any],
+              let data = readback["data"] as? [String: Any],
+              let readbackCategories = data["categories"] as? [String],
+              !readbackCategories.isEmpty else {
+            return false
+        }
+        return Set(categories) == Set(readbackCategories)
+    }
+
+    // AccessibilityChannel+Library `encodeLibraryRoot` →
+    // {"source": <tag>, "root": LibraryRoot}. The probe sends empty params, so
+    // the mode defaults to `disk`; a disk scan that throws silently falls back
+    // to the live panel scan and re-tags the source, so both tags are legal.
+    static let tracksScanLibrary = OperationOracle(
+        .tracksScanLibrary,
+        strength: .shapeAndDomain,
+        constraints: [
+            .enumMember(key: "source", allowed: ["disk", "panel"]),
+            .typedField(key: "root", type: .object),
+            .typedField(key: "root.categories", type: .array),
+            .numericRange(key: "root.nodeCount", min: 0, max: 10_000_000),
+            .numericRange(key: "root.leafCount", min: 0, max: 10_000_000),
+            .numericRange(key: "root.folderCount", min: 0, max: 10_000_000),
+            .numericRange(key: "root.scanDurationMs", min: 0, max: 3_600_000),
+            .typedField(key: "root.selectionRestored", type: .bool),
+        ]
+    )
+
+    // AccessibilityChannel+Library `ResolvePathResponse` (nils omitted).
+    // NOTE: unreachable under the current probe (empty params → the dispatcher's
+    // `path.isEmpty` gate answers invalid_params). The cold-cache success body
+    // is {"exists":false,"reason":…}, so only `exists` is always present.
+    static let tracksResolvePath = OperationOracle(
+        custom: .tracksResolvePath,
+        reason: """
+            The success contract guarantees exactly one field — `exists: Bool` — \
+            because ResolvePathResponse omits every nil. No constant-valued \
+            field exists, and a constraint on `exists` could only restate its \
+            type. The load-bearing semantics are CONDITIONAL: a hit must name \
+            what it matched and how it was classified; a miss must say why. The \
+            constraint model has no implication case, so the conditional lives \
+            in the closure.
+            """
+    ) { responseData, _ in
+        guard let response = JSONInspector.parse(responseData) as? [String: Any],
+              let exists = response["exists"], JSONInspector.isBoolean(exists) else {
+            return false
+        }
+        guard (exists as? NSNumber)?.boolValue == true else {
+            // A miss must explain itself rather than answering a bare false.
+            return (response["reason"] as? String)?.isEmpty == false
+        }
+        // A hit must name the matched path and classify the node it found.
+        guard let matchedPath = response["matchedPath"] as? String,
+              !matchedPath.isEmpty,
+              let kind = response["kind"] as? String else {
+            return false
+        }
+        // LibraryNodeKind raw values.
+        return ["folder", "leaf", "truncated", "probeTimeout", "cycle"].contains(kind)
+    }
+
+    // AccessibilityChannel+Library `runLivePluginPresetScan` → PluginPresetCache.
+    // schemaVersion/pluginName/pluginIdentifier/contentHash are hardcoded at the
+    // encode site; measuredSubmenuOpenDelayMs echoes the settle delay, which the
+    // dispatcher defaults to 250 when the probe omits it — an echo the oracle
+    // pins so a handler that ignores the parameter is caught.
+    static let tracksScanPluginPresets = OperationOracle(
+        .tracksScanPluginPresets,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schemaVersion", expected: .number(1)),
+            .valueEquals(key: "pluginName", expected: .string("(focused-plugin)")),
+            .valueEquals(key: "contentHash", expected: .string("(deferred)")),
+            .valueEquals(key: "measuredSubmenuOpenDelayMs", expected: .number(250)),
+            .typedField(key: "root", type: .object),
+            .numericRange(key: "nodeCount", min: 0, max: 10_000_000),
+            .numericRange(key: "leafCount", min: 0, max: 10_000_000),
+            .numericRange(key: "scanDurationMs", min: 0, max: 3_600_000),
+        ]
+    )
+}

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+// #373 Phase A — data-driven semantic oracles for the read-only (class A)
+// operation surface.
+//
+// WHY: `QualificationSemanticReadbackValidator` shipped with a single bespoke
+// case (system.health). Every other read-only operation fell through to `nil`,
+// which the runner honestly records as `protocolSmoke` — "the transport worked,
+// nobody checked the meaning". PromotionGate requires every operation
+// passed-or-waived, so the read-only surface could never qualify.
+//
+// This file gives each read-only spec an oracle: a declarative set of
+// constraints over the operation's ACTUAL response shape (derived by reading
+// each dispatcher handler, not by guessing). The oracle table is census-tested
+// against the registry so the two cannot drift, and every oracle is
+// mutation-tested so an oracle that cannot fail a corrupted payload fails CI.
+//
+// Presence-only oracles are FORBIDDEN: an oracle must carry at least one VALUE
+// constraint (valueEquals / numericRange / enumMember) or be an explicitly
+// reasoned `.custom` escape hatch.
+
+/// A JSON leaf value an oracle can pin exactly.
+enum JSONPrimitive: Sendable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+}
+
+/// The JSON type an oracle can require of a field.
+enum JSONType: String, Sendable, Equatable {
+    case string
+    case number
+    case bool
+    case array
+    case object
+    case null
+}
+
+/// One declarative check against an operation's response payload.
+///
+/// `key` is a dotted key path resolved against the parsed response:
+/// `""` addresses the root value (used by operations whose whole body is a
+/// bare JSON scalar), `"a.b"` descends objects, and `"a.0"` indexes arrays.
+enum OracleConstraint: Sendable {
+    /// Fixture-pinned exact value. The strongest form — use wherever the
+    /// handler emits a literal constant (schema tags, hardcoded honesty flags).
+    case valueEquals(key: String, expected: JSONPrimitive)
+    /// Environment-dependent number confined to a semantically legal domain.
+    case numericRange(key: String, min: Double, max: Double)
+    /// Field must be one of a closed set of legal tokens.
+    case enumMember(key: String, allowed: [String])
+    /// Field must be an array with at least one element.
+    case nonEmptyArray(key: String)
+    /// Field must be present with the given JSON type.
+    case typedField(key: String, type: JSONType)
+
+    var key: String {
+        switch self {
+        case .valueEquals(let key, _),
+             .numericRange(let key, _, _),
+             .enumMember(let key, _),
+             .nonEmptyArray(let key),
+             .typedField(let key, _):
+            return key
+        }
+    }
+
+    /// VALUE constraints pin meaning; the others only pin shape. The strength
+    /// meta-test uses this to forbid presence-only oracles.
+    var isValueConstraint: Bool {
+        switch self {
+        case .valueEquals, .numericRange, .enumMember:
+            return true
+        case .nonEmptyArray, .typedField:
+            return false
+        }
+    }
+
+    func isSatisfied(by root: Any) -> Bool {
+        guard let value = JSONPath.resolve(root, keyPath: key) else { return false }
+        switch self {
+        case .valueEquals(_, let expected):
+            return JSONInspector.primitive(of: value) == expected
+        case .numericRange(_, let min, let max):
+            guard let number = JSONInspector.number(of: value) else { return false }
+            return number >= min && number <= max
+        case .enumMember(_, let allowed):
+            guard let token = JSONInspector.enumToken(of: value) else { return false }
+            return allowed.contains(token)
+        case .nonEmptyArray:
+            guard let array = value as? [Any] else { return false }
+            return !array.isEmpty
+        case .typedField(_, let type):
+            return JSONInspector.type(of: value) == type
+        }
+    }
+}
+
+enum OracleStrength: String, Sendable {
+    /// Every constraint is an exact fixture-pinned value.
+    case value
+    /// Mixes exact values with domain/shape constraints for the
+    /// environment-dependent fields.
+    case shapeAndDomain
+    /// Escape hatch: the response is not key-addressable JSON, or the check is
+    /// a response↔readback cross-check the constraint data model cannot express.
+    case custom
+}
+
+struct OperationOracle: Sendable {
+    let operationID: OperationID
+    let strength: OracleStrength
+    let constraints: [OracleConstraint]
+    /// Required for `.custom`: why the declarative constraints cannot express
+    /// this operation's check. Enforced by the strength meta-test.
+    let customReason: String?
+    /// Escape hatch. Receives the raw response and the raw independent readback.
+    /// Returns nil only if the oracle cannot render a verdict at all.
+    let custom: (@Sendable (Data, Data) -> Bool?)?
+
+    init(
+        _ operationID: OperationID,
+        strength: OracleStrength,
+        constraints: [OracleConstraint]
+    ) {
+        self.operationID = operationID
+        self.strength = strength
+        self.constraints = constraints
+        customReason = nil
+        custom = nil
+    }
+
+    init(
+        custom operationID: OperationID,
+        reason: String,
+        evaluate: @escaping @Sendable (Data, Data) -> Bool?
+    ) {
+        self.operationID = operationID
+        strength = .custom
+        constraints = []
+        customReason = reason
+        custom = evaluate
+    }
+
+    /// The oracle carries real meaning (not just presence checks).
+    var isSemanticallyLoadBearing: Bool {
+        if strength == .custom {
+            return custom != nil && customReason?.isEmpty == false
+        }
+        return constraints.contains { $0.isValueConstraint }
+    }
+
+    func evaluate(responseData: Data, readbackData: Data) -> Bool? {
+        if let custom {
+            return custom(responseData, readbackData)
+        }
+        guard let root = JSONInspector.parse(responseData) else { return false }
+        return constraints.allSatisfy { $0.isSatisfied(by: root) }
+    }
+}
+
+// MARK: - JSON access
+
+enum JSONInspector {
+    /// `.fragmentsAllowed`: `project.is_running` answers with a bare `true` /
+    /// `false` literal, which is a legal JSON fragment but not an object.
+    static func parse(_ data: Data) -> Any? {
+        try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+
+    /// NSNumber bridges to both Bool and Double in Swift, so `as? Bool` cannot
+    /// distinguish `true` from `1`. CoreFoundation's type id can.
+    static func isBoolean(_ value: Any) -> Bool {
+        guard let number = value as? NSNumber else { return false }
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
+    }
+
+    static func type(of value: Any) -> JSONType {
+        if value is NSNull { return .null }
+        if isBoolean(value) { return .bool }
+        if value is NSNumber { return .number }
+        if value is String { return .string }
+        if value is [Any] { return .array }
+        if value is [String: Any] { return .object }
+        return .null
+    }
+
+    static func number(of value: Any) -> Double? {
+        guard !isBoolean(value), let number = value as? NSNumber else { return nil }
+        return number.doubleValue
+    }
+
+    static func primitive(of value: Any) -> JSONPrimitive? {
+        switch type(of: value) {
+        case .null: return .null
+        case .bool: return .bool((value as? NSNumber)?.boolValue ?? false)
+        case .number: return number(of: value).map { .number($0) }
+        case .string: return (value as? String).map { .string($0) }
+        case .array, .object: return nil
+        }
+    }
+
+    /// Enum membership is checked against the token's string form. Booleans are
+    /// rendered as `true`/`false` so a bare-scalar body can be domain-checked.
+    static func enumToken(of value: Any) -> String? {
+        switch type(of: value) {
+        case .string: return value as? String
+        case .bool: return ((value as? NSNumber)?.boolValue ?? false) ? "true" : "false"
+        default: return nil
+        }
+    }
+}
+
+enum JSONPath {
+    /// Resolves a dotted key path. `""` is the root. Numeric components index
+    /// arrays. Returns nil when any component is absent — an absent key can
+    /// never satisfy a constraint, which is what makes drop-the-key mutations
+    /// fail closed.
+    static func resolve(_ root: Any, keyPath: String) -> Any? {
+        guard !keyPath.isEmpty else { return root }
+        var current: Any = root
+        for component in keyPath.split(separator: ".") {
+            if let object = current as? [String: Any], let next = object[String(component)] {
+                current = next
+            } else if let array = current as? [Any],
+                      let index = Int(component),
+                      index >= 0,
+                      index < array.count {
+                current = array[index]
+            } else {
+                return nil
+            }
+        }
+        return current
+    }
+}

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -51,15 +51,22 @@ struct QualificationRunnerTests {
         let attestation = try await fixture.qualify()
         let operationCases = attestation.cases.filter { $0.id.hasPrefix("in-process/") }
 
+        // #373 Phase A shifted these counts. Before: only system.health had a
+        // semantic validator, so the other 20 read-only ops were honestly
+        // recorded protocolSmoke ("transport worked, nobody checked meaning").
+        // Now every read-only spec has an oracle, so a read that returns its
+        // real payload qualifies: passed == 21 (20 oracles + health's bespoke
+        // validator), protocolSmoke == 0. The 86 mutating ops are unchanged —
+        // they still defer to ADR-001-c for live mutation.
         #expect(operationCases.count == 107)
-        #expect(operationCases.filter { $0.status == .passed }.count == 1)
-        #expect(operationCases.filter { $0.status == .protocolSmoke }.count == 20)
+        #expect(operationCases.filter { $0.status == .passed }.count == 21)
+        #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
         #expect(operationCases.filter { $0.status == .notQualified }.count == 86)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
-        #expect(operationCases.filter { $0.status == .protocolSmoke }.allSatisfy {
-            $0.verificationKind == .protocolSmoke
-                && $0.deferral?.code == .semanticValidatorUnavailable
-                && $0.readback?.verified == false
+        #expect(operationCases.filter { $0.status == .passed }.allSatisfy {
+            $0.verificationKind == .semanticReadback
+                && $0.deferral == nil
+                && $0.readback?.verified == true
         })
         #expect(operationCases.filter { $0.status == .notQualified }.allSatisfy {
             $0.verificationKind == .typedDeferral
@@ -95,7 +102,12 @@ struct QualificationRunnerTests {
         #expect(result.readback?.verified == false)
     }
 
-    @Test func readOperationWithoutValidatorIsProtocolSmoke() throws {
+    /// #373 Phase A retired the protocolSmoke bucket for read-only operations.
+    /// Before, system.permissions had no validator, so ANY well-formed body was
+    /// recorded protocolSmoke — "the transport worked, nobody checked". Now it
+    /// has an oracle, and this body (invented JSON, not the prose the handler
+    /// actually emits) is a semantic mismatch, not an unchecked smoke pass.
+    @Test func readOperationWithAnOracleIsNoLongerProtocolSmoke() throws {
         let spec = try #require(OperationRegistry.specs.first { $0.id == .systemPermissions })
         let result = QualificationOperationResult(
             operationID: spec.id.rawValue,
@@ -114,9 +126,24 @@ struct QualificationRunnerTests {
             failureReason: nil
         )
 
-        #expect(result.status.rawValue == "protocol_smoke")
+        #expect(result.status == .notQualified)
+        #expect(result.status.rawValue != "protocol_smoke")
         #expect(!result.verified)
+        #expect(result.deferral?.code == .semanticMismatch)
         #expect(result.readback?.verified == false)
+    }
+
+    /// The structural consequence, pinned: with every read-only spec oracled,
+    /// no read-only operation can reach protocolSmoke. If a future read-only op
+    /// lands without an oracle the census test fails first — this one records
+    /// why that matters.
+    @Test func noReadOnlyOperationCanFallThroughToProtocolSmoke() {
+        let unoracled = OperationRegistry.specs
+            .filter { $0.mutability == .readOnly && $0.availability != .unsupported }
+            .filter { spec in
+                spec.id != .systemHealth && SemanticOracleTable.byOperationID[spec.id] == nil
+            }
+        #expect(unoracled.isEmpty)
     }
 
     @Test func readErrorIsNotLabeledSemanticMismatch() throws {
@@ -254,7 +281,13 @@ struct QualificationRunnerTests {
         #expect(try Self.resultObject(decision)["promotable"] as? Bool == true)
     }
 
-    @Test func individualGovernedProtocolSmokeWaiverSatisfiesRequiredOperation() async throws {
+    /// #373 Phase A inverted this test's premise, and the inversion is the
+    /// point. This used to waive system.permissions because it could only reach
+    /// protocolSmoke — a validator-shaped hole a waiver had to paper over. The
+    /// op now qualifies on its own semantics, so waiving it is no longer
+    /// governance, it is noise: the gate must reject a waiver for a passing
+    /// case rather than let a stale waiver linger over a healthy operation.
+    @Test func waiverForNowQualifyingReadOperationIsRejected() async throws {
         let spec = try #require(OperationRegistry.specs.first { $0.id == .systemPermissions })
         let fixture = try Fixture(specs: [spec])
         defer { fixture.remove() }
@@ -267,13 +300,16 @@ struct QualificationRunnerTests {
 
         let attestation = try await fixture.qualify(waiversURL: fixture.waiversURL)
         let operationCase = try #require(attestation.cases.first { $0.id == waiver.caseID })
-        #expect(operationCase.status == .waived)
-        #expect(operationCase.verificationKind == .typedDeferral)
-        #expect(operationCase.deferral?.code == .semanticValidatorUnavailable)
+        #expect(operationCase.status == .passed)
+        #expect(operationCase.verified)
+        #expect(operationCase.verificationKind == .semanticReadback)
+        #expect(operationCase.deferral == nil)
 
         let decision = await fixture.verify(expectedSHA256: fixture.binarySHA256)
-        #expect(decision.exitCode == 0)
-        #expect(try Self.resultObject(decision)["promotable"] as? Bool == true)
+        #expect(decision.exitCode != 0)
+        #expect(Self.rejectionReasons(try Self.resultObject(decision)).contains(
+            "waiverForPassingCase"
+        ))
     }
 
     @Test func forgedCoherentBundleWithoutTrustedSignatureRejectsPromotion() async throws {
@@ -1496,10 +1532,13 @@ struct QualificationRunnerTests {
         // ship axis (desktop/ko-KR) is not qualified (no waiver supplied).
         #expect(aggregateCases.filter { $0.status == .failed }.count == 1)
         #expect(aggregateCases.filter { $0.status == .notQualified }.count == 1)
-        #expect(operationCases.filter { $0.status == .passed }.count == 1)
-        #expect(operationCases.filter { $0.status == .protocolSmoke }.count == 20)
+        // #373 Phase A: the read-only surface now qualifies semantically.
+        #expect(operationCases.filter { $0.status == .passed }.count == 21)
+        #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
         #expect(operationCases.filter { $0.status == .notQualified }.count == 86)
-        #expect(attestation.passed == 1)
+        // #373 Phase A: 20 oracled read-only ops + system.health's bespoke
+        // validator. The aggregate axes contribute no passes here.
+        #expect(attestation.passed == 21)
         #expect(attestation.failed == 1)
 
         for qualificationCase in operationCases {
@@ -1509,15 +1548,12 @@ struct QualificationRunnerTests {
             ))
             #expect(qualificationCase.id == "in-process/\(spec.id.rawValue)")
             #expect(OperationHandlerRegistry.handler(tool: qualificationCase.tool, command: qualificationCase.command) != nil)
-            if spec.id == .systemHealth {
+            if spec.mutability == .readOnly {
+                // #373 Phase A: health via its bespoke validator, every other
+                // read-only spec via its oracle — both are semantic readbacks.
                 #expect(qualificationCase.status == .passed)
                 #expect(qualificationCase.verified)
                 #expect(qualificationCase.verificationKind == .semanticReadback)
-            } else if spec.mutability == .readOnly {
-                #expect(qualificationCase.status == .protocolSmoke)
-                #expect(!qualificationCase.verified)
-                #expect(qualificationCase.verificationKind == .protocolSmoke)
-                #expect(qualificationCase.deferral?.code == .semanticValidatorUnavailable)
             } else {
                 #expect(qualificationCase.status == .notQualified)
                 #expect(!qualificationCase.verified)
@@ -2703,17 +2739,29 @@ struct QualificationRunnerTests {
             if !isMutation, remainingQualifiedReads != nil {
                 remainingQualifiedReads? -= 1
             }
+            // #373 Phase A: read-only ops now have real semantic oracles, so a
+            // generic {"operation":…,"state":"A"} stub no longer models a
+            // qualifying read — the oracle would (correctly) reject it. Read-only
+            // specs are driven with the realistic per-operation payloads the
+            // oracle fixtures pin, which are themselves derived from the real
+            // dispatcher shapes. systemHealth keeps its bespoke full-payload
+            // equality, so it is fed the same health body on both sides.
+            let oracleFixture = spec.mutability == .readOnly
+                ? SemanticOracleFixtures.byOperationID[spec.id]
+                : nil
             let response = spec.id == nonObjectResponseOperationID
                 ? Data("plain text response".utf8)
                 : spec.id == .systemHealth
                 ? stableHealth
-                : Data((isMutation
+                : oracleFixture.map(\.responseData)
+                ?? Data((isMutation
                     ? "{\"operation\":\"\(spec.id.rawValue)\",\"state\":\"C\",\"error\":\"invalid_params\",\"write_attempted\":false}"
                     : "{\"operation\":\"\(spec.id.rawValue)\",\"state\":\"A\",\"write_attempted\":false}"
                 ).utf8)
             let readback = spec.id == .systemHealth
                 ? stableHealth
-                : Data("{\"operation_readback\":\"\(spec.id.rawValue)\"}".utf8)
+                : oracleFixture.map(\.readbackData)
+                ?? Data("{\"operation_readback\":\"\(spec.id.rawValue)\"}".utf8)
             return (
                 spec.id.rawValue,
                 QualificationOperationResult(

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -1,0 +1,463 @@
+import Foundation
+@testable import LogicProMCP
+
+// #373 Phase A — realistic per-operation payloads.
+//
+// Each entry is a faithful sample of what the operation's dispatcher actually
+// emits (shapes read from the handlers, not invented). One source of truth,
+// used three ways:
+//   1. happy-path assertions — the oracle passes a realistic payload;
+//   2. the mutation harness — every constraint is corrupted and must fail;
+//   3. QualificationRunnerTests' canned drive responses, so the runner's
+//      classification counts are exercised against the same shapes.
+//
+// `customMutants` carries hand-written corruptions for `.custom` oracles, whose
+// checks the generic mutator cannot derive from a constraint list.
+
+/// What a hand-written corruption is meant to prove. Counting mutants is
+/// gameable — four garbage strings would "cover" an oracle while proving only
+/// that it rejects garbage. The harness requires each KIND, so every custom
+/// oracle must demonstrate it rejects a payload that parses perfectly well and
+/// is merely WRONG.
+enum CustomMutantKind: String, CaseIterable {
+    /// Unparseable or structurally absent — proves the oracle rejects noise.
+    case malformed
+    /// Parses fine, well-formed, violates a load-bearing semantic clause.
+    case wellFormedButWrong
+    /// Response is fine; the readback disagrees with it. Only meaningful for
+    /// oracles that actually compare the two payloads.
+    case readbackDivergence
+}
+
+struct CustomMutant {
+    let kind: CustomMutantKind
+    let response: String
+    /// Replaces the fixture readback — required for `.readbackDivergence`.
+    let readbackOverride: String?
+
+    init(_ kind: CustomMutantKind, _ response: String, readbackOverride: String? = nil) {
+        self.kind = kind
+        self.response = response
+        self.readbackOverride = readbackOverride
+    }
+}
+
+struct SemanticOracleFixture {
+    let response: String
+    let readback: String
+    /// Corruptions that MUST make the oracle fail. Only required for `.custom`
+    /// oracles; declarative oracles are mutated generically from constraints.
+    let customMutants: [CustomMutant]
+
+    init(response: String, readback: String, customMutants: [CustomMutant] = []) {
+        self.response = response
+        self.readback = readback
+        self.customMutants = customMutants
+    }
+
+    var responseData: Data { Data(response.utf8) }
+    var readbackData: Data { Data(readback.utf8) }
+}
+
+enum SemanticOracleFixtures {
+    static let health = """
+        {"logic_pro_running":true,"logic_pro_version":"11.2",\
+        "logic_pro_bundle_id":"com.apple.logic10","logic_pro_variant":"desktop",\
+        "logic_pro_ui_locale":"en-US","process_metadata_resolved":true,\
+        "logic_pro_variants":[]}
+        """
+
+    static let operationsCatalog = """
+        {"schema_version":1,"generated_at":"1970-01-01T00:16:40Z",\
+        "operation_count":1,"operations":[]}
+        """
+
+    static let seededTraceID = "lpmcp_00000000-0000-0000-0000-000000000000"
+
+    static let systemHelpText = """
+        logic_system commands:
+          health            -> {} — Channel status + cache info
+          permissions       -> {} — macOS permission status
+          refresh_cache     -> {} — Force AX re-poll
+          export_support_bundle -> { dir?: String } — Write privacy-safe local diagnostics
+          list_recent_traces -> { limit?: Int } — List recent in-process operation traces
+          get_trace         -> { trace_id: String } — Read one in-process operation trace
+          clear_traces      -> { confirmed: Bool } — Clear diagnostic evidence
+          saga_preflight    -> { steps: [step], idempotency_key: String } — writes 0
+          saga_execute      -> { steps: [step], idempotency_key: String } — Execute ordered steps
+          saga_status       -> { idempotency_key: String } — Read the session journal
+          saga_cancel       -> { idempotency_key: String } — Request cancellation
+          help              -> { category: String } — Param docs per category
+
+        Categories: transport, tracks, mixer, midi, edit, navigate, project, audio, plugins, system
+
+        Read health via resource: logic://system/health
+        """
+
+    static let byOperationID: [OperationID: SemanticOracleFixture] = [
+        .systemPermissions: SemanticOracleFixture(
+            response: """
+                Accessibility: granted
+                Automation (Logic Pro): granted
+                Automation (System Events): granted
+                PostEvent (CGEvent): granted
+                """,
+            readback: health,
+            customMutants: [
+                .init(.malformed, ""),
+                .init(.malformed, "{\"state\":\"A\",\"permissions\":[]}"),
+                // A permission line silently dropped — reads as a normal
+                // summary, but System Events is unaccounted for.
+                .init(.wellFormedButWrong, """
+                    Accessibility: granted
+                    Automation (Logic Pro): granted
+                    PostEvent (CGEvent): granted
+                    """),
+                // A label outside the closed state set.
+                .init(.wellFormedButWrong, """
+                    Accessibility: probably fine
+                    Automation (Logic Pro): granted
+                    Automation (System Events): granted
+                    PostEvent (CGEvent): granted
+                    """),
+                // FIX-5 regression guard: a prefix match would have accepted
+                // this "granted"-prefixed impostor label.
+                .init(.wellFormedButWrong, """
+                    Accessibility: granted_evil
+                    Automation (Logic Pro): granted
+                    Automation (System Events): granted
+                    PostEvent (CGEvent): granted
+                    """),
+            ]
+        ),
+        .systemRefreshCache: SemanticOracleFixture(
+            response: "State refresh completed via AX fallback poller.",
+            readback: health,
+            customMutants: [
+                .init(.malformed, ""),
+                .init(.malformed, "{\"state\":\"A\"}"),
+                // Plausible prose that is not one of the two legal sentences.
+                .init(.wellFormedButWrong, "State refresh maybe happened."),
+                // One character short of the real sentence.
+                .init(.wellFormedButWrong, "State refresh completed via AX fallback poller"),
+            ]
+        ),
+        .systemHelp: SemanticOracleFixture(
+            response: systemHelpText,
+            readback: operationsCatalog,
+            customMutants: [
+                .init(.malformed, ""),
+                // Wrong category section — the probe asked for "system", so
+                // this is a real help document that ignored the parameter.
+                .init(.wellFormedButWrong, "logic_transport commands:\n  play -> {}"),
+                // A documented command silently dropped from the section.
+                .init(.wellFormedButWrong, systemHelpText.replacingOccurrences(
+                    of: "  saga_status       -> { idempotency_key: String } — Read the session journal\n",
+                    with: ""
+                )),
+                // The category enumeration drifted out of lockstep.
+                .init(.wellFormedButWrong, systemHelpText.replacingOccurrences(
+                    of: "Categories: transport, tracks, mixer, midi, edit, navigate, project, audio, plugins, system",
+                    with: "Categories: transport, tracks"
+                )),
+            ]
+        ),
+        .systemListRecentTraces: SemanticOracleFixture(
+            response: """
+                {"traces":[{"trace_id":"\(seededTraceID)",\
+                "operation_id":"system.saga_execute","phase_count":2,\
+                "readback_state":"C"}]}
+                """,
+            readback: operationsCatalog
+        ),
+        .systemGetTrace: SemanticOracleFixture(
+            response: """
+                {"trace_id":"\(seededTraceID)","operation_id":"system.saga_execute",\
+                "events":[{"phase":"request.received","timestamp":"0.0","attributes":{}},\
+                {"phase":"result.emitted","timestamp":"1.0","attributes":{}}]}
+                """,
+            readback: operationsCatalog
+        ),
+        .systemClearTraces: SemanticOracleFixture(
+            response: """
+                {"success":true,"receipt_path":"/tmp/logic-pro-mcp/trace-receipt.jsonl",\
+                "cleared_trace_count":3}
+                """,
+            readback: operationsCatalog
+        ),
+        .systemSagaPreflight: SemanticOracleFixture(
+            response: """
+                {"journal_scope":"session",\
+                "journal_persistence":"cleared_on_server_session_end",\
+                "journal_survives_process_restart":false,"ok":true,"issues":[],\
+                "before_state_availability":[],"writes_performed":0}
+                """,
+            readback: health
+        ),
+        .systemSagaStatus: SemanticOracleFixture(
+            response: """
+                {"journal_scope":"session",\
+                "journal_persistence":"cleared_on_server_session_end",\
+                "journal_survives_process_restart":false,\
+                "idempotency_key":"qualification-read-probe",\
+                "record":{"status":"completed","outcome":{"state":"A"}}}
+                """,
+            readback: health
+        ),
+        .pluginsGetInventory: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","hc_schema":2,\
+                "operation":"logic_plugins.get_inventory","track":0,\
+                "plugins_source":"ax","plugins_fetched_at":"1970-01-01T00:00:00Z",\
+                "plugins_unknown_reason":null,"mixer_reveal_attempted":false,\
+                "mixer_reveal_strategies":[],"complete":true,"plugins":[]}
+                """,
+            readback: "{\"channel_strips\":[]}"
+        ),
+        .projectIsRunning: SemanticOracleFixture(
+            response: "true",
+            readback: "{\"cache_age_sec\":1.0,\"fetched_at\":null,\"ax_occluded\":false,"
+                + "\"source\":\"ax_live\",\"data\":{\"name\":\"Untitled\",\"trackCount\":0}}",
+            customMutants: [
+                .init(.malformed, ""),
+                .init(.malformed, "yes"),
+                // Parses as JSON, but a quoted string is not a boolean literal.
+                .init(.wellFormedButWrong, "\"true\""),
+                // Parses as JSON, but the contract is a bare scalar, not an
+                // envelope — a client reading this gets a truthy object either way.
+                .init(.wellFormedButWrong, "{\"running\":true}"),
+                .init(.wellFormedButWrong, "True"),
+            ]
+        ),
+        .projectGetRegions: SemanticOracleFixture(
+            response: """
+                {"regions":[{"name":"Audio 1","trackIndex":0,"startBar":1,"endBar":5,\
+                "kind":"audio","rawHelp":null}],"complete":false,\
+                "scope":"visible_arrange_area","reason":"logic_ax_viewport_only",\
+                "returned_count":1,"_debug":{"layoutItems":1,"nonRegion":0}}
+                """,
+            readback: "{\"cache_age_sec\":1.0,\"fetched_at\":null,\"ax_occluded\":false,"
+                + "\"source\":\"ax_live\",\"data\":[]}"
+        ),
+        .projectExportPlan: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_export_manifest.v1","run_id":"run-1",\
+                "generated_at":"1970-01-01T00:00:00Z","status":"planned",\
+                "execution_mode":"dry_run_only","output_root":"/tmp/exports",\
+                "collision_policy":"suffix","naming_policy":"project_name",\
+                "project_count":1,"projects":[{"path":"/tmp/a.logicx"}],\
+                "required_confirmations":[],"unsupported_or_blocked_steps":[],\
+                "baseline_verification":[],"enhancement_path":[],\
+                "next_safe_action":"review_export_plan"}
+                """,
+            readback: "{\"cache_age_sec\":null,\"fetched_at\":null,\"ax_occluded\":false,"
+                + "\"source\":\"default\",\"data\":{\"name\":\"Untitled\",\"trackCount\":0}}"
+        ),
+        .projectAudit: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_project_audit.v1","status":"ok",\
+                "generated_at":"1970-01-01T00:00:00Z","read_only":true,\
+                "project":{"name":"Untitled","sample_rate":48000,"tempo":120,\
+                "time_signature":"4/4","track_count":3,"provenance":"ax_live"},\
+                "evidence":{"has_document":true,"ax_occluded":false},\
+                "findings":[],"cleanup_plan":[]}
+                """,
+            readback: """
+                {"schema":"logic_pro_mcp_project_audit.v1","status":"ok",\
+                "generated_at":"1970-01-01T00:00:00Z","read_only":true,\
+                "project":{"name":"Untitled","sample_rate":48000,"tempo":120,\
+                "time_signature":"4/4","track_count":3,"provenance":"ax_live"},\
+                "evidence":{"has_document":true,"ax_occluded":false},\
+                "findings":[],"cleanup_plan":[]}
+                """
+        ),
+        .projectCleanupPlan: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_project_cleanup_plan.v1",\
+                "source_audit_schema":"logic_pro_mcp_project_audit.v1","status":"ok",\
+                "generated_at":"1970-01-01T00:00:00Z","read_only":true,\
+                "requires_plan_confirmation":true,"steps":[]}
+                """,
+            readback: """
+                {"schema":"logic_pro_mcp_project_cleanup_plan.v1",\
+                "source_audit_schema":"logic_pro_mcp_project_audit.v1","status":"ok",\
+                "generated_at":"1970-01-01T00:00:00Z","read_only":true,\
+                "requires_plan_confirmation":true,"steps":[]}
+                """
+        ),
+        // A successful analysis of a real bounce. NOT the empty-params probe
+        // body: that one is `verification.status:"fail"`, and AudioDispatcher
+        // sets `isError: status == .fail`, so a fail body can never reach this
+        // oracle with isError:false. Pairing a fail body with a qualifying
+        // (isError:false) drive would have modelled a state the handler cannot
+        // produce — the fixture now models the success the oracle exists to pin.
+        .audioAnalyzeFile: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_audio_analysis.v1",\
+                "path":"/Users/qualification/bounce.wav","exists":true,\
+                "format":"wav","duration_seconds":12.5,"sample_rate":48000,\
+                "channel_count":2,"frame_count":600000,"file_size_bytes":2400044,\
+                "rms_dbfs":-18.2,"peak_dbfs":-1.0,"true_peak_dbfs":-0.9,\
+                "loudness_estimate_lufs":-14.2,"loudness_method":"rms_estimate",\
+                "silence_ratio":0.02,"non_silent_duration_seconds":12.25,\
+                "spectral_centroid_hz":2200.0,\
+                "frequency_peaks":[{"frequencyHz":440.0,"magnitude":0.8}],\
+                "verification":{"status":"pass","reasons":[]}}
+                """,
+            readback: health
+        ),
+        .midiListPorts: SemanticOracleFixture(
+            response: """
+                {"sources":["IAC Driver Bus 1","Logic Pro Virtual In"],\
+                "destinations":["IAC Driver Bus 1"]}
+                """,
+            readback: """
+                {"sources":["IAC Driver Bus 1","Logic Pro Virtual In"],\
+                "destinations":["IAC Driver Bus 1"]}
+                """,
+            customMutants: [
+                .init(.malformed, "not json"),
+                // Well-formed JSON object, but the contract's keys are absent.
+                .init(.wellFormedButWrong, "{\"destinations\":[\"IAC Driver Bus 1\"]}"),
+                .init(.wellFormedButWrong, "{\"ports\":[\"IAC Driver Bus 1\"]}"),
+                // A truncated port list — the exact damage this echo check
+                // exists to catch.
+                .init(
+                    .readbackDivergence,
+                    "{\"sources\":[\"IAC Driver Bus 1\"],\"destinations\":[\"IAC Driver Bus 1\"]}"
+                ),
+                // Ordering is part of the identity: the resource serves the same
+                // handler's bytes, so a reorder means something transformed them.
+                .init(
+                    .readbackDivergence,
+                    "{\"sources\":[\"Logic Pro Virtual In\",\"IAC Driver Bus 1\"],"
+                        + "\"destinations\":[\"IAC Driver Bus 1\"]}"
+                ),
+                // Response is fine; the readback is a degraded resource body.
+                .init(
+                    .readbackDivergence,
+                    """
+                    {"sources":["IAC Driver Bus 1","Logic Pro Virtual In"],\
+                    "destinations":["IAC Driver Bus 1"]}
+                    """,
+                    readbackOverride: "{\"error\":\"CoreMIDI client not initialized\"}"
+                ),
+            ]
+        ),
+        .tracksListLibrary: SemanticOracleFixture(
+            response: """
+                {"categories":["Bass","Drum Kit"],\
+                "presetsByCategory":{"Bass":["Deep Sub"],"Drum Kit":["SoCal"]},\
+                "currentCategory":"Bass","currentPreset":"Deep Sub"}
+                """,
+            readback: """
+                {"cache_age_sec":12.0,"fetched_at":"1970-01-01T00:00:00Z",\
+                "ax_occluded":false,"data":{"categories":["Bass","Drum Kit"],\
+                "presetsByCategory":{"Bass":["Deep Sub"],"Drum Kit":["SoCal"]},\
+                "source":"ax"}}
+                """,
+            customMutants: [
+                .init(.malformed, "not json"),
+                // Advertises a category it cannot enumerate presets for.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"categories\":[\"Bass\",\"Ghost\"],\"presetsByCategory\":"
+                        + "{\"Bass\":[\"Deep Sub\"]},\"currentCategory\":\"Bass\"}"
+                ),
+                // presetsByCategory carries the key, but not a preset LIST.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"categories\":[\"Bass\"],\"presetsByCategory\":"
+                        + "{\"Bass\":\"Deep Sub\"},\"currentCategory\":\"Bass\"}"
+                ),
+                // Vacuous: an empty inventory is internally "consistent" and
+                // agrees with an empty readback, but verifies nothing.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"categories\":[],\"presetsByCategory\":{}}",
+                    readbackOverride: "{\"cache_age_sec\":1.0,\"fetched_at\":null,"
+                        + "\"ax_occluded\":false,\"data\":{\"categories\":[]}}"
+                ),
+                .init(.wellFormedButWrong, "{\"categories\":[\"Bass\",\"Drum Kit\"]}"),
+                // Response is internally consistent but disagrees with the read.
+                .init(
+                    .readbackDivergence,
+                    "{\"categories\":[\"Bass\"],\"presetsByCategory\":"
+                        + "{\"Bass\":[\"Deep Sub\"]},\"currentCategory\":\"Bass\"}"
+                ),
+                // Degraded readback (cache miss) must fail closed, not soft-pass
+                // on internal consistency alone.
+                .init(
+                    .readbackDivergence,
+                    """
+                    {"categories":["Bass","Drum Kit"],\
+                    "presetsByCategory":{"Bass":["Deep Sub"],"Drum Kit":["SoCal"]},\
+                    "currentCategory":"Bass","currentPreset":"Deep Sub"}
+                    """,
+                    readbackOverride: "{\"cached\":false,\"note\":\"Run logic_library scan to populate\"}"
+                ),
+            ]
+        ),
+        .tracksScanLibrary: SemanticOracleFixture(
+            response: """
+                {"source":"disk","root":{"generatedAt":"1970-01-01T00:00:00Z",\
+                "scanDurationMs":42,"measuredSettleDelayMs":0,"selectionRestored":true,\
+                "truncatedBranches":0,"probeTimeouts":0,"cycleCount":0,"nodeCount":3,\
+                "leafCount":2,"folderCount":1,"candidatePatchCount":2,\
+                "nonApplicablePatchCount":0,"root":{"name":"Library","path":"/",\
+                "kind":"folder","children":[]},"categories":["Bass"],\
+                "presetsByCategory":{"Bass":["Deep Sub"]},"skippedDirectoryCount":0,\
+                "scanWarnings":[]}}
+                """,
+            readback: """
+                {"cache_age_sec":12.0,"fetched_at":"1970-01-01T00:00:00Z",\
+                "ax_occluded":false,"data":{"categories":["Bass"],"source":"ax"}}
+                """
+        ),
+        .tracksResolvePath: SemanticOracleFixture(
+            response: """
+                {"exists":true,"kind":"leaf","matchedPath":"Bass/Deep Sub",\
+                "source":"disk","loadable":true}
+                """,
+            readback: """
+                {"cache_age_sec":12.0,"fetched_at":"1970-01-01T00:00:00Z",\
+                "ax_occluded":false,"data":{"categories":["Bass"],"source":"ax"}}
+                """,
+            customMutants: [
+                .init(.malformed, "not json"),
+                .init(.malformed, "{}"),
+                // A hit that cannot say what it matched.
+                .init(.wellFormedButWrong, "{\"exists\":true,\"kind\":\"leaf\"}"),
+                // A hit that cannot classify the node it found.
+                .init(.wellFormedButWrong, "{\"exists\":true,\"matchedPath\":\"Bass/Deep Sub\"}"),
+                // A hit classified outside LibraryNodeKind.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"exists\":true,\"kind\":\"mystery\",\"matchedPath\":\"Bass/Deep Sub\"}"
+                ),
+                // A bare miss with no explanation.
+                .init(.wellFormedButWrong, "{\"exists\":false}"),
+                // `exists` stringified — NSNumber/String confusion must not pass.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"exists\":\"true\",\"kind\":\"leaf\",\"matchedPath\":\"Bass/Deep Sub\"}"
+                ),
+            ]
+        ),
+        .tracksScanPluginPresets: SemanticOracleFixture(
+            response: """
+                {"schemaVersion":1,"pluginName":"(focused-plugin)",\
+                "pluginIdentifier":"(unknown — T6 will resolve via AU registry)",\
+                "contentHash":"(deferred)","generatedAt":"1970-01-01T00:00:00Z",\
+                "scanDurationMs":18,"measuredSubmenuOpenDelayMs":250,\
+                "truncatedBranches":0,"probeTimeouts":0,"cycleCount":0,\
+                "nodeCount":2,"leafCount":1,"folderCount":1,\
+                "root":{"name":"Setting","path":"","kind":"folder","children":[]}}
+                """,
+            readback: """
+                {"cache_age_sec":12.0,"fetched_at":"1970-01-01T00:00:00Z",\
+                "ax_occluded":false,"data":{"categories":["Bass"],"source":"ax"}}
+                """
+        ),
+    ]
+}

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -1,0 +1,523 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// #373 Phase A — engine unit tests, census meta-tests, the anti-checkbox
+// strength gate, and the mutation harness.
+
+@Suite("#373 semantic oracle engine")
+struct SemanticOracleEngineTests {
+    private func root(_ json: String) -> Any {
+        JSONInspector.parse(Data(json.utf8))!
+    }
+
+    // MARK: - constraint semantics
+
+    @Test func valueEqualsMatchesEachPrimitiveAndRejectsMismatches() {
+        let object = root(#"{"s":"x","n":4,"b":true,"z":null}"#)
+        #expect(OracleConstraint.valueEquals(key: "s", expected: .string("x")).isSatisfied(by: object))
+        #expect(OracleConstraint.valueEquals(key: "n", expected: .number(4)).isSatisfied(by: object))
+        #expect(OracleConstraint.valueEquals(key: "b", expected: .bool(true)).isSatisfied(by: object))
+        #expect(OracleConstraint.valueEquals(key: "z", expected: .null).isSatisfied(by: object))
+
+        #expect(!OracleConstraint.valueEquals(key: "s", expected: .string("y")).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "n", expected: .number(5)).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "b", expected: .bool(false)).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "missing", expected: .string("x")).isSatisfied(by: object))
+    }
+
+    /// NSNumber bridges booleans and numbers alike; an oracle that pinned
+    /// `true` must not be satisfied by `1`, or every boolean honesty flag in the
+    /// table becomes forgeable.
+    @Test func valueEqualsDoesNotConflateBooleanAndNumericOne() {
+        let object = root(#"{"flag":1,"real":true}"#)
+        #expect(!OracleConstraint.valueEquals(key: "flag", expected: .bool(true)).isSatisfied(by: object))
+        #expect(OracleConstraint.valueEquals(key: "flag", expected: .number(1)).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "real", expected: .number(1)).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "real", type: .bool).isSatisfied(by: object))
+        #expect(!OracleConstraint.typedField(key: "flag", type: .bool).isSatisfied(by: object))
+        #expect(!OracleConstraint.typedField(key: "real", type: .number).isSatisfied(by: object))
+    }
+
+    @Test func numericRangeIsInclusiveAndRejectsOutOfDomainAndNonNumbers() {
+        let object = root(#"{"low":0,"high":10,"mid":5,"text":"5","flag":true}"#)
+        #expect(OracleConstraint.numericRange(key: "low", min: 0, max: 10).isSatisfied(by: object))
+        #expect(OracleConstraint.numericRange(key: "high", min: 0, max: 10).isSatisfied(by: object))
+        #expect(OracleConstraint.numericRange(key: "mid", min: 0, max: 10).isSatisfied(by: object))
+
+        #expect(!OracleConstraint.numericRange(key: "high", min: 0, max: 9).isSatisfied(by: object))
+        #expect(!OracleConstraint.numericRange(key: "low", min: 1, max: 10).isSatisfied(by: object))
+        #expect(!OracleConstraint.numericRange(key: "text", min: 0, max: 10).isSatisfied(by: object))
+        // A boolean is not a number in range, however NSNumber bridges it.
+        #expect(!OracleConstraint.numericRange(key: "flag", min: 0, max: 10).isSatisfied(by: object))
+        #expect(!OracleConstraint.numericRange(key: "missing", min: 0, max: 10).isSatisfied(by: object))
+    }
+
+    @Test func enumMemberAcceptsLegalTokensAndRejectsOutsiders() {
+        let object = root(#"{"status":"ok","flag":false,"n":1}"#)
+        #expect(OracleConstraint.enumMember(key: "status", allowed: ["ok", "bad"]).isSatisfied(by: object))
+        #expect(!OracleConstraint.enumMember(key: "status", allowed: ["bad"]).isSatisfied(by: object))
+        #expect(OracleConstraint.enumMember(key: "flag", allowed: ["true", "false"]).isSatisfied(by: object))
+        // Numbers have no enum token — they must not be coerced into one.
+        #expect(!OracleConstraint.enumMember(key: "n", allowed: ["1"]).isSatisfied(by: object))
+        #expect(!OracleConstraint.enumMember(key: "missing", allowed: ["ok"]).isSatisfied(by: object))
+    }
+
+    @Test func nonEmptyArrayRejectsEmptyMissingAndNonArrays() {
+        let object = root(#"{"full":[1],"empty":[],"object":{}}"#)
+        #expect(OracleConstraint.nonEmptyArray(key: "full").isSatisfied(by: object))
+        #expect(!OracleConstraint.nonEmptyArray(key: "empty").isSatisfied(by: object))
+        #expect(!OracleConstraint.nonEmptyArray(key: "object").isSatisfied(by: object))
+        #expect(!OracleConstraint.nonEmptyArray(key: "missing").isSatisfied(by: object))
+    }
+
+    @Test func typedFieldDiscriminatesEveryJSONType() {
+        let object = root(#"{"s":"x","n":1,"b":true,"a":[],"o":{},"z":null}"#)
+        #expect(OracleConstraint.typedField(key: "s", type: .string).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "n", type: .number).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "b", type: .bool).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "a", type: .array).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "o", type: .object).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "z", type: .null).isSatisfied(by: object))
+
+        #expect(!OracleConstraint.typedField(key: "s", type: .number).isSatisfied(by: object))
+        #expect(!OracleConstraint.typedField(key: "a", type: .object).isSatisfied(by: object))
+        #expect(!OracleConstraint.typedField(key: "missing", type: .string).isSatisfied(by: object))
+    }
+
+    // MARK: - key paths
+
+    @Test func keyPathsResolveNestingIndexingAndTheRoot() {
+        let object = root(#"{"a":{"b":[{"c":7}]},"list":[1,2]}"#)
+        #expect(OracleConstraint.valueEquals(key: "a.b.0.c", expected: .number(7)).isSatisfied(by: object))
+        #expect(OracleConstraint.valueEquals(key: "list.1", expected: .number(2)).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "list.9", expected: .number(2)).isSatisfied(by: object))
+        #expect(!OracleConstraint.valueEquals(key: "a.b.0.missing", expected: .number(7)).isSatisfied(by: object))
+        // The empty key path addresses the root value.
+        #expect(OracleConstraint.typedField(key: "", type: .object).isSatisfied(by: object))
+        #expect(OracleConstraint.typedField(key: "", type: .bool).isSatisfied(by: root("true")))
+    }
+
+    @Test func nonJSONResponseFailsDeclarativeOraclesRatherThanPassingVacuously() {
+        let oracle = OperationOracle(
+            .projectAudit,
+            strength: .shapeAndDomain,
+            constraints: [.valueEquals(key: "read_only", expected: .bool(true))]
+        )
+        // Verdicts are reduced to a plain Bool OUTSIDE the macro: this repo has
+        // a history of `#expect(optionalBool == true)` expanding to a dead
+        // assertion that always passes (issue #92).
+        let verdict: Bool = oracle.evaluate(
+            responseData: Data("not json".utf8),
+            readbackData: Data()
+        ) == true
+        #expect(!verdict)
+    }
+
+    /// An oracle with no constraints would pass everything. `allSatisfy` over an
+    /// empty list is vacuously true, so the strength gate — not the engine — is
+    /// what keeps this from shipping; assert the hazard exists so the gate's
+    /// purpose stays legible.
+    @Test func constraintlessDeclarativeOracleIsVacuousAndSoIsRejectedByTheStrengthGate() {
+        let vacuous = OperationOracle(.projectAudit, strength: .shapeAndDomain, constraints: [])
+        let passesAnything: Bool = vacuous.evaluate(
+            responseData: Data("{}".utf8),
+            readbackData: Data()
+        ) == true
+        #expect(passesAnything)
+        #expect(!vacuous.isSemanticallyLoadBearing)
+    }
+}
+
+// MARK: - census
+
+@Suite("#373 semantic oracle census")
+struct SemanticOracleCensusTests {
+    /// The registry is truth. If a spec flips to read-only, or a new read-only
+    /// op lands, this fails until the table covers it — the oracle set can never
+    /// silently under-cover the surface.
+    @Test func everyReadOnlySpecHasAnOracle() {
+        let missing = SemanticOracleTable.coveredSpecIDs
+            .subtracting(SemanticOracleTable.byOperationID.keys)
+        #expect(missing.isEmpty, "read-only specs with no oracle: \(missing.map(\.rawValue).sorted())")
+    }
+
+    /// The mirror image: an oracle for something that is not a qualifying
+    /// read-only spec is dead weight that would never run.
+    @Test func everyOracleMapsToAReadOnlySpec() {
+        let extra = Set(SemanticOracleTable.byOperationID.keys)
+            .subtracting(SemanticOracleTable.coveredSpecIDs)
+        #expect(extra.isEmpty, "oracles with no read-only spec: \(extra.map(\.rawValue).sorted())")
+    }
+
+    @Test func healthKeepsItsBespokeValidatorAndIsNotInTheTable() {
+        #expect(SemanticOracleTable.byOperationID[.systemHealth] == nil)
+        #expect(!SemanticOracleTable.coveredSpecIDs.contains(.systemHealth))
+    }
+
+    @Test func tableHasNoDuplicateEntries() {
+        #expect(SemanticOracleTable.all.count == SemanticOracleTable.byOperationID.count)
+    }
+
+    /// Pins the reconciled surface. The C1 classification named 20 ops but two
+    /// of its names disagree with the registry: `edit.select_all` is registered
+    /// MUTATING (so it is out), and `system.clear_traces` is registered
+    /// read-only (so it is in). Both were reconciled toward the registry.
+    @Test func reconciledReadOnlySurfaceIsTwentyOperations() {
+        #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
+        #expect(!SemanticOracleTable.coveredSpecIDs.contains(.editSelectAll))
+        #expect(SemanticOracleTable.coveredSpecIDs.contains(.systemClearTraces))
+
+        let selectAll = OperationRegistry.specs.first { $0.id == .editSelectAll }
+        #expect(selectAll?.mutability == .mutating)
+        let clearTraces = OperationRegistry.specs.first { $0.id == .systemClearTraces }
+        #expect(clearTraces?.mutability == .readOnly)
+        let refreshCache = OperationRegistry.specs.first { $0.id == .systemRefreshCache }
+        #expect(refreshCache?.mutability == .readOnly)
+    }
+}
+
+// MARK: - strength (anti-checkbox gate)
+
+@Suite("#373 semantic oracle strength")
+struct SemanticOracleStrengthTests {
+    /// Presence-only oracles are forbidden. Every oracle must pin meaning: at
+    /// least one VALUE constraint, or an explicitly reasoned escape hatch.
+    @Test func noOracleIsPresenceOnly() {
+        let weak = SemanticOracleTable.all
+            .filter { !$0.isSemanticallyLoadBearing }
+            .map(\.operationID.rawValue)
+        #expect(weak.isEmpty, "presence-only oracles: \(weak.sorted())")
+    }
+
+    @Test func declarativeOraclesCarryAValueConstraintAndNoHatch() {
+        for oracle in SemanticOracleTable.all where oracle.strength != .custom {
+            let hasValueConstraint = oracle.constraints.contains(where: { $0.isValueConstraint })
+            #expect(hasValueConstraint, "\(oracle.operationID.rawValue) has no value constraint")
+            let hasHatch = oracle.custom != nil
+            #expect(!hasHatch, "\(oracle.operationID.rawValue) is not .custom but has a hatch")
+        }
+    }
+
+    @Test func customOraclesAreExactlyTheSanctionedSetAndEachDocumentsWhy() {
+        let actual = Set(SemanticOracleTable.customOracles.map(\.operationID))
+        #expect(actual == SemanticOracleTable.sanctionedCustomOperationIDs)
+        for oracle in SemanticOracleTable.customOracles {
+            let hasHatch = oracle.custom != nil
+            #expect(hasHatch, "\(oracle.operationID.rawValue) is .custom with no closure")
+            #expect(oracle.constraints.isEmpty)
+            // A reason is what separates a documented hatch from a shrug.
+            let reason = oracle.customReason ?? ""
+            #expect(reason.count > 40, "\(oracle.operationID.rawValue) reason is too thin")
+        }
+    }
+
+    @Test func strengthValueMeansEveryConstraintIsExact() {
+        for oracle in SemanticOracleTable.all where oracle.strength == .value {
+            let allExact = oracle.constraints.allSatisfy(Self.isExactValue)
+            #expect(allExact, "\(oracle.operationID.rawValue) claims .value strength inexactly")
+        }
+    }
+
+    private static func isExactValue(_ constraint: OracleConstraint) -> Bool {
+        if case .valueEquals = constraint { return true }
+        return false
+    }
+}
+
+// MARK: - fixtures + mutation harness
+
+@Suite("#373 semantic oracle fixtures and mutation")
+struct SemanticOracleMutationTests {
+    @Test func everyOracleHasAFixture() {
+        let missing = Set(SemanticOracleTable.byOperationID.keys)
+            .subtracting(SemanticOracleFixtures.byOperationID.keys)
+        #expect(missing.isEmpty, "oracles with no fixture: \(missing.map(\.rawValue).sorted())")
+    }
+
+    /// Happy path: a realistic payload from the real handler shape passes.
+    @Test(arguments: SemanticOracleTable.all.map(\.operationID))
+    func oraclePassesItsRealisticFixture(operationID: OperationID) throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[operationID])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
+        // #require unwraps the Bool? verdict, so the assertion below is over a
+        // plain Bool — never a dead `optional == true` comparison (issue #92).
+        let verdict = try #require(oracle.evaluate(
+            responseData: fixture.responseData,
+            readbackData: fixture.readbackData
+        ))
+        #expect(verdict, "\(operationID.rawValue) rejected its own realistic fixture")
+    }
+
+    /// The anti-checkbox tool. For every constraint of every declarative oracle,
+    /// corrupt the fixture the way that constraint exists to catch (drop the
+    /// key, push the value out of domain, wrong-type it) and require the oracle
+    /// to FAIL. A constraint whose mutants still pass is decoration.
+    @Test(arguments: SemanticOracleTable.all.map(\.operationID))
+    func everyConstraintRejectsItsMutants(operationID: OperationID) throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[operationID])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
+        guard oracle.strength != .custom else { return }
+        let root = try #require(JSONInspector.parse(fixture.responseData))
+
+        for constraint in oracle.constraints {
+            let mutants = JSONMutator.mutants(for: constraint, in: root)
+            #expect(
+                !mutants.isEmpty,
+                "\(operationID.rawValue): no mutant generated for \(constraint.key)"
+            )
+            for mutant in mutants {
+                let data = try #require(JSONMutator.encode(mutant.json))
+                let survived: Bool = oracle.evaluate(
+                    responseData: data,
+                    readbackData: fixture.readbackData
+                ) == true
+                #expect(
+                    !survived,
+                    "\(operationID.rawValue): oracle survived mutant [\(mutant.label)] — constraint on '\(constraint.key)' is not load-bearing"
+                )
+            }
+        }
+    }
+
+    /// `.custom` oracles cannot be mutated generically, so each ships explicit
+    /// corruptions. An escape hatch with no failing mutant is unfalsifiable.
+    ///
+    /// Counting mutants would be gameable — four garbage strings "cover" an
+    /// oracle while proving only that it rejects noise. So the KINDS are
+    /// required: every custom oracle must reject a payload that parses fine and
+    /// is merely wrong, and every cross-checking oracle must reject a response
+    /// whose readback disagrees with it.
+    @Test(arguments: SemanticOracleTable.customOracles.map(\.operationID))
+    func customOraclesRejectEachRequiredMutantKind(operationID: OperationID) throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[operationID])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
+        let kinds = Set(fixture.customMutants.map(\.kind))
+
+        #expect(
+            kinds.contains(.malformed),
+            "\(operationID.rawValue): needs a malformed mutant"
+        )
+        #expect(
+            kinds.contains(.wellFormedButWrong),
+            "\(operationID.rawValue): needs a well-formed-but-semantically-wrong mutant — rejecting garbage alone proves nothing"
+        )
+        if Self.crossCheckingOperationIDs.contains(operationID) {
+            #expect(
+                kinds.contains(.readbackDivergence),
+                "\(operationID.rawValue): cross-checking oracle needs a readback-divergence mutant"
+            )
+        }
+
+        for mutant in fixture.customMutants {
+            let readback = mutant.readbackOverride.map { Data($0.utf8) } ?? fixture.readbackData
+            let survived: Bool = oracle.evaluate(
+                responseData: Data(mutant.response.utf8),
+                readbackData: readback
+            ) == true
+            #expect(
+                !survived,
+                "\(operationID.rawValue): custom oracle survived \(mutant.kind.rawValue) mutant [\(mutant.response.prefix(60))]"
+            )
+        }
+    }
+
+    /// The oracles whose check compares the response against the readback. Only
+    /// these can meaningfully be given a divergence mutant.
+    static let crossCheckingOperationIDs: Set<OperationID> = [.midiListPorts, .tracksListLibrary]
+
+    /// A custom oracle that returns nil on a good payload would silently
+    /// downgrade its operation to protocolSmoke — an escape hatch declining to
+    /// render a verdict at all. Every oracle must commit on its own fixture.
+    @Test(arguments: SemanticOracleTable.all.map(\.operationID))
+    func everyOracleRendersAVerdictOnItsFixture(operationID: OperationID) throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[operationID])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
+        let declined: Bool = oracle.evaluate(
+            responseData: fixture.responseData,
+            readbackData: fixture.readbackData
+        ) == nil
+        #expect(!declined, "\(operationID.rawValue) declined to render a verdict on its own fixture")
+    }
+
+    /// Wiring: the validator must actually consult the table, not just own it.
+    @Test(arguments: SemanticOracleTable.all.map(\.operationID))
+    func validatorRoutesEachReadOnlyOperationToItsOracle(operationID: OperationID) throws {
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
+        let routed = try #require(QualificationSemanticReadbackValidator.validate(
+            operationID: operationID.rawValue,
+            responseData: fixture.responseData,
+            readbackData: fixture.readbackData
+        ))
+        #expect(routed, "\(operationID.rawValue) is not routed to its oracle")
+        // And a corrupted payload must not be waved through as "no validator":
+        // a nil here would silently downgrade the op to protocolSmoke.
+        let corrupt = try #require(QualificationSemanticReadbackValidator.validate(
+            operationID: operationID.rawValue,
+            responseData: Data(#"{"__corrupt__":true}"#.utf8),
+            readbackData: fixture.readbackData
+        ))
+        #expect(!corrupt, "\(operationID.rawValue) passed a corrupt payload")
+    }
+
+    @Test func validatorStillReturnsNilForOperationsWithNoOracle() {
+        // A mutating op has no oracle; it must stay honestly unvalidated here.
+        let mutating: Bool = QualificationSemanticReadbackValidator.validate(
+            operationID: OperationID.transportPlay.rawValue,
+            responseData: Data("{}".utf8),
+            readbackData: Data("{}".utf8)
+        ) == nil
+        #expect(mutating)
+        let unknown: Bool = QualificationSemanticReadbackValidator.validate(
+            operationID: "not.an.operation",
+            responseData: Data("{}".utf8),
+            readbackData: Data("{}".utf8)
+        ) == nil
+        #expect(unknown)
+    }
+
+    @Test func healthRetainsItsBespokeFullPayloadEquality() throws {
+        let health = Data(SemanticOracleFixtures.health.utf8)
+        let matches = try #require(QualificationSemanticReadbackValidator.validate(
+            operationID: OperationID.systemHealth.rawValue,
+            responseData: health,
+            readbackData: health
+        ))
+        #expect(matches)
+        let drifted = Data(
+            SemanticOracleFixtures.health
+                .replacingOccurrences(
+                    of: "\"logic_pro_running\":true",
+                    with: "\"logic_pro_running\":false"
+                )
+                .utf8
+        )
+        let mismatch = try #require(QualificationSemanticReadbackValidator.validate(
+            operationID: OperationID.systemHealth.rawValue,
+            responseData: health,
+            readbackData: drifted
+        ))
+        #expect(!mismatch)
+    }
+}
+
+// MARK: - mutator
+
+enum JSONMutator {
+    struct Mutant {
+        let label: String
+        let json: Any
+    }
+
+    static func encode(_ json: Any) -> Data? {
+        try? JSONSerialization.data(withJSONObject: json, options: [.fragmentsAllowed])
+    }
+
+    /// Derives, from the constraint itself, the corruptions it claims to catch.
+    static func mutants(for constraint: OracleConstraint, in root: Any) -> [Mutant] {
+        let key = constraint.key
+        var mutants: [Mutant] = []
+        if let dropped = remove(root, keyPath: key) {
+            mutants.append(Mutant(label: "drop \(key)", json: dropped))
+        }
+        switch constraint {
+        case .valueEquals(_, let expected):
+            mutants.append(contentsOf: replacements(root, key, [("alien value", alien(of: expected))]))
+        case .numericRange(_, let min, let max):
+            mutants.append(contentsOf: replacements(root, key, [
+                ("above max", max + 1),
+                ("below min", min - 1),
+                ("not a number", "not-a-number"),
+            ]))
+        case .enumMember:
+            mutants.append(contentsOf: replacements(root, key, [
+                ("outside enum", "__not_a_member__"),
+            ]))
+        case .nonEmptyArray:
+            mutants.append(contentsOf: replacements(root, key, [("emptied", [Any]())]))
+        case .typedField(_, let type):
+            mutants.append(contentsOf: replacements(root, key, [("wrong type", wrongTyped(type))]))
+        }
+        return mutants
+    }
+
+    private static func replacements(
+        _ root: Any,
+        _ key: String,
+        _ values: [(String, Any)]
+    ) -> [Mutant] {
+        values.compactMap { label, value in
+            set(root, keyPath: key, to: value).map { Mutant(label: "\(label) at \(key)", json: $0) }
+        }
+    }
+
+    private static func alien(of primitive: JSONPrimitive) -> Any {
+        switch primitive {
+        case .string(let value): return value + "__oracle_mutant__"
+        case .number(let value): return value + 1
+        case .bool(let value): return !value
+        case .null: return "no longer null"
+        }
+    }
+
+    private static func wrongTyped(_ type: JSONType) -> Any {
+        switch type {
+        case .string: return 42
+        case .number: return "42"
+        case .bool: return "true"
+        case .array: return [String: Any]()
+        case .object: return [Any]()
+        case .null: return 1
+        }
+    }
+
+    static func set(_ root: Any, keyPath: String, to value: Any) -> Any? {
+        transform(root, components: keyPath.split(separator: ".").map(String.init)) { _ in value }
+    }
+
+    static func remove(_ root: Any, keyPath: String) -> Any? {
+        transform(root, components: keyPath.split(separator: ".").map(String.init)) { _ in nil }
+    }
+
+    /// Walks the key path and applies `leaf` at the end. Returns nil when the
+    /// path does not exist, which keeps a typo'd fixture key from silently
+    /// producing a no-op "mutant" that the oracle would rightly pass.
+    private static func transform(
+        _ current: Any,
+        components: [String],
+        leaf: (Any) -> Any?
+    ) -> Any? {
+        guard let head = components.first else { return leaf(current) }
+        let tail = Array(components.dropFirst())
+        if var object = current as? [String: Any] {
+            guard let child = object[head] else { return nil }
+            if tail.isEmpty {
+                if let replacement = leaf(child) {
+                    object[head] = replacement
+                } else {
+                    object.removeValue(forKey: head)
+                }
+            } else {
+                guard let updated = transform(child, components: tail, leaf: leaf) else { return nil }
+                object[head] = updated
+            }
+            return object
+        }
+        if var array = current as? [Any], let index = Int(head), index >= 0, index < array.count {
+            if tail.isEmpty {
+                if let replacement = leaf(array[index]) {
+                    array[index] = replacement
+                } else {
+                    array.remove(at: index)
+                }
+            } else {
+                guard let updated = transform(array[index], components: tail, leaf: leaf) else {
+                    return nil
+                }
+                array[index] = updated
+            }
+            return array
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

#373 **Phase A** — the qualification runner's semantic validator covered exactly one operation (`system.health`); the other 20 read-only operations fell through to `protocolSmoke` ("the transport worked, nobody checked the meaning"), so the read-only surface could never qualify and PromotionGate could never pass.

**Data-driven oracle engine** (`SemanticOracles.swift`): declarative constraints (`valueEquals` / `numericRange` / `enumMember` / `nonEmptyArray` / `typedField`) resolved over dotted key paths against the parsed response; absent keys fail closed; a bare-scalar body is addressable as the root path. Booleans are distinguished from numeric `1` via `CFBooleanGetTypeID` so a pinned `true` cannot be forged. Presence-only oracles are forbidden by a strength meta-test: every oracle carries at least one VALUE constraint or is an explicitly reasoned `.custom`.

**Oracle table** (`SemanticOracleTable.swift`): one oracle per read-only registry spec — 13 declarative, 7 `.custom` with documented irreducibility reasons (3 prose bodies, 1 bare-scalar body, 2 response↔readback cross-checks, 1 conditional contract). The ratified ≤5 custom budget was replaced by something stricter: an explicit `sanctionedCustomOperationIDs` allowlist enforced by set-equality meta-test (a new hatch cannot appear — and a stale sanction cannot linger — without failing CI).

**Registry reconciliation (registry is truth)**: the planning list was wrong on two names — `edit.select_all` is registered mutating (excluded), `system.clear_traces` is registered read-only (included). Census meta-tests pin both directions (`readOnlySpecs − oracles == ∅`, `oracles − readOnlySpecs == ∅`) plus the 20-operation surface count.

**Mutation harness**: every oracle must fail each corrupted variant of its fixture payload (key dropped / value flipped out of domain / type swapped). Harness falsification-tested: neutering constraint evaluation to always-true produced 184 "oracle survived mutant" detections; reverted clean.

**Fixture counts**: `passed 1→21`, `protocolSmoke 20→0` (structurally unreachable for read-only ops now), `notQualified 86` unchanged (mutating surface, ADR-001-c). Two legacy tests whose premises this phase voids were inverted to pin the new truth, including: a stale waiver for a now-qualifying operation is rejected as `waiverForPassingCase`.

Known Phase-B gaps (tracked on #373): probe params leave 6 read-only ops unable to reach `passed` live (they error before the oracle is consulted — honest failure, never a false pass); `.crossCheck`/`.implies` constraint cases to shrink the custom hatch 7→3.

**Adversarial gate round (applied pre-merge):** the gate confirmed the deviations and raised 5 P1 / 3 P2, all resolved: `midi.list_ports` cross-check honestly re-labeled same-handler echo/transport-consistency (the resource re-invokes the same handler — no independent MIDI probe exists today); `plugins.get_inventory` had an internal contradiction (allowed State B while requiring the `plugins` array State B omits — would false-fail every honest B) — resolved STRICTER: only State A qualifies (State B is by construction unverified; passing it would launder "couldn't check" into "checked"); `tracks.list_library` fails closed on degraded/cache-miss readback, types preset lists, rejects vacuous empty agreement; the custom-oracle mutation harness now requires typed mutant classes per op (malformed / well-formed-but-wrong / readback-divergence for cross-checkers) instead of a gameable count; `system.permissions` labels match the closed 4-remainder set exactly (`granted_evil` mutant-guarded); every oracle must render a non-nil verdict on its own fixture; `audio.analyze_file` accepts `{pass,warn}` only and its fixture is a realistic pass body (a fail body always carries `isError` at the dispatcher).

## Verification
Sanctioned filter: **143/143** (reviewer independently re-ran pre-fix at 142/142). Adjacent suites 128/128. Harness falsification-tested end-to-end: neutering `evaluate()` produced **184 declarative + 38 custom** survived-mutant detections (242 issues); reverted clean. Full suite `--no-parallel` green on the exact PR head. Adversarial gate verdict + fix confirmation recorded in PR comments.
