### PR TITLE
saga: LPMCP-PRD-005 — two-tier journal, bounded reclaim without silent replay-protection lapse

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -436,6 +436,14 @@ struct SystemDispatcher: OperationTraceDispatching {
                 journalIssues = [[
                     "code": HonestContract.FailureError.unsupportedState.rawValue,
                 ]]
+            case .outcomeEvicted(let terminal):
+                // LPMCP-PRD-005: unlike `.completed` (where execute hands back
+                // the stored body and preflight stays ok), an evicted body means
+                // execute WILL refuse — so preflight must say so up front.
+                journalIssues = [[
+                    "code": HonestContract.FailureError.sagaOutcomeUnavailable.rawValue,
+                    "terminal_kind": terminal.rawValue,
+                ]]
             case .available, .inProgress, .completed:
                 journalIssues = []
             }
@@ -457,12 +465,17 @@ struct SystemDispatcher: OperationTraceDispatching {
             let issues = preflight.issues.map(SagaWire.preflightIssue)
                 + availabilityIssues
                 + journalIssues
-            let body = SagaWire.sessionFields.merging([
-                "ok": issues.isEmpty,
-                "issues": issues,
-                "before_state_availability": SagaWire.availabilityObjects(availability, plan: plan),
-                "writes_performed": 0,
-            ]) { _, new in new }
+            let body = SagaWire.sessionFields
+                .merging(SagaWire.journalMetricsFields(await sagaJournal.metrics())) { _, new in new }
+                .merging([
+                    "ok": issues.isEmpty,
+                    "issues": issues,
+                    "before_state_availability": SagaWire.availabilityObjects(
+                        availability,
+                        plan: plan
+                    ),
+                    "writes_performed": 0,
+                ]) { _, new in new }
             return toolTextResult(HonestContract.jsonString(body))
 
         case "saga_execute":
@@ -515,6 +528,15 @@ struct SystemDispatcher: OperationTraceDispatching {
             case .capacityExceeded:
                 return await finalizeTrace(
                     SagaWire.journalCapacityExceeded(plan.idempotencyKey),
+                    traceID: traceID
+                )
+            case .outcomeEvicted(let terminal):
+                // LPMCP-PRD-005: this key already ran to a terminal state in
+                // this session. Returning here — before any executor exists —
+                // is what makes "an evicted body never re-fires a write"
+                // structural rather than a promise.
+                return await finalizeTrace(
+                    SagaWire.outcomeUnavailable(plan.idempotencyKey, terminal: terminal),
                     traceID: traceID
                 )
             case .started(let journalClaim):
@@ -674,16 +696,33 @@ struct SystemDispatcher: OperationTraceDispatching {
                 details = [
                     "status": "cancelled",
                     "verified": verified,
+                    "outcome_retained": true,
                     "outcome": SagaWire.jsonObject(outcome.body),
                 ]
             case .completed(let outcome):
-                details = ["status": "completed", "outcome": SagaWire.jsonObject(outcome.body)]
+                details = [
+                    "status": "completed",
+                    "outcome_retained": true,
+                    "outcome": SagaWire.jsonObject(outcome.body),
+                ]
+            case .outcomeEvicted(let terminal):
+                // LPMCP-PRD-005: `status` still names the terminal path the key
+                // took — the replay-protection record is intact. `outcome` is
+                // ABSENT (not null, not a stand-in) and `outcome_retained:false`
+                // says why. `verified` is likewise absent for an evicted
+                // cancellation: it lived in the body, and inventing one would be
+                // the exact dishonesty this record exists to prevent.
+                details = ["status": terminal.rawValue, "outcome_retained": false]
             }
             return toolTextResult(HonestContract.jsonString(
-                SagaWire.sessionFields.merging([
-                    "idempotency_key": idempotencyKey,
-                    "record": details,
-                ]) { _, new in new }
+                SagaWire.sessionFields
+                    .merging(SagaWire.journalMetricsFields(await sagaJournal.metrics())) {
+                        _, new in new
+                    }
+                    .merging([
+                        "idempotency_key": idempotencyKey,
+                        "record": details,
+                    ]) { _, new in new }
             ))
 
         case "saga_cancel":
@@ -708,6 +747,10 @@ struct SystemDispatcher: OperationTraceDispatching {
                     hint: "The saga is already completed",
                     extras: ["idempotency_key": idempotencyKey]
                 )
+            case .outcomeEvicted(let terminal):
+                // LPMCP-PRD-005: the key IS known and terminal — answering
+                // `element_not_found` here would deny a record we still hold.
+                result = SagaWire.outcomeUnavailable(idempotencyKey, terminal: terminal)
             case .requested, .alreadyRequested:
                 result = toolTextResult(HonestContract.encodeStateB(
                     reason: .sagaCancellationPending,

--- a/Sources/LogicProMCP/Saga/SagaJournal.swift
+++ b/Sources/LogicProMCP/Saga/SagaJournal.swift
@@ -1,12 +1,47 @@
+import CryptoKit
 import Foundation
 import MCP
 
+/// LPMCP-PRD-005 — the session saga journal is split into two independently
+/// bounded tiers so that saturation costs OUTCOME BODIES, never same-key replay
+/// protection.
+///
+/// - The COMPACT tier (`idempotencySet`) holds one small row per key ever begun
+///   in this generation: plan hash, terminal kind, sequence. It is append-only
+///   within a generation — a key that reached a terminal state is NEVER dropped
+///   while the session lives, so a replayed key can never fall back to
+///   `.started` and re-fire a write.
+/// - The BODY tier holds the full state a caller can still be handed back:
+///   in-flight entries (`entries`, plan + claim, never evictable) and stored
+///   terminal outcomes (`outcomeBodies`, evictable oldest-first). It is bounded
+///   by `maxRecords`.
+///
+/// When a body is evicted the compact row survives, so the key answers
+/// `.outcomeEvicted` — "this already ran, and I can no longer show you what
+/// happened". That is deliberately NOT `.completed` (which would replay a body
+/// we no longer have) and NOT `.started` (which would re-execute a write).
+///
+/// There is no wall-clock TTL anywhere: eviction is count-based and ordered by
+/// begin sequence, so behaviour is deterministic and testable.
 actor SagaJournal {
+    /// Bounds the BODY tier: in-flight entries + retained terminal outcomes.
     static let defaultMaxRecords = 1_024
+    /// Bounds the COMPACT tier: every key begun in this generation.
+    static let defaultCompactCapacity = 65_536
 
     struct StoredOutcome: Equatable, Sendable {
         let body: String
         let isError: Bool
+    }
+
+    /// WHICH terminal path a key finished on — NOT a claim that the caller's
+    /// intent succeeded. A saga that only partially applied still terminates via
+    /// `.completed` (with an isError body). Once the body is evicted, this is
+    /// all that survives, so callers must reconcile with a live read rather than
+    /// read `completed` as "it worked".
+    enum TerminalKind: String, Equatable, Sendable {
+        case completed
+        case cancelled
     }
 
     struct Claim: Equatable, Sendable {
@@ -20,6 +55,7 @@ actor SagaJournal {
         case cancellationRequested
         case cancelled(StoredOutcome, verified: Bool)
         case completed(StoredOutcome)
+        case outcomeEvicted(terminal: TerminalKind)
     }
 
     enum BeginResult: Equatable, Sendable {
@@ -28,6 +64,7 @@ actor SagaJournal {
         case cancellationRequested
         case cancelled
         case completed(StoredOutcome)
+        case outcomeEvicted(terminal: TerminalKind)
         case conflict
         case capacityExceeded
     }
@@ -38,6 +75,7 @@ actor SagaJournal {
         case cancellationRequested
         case cancelled
         case completed
+        case outcomeEvicted(terminal: TerminalKind)
         case conflict
         case capacityExceeded
     }
@@ -47,57 +85,159 @@ actor SagaJournal {
         case alreadyRequested
         case cancelled(StoredOutcome, verified: Bool)
         case completed
+        case outcomeEvicted(terminal: TerminalKind)
         case notFound
+    }
+
+    /// Ops/test counters for the two tiers. Deliberately NOT a caller-recovery
+    /// API: nothing here tells a client "retry later and it will fit".
+    struct Metrics: Equatable, Sendable {
+        /// Body-tier occupancy: in-flight entries + retained terminal outcomes.
+        /// Compare against `recordCapacity`.
+        let fullBodyCount: Int
+        let compactCount: Int
+        /// Monotonic for the life of the process — `clear()` does not reset it.
+        let bodyEvictions: UInt64
+        let compactCapacity: Int
+        let recordCapacity: Int
+    }
+
+    /// Only ever an in-flight state — terminal keys leave `entries` entirely,
+    /// which makes "a live entry is terminal" unrepresentable.
+    private enum LiveRecord: Equatable, Sendable {
+        case inProgress
+        case cancellationRequested
+    }
+
+    private enum TerminalRecord: Equatable, Sendable {
+        case completed(StoredOutcome)
+        case cancelled(StoredOutcome, verified: Bool)
+
+        var kind: TerminalKind {
+            switch self {
+            case .completed: .completed
+            case .cancelled: .cancelled
+            }
+        }
+
+        var record: Record {
+            switch self {
+            case .completed(let outcome): .completed(outcome)
+            case .cancelled(let outcome, let verified): .cancelled(outcome, verified: verified)
+            }
+        }
     }
 
     private struct Entry: Sendable {
         let plan: SagaPlan
         let claim: Claim
-        var record: Record
+        var record: LiveRecord
+    }
+
+    /// The append-only identity row. `planHash` replaces holding the whole plan
+    /// once the body is gone; `sequence` is the begin order that drives
+    /// oldest-first body eviction.
+    private struct CompactRow: Sendable {
+        let planHash: String
+        let sequence: UInt64
+        var terminal: TerminalKind?
+    }
+
+    private struct TerminalBody: Sendable {
+        let record: TerminalRecord
+        let sequence: UInt64
     }
 
     private let maxRecords: Int
+    private let compactCapacity: Int
     private var entries: [String: Entry] = [:]
+    private var idempotencySet: [String: CompactRow] = [:]
+    private var outcomeBodies: [String: TerminalBody] = [:]
+    private var bodyEvictions: UInt64 = 0
     private var generation: UInt64 = 0
     private var sequence: UInt64 = 0
 
-    init(maxRecords: Int = SagaJournal.defaultMaxRecords) {
+    init(
+        maxRecords: Int = SagaJournal.defaultMaxRecords,
+        compactCapacity: Int = SagaJournal.defaultCompactCapacity
+    ) {
         self.maxRecords = max(1, maxRecords)
+        self.compactCapacity = max(max(1, maxRecords), compactCapacity)
+    }
+
+    func metrics() -> Metrics {
+        Metrics(
+            fullBodyCount: entries.count + outcomeBodies.count,
+            compactCount: idempotencySet.count,
+            bodyEvictions: bodyEvictions,
+            compactCapacity: compactCapacity,
+            recordCapacity: maxRecords
+        )
     }
 
     func disposition(for plan: SagaPlan) -> PlanDisposition {
-        guard let entry = entries[plan.idempotencyKey] else {
-            return entries.count >= maxRecords ? .capacityExceeded : .available
+        if let entry = entries[plan.idempotencyKey] {
+            guard entry.plan == plan else { return .conflict }
+            switch entry.record {
+            case .inProgress: return .inProgress
+            case .cancellationRequested: return .cancellationRequested
+            }
         }
-        guard entry.plan == plan else { return .conflict }
-        switch entry.record {
-        case .inProgress: return .inProgress
-        case .cancellationRequested: return .cancellationRequested
-        case .cancelled: return .cancelled
-        case .completed: return .completed
+        if let row = idempotencySet[plan.idempotencyKey] {
+            guard Self.planHash(plan) == row.planHash, let terminal = row.terminal else {
+                return .conflict
+            }
+            guard let body = outcomeBodies[plan.idempotencyKey] else {
+                return .outcomeEvicted(terminal: terminal)
+            }
+            switch body.record {
+            case .completed: return .completed
+            case .cancelled: return .cancelled
+            }
         }
+        return canAdmitNewKey() ? .available : .capacityExceeded
     }
 
     func begin(_ plan: SagaPlan) -> BeginResult {
         if let entry = entries[plan.idempotencyKey] {
             guard entry.plan == plan else { return .conflict }
             switch entry.record {
-            case .inProgress:
-                return .inProgress
-            case .cancellationRequested:
-                return .cancellationRequested
-            case .cancelled:
-                return .cancelled
-            case .completed(let outcome):
-                return .completed(outcome)
+            case .inProgress: return .inProgress
+            case .cancellationRequested: return .cancellationRequested
             }
         }
-        guard entries.count < maxRecords else { return .capacityExceeded }
+        if let row = idempotencySet[plan.idempotencyKey] {
+            // The plan itself is gone once a key goes terminal, so identity is
+            // re-established by hashing the incoming plan. A mismatch is the
+            // same `.conflict` full-plan equality reports for a live key.
+            guard Self.planHash(plan) == row.planHash, let terminal = row.terminal else {
+                return .conflict
+            }
+            guard let body = outcomeBodies[plan.idempotencyKey] else {
+                return .outcomeEvicted(terminal: terminal)
+            }
+            switch body.record {
+            case .completed(let outcome): return .completed(outcome)
+            case .cancelled: return .cancelled
+            }
+        }
+        guard idempotencySet.count < compactCapacity else { return .capacityExceeded }
+        while entries.count + outcomeBodies.count >= maxRecords {
+            // Fail closed when nothing is evictable (a body tier full of
+            // in-flight sagas): admitting anyway would mean dropping a plan we
+            // still need for equality.
+            guard evictOldestBody() else { return .capacityExceeded }
+        }
         sequence &+= 1
         let claim = Claim(
             idempotencyKey: plan.idempotencyKey,
             generation: generation,
             sequence: sequence
+        )
+        idempotencySet[plan.idempotencyKey] = CompactRow(
+            planHash: Self.planHash(plan),
+            sequence: sequence,
+            terminal: nil
         )
         entries[plan.idempotencyKey] = Entry(plan: plan, claim: claim, record: .inProgress)
         return .started(claim)
@@ -106,11 +246,10 @@ actor SagaJournal {
     @discardableResult
     func complete(_ claim: Claim, outcome: StoredOutcome) -> Bool {
         guard claim.generation == generation,
-              var entry = entries[claim.idempotencyKey],
+              let entry = entries[claim.idempotencyKey],
               entry.claim == claim,
               entry.record == .inProgress else { return false }
-        entry.record = .completed(outcome)
-        entries[claim.idempotencyKey] = entry
+        finalize(claim.idempotencyKey, record: .completed(outcome), sequence: claim.sequence)
         return true
     }
 
@@ -121,77 +260,152 @@ actor SagaJournal {
         verified: Bool
     ) -> Bool {
         guard claim.generation == generation,
-              var entry = entries[claim.idempotencyKey],
+              let entry = entries[claim.idempotencyKey],
               entry.claim == claim,
               entry.record == .cancellationRequested else { return false }
-        entry.record = .cancelled(outcome, verified: verified)
-        entries[claim.idempotencyKey] = entry
+        finalize(
+            claim.idempotencyKey,
+            record: .cancelled(outcome, verified: verified),
+            sequence: claim.sequence
+        )
         return true
     }
 
-    func abandon(_ claim: Claim) {
-        guard claim.generation == generation,
-              let entry = entries[claim.idempotencyKey],
-              entry.claim == claim,
-              entry.record == .inProgress else { return }
-        entries.removeValue(forKey: claim.idempotencyKey)
-    }
-
+    /// The ONLY legitimate pre-write retract of a compact row.
+    ///
+    /// LPMCP-PRD-005: dropping a compact row is dropping replay protection, so
+    /// it is only sound where "no write happened" is PROVABLE rather than
+    /// assumed. It is provable here and nowhere else: the mutation gate refused,
+    /// so the claim never reached an executor. `inProgress` alone cannot carry
+    /// that proof — it IS the write window — which is why no general
+    /// `abandon(claim)` escape door exists on this API.
     func finishGateRefusal(_ claim: Claim, cancellationOutcome: StoredOutcome) {
         guard claim.generation == generation,
-              var entry = entries[claim.idempotencyKey],
+              let entry = entries[claim.idempotencyKey],
               entry.claim == claim else { return }
         switch entry.record {
         case .inProgress:
-            entries.removeValue(forKey: claim.idempotencyKey)
+            forget(claim.idempotencyKey)
         case .cancellationRequested:
-            entry.record = .cancelled(cancellationOutcome, verified: true)
-            entries[claim.idempotencyKey] = entry
-        case .cancelled, .completed:
-            break
+            finalize(
+                claim.idempotencyKey,
+                record: .cancelled(cancellationOutcome, verified: true),
+                sequence: claim.sequence
+            )
         }
     }
 
     @discardableResult
     func completeBeforeWrite(_ claim: Claim, outcome: StoredOutcome) -> Bool {
         guard claim.generation == generation,
-              var entry = entries[claim.idempotencyKey],
+              let entry = entries[claim.idempotencyKey],
               entry.claim == claim else { return false }
         switch entry.record {
         case .inProgress:
-            entry.record = .completed(outcome)
+            finalize(claim.idempotencyKey, record: .completed(outcome), sequence: claim.sequence)
         case .cancellationRequested:
-            entry.record = .cancelled(outcome, verified: true)
-        case .cancelled, .completed:
-            return false
+            finalize(
+                claim.idempotencyKey,
+                record: .cancelled(outcome, verified: true),
+                sequence: claim.sequence
+            )
         }
-        entries[claim.idempotencyKey] = entry
         return true
     }
 
     func record(for idempotencyKey: String) -> Record? {
-        entries[idempotencyKey]?.record
+        if let entry = entries[idempotencyKey] {
+            switch entry.record {
+            case .inProgress: return .inProgress
+            case .cancellationRequested: return .cancellationRequested
+            }
+        }
+        guard let row = idempotencySet[idempotencyKey], let terminal = row.terminal else {
+            return nil
+        }
+        guard let body = outcomeBodies[idempotencyKey] else {
+            return .outcomeEvicted(terminal: terminal)
+        }
+        return body.record.record
     }
 
     func cancel(idempotencyKey: String) -> CancelResult {
-        guard var entry = entries[idempotencyKey] else { return .notFound }
-        switch entry.record {
-        case .inProgress:
-            entry.record = .cancellationRequested
-            entries[idempotencyKey] = entry
-            return .requested
-        case .cancellationRequested:
-            return .alreadyRequested
-        case .cancelled(let outcome, let verified):
-            return .cancelled(outcome, verified: verified)
-        case .completed:
-            return .completed
+        if var entry = entries[idempotencyKey] {
+            switch entry.record {
+            case .inProgress:
+                entry.record = .cancellationRequested
+                entries[idempotencyKey] = entry
+                return .requested
+            case .cancellationRequested:
+                return .alreadyRequested
+            }
+        }
+        guard let row = idempotencySet[idempotencyKey], let terminal = row.terminal else {
+            return .notFound
+        }
+        guard let body = outcomeBodies[idempotencyKey] else {
+            return .outcomeEvicted(terminal: terminal)
+        }
+        switch body.record {
+        case .completed: return .completed
+        case .cancelled(let outcome, let verified): return .cancelled(outcome, verified: verified)
         }
     }
 
     func clear() {
         generation &+= 1
         entries.removeAll(keepingCapacity: true)
+        idempotencySet.removeAll(keepingCapacity: true)
+        outcomeBodies.removeAll(keepingCapacity: true)
+    }
+
+    // MARK: - private
+
+    /// Moves a key from the in-flight tier to the terminal tier. Body-tier
+    /// occupancy is unchanged (one entry out, one body in), so terminating a
+    /// saga never triggers eviction — only admitting a NEW key does.
+    private func finalize(_ key: String, record: TerminalRecord, sequence: UInt64) {
+        entries.removeValue(forKey: key)
+        idempotencySet[key]?.terminal = record.kind
+        outcomeBodies[key] = TerminalBody(record: record, sequence: sequence)
+    }
+
+    private func forget(_ key: String) {
+        entries.removeValue(forKey: key)
+        idempotencySet.removeValue(forKey: key)
+        outcomeBodies.removeValue(forKey: key)
+    }
+
+    private func evictOldestBody() -> Bool {
+        guard let oldest = outcomeBodies.min(by: { $0.value.sequence < $1.value.sequence })
+        else { return false }
+        outcomeBodies.removeValue(forKey: oldest.key)
+        bodyEvictions &+= 1
+        return true
+    }
+
+    private func canAdmitNewKey() -> Bool {
+        guard idempotencySet.count < compactCapacity else { return false }
+        guard entries.count + outcomeBodies.count >= maxRecords else { return true }
+        return !outcomeBodies.isEmpty
+    }
+
+    /// SHA256 over a `.sortedKeys` canonical JSON encoding of the plan. Hashing
+    /// the encoded plan — rather than concatenating fields with a delimiter —
+    /// is what keeps a crafted step value from forging another plan's identity.
+    ///
+    /// A plan that cannot be encoded (e.g. a directly-constructed plan carrying
+    /// a non-finite number, which the wire layer already rejects) hashes to a
+    /// per-call unique sentinel. That fails CLOSED: such a plan can never match
+    /// a stored row, so it answers `.conflict` rather than aliasing another
+    /// saga's record.
+    private static func planHash(_ plan: SagaPlan) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(plan) else {
+            return "unencodable:\(UUID().uuidString)"
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -274,6 +488,47 @@ enum SagaWire {
             hint: "The session saga journal has reached its bounded record capacity",
             extras: ["idempotency_key": idempotencyKey]
         )
+    }
+
+    /// LPMCP-PRD-005 — the key is replay-protected but its outcome body is gone.
+    ///
+    /// The hint deliberately refuses to imply success: `terminal_kind` only says
+    /// WHICH path terminated, and a `completed` saga may still have applied
+    /// partially. The only honest recovery is to observe current state, so the
+    /// hint routes the caller to a live read and explicitly forbids re-firing
+    /// the same intent (`safe_to_retry: false`).
+    static func outcomeUnavailable(
+        _ idempotencyKey: String,
+        terminal: SagaJournal.TerminalKind
+    ) -> CallTool.Result {
+        scopedStateC(
+            .sagaOutcomeUnavailable,
+            hint: "This idempotency_key already reached a terminal saga state in this session, "
+                + "but its stored outcome body is no longer retained (bounded outcome retention). "
+                + "'\(terminal.rawValue)' names the terminal path only — it does NOT assert the "
+                + "intent succeeded. Reconcile the current state with a live read "
+                + "(system.saga_status, or the relevant read operations) and decide from what you "
+                + "observe; do NOT re-fire the same intent blindly.",
+            extras: [
+                "idempotency_key": idempotencyKey,
+                "terminal_kind": terminal.rawValue,
+                "outcome_retained": false,
+                "safe_to_retry": false,
+                "write_attempted": false,
+            ]
+        )
+    }
+
+    /// Ops/test counters for the journal's two bounded tiers. NOT a
+    /// caller-recovery API — nothing here promises a retry will fit.
+    static func journalMetricsFields(_ metrics: SagaJournal.Metrics) -> [String: Any] {
+        [
+            "journal_full_body_count": metrics.fullBodyCount,
+            "journal_compact_count": metrics.compactCount,
+            "journal_body_evictions": metrics.bodyEvictions,
+            "journal_compact_capacity": metrics.compactCapacity,
+            "journal_record_capacity": metrics.recordCapacity,
+        ]
     }
 
     static func preflightIssue(_ preflightIssue: PreflightIssue) -> [String: Any] {

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -199,6 +199,11 @@ enum HonestContract {
         case sagaInProgress = "saga_in_progress"
         case idempotencyKeyConflict = "idempotency_key_conflict"
         case sagaJournalCapacityExceeded = "saga_journal_capacity_exceeded"
+        // LPMCP-PRD-005: the saga already reached a terminal state in this
+        // session but its stored outcome body has been evicted under bounded
+        // retention. Distinct from `sagaJournalCapacityExceeded`, which means
+        // "cannot admit a NEW key".
+        case sagaOutcomeUnavailable = "saga_outcome_unavailable"
         case notSupported = "not_supported"
         case sagaExecutionFailed = "saga_execution_failed"
     }
@@ -386,6 +391,10 @@ enum HonestContract {
         FailureError.traceClearReceiptFailed.rawValue,
         FailureError.idempotencyKeyConflict.rawValue,
         FailureError.sagaJournalCapacityExceeded.rawValue,
+        // LPMCP-PRD-005: an evicted outcome body is terminal — no other channel
+        // and no retry can reconstruct a body this session no longer holds. The
+        // caller must reconcile with a live read.
+        FailureError.sagaOutcomeUnavailable.rawValue,
     ]
 
     /// Returns true if the given message is a State-C envelope whose `error`

--- a/Tests/LogicProMCPTests/SagaJournalReclaimTests.swift
+++ b/Tests/LogicProMCPTests/SagaJournalReclaimTests.swift
@@ -1,0 +1,629 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// Minimal write probe for the reclaim surface: only `mixer.set_volume` is
+/// exercised, and every landed write moves BOTH the live surface and the cache
+/// mirror so a saga verifies cleanly.
+private actor SagaReclaimWriteProbeChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private let cache: StateCache
+    private let surface: SagaLiveTrackSurface
+    private var calls: [String] = []
+
+    init(cache: StateCache, surface: SagaLiveTrackSurface) {
+        self.cache = cache
+        self.surface = surface
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        calls.append(operation)
+        guard let rawIndex = params["index"], let index = Int(rawIndex) else {
+            return .error(HonestContract.encodeStateC(error: .invalidParams))
+        }
+        switch operation {
+        case "mixer.set_volume":
+            guard let rawValue = params["volume"], let value = Double(rawValue) else {
+                return .error(HonestContract.encodeStateC(error: .invalidParams))
+            }
+            surface.update(index) { $0.volume = value }
+            await cache.updateTrack(at: index) { $0.volume = value }
+        default:
+            return .error(HonestContract.encodeStateC(error: .commandNotExposed))
+        }
+        return .success(HonestContract.encodeStateA(extras: ["operation": operation]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "saga reclaim write probe")
+    }
+
+    func writeCount() -> Int { calls.count }
+}
+
+/// Counts step executions so "did this saga re-run?" is directly assertable.
+private actor SagaReclaimCountingExecutor: SagaStepExecutor {
+    private var states: [TargetReference: Value]
+    private var runs = 0
+
+    init(states: [TargetReference: Value]) {
+        self.states = states
+    }
+
+    func run(_ step: SagaStep) async -> StepResult {
+        runs += 1
+        if let target = step.targetRef,
+           let desired = step.params[step.expectedInverse.valueParameter] {
+            states[target] = desired
+        }
+        return StepResult(state: .stateA, writeBoundaryCrossed: true, detail: "synthetic A")
+    }
+
+    func readState(_ step: SagaStep) async -> ObservedState? {
+        guard let target = step.targetRef, let value = states[target] else { return nil }
+        return ObservedState(value: value, evidence: "reclaim counting executor")
+    }
+
+    func runCount() -> Int { runs }
+}
+
+@Suite("SagaJournal bounded reclaim", .serialized)
+struct SagaJournalReclaimTests {
+    private struct Fixture: Sendable {
+        let router: ChannelRouter
+        let cache: StateCache
+        let surface: SagaLiveTrackSurface
+        let targetRegistry: TargetRegistry
+        let journal: SagaJournal
+        let channel: SagaReclaimWriteProbeChannel
+        let target: TargetReference
+    }
+
+    // MARK: - helpers
+
+    private func withSagaFeatures<Result>(
+        _ operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await FeatureFlags.withAdr004MutationSagaForTests(true) {
+            try await FeatureFlags.withAdr002TargetRefForTests(true, operation: operation)
+        }
+    }
+
+    private func makeFixture(journal: SagaJournal) async -> Fixture {
+        let cache = StateCache()
+        let tracks = [TrackState(id: 0, name: "Bass", type: .audio, volume: 0.25)]
+        await cache.updateTracks(tracks)
+        let surface = SagaLiveTrackSurface(tracks)
+        let targetRegistry = TargetRegistry()
+        let descriptor = TargetDescriptor(trackIndex: 0, trackName: "Bass")
+        let target = await targetRegistry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        let channel = SagaReclaimWriteProbeChannel(cache: cache, surface: surface)
+        let router = ChannelRouter()
+        await router.register(channel)
+        return Fixture(
+            router: router,
+            cache: cache,
+            surface: surface,
+            targetRegistry: targetRegistry,
+            journal: journal,
+            channel: channel,
+            target: target
+        )
+    }
+
+    private func dispatch(
+        command: String,
+        params: [String: Value],
+        fixture: Fixture
+    ) async -> CallTool.Result {
+        await SystemDispatcher.handle(
+            command: command,
+            params: params,
+            router: fixture.router,
+            cache: fixture.cache,
+            targetRegistry: fixture.targetRegistry,
+            sagaJournal: fixture.journal,
+            sagaLiveReadback: fixture.surface.readback
+        )
+    }
+
+    private func resultObject(_ result: CallTool.Result) throws -> [String: Any] {
+        guard case .text(let text, _, _) = result.content.first else {
+            Issue.record("expected text tool result")
+            return [:]
+        }
+        return try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        )
+    }
+
+    /// A wire plan that sets track 0's volume — distinct `value` per key keeps
+    /// each saga's verification independent.
+    private func wirePlan(_ fixture: Fixture, key: String, value: Double) -> [String: Value] {
+        [
+            "idempotency_key": .string(key),
+            "steps": .array([.object([
+                "operation_id": .string(OperationID.mixerSetVolume.rawValue),
+                "target_ref": .string(fixture.target.rawValue),
+                "params": .object(["value": .double(value)]),
+                "expected_inverse": .object([
+                    "operation_id": .string(OperationID.mixerSetVolume.rawValue),
+                    "value_parameter": .string("value"),
+                ]),
+            ])]),
+        ]
+    }
+
+    /// A journal-only plan. Never executed — the journal never inspects step
+    /// semantics, only plan identity.
+    private func unitPlan(_ key: String, name: String = "Lead") -> SagaPlan {
+        SagaPlan(
+            steps: [SagaStep(
+                operationID: .tracksRename,
+                targetRef: TargetReference(rawValue: "track:0"),
+                params: ["name": .string(name)],
+                expectedInverse: SagaExpectedInverse(
+                    operationID: .tracksRename,
+                    valueParameter: "name"
+                )
+            )],
+            idempotencyKey: key
+        )
+    }
+
+    private func storedOutcome(_ marker: String) -> SagaJournal.StoredOutcome {
+        SagaJournal.StoredOutcome(
+            body: HonestContract.encodeStateA(extras: ["marker": marker]),
+            isError: false
+        )
+    }
+
+    /// Drives `key` to a retained terminal `completed` record.
+    @discardableResult
+    private func terminate(
+        _ journal: SagaJournal,
+        key: String,
+        name: String = "Lead"
+    ) async -> Bool {
+        guard case .started(let claim) = await journal.begin(unitPlan(key, name: name)) else {
+            Issue.record("expected a fresh claim for \(key)")
+            return false
+        }
+        return await journal.complete(claim, outcome: storedOutcome(key))
+    }
+
+    private func isStarted(_ result: SagaJournal.BeginResult) -> Bool {
+        if case .started = result { return true }
+        return false
+    }
+
+    // MARK: - RED: body reclaim
+
+    @Test("insertion pressure evicts the oldest terminal body instead of failing closed")
+    func bodyEvictionAdmitsNewKeys() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "k1")
+        await terminate(journal, key: "k2")
+
+        let third = await journal.begin(unitPlan("k3"))
+
+        #expect(third != .capacityExceeded)
+        #expect(isStarted(third))
+    }
+
+    @Test("an evicted terminal key never re-executes and never answers started")
+    func evictedTerminalKeyNeverReExecutes() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "k1")
+        await terminate(journal, key: "k2")
+        _ = await journal.begin(unitPlan("k3"))
+
+        let retry = await journal.begin(unitPlan("k1"))
+
+        #expect(!isStarted(retry))
+        #expect(retry != .capacityExceeded)
+        #expect(retry != .completed(storedOutcome("k1")))
+    }
+
+    @Test("cancel on a body-less terminal is typed, never notFound or completed")
+    func cancelOnBodylessTerminalIsTyped() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "k1")
+        await terminate(journal, key: "k2")
+        _ = await journal.begin(unitPlan("k3"))
+
+        let cancel = await journal.cancel(idempotencyKey: "k1")
+
+        #expect(cancel != .notFound)
+        #expect(cancel != .completed)
+    }
+
+    @Test("an evicted body keeps its compact row and reports the terminal path")
+    func evictedBodyRetainsCompactRow() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "k1")
+        await terminate(journal, key: "k2")
+        _ = await journal.begin(unitPlan("k3"))
+        let metrics = await journal.metrics()
+
+        #expect(await journal.begin(unitPlan("k1")) == .outcomeEvicted(terminal: .completed))
+        #expect(await journal.record(for: "k1") == .outcomeEvicted(terminal: .completed))
+        #expect(await journal.disposition(for: unitPlan("k1"))
+            == .outcomeEvicted(terminal: .completed))
+        #expect(await journal.cancel(idempotencyKey: "k1")
+            == .outcomeEvicted(terminal: .completed))
+        // The compact row survives eviction; only the body is gone.
+        #expect(metrics.compactCount == 3)
+        #expect(metrics.fullBodyCount == 2)
+        #expect(metrics.bodyEvictions == 1)
+        // k2 is younger than k1, so k1's body is the one that goes.
+        #expect(await journal.begin(unitPlan("k2")) == .completed(storedOutcome("k2")))
+    }
+
+    @Test("an evicted cancellation reports the cancelled terminal path")
+    func evictedCancellationReportsCancelled() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        guard case .started(let claim) = await journal.begin(unitPlan("c1")) else {
+            Issue.record("expected a fresh claim")
+            return
+        }
+        #expect(await journal.cancel(idempotencyKey: "c1") == .requested)
+        #expect(await journal.completeCancellation(
+            claim,
+            outcome: storedOutcome("c1"),
+            verified: true
+        ))
+        await terminate(journal, key: "c2")
+        _ = await journal.begin(unitPlan("c3"))
+
+        #expect(await journal.begin(unitPlan("c1")) == .outcomeEvicted(terminal: .cancelled))
+        #expect(await journal.record(for: "c1") == .outcomeEvicted(terminal: .cancelled))
+    }
+
+    // MARK: - the load-bearing invariant
+
+    @Test("no terminal key ever answers started, at any insertion pressure")
+    func terminalKeysNeverLapseWithinAGeneration() async throws {
+        let journal = SagaJournal(maxRecords: 4)
+        var terminalKeys: [String] = []
+
+        for index in 0..<64 {
+            let key = "key-\(index)"
+            if case .started(let claim) = await journal.begin(unitPlan(key)) {
+                await journal.complete(claim, outcome: storedOutcome(key))
+                terminalKeys.append(key)
+            }
+            // After EVERY insertion, every key that ever went terminal must
+            // still refuse to start. This is the whole point of the compact
+            // tier: saturation costs bodies, never replay protection.
+            for terminal in terminalKeys {
+                let replay = await journal.begin(unitPlan(terminal))
+                #expect(!isStarted(replay))
+                #expect(replay != .capacityExceeded)
+                #expect(replay != .conflict)
+            }
+        }
+
+        #expect(terminalKeys.count == 64)
+        let metrics = await journal.metrics()
+        #expect(metrics.compactCount == 64)
+        #expect(metrics.fullBodyCount <= 4)
+        #expect(metrics.bodyEvictions == 60)
+    }
+
+    @Test("in-flight entries are never evicted and saturate fail-closed")
+    func inProgressEntriesAreImmuneToEviction() async throws {
+        let journal = SagaJournal(maxRecords: 3)
+        for index in 0..<3 {
+            #expect(isStarted(await journal.begin(unitPlan("live-\(index)"))))
+        }
+
+        #expect(await journal.begin(unitPlan("live-new")) == .capacityExceeded)
+        #expect(await journal.disposition(for: unitPlan("live-new")) == .capacityExceeded)
+        for index in 0..<3 {
+            #expect(await journal.record(for: "live-\(index)") == .inProgress)
+        }
+        let metrics = await journal.metrics()
+        #expect(metrics.bodyEvictions == 0)
+        #expect(metrics.fullBodyCount == 3)
+    }
+
+    @Test("compact tier exhaustion still fails closed with capacityExceeded")
+    func compactCapacityExhaustionFailsClosed() async throws {
+        let journal = SagaJournal(maxRecords: 2, compactCapacity: 2)
+        await terminate(journal, key: "c1")
+        await terminate(journal, key: "c2")
+
+        #expect(await journal.begin(unitPlan("c3")) == .capacityExceeded)
+        // Both admitted keys stay replay-protected.
+        #expect(await journal.begin(unitPlan("c1")) == .completed(storedOutcome("c1")))
+        #expect(await journal.begin(unitPlan("c2")) == .completed(storedOutcome("c2")))
+    }
+
+    // MARK: - plan identity
+
+    @Test("a different plan on a retained terminal key conflicts")
+    func planIdentityConflictsWhileBodyRetained() async throws {
+        let journal = SagaJournal(maxRecords: 4)
+        await terminate(journal, key: "identity", name: "Lead")
+
+        #expect(await journal.begin(unitPlan("identity", name: "Other")) == .conflict)
+        #expect(await journal.disposition(for: unitPlan("identity", name: "Other")) == .conflict)
+        #expect(await journal.begin(unitPlan("identity", name: "Lead"))
+            == .completed(storedOutcome("identity")))
+    }
+
+    @Test("a different plan on an evicted terminal key still conflicts")
+    func planIdentityConflictsAfterBodyEviction() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "identity", name: "Lead")
+        await terminate(journal, key: "filler")
+        _ = await journal.begin(unitPlan("pressure"))
+        #expect(await journal.record(for: "identity") == .outcomeEvicted(terminal: .completed))
+
+        // The plan is gone, so this is the hash path doing the work.
+        #expect(await journal.begin(unitPlan("identity", name: "Other")) == .conflict)
+        #expect(await journal.disposition(for: unitPlan("identity", name: "Other")) == .conflict)
+        #expect(await journal.begin(unitPlan("identity", name: "Lead"))
+            == .outcomeEvicted(terminal: .completed))
+    }
+
+    // MARK: - generation
+
+    @Test("clear resets both tiers but keeps the eviction counter monotonic")
+    func clearResetsBothTiers() async throws {
+        let journal = SagaJournal(maxRecords: 2)
+        await terminate(journal, key: "g1")
+        await terminate(journal, key: "g2")
+        _ = await journal.begin(unitPlan("g3"))
+        #expect(await journal.metrics().bodyEvictions == 1)
+
+        await journal.clear()
+        let metrics = await journal.metrics()
+
+        #expect(metrics.compactCount == 0)
+        #expect(metrics.fullBodyCount == 0)
+        #expect(await journal.record(for: "g1") == nil)
+        #expect(await journal.record(for: "g3") == nil)
+        // A new generation is a new session: keys are free to start again.
+        #expect(isStarted(await journal.begin(unitPlan("g1"))))
+        // Monotonic across generations — it is an ops counter, not tier state.
+        #expect(metrics.bodyEvictions == 1)
+    }
+
+    // MARK: - RED: wire
+
+    @Test("saga_execute retry of an evicted key answers saga_outcome_unavailable")
+    func wireRetryOfEvictedKeyIsOutcomeUnavailable() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture(journal: SagaJournal(maxRecords: 1))
+            let first = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "evict-first", value: 0.5),
+                fixture: fixture
+            ))
+            let second = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "evict-second", value: 0.6),
+                fixture: fixture
+            ))
+            let writesBeforeRetry = await fixture.channel.writeCount()
+            let retry = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "evict-first", value: 0.5),
+                fixture: fixture
+            ))
+
+            #expect(first["state"] as? String == "A")
+            #expect(second["state"] as? String == "A")
+            #expect(retry["state"] as? String == "C")
+            #expect(retry["error"] as? String == "saga_outcome_unavailable")
+            #expect(retry["safe_to_retry"] as? Bool == false)
+            #expect(retry["write_attempted"] as? Bool == false)
+            #expect(retry["outcome_retained"] as? Bool == false)
+            #expect(await fixture.channel.writeCount() == writesBeforeRetry)
+        }
+    }
+
+    @Test("saga_status reports a body-less terminal honestly")
+    func wireStatusReportsEvictedBody() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture(journal: SagaJournal(maxRecords: 1))
+            _ = await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "status-first", value: 0.5),
+                fixture: fixture
+            )
+            _ = await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "status-second", value: 0.6),
+                fixture: fixture
+            )
+            let status = try resultObject(await dispatch(
+                command: "saga_status",
+                params: ["idempotency_key": .string("status-first")],
+                fixture: fixture
+            ))
+            let record = try #require(status["record"] as? [String: Any])
+
+            #expect(record["status"] as? String == "completed")
+            #expect(record["outcome_retained"] as? Bool == false)
+            #expect(record["outcome"] == nil)
+        }
+    }
+
+    @Test("saga_journal_capacity_exceeded keeps its existing envelope shape")
+    func wireCapacityExceededShapeUnchanged() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture(
+                journal: SagaJournal(maxRecords: 1, compactCapacity: 1)
+            )
+            let first = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "cap-first", value: 0.5),
+                fixture: fixture
+            ))
+            let second = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "cap-second", value: 0.6),
+                fixture: fixture
+            ))
+
+            #expect(first["state"] as? String == "A")
+            #expect(second["state"] as? String == "C")
+            #expect(second["error"] as? String == "saga_journal_capacity_exceeded")
+            #expect(second["idempotency_key"] as? String == "cap-second")
+            #expect(second["journal_scope"] as? String == "session")
+            // Capacity is distinct from an evicted body: no key was admitted, so
+            // there is no terminal path to name.
+            #expect(second["terminal_kind"] == nil)
+            #expect(second["outcome_retained"] == nil)
+        }
+    }
+
+    /// LPMCP-PRD-005 item 8: `MutationSaga.sessions` is request-local scratch and
+    /// must NOT be dual-bounded — SystemDispatcher builds a fresh MutationSaga
+    /// per preflight and per execute, so `sessions` never outlives one call.
+    ///
+    /// This is the strongest DETERMINISTIC runtime pin available. A code-shape
+    /// census could only prove the constructor is textually inside the case; this
+    /// proves request-locality behaviourally. `journal.clear()` starts a new
+    /// generation, so the journal cannot answer the replayed key — the request
+    /// reaches MutationSaga. If a MutationSaga instance were shared across
+    /// dispatcher calls, `sessions[key]` would still hold the first outcome and
+    /// short-circuit `execute` (MutationSaga.swift:416), so NO new write would
+    /// land. A fresh instance per call re-runs the step, so the write count
+    /// strictly increases.
+    @Test("dispatcher saga paths keep MutationSaga.sessions request-local")
+    func mutationSagaSessionsAreRequestLocal() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture(journal: SagaJournal())
+            let first = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "local", value: 0.5),
+                fixture: fixture
+            ))
+            let writesAfterFirst = await fixture.channel.writeCount()
+
+            await fixture.journal.clear()
+            let replay = try resultObject(await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "local", value: 0.5),
+                fixture: fixture
+            ))
+
+            #expect(first["state"] as? String == "A")
+            #expect(replay["state"] as? String == "A")
+            #expect(writesAfterFirst == 1)
+            #expect(await fixture.channel.writeCount() == 2)
+            // A shared MutationSaga would have replayed the cached outcome and
+            // reported `duplicate` from its own scratch instead.
+            #expect(replay["duplicate"] as? Bool == false)
+        }
+    }
+
+    /// The other half of the request-locality pin: this proves the behaviour
+    /// `mutationSagaSessionsAreRequestLocal` excludes is REAL. One MutationSaga
+    /// instance replaying the same key answers from `sessions` and runs no
+    /// steps. So the dispatcher test's "the replay ran the step again" outcome
+    /// is only reachable with a fresh instance per call — without this, that
+    /// test could pass for the wrong reason.
+    @Test("one MutationSaga instance suppresses re-execution from its session scratch")
+    func mutationSagaSessionsSuppressReExecutionWithinOneInstance() async throws {
+        try await withSagaFeatures {
+            let registry = TargetRegistry()
+            let descriptor = TargetDescriptor(trackIndex: 0, trackName: "Bass")
+            let target = await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            )
+            let executor = SagaReclaimCountingExecutor(states: [target: .double(0.25)])
+            let saga = MutationSaga(
+                targetRegistry: registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            )
+            let plan = SagaPlan(
+                steps: [SagaStep(
+                    operationID: .mixerSetVolume,
+                    targetRef: target,
+                    params: ["value": .double(0.5)],
+                    expectedInverse: SagaExpectedInverse(
+                        operationID: .mixerSetVolume,
+                        valueParameter: "value"
+                    )
+                )],
+                idempotencyKey: "instance-local"
+            )
+
+            _ = await saga.execute(plan, executor: executor)
+            let afterFirst = await executor.runCount()
+            _ = await saga.execute(plan, executor: executor)
+
+            #expect(afterFirst == 1)
+            #expect(await executor.runCount() == afterFirst)
+        }
+    }
+
+    @Test("saga_status and saga_preflight publish journal tier metrics")
+    func wireObservabilityExtras() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture(journal: SagaJournal(maxRecords: 1))
+            _ = await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "metrics-first", value: 0.5),
+                fixture: fixture
+            )
+            let status = try resultObject(await dispatch(
+                command: "saga_status",
+                params: ["idempotency_key": .string("metrics-first")],
+                fixture: fixture
+            ))
+            let preflight = try resultObject(await dispatch(
+                command: "saga_preflight",
+                params: wirePlan(fixture, key: "metrics-second", value: 0.6),
+                fixture: fixture
+            ))
+
+            for body in [status, preflight] {
+                #expect(body["journal_full_body_count"] as? Int == 1)
+                #expect(body["journal_compact_count"] as? Int == 1)
+                #expect(body["journal_body_evictions"] as? Int == 0)
+                #expect(body["journal_compact_capacity"] as? Int
+                    == SagaJournal.defaultCompactCapacity)
+                #expect(body["journal_record_capacity"] as? Int == 1)
+            }
+
+            // Drive an eviction and prove the counter moves and only ever up.
+            _ = await dispatch(
+                command: "saga_execute",
+                params: wirePlan(fixture, key: "metrics-second", value: 0.6),
+                fixture: fixture
+            )
+            let after = try resultObject(await dispatch(
+                command: "saga_status",
+                params: ["idempotency_key": .string("metrics-second")],
+                fixture: fixture
+            ))
+            let later = try resultObject(await dispatch(
+                command: "saga_status",
+                params: ["idempotency_key": .string("metrics-second")],
+                fixture: fixture
+            ))
+
+            #expect(after["journal_body_evictions"] as? Int == 1)
+            #expect(later["journal_body_evictions"] as? Int == 1)
+            #expect(after["journal_compact_count"] as? Int == 2)
+            #expect(after["journal_full_body_count"] as? Int == 1)
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/SagaSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/SagaSurfaceTests.swift
@@ -912,10 +912,17 @@ struct SagaSurfaceTests {
         }
     }
 
