### PR TITLE
registry: LPMCP-PRD-007 — index-binding ratchet (rename + corroboration tier)

### DIFF
--- a/Scripts/live-e2e-test.py
+++ b/Scripts/live-e2e-test.py
@@ -547,6 +547,22 @@ def read_tracks_data(client):
     return data if isinstance(data, list) else None
 
 
+def live_track_name(client, index):
+    """PRD-007: the live name at a track index, for corroborating the seed-set
+    ops (delete / duplicate / set_instrument) that no longer accept a bare
+    index. Returns None if the header is unreadable, in which case the caller's
+    seed-op will honestly fail closed with index_binding_corroboration_required."""
+    tracks = read_tracks_data(client)
+    if not isinstance(tracks, list):
+        return None
+    for track in tracks:
+        if isinstance(track, dict) and track.get("id") == index:
+            name = track.get("name")
+            if isinstance(name, str) and name.strip():
+                return name
+    return None
+
+
 def read_track_regions(client, index):
     regions = safe_json(resource_text(read_resource(client, f"logic://tracks/{index}/regions")))
     return regions if isinstance(regions, list) else None
@@ -1783,12 +1799,18 @@ def main():
     # (`panel_open_after_failure`), and a library read between the two attempts
     # must still succeed (panel not wedged).
     invalid_path = "ZZZNoSuchCategory/ZZZNoSuchPreset"
+    # PRD-007 index binding: set_instrument is `.corroborated`. The binding gate
+    # runs AFTER request-shape validation but BEFORE the (invalid-)path load, so
+    # to still exercise the #222 invalid-path drift behavior we must clear the
+    # gate first by corroborating index 0 against its live header name.
+    name0 = live_track_name(client, 0)
+    corro = {"expected_name": name0} if name0 else {}
     d1 = tool_json(call_tool(client, "logic_tracks", "set_instrument",
-                             {"index": 0, "path": invalid_path})) or {}
+                             {"index": 0, "path": invalid_path, **corro})) or {}
     mid = read_resource(client, "logic://library/inventory")
     mid_ok = mid is not None and safe_json(resource_text(mid)) is not None
     d2 = tool_json(call_tool(client, "logic_tracks", "set_instrument",
-                             {"index": 0, "path": invalid_path})) or {}
+                             {"index": 0, "path": invalid_path, **corro})) or {}
     T("set_instrument invalid path is a deterministic State C (#222)", "ok",
       lambda _: d1.get("success") is False and isinstance(d1.get("error"), str))
     T("set_instrument failure does not cascade on the next attempt (#222)", "ok",

--- a/Scripts/spike-channel-eq-census.py
+++ b/Scripts/spike-channel-eq-census.py
@@ -475,6 +475,20 @@ def create_audio_track(client: MCPClient) -> Optional[int]:
     return index
 
 
+def live_track_name(client: MCPClient, track_index: int) -> Optional[str]:
+    """PRD-007: the live name at a track index, for corroborating the seed-set
+    ops (insert_verified / delete) that no longer accept a bare index."""
+    tracks = tracks_snapshot(client)
+    if not isinstance(tracks, list):
+        return None
+    for track in tracks:
+        if isinstance(track, dict) and track.get("id") == track_index:
+            name = track.get("name")
+            if isinstance(name, str) and name.strip():
+                return name
+    return None
+
+
 def insert_channel_eq(client: MCPClient, track_index: int, insert_index: int, project_path: str) -> bool:
     send_escape("pre_insert_escape")
     params = {
@@ -484,6 +498,12 @@ def insert_channel_eq(client: MCPClient, track_index: int, insert_index: int, pr
         "mode": "duplicate_applyback",
         "project_expected_path": project_path,
     }
+    # PRD-007 index binding: insert_verified is `.corroborated`, so a bare track
+    # index is refused. Corroborate against the live header name of the track we
+    # created earlier in this spike.
+    expected_name = live_track_name(client, track_index)
+    if expected_name is not None:
+        params["expected_name"] = expected_name
     response = call_tool(client, "logic_plugins", "insert_verified", params, timeout=60)
     payload = tool_json(response)
     send_escape("post_insert_escape")
@@ -498,7 +518,13 @@ def cleanup_created_track(client: MCPClient, track_index: Optional[int]) -> None
         emit("cleanup_track_delete", "missing", reason="no created track index")
         send_escape("cleanup_post_escape")
         return
-    response = call_tool(client, "logic_tracks", "delete", {"index": track_index}, timeout=30)
+    # PRD-007 index binding: tracks.delete is `.corroborated` — corroborate the
+    # index against the live header name before the irreversible delete.
+    delete_params: Dict[str, Any] = {"index": track_index}
+    expected_name = live_track_name(client, track_index)
+    if expected_name is not None:
+        delete_params["expected_name"] = expected_name
+    response = call_tool(client, "logic_tracks", "delete", delete_params, timeout=30)
     payload = tool_json(response)
     emit("cleanup_track_delete", "ok" if isinstance(payload, dict) and payload.get("state") == "A" else "failed", index=track_index, response=payload or response)
     send_escape("cleanup_post_escape")

--- a/Sources/LogicProMCP/Dispatchers/IndexBindingGuard.swift
+++ b/Sources/LogicProMCP/Dispatchers/IndexBindingGuard.swift
@@ -1,0 +1,229 @@
+import Foundation
+import MCP
+
+/// PRD-007 (ADR-002 #285) — the index-binding ratchet's enforcement point.
+///
+/// ## What this defends
+///
+/// A track index is an ORDINAL, not an identity. Between the moment a caller
+/// reads `logic://tracks` and the moment its write lands, a user drag, a track
+/// creation, or a folder collapse can shift every row down one — and the write
+/// then destroys a track the caller never named, reporting State A. The ref path
+/// (`target_ref`) closes this by binding to a session-stable identity, but it is
+/// opt-in and flag-gated, so the bare-index path stayed wide open on ops where
+/// the mistake is unrecoverable.
+///
+/// This guard NARROWS that window for `.corroborated` ops — to the interval
+/// between the live-header read and the write itself — by demanding the caller
+/// state WHAT they believe sits at the index (`expected_name`), then proving it
+/// against the LIVE surface before any write is attempted. It is a pre-write
+/// proof, NOT atomic with the write: a reorder that lands inside the
+/// guard-to-write interval can still write to the wrong track. Only `target_ref`
+/// (and the future `.refRequired` tier) bind an identity across the write and
+/// close the window entirely; corroboration is the best a bare index can do.
+///
+/// ## Why the uniqueness check is not optional
+///
+/// Matching `expected_name` at the index looks sufficient and is not. Two tracks
+/// sharing a name can swap positions and leave `(index, name)` self-consistent
+/// at BOTH ordinals — corroboration passes while the write lands on the wrong
+/// one. So a non-unique match is refused outright and the caller is pushed to
+/// `target_ref`, the only binding a swap cannot fool.
+///
+/// ## Invariants
+///
+/// - Runs ONLY on the index path. When `target_ref` is supplied the ref
+///   machinery runs instead — never both (see `Outcome.reject` on the combo).
+/// - Reads the LIVE header scan, never `StateCache`: the cache lags an
+///   out-of-band reorder by the poll interval, which is precisely the window
+///   being defended. Verifying against it would be theatre.
+/// - Every failure is PRE-write: `write_attempted:false` is a fact here, not a
+///   claim, because the guard returns before the dispatcher routes anything.
+/// - Unreadable is never agreement: a nil scan fails closed.
+enum IndexBindingGuard {
+    /// The corroboration param. Single source; see
+    /// `OperationRegistry.corroborationParam` for why it is not `name`.
+    static let expectedNameParam = OperationRegistry.corroborationParam
+
+    /// Reject `expected_name` + `target_ref` in the same call.
+    ///
+    /// MUST be called BEFORE `target_ref` resolution: a stale/unavailable ref
+    /// otherwise fails first and reports `stale_target_reference` /
+    /// `target_ref_unavailable`, hiding the caller's real mistake (they sent two
+    /// competing bindings) behind a diagnosis of the one they shouldn't fix.
+    ///
+    /// Documented choice (PRD-007): reject rather than cross-check the two for
+    /// agreement. The ref path already proves live identity and uniqueness (F5),
+    /// so cross-checking would stack a second proof with a second error
+    /// vocabulary over one failure. Exactly one binding wins per call.
+    static func conflictingBindingFailure(
+        policy: IndexBindingPolicy?,
+        operation: String,
+        params: [String: Value]
+    ) -> CallTool.Result? {
+        guard policy == .corroborated,
+              params["target_ref"] != nil,
+              trimmedNonEmpty(params[expectedNameParam]?.stringValue) != nil else { return nil }
+        return toolInvalidParamsResult(
+            "\(expectedNameParam) cannot be combined with target_ref — supply exactly one binding: target_ref (stable identity) or \(expectedNameParam) (index corroboration)",
+            extras: [
+                "operation": operation,
+                "write_attempted": false,
+                "safe_to_retry": true,
+            ]
+        )
+    }
+
+    /// Evaluate the binding proof for an index-path write.
+    ///
+    /// Takes the `policy` directly rather than looking it up from an
+    /// `OperationID` so the `.refRequired` tier is testable via a synthetic spec
+    /// while no production op carries it yet.
+    ///
+    /// - Returns: `nil` when the write may proceed; otherwise the fail-closed
+    ///   State C result the dispatcher must return verbatim.
+    static func evaluate(
+        policy: IndexBindingPolicy?,
+        operation: String,
+        params: [String: Value],
+        index: Int,
+        liveTrackNames: (@Sendable () -> [Int: String]?)?
+    ) -> CallTool.Result? {
+        // The ref path owns this call and carries its own live-identity and
+        // ambiguity guards (F5) — no second stack. The illegal combination was
+        // already rejected pre-resolution by `conflictingBindingFailure`.
+        if params["target_ref"] != nil { return nil }
+
+        let expectedName = trimmedNonEmpty(params[expectedNameParam]?.stringValue)
+
+        switch policy {
+        case .none, .some(.legacyIndexAllowed):
+            return nil
+
+        case .some(.refRequired):
+            return toolStateCResult(
+                .stableTargetRequired,
+                hint: "\(operation) accepts only a stable target_ref — a bare index cannot be bound to a track identity for this operation",
+                extras: [
+                    "operation": operation,
+                    "requested_index": index,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            )
+
+        case .some(.corroborated):
+            guard let expectedName else {
+                return toolStateCResult(
+                    .indexBindingCorroborationRequired,
+                    hint: "\(operation) will not write to a bare index: supply \(expectedNameParam) (the track name you expect at index \(index)) so the target can be corroborated against the live surface, or supply target_ref to bind by stable identity instead",
+                    extras: [
+                        "operation": operation,
+                        "requested_index": index,
+                        "what_was_attempted": "bind \(operation) to index \(index)",
+                        "what_was_observed": "no \(expectedNameParam) and no target_ref — the index is an unproven ordinal",
+                        "write_attempted": false,
+                        "safe_to_retry": true,
+                    ]
+                )
+            }
+            return corroborate(
+                operation: operation,
+                index: index,
+                expectedName: expectedName,
+                liveTrackNames: liveTrackNames
+            )
+        }
+    }
+
+    /// Prove `expectedName` identifies the live track at `index`, uniquely.
+    private static func corroborate(
+        operation: String,
+        index: Int,
+        expectedName: String,
+        liveTrackNames: (@Sendable () -> [Int: String]?)?
+    ) -> CallTool.Result? {
+        // A nil probe is an UNREADABLE surface, not an absent check: the
+        // deterministic test path leaves it nil by default, and a corroborated
+        // op must never be talked into writing by the mere absence of evidence.
+        guard let scanned = liveTrackNames?() else {
+            return identityMismatchResult(
+                operation: operation,
+                index: index,
+                expectedName: expectedName,
+                observedName: nil,
+                reason: "header_unreadable"
+            )
+        }
+
+        let names = scanned.mapValues { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard let live = names[index], live == expectedName else {
+            return identityMismatchResult(
+                operation: operation,
+                index: index,
+                expectedName: expectedName,
+                observedName: names[index],
+                reason: names[index] == nil ? "header_unreadable" : "name_mismatch"
+            )
+        }
+
+        let sameNameIndices = names.filter { $0.value == expectedName }.keys.sorted()
+        guard sameNameIndices.count == 1 else {
+            return toolStateCResult(
+                .targetNameAmbiguous,
+                hint: "\(operation) refused: '\(expectedName)' names \(sameNameIndices.count) live tracks, so matching it at index \(index) does not prove which one this is (same-named tracks can swap and stay self-consistent) — supply target_ref to bind by stable identity",
+                extras: [
+                    "operation": operation,
+                    "requested_index": index,
+                    "expected_track_name": expectedName,
+                    "ambiguous_track_indices": sameNameIndices,
+                    "what_was_attempted": "corroborate index \(index) against \(expectedNameParam) '\(expectedName)'",
+                    "what_was_observed": "live track name '\(expectedName)' appeared at indices \(sameNameIndices.map(String.init).joined(separator: ", "))",
+                    "write_attempted": false,
+                    "safe_to_retry": false,
+                ]
+            )
+        }
+        return nil
+    }
+
+    /// Fail-closed State C for a corroboration that did not hold. Carries the
+    /// same evidence keys the F1/F5 wrong-target guards emit
+    /// (`expected_track_name` / `observed_track_name` / `what_was_attempted` /
+    /// `what_was_observed`) so all three report a uniform shape.
+    private static func identityMismatchResult(
+        operation: String,
+        index: Int,
+        expectedName: String,
+        observedName: String?,
+        reason: String
+    ) -> CallTool.Result {
+        toolStateCResult(
+            .targetIdentityMismatch,
+            hint: observedName == nil
+                ? "\(operation) refused: the live track header at index \(index) could not be read, so \(expectedNameParam) '\(expectedName)' could not be corroborated — an unreadable surface is never treated as agreement"
+                : "\(operation) refused: index \(index) is live track '\(observedName!)', not \(expectedNameParam) '\(expectedName)' — the ordinal moved (out-of-band reorder); re-read logic://tracks, or supply target_ref to bind by stable identity",
+            extras: [
+                "operation": operation,
+                "requested_index": index,
+                "reason": reason,
+                "expected_track_name": expectedName,
+                "observed_track_name": observedName as Any? ?? NSNull(),
+                "what_was_attempted": "corroborate index \(index) against \(expectedNameParam) '\(expectedName)' before writing",
+                "what_was_observed": observedName.map { "index \(index) live track name is '\($0)'" }
+                    ?? "index \(index) live track name was unreadable",
+                "write_attempted": false,
+                // Retrying the same (index, expected_name) reproduces the same
+                // refusal — the caller must re-read or re-bind first, so this is
+                // not a transient failure to hammer.
+                "safe_to_retry": false,
+            ]
+        )
+    }
+
+    private static func trimmedNonEmpty(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+}

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -41,7 +41,7 @@ struct PluginsDispatcher: OperationTraceDispatching {
 
     static let tool = commandTool(
         name: "logic_plugins",
-        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required) }. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_param_verified and insert_verified ALSO accept a session-stable { target_ref: String } from logic://tracks (trk_…) or logic_plugins.get_inventory (ins_…); plugin-insert refs resolve track and physical insert, and explicit track/insert values must agree when supplied or the op fails closed (stale_target_reference); when the flag is off, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use explicit selectors.",
+        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required), expected_name: String }. PRD-007 index binding: insert_verified is `corroborated` — a bare `track` index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique across the surface) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false and takes no verified-op gate. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): set_param_verified and insert_verified ALSO accept a session-stable { target_ref: String } from logic://tracks (trk_…) or logic_plugins.get_inventory (ins_…); plugin-insert refs resolve track and physical insert, and explicit track/insert values must agree when supplied or the op fails closed (stale_target_reference); when the flag is off, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use explicit selectors.",
         commandDescription: "Verified plugin command to execute"
     )
 
