### PR TITLE
trace: #389 — write_boundary.crossed commits at first armed channel dispatch (arm/commit)

### DIFF
--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -161,6 +161,10 @@ actor ChannelRouter {
             await OperationTraceContext.record(.channelStarted, attributes: [
                 "channel": channelID.rawValue,
             ])
+            // #389: an armed write boundary commits HERE — the first channel
+            // that actually executes — and never on a route that resolved no
+            // channel. Reads route without an arm, so this is a no-op for them.
+            await OperationTraceWriteBoundaryArm.commitIfArmed()
             let result = await channel.execute(operation: operation, params: params)
             await OperationTraceContext.record(.channelCompleted, attributes: [
                 "channel": channelID.rawValue,

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -277,6 +277,27 @@ extension OperationTraceDispatching {
         return id
     }
 
+    /// #389: arm `write_boundary.crossed` for EXACTLY the routed write in
+    /// `route`, then let `ChannelRouter` commit it at the first channel it
+    /// actually dispatches. The arm clears on exit whether or not it committed,
+    /// so a dead route (no channel) records no boundary and a later read route
+    /// can never inherit this write's arm.
+    ///
+    /// Wrap the WRITE route only — never widen the scope back over pre-reads
+    /// (`liveTransportState` and friends), which is exactly the false boundary
+    /// this replaces.
+    static func withWriteBoundaryArmed<T>(
+        _ traceID: TraceID?,
+        _ route: () async -> T
+    ) async -> T {
+        await OperationTraceWriteBoundaryArm.armed(traceID, route)
+    }
+
+    /// Immediate, unconditional boundary for genuine first writes that do NOT
+    /// go through `ChannelRouter` (support-bundle/export materialization, the
+    /// project lifecycle AppleScript, the cleanup_apply parent). Router-backed
+    /// writes must use `withWriteBoundaryArmed` instead — this call cannot know
+    /// whether a channel was ever dispatched.
     static func recordWriteBoundary(_ traceID: TraceID?) async {
         if let onWriteBoundary = OperationTraceParentBoundary.onWriteBoundary {
             await onWriteBoundary()

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -86,11 +86,12 @@ struct EditDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "edit.quantize",
-                params: ["value": value]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "edit.quantize",
+                    params: ["value": value]
+                )
+            }
             return await finalizeTrace(
                 toolTextResultTreatingUnverifiedAsError(result),
                 traceID: traceID
@@ -106,12 +107,15 @@ struct EditDispatcher: OperationTraceDispatching {
         router: ChannelRouter,
         traceID: TraceID?
     ) async -> CallTool.Result {
-        await recordWriteBoundary(traceID)
         switch route {
         case .regular(let operation):
-            return await routedTextResult(router, operation: operation)
+            return await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: operation)
+            }
         case .unverifiedIsError(let operation):
-            let result = await router.route(operation: operation)
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: operation)
+            }
             return toolTextResultTreatingUnverifiedAsError(result)
         }
     }

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -108,10 +108,11 @@ struct MIDIDispatcher: OperationTraceDispatching {
             case .success(let port):
                 let opKey = port == "midi" ? "midi.play_sequence" : "midi.play_sequence.\(port)"
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await routedTextResult(router, operation: opKey, params: [
-                    "notes": notes,
-                ])
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await routedTextResult(router, operation: opKey, params: [
+                        "notes": notes,
+                    ])
+                }
                 return await finalizeTrace(result, traceID: traceID)
             }
 
@@ -199,8 +200,9 @@ struct MIDIDispatcher: OperationTraceDispatching {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "midi.send_sysex", params: ["data": data])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "midi.send_sysex", params: ["data": data])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "import_file":
@@ -213,10 +215,11 @@ struct MIDIDispatcher: OperationTraceDispatching {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "midi.import_file", params: [
-                "path": path,
-            ])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "midi.import_file", params: [
+                    "path": path,
+                ])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "create_virtual_port":
@@ -224,10 +227,11 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 return reject
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "midi.create_virtual_port", params: [
-                "name": stringParam(params, "name", default: "Virtual Port"),
-            ])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "midi.create_virtual_port", params: [
+                    "name": stringParam(params, "name", default: "Virtual Port"),
+                ])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "list_ports":
@@ -241,8 +245,9 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 return reject
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mmc.play")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mmc.play")
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_stop":
@@ -250,8 +255,9 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 return reject
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mmc.stop")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mmc.stop")
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_record":
@@ -259,8 +265,9 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 return reject
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mmc.record_strobe")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mmc.record_strobe")
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "mmc_locate":
@@ -287,11 +294,12 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 // `verified:false` — it never confirmed the playhead landed.
                 let position = "\(bar).1.1.1"
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "transport.goto_position",
-                    params: ["position": position]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "transport.goto_position",
+                        params: ["position": position]
+                    )
+                }
                 let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                     result,
                     requestedPosition: position,
@@ -304,10 +312,11 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 return toolInvalidParamsResult("mmc_locate 'time' must be HH:MM:SS:FF")
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mmc.locate", params: [
-                "time": time,
-            ])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mmc.locate", params: [
+                    "time": time,
+                ])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "step_input":
@@ -328,11 +337,12 @@ struct MIDIDispatcher: OperationTraceDispatching {
             case .failure(let msg): return toolInvalidParamsResult(msg.message)
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "midi.step_input", params: [
-                "note": String(note),
-                "duration": duration,
-            ])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "midi.step_input", params: [
+                    "note": String(note),
+                    "duration": duration,
+                ])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         default:
@@ -368,8 +378,9 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 var allParams = additionalParams
                 allParams["channel"] = String(wireChannel)
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await routedTextResult(router, operation: opKey, params: allParams)
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await routedTextResult(router, operation: opKey, params: allParams)
+                }
                 return await finalizeTrace(result, traceID: traceID)
             }
         }

--- a/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MixerDispatcher.swift
@@ -77,14 +77,16 @@ struct MixerDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = TargetRefResolver.addEvidence(
-                resolvedReference,
-                fingerprint: resolvedFingerprint,
-                to: await routedTextResult(router, operation: "mixer.set_volume", params: [
+            let routed = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mixer.set_volume", params: [
                     "index": String(index),
                     "volume": String(volume),
                 ])
+            }
+            let result = TargetRefResolver.addEvidence(
+                resolvedReference,
+                fingerprint: resolvedFingerprint,
+                to: routed
             )
             return await finalizeTrace(result, traceID: traceID)
 
@@ -124,14 +126,16 @@ struct MixerDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = TargetRefResolver.addEvidence(
-                resolvedReference,
-                fingerprint: resolvedFingerprint,
-                to: await routedTextResult(router, operation: "mixer.set_pan", params: [
+            let routed = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mixer.set_pan", params: [
                     "index": String(index),
                     "pan": String(pan),
                 ])
+            }
+            let result = TargetRefResolver.addEvidence(
+                resolvedReference,
+                fingerprint: resolvedFingerprint,
+                to: routed
             )
             return await finalizeTrace(result, traceID: traceID)
 
