### PR TITLE
trace,policy: fix two live-found defects — Instant-debug timestamps (#388), Korean confirmation message (#390)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -1214,7 +1214,7 @@ struct SystemDispatcher: OperationTraceDispatching {
             let events: [[String: Any]] = trace.events.map { event in
                 [
                     "phase": event.phase.rawValue,
-                    "timestamp": String(describing: event.timestamp),
+                    "timestamp": ISO8601DateFormatter.cacheFormatter.string(from: event.wallClock),
                     "attributes": event.attributes,
                 ]
             }

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -98,7 +98,13 @@ enum TracePrivacyClass: String, Codable, Sendable {
 
 struct TraceEvent: Sendable {
     let phase: TracePhase
+    /// Monotonic capture, kept internal for deterministic ordering.
     let timestamp: ContinuousClock.Instant
+    /// Wall-clock capture at record time. #388: the public `timestamp` field is
+    /// serialized from THIS as ISO-8601 UTC (matching the trace-clear
+    /// `cleared_at` and saga `sampled_at` receipts) — never the monotonic
+    /// `Instant`, whose debug string ("Instant(_value: …)") leaked to callers.
+    let wallClock: Date
     let attributes: [String: String]
     let privacyClasses: [String: TracePrivacyClass]
 }
@@ -177,6 +183,7 @@ actor OperationTraceStore {
         trace.events.append(TraceEvent(
             phase: phase,
             timestamp: .now,
+            wallClock: Date(),
             attributes: filtered.values,
             privacyClasses: filtered.privacyClasses
         ))

--- a/Sources/LogicProMCP/Server/SupportBundle.swift
+++ b/Sources/LogicProMCP/Server/SupportBundle.swift
@@ -231,7 +231,7 @@ struct SupportBundleBuilder: Sendable {
                     }
                     return TraceEventRecord(
                         phase: event.phase.rawValue,
-                        timestamp: String(describing: event.timestamp),
+                        timestamp: ISO8601DateFormatter.cacheFormatter.string(from: event.wallClock),
                         attributes: attributes,
                         privacyClasses: classes
                     )

--- a/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
+++ b/Sources/LogicProMCP/Utilities/DestructivePolicy.swift
@@ -60,7 +60,7 @@ enum DestructivePolicy {
             "status": "confirmation_required",
             "command": command,
             "level": levelLabel,
-            "message": "이 작업은 프로젝트 상태를 변경하거나 데이터 손실을 유발할 수 있습니다.",
+            "message": "This operation may change project state or cause data loss.",
             "confirm_command": "logic_project(\"\(command)\", {confirmed: true})",
         ])
     }

--- a/Tests/LogicProMCPTests/DestructiveOperationTests.swift
+++ b/Tests/LogicProMCPTests/DestructiveOperationTests.swift
@@ -47,6 +47,24 @@ private final class AppleScriptOpenHarness: @unchecked Sendable {
     #expect(response == nil) // L1 executes immediately
 }
 
+/// #390 (P2): the public (English) confirmation envelope must not leak
+/// non-English text. Every field value is ASCII-only and `message` is the
+/// ratified English sentence. RED-first (pre-fix `message` is Korean).
+@Test func testConfirmationResponseIsEnglishASCII() throws {
+    let response = try #require(DestructivePolicy.confirmationResponse(command: "quit"))
+    let object = try #require(sharedJSONObject(response))
+    #expect(
+        object["message"] as? String
+            == "This operation may change project state or cause data loss."
+    )
+    for (_, value) in object {
+        if let string = value as? String {
+            let asciiOnly = string.allSatisfy(\.isASCII)
+            #expect(asciiOnly, "non-ASCII leaked into a field value: \(string)")
+        }
+    }
+}
+
 @Test func testTransportWhitelist() {
     #expect(AppleScriptSafety.isAllowedTransportAction("play"))
     #expect(AppleScriptSafety.isAllowedTransportAction("stop"))

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -850,3 +850,53 @@ extension OperationTraceTests {
         try await assertTracePreservesResult(isError: true)
     }
 }