@@ -50,7 +50,18 @@ struct PluginsDispatcher: OperationTraceDispatching {
         params: [String: Value],
         router: ChannelRouter,
         cache: StateCache,
-        targetRegistry: TargetRegistry? = nil
+        targetRegistry: TargetRegistry? = nil,
+        // PRD-007 — live AX track-header scan for `insert_verified`'s index-path
+        // corroboration. The verified plugin surface historically passed nil to
+        // the resolver and did its F1 identity cross-check INSIDE the AX write
+        // (via `expected_track_name`), which is unreachable on the bare-index
+        // path and cannot see across tracks to detect a duplicate name. The
+        // ratchet needs a pre-write, dispatcher-side check with a typed
+        // fail-closed shape, so the scan is threaded in here the way
+        // TrackDispatcher already does. Nil by default: the deterministic suite
+        // never touches live AX; production wires the real reader at the
+        // dispatch chokepoint.
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil
     ) async -> CallTool.Result {
         if let projectFailure = await TargetRefResolver.validateProjectReference(
             params,
@@ -58,6 +69,16 @@ struct PluginsDispatcher: OperationTraceDispatching {
             operation: "plugin.\(command)"
         ) {
             return projectFailure
+        }
+
+        // PRD-007: reject two competing bindings BEFORE ref resolution, so a
+        // stale ref cannot mask the caller's actual mistake.
+        if let conflict = IndexBindingGuard.conflictingBindingFailure(
+            policy: indexBindingPolicy(for: command),
+            operation: "logic_plugins.\(command)",
+            params: params
+        ) {
+            return conflict
         }
 
         switch command {
@@ -139,6 +160,21 @@ struct PluginsDispatcher: OperationTraceDispatching {
             )
 
         case "insert_verified":
+            // PRD-007: corroborate the bare-index target BEFORE taking the
+            // verified-op gate or starting a trace — a refusal here has no side
+            // effect of any kind. Skipped when `track` is absent/malformed: the
+            // channel's own schema step reports that precisely, and a missing
+            // selector cannot mutate a wrong target anyway.
+            if let requestedTrack = intParamOrNil(params, "track"), requestedTrack >= 0,
+               let bindingFailure = IndexBindingGuard.evaluate(
+                   policy: indexBindingPolicy(for: command),
+                   operation: "logic_plugins.insert_verified",
+                   params: params,
+                   index: requestedTrack,
+                   liveTrackNames: liveTrackNames
+               ) {
+                return bindingFailure
+            }
             let traceID = await startTraceIfEnabled(command: command)
             var resolvedReference: TargetReference?
             var resolvedFingerprint: String?
@@ -200,6 +236,12 @@ struct PluginsDispatcher: OperationTraceDispatching {
         default:
             return Self.unhandledCommandResult(command, label: "plugins")
         }
+    }
+
+    /// PRD-007: the registry is the single source of the index-binding tier —
+    /// dispatchers never hardcode which ops are ratcheted.
+    private static func indexBindingPolicy(for command: String) -> IndexBindingPolicy? {
+        OperationRegistry.spec(tool: ToolID.logicPlugins.rawValue, command: command)?.indexBinding
     }
 
     // MARK: - Verified-op serialization (R14)

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -12,7 +12,7 @@ struct TrackDispatcher: OperationTraceDispatching {
 
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, when LOGIC_MCP_ADR002_TARGET_REF=1, { name: String, target_ref: String, index?: Int }; when the flag is off, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int }; set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String } or { category: String, preset: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the flag is off, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, when LOGIC_MCP_ADR002_TARGET_REF=1, { name: String, target_ref: String, index?: Int }; when the flag is off, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int, expected_name: String } (PRD-007 index binding: delete, duplicate and set_instrument are `corroborated` — a bare index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false); set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String, expected_name: String } or { category: String, preset: String, expected_name: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (LOGIC_MCP_ADR002_TARGET_REF=1): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the flag is off, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -43,6 +43,16 @@ struct TrackDispatcher: OperationTraceDispatching {
             operation: "track.\(command)"
         ) {
             return projectFailure
+        }
+
+        // PRD-007: reject two competing bindings BEFORE ref resolution, so a
+        // stale ref cannot mask the caller's actual mistake.
+        if let conflict = IndexBindingGuard.conflictingBindingFailure(
+            policy: indexBindingPolicy(for: command),
+            operation: "track.\(command)",
+            params: params
+        ) {
+            return conflict
         }
 
         if let operation = modalGuardedTrackOperation(for: command), dialogPresent() {
@@ -174,6 +184,15 @@ struct TrackDispatcher: OperationTraceDispatching {
             case .failure(let result):
                 return result
             }
+            if let bindingFailure = IndexBindingGuard.evaluate(
+                policy: indexBindingPolicy(for: "delete"),
+                operation: "track.delete",
+                params: params,
+                index: index,
+                liveTrackNames: liveTrackNames
+            ) {
+                return bindingFailure
+            }
             let traceID = await startTraceIfEnabled(command: command)
             await recordWriteBoundary(traceID)
             let selectResult = await router.route(
@@ -242,6 +261,15 @@ struct TrackDispatcher: OperationTraceDispatching {
                 resolvedFingerprint = resolved.binding?.observedFingerprint
             case .failure(let result):
                 return result
+            }
+            if let bindingFailure = IndexBindingGuard.evaluate(
+                policy: indexBindingPolicy(for: "duplicate"),
+                operation: "track.duplicate",
+                params: params,
+                index: index,
+                liveTrackNames: liveTrackNames
+            ) {
+                return bindingFailure
             }
             let traceID = await startTraceIfEnabled(command: command)
             await recordWriteBoundary(traceID)
@@ -687,6 +715,21 @@ struct TrackDispatcher: OperationTraceDispatching {
                     traceID: traceID
                 )
             }
+            // PRD-007: LAST gate before the write. Deliberately ordered after
+            // request-shape validation and the blocking-dialog precondition: a
+            // malformed request is malformed whatever it points at, and a wedged
+            // session is wedged for every target — reporting an unproven binding
+            // for either would answer a question the caller didn't ask yet.
+            // Binding is the final question: "is this the thing you meant?"
+            if let bindingFailure = IndexBindingGuard.evaluate(
+                policy: indexBindingPolicy(for: "set_instrument"),
+                operation: "track.set_instrument",
+                params: params,
+                index: index,
+                liveTrackNames: liveTrackNames
+            ) {
+                return await finalizeTrace(bindingFailure, traceID: traceID)
+            }
             await recordWriteBoundary(traceID)
             let result = await router.route(
                 operation: "track.set_instrument",
@@ -789,6 +832,13 @@ struct TrackDispatcher: OperationTraceDispatching {
     /// set op, then surfaces a #106 State-B (unverified) channel success as an
     /// error. Per-command error-hint strings are preserved verbatim via
     /// `command`; `operation` is the channel op ("track.set_mute", etc.).
+    /// PRD-007: the registry is the single source of the index-binding tier —
+    /// dispatchers never hardcode which ops are ratcheted, so a seed-set change
+    /// is one registry edit and the census catches any drift.
+    private static func indexBindingPolicy(for command: String) -> IndexBindingPolicy? {
+        OperationRegistry.spec(tool: ToolID.logicTracks.rawValue, command: command)?.indexBinding
+    }
+
     private static func handleToggle(
         command: String,
         operation: String,

--- a/Sources/LogicProMCP/Server/OperationCatalog.swift
+++ b/Sources/LogicProMCP/Server/OperationCatalog.swift
@@ -28,6 +28,10 @@ struct OperationCatalogEntry: Codable, Sendable, Equatable {
     let allowedParams: [String]
     let capability: String
     let dirtySections: [String]
+    /// PRD-007: absent for ops with no target to mis-bind (see
+    /// `OperationSpec.indexBinding`), so the wire distinguishes "not applicable"
+    /// from any tier value rather than flattening both into a string.
+    let indexBinding: String?
 }
 
 enum OperationCatalog {
@@ -48,7 +52,8 @@ enum OperationCatalog {
                     availability: wire(spec.availability),
                     allowedParams: spec.allowedParams.sorted(),
                     capability: spec.capability.rawValue,
-                    dirtySections: spec.dirtySections.map(\.rawValue).sorted()
+                    dirtySections: spec.dirtySections.map(\.rawValue).sorted(),
+                    indexBinding: spec.indexBinding.map(wire)
                 )
             }
         return OperationCatalogSnapshot(
@@ -69,7 +74,15 @@ enum OperationCatalog {
     private static func wire(_ value: TargetPolicy) -> String {
         switch value {
         case .none: "none"
-        case .requiresStableTarget: "requires_stable_target"
+        case .acceptsStableTarget: "accepts_stable_target"
+        }
+    }
+
+    private static func wire(_ value: IndexBindingPolicy) -> String {
+        switch value {
+        case .refRequired: "ref_required"
+        case .corroborated: "corroborated"
+        case .legacyIndexAllowed: "legacy_index_allowed"
         }
     }
 

--- a/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
@@ -14,6 +14,14 @@ struct HandlerDependencies: Sendable {
     /// dispatch census) inject a stub so exercising `launch`/`quit` cases
     /// can never touch the real app lifecycle.
     let projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)?
+    /// PRD-007: explicit seam for the LIVE AX track-header scan that the
+    /// index-binding ratchet corroborates a bare index against. `nil` =
+    /// production `AXLogicProElements.trackNames()`. Tests inject a fixed
+    /// surface so `.corroborated` ops stay deterministically exercisable
+    /// end-to-end — without this seam the only way to drive them through the
+    /// real handler would be live AX, and their index path would silently drop
+    /// out of the deterministic census.
+    let liveTrackNames: (@Sendable () -> [Int: String]?)?
 
     init(
         router: ChannelRouter,
@@ -24,7 +32,8 @@ struct HandlerDependencies: Sendable {
         supportBundleExporter: SystemDispatcher.SupportBundleExporter?,
         sagaJournal: SagaJournal = SagaJournal(),
         mutationGate: LogicMutationGate? = nil,
-        projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)? = nil
+        projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)? = nil,
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil
     ) {
         self.router = router
         self.cache = cache
@@ -35,6 +44,13 @@ struct HandlerDependencies: Sendable {
         self.sagaJournal = sagaJournal
         self.mutationGate = mutationGate
         self.projectLifecycleExecute = projectLifecycleExecute
+        self.liveTrackNames = liveTrackNames
+    }
+
+    /// The live header reader to hand a dispatcher: the injected seam when a
+    /// test supplies one, else the production AX scan.
+    var liveTrackNamesReader: @Sendable () -> [Int: String]? {
+        liveTrackNames ?? { AXLogicProElements.trackNames() }
     }
 }
 
@@ -222,7 +238,7 @@ enum OperationHandlerRegistry {
                     // track-header reader so the target_ref mutation boundary
                     // fails closed on an out-of-band reorder.
                     liveTrackName: { AXLogicProElements.trackName(at: $0) },
-                    liveTrackNames: { AXLogicProElements.trackNames() }
+                    liveTrackNames: dependencies.liveTrackNamesReader
                 )
             }
         case .logicNavigate:
@@ -255,7 +271,7 @@ enum OperationHandlerRegistry {
                     // track-header reader so saga-replayed target_ref track/mixer
                     // steps fail closed on an out-of-band reorder.
                     liveTrackName: { AXLogicProElements.trackName(at: $0) },
-                    liveTrackNames: { AXLogicProElements.trackNames() },
+                    liveTrackNames: dependencies.liveTrackNamesReader,
                     // LPMCP-PRD-004 — saga before-state/verification/compensation
                     // read the live AX surface, never the cache mirror.
                     sagaLiveReadback: .production
@@ -268,7 +284,8 @@ enum OperationHandlerRegistry {
                     params: params,
                     router: dependencies.router,
                     cache: dependencies.cache,
-                    targetRegistry: dependencies.targetRegistry
+                    targetRegistry: dependencies.targetRegistry,
+                    liveTrackNames: dependencies.liveTrackNamesReader
                 )
             }
         case .logicEdit:
@@ -330,7 +347,7 @@ enum OperationHandlerRegistry {
                     // track-header reader so the target_ref mutation boundary
                     // fails closed on an out-of-band reorder.
                     liveTrackName: { AXLogicProElements.trackName(at: $0) },
-                    liveTrackNames: { AXLogicProElements.trackNames() }
+                    liveTrackNames: dependencies.liveTrackNamesReader
                 )
             }
         }

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -133,9 +133,35 @@ enum ConfirmationPolicy: Sendable, Equatable {
     case l3
 }
 
+/// Whether an operation will ACCEPT a session-stable `target_ref` in place of a
+/// raw index. Deliberately named `acceptsStableTarget` (PRD-007): the old
+/// `requiresStableTarget` spelling claimed a requirement the registry never
+/// enforced — these ops have always accepted a bare index too. What is actually
+/// required of the index path is declared by `IndexBindingPolicy`, a separate
+/// axis. No alias case: the rename is the point, so every stale use site breaks
+/// at compile time rather than silently reading the old meaning.
 enum TargetPolicy: Sendable, Equatable {
     case none
-    case requiresStableTarget
+    case acceptsStableTarget
+}
+
+/// PRD-007 — what an index-keyed mutating operation demands before it will write
+/// to a bare ordinal. Orthogonal to `TargetPolicy` (which describes what the op
+/// accepts) and applied only when no `target_ref` is supplied.
+///
+/// The tiers form a ratchet: ops move `.legacyIndexAllowed` → `.corroborated` →
+/// `.refRequired` as their index paths are closed, and each move is a registry
+/// row flip whose census diff is the receipt.
+enum IndexBindingPolicy: Sendable, Equatable, CaseIterable {
+    /// A bare index is refused outright — only a stable `target_ref` binds.
+    /// Assigned to ZERO production ops today; see `refRequiredOperationIDs`.
+    case refRequired
+    /// A bare index must be corroborated by an `expected_name` that matches the
+    /// LIVE header at that index AND is unique across the live surface.
+    case corroborated
+    /// The historical unguarded index path. Deprecated — every remaining member
+    /// is pinned by census so shrinking the set is a deliberate diff.
+    case legacyIndexAllowed
 }
 
 enum VerificationPolicy: Sendable, Equatable {
@@ -198,6 +224,14 @@ struct OperationSpec: Sendable {
     /// whole world changed); everything else currently relies on the poller
     /// and targeted post-write updates, declared as an empty set.
     let dirtySections: Set<CacheSectionID>
+    /// PRD-007: what this op demands of a bare index. Non-nil for EXACTLY the
+    /// target-bearing mutating ops — the only specs with an index path that can
+    /// hit the wrong target — and nil everywhere else, because the tier would be
+    /// meaningless on an op that has no target to mis-bind. Derived, never
+    /// hand-set per row: `indexBinding(for:target:mutability:)` is the one place
+    /// the seed set is declared, so a new spec cannot forget the axis.
+    /// The census asserts both halves of that invariant.
+    let indexBinding: IndexBindingPolicy?
 
     init(
         id: OperationID,
@@ -214,6 +248,11 @@ struct OperationSpec: Sendable {
         capability: CapabilityID,
         dirtySections: Set<CacheSectionID> = []
     ) {
+        self.indexBinding = OperationRegistry.indexBinding(
+            for: id,
+            target: target,
+            mutability: mutability
+        )
         self.id = id
         self.tool = tool
         self.command = command
@@ -368,16 +407,85 @@ enum OperationRegistry {
         .tracksRecordSequence: ["port"],
     ]
 
+    /// PRD-007 seed set — the index-keyed ops whose index path is ratcheted to
+    /// `.corroborated`.
+    ///
+    /// DELIBERATELY NOT DERIVED from `ConfirmationPolicy` or any destructiveness
+    /// flag: those are orthogonal axes and derivation would be wrong in both
+    /// directions. `tracks.delete` is `confirmation: .none` yet is the single
+    /// most wrong-target-irreversible op in the registry; `mixer.insert_plugin`
+    /// is `.l2` yet is not even target-bearing. Confirmation answers "did the
+    /// human mean to do this?"; index binding answers "is this the thing they
+    /// meant to do it TO?". A human can confirm an intent perfectly and still
+    /// have it land on the wrong track. Hence: an explicit list.
+    ///
+    /// Membership test = wrong-target irreversibility, not blast radius:
+    ///   - tracks.delete        destroys the wrong track outright.
+    ///   - tracks.duplicate     mutates topology; wrong-target = phantom copy.
+    ///   - tracks.set_instrument replace-class; overwrites the wrong strip's patch.
+    ///   - plugins.insert_verified insert-class topology on a trackIndex-keyed target.
+    /// Excluded: reversible param writes and state toggles (mixer.set_volume /
+    /// set_pan, plugins.set_param_verified, tracks.select / rename / mute / solo
+    /// / arm / arm_only / set_automation) — a wrong-target write there is
+    /// recoverable, so the ratchet's cost is not yet earned.
+    ///
+    /// KNOWN RESIDUAL (next batch): `mixer.insert_plugin` is an index-keyed
+    /// plugin insert that this tier CANNOT cover, because its `TargetPolicy` is
+    /// `.none` — it accepts no `target_ref`, so `.corroborated`'s "or supply a
+    /// target_ref" escape hatch would be unofferable. Ratcheting it requires
+    /// first making it target-bearing.
+    static let corroboratedOperationIDs: Set<OperationID> = [
+        .tracksDelete, .tracksDuplicate, .tracksSetInstrument, .pluginsInsertVerified,
+    ]
+
+    /// PRD-007: pinned empty this increment. `.refRequired` is implemented and
+    /// unit-tested via a synthetic spec, but assigned to no production op — the
+    /// promotion is a registry row flip in a later batch, so this set going
+    /// non-empty IS the promotion receipt in the census diff.
+    /// Planned first promotion: `tracks.delete` (already `.corroborated`), once
+    /// `FeatureFlags.adr002TargetRef` defaults ON and `target_ref` is reachable
+    /// by every caller — until then `.refRequired` would strand the index path
+    /// with no usable alternative.
+    static let refRequiredOperationIDs: Set<OperationID> = []
+
+    /// The corroboration parameter. NOT `name`: several target-bearing ops
+    /// already spend `name` on an operand (`tracks.rename`'s NEW name,
+    /// `tracks.select`'s by-name selector), so overloading it would make the
+    /// binding proof indistinguishable from the payload.
+    static let corroborationParam = "expected_name"
+
+    /// The single source of the index-binding axis. Non-nil exactly for
+    /// target-bearing mutating specs (see `OperationSpec.indexBinding`).
+    static func indexBinding(
+        for operationID: OperationID,
+        target: TargetPolicy,
+        mutability: Mutability
+    ) -> IndexBindingPolicy? {
+        guard target == .acceptsStableTarget, mutability == Mutability.`mutating` else {
+            return nil
+        }
+        if refRequiredOperationIDs.contains(operationID) { return .refRequired }
+        if corroboratedOperationIDs.contains(operationID) { return .corroborated }
+        return .legacyIndexAllowed
+    }
+
     private static func allowedParams(
         for operationID: OperationID,
         target: TargetPolicy = .none,
+        mutability: Mutability = Mutability.`mutating`,
         commandSpecific: Set<String>
     ) -> Set<String> {
         var allowed = commandSpecific
             .union(legacyIgnoredParamsByOperation[operationID] ?? [])
-        if target == .requiresStableTarget {
+        if target == .acceptsStableTarget {
             allowed.insert("target_ref")
             allowed.insert("project_ref")
+        }
+        // PRD-007: the corroboration param is accepted only where it is
+        // meaningful — a `.corroborated` op's index path. Adding it registry-wide
+        // would advertise a binding proof that most ops silently ignore.
+        if indexBinding(for: operationID, target: target, mutability: mutability) == .corroborated {
+            allowed.insert(corroborationParam)
         }
         return allowed
     }
@@ -416,10 +524,10 @@ enum OperationRegistry {
             .mixerSetVolume,
             "set_volume",
             .none,
-            TargetPolicy.requiresStableTarget,
+            TargetPolicy.acceptsStableTarget,
             ["index", "track", "value", "volume"]
         ),
-        (.mixerSetPan, "set_pan", .none, .requiresStableTarget, ["index", "pan", "track", "value"]),
+        (.mixerSetPan, "set_pan", .none, .acceptsStableTarget, ["index", "pan", "track", "value"]),
         (.mixerSetMasterVolume, "set_master_volume", .none, .none, ["value", "volume"]),
         (
             .mixerSetPluginParam,
@@ -559,7 +667,7 @@ enum OperationRegistry {
             Mutability.`mutating`,
             DeadlineClass.medium,
             VerificationPolicy.readbackRequired,
-            TargetPolicy.requiresStableTarget,
+            TargetPolicy.acceptsStableTarget,
             [
                 "insert", "mode", "param", "plugin", "plugin_id", "plugin_name",
                 "project_expected_path", "track", "unit", "value",
@@ -571,7 +679,7 @@ enum OperationRegistry {
             Mutability.`mutating`,
             DeadlineClass.medium,
             VerificationPolicy.readbackRequired,
-            TargetPolicy.requiresStableTarget,
+            TargetPolicy.acceptsStableTarget,
             [
                 "insert", "mode", "plugin", "plugin_id", "plugin_name", "project_expected_path",
                 "slot", "track",
@@ -592,6 +700,7 @@ enum OperationRegistry {
             allowedParams: allowedParams(
                 for: entry.0,
                 target: entry.5,
+                mutability: entry.2,
                 commandSpecific: entry.6
             ),
             capability: CapabilityID(rawValue: entry.0.rawValue)
@@ -739,23 +848,23 @@ enum OperationRegistry {
             Mutability.`mutating`,
             DeadlineClass.short,
             VerificationPolicy.readbackRequired,
-            TargetPolicy.requiresStableTarget,
+            TargetPolicy.acceptsStableTarget,
             ["index", "name", "track"]
         ),
         (.tracksCreateAudio, "create_audio", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none, []),
         (.tracksCreateInstrument, "create_instrument", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none, []),
         (.tracksCreateDrummer, "create_drummer", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none, []),
         (.tracksCreateExternalMIDI, "create_external_midi", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.none, []),
-        (.tracksDelete, "delete", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["index", "track"]),
-        (.tracksDuplicate, "duplicate", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.requiresStableTarget, ["index", "track"]),
-        (.tracksRename, "rename", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["index", "name", "track"]),
-        (.tracksMute, "mute", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["enabled", "index", "track"]),
-        (.tracksSolo, "solo", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["enabled", "index", "track"]),
-        (.tracksArm, "arm", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["enabled", "index", "track"]),
-        (.tracksArmOnly, "arm_only", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["index", "track"]),
+        (.tracksDelete, "delete", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "track"]),
+        (.tracksDuplicate, "duplicate", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.acceptsStableTarget, ["index", "track"]),
+        (.tracksRename, "rename", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "name", "track"]),
+        (.tracksMute, "mute", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["enabled", "index", "track"]),
+        (.tracksSolo, "solo", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["enabled", "index", "track"]),
+        (.tracksArm, "arm", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["enabled", "index", "track"]),
+        (.tracksArmOnly, "arm_only", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "track"]),
         (.tracksRecordSequence, "record_sequence", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired, TargetPolicy.none, ["bar", "notes", "tempo"]),
-        (.tracksSetAutomation, "set_automation", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["index", "mode", "track"]),
-        (.tracksSetInstrument, "set_instrument", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.requiresStableTarget, ["category", "index", "path", "preset"]),
+        (.tracksSetAutomation, "set_automation", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "mode", "track"]),
+        (.tracksSetInstrument, "set_instrument", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["category", "index", "path", "preset"]),
         (.tracksListLibrary, "list_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none, []),
         (.tracksScanLibrary, "scan_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none, ["mode"]),
         (.tracksResolvePath, "resolve_path", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, TargetPolicy.none, ["path"]),
@@ -775,6 +884,7 @@ enum OperationRegistry {
             allowedParams: allowedParams(
                 for: entry.0,
                 target: entry.5,
+                mutability: entry.2,
                 commandSpecific: entry.6
             ),
             capability: CapabilityID(rawValue: entry.0.rawValue)

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -101,6 +101,41 @@ enum HonestContract {
         case staleSnapshot = "stale_snapshot"
         case staleTargetReference = "stale_target_reference"
         case targetRefUnavailable = "target_ref_unavailable"
+
+        // PRD-007 (ADR-002 #285) — index-binding ratchet. These describe the
+        // INDEX path's binding proof and are deliberately NOT folded into
+        // `.staleTargetReference`, which means something different and
+        // narrower: a `target_ref` token that no longer resolves. Here no ref
+        // exists at all, so reporting one as stale would send the caller
+        // hunting a token they never held.
+        //
+        // CLASSIFICATION (CTO ruling, PRD-007 P2-5): these four are deliberately
+        // NOT added to `terminalErrorCodes`. Every one is raised pre-route and
+        // pre-write, and every one is caller-correctable in place — supply or fix
+        // `expected_name` (or switch to `target_ref`) and retry. That is exactly
+        // the retryable posture of `.targetRefUnavailable`, not a terminal
+        // channel-exhaustion or unsupported-surface failure. Re-classifying to
+        // terminal is a separate decision, warranted only if live soak shows
+        // callers hammering an uncorrectable case; nothing here is uncorrectable.
+        /// A `.corroborated` op was called with a bare index and no
+        /// `expected_name` (and no `target_ref`), so the ordinal is unproven.
+        /// Nothing was read or written — supplying either binding is a safe retry.
+        case indexBindingCorroborationRequired = "index_binding_corroboration_required"
+        /// The live header at the supplied index does not carry the
+        /// `expected_name` the caller corroborated with — the ordinal moved
+        /// under them — or the header could not be read at all
+        /// (`reason: header_unreadable`), which is never read as agreement.
+        /// Fail-closed pre-write: the wrong track was NOT touched.
+        case targetIdentityMismatch = "target_identity_mismatch"
+        /// `expected_name` matched the live header at the supplied index but is
+        /// NOT unique across the live surface. Two same-named tracks can swap
+        /// positions and keep (index, name) self-consistent, so a match proves
+        /// nothing; only a `target_ref` survives the swap.
+        case targetNameAmbiguous = "target_name_ambiguous"
+        /// A `.refRequired` op was called with a bare index. Unlike
+        /// `.indexBindingCorroborationRequired`, no `expected_name` can rescue
+        /// this — a stable `target_ref` is the only accepted binding.
+        case stableTargetRequired = "stable_target_required"
         case windowOpenFailed = "window_open_failed"
         case windowIdentityUnresolved = "window_identity_unresolved"
         case paramControlNotFound = "param_control_not_found"

--- a/Tests/LogicProMCPTests/ADR002ATargetKindTests.swift
+++ b/Tests/LogicProMCPTests/ADR002ATargetKindTests.swift
@@ -35,6 +35,13 @@ private actor ADR002ATestChannel: Channel {
 
 @Suite(.serialized)
 struct ADR002ATargetKindTests {
+    /// PRD-007: the LIVE header scan corresponding to `cacheWithTracks`. The
+    /// seed-set ops corroborate against the live surface, never the cache, so
+    /// index-path tests must supply both.
+    private let liveTrackHeaders: @Sendable () -> [Int: String]? = {
+        [0: "Kick", 1: "Snare", 2: "Bass"]
+    }
+
     private func cacheWithTracks() async -> StateCache {
         let cache = StateCache()
         await cache.updateTracks([
@@ -551,10 +558,11 @@ struct ADR002ATargetKindTests {
             let (duplicateRouter, _) = await router(ids: [.accessibility, .midiKeyCommands, .cgEvent])
             let result = await TrackDispatcher.handle(
                 command: "duplicate",
-                params: ["index": .int(2)],
+                params: ["index": .int(2), "expected_name": .string("Bass")],
                 router: duplicateRouter,
                 cache: cache,
-                targetRegistry: registry
+                targetRegistry: registry,
+                liveTrackNames: liveTrackHeaders
             )
             #expect(result.isError == false)
             #expect(await registry.currentTopologyGeneration == 1)
@@ -581,10 +589,15 @@ struct ADR002ATargetKindTests {
             let (router, _) = await router()
             let result = await TrackDispatcher.handle(
                 command: "set_instrument",
-                params: ["index": .int(2), "path": .string("/tmp/instrument.patch")],
+                params: [
+                    "index": .int(2),
+                    "path": .string("/tmp/instrument.patch"),
+                    "expected_name": .string("Bass"),
+                ],
                 router: router,
                 cache: cache,
-                targetRegistry: registry
+                targetRegistry: registry,
+                liveTrackNames: liveTrackHeaders
             )
             #expect(result.isError == false)
             #expect(await registry.currentTopologyGeneration == 1)
@@ -605,10 +618,15 @@ struct ADR002ATargetKindTests {
             let (mutationRouter, _) = await router()
             let mutation = await TrackDispatcher.handle(
                 command: "set_instrument",
-                params: ["index": .int(2), "path": .string("/tmp/instrument.patch")],
+                params: [
+                    "index": .int(2),
+                    "path": .string("/tmp/instrument.patch"),
+                    "expected_name": .string("Bass"),
+                ],
                 router: mutationRouter,
                 cache: cache,
-                targetRegistry: registry
+                targetRegistry: registry,
+                liveTrackNames: liveTrackHeaders
             )
             #expect(mutation.isError == false)
             #expect(await registry.currentTopologyGeneration == 1)

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -1300,17 +1300,32 @@ private func liveTransportJSON(
     await router.register(ax)
     let cache = StateCache()
 
+    // PRD-007: set_instrument is `.corroborated` — a bare index no longer
+    // reaches the router, so this routing test now states the target identity
+    // the way a real caller must.
+    let liveNames = sharedLiveTrackNames([1: "Bass Legacy", 2: "Bass Path"])
     let pathResult = await TrackDispatcher.handle(
         command: "set_instrument",
-        params: ["index": .string("2"), "path": .string("Bass/Sub Bass")],
+        params: [
+            "index": .string("2"),
+            "path": .string("Bass/Sub Bass"),
+            "expected_name": .string("Bass Path"),
+        ],
         router: router,
-        cache: cache
+        cache: cache,
+        liveTrackNames: liveNames
     )
     let legacyResult = await TrackDispatcher.handle(
         command: "set_instrument",
-        params: ["index": .int(1), "category": .string("Bass"), "preset": .string("Sub Bass")],
+        params: [
+            "index": .int(1),
+            "category": .string("Bass"),
+            "preset": .string("Sub Bass"),
+            "expected_name": .string("Bass Legacy"),
+        ],
         router: router,
-        cache: cache
+        cache: cache,
+        liveTrackNames: liveNames
     )
     let resolveResult = await TrackDispatcher.handle(
         command: "resolve_path",
@@ -1593,17 +1608,22 @@ private func liveTransportJSON(
     await successRouter.register(keyCmd)
     let cache = StateCache()
 
+    // PRD-007: delete/duplicate are `.corroborated`, so reaching the selection
+    // flow at all now requires proving what sits at index 2.
+    let liveNames = sharedLiveTrackNames([2: "Bass"])
     let deleteResult = await TrackDispatcher.handle(
         command: "delete",
-        params: ["index": .int(2)],
+        params: ["index": .int(2), "expected_name": .string("Bass")],
         router: successRouter,
-        cache: cache
+        cache: cache,
+        liveTrackNames: liveNames
     )
     let duplicateResult = await TrackDispatcher.handle(
         command: "duplicate",
-        params: ["index": .int(2)],
+        params: ["index": .int(2), "expected_name": .string("Bass")],
         router: successRouter,
-        cache: cache
+        cache: cache,
+        liveTrackNames: liveNames
     )
 
     #expect(!deleteResult.isError!)
@@ -1621,14 +1641,23 @@ private func liveTransportJSON(
 
     let failureRouter = ChannelRouter()
     await failureRouter.register(keyCmd)
+    // PRD-007: corroborate index 9 so this still exercises the SELECT-failure
+    // path it was written for. Without it the call would fail closed earlier on
+    // the binding proof and this assertion would pass for the wrong reason.
     let failureResult = await TrackDispatcher.handle(
         command: "delete",
-        params: ["index": .int(9)],
+        params: ["index": .int(9), "expected_name": .string("Orphan")],
         router: failureRouter,
-        cache: cache
+        cache: cache,
+        liveTrackNames: sharedLiveTrackNames([9: "Orphan"])
     )
 
     #expect(failureResult.isError!)
+    #expect(
+        sharedJSONObject(dispatcherText(failureResult))?["error"] as? String
+            != "index_binding_corroboration_required",
+        "must reach the selection-failure path, not stop at the binding gate"
+    )
 }
 
 /// Mock channel that returns a State A envelope (`success:true`,
@@ -1670,11 +1699,14 @@ actor VerifiedSelectMockChannel: Channel {
     await router.register(mcu)
     await router.register(keyCmd)
 
+    // PRD-007: corroborate so this still reaches the selection-failure path
+    // rather than stopping at the binding gate.
     let result = await TrackDispatcher.handle(
         command: "duplicate",
-        params: ["index": .int(9)],
+        params: ["index": .int(9), "expected_name": .string("Orphan")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([9: "Orphan"])
     )
 
     #expect(result.isError!)

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -78,15 +78,15 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_tracks", command: "create_instrument", params: [:], operation: "track.create_instrument", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "create_drummer", params: [:], operation: "track.create_drummer", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "create_external_midi", params: [:], operation: "track.create_external_midi", destinations: [], invariant: .minimumV1),
-            RouteCase(tool: "logic_tracks", command: "delete", params: ["index": .int(0)], operation: "track.delete", destinations: [], invariant: .minimumV1),
-            RouteCase(tool: "logic_tracks", command: "duplicate", params: ["index": .int(0)], operation: "track.duplicate", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_tracks", command: "delete", params: ["index": .int(2), "expected_name": .string("Bass")], operation: "track.delete", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_tracks", command: "duplicate", params: ["index": .int(2), "expected_name": .string("Bass")], operation: "track.duplicate", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "rename", params: ["index": .int(0), "name": .string("HC Renamed")], operation: "track.rename", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "mute", params: ["index": .int(0), "enabled": .bool(true)], operation: "track.set_mute", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "solo", params: ["index": .int(0), "enabled": .bool(true)], operation: "track.set_solo", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "arm", params: ["index": .int(0), "enabled": .bool(true)], operation: "track.set_arm", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "arm_only", params: ["index": .int(1)], operation: "track.arm_only", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "set_automation", params: ["index": .int(0), "mode": .string("read")], operation: "track.set_automation", destinations: [], invariant: .minimumV1),
-            RouteCase(tool: "logic_tracks", command: "set_instrument", params: ["index": .int(0), "path": .string("/Library/Application Support/Logic/Patches/Instrument/HC.patch")], operation: "track.set_instrument", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_tracks", command: "set_instrument", params: ["index": .int(2), "path": .string("/Library/Application Support/Logic/Patches/Instrument/HC.patch"), "expected_name": .string("Bass")], operation: "track.set_instrument", destinations: [], invariant: .minimumV1),
 
             RouteCase(tool: "logic_mixer", command: "set_volume", params: ["track": .int(0), "value": .double(0.5)], operation: "mixer.set_volume", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_mixer", command: "set_pan", params: ["track": .int(0), "value": .double(0)], operation: "mixer.set_pan", destinations: [], invariant: .minimumV1),
@@ -308,7 +308,7 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_system", command: "saga_cancel", params: [:], operation: "system.saga_cancel", destinations: [], invariant: .minimumV1),
 
             RouteCase(tool: "logic_plugins", command: "set_param_verified", params: ["track": .int(0), "insert": .int(0), "plugin": .string("logic.stock.gain"), "param": .string("gain_db"), "value": .double(0), "unit": .string("dB"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.set_param_verified", destinations: [], invariant: .minimumV1),
-            RouteCase(tool: "logic_plugins", command: "insert_verified", params: ["track": .int(0), "insert": .int(0), "plugin": .string("Gain"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.insert_verified", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_plugins", command: "insert_verified", params: ["track": .int(2), "insert": .int(0), "plugin": .string("Gain"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath), "expected_name": .string("Bass")], operation: "plugin.insert_verified", destinations: [], invariant: .minimumV1),
         ]
     }
 
@@ -441,7 +441,7 @@ struct HCGlobalInvariantTests {
                 sleep: { _ in }
             )
         case "logic_tracks":
-            return await TrackDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache)
+            return await TrackDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache, liveTrackNames: hcLiveTrackHeaders)
         case "logic_mixer":
             return await MixerDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache)
         case "logic_midi":
@@ -472,11 +472,17 @@ struct HCGlobalInvariantTests {
                 }
             )
         case "logic_plugins":
-            return await PluginsDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache)
+            return await PluginsDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache, liveTrackNames: hcLiveTrackHeaders)
         default:
             Issue.record("Unhandled HC invariant tool \(routeCase.tool)")
             return toolTextResult("Unhandled HC invariant tool \(routeCase.tool)", isError: true)
         }
+    }
+
+    /// PRD-007: LIVE header scan mirroring `seedCache`, including its duplicate
+    /// "Kick" — the seed-set routes corroborate against this, not the cache.
+    private static let hcLiveTrackHeaders: @Sendable () -> [Int: String]? = {
+        [0: "Kick", 1: "Kick", 2: "Bass"]
     }
 
     private static func seedCache(_ cache: StateCache) async {

--- a/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import LogicProMCP
+
+// PRD-007 (ADR-002 #285) — the index-binding ratchet's censuses.
+//
+// These are RECEIPTS, not behaviour tests. The ratchet only means something if
+// moving an op between tiers is a visible, deliberate diff — so each tier is
+// pinned by explicit operation-ID list. A census failure is not necessarily a
+// bug: it is the reviewer's cue that the contract moved, and the diff is the
+// evidence of which way.
+
+@Suite("PRD-007 index-binding census")
+struct IndexBindingCensusTests {
+    private static func specs(_ ids: Set<OperationID>) -> [OperationSpec] {
+        OperationRegistry.specs.filter { ids.contains($0.id) }
+    }
+
+    private static func ids(where predicate: (OperationSpec) -> Bool) -> Set<OperationID> {
+        Set(OperationRegistry.specs.filter(predicate).map(\.id))
+    }
+
+    // MARK: - (a) seed set is corroborated and accepts the corroboration param
+
+    @Test("census (a): the seed set is exactly the corroborated tier")
+    func seedSetIsCorroborated() {
+        // The pin. Changing this literal is the only legitimate way to change
+        // which ops demand corroboration — and reviewing that diff is the point.
+        let expectedSeedSet: Set<OperationID> = [
+            .tracksDelete,          // irreversible topology destruction
+            .tracksDuplicate,       // topology mutation; wrong target = phantom copy
+            .tracksSetInstrument,   // replace-class; overwrites the wrong strip's patch
+            .pluginsInsertVerified, // insert-class topology, trackIndex-keyed
+        ]
+        #expect(OperationRegistry.corroboratedOperationIDs == expectedSeedSet)
+        #expect(Self.ids { $0.indexBinding == .corroborated } == expectedSeedSet)
+    }
+
+    @Test("census (a): every seed op advertises expected_name")
+    func seedSetAdvertisesCorroborationParam() {
+        for spec in Self.specs(OperationRegistry.corroboratedOperationIDs) {
+            #expect(
+                spec.allowedParams.contains(OperationRegistry.corroborationParam),
+                "\(spec.id.rawValue) is corroborated but does not accept \(OperationRegistry.corroborationParam) — callers could not satisfy the gate"
+            )
+            // The escape hatch the refusal hint promises must actually exist.
+            #expect(
+                spec.allowedParams.contains("target_ref"),
+                "\(spec.id.rawValue) refusal offers target_ref as an alternative; it must accept one"
+            )
+            #expect(spec.target == .acceptsStableTarget, "\(spec.id.rawValue)")
+            #expect(spec.mutability == Mutability.`mutating`, "\(spec.id.rawValue)")
+        }
+    }
+
+    @Test("census (a): no op outside the seed set advertises expected_name")
+    func corroborationParamIsNotAdvertisedElsewhere() {
+        let advertising = Self.ids { $0.allowedParams.contains(OperationRegistry.corroborationParam) }
+        #expect(
+            advertising == OperationRegistry.corroboratedOperationIDs,
+            "expected_name must not be advertised by ops that would silently ignore it"
+        )
+    }
+
+    // MARK: - (b) refRequired is empty today
+
+    @Test("census (b): refRequired is assigned to zero production ops")
+    func refRequiredIsEmpty() {
+        // PINNED EMPTY. `.refRequired` is implemented and unit-tested via a
+        // synthetic spec, but no production op carries it yet.
+        //
+        // PLANNED PROMOTION: `tracks.delete` (today `.corroborated`) moves here
+        // once `FeatureFlags.adr002TargetRef` defaults ON — until every caller
+        // can actually obtain a `target_ref`, `.refRequired` would strand the
+        // index path with no usable alternative, which is a refusal to serve
+        // rather than a safety gain.
+        //
+        // This set going non-empty IS the promotion receipt.
+        #expect(OperationRegistry.refRequiredOperationIDs.isEmpty)
+        #expect(Self.ids { $0.indexBinding == .refRequired }.isEmpty)
+    }
+
+    // MARK: - (c) the legacy deprecation census
+
+    @Test("census (c): legacyIndexAllowed is pinned exactly")
+    func legacyIndexAllowedIsPinned() throws {
+        // DEPRECATED TIER. Every member still writes to a bare, unproven
+        // ordinal. Shrinking this list is the ratchet turning; it must never
+        // grow. Each entry earns its place only by being reversible — a
+        // wrong-target write here is recoverable by the user.
+        let expectedLegacy: Set<OperationID> = [
+            .mixerSetVolume,           // reversible level write
+            .mixerSetPan,              // reversible pan write
+            .pluginsSetParamVerified,  // reversible param write (verified readback)
+            .tracksSelect,             // selection only; no persistent state change
+            .tracksRename,             // reversible: rename back
+            .tracksMute,               // reversible toggle
+            .tracksSolo,               // reversible toggle
+            .tracksArm,                // reversible toggle
+            .tracksArmOnly,            // reversible toggle
+            .tracksSetAutomation,      // reversible mode switch
+        ]
+        #expect(Self.ids { $0.indexBinding == .legacyIndexAllowed } == expectedLegacy)
+
+        // KNOWN RESIDUAL, deliberately NOT in any tier: `mixer.insert_plugin` is
+        // an index-keyed plugin INSERT (irreversible-class by the seed set's own
+        // test) that this axis cannot cover, because its TargetPolicy is `.none`
+        // — it accepts no target_ref, so `.corroborated`'s "or supply target_ref"
+        // escape hatch would be unofferable. Ratcheting it requires first making
+        // it target-bearing. Asserted here so the gap is a tracked fact, not an
+        // oversight that reads as coverage. The FULL hazard class (this op plus
+        // its reversible sibling) is pinned by `unratchetedTrackKeyedHazardsArePinned`.
+        let insertPlugin = try #require(
+            OperationRegistry.specs.first { $0.id == .mixerInsertPlugin }
+        )
+        #expect(insertPlugin.target == TargetPolicy.none)
+        #expect(insertPlugin.indexBinding == nil)
+    }
+
+    // MARK: - (c') the unratcheted-hazard tripwire
+
+    @Test("census (c'): index-keyed mutating ops that are NOT target-bearing are pinned")
+    func unratchetedTrackKeyedHazardsArePinned() {
+        // THE TRIPWIRE (team-lead ruling, PRD-007). An op that keys on a track
+        // strip but carries `target: .none` has an index path the ratchet CANNOT
+        // reach: `.corroborated`/`.refRequired` only attach to target-bearing
+        // specs, and its corroboration refusal could not honestly offer
+        // "use target_ref instead" — it accepts none. Such an op therefore keeps
+        // a wrong-target index path with no in-tier remedy.
+        //
+        // Pinning the exact set makes that gap a CI-carried receipt, not prose:
+        // any NEW op added to this class fails this census and forces an explicit
+        // decision (give it target_ref, then a tier) instead of silently
+        // inheriting an unratcheted index path. Same no-open-ended-runway rule as
+        // the refRequired==[] census.
+        //
+        // Discriminator = carries a track-strip selector (`track`/`track_index`).
+        // `index`-only ops (navigate marker ops) are deliberately EXCLUDED: their
+        // `index` addresses a marker, not a track, which is a different (and not
+        // PRD-007-scoped) wrong-target class.
+        let hazards = Self.ids {
+            $0.mutability == Mutability.`mutating`
+                && $0.target == .none
+                && !$0.allowedParams.isDisjoint(with: ["track", "track_index"])
+        }
+        // PLANNED PROMOTIONS (each a later batch; the plumbing is a TargetPolicy
+        // row + resolver change, a separate contract move from this PR):
+        //   • mixer.insert_plugin    → give target_ref, then .corroborated
+        //                              (irreversible insert; wrong-target is a real defect).
+        //   • mixer.set_plugin_param → give target_ref, then .legacyIndexAllowed
+        //                              (reversible param write; ratchet cost not yet earned,
+        //                              but it still must become target-bearing to leave this set).
+        // This set may only SHRINK. Growth = a new hazard needing a decision.
+        #expect(hazards == [.mixerInsertPlugin, .mixerSetPluginParam])
+
+        // The distinguishing property is real, not incidental: none of these can
+        // accept the escape hatch their would-be corroboration refusal names.
+        for spec in Self.specs(hazards) {
+            #expect(!spec.allowedParams.contains("target_ref"), "\(spec.id.rawValue)")
+            #expect(spec.indexBinding == nil, "\(spec.id.rawValue) is not tier-eligible until target-bearing")
+        }
+    }
+
+    // MARK: - the axis's shape invariant
+
+    @Test("census: indexBinding is non-nil for exactly the target-bearing mutating ops")
+    func indexBindingAppliesExactlyToTargetBearingMutations() {
+        for spec in OperationRegistry.specs {
+            let isTargetBearingMutation =
+                spec.target == .acceptsStableTarget && spec.mutability == Mutability.`mutating`
+            #expect(
+                (spec.indexBinding != nil) == isTargetBearingMutation,
+                "\(spec.id.rawValue): indexBinding=\(String(describing: spec.indexBinding)) but target-bearing-mutation=\(isTargetBearingMutation)"
+            )
+        }
+        // Every tier's members are disjoint and together cover the whole axis.
+        let tiered = Self.ids { $0.indexBinding != nil }
+        let union = OperationRegistry.corroboratedOperationIDs
+            .union(OperationRegistry.refRequiredOperationIDs)
+            .union(Self.ids { $0.indexBinding == .legacyIndexAllowed })
+        #expect(tiered == union)
+        #expect(
+            OperationRegistry.corroboratedOperationIDs
+                .intersection(OperationRegistry.refRequiredOperationIDs)
+                .isEmpty,
+            "an op cannot be both corroborated and ref-required"
+        )
+    }
+
+    // MARK: - (d) the rename census
+
+    @Test("census (d): no 'requires_stable_target' spelling survives in the catalog")
+    func renameLeavesNoStaleWireString() {
+        // The rename's whole point: the wire must not carry a name that claims a
+        // requirement the registry never enforced. A catalog walk (not a grep)
+        // so this proves the SHIPPED surface, not just the source text.
+        let snapshot = OperationCatalog.snapshot()
+        for entry in snapshot.operations {
+            #expect(
+                entry.target != "requires_stable_target",
+                "\(entry.id) still advertises the retired target policy string"
+            )
+            #expect(
+                ["none", "accepts_stable_target"].contains(entry.target),
+                "\(entry.id) has unknown target policy '\(entry.target)'"
+            )
+        }
+        let encoded = try? JSONEncoder().encode(snapshot)
+        let json = encoded.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        #expect(!json.isEmpty)
+        #expect(
+            !json.contains("requires_stable_target"),
+            "the retired policy string must not appear anywhere in the published catalog"
+        )
+        #expect(json.contains("accepts_stable_target"), "the new spelling must be published")
+    }
+
+    @Test("census (d): the target policy wire strings are exactly the two live spellings")
+    func targetPolicyWireStringsPinned() {
+        let published = Set(OperationCatalog.snapshot().operations.map(\.target))
+        #expect(published == ["none", "accepts_stable_target"])
+    }
+
+    // MARK: - catalog publishes the new axis
+
+    @Test("catalog: index_binding is published for exactly the tiered ops")
+    func catalogPublishesIndexBinding() throws {
+        let snapshot = OperationCatalog.snapshot()
+        let bySpecID = Dictionary(
+            uniqueKeysWithValues: OperationRegistry.specs.map { ($0.id.rawValue, $0) }
+        )
+        var published: [String: String] = [:]
+        for entry in snapshot.operations {
+            let spec = try #require(bySpecID[entry.id])
+            switch spec.indexBinding {
+            case nil:
+                #expect(entry.indexBinding == nil, "\(entry.id) must publish no tier")
+            case .some(let policy):
+                let wire = try #require(entry.indexBinding, "\(entry.id) must publish its tier")
+                published[entry.id] = wire
+                #expect(wire == Self.expectedWire(policy), "\(entry.id)")
+            }
+        }
+        #expect(published["tracks.delete"] == "corroborated")
+        #expect(published["tracks.rename"] == "legacy_index_allowed")
+        #expect(published["plugins.insert_verified"] == "corroborated")
+        #expect(published["plugins.get_inventory"] == nil, "read-only op has no index binding")
+        #expect(Set(published.values) == ["corroborated", "legacy_index_allowed"])
+    }
+
+    private static func expectedWire(_ policy: IndexBindingPolicy) -> String {
+        switch policy {
+        case .refRequired: "ref_required"
+        case .corroborated: "corroborated"
+        case .legacyIndexAllowed: "legacy_index_allowed"
+        }
+    }
+}
+
+// MARK: - .refRequired via a synthetic spec
+
+// `.refRequired` carries zero production ops this increment, but shipping an
+// unexercised enum case is how a tier rots before it is ever used. The guard is
+// a pure function over an injected policy, so the tier is provable today
+// against a synthetic spec — and the promotion (a registry row flip) then only
+// has to change the row, not discover that the mechanism never worked.
+@Suite("PRD-007 refRequired tier (synthetic)")
+struct IndexBindingRefRequiredTests {
+    private static let syntheticHeaders: @Sendable () -> [Int: String]? = { [3: "Drums"] }
+
+    @Test("refRequired: a bare index is refused with stable_target_required")
+    func refRequiredRefusesBareIndex() throws {
+        let result = IndexBindingGuard.evaluate(
+            policy: .refRequired,
+            operation: "synthetic.ref_required_op",
+            params: ["index": .int(3)],
+            index: 3,
+            liveTrackNames: Self.syntheticHeaders
+        )
+        let refusal = try #require(result)
+        let object = try #require(sharedJSONObject(sharedToolText(refusal)))
+        #expect(object["error"] as? String == "stable_target_required")
+        #expect(object["state"] as? String == "C")
+        #expect(object["write_attempted"] as? Bool == false)
+        #expect(object["requested_index"] as? Int == 3)
+    }
+
+    @Test("refRequired: expected_name cannot rescue a bare index")
+    func refRequiredIgnoresCorroboration() throws {
+        // The whole distinction from `.corroborated`: no amount of name evidence
+        // substitutes for a stable identity at this tier. A correct, unique,
+        // live-matching name must STILL be refused.
+        let result = IndexBindingGuard.evaluate(
+            policy: .refRequired,
+            operation: "synthetic.ref_required_op",
+            params: ["index": .int(3), "expected_name": .string("Drums")],
+            index: 3,
+            liveTrackNames: Self.syntheticHeaders
+        )
+        let refusal = try #require(result)
+        let object = try #require(sharedJSONObject(sharedToolText(refusal)))
+        #expect(object["error"] as? String == "stable_target_required")
+        #expect(object["write_attempted"] as? Bool == false)
+    }
+
+    @Test("refRequired: a supplied target_ref passes the guard to the ref machinery")
+    func refRequiredAcceptsTargetRef() {
+        let result = IndexBindingGuard.evaluate(
+            policy: .refRequired,
+            operation: "synthetic.ref_required_op",
+            params: ["target_ref": .string("trk_abc")],
+            index: 3,
+            liveTrackNames: Self.syntheticHeaders
+        )
+        #expect(result == nil)
+    }
+
+    @Test("legacyIndexAllowed and non-tiered ops never gate")
+    func untieredPoliciesNeverGate() {
+        for policy: IndexBindingPolicy? in [.legacyIndexAllowed, nil] {
+            let result = IndexBindingGuard.evaluate(
+                policy: policy,
+                operation: "synthetic.legacy_op",
+                params: ["index": .int(3)],
+                index: 3,
+                liveTrackNames: nil
+            )
+            #expect(result == nil, "policy \(String(describing: policy)) must not gate the index path")
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
@@ -1,0 +1,593 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import LogicProMCP
+
+// PRD-007 (ADR-002 #285) — index-binding ratchet.
+//
+// The `.corroborated` tier closes the wrong-target window on the INDEX path of
+// irreversible / topology-mutating ops. Before this ratchet, `tracks.delete`
+// with a bare `index` wrote to whatever row happened to sit at that ordinal —
+// an out-of-band reorder between the caller's read and its write silently
+// destroyed the wrong track, with a State A claiming success.
+//
+// The contract under test, for a seed-set op called WITHOUT `target_ref`:
+//   - no `expected_name`               -> index_binding_corroboration_required
+//   - `expected_name` != live name     -> target_identity_mismatch
+//   - live header unreadable           -> target_identity_mismatch (header_unreadable)
+//   - `expected_name` matches but is
+//     NON-UNIQUE across the live surface -> target_name_ambiguous
+//   - unique match                     -> the existing index write path, unchanged
+// Every failure is pre-write and fail-closed: `write_attempted:false` AND the
+// probe channels record zero routed operations.
+
+// MARK: - Fixtures
+
+/// Live AX header scan fixture. Mirrors `AXLogicProElements.trackNames()`'s
+/// shape (`[Int: String]?`, nil == unreadable) so these tests exercise the same
+/// primitive the F5/ref path uses instead of reaching into the state cache.
+private func liveHeaders(_ names: [Int: String]) -> @Sendable () -> [Int: String]? {
+    { names }
+}
+
+private let unreadableHeaders: @Sendable () -> [Int: String]? = { nil }
+
+private func corroborationErrorCode(_ result: CallTool.Result) -> String? {
+    sharedJSONObject(sharedToolText(result))?["error"] as? String
+}
+
+private func writeAttempted(_ result: CallTool.Result) -> Bool? {
+    sharedJSONObject(sharedToolText(result))?["write_attempted"] as? Bool
+}
+
+// MARK: - tracks.delete (seed set)
+
+@Test func testDeleteWithoutExpectedNameRequiresCorroboration() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2)],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    #expect(result.isError!, "bare-index delete must fail closed")
+    #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
+    #expect(writeAttempted(result) == false)
+
+    // Proof of no side effect: nothing was routed at all — not even the
+    // `track.select` that precedes the delete.
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.isEmpty, "corroboration must fail BEFORE any routed op")
+    #expect(keyCmdOps.isEmpty, "track.delete must never be routed")
+}
+
+@Test func testDeleteCorroborationRequiredHintNamesBothRoutes() async {
+    let router = ChannelRouter()
+    await router.register(VerifiedSelectMockChannel(id: .mcu))
+    await router.register(MockChannel(id: .midiKeyCommands))
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2)],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    let object = sharedJSONObject(sharedToolText(result))
+    let hint = (object?["hint"] as? String) ?? ""
+    #expect(hint.contains("expected_name"), "hint must name the corroboration route, got: \(hint)")
+    #expect(hint.contains("target_ref"), "hint must name the stable-ref route, got: \(hint)")
+    #expect(object?["safe_to_retry"] as? Bool == true, "supplying the missing param is a safe retry")
+}
+
+@Test func testDeleteWithMismatchedExpectedNameFailsClosed() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    // The caller believes index 2 is "Drums"; the live surface says "Bass"
+    // (someone reordered the tracks out of band). This is the exact wrong-target
+    // deletion the ratchet exists to prevent.
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("Drums")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([1: "Drums", 2: "Bass"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "target_identity_mismatch")
+    #expect(writeAttempted(result) == false)
+
+    let object = sharedJSONObject(sharedToolText(result))
+    #expect(object?["expected_track_name"] as? String == "Drums")
+    #expect(object?["observed_track_name"] as? String == "Bass")
+
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.isEmpty, "no write may be attempted on identity mismatch")
+    #expect(keyCmdOps.isEmpty, "the wrong track must NOT be deleted")
+}
+
+@Test func testDeleteWithUnreadableLiveHeaderFailsClosed() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("Drums")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: unreadableHeaders
+    )
+
+    #expect(result.isError!, "an unreadable live surface must not be read as agreement")
+    #expect(corroborationErrorCode(result) == "target_identity_mismatch")
+    #expect(writeAttempted(result) == false)
+
+    let object = sharedJSONObject(sharedToolText(result))
+    #expect(object?["reason"] as? String == "header_unreadable")
+
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.isEmpty)
+    #expect(keyCmdOps.isEmpty)
+}
+
+@Test func testDeleteWithAmbiguousLiveNameFailsClosed() async {
+    // THE load-bearing case. Two tracks share a name, so (index, name) stays
+    // self-consistent even after they swap positions: corroboration would PASS
+    // while pointing at the wrong track. Uniqueness is therefore required, and
+    // the caller is pushed to the only binding that survives a swap: target_ref.
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("Gtr")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Gtr", 5: "Gtr"])
+    )
+
+    #expect(result.isError!, "a matching name that is not unique proves nothing")
+    #expect(corroborationErrorCode(result) == "target_name_ambiguous")
+    #expect(writeAttempted(result) == false)
+
+    let object = sharedJSONObject(sharedToolText(result))
+    #expect(object?["ambiguous_track_indices"] as? [Int] == [2, 5])
+    let hint = (object?["hint"] as? String) ?? ""
+    #expect(hint.contains("target_ref"), "ambiguity's only real escape is a stable ref, got: \(hint)")
+
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.isEmpty)
+    #expect(keyCmdOps.isEmpty)
+}
+
+@Test func testDeleteWithUniqueMatchingNameProceeds() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("Drums")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([1: "Bass", 2: "Drums", 3: "Vox"])
+    )
+
+    #expect(!(result.isError!), "corroborated delete must proceed unchanged")
+
+    // The pre-existing index write path is untouched: select-then-delete.
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.count == 1)
+    #expect(mcuOps[0].0 == "track.select")
+    #expect(mcuOps[0].1 == ["index": "2"])
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "track.delete")
+    // The corroboration param is a binding proof, not a write param — it must
+    // not leak into the routed channel params.
+    #expect(keyCmdOps[0].1["expected_name"] == nil)
+}
+
+@Test func testDeleteExpectedNameIsTrimmedBeforeComparison() async {
+    let router = ChannelRouter()
+    await router.register(VerifiedSelectMockChannel(id: .mcu))
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("  Drums  ")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    #expect(!(result.isError!), "trimmed comparison matches the F5 path's semantics")
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.count == 1)
+}
+
+@Test func testDeleteWithBlankExpectedNameRequiresCorroboration() async {
+    // A blank string is not a corroboration — it must be treated as absent
+    // rather than compared (and certainly never matched against a blank header).
+    let router = ChannelRouter()
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(VerifiedSelectMockChannel(id: .mcu))
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: ["index": .int(2), "expected_name": .string("   ")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "   "])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.isEmpty)
+}
+
+// MARK: - tracks.duplicate / tracks.set_instrument (seed set)
+
+@Test func testDuplicateWithoutExpectedNameRequiresCorroboration() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "duplicate",
+        params: ["index": .int(3)],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([3: "Keys"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.isEmpty)
+    #expect(keyCmdOps.isEmpty)
+}
+
+@Test func testDuplicateWithUniqueMatchingNameProceeds() async {
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "duplicate",
+        params: ["index": .int(4), "expected_name": .string("Keys")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([4: "Keys"])
+    )
+
+    #expect(!(result.isError!))
+    let mcuOps = await mcu.executedOps
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(mcuOps.count == 1)
+    #expect(mcuOps[0].0 == "track.select")
+    #expect(keyCmdOps.count == 1)
+    #expect(keyCmdOps[0].0 == "track.duplicate")
+}
+
+@Test func testDuplicateWithMismatchedExpectedNameFailsClosed() async {
+    let router = ChannelRouter()
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(VerifiedSelectMockChannel(id: .mcu))
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "duplicate",
+        params: ["index": .int(4), "expected_name": .string("Keys")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([4: "Strings"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "target_identity_mismatch")
+    #expect(writeAttempted(result) == false)
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.isEmpty)
+}
+
+@Test func testSetInstrumentWithoutExpectedNameRequiresCorroboration() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handle(
+        command: "set_instrument",
+        params: ["index": .int(1), "path": .string("Piano/Grand")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([1: "Piano"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty, "the patch load must never reach the router")
+}
+
+@Test func testSetInstrumentWithMismatchedExpectedNameFailsClosed() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handle(
+        command: "set_instrument",
+        params: [
+            "index": .int(1),
+            "path": .string("Piano/Grand"),
+            "expected_name": .string("Piano"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([1: "Lead Synth"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "target_identity_mismatch")
+    #expect(writeAttempted(result) == false)
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty, "the wrong track's instrument must NOT be replaced")
+}
+
+@Test func testSetInstrumentWithUniqueMatchingNameProceeds() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    _ = await TrackDispatcher.handle(
+        command: "set_instrument",
+        params: [
+            "index": .int(1),
+            "path": .string("Piano/Grand"),
+            "expected_name": .string("Piano"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([0: "Drums", 1: "Piano"])
+    )
+
+    let axOps = await ax.executedOps
+    #expect(axOps.count == 1, "corroborated set_instrument must reach the router")
+    guard axOps.count == 1 else { return }
+    #expect(axOps[0].0 == "track.set_instrument")
+    #expect(axOps[0].1["index"] == "1")
+    #expect(axOps[0].1["path"] == "Piano/Grand")
+    #expect(axOps[0].1["expected_name"] == nil, "binding proof must not leak into write params")
+}
+
+// MARK: - plugins.insert_verified (seed set — dispatcher-level, P2-2)
+
+// insert_verified is `.corroborated` too, but its guard lives on a different
+// call site (PluginsDispatcher, pre verified-op-gate) with its own live-scan
+// seam, so it gets its own dispatcher-level proof rather than riding the track
+// suite. `plugin.insert_verified` routes to `.accessibility`; a MockChannel
+// there records whether any AX write was attempted.
+
+@Test func testInsertVerifiedWithoutExpectedNameRequiresCorroboration() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await PluginsDispatcher.handle(
+        command: "insert_verified",
+        params: [
+            "track": .int(2),
+            "insert": .int(0),
+            "plugin": .string("Gain"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string("/tmp/p.logicx"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Bass"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
+    #expect(writeAttempted(result) == false)
+    // The guard precedes the verified-op gate AND the router — nothing routed.
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty, "corroboration must fail before the AX insert is attempted")
+}
+
+@Test func testInsertVerifiedWithMismatchedExpectedNameFailsClosed() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    // Caller believes track 2 is "Bass"; the live surface says "Lead".
+    let result = await PluginsDispatcher.handle(
+        command: "insert_verified",
+        params: [
+            "track": .int(2),
+            "insert": .int(0),
+            "plugin": .string("Gain"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string("/tmp/p.logicx"),
+            "expected_name": .string("Bass"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([1: "Bass", 2: "Lead"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "target_identity_mismatch")
+    #expect(writeAttempted(result) == false)
+
+    let object = sharedJSONObject(sharedToolText(result))
+    #expect(object?["expected_track_name"] as? String == "Bass")
+    #expect(object?["observed_track_name"] as? String == "Lead")
+
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty, "the wrong track's insert chain must NOT be mutated")
+}
+
+@Test func testInsertVerifiedWithAmbiguousLiveNameFailsClosed() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await PluginsDispatcher.handle(
+        command: "insert_verified",
+        params: [
+            "track": .int(2),
+            "insert": .int(0),
+            "plugin": .string("Gain"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string("/tmp/p.logicx"),
+            "expected_name": .string("Gtr"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Gtr", 6: "Gtr"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "target_name_ambiguous")
+    #expect(writeAttempted(result) == false)
+    let object = sharedJSONObject(sharedToolText(result))
+    #expect(object?["ambiguous_track_indices"] as? [Int] == [2, 6])
+
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty)
+}
+
+@Test func testInsertVerifiedRejectsExpectedNameCombinedWithTargetRef() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await PluginsDispatcher.handle(
+        command: "insert_verified",
+        params: [
+            "track": .int(2),
+            "insert": .int(0),
+            "plugin": .string("Gain"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string("/tmp/p.logicx"),
+            "expected_name": .string("Bass"),
+            "target_ref": .string("trk_whatever"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Bass"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "invalid_params")
+    #expect(writeAttempted(result) == false)
+    let axOps = await ax.executedOps
+    #expect(axOps.isEmpty)
+}
+
+// MARK: - Controls (must be unaffected by the ratchet)
+
+@Test func testNonSeedMuteIsUnaffectedByCorroboration() async {
+    // `tracks.mute` is `.legacyIndexAllowed`: a reversible toggle. The ratchet
+    // must not silently widen to every target-bearing op.
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handle(
+        command: "mute",
+        params: ["index": .int(2), "enabled": .bool(true)],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    #expect(corroborationErrorCode(result) != "index_binding_corroboration_required")
+    let axOps = await ax.executedOps
+    #expect(axOps.count == 1, "legacy index path stays open for reversible ops")
+    guard axOps.count == 1 else { return }
+    #expect(axOps[0].0 == "track.set_mute")
+}
+
+@Test func testNonSeedRenameIsUnaffectedByCorroboration() async {
+    let router = ChannelRouter()
+    let ax = MockChannel(id: .accessibility)
+    await router.register(ax)
+
+    let result = await TrackDispatcher.handle(
+        command: "rename",
+        params: ["index": .int(2), "name": .string("New Name")],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    #expect(corroborationErrorCode(result) != "index_binding_corroboration_required")
+    let axOps = await ax.executedOps
+    #expect(!axOps.isEmpty, "rename's legacy index path must stay open")
+}
+
+@Test func testSeedOpRejectsExpectedNameCombinedWithTargetRef() async {
+    // Documented choice: `expected_name` + `target_ref` is rejected outright
+    // rather than cross-checked. The ref path already carries its own live
+    // identity + ambiguity guards (F5); accepting both would stack two binding
+    // proofs with two error vocabularies for one failure. Exactly one wins.
+    let router = ChannelRouter()
+    let mcu = VerifiedSelectMockChannel(id: .mcu)
+    let keyCmd = MockChannel(id: .midiKeyCommands)
+    await router.register(mcu)
+    await router.register(keyCmd)
+
+    let result = await TrackDispatcher.handle(
+        command: "delete",
+        params: [
+            "index": .int(2),
+            "expected_name": .string("Drums"),
+            "target_ref": .string("trk_whatever"),
+        ],
+        router: router,
+        cache: StateCache(),
+        liveTrackNames: liveHeaders([2: "Drums"])
+    )
+
+    #expect(result.isError!)
+    #expect(corroborationErrorCode(result) == "invalid_params")
+    #expect(writeAttempted(result) == false)
+    let keyCmdOps = await keyCmd.executedOps
+    #expect(keyCmdOps.isEmpty)
+}

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -196,12 +196,27 @@ struct OperationCatalogTests {
 
     private static func expectedAllowedParams(for spec: OperationSpec) -> Set<String> {
         var expected = spec.allowedParams.intersection(["index", "project_ref", "track"])
-        if spec.target == .requiresStableTarget {
+        if spec.target == .acceptsStableTarget {
             expected.insert("target_ref")
+        }
+        // PRD-007: the corroboration param rides exactly the `.corroborated`
+        // tier. This mirrors the target_ref derivation above; the seed set
+        // itself is pinned independently, by explicit op-ID list, in the
+        // IndexBinding census (so this staying derived is not a tautology).
+        if spec.indexBinding == .corroborated {
+            expected.insert(OperationRegistry.corroborationParam)
         }
         return expected
             .union(commandParams[spec.id] ?? [])
             .union(legacyIgnoredParams[spec.id] ?? [])
+    }
+
+    /// PRD-007: LIVE header scan mirroring `routedSelectorInvocations`'s cache
+    /// (`Track 0`…`Track 8`, all unique). Injected through the
+    /// `HandlerDependencies` seam so the `.corroborated` ops stay provable
+    /// deterministically instead of dropping to live-only qualification.
+    private static let selectorProbeLiveTrackNames: @Sendable () -> [Int: String]? = {
+        Dictionary(uniqueKeysWithValues: (0...8).map { ($0, "Track \($0)") })
     }
 
     private static func validSelectorParams(
@@ -224,8 +239,12 @@ struct OperationCatalogTests {
             params["plugin_name"] = .string("Gain")
             params["confirmed"] = .bool(true)
         case .navigateGotoMarker, .navigateDeleteMarker,
-             .tracksSelect, .tracksDelete, .tracksDuplicate, .tracksArmOnly:
+             .tracksSelect, .tracksArmOnly:
             break
+        case .tracksDelete, .tracksDuplicate:
+            // PRD-007 `.corroborated`: prove the target before the selector can
+            // be forwarded. Matches `selectorProbeLiveTrackNames`.
+            params[OperationRegistry.corroborationParam] = .string("Track \(value)")
         case .navigateRenameMarker, .tracksRename:
             params["name"] = .string("Selector Probe")
         case .tracksMute, .tracksSolo, .tracksArm:
@@ -234,6 +253,7 @@ struct OperationCatalogTests {
             params["mode"] = .string("read")
         case .tracksSetInstrument:
             params["path"] = .string("/tmp/selector-probe.patch")
+            params[OperationRegistry.corroborationParam] = .string("Track \(value)")
         default:
             return nil
         }
@@ -272,7 +292,8 @@ struct OperationCatalogTests {
                 runtime: .fastTest
             ),
             dialogPresent: { false },
-            supportBundleExporter: nil
+            supportBundleExporter: nil,
+            liveTrackNames: Self.selectorProbeLiveTrackNames
         )
         let handler = try #require(OperationHandlerRegistry.handler(for: spec.id))
         _ = await handler(dependencies, params)
@@ -311,7 +332,7 @@ struct OperationCatalogTests {
     private static func wire(_ value: TargetPolicy) -> String {
         switch value {
         case .none: "none"
-        case .requiresStableTarget: "requires_stable_target"
+        case .acceptsStableTarget: "accepts_stable_target"
         }
     }
 
@@ -630,7 +651,7 @@ struct OperationCatalogTests {
         let handlers = await LogicProServer().makeHandlers()
 
         for spec in OperationRegistry.specs {
-            let requiresTarget = spec.target == .requiresStableTarget
+            let requiresTarget = spec.target == .acceptsStableTarget
             #expect(spec.allowedParams.contains("target_ref") == requiresTarget, "\(spec.id.rawValue)")
 
             if requiresTarget {
@@ -751,7 +772,7 @@ struct OperationCatalogTests {
             $0.allowedParams.contains("target_ref")
         }.map(\.id))
         let targetBearing = Set(OperationRegistry.specs.filter {
-            $0.target == .requiresStableTarget
+            $0.target == .acceptsStableTarget
         }.map(\.id))
         #expect(actualIndex.count == 17)
         #expect(actualTrack.count == 16)
@@ -878,18 +899,26 @@ struct OperationCatalogTests {
             #expect(row["allowedParams"] as? [String] == spec.allowedParams.sorted())
             #expect(
                 (row["allowedParams"] as? [String])?.contains("target_ref")
-                    == (spec.target == .requiresStableTarget)
+                    == (spec.target == .acceptsStableTarget)
             )
             #expect(row["capability"] as? String == spec.capability.rawValue)
             #expect(
                 row["dirtySections"] as? [String]
                     == spec.dirtySections.map(\.rawValue).sorted()
             )
-            #expect(row.keys.sorted() == [
+            var expectedKeys = [
                 "allowedParams", "availability", "capability", "command", "confirmation",
                 "deadline", "dirtySections", "id", "mutability", "retry", "target",
                 "tool", "verification",
-            ])
+            ]
+            // PRD-007: `indexBinding` is published ONLY for the tiered
+            // (target-bearing mutating) ops. Ops with no target to mis-bind omit
+            // the key entirely rather than publishing a null, so a client can
+            // tell "no tier applies" from any tier value.
+            if spec.indexBinding != nil {
+                expectedKeys.append("indexBinding")
+            }
+            #expect(row.keys.sorted() == expectedKeys.sorted(), "\(spec.id.rawValue)")
         }
 
         let toolCommands = operations.compactMap { row -> String? in

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -65,7 +65,7 @@ struct OperationRegistryCoverageTests {
         let mutating = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
         let readOnly = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let targetBearingIDs = Set(mutating
-            .filter { $0.target == .requiresStableTarget }
+            .filter { $0.target == .acceptsStableTarget }
             .map(\.id))
         let targetless = mutating.filter { $0.target == .none }
         let expectedTargetBearingIDs: Set<OperationID> = [

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -173,7 +173,7 @@ struct OperationRegistryTests {
             #expect(spec.command == command)
             #expect(spec.mutability == Mutability.`mutating`)
             #expect(spec.confirmation == (command == "insert_plugin" ? .l2 : .none))
-            #expect(spec.target == (targetBearingCommands.contains(command) ? .requiresStableTarget : .none))
+            #expect(spec.target == (targetBearingCommands.contains(command) ? .acceptsStableTarget : .none))
             #expect(spec.verification == .readbackRequired)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == .short)
@@ -404,7 +404,7 @@ struct OperationRegistryTests {
             #expect(spec.confirmation == (id == .systemClearTraces ? .l2 : .none))
             #expect(spec.target == (
                 id == .pluginsSetParamVerified || id == .pluginsInsertVerified
-                    ? .requiresStableTarget
+                    ? .acceptsStableTarget
                     : .none
             ))
             #expect(spec.verification == entry.verification)
@@ -1002,7 +1002,7 @@ struct OperationRegistryTests {
             #expect(spec.command == entry.command)
             #expect(spec.mutability == entry.mutability)
             #expect(spec.confirmation == .none)
-            #expect(spec.target == (targetBearingCommands.contains(entry.command) ? .requiresStableTarget : .none))
+            #expect(spec.target == (targetBearingCommands.contains(entry.command) ? .acceptsStableTarget : .none))
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
             #expect(spec.deadline == entry.deadline)

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -335,6 +335,14 @@ extension OperationTraceTests {
     }
 }
 
+/// PRD-007: the LIVE header surface the corroborated ops check against. Single
+/// unique row so the seed-set ops clear the binding gate and their traced write
+/// path stays exercised by this census.
+let operationTraceCoverageTrackName = "Trace Coverage Track"
+private let operationTraceCoverageLiveTrackNames: @Sendable () -> [Int: String]? = {
+    [0: operationTraceCoverageTrackName]
+}
+
 private func dispatchOperationTraceCoverageSpec(
     _ spec: OperationSpec,
     params: [String: Value],
@@ -384,7 +392,8 @@ private func dispatchOperationTraceCoverageSpec(
             command: spec.command,
             params: params,
             router: router,
-            cache: cache
+            cache: cache,
+            liveTrackNames: operationTraceCoverageLiveTrackNames
         )
     case .logicEdit:
         return await EditDispatcher.handle(
@@ -424,7 +433,8 @@ private func dispatchOperationTraceCoverageSpec(
             command: spec.command,
             params: params,
             router: router,
-            cache: cache
+            cache: cache,
+            liveTrackNames: operationTraceCoverageLiveTrackNames
         )
     }
 }
@@ -482,6 +492,9 @@ private func operationTraceCoverageParams(
             "track": .int(0), "insert": .int(0), "plugin": .string("Gain"),
             "mode": .string("duplicate_applyback"),
             "project_expected_path": .string(fixtures.projectPath),
+            // PRD-007 `.corroborated`: the binding gate precedes the traced
+            // write, so the trace census must clear it.
+            OperationRegistry.corroborationParam: .string(operationTraceCoverageTrackName),
         ]
     case .editQuantize:
         return ["value": .string("1/16")]
@@ -532,8 +545,13 @@ private func operationTraceCoverageParams(
         return ["note": .int(60), "duration": .string("1/16")]
     case .midiMMCLocate:
         return ["bar": .int(1)]
-    case .tracksSelect, .tracksDelete, .tracksDuplicate, .tracksArmOnly:
+    case .tracksSelect, .tracksArmOnly:
         return ["index": .int(0)]
+    case .tracksDelete, .tracksDuplicate:
+        return [
+            "index": .int(0),
+            OperationRegistry.corroborationParam: .string(operationTraceCoverageTrackName),
+        ]
     case .tracksRename:
         return ["index": .int(0), "name": .string("Trace Coverage")]
     case .tracksMute, .tracksSolo, .tracksArm:
@@ -543,7 +561,11 @@ private func operationTraceCoverageParams(
     case .tracksSetAutomation:
         return ["index": .int(0), "mode": .string("read")]
     case .tracksSetInstrument:
-        return ["index": .int(0), "path": .string("Pianos/Trace Coverage.patch")]
+        return [
+            "index": .int(0),
+            "path": .string("Pianos/Trace Coverage.patch"),
+            OperationRegistry.corroborationParam: .string(operationTraceCoverageTrackName),
+        ]
     case .tracksResolvePath:
         return ["path": .string("Pianos/Trace Coverage.patch")]
     case .audioAnalyzeFile:

--- a/Tests/LogicProMCPTests/SharedTestHelpers.swift
+++ b/Tests/LogicProMCPTests/SharedTestHelpers.swift
@@ -13,6 +13,17 @@ let codexSeatbeltCoreMIDIDisabled: ConditionTrait = .disabled(
     "Codex seatbelt denies the CoreMIDI service connection; this remains live qualification."
 )
 
+/// PRD-007 — live AX header-scan fixture for `.corroborated` ops.
+///
+/// Mirrors `AXLogicProElements.trackNames()`'s shape (`[Int: String]?`, nil ==
+/// unreadable). Seed-set ops (`tracks.delete` / `duplicate` / `set_instrument`,
+/// `logic_plugins.insert_verified`) refuse a bare index, so any deterministic
+/// test that wants one of them to REACH the router must supply both this scan
+/// and a matching `expected_name` — exactly what a real caller must now do.
+func sharedLiveTrackNames(_ names: [Int: String]) -> @Sendable () -> [Int: String]? {
+    { names }
+}
+
 /// Extract text from a CallTool.Result, supporting both .text and .resource content types.
 func sharedToolText(_ result: CallTool.Result) -> String {
     guard let first = result.content.first else { return "" }

--- a/Tests/LogicProMCPTests/TargetRegistryTests.swift
+++ b/Tests/LogicProMCPTests/TargetRegistryTests.swift
@@ -350,22 +350,30 @@ struct TargetRegistryTests {
                 cache: StateCache(),
                 targetRegistry: trackRegistry
             )
+            // PRD-007: delete/duplicate are `.corroborated` — they must clear
+            // the binding gate to reach the write that bumps the generation.
+            let liveNames = sharedLiveTrackNames([0: "Generation Track"])
             _ = await TrackDispatcher.handle(
                 command: "delete",
-                params: ["index": .int(0)],
+                params: ["index": .int(0), "expected_name": .string("Generation Track")],
                 router: trackRouter,
                 cache: StateCache(),
-                targetRegistry: trackRegistry
+                targetRegistry: trackRegistry,
+                liveTrackNames: liveNames
             )
             _ = await TrackDispatcher.handle(
                 command: "duplicate",
-                params: ["index": .int(0)],
+                params: ["index": .int(0), "expected_name": .string("Generation Track")],
                 router: trackRouter,
                 cache: StateCache(),
-                targetRegistry: trackRegistry
+                targetRegistry: trackRegistry,
+                liveTrackNames: liveNames
             )
             #expect(await trackRegistry.currentTopologyGeneration == 3)
 
+            // insert_verified supplies no `track`, so the binding gate is skipped
+            // (the channel reports the missing selector) and this still exercises
+            // the generation bump exactly as before.
             _ = await PluginsDispatcher.handle(
                 command: "insert_verified",
                 params: [:],

--- a/Tests/LogicProMCPTests/TrackDispatcherDeleteTests.swift
+++ b/Tests/LogicProMCPTests/TrackDispatcherDeleteTests.swift
@@ -59,9 +59,10 @@ private actor StateBSelectMockChannel: Channel {
     // Act
     let result = await TrackDispatcher.handle(
         command: "delete",
-        params: ["index": .int(2)],
+        params: ["index": .int(2), "expected_name": .string("Target")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([2: "Target"])
     )
 
     // Assert — dispatcher returned an error and never routed `track.delete`.
@@ -95,9 +96,10 @@ private actor StateBSelectMockChannel: Channel {
 
     let result = await TrackDispatcher.handle(
         command: "delete",
-        params: ["index": .int(3)],
+        params: ["index": .int(3), "expected_name": .string("Target")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([3: "Target"])
     )
 
     #expect(!(result.isError!), "delete must succeed on State A select")
@@ -126,9 +128,10 @@ private actor StateBSelectMockChannel: Channel {
 
     let result = await TrackDispatcher.handle(
         command: "duplicate",
-        params: ["index": .int(3)],
+        params: ["index": .int(3), "expected_name": .string("Target")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([3: "Target"])
     )
 
     #expect(result.isError!, "duplicate must error on State B select")
@@ -159,9 +162,10 @@ private actor StateBSelectMockChannel: Channel {
 
     let result = await TrackDispatcher.handle(
         command: "duplicate",
-        params: ["index": .int(4)],
+        params: ["index": .int(4), "expected_name": .string("Target")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([4: "Target"])
     )
 
     #expect(!(result.isError!), "duplicate must succeed on State A select")
@@ -187,9 +191,10 @@ private actor StateBSelectMockChannel: Channel {
 
     let result = await TrackDispatcher.handle(
         command: "delete",
-        params: ["index": .int(7)],
+        params: ["index": .int(7), "expected_name": .string("Target")],
         router: router,
-        cache: StateCache()
+        cache: StateCache(),
+        liveTrackNames: sharedLiveTrackNames([7: "Target"])
     )
 
     let text = sharedToolText(result)

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,47 @@ Every tool in `tools/list` advertises an `outputSchema`. Mixed command tools adv
 `logic://session-players/{id}`, `logic://workflow-plans/session?prompt={prompt}`,
 `logic://workflow-skills/{id}`, `logic://workflow-skills/search?query={query}`.
 
-Registered operations reject unknown command-parameter keys at the runtime boundary by default, before cache access, mutation gates, or dispatcher invocation. The State C `invalid_params` response includes sorted `unknown_params` and `allowed_params`. Selector keys are operation-scoped: `target_ref` is recognized only when the operation's target policy is `requiresStableTarget`, while `index` and `track` appear only on operations whose dispatcher consumes those aliases. The exact per-operation set is published by `logic://system/operations`; `record_sequence` also preserves its ignored `instrument` / `instrument_path` inputs. Set `LOGIC_MCP_ADR003_STRICT_PARAMS=0` only as a temporary compatibility escape hatch for registered-command parameter pass-through; it does not expose unregistered commands or dispatcher-only aliases.
+Registered operations reject unknown command-parameter keys at the runtime boundary by default, before cache access, mutation gates, or dispatcher invocation. The State C `invalid_params` response includes sorted `unknown_params` and `allowed_params`. Selector keys are operation-scoped: `target_ref` is recognized only when the operation's target policy is `accepts_stable_target`, while `index` and `track` appear only on operations whose dispatcher consumes those aliases. `expected_name` is recognized only on the `corroborated` index-binding tier (see [Index binding](#index-binding)). The exact per-operation set is published by `logic://system/operations`; `record_sequence` also preserves its ignored `instrument` / `instrument_path` inputs. Set `LOGIC_MCP_ADR003_STRICT_PARAMS=0` only as a temporary compatibility escape hatch for registered-command parameter pass-through; it does not expose unregistered commands or dispatcher-only aliases.
+
+### Index binding
+
+A track index is an **ordinal, not an identity**. Between the moment you read `logic://tracks` and the moment your write lands, a drag, a track creation, or a folder collapse can shift every row — and an index-keyed write then lands on a track you never named. `target_ref` (ADR-002) solves this by binding to a session-stable identity, but it is opt-in, so the registry declares what each operation demands of a **bare index** on a second, orthogonal axis: `index_binding`, published per-operation by `logic://system/operations`.
+
+The field is present only on operations that are both target-bearing (`target` = `accepts_stable_target`) and mutating — the only ones with an index path that can hit a wrong target. Read-only and non-target operations omit it entirely rather than publishing a null.
+
+| Tier | Meaning | Today |
+| --- | --- | --- |
+| `ref_required` | A bare index is refused; only `target_ref` binds. | **No operations.** Implemented and tested; the first promotion is a registry row flip and will appear as a catalog diff. |
+| `corroborated` | A bare index must be corroborated by `expected_name`. | `tracks.delete`, `tracks.duplicate`, `tracks.set_instrument`, `plugins.insert_verified` |
+| `legacy_index_allowed` | The historical unguarded index path. | **Deprecated** — see below. |
+
+#### The corroboration contract
+
+For a `corroborated` operation called **without** `target_ref`, supply `expected_name`: the track name you believe sits at the index. (It is not spelled `name` because several of these operations already spend `name` on an operand — `tracks.rename`'s new name, `tracks.select`'s by-name selector.) The server then reads the **live** track header before writing — never the state cache, which lags an out-of-band reorder by the poll interval and would therefore agree with exactly the stale view being defended against.
+
+Every failure below is fail-closed and **pre-write**: `write_attempted: false` is a fact, not a claim — the operation returns before anything is routed.
+
+| Condition | State C error | `safe_to_retry` |
+| --- | --- | --- |
+| No `expected_name` and no `target_ref` | `index_binding_corroboration_required` | `true` — supply either binding |
+| Live name at the index ≠ `expected_name` | `target_identity_mismatch` (`reason: name_mismatch`) | `false` — re-read `logic://tracks` first |
+| Live header unreadable | `target_identity_mismatch` (`reason: header_unreadable`) | `false` — an unreadable surface is never read as agreement |
+| `expected_name` matches but names >1 live track | `target_name_ambiguous` | `false` — use `target_ref` |
+| `expected_name` **and** `target_ref` both supplied | `invalid_params` | `true` — send exactly one binding |
+
+Uniqueness is not a nicety. Two tracks sharing a name can swap positions and leave `(index, name)` self-consistent at **both** ordinals, so a match would prove nothing; `target_ref` is the only binding a swap cannot fool. Supplying `target_ref` bypasses this path entirely — the reference machinery carries its own live-identity and ambiguity checks, and the two are never stacked.
+
+**Corroboration is a pre-write proof, not atomic with the write.** It reads the live header, then writes; a reorder that lands in that narrow guard-to-write interval can still put the write on the wrong track. Corroboration *narrows* the wrong-target window (from "any time since your last read" down to "the guard-to-write interval"); it does not eliminate it. Only `target_ref` — and the future `ref_required` tier — bind an identity that holds across the write and close the window entirely. Prefer `target_ref` when wrong-target cost is high.
+
+`expected_name` is a binding proof, not a write parameter: it is never forwarded to the channel, and a matching, unique corroboration leaves the existing index write path completely unchanged.
+
+#### Deprecation: `legacy_index_allowed`
+
+This tier is the pre-ratchet behaviour and is **deprecated**. Its members still write to a bare, unproven ordinal; each remains only because a wrong-target write there is *recoverable* (`mixer.set_volume`, `mixer.set_pan`, `plugins.set_param_verified`, `tracks.select`, `tracks.rename`, `tracks.mute`, `tracks.solo`, `tracks.arm`, `tracks.arm_only`, `tracks.set_automation`). The set is pinned by census and may only shrink. Prefer `target_ref` on these operations today; do not build on the assumption that a bare index will keep being accepted.
+
+A gap is tracked rather than papered over: two mutating operations key on a track strip yet carry target policy `none` — **`mixer.insert_plugin`** (irreversible insert) and **`mixer.set_plugin_param`** (reversible param write). Because they accept no `target_ref`, the corroboration refusal could not honestly offer one as an alternative, so neither carries a tier. Ratcheting either requires first making it target-bearing (`insert_plugin` would then become `corroborated`; `set_plugin_param`, being reversible, `legacy_index_allowed`).
+
+This exact set is pinned by census — it may only shrink, and any new operation added to the class fails CI until an explicit decision is made. The census discriminator is: **mutating**, target policy **`none`**, and carrying a track-strip selector (`track` or `track_index`). The bare `index` alias is deliberately *not* part of the discriminator: the operations that take `index` without a track-strip selector are the marker operations (`navigate.goto_marker`, `navigate.delete_marker`, `navigate.rename_marker`), whose `index` addresses a marker, not a track — a different wrong-target class that ADR-002 index binding does not cover.
 
 ### Track state values (`logic://tracks`)
 
@@ -95,6 +135,8 @@ Read current state from `logic://transport/state` after any transport mutation.
 Use explicit indices or names. Track mutation fails closed when the target cannot be identified or read back.
 
 Common commands: `select`, `create_audio`, `create_instrument`, `create_drummer`, `create_external_midi`, `delete`, `duplicate`, `rename`, `mute`, `solo`, `arm`, `arm_only`, `record_sequence`, `set_automation`, `set_instrument`, `list_library`, `scan_library`, `resolve_path`, `scan_plugin_presets`.
+
+**`delete`, `duplicate`, and `set_instrument` no longer accept a bare index.** They are `corroborated` (see [Index binding](#index-binding)): pass `expected_name` (the track name you expect at that index) or `target_ref`. Without one, they fail closed with `index_binding_corroboration_required` and write nothing.
 
 `set_automation` is State B (MCU write, no readback echo).
 


### PR DESCRIPTION
## Summary

Debt **LPMCP-PRD-007** (ADR-002 #285, decision recorded on the issue): the `requires_stable_target` policy only **widened** accepted params — with the ADR-002 flag off (production default), every target-bearing mutation ran index-only, which is precisely the wrong-target hazard the ADR exists to close. The RED-first proof in this PR demonstrates it: on current main, a stale index deletes the **wrong track** and reports success.

**Part 1 of the adversarially-debated S1″ design** (flag default-ON is a separate follow-up PR):

- **Rename the lie**: `TargetPolicy.requiresStableTarget` → `.acceptsStableTarget`; wire string `accepts_stable_target`. No alias; a catalog-walk census proves no stale spelling survives on the shipped surface.
- **New registry axis** `OperationSpec.indexBinding` — `.refRequired` / `.corroborated` / `.legacyIndexAllowed` — derived in one place so a new spec cannot forget it; census pins both halves (target-bearing mutating specs have exactly one policy; others none).
- **Real assignments now** (no knob-without-policy): seed `.corroborated` set = `tracks.delete`, `tracks.duplicate`, `tracks.set_instrument`, `plugins.insert_verified` — an explicit list, deliberately NOT projected from Confirmation/Destructive policy (orthogonal axes: `tracks.delete` is confirmation-`none` yet wrong-target-irreversible).
- **`IndexBindingGuard`** (pre-write, fail-closed, pure function): a seed op on the index path requires `expected_name`, verified against the **live** header scan (never `StateCache` — the cache lags exactly the window being defended). Missing → `index_binding_corroboration_required`; mismatch/unreadable header → `target_identity_mismatch`; **non-unique live name → `target_name_ambiguous`** (two same-named tracks can swap and keep `(index, name)` self-consistent — uniqueness is what an ordinal cannot prove; the caller is pushed to `target_ref`); `expected_name`+`target_ref` together → `invalid_params` (exactly one binding proof per call). All failures are pre-write State C with `write_attempted:false`.
- **`plugins.insert_verified`** gains a pre-write guard seam (`liveTrackNames` threaded into `PluginsDispatcher`) — it previously did its identity check *inside* the AX write, the wrong side of the boundary; the in-write F1 guard is retained as defense in depth.
- **`.refRequired`** implemented and unit-tested via a synthetic spec; assigned to **zero** production ops, pinned by census with the planned promotion named — the flip is a deliberate registry-row diff next batch, not an open-ended runway.
- **Hazard tripwire census**: the structural class "index-keyed mutating op that is NOT target-bearing" is pinned exactly `== [mixer.insert_plugin, mixer.set_plugin_param]` with per-op planned promotions — any future op in the class fails CI and forces an explicit decision instead of inheriting an unratcheted index path. (Mitigating context from the live confirmation-surface map: `mixer.insert_plugin` is one of only nine L2/L3 confirmation-gated ops, so its unratcheted index path still sits behind a human-confirmation gate until its promotion batch.) (The set was corrected from one op to two during implementation — the census would otherwise have pinned a falsehood.)
- Docs: `docs/API.md` index-binding section (tiers, corroboration contract, uniqueness rationale, **explicit TOCTOU honesty**: corroboration is pre-write proof, not atomic with the write — only `target_ref` closes identity), plus both MCP tool descriptions.

**Adversarial gate round (applied pre-merge):** verdict PROCEED-WITH-FIXES, zero P0/P1. All seven attack axes held: no bypass route (saga's reversible allowlist contains no seed ops; keycmd/MCU/CGEvent run only after the dispatcher gate), guard fail-closed on nil/partial header reads, ref path untouched, modified test fixtures strengthened not weakened. P2 round applied: TOCTOU residual-window honesty in docs+comment, dispatcher-level RED coverage for the plugins call site, spike-script bare-index callers fixed, tripwire discriminator documented; the terminal-classification suggestion was deliberately declined with rationale recorded in-code (corroboration failures are caller-correctable → retryable, parity with `target_ref_unavailable`).

## Verification

RED-first proofs captured pre-implementation, including the load-bearing wrong-target case: *mismatched name on `tracks.delete` — today's code deletes the wrong track; post-guard it refuses pre-write*. Focused IndexBinding suite green; ticket filter green; **full `swift test --no-parallel` green on the final diff** (counts in PR comments with the gate verdict).