@@ -159,10 +163,11 @@ struct MixerDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await routedTextResult(router, operation: "mixer.set_master_volume", params: [
-                "volume": String(volume),
-            ])
+            let result = await withWriteBoundaryArmed(traceID) {
+                await routedTextResult(router, operation: "mixer.set_master_volume", params: [
+                    "volume": String(volume),
+                ])
+            }
             return await finalizeTrace(result, traceID: traceID)
 
         case "toggle_eq":
@@ -212,12 +217,13 @@ struct MixerDispatcher: OperationTraceDispatching {
                 return toolInvalidParamsResult("insert_plugin \(hint)")
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let channelResult = await router.route(operation: "plugin.insert", params: [
-                "track": String(track),
-                "slot": String(slot),
-                "plugin_name": spec.canonicalName,
-            ])
+            let channelResult = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "plugin.insert", params: [
+                    "track": String(track),
+                    "slot": String(slot),
+                    "plugin_name": spec.canonicalName,
+                ])
+            }
             if FeatureFlags.adr002TargetRef, channelResultIsVerified(channelResult) {
                 await targetRegistry?.bumpTopologyGeneration()
             }
@@ -280,11 +286,12 @@ struct MixerDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let selectResult = await router.route(
-                operation: "track.select",
-                params: ["index": String(track)]
-            )
+            let selectResult = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.select",
+                    params: ["index": String(track)]
+                )
+            }
             guard selectResult.isSuccess else {
                 return await finalizeTrace(
                     toolTextResult(selectResult.message, isError: true),

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -35,11 +35,12 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "transport.goto_position",
-                params: ["position": "\(bar).1.1.1"]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "transport.goto_position",
+                    params: ["position": "\(bar).1.1.1"]
+                )
+            }
             let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                 result,
                 requestedPosition: "\(bar).1.1.1",
@@ -60,11 +61,12 @@ struct NavigateDispatcher: OperationTraceDispatching {
             let markers = await cache.getMarkers()
             func routeMarkerTarget(_ target: MarkerState) async -> CallTool.Result {
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                var result = await router.route(
-                    operation: "transport.goto_position",
-                    params: ["position": target.position]
-                )
+                var result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "transport.goto_position",
+                        params: ["position": target.position]
+                    )
+                }
                 // canonical 마커는 응답 그대로. fallback/unknown 만 uncertainty
                 // 머신 가독으로 surface (HC State A/B 한정; State C 보존).
                 if !target.positionSource.isCanonical {
@@ -168,11 +170,12 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "nav.delete_marker",
-                params: ["index": String(index)]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "nav.delete_marker",
+                    params: ["index": String(index)]
+                )
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "rename_marker":
@@ -199,11 +202,12 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "nav.rename_marker",
-                params: ["index": String(index), "name": name]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "nav.rename_marker",
+                    params: ["index": String(index), "name": name]
+                )
+            }
             return await finalizeTrace(
                 toolTextResultTreatingUnverifiedAsError(result),
                 traceID: traceID
@@ -211,8 +215,9 @@ struct NavigateDispatcher: OperationTraceDispatching {
 
         case "zoom_to_fit":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "nav.zoom_to_fit")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "nav.zoom_to_fit")
+            }
             return await finalizeTrace(
                 toolTextResultTreatingUnverifiedAsError(result),
                 traceID: traceID
@@ -232,30 +237,33 @@ struct NavigateDispatcher: OperationTraceDispatching {
             switch level {
             case "in":
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "nav.set_zoom_level",
-                    params: ["level": "8"]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "nav.set_zoom_level",
+                        params: ["level": "8"]
+                    )
+                }
                 return await finalizeTrace(
                     toolTextResultTreatingUnverifiedAsError(result),
                     traceID: traceID
                 )
             case "out":
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "nav.set_zoom_level",
-                    params: ["level": "2"]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "nav.set_zoom_level",
+                        params: ["level": "2"]
+                    )
+                }
                 return await finalizeTrace(
                     toolTextResultTreatingUnverifiedAsError(result),
                     traceID: traceID
                 )
             case "fit":
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(operation: "nav.zoom_to_fit")
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(operation: "nav.zoom_to_fit")
+                }
                 return await finalizeTrace(
                     toolTextResultTreatingUnverifiedAsError(result),
                     traceID: traceID
@@ -268,11 +276,12 @@ struct NavigateDispatcher: OperationTraceDispatching {
                     )
                 }
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "nav.set_zoom_level",
-                    params: ["level": String(numericLevel)]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "nav.set_zoom_level",
+                        params: ["level": String(numericLevel)]
+                    )
+                }
                 return await finalizeTrace(
                     toolTextResultTreatingUnverifiedAsError(result),
                     traceID: traceID
@@ -302,8 +311,9 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: operation)
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: operation)
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
@@ -323,8 +333,9 @@ struct NavigateDispatcher: OperationTraceDispatching {
         // counts were equal on success → every verified-by-readback create fell
         // to the State-B readback-mismatch path. Still fail-closed: a nil/short
         // readback below returns State B.
-        await recordWriteBoundary(traceID)
-        let openResult = await router.route(operation: "nav.open_marker_list")
+        let openResult = await withWriteBoundaryArmed(traceID) {
+            await router.route(operation: "nav.open_marker_list")
+        }
         guard openResult.isSuccess else {
             return toolTextResult(openResult)
         }

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -146,9 +146,10 @@ struct PluginsDispatcher: OperationTraceDispatching {
                         return result
                     }
                 }
-                await recordWriteBoundary(traceID)
-                return await routedTextResult(router, operation: "plugin.set_param_verified",
-                                              params: writeParams)
+                return await withWriteBoundaryArmed(traceID) {
+                    await routedTextResult(router, operation: "plugin.set_param_verified",
+                                           params: writeParams)
+                }
             }
             return await finalizeTrace(
                 TargetRefResolver.addEvidence(
@@ -214,11 +215,12 @@ struct PluginsDispatcher: OperationTraceDispatching {
                         return result
                     }
                 }
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "plugin.insert_verified",
-                    params: writeParams
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "plugin.insert_verified",
+                        params: writeParams
+                    )
+                }
                 if FeatureFlags.adr002TargetRef, channelResultIsVerified(result) {
                     await targetRegistry?.bumpTopologyGeneration()
                 }

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -198,8 +198,9 @@ struct ProjectDispatcher: OperationTraceDispatching {
                 )
             }
             audit(command, phase: .executed)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "project.new")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "project.new")
+            }
             // v3.1.2 (P0-3) — clear cache on lifecycle success so the next
             // resource read / name-based routing decision sees the fresh
             // project's tracks instead of the previous project's stale list.