-    @Test("bounded journal rejects new keys without evicting completed outcomes")
+    /// LPMCP-PRD-005: capacity now means "cannot admit a NEW key" — the COMPACT
+    /// replay-protection tier is full. This test used to pin `maxRecords: 1`
+    /// (the body tier) rejecting a second key; bodies are now reclaimable, so
+    /// exhausting the body tier admits the new key by evicting an older BODY
+    /// (see SagaJournalReclaimTests). Saturating the compact tier is what still
+    /// fails closed, and it must, because admitting a key we cannot
+    /// replay-protect is a correctness hole rather than an availability one.
+    @Test("bounded journal fails closed once the compact replay tier is full")
     func journalCapacityFailsClosed() async throws {
         try await withSagaFeatures {
-            let journal = SagaJournal(maxRecords: 1)
+            let journal = SagaJournal(maxRecords: 1, compactCapacity: 1)
             let fixture = await makeFixture(journal: journal)
             let first = try resultObject(await dispatch(
                 command: "saga_execute",

--- a/docs/API.md
+++ b/docs/API.md
@@ -214,6 +214,17 @@ With `LOGIC_MCP_ADR005_OPERATION_TRACE=1`, `list_recent_traces` returns bounded 
 
 The bounded journal belongs only to the current server session and is cleared on session end or process restart. A completed duplicate key returns its stored outcome with `duplicate:true`; `saga_status` reads that record. `saga_cancel` returns a typed refusal for active work because the current engine has no safe cancellation seam. Ordered work with compensation does not promise all-or-nothing completion or durable recovery.
 
+The journal keeps two independently bounded tiers, so pressure costs stored evidence rather than safety:
+
+- **Replay protection (whole session).** Every `idempotency_key` begun in a session stays recorded for that whole session. A key that reached a terminal state never starts again — replay protection does not lapse, expire, or time out. There is no wall-clock TTL.
+- **Outcome bodies (most recent N).** Full stored outcomes are retained for the most recent `journal_record_capacity` sagas (default 1024). Under insertion pressure the oldest terminal body is dropped; in-flight sagas are never dropped.
+
+Retrying an older completed saga whose body was dropped returns `saga_outcome_unavailable` (State C, terminal) instead of the original body — never a re-execution. It carries `terminal_kind` (`completed` or `cancelled`), `outcome_retained:false`, `safe_to_retry:false`, and `write_attempted:false`. `terminal_kind` names only which path the saga terminated on; it is **not** a claim that the intent succeeded (a `completed` saga may have applied only partially). Reconcile by observing current state via `saga_status` or the relevant read operations — do not re-fire the same intent blindly. `saga_status` for such a key still reports its terminal `status` with `outcome_retained:false` and no `outcome`.
+
+`saga_journal_capacity_exceeded` remains distinct and unchanged in meaning: the journal cannot admit a **new** key. It is returned under either of two conditions — the session's replay-protection tier (`journal_compact_capacity`, default 65536) is full, or the outcome tier is fully occupied by in-flight sagas and therefore holds no terminal body that can be reclaimed. Both stay fail-closed: admitting a key the session cannot replay-protect, or evicting a saga still running, would be a correctness hole rather than an availability one.
+
+`saga_status` and `saga_preflight` publish `journal_full_body_count`, `journal_compact_count`, `journal_body_evictions`, `journal_compact_capacity`, and `journal_record_capacity` for operators. These are diagnostics only — none of them promises that a later retry will fit, and `journal_survives_process_restart` stays `false`.
+
 ### Not-exposed commands
 
 A few command tokens are recognised by the dispatchers but are deliberately **not part of the production MCP contract** (no deterministic / verified path exists yet). They are excluded from the workflow command census and return a single machine-classifiable State C shape — `error: "command_not_exposed"`, `not_exposed: true`, `supported: false`, plus the `operation` — so a complete-surface demo/test harness can classify them as *expected*, not a malfunction:


### PR DESCRIPTION
## Summary

Debt **LPMCP-PRD-005** (P1, ADR-004 #287): the saga journal — the mutation idempotency/replay-protection record — was a single bounded map that turned permanently `capacityExceeded` at 1,024 records: availability death for long sessions and the 30-minute soak, with the only alternatives being silent eviction (re-opens double-execution on retry of an evicted key — a wrong-write class for a DAW) or the status quo.

**Design (adversarially debate-ratified before implementation):** split the journal into two tiers so replay protection NEVER silently lapses in a session while memory stays bounded:

- **Compact idempotency set** — `key → {plan_hash, terminal_kind, sequence}`, **append-only within a generation** (never dropped in-session), capacity 65,536. Plan identity survives body eviction as a SHA256 over the `sortedKeys` JSON of the canonical plan (structural, no delimiter concatenation), so a same-key/different-plan retry still answers `.conflict` exactly as full-plan equality does for live keys.
- **Outcome-body tier** — full stored outcomes for in-flight + terminal records, bounded at the existing 1,024 **combined** (preserves today's total memory ceiling). Under admission pressure the oldest-by-sequence *terminal* body is evicted; in-flight sagas are never evictable, and when nothing is evictable the journal fails closed with the unchanged `capacityExceeded`.
- **Typed honesty for the gap:** a retry of a body-evicted key answers new `saga_outcome_unavailable` (State C, `terminal_kind`, `outcome_retained:false`, `safe_to_retry:false`, `write_attempted:false` — per-call semantics) with a hint that explicitly says the terminal kind names the termination path, NOT intent success, and directs reconciliation via live reads. It never re-executes and never replays a body it no longer holds. `BeginResult`/`PlanDisposition`/`CancelResult` gain `.outcomeEvicted(terminal:)` — `completed` is never overloaded body-less.
- **No wall-clock TTL anywhere** (pressure is the trigger; correctness is time-independent). **Restart durability is out of scope by existing contract** (`journal_survives_process_restart:false` is already on the wire and live-attested); a durable journal is its own future increment.
- **Observability:** `saga_status`/`saga_preflight` expose `journal_full_body_count` / `journal_compact_count` / `journal_body_evictions` (monotonic) / both capacities — ops/test metrics, explicitly not a caller-recovery API.
- `MutationSaga.sessions` was investigated and is request-local in production wiring (fresh instance per preflight/execute); instead of dual-bounding it, two complementary tests pin request-locality behaviourally (replay-after-clear re-executes; a deliberately shared instance provably would suppress that re-execution — jointly excluding a shared-instance regression).

RED-first: 6 new behaviors captured failing against the old API (18 assertion failures) before implementation. A legacy test that pinned the old debt in its own name ("rejects new keys **without evicting** completed outcomes") is inverted to pin the new fail-closed boundary (compact-tier exhaustion).

**Adversarial gate round (applied pre-merge):** verdict PROCEED-WITH-FIXES; the one P1 — a new `abandon(_:)` method with zero callers and zero tests that had become an escape door from the append-only invariant (inProgress IS the write window, so its "never wrote" premise is unenforceable, and it erased the compact row) — is deleted; `finishGateRefusal` remains the only retract, provably pre-write because the mutation gate was never acquired, with that reasoning now documented at the call site. docs capacity wording aligned to name both fail-closed conditions. All five reported implementer decisions were ratified (combined body-tier ceiling, metric semantics, absent-not-null evicted keys, unencodable-plan conflict sentinel, legacy-test inversion).

## Verification
Ticket filter 73 passed; extended saga/dispatcher/HC filter 413 passed; **full suite `--no-parallel` 2,922 passed on the final diff**. RED excerpts for all 6 new behaviors captured pre-implementation. Adversarial gate verdict recorded in PR comments.
