### PR TITLE
feature-flag: ADR-005 operation trace DEFAULT ON (#288 R2 promotion)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -1197,7 +1197,7 @@ struct SystemDispatcher: OperationTraceDispatching {
             guard FeatureFlags.adr005OperationTrace else {
                 return toolStateCResult(
                     .notSupported,
-                    hint: "Operation tracing is disabled; set LOGIC_MCP_ADR005_OPERATION_TRACE=1",
+                    hint: "Operation tracing is on by default; it was disabled with LOGIC_MCP_ADR005_OPERATION_TRACE=0",
                     extras: [
                         "operation": "system.get_trace",
                         "trace_disabled": true,
@@ -1253,8 +1253,9 @@ struct SystemDispatcher: OperationTraceDispatching {
                 return toolTextResult(
                     HonestContract.encodeStateC(
                         error: .traceDisabled,
-                        hint: "Operation tracing is disabled; nothing was cleared. "
-                            + "Enable LOGIC_MCP_ADR005_OPERATION_TRACE=1 to record and manage traces.",
+                        hint: "Operation tracing is on by default; it was disabled with "
+                            + "LOGIC_MCP_ADR005_OPERATION_TRACE=0, so nothing was cleared. "
+                            + "Unset the variable (or set it to any value other than \"0\") to record and manage traces.",
                         extras: ["trace_disabled": true, "write_attempted": false]
                     ),
                     isError: true

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -1198,6 +1198,13 @@ private final class QualificationSubprocessSession: @unchecked Sendable {
         // honestly flip to "1". Tracked as PRD-007 follow-up, not fixed here.
         environment["LOGIC_MCP_ADR002_TARGET_REF"] = "0"
         environment["LOGIC_MCP_ADR003_STRICT_PARAMS"] = "1"
+        // ADR-005 #288 R2: operation tracing is now DEFAULT ON, so this "1" no
+        // longer pins a special-case configuration — it pins the SAME behavior a
+        // default deployment runs. Unlike the ADR-002 pin above, promotion
+        // REMOVES the divergence rather than introducing one: qualification and
+        // production now agree here. Left as an explicit "1" (no pin change) so
+        // the intent stays legible and a future kill-switch default flip can't
+        // silently drift qualification off the shipped behavior.
         environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] = "1"
         process.executableURL = request.executableURL.standardizedFileURL
         process.currentDirectoryURL = request.executableURL.deletingLastPathComponent()

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -51,11 +51,20 @@ enum FeatureFlags: Sendable {
         return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR004_MUTATION_SAGA"] == "1"
     }
 
+    /// PRD (ADR-005 #288 R2): promoted from opt-in to DEFAULT ON, so the
+    /// variable is now a kill-switch — read with `!= "0"` because an absent
+    /// variable must mean ON. Only the exact string "0" rolls back; deployments
+    /// already passing the pre-promotion "1" see no change. R2 debate ratified
+    /// the flip: measured overhead is 45.7µs/op (see OperationTraceOverheadBench)
+    /// — 3-4 orders of magnitude under AX round-trip latency; the store is
+    /// bounded (128 traces / 8MiB FIFO); the write-time privacy allowlist is
+    /// live-verified; so the support value — a `trace_id` on every result — is
+    /// worth carrying by default.
     static var adr005OperationTrace: Bool {
         #if DEBUG
         if let adr005OperationTraceOverride { return adr005OperationTraceOverride }
         #endif
-        return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] == "1"
+        return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] != "0"
     }
 
     #if DEBUG

--- a/Tests/LogicProMCPTests/FeatureFlagsTests.swift
+++ b/Tests/LogicProMCPTests/FeatureFlagsTests.swift
@@ -87,10 +87,41 @@ struct FeatureFlagEnvironmentTests {
         }
     }
 
-    @Test("ADR-005 operation trace stays default OFF")
-    func operationTraceDefaultsToFalse() {
+    // ADR-005 #288 R2: `LOGIC_MCP_ADR005_OPERATION_TRACE` is DEFAULT ON. Same
+    // kill-switch shape as ADR-002 above — read with `!= "0"`, so an absent
+    // variable means ON and only the exact string "0" disables tracing. Bare /
+    // negated `#expect` spellings only (see the suite header: `== true/false`
+    // is DEAD under this toolchain and would pass against the old `== "1"`).
+    @Test("(a) ADR-005 no env and no override reads as ON — the shipped default")
+    func operationTraceDefaultsToOn() {
         Self.withEnv("LOGIC_MCP_ADR005_OPERATION_TRACE", nil) {
+            #expect(FeatureFlags.adr005OperationTrace)
+        }
+    }
+
+    @Test("(b) ADR-005 the =0 kill-switch disables tracing — the rollback path")
+    func operationTraceKillSwitchZeroDisables() {
+        Self.withEnv("LOGIC_MCP_ADR005_OPERATION_TRACE", "0") {
             #expect(!FeatureFlags.adr005OperationTrace)
+        }
+    }
+
+    @Test("(c) ADR-005 the pre-promotion =1 opt-in spelling still reads as ON")
+    func operationTraceExplicitOneStaysOn() {
+        Self.withEnv("LOGIC_MCP_ADR005_OPERATION_TRACE", "1") {
+            #expect(FeatureFlags.adr005OperationTrace)
+        }
+    }
+
+    @Test("ADR-005 kill-switch matches \"0\" exactly — =false does NOT disable")
+    func operationTraceKillSwitchMatchesZeroExactly() {
+        for notDisabled in ["false", "off", "no", "", " 0", "00"] {
+            Self.withEnv("LOGIC_MCP_ADR005_OPERATION_TRACE", notDisabled) {
+                #expect(
+                    FeatureFlags.adr005OperationTrace,
+                    "LOGIC_MCP_ADR005_OPERATION_TRACE=\(notDisabled) must NOT read as disabled — only \"0\" is the kill-switch"
+                )
+            }
         }
     }
 }

--- a/Tests/LogicProMCPTests/OperationTraceOverheadBench.swift
+++ b/Tests/LogicProMCPTests/OperationTraceOverheadBench.swift
@@ -1,0 +1,133 @@
+import Foundation
+import MCP
+import Testing
+@testable import LogicProMCP
+
+/// #288 R2: in-process microbenchmark for ADR-005 operation-trace overhead.
+///
+/// This is deliberately NOT a live-AX loop — AX round-trip latency (tens of
+/// milliseconds) swamps microsecond-scale tracing cost, so a live loop cannot
+/// resolve the trace machinery's own overhead. Instead this drives the REAL
+/// dispatch path — `TransportDispatcher.handle(command: "set_tempo", ...)` —
+/// through a fake `.accessibility` channel that answers instantly, isolating
+/// the cost of:
+///   `startTraceIfEnabled` → `OperationTraceContext.record` (×N via
+///   `router.route`) → `finalizeTrace` → `OperationTraceStore` actor hops.
+///
+/// Confirmed real (not a stub): `TransportDispatcher.handle` "set_tempo" calls
+/// `startTraceIfEnabled` (DispatcherSupport.swift:242) which calls
+/// `OperationTraceStore.shared.start`/`.record` (OperationTrace.swift:232,253);
+/// `router.route` (ChannelRouter.swift:104) records `.routeEvaluated`,
+/// `.channelStarted`, `.channelCompleted` via `OperationTraceContext.record`
+/// (OperationTrace.swift:112), which forwards to the same
+/// `OperationTraceStore.shared.record`; `OperationTraceWriteBoundaryArm
+/// .commitIfArmed` (OperationTrace.swift:48) records `.writeBoundaryCrossed`;
+/// `finalizeTrace` (DispatcherSupport.swift:309) records
+/// `.verificationCompleted` + `.resultEmitted` and calls `.complete`. Every one
+/// of those is the production `actor OperationTraceStore` — no mock/stub store
+/// is substituted anywhere in this file.
+private actor OperationTraceOverheadChannel: Channel {
+    nonisolated let id: ChannelID
+
+    init(id: ChannelID) {
+        self.id = id
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        .success("ok")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "operation trace overhead bench")
+    }
+}
+
+extension OperationTraceTests {
+    /// Deliverable: per-op trace overhead in µs = (tracedTotal - untracedTotal) / N.
+    /// The `< 500µs` assertion is a SANITY CEILING for regression-guard purposes
+    /// only — the absolute measured number below is the actual #288 R2 input,
+    /// not this threshold. Do not tighten this into a flaky perf gate.
+    @Test func OperationTraceOverheadMicrobench() async throws {
+        let router = ChannelRouter()
+        await router.register(OperationTraceOverheadChannel(id: .accessibility))
+        let cache = StateCache()
+        let iterations = 10_000
+        let params: [String: Value] = ["tempo": .double(120)]
+
+        // Every iteration goes through a real mutation-gate-shaped context
+        // (mutationGateAcquired: true) so the traced run exercises the
+        // mutationGateWaitStarted/Acquired phases too, not just the
+        // unconditional request/route/channel/result phases.
+        func runDispatch() async {
+            let traceContext = OperationTraceContext(mutationGateAcquired: true)
+            _ = await OperationTraceContext.$current.withValue(traceContext) {
+                await TransportDispatcher.handle(
+                    command: "set_tempo",
+                    params: params,
+                    router: router,
+                    cache: cache,
+                    sleep: { _ in }
+                )
+            }
+        }
+
+        // Warm up (JIT/allocator steady state) outside both timed windows.
+        for _ in 0..<200 {
+            await FeatureFlags.withAdr005OperationTraceForTests(false) {
+                await runDispatch()
+            }
+        }
+
+        let offStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            await FeatureFlags.withAdr005OperationTraceForTests(false) {
+                await runDispatch()
+            }
+        }
+        let offElapsed = ContinuousClock.now - offStart
+
+        for _ in 0..<200 {
+            await FeatureFlags.withAdr005OperationTraceForTests(true) {
+                await runDispatch()
+            }
+            await OperationTraceStore.shared.clear()
+        }
+
+        let onStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            await FeatureFlags.withAdr005OperationTraceForTests(true) {
+                await runDispatch()
+            }
+            // Keep the store from growing unbounded across 10k traced runs;
+            // eviction would otherwise kick in mid-measurement and skew later
+            // iterations relative to earlier ones.
+            await OperationTraceStore.shared.clear()
+        }
+        let onElapsed = ContinuousClock.now - onStart
+
+        let offMicros = Double(offElapsed.components.seconds) * 1_000_000
+            + Double(offElapsed.components.attoseconds) / 1_000_000_000_000
+        let onMicros = Double(onElapsed.components.seconds) * 1_000_000
+            + Double(onElapsed.components.attoseconds) / 1_000_000_000_000
+        let perOpOverheadMicros = (onMicros - offMicros) / Double(iterations)
+
+        // The absolute number is the #288 R2 deliverable — printed so it shows
+        // in test output; the #expect below is a loose anti-regression ceiling.
+        print(
+            "OperationTraceOverheadMicrobench: N=\(iterations) "
+                + "off_total_us=\(String(format: "%.1f", offMicros)) "
+                + "on_total_us=\(String(format: "%.1f", onMicros)) "
+                + "per_op_overhead_us=\(String(format: "%.2f", perOpOverheadMicros))"
+        )
+
+        #expect(
+            perOpOverheadMicros < 500,
+            Comment(rawValue: "trace overhead regression: \(perOpOverheadMicros)µs/op exceeds 500µs sanity ceiling (off=\(offMicros)µs on=\(onMicros)µs, N=\(iterations))")
+        )
+
+        await OperationTraceStore.shared.clear()
+    }
+}

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -49,7 +49,9 @@ private actor OperationTraceTransportChannel: Channel {
 @Suite(.serialized)
 struct OperationTraceTests {
     @Test func OperationTraceTransportFlagOff() async {
-        let previous = replaceOperationTraceFlag(with: nil)
+        // ADR-005 #288 R2: tracing is DEFAULT ON, so proving the OFF path needs
+        // the explicit "0" kill-switch — an unset variable now means ON.
+        let previous = replaceOperationTraceFlag(with: "0")
         defer { _ = replaceOperationTraceFlag(with: previous) }
 
         let router = ChannelRouter()
@@ -582,7 +584,9 @@ private actor OperationTraceMixerChannel: Channel {
 extension OperationTraceTests {
     @Test(arguments: ["set_volume", "set_pan"])
     func OperationTraceMixerFlagOff(command: String) async {
-        let previous = replaceOperationTraceFlag(with: nil)
+        // ADR-005 #288 R2: DEFAULT ON — the OFF path is pinned via the "0"
+        // kill-switch, not an unset variable.
+        let previous = replaceOperationTraceFlag(with: "0")
         defer { _ = replaceOperationTraceFlag(with: previous) }
         await OperationTraceStore.shared.clear()
 
@@ -759,7 +763,9 @@ private actor OperationTraceTrackChannel: Channel {
 extension OperationTraceTests {
     @Test(arguments: ["rename", "mute"])
     func OperationTraceTracksFlagOff(command: String) async {
-        let previous = replaceOperationTraceFlag(with: nil)
+        // ADR-005 #288 R2: DEFAULT ON — the OFF path is pinned via the "0"
+        // kill-switch, not an unset variable.
+        let previous = replaceOperationTraceFlag(with: "0")
         defer { _ = replaceOperationTraceFlag(with: previous) }
         await OperationTraceStore.shared.clear()
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -248,7 +248,7 @@ Common commands: `health`, `permissions`, `refresh_cache`, `export_support_bundl
 
 Use `health` for channel readiness and `help` for command summaries. `help` accepts category `all`, `transport`, `tracks`, `mixer`, `midi`, `edit`, `navigate`, `project`, `audio`, `plugins`, or `system`.
 
-With `LOGIC_MCP_ADR005_OPERATION_TRACE=1`, `list_recent_traces` returns bounded summaries from the in-process trace store and accepts optional `limit`.
+Operation tracing is on by default (set `LOGIC_MCP_ADR005_OPERATION_TRACE=0` to disable), so every **successful** mutating result (State A/B) carries a `trace_id`; State C failures do not (nothing was traced to completion). `list_recent_traces` returns bounded summaries from the in-process trace store and accepts optional `limit`.
 `get_trace` returns one stored trace by required `trace_id`.
 `clear_traces` clears only the in-process trace store and requires `confirmed:true` because it destroys in-session diagnostic evidence.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,7 +70,7 @@ Kernel increments merged to `main`. State-changing pilot paths stay behind their
 - Merged: #318.
 
 ### ADR-005 — Operation Trace and Support Bundle (`In Implementation`)
-- `OperationTraceStore` actor (bounded ring buffer, privacy allowlist), trace-ID + event-phase model with explicit `write_boundary.crossed` instrumentation behind `FeatureFlags.adr005OperationTrace`. `logic_system` trace query commands added.
+- `OperationTraceStore` actor (bounded ring buffer, privacy allowlist), trace-ID + event-phase model with explicit `write_boundary.crossed` instrumentation. **Default-ON** as of the #288 R2 promotion (`FeatureFlags.adr005OperationTrace`, kill-switch `LOGIC_MCP_ADR005_OPERATION_TRACE=0`): successful mutating results carry a `trace_id` by default; measured overhead ~45.7µs/op (3-4 orders under AX latency). `logic_system` trace query commands added.
 - **Coverage is registry-driven across all 86 mutating operations on 9 dispatchers** (a permanent gate iterates `OperationRegistry.specs` and pins the census), not just the original transport/mixer/tracks pilot. Honest scope: this proves trace *existence* per mutating op; write-boundary placement against real AX writes and the richer phase set (route/target/gate/verification-poll/reconciliation/compensation) remain outstanding — 9 of 13 declared `TracePhase` cases are not yet recorded anywhere, and saga child traces are not yet correlated to their parent.
 - Local-only support bundle ships (`doctor.json`, `manifest.json`, `metadata.json`, `redaction_report.json`, `traces.json`, `SHA256SUMS`) with a privacy-class registry and a leak scan; a broader CI fixture corpus is still outstanding.
 - Merged: #317, #320, #330.


### PR DESCRIPTION
## Summary
Promotes `LOGIC_MCP_ADR005_OPERATION_TRACE` to **default-ON** (exact `0` kill-switch), the #288 R2 flag-promotion decision. Successful mutating results (State A/B) carry a `trace_id` by default; State C failures do not. Read-only ops unchanged.

Ratified in the R2 debate on measured evidence: **~45.7µs/op** overhead (N=10k in-process microbench on the real dispatch→actor-store path — shipped as `OperationTraceOverheadBench.swift`, the R2 artifact + anti-regression ceiling), 3-4 orders under AX op latency; store bounded (128/8MiB FIFO); write-time privacy allowlist live-verified.

**Gate (grok) PASS, zero P0/P1**: trace_id envelope change is the intended R2 product goal (documented), not a leak; single flag gate (R3-ready for a default-absent env chain); kill-switch `=0` fully restores pre-promotion behavior; default-ON test is load-bearing. P2 doc fixes applied (API.md State-C skip clarified; ADR-005 README default-ON note). QualificationTransport pin stays `1` — promotion REMOVES the qual/prod divergence (unlike ADR-002's `0` pin).

Closes the #288 R2 residual. R1 (write-boundary truthfulness) already live-verified via #396; R3 (default-absent consumption chain) to be captured post-merge, then #288 gets its terminal receipt.

## Verification
Full suite `--no-parallel`: **2,973 passed**.