@@ -245,11 +246,12 @@ struct ProjectDispatcher: OperationTraceDispatching {
                 )
             }
             audit(command, phase: .executed)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "project.open",
-                params: ["path": path]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "project.open",
+                    params: ["path": path]
+                )
+            }
             // v3.1.2 (P0-3) — same cache stale-after-lifecycle bug as `new`.
             await invalidateOnSuccess(command: command, result: result, cache: cache, targetRegistry: targetRegistry)
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
@@ -268,8 +270,9 @@ struct ProjectDispatcher: OperationTraceDispatching {
             // verification lives in the AppleScript channel (the reliable
             // writer, now tried first) so it stays DI-testable like save_as;
             // the dispatcher just routes + surfaces the channel's HC verdict.
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "project.save")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "project.save")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "save_as":
@@ -305,11 +308,12 @@ struct ProjectDispatcher: OperationTraceDispatching {
                 )
             }
             audit(command, phase: .executed)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "project.save_as",
-                params: ["path": path]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "project.save_as",
+                    params: ["path": path]
+                )
+            }
             if FeatureFlags.adr002TargetRef {
                 await invalidateOnSuccess(command: command, result: result, cache: cache, targetRegistry: targetRegistry)
             }
@@ -342,11 +346,12 @@ struct ProjectDispatcher: OperationTraceDispatching {
                 )
             }
             audit(command, phase: .executed)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "project.close",
-                params: ["saving": saving]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "project.close",
+                    params: ["saving": saving]
+                )
+            }
             // v3.1.2 (P0-3) — closing the project leaves the cache stuffed
             // with the just-closed tracks/regions/markers. Clear so resource
             // reads honestly reflect "no project" until the next open.
@@ -376,8 +381,9 @@ struct ProjectDispatcher: OperationTraceDispatching {
                 return await finalizeTrace(block, traceID: traceID)
             }
             audit(command, phase: .executed)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "project.bounce")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "project.bounce")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "is_running":
@@ -692,6 +698,12 @@ struct ProjectDispatcher: OperationTraceDispatching {
         }
 
         var renamed: [[String: Any]] = []