+
+// MARK: - Live-discovered defects (2026-07-17)
+
+extension OperationTraceTests {
+    /// #388 (P1): every get_trace event `timestamp` must be an ISO-8601 UTC
+    /// wall-clock string (the same format as the trace-clear `cleared_at` and
+    /// saga `sampled_at` receipts), never a raw `ContinuousClock.Instant` debug
+    /// string like "Instant(_value: 2451508.288 seconds)". RED-first.
+    @Test func getTraceEmitsISO8601Timestamps() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let id = await OperationTraceStore.shared.start(
+            operationID: OperationID.transportPlay.rawValue
+        )
+        await OperationTraceStore.shared.record(
+            id, phase: .requestReceived, attributes: ["command": "play"]
+        )
+        await OperationTraceStore.shared.record(id, phase: .writeBoundaryCrossed)
+        await OperationTraceStore.shared.record(id, phase: .resultEmitted)
+        await OperationTraceStore.shared.complete(id)
+
+        let getResult = await SystemDispatcher.handle(
+            command: "get_trace",
+            params: ["trace_id": .string(id.rawValue)],
+            router: ChannelRouter(),
+            cache: StateCache()
+        )
+        let get = try #require(sharedJSONObject(sharedToolText(getResult)))
+        let events = try #require(get["events"] as? [[String: Any]])
+        #expect(!events.isEmpty)
+
+        // Matches ISO8601DateFormatter.cacheFormatter ([.withInternetDateTime,
+        // .withFractionalSeconds]) output, e.g. 2026-07-17T12:34:56.789Z.
+        let isoPattern = #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$"#
+        for event in events {
+            let timestamp = try #require(event["timestamp"] as? String)
+            #expect(
+                !timestamp.contains("Instant("),
+                "timestamp leaked a ContinuousClock.Instant debug string: \(timestamp)"
+            )
+            #expect(
+                timestamp.range(of: isoPattern, options: .regularExpression) != nil,
+                "timestamp is not ISO-8601 UTC: \(timestamp)"
+            )
+        }
+        await OperationTraceStore.shared.clear()
+    }
+}

--- a/Tests/LogicProMCPTests/SupportBundleTests.swift
+++ b/Tests/LogicProMCPTests/SupportBundleTests.swift
@@ -23,6 +23,7 @@ struct SupportBundleTests {
                 TraceEvent(
                     phase: .requestReceived,
                     timestamp: .now,
+                    wallClock: Date(timeIntervalSince1970: 1_700_000_000),
                     attributes: [
                         "operation_id": OperationID.transportPlay.rawValue,
                         "command": "play",


### PR DESCRIPTION
## Summary
Two defects the standing live-usage gate found against real Logic 12.3 (exact head), which the deterministic suite had missed:

**#388** — `get_trace` (and the support-bundle trace export) serialized each event timestamp as the raw `ContinuousClock.Instant` debug string `Instant(_value: 2451508.288 seconds)` — a private underscore property on the public wire, not wall-clock, unstable across Swift/OS. Unit tests used a fake clock and asserted phase *presence*, never format, so it survived every hardening pass on this surface. Fix: capture a wall-clock `Date` at record time, serialize ISO-8601 (reusing the exact `cleared_at`/`sampled_at` formatter); the monotonic `Instant` stays internal as the ordering key.

**#390** — `DestructivePolicy` L2/L3 confirmation-required responses returned a hardcoded Korean `message` on the public (English) surface — every gated op, every locale (v2.0.0-era, unconditional). Fix: English message + an ASCII-only assertion on every response field.

RED-first for both (captured against the live Instant string and the Korean literal). Focused suite green (59). #388's support-bundle sibling leak fixed in the same pass.

**#389** (systemic `write_boundary.crossed` pre-write phase, ~55 sites / 9 dispatchers) is deliberately **split to its own branch** — a Level-2 change to the ADR-005 tracing core, adversarial-design-gate ratified (per-route scoped arm/commit, 10 amendments) rather than squeezed into this small fix. Consumer audit confirmed it is trace-honesty only; the functional saga-compensation field is envelope-driven and untouched.

## Verification
Focused `OperationTrace|DestructivePolicy|SupportBundle|Confirmation|Destructive`: 59 passed. Full suite runs in CI.