+        // #389: cleanup_apply reaches the router only through nested
+        // TrackDispatcher.handle calls, each of which arms and commits its OWN
+        // child boundary — the parent trace would otherwise show none. Keep the
+        // explicit parent emit here; propagating a child's committed boundary up
+        // to its parent trace (so this becomes observation, not intent, like the
+        // routed ops) is future work.
         await recordWriteBoundary(traceID)
         for (target, newName) in zip(targets, names) {
             let result = await TrackDispatcher.handle(
@@ -973,6 +985,9 @@ struct ProjectDispatcher: OperationTraceDispatching {
         sleep: (UInt64) async -> Void,
         traceID: TraceID?
     ) async -> CallTool.Result {
+        // #389: no router involved — the AppleScript launch/quit IS the external
+        // effect, and it is about to run unconditionally, so the immediate emit
+        // is an honest observation of the genuine first write.
         await recordWriteBoundary(traceID)
         let execution = await execute(script)
         if let executionError = execution.executionError {

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
@@ -159,11 +159,12 @@ extension TrackDispatcher {
         // above), so the goto-dialog is enabled on any non-empty project,
         // and on an empty project the playhead is already at bar 1 and the
         // slider fallback succeeds trivially.
-        await recordWriteBoundary(traceID)
-        let gotoResult = await router.route(
-            operation: "transport.goto_position",
-            params: ["bar": "1"]
-        )
+        let gotoResult = await withWriteBoundaryArmed(traceID) {
+            await router.route(
+                operation: "transport.goto_position",
+                params: ["bar": "1"]
+            )
+        }
         guard gotoResult.isSuccess else {
             return toolTextResult(
                 "record_sequence failed to reset playhead to bar 1 (required for accurate import): \(gotoResult.message)",

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -84,11 +84,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 ) {
                 case .success(let resolved):
                     let traceID = await startTraceIfEnabled(command: command)
-                    await recordWriteBoundary(traceID)
-                    let result = await router.route(
-                        operation: "track.select",
-                        params: ["index": String(resolved.index)]
-                    )
+                    let result = await withWriteBoundaryArmed(traceID) {
+                        await router.route(
+                            operation: "track.select",
+                            params: ["index": String(resolved.index)]
+                        )
+                    }
                     return await finalizeTrace(
                         TargetRefResolver.addEvidence(
                             resolved.reference,
@@ -115,11 +116,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                     )
                 }
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "track.select",
-                    params: ["index": String(index)]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "track.select",
+                        params: ["index": String(index)]
+                    )
+                }
                 return await finalizeTrace(toolTextResult(result), traceID: traceID)
             }
             let name = stringParam(params, "name")
@@ -127,11 +129,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 let tracks = await cache.getTracks()
                 if let track = tracks.first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
                     let traceID = await startTraceIfEnabled(command: command)
-                    await recordWriteBoundary(traceID)
-                    let result = await router.route(
-                        operation: "track.select",
-                        params: ["index": String(track.id)]
-                    )
+                    let result = await withWriteBoundaryArmed(traceID) {
+                        await router.route(
+                            operation: "track.select",
+                            params: ["index": String(track.id)]
+                        )
+                    }
                     return await finalizeTrace(toolTextResult(result), traceID: traceID)
                 }
                 return toolStateCResult(
@@ -148,8 +151,9 @@ struct TrackDispatcher: OperationTraceDispatching {
         case "create_audio", "create_instrument", "create_drummer", "create_external_midi":
             // 4 byte-identical bodies; the channel op is always "track.<command>".
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "track.\(command)")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "track.\(command)")
+            }
             if result.isSuccess, !channelSuccessIsVerified(result) {
                 return await finalizeTrace(
                     toolTextResult(result.message, isError: true),
@@ -194,11 +198,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 return bindingFailure
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let selectResult = await router.route(
-                operation: "track.select",
-                params: ["index": String(index)]
-            )
+            let selectResult = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.select",
+                    params: ["index": String(index)]
+                )
+            }
             guard selectResult.isSuccess else {
                 return await finalizeTrace(
                     toolTextResult(selectResult.message, isError: true),
@@ -272,11 +277,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 return bindingFailure
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let selectResult = await router.route(
-                operation: "track.select",
-                params: ["index": String(index)]
-            )
+            let selectResult = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.select",
+                    params: ["index": String(index)]
+                )
+            }
             guard selectResult.isSuccess else {
                 return await finalizeTrace(
                     toolTextResult(selectResult.message, isError: true),
@@ -357,11 +363,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "track.rename",
-                params: ["index": String(index), "name": name]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.rename",
+                    params: ["index": String(index), "name": name]
+                )
+            }
             guard result.isSuccess else {
                 return await finalizeTrace(
                     toolTextResult(result.message, isError: true),
@@ -511,27 +518,38 @@ struct TrackDispatcher: OperationTraceDispatching {
             }
             let tracks = await cache.getTracks()
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            var disarmed: [Int] = []
-            var unverifiedDisarm: [Int] = []
-            var failedDisarm: [Int] = []
-            for t in tracks where t.id != index && t.isArmed {
-                let r = await router.route(
-                    operation: "track.set_arm",
-                    params: ["index": String(t.id), "enabled": "false"]
-                )
-                if !r.isSuccess {
-                    failedDisarm.append(t.id)
-                } else if trackToggleResultIsVerified(r) {
-                    disarmed.append(t.id)
-                } else {
-                    unverifiedDisarm.append(t.id)
+            // #389: arm_only's write is the whole disarm-sweep + target-arm
+            // sequence, so ONE arm scope spans it — the once-commit bit puts the
+            // boundary on whichever of those routes dispatches a channel first
+            // (a disarm hop when other tracks are armed, else the target arm).
+            let armSequence = await withWriteBoundaryArmed(traceID) {
+                () async -> (disarmed: [Int], unverified: [Int], failed: [Int], armResult: ChannelResult) in
+                var disarmed: [Int] = []
+                var unverifiedDisarm: [Int] = []
+                var failedDisarm: [Int] = []
+                for t in tracks where t.id != index && t.isArmed {
+                    let r = await router.route(
+                        operation: "track.set_arm",
+                        params: ["index": String(t.id), "enabled": "false"]
+                    )
+                    if !r.isSuccess {
+                        failedDisarm.append(t.id)
+                    } else if trackToggleResultIsVerified(r) {
+                        disarmed.append(t.id)
+                    } else {
+                        unverifiedDisarm.append(t.id)
+                    }
                 }
+                let armResult = await router.route(
+                    operation: "track.set_arm",
+                    params: ["index": String(index), "enabled": "true"]
+                )
+                return (disarmed, unverifiedDisarm, failedDisarm, armResult)
             }
-            let armResult = await router.route(
-                operation: "track.set_arm",
-                params: ["index": String(index), "enabled": "true"]
-            )
+            let disarmed = armSequence.disarmed
+            let unverifiedDisarm = armSequence.unverified
+            let failedDisarm = armSequence.failed
+            let armResult = armSequence.armResult
             // If the primary arm action failed, return an explicit error instead
             // of a structured success payload. Partial-disarm visibility still
             // available in the error detail.
@@ -657,11 +675,12 @@ struct TrackDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "track.set_automation",
-                params: ["index": String(index), "mode": mode]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.set_automation",
+                    params: ["index": String(index), "mode": mode]
+                )
+            }
             return await finalizeTrace(
                 TargetRefResolver.addEvidence(
                     resolvedReference,
@@ -730,11 +749,12 @@ struct TrackDispatcher: OperationTraceDispatching {
             ) {
                 return await finalizeTrace(bindingFailure, traceID: traceID)
             }
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "track.set_instrument",
-                params: routeParams
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.set_instrument",
+                    params: routeParams
+                )
+            }
             if FeatureFlags.adr002TargetRef, channelResultIsVerified(result) {
                 await targetRegistry?.bumpTopologyGeneration()
             }
@@ -883,11 +903,12 @@ struct TrackDispatcher: OperationTraceDispatching {
         } else {
             enabled = true
         }
-        await recordWriteBoundary(traceID)
-        let result = await router.route(
-            operation: operation,
-            params: ["index": String(index), "enabled": String(enabled)]
-        )
+        let result = await withWriteBoundaryArmed(traceID) {
+            await router.route(
+                operation: operation,
+                params: ["index": String(index), "enabled": String(enabled)]
+            )
+        }
         // #106: never surface an unverified channel success — a State B
         // "success without read-back" is reported as an error so callers
         // can't mistake a fired-but-unconfirmed toggle for a verified one.

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -70,27 +70,31 @@ struct TransportDispatcher: OperationTraceDispatching {
 
         case "rewind":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.rewind")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.rewind")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "fast_forward":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.fast_forward")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.fast_forward")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_cycle":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.toggle_cycle")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.toggle_cycle")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_metronome":
             let traceID = await startTraceIfEnabled(command: command)
             let beforeTransport = await liveTransportState(router: router, cache: cache)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.toggle_metronome")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.toggle_metronome")
+            }
             let finalized = await finalizeToggleMetronomeResult(
                 result,
                 beforeTransport: beforeTransport,
@@ -101,14 +105,16 @@ struct TransportDispatcher: OperationTraceDispatching {
 
         case "toggle_count_in":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.toggle_count_in")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.toggle_count_in")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "toggle_autopunch":
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(operation: "transport.toggle_autopunch")
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(operation: "transport.toggle_autopunch")
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "set_tempo":
@@ -131,11 +137,12 @@ struct TransportDispatcher: OperationTraceDispatching {
                     )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "transport.set_tempo",
-                params: ["bpm": String(tempo)]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "transport.set_tempo",
+                    params: ["bpm": String(tempo)]
+                )
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         case "goto_position":
@@ -170,11 +177,12 @@ struct TransportDispatcher: OperationTraceDispatching {
                     )
                 }
                 let traceID = await startTraceIfEnabled(command: command)
-                await recordWriteBoundary(traceID)
-                let result = await router.route(
-                    operation: "transport.goto_position",
-                    params: ["position": "\(bar).1.1.1"]
-                )
+                let result = await withWriteBoundaryArmed(traceID) {
+                    await router.route(
+                        operation: "transport.goto_position",
+                        params: ["position": "\(bar).1.1.1"]
+                    )
+                }
                 let finalized = await finalizeGotoPositionResult(
                     result,
                     requestedPosition: "\(bar).1.1.1",
@@ -193,11 +201,12 @@ struct TransportDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "transport.goto_position",
-                params: ["position": time]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "transport.goto_position",
+                    params: ["position": time]
+                )
+            }
             let finalized = await finalizeGotoPositionResult(
                 result,
                 requestedPosition: time,
@@ -231,11 +240,12 @@ struct TransportDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            await recordWriteBoundary(traceID)
-            let result = await router.route(
-                operation: "transport.set_cycle_range",
-                params: ["start": "\(start).1.1.1", "end": "\(end).1.1.1"]
-            )
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "transport.set_cycle_range",
+                    params: ["start": "\(start).1.1.1", "end": "\(end).1.1.1"]
+                )
+            }
             return await finalizeTrace(toolTextResult(result), traceID: traceID)
 
         default:
@@ -288,8 +298,9 @@ struct TransportDispatcher: OperationTraceDispatching {
             )))
         }
 
-        await recordWriteBoundary(traceID)
-        let writeResult = await router.route(operation: "transport.stop")
+        let writeResult = await withWriteBoundaryArmed(traceID) {
+            await router.route(operation: "transport.stop")
+        }
         guard writeResult.isSuccess else {
             return toolTextResult(writeResult)
         }
@@ -377,8 +388,9 @@ struct TransportDispatcher: OperationTraceDispatching {
             )))
         }
 
-        await recordWriteBoundary(traceID)
-        let writeResult = await router.route(operation: "transport.pause")
+        let writeResult = await withWriteBoundaryArmed(traceID) {
+            await router.route(operation: "transport.pause")
+        }
         let writePayload = jsonValue(from: writeResult.message)
 
         var attempts = 0
@@ -645,8 +657,9 @@ struct TransportDispatcher: OperationTraceDispatching {
             )))
         }
 
-        await recordWriteBoundary(traceID)
-        let writeResult = await router.route(operation: action.operation)
+        let writeResult = await withWriteBoundaryArmed(traceID) {
+            await router.route(operation: action.operation)
+        }
         let writePayload = jsonValue(from: writeResult.message)
         var attempts = 0
         var afterState: TransportState?

--- a/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportExecutor.swift
@@ -232,6 +232,10 @@ enum ProjectExportExecutor {
         }
 
         // (3a) Open the project (existing open path through the router).
+        // #389 known residual (accepted, not fixed): this notify fires BEFORE the
+        // open route, so an export boundary is still intent — not observation —
+        // if that route dispatches no channel. The arm/commit seam covers routed
+        // dispatcher writes, not this injected callback.
         await firstWriteNotifier.notify()
         let openResult = await router.route(
             operation: "project.open",

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -4,6 +4,70 @@ enum OperationTraceParentBoundary {
     @TaskLocal static var onWriteBoundary: (@Sendable () async -> Void)?
 }
 
+/// #389: arm/commit carrier for `write_boundary.crossed`.
+///
+/// The phase used to be recorded by the dispatcher *before* it routed, which
+/// made it a claim of intent rather than an observation: a route that resolved
+/// no channel (unknown op, empty chain, unregistered/unhealthy channel, or a
+/// preflight skip) still stamped a boundary it never crossed. The dispatcher now
+/// only ARMS the boundary; the router COMMITS it at the first channel that is
+/// actually dispatched, so the phase can only appear when a channel executed.
+///
+/// The arm is deliberately scoped to exactly ONE `router.route` call (see
+/// `withWriteBoundaryArmed`) and is cleared on scope exit whether or not the
+/// commit fired. A sticky, op-lifetime arm is FORBIDDEN: dispatchers that read
+/// before they write (the `toggle_metronome` read-then-write class) would commit
+/// the boundary onto the *pre-read's* channel.started — a false boundary earlier
+/// than the write. TaskLocal scoping makes that structurally impossible instead
+/// of relying on call-site ordering staying as it is today.
+final class OperationTraceWriteBoundaryArm: @unchecked Sendable {
+    /// Sibling TaskLocal, never state on `ChannelRouter` (a shared actor would
+    /// leak arms across concurrent ops) nor on `OperationTraceStore`.
+    @TaskLocal static var current: OperationTraceWriteBoundaryArm?
+
+    private let lock = NSLock()
+    private let traceID: TraceID?
+    private var committed = false
+
+    init(traceID: TraceID?) {
+        self.traceID = traceID
+    }
+
+    /// Once-commit bit: true for the first armed channel.started only, so a
+    /// fallback chain that retries on a second channel records one boundary.
+    private func claimCommit() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if committed { return false }
+        committed = true
+        return true
+    }
+
+    /// Called by `ChannelRouter` at each channel.started. No arm (read route,
+    /// or a write route outside an arm scope) means no-op.
+    static func commitIfArmed() async {
+        guard let arm = current, arm.claimCommit() else { return }
+        // Saga parents inherit the corrected timing through the same hook the
+        // pre-route emit used, so a child's first real write moves the parent
+        // boundary too.
+        if let onWriteBoundary = OperationTraceParentBoundary.onWriteBoundary {
+            await onWriteBoundary()
+        }
+        // Explicit ID: `OperationTraceContext.record` no-ops when the op's
+        // trace is not registered in this task's context (dispatcher-scoped
+        // tests, saga children), but the boundary is still honest there.
+        guard let traceID = arm.traceID else { return }
+        await OperationTraceStore.shared.record(traceID, phase: .writeBoundaryCrossed)
+    }
+
+    /// Arm the boundary for the duration of `route` only.
+    static func armed<T>(_ traceID: TraceID?, _ route: () async -> T) async -> T {
+        await $current.withValue(OperationTraceWriteBoundaryArm(traceID: traceID)) {
+            await route()
+        }
+    }
+}
+
 /// ADR-005: task-scoped carrier that lets deep seams (router, channels,
 /// verification polls, saga) record onto the active operation trace without
 /// threading a TraceID through every signature. The server opens one scope
@@ -81,6 +145,19 @@ enum TracePhase: String, Codable, Sendable, CaseIterable {
     case mutationGateAcquired = "mutation_gate.acquired"
     case routeEvaluated = "route.evaluated"
     case channelStarted = "channel.started"
+    /// #389 — diagnostic only. Means: the first channel-execute entry under an
+    /// armed write route (or, for the non-router writers, the genuine first
+    /// external effect: support-bundle/export materialization and the project
+    /// lifecycle AppleScript). It is NOT the HC `write_attempted` flag and NOT
+    /// saga compensation input — both of those stay envelope-driven via
+    /// `StepResult.writeBoundaryCrossed`, which this phase never feeds.
+    ///
+    /// Known residual (accepted): when an armed route's first channel fails
+    /// before its effect lands and a fallback channel then succeeds, the
+    /// boundary sits at the first attempt, not the channel that wrote. Moving
+    /// it would need commit-inside-the-channel, which is out of scope; the
+    /// phase's contract is "a channel began executing this write", not "this
+    /// exact channel wrote".
     case writeBoundaryCrossed = "write_boundary.crossed"
     case channelCompleted = "channel.completed"
     case verificationPoll = "verification.poll"

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -82,6 +82,55 @@ private struct OperationTraceCoverageFixtures {
     let midiPath: String
 }
 
+/// Shared fixture for the #389 store-wide censuses: the same temp project /
+/// output roots, all-channel router and seeded cache the mutating census builds,
+/// so both censuses drive the real bound dispatchers over every mutating spec.
+private struct OperationTraceCensusContext {
+    let fixtures: OperationTraceCoverageFixtures
+    let router: ChannelRouter
+    let cache: StateCache
+    let mutatingSpecs: [OperationSpec]
+    let cleanup: @Sendable () -> Void
+}
+
+private func makeOperationTraceCensusContext() async throws -> OperationTraceCensusContext {
+    let projectRoot = try makeExecTempDir()
+    let outputRoot = try makeExecTempDir()
+    let project = try makeLogicxProject(in: projectRoot, named: "Trace Census")
+    let resources = project.appendingPathComponent("Resources", isDirectory: true)
+    let alternative = project.appendingPathComponent("Alternatives/000", isDirectory: true)
+    try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: alternative, withIntermediateDirectories: true)
+    try Data().write(to: resources.appendingPathComponent("ProjectInformation.plist"))
+    try Data().write(to: alternative.appendingPathComponent("ProjectData"))
+    let midiFile = try SMFWriter.temporaryMIDIFile()
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: midiFile.fileURL)
+
+    let router = ChannelRouter()
+    for channelID in ChannelID.allCases {
+        await router.register(OperationTraceCoverageChannel(id: channelID))
+    }
+    let cache = StateCache()
+    await cache.updateMarkers([
+        MarkerState(id: 0, name: "Coverage Marker", position: "1.1.1.1", positionSource: .parser),
+    ])
+    return OperationTraceCensusContext(
+        fixtures: OperationTraceCoverageFixtures(
+            projectPath: project.path,
+            outputRoot: outputRoot.path,
+            midiPath: midiFile.fileURL.path
+        ),
+        router: router,
+        cache: cache,
+        mutatingSpecs: OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` },
+        cleanup: {
+            try? FileManager.default.removeItem(at: projectRoot)
+            try? FileManager.default.removeItem(at: outputRoot)
+            SMFWriter.cleanupTemporaryMIDIFile(midiFile)
+        }
+    )
+}
+
 private let operationTraceCoverageFileReader = LogicProjectFileReader.Runtime(
     currentDocumentPath: { nil },
     now: Date.init,
@@ -278,6 +327,140 @@ extension OperationTraceTests {
                 Comment(rawValue: "Read-only command recorded writeBoundaryCrossed: \(spec.id.rawValue)")
             )
         }
+
+        await OperationTraceStore.shared.clear()
+    }
+
+    /// #389 store-wide ORDERING census. For every mutating registry spec, no
+    /// trace may place `writeBoundaryCrossed` before its first `channelStarted`:
+    /// the boundary is committed BY the router at the channel it dispatches, so
+    /// a boundary that precedes every channel is a boundary the op never crossed.
+    /// Traces that have one phase but not the other are exempt — non-router
+    /// writers (export/AppleScript) legitimately have a boundary and no channel,
+    /// and a route that dispatched nothing legitimately has neither.
+    @Test func OperationTraceWriteBoundaryNeverPrecedesChannelStartedCensus() async throws {
+        let previous = replaceOperationTraceCoverageFlag(with: "1")
+        defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
+        let rootKey = "LOGIC_MCP_SUPPORT_BUNDLE_ROOT_OVERRIDE"
+        let previousRoot = getenv(rootKey).map { String(cString: $0) }
+        setenv(rootKey, FileManager.default.temporaryDirectory.path, 1)
+        defer {
+            if let previousRoot { setenv(rootKey, previousRoot, 1) } else { unsetenv(rootKey) }
+        }
+
+        let context = try await makeOperationTraceCensusContext()
+        defer { context.cleanup() }
+
+        var tracesWithBoth = 0
+        for spec in context.mutatingSpecs {
+            await OperationTraceStore.shared.clear()
+            let traceContext = OperationTraceContext(mutationGateAcquired: true)
+            _ = await OperationTraceContext.$current.withValue(traceContext) {
+                await dispatchOperationTraceCoverageSpec(
+                    spec,
+                    params: operationTraceCoverageParams(for: spec.id, fixtures: context.fixtures),
+                    router: context.router,
+                    cache: context.cache
+                )
+            }
+            for trace in await OperationTraceStore.shared.recent(limit: 128) {
+                let phases = trace.events.map(\.phase)
+                guard let boundary = phases.firstIndex(of: .writeBoundaryCrossed),
+                      let firstChannel = phases.firstIndex(of: .channelStarted) else { continue }
+                tracesWithBoth += 1
+                #expect(
+                    boundary >= firstChannel,
+                    Comment(rawValue: "\(spec.id.rawValue): writeBoundaryCrossed at \(boundary) precedes first channelStarted at \(firstChannel)")
+                )
+            }
+        }
+        // Guard the guard: if no traced op ever produced both phases the loop
+        // above would pass vacuously and prove nothing.
+        #expect(tracesWithBoth > 0, "ordering census exercised no trace with both phases")
+
+        await OperationTraceStore.shared.clear()
+    }
+
+    /// #389 store-wide PRESENCE census — the failure mode ordering is blind to.
+    /// An op whose arm was forgotten (or whose scope closed before the route)
+    /// records channels but NO boundary, and every ordering assertion still
+    /// passes because the phase simply is not there. For each mutating spec that
+    /// dispatched a channel under an armed write path, assert the boundary EXISTS
+    /// at/after that channel.
+    @Test func OperationTraceWriteBoundaryPresentForDispatchedMutationsCensus() async throws {
+        let previous = replaceOperationTraceCoverageFlag(with: "1")
+        defer { _ = replaceOperationTraceCoverageFlag(with: previous) }
+        let rootKey = "LOGIC_MCP_SUPPORT_BUNDLE_ROOT_OVERRIDE"
+        let previousRoot = getenv(rootKey).map { String(cString: $0) }
+        setenv(rootKey, FileManager.default.temporaryDirectory.path, 1)
+        defer {
+            if let previousRoot { setenv(rootKey, previousRoot, 1) } else { unsetenv(rootKey) }
+        }
+
+        let context = try await makeOperationTraceCensusContext()
+        defer { context.cleanup() }
+
+        // `eligible` = ops observed dispatching a channel in THIS run; `covered`
+        // = those that also carried the boundary. The invariant is equality:
+        // every op that reached a channel crossed a write boundary and must say
+        // so. Deriving `eligible` from the run (rather than a hardcoded floor)
+        // means a regression that silently drops armed coverage is caught at any
+        // scale, not just below an arbitrary threshold.
+        var eligible: [String] = []
+        var covered: [String] = []
+        for spec in context.mutatingSpecs {
+            await OperationTraceStore.shared.clear()
+            let traceContext = OperationTraceContext(mutationGateAcquired: true)
+            // The probe counts commits independently of the store, so an op that
+            // dispatches a channel with a nil/unregistered trace is still seen.
+            let boundaryProbe = WriteBoundaryProbe()
+            _ = await OperationTraceParentBoundary.$onWriteBoundary.withValue({
+                await boundaryProbe.record()
+            }) {
+                await OperationTraceContext.$current.withValue(traceContext) {
+                    await dispatchOperationTraceCoverageSpec(
+                        spec,
+                        params: operationTraceCoverageParams(for: spec.id, fixtures: context.fixtures),
+                        router: context.router,
+                        cache: context.cache
+                    )
+                }
+            }
+
+            guard let trace = await OperationTraceStore.shared.recent(limit: 128)
+                .first(where: { $0.operationID == spec.id.rawValue }) else { continue }
+            let phases = trace.events.map(\.phase)
+            guard let firstChannel = phases.firstIndex(of: .channelStarted) else { continue }
+            eligible.append(spec.id.rawValue)
+            // A channel executed for a mutating op ⇒ the write boundary was
+            // crossed and must be recorded at/after that channel.
+            guard let boundary = phases.firstIndex(of: .writeBoundaryCrossed) else {
+                Issue.record(Comment(rawValue: "\(spec.id.rawValue): dispatched a channel but recorded NO writeBoundaryCrossed"))
+                continue
+            }
+            #expect(
+                boundary >= firstChannel,
+                Comment(rawValue: "\(spec.id.rawValue): boundary at \(boundary) precedes channelStarted at \(firstChannel)")
+            )
+            #expect(
+                await boundaryProbe.count > 0,
+                Comment(rawValue: "\(spec.id.rawValue): recorded a boundary but never fired the parent hook")
+            )
+            covered.append(spec.id.rawValue)
+        }
+        // The honest invariant: channel-dispatching ⇒ boundary-carrying, for
+        // every op, with no coverage floor to hide behind.
+        let missing = Set(eligible).subtracting(covered).sorted()
+        #expect(
+            covered.count == eligible.count,
+            Comment(rawValue: "\(missing.count)/\(eligible.count) channel-dispatching ops carried no write boundary: \(missing)")
+        )
+        // Guard the guard: a refactor that stopped dispatching channels entirely
+        // would make the equality above hold vacuously (0 == 0).
+        #expect(
+            eligible.count >= 40,
+            Comment(rawValue: "presence census only saw \(eligible.count) channel-dispatching ops: \(eligible.sorted())")
+        )
 
         await OperationTraceStore.shared.clear()
     }

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -207,14 +207,15 @@ struct OperationTraceTests {
         let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
         #expect(context.traceID?.rawValue == rawID)
         // transport.play performs three routed calls — the pre-state probe,
-        // the mutation itself (write boundary recorded just before it), and
-        // the verification readback — and every one is visible on the trace.
+        // the mutation itself, and the verification readback — and every one is
+        // visible on the trace. #389: the write boundary sits INSIDE the second
+        // (mutating) route, committed by the router at that channel's start —
+        // never in the pre-read's channel group and never before any route.
         #expect(trace.events.map(\.phase) == [
             .requestReceived, .inputValidated,
             .mutationGateWaitStarted, .mutationGateAcquired,
             .routeEvaluated, .channelStarted, .channelCompleted,
-            .writeBoundaryCrossed,
-            .routeEvaluated, .channelStarted, .channelCompleted,
+            .routeEvaluated, .channelStarted, .writeBoundaryCrossed, .channelCompleted,
             .routeEvaluated, .channelStarted, .channelCompleted,
             .verificationCompleted, .resultEmitted,
         ])
@@ -227,6 +228,54 @@ struct OperationTraceTests {
                 OperationTraceStore.attributePrivacyClasses.keys
             ))
         })
+    }
+
+    /// #389 read-then-write pin. `toggle_metronome` probes live transport state
+    /// BEFORE it writes, so it is the class that a sticky, op-lifetime write-boundary
+    /// arm gets wrong: the arm would commit on the PRE-READ's channel.started and
+    /// report a boundary the op had not yet crossed. The arm is scoped to the write
+    /// route alone, so the boundary must land inside the second route group — after
+    /// the pre-read's channel bracket closes, never inside it.
+    @Test func OperationTraceReadThenWriteBoundarySkipsPreReadChannel() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTransportChannel(states: [
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+            #"{"isPlaying":false,"isRecording":false,"position":"1.1.1.1","tempo":120}"#,
+        ])
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let context = OperationTraceContext(mutationGateAcquired: true)
+        _ = await OperationTraceContext.$current.withValue(context) {
+            await TransportDispatcher.handle(
+                command: "toggle_metronome",
+                params: [:],
+                router: router,
+                cache: StateCache(),
+                sleep: { _ in }
+            )
+        }
+
+        let traceID = try #require(context.traceID)
+        let trace = try #require(await OperationTraceStore.shared.trace(traceID))
+        let phases = trace.events.map(\.phase)
+        let boundary = try #require(phases.firstIndex(of: .writeBoundaryCrossed))
+        // The pre-read routes first; the boundary belongs to the route AFTER it.
+        let routesBeforeBoundary = phases[..<boundary].filter { $0 == .routeEvaluated }.count
+        #expect(
+            routesBeforeBoundary == 2,
+            "boundary must sit in the WRITE route group, not the pre-read's (routes before it: \(routesBeforeBoundary))"
+        )
+        // The pre-read's channel bracket must be fully closed before the boundary.
+        let firstCompleted = try #require(phases.firstIndex(of: .channelCompleted))
+        #expect(boundary > firstCompleted, "boundary must not land inside the pre-read channel group")
+        let executed = await channel.executedOperations
+        #expect(executed.first == "transport.get_state")
+        #expect(executed.contains("transport.toggle_metronome"))
+        await OperationTraceStore.shared.clear()
     }
 
     /// Saga-child correlation: a context carrying a parent trace ID stamps
@@ -608,6 +657,58 @@ extension OperationTraceTests {
         })
     }
 
+    /// #389: write_boundary.crossed must (a) never be recorded when the op
+    /// resolves no route (no channel is dispatched), and (b) on a successful op
+    /// sit at/after the writing channel.started and before verification.
+    @Test
+    func writeBoundaryHonorsChannelDispatch() async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+
+        // (a) No channel registered → route resolves nothing → NO write boundary.
+        await OperationTraceStore.shared.clear()
+        let deadContext = OperationTraceContext(mutationGateAcquired: true)
+        _ = await OperationTraceContext.$current.withValue(deadContext) {
+            await MixerDispatcher.handle(
+                command: "set_volume",
+                params: ["track": .int(2), "value": .double(0.5)],
+                router: ChannelRouter(),
+                cache: StateCache()
+            )
+        }
+        let deadTraceID = try #require(deadContext.traceID)
+        let deadTrace = try #require(await OperationTraceStore.shared.trace(deadTraceID))
+        let deadPhases = deadTrace.events.map(\.phase)
+        #expect(!deadPhases.contains(.channelStarted))
+        #expect(
+            !deadPhases.contains(.writeBoundaryCrossed),
+            "a write with no dispatched channel must not record write_boundary.crossed"
+        )
+
+        // (b) Healthy channel → boundary at/after channel.started, before verify.
+        await OperationTraceStore.shared.clear()
+        let router = ChannelRouter()
+        await router.register(OperationTraceMixerChannel())
+        let context = OperationTraceContext(mutationGateAcquired: true)
+        _ = await OperationTraceContext.$current.withValue(context) {
+            await MixerDispatcher.handle(
+                command: "set_volume",
+                params: ["track": .int(2), "value": .double(0.5)],
+                router: router,
+                cache: StateCache()
+            )
+        }
+        let traceID = try #require(context.traceID)
+        let trace = try #require(await OperationTraceStore.shared.trace(traceID))
+        let phases = trace.events.map(\.phase)
+        let boundary = try #require(phases.firstIndex(of: .writeBoundaryCrossed))
+        let started = try #require(phases.firstIndex(of: .channelStarted))
+        let verified = try #require(phases.firstIndex(of: .verificationCompleted))
+        #expect(boundary >= started, "write_boundary.crossed must be at/after channel.started")
+        #expect(boundary < verified, "write_boundary.crossed must be before verification.completed")
+        await OperationTraceStore.shared.clear()
+    }
+
     @Test(arguments: ["set_volume", "set_pan"])
     func OperationTraceMixerInvalidParamsDoNotTrace(command: String) async {
         let previous = replaceOperationTraceFlag(with: "1")
@@ -679,6 +780,45 @@ extension OperationTraceTests {
         #expect(sharedJSONObject(sharedToolText(result))?["trace_id"] == nil)
         #expect(await channel.executedOperations == [operation])
         #expect(await OperationTraceStore.shared.recent().isEmpty)
+    }
+
+    /// #389 scoped ordering pin for the tracks surface. The tracks dispatcher
+    /// routes its writes through `handleToggle`, a seam the transport/mixer pins
+    /// do not cover — under a trace context its boundary must be committed BY the
+    /// router at the channel it dispatched, never stamped ahead of it.
+    @Test(arguments: ["rename", "mute"])
+    func OperationTraceTracksScopedBoundaryFollowsChannelStarted(command: String) async throws {
+        let previous = replaceOperationTraceFlag(with: "1")
+        defer { _ = replaceOperationTraceFlag(with: previous) }
+        await OperationTraceStore.shared.clear()
+
+        let channel = OperationTraceTrackChannel()
+        let router = ChannelRouter()
+        await router.register(channel)
+
+        let context = OperationTraceContext(mutationGateAcquired: true)
+        _ = await OperationTraceContext.$current.withValue(context) {
+            await TrackDispatcher.handle(
+                command: command,
+                params: command == "rename"
+                    ? ["index": .int(2), "name": .string("Trace Track")]
+                    : ["index": .int(2), "enabled": .bool(true)],
+                router: router,
+                cache: StateCache()
+            )
+        }
+
+        let traceID = try #require(context.traceID)
+        let trace = try #require(await OperationTraceStore.shared.trace(traceID))
+        let phases = trace.events.map(\.phase)
+        let boundary = try #require(phases.firstIndex(of: .writeBoundaryCrossed))
+        let started = try #require(phases.firstIndex(of: .channelStarted))
+        let verified = try #require(phases.firstIndex(of: .verificationCompleted))
+        #expect(boundary >= started, "write_boundary.crossed must be at/after channel.started")
+        #expect(boundary < verified, "write_boundary.crossed must be before verification.completed")
+        let operation = command == "rename" ? "track.rename" : "track.set_mute"
+        #expect(await channel.executedOperations == [operation])
+        await OperationTraceStore.shared.clear()
     }
 
     @Test(arguments: ["rename", "mute"])


### PR DESCRIPTION
## Summary

Live-gate defect #389: the `write_boundary.crossed` trace phase was recorded at **intent time** (immediately before `router.route`) at ~63 dispatcher call sites across 9 dispatchers — before the write's own `route.evaluated`/`channel.started` ever fired, violating the `TracePhase` enum's own declared order. A dead-route op recorded a boundary despite never touching a channel; `transport.toggle_metronome` only *looked* correct because an unrelated pre-write read cycle ran in front. Found live against real Logic; the deterministic suite never caught it because its tests asserted phase *presence*, not order.

**Consumer audit first** (recorded on the issue): two things share the "write boundary" name. The **functional** `StepResult.writeBoundaryCrossed` (saga compensation input) is computed from the response envelope's `write_attempted` flag — independent of the trace phase, correct, untouched. The **diagnostic** trace phase is the one with the bug; nothing branches on it for a rollback decision. So severity = trace-honesty (moderate), not compensation suppression.

**Fix — arm/commit** (adversarial-design-gate ratified, 10 amendments):
- New `OperationTraceWriteBoundaryArm`: a sibling `@TaskLocal` holding the traceID + a lock-guarded once-commit bit. `withWriteBoundaryArmed(traceID) { await router.route(...) }` sets it **only inside the closure** — a fresh instance per call, cleared on TaskLocal unwind whether or not commit fired. **Per-route / RAII-scoped, never op-lifetime sticky** — the sticky form was blocked by the design gate because an early arm plus an intervening read route false-commits (the toggle_metronome read-then-write class).
- `ChannelRouter.route` commits once, immediately **after** `.channelStarted` and before `channel.execute`: records `.writeBoundaryCrossed` on the explicit armed ID + fires `OperationTraceParentBoundary.onWriteBoundary` (saga parent inherits the corrected timing) + disarms. Dead route / empty chain / unhealthy skip / preflight bail never reach that line ⇒ no boundary.
- 5 genuine non-channel writes keep immediate emission (bypass arm/commit): support-bundle export ×2, project export `onFirstWrite`, lifecycle AppleScript, cleanup_apply parent. Grep confirmed no other non-router external effect under an active context.
- SagaExecution untouched — the functional field is byte-identical.

## Verification
Focused suite 366; **full `--no-parallel` 2,968 passed**. RED-first: dead-route records no boundary (was: recorded); success orders boundary at/after channel.started (was: index 4 before started's 6). Two new store-wide censuses over all 86 mutating specs — **ordering** (no writeBoundaryCrossed before first channelStarted) and **presence** (a channel-dispatching op MUST carry the boundary) — each mutation-verified: reverting a single arm/emit turns exactly one census RED, and the presence census catches the absence the ordering census is blind to. Read-then-write pin (toggle_metronome boundary not in the pre-read channel group) mutation-verified against the exact sticky-arm the gate blocked. Every new load-bearing assertion uses live `#expect` spellings (issue #393 dead-form avoided) and was reverted-to-RED.

**Gate round (P2s applied):** the presence census was strengthened from a soft `>= 40` floor to **dynamic equality** (`covered.count == eligible.count`, eligible derived from ops that actually dispatched a channel in the run) — the mutation receipt justifies it: deleting one arm in `handleToggle` produced `74 == 77` FAIL naming `["tracks.arm","tracks.mute","tracks.solo"]`, a regression the old floor would have silently passed (74 ≥ 40, ~37 ops of slack). A tracks scoped ordering test was added (parameterized rename+mute, covering the `handleToggle` seam neither the transport pin nor the mixer test touches), mutation-checked.

Accepted residuals, documented in-code: cleanup_apply parent intent-boundary (observation lives on child traces), export_run FirstWriteNotifier-fires-before-open (known phase-order residual on the export path), first-hop-only arms on multi-route ops, boundary-at-first-attempted-channel under fallback.
