### PR TITLE
saga: qualification-only partial-state fault seam (ADR-004)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -578,7 +578,15 @@ struct SystemDispatcher: OperationTraceDispatching {
                     dialogPresent: dialogPresent,
                     liveReadback: sagaLiveReadback ?? .unavailable,
                     liveTrackName: liveTrackName,
-                    liveTrackNames: liveTrackNames
+                    liveTrackNames: liveTrackNames,
+                    // ADR-004 / issue #287 — qualification-only fault seam. nil
+                    // in normal operation; engages only when the operator sets
+                    // LOGIC_PRO_MCP_FAULT_INJECT=partial_state to qualify real
+                    // reverse-order compensation. Never a product code path.
+                    faultSeam: SagaPartialStateFaultSeam.resolve(
+                        environment: ProcessInfo.processInfo.environment,
+                        stepCount: plan.steps.count
+                    )
                 )
                 let saga = MutationSaga(
                     targetRegistry: targetRegistry,

--- a/Sources/LogicProMCP/Saga/SagaExecution.swift
+++ b/Sources/LogicProMCP/Saga/SagaExecution.swift
@@ -79,6 +79,82 @@ extension SagaLiveReadback {
     )
 }
 
+/// ADR-004 / issue #287 — a QUALIFICATION-ONLY saga fault seam.
+///
+/// This is a test affordance, NOT a product feature. It is a completely dead
+/// branch unless `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` is explicitly set:
+/// `resolve(environment:stepCount:)` returns nil in every other case, so the
+/// executor holds no seam and `run` takes its normal path unchanged.
+///
+/// When engaged it fails EXACTLY ONE forward saga step BEFORE that step's real
+/// write — the returned StepResult is State C with `writeBoundaryCrossed=false`,
+/// and no dispatch happens, so the injected step mutates nothing. Earlier steps
+/// really apply, so the saga's own `compensate()` runs REAL reverse-order
+/// compensation over them: exercising that path is the whole reason this seam
+/// exists. It NEVER touches `readState`, so the before-state a rollback restores
+/// stays truthful.
+///
+/// Mirrors `QualificationFaultInjection(environment:)`'s nil-unless-set contract
+/// exactly: same env key, same `partial_state` mode. Only that mode engages the
+/// saga — `.timeout` belongs to the transport probe and leaves the saga inert.
+final class SagaPartialStateFaultSeam: @unchecked Sendable {
+    /// Optional operator override pinning WHICH forward step fails. Zero-based;
+    /// an absent, unparseable, or out-of-range value falls back to the LAST
+    /// step so the affordance stays predictable.
+    static let stepEnvironmentKey = "LOGIC_PRO_MCP_FAULT_INJECT_STEP"
+
+    private let injectedStepIndex: Int
+    private let lock = NSLock()
+    private var forwardCursor = 0
+
+    private init(injectedStepIndex: Int) {
+        self.injectedStepIndex = injectedStepIndex
+    }
+
+    /// Returns nil unless `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` is set —
+    /// the dead-branch guard. `stepCount` (the plan's step count, known only at
+    /// construction) resolves the default LAST target.
+    static func resolve(
+        environment: [String: String],
+        stepCount: Int
+    ) -> SagaPartialStateFaultSeam? {
+        guard stepCount > 0,
+              let injection = QualificationFaultInjection(environment: environment),
+              injection.mode == .partialState else {
+            return nil
+        }
+        let injectedStepIndex: Int
+        if let raw = environment[stepEnvironmentKey]?.trimmingCharacters(in: .whitespaces),
+           let parsed = Int(raw),
+           parsed >= 0,
+           parsed < stepCount {
+            injectedStepIndex = parsed
+        } else {
+            injectedStepIndex = stepCount - 1
+        }
+        return SagaPartialStateFaultSeam(injectedStepIndex: injectedStepIndex)
+    }
+
+    /// Advances the run cursor and, iff this run is the injected step, returns a
+    /// State-C result that short-circuits the executor BEFORE the real write.
+    /// Monotonic and single-shot by construction: the cursor only equals
+    /// `injectedStepIndex` on the intended forward step; every later run —
+    /// including the compensation inverses — sees a higher cursor and returns
+    /// nil, so real compensation dispatches for real.
+    func injectionResult(for step: SagaStep) -> StepResult? {
+        lock.lock()
+        let cursor = forwardCursor
+        forwardCursor += 1
+        lock.unlock()
+        guard cursor == injectedStepIndex else { return nil }
+        return StepResult(
+            state: .stateC,
+            writeBoundaryCrossed: false,
+            detail: "\(step.operationID.rawValue): error=qualification_fault_injected_partial_state"
+        )
+    }
+}
+
 struct ProductionSagaStepExecutor: SagaStepExecutor {
     private static let allowlist: Set<OperationID> = [
         .tracksRename,
@@ -111,6 +187,11 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
     /// deterministic; `sampled_at` is provenance metadata and never an input to
     /// a saga decision.
     private let now: @Sendable () -> Date
+    /// ADR-004 / issue #287 — qualification-only fault seam. nil in all normal
+    /// operation (env unset); non-nil ONLY when the operator explicitly set
+    /// `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` to qualify compensation. A
+    /// test affordance, never a product code path — see SagaPartialStateFaultSeam.
+    private let faultSeam: SagaPartialStateFaultSeam?
 
     init(
         router: ChannelRouter,
@@ -120,7 +201,8 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
         liveReadback: SagaLiveReadback,
         liveTrackName: (@Sendable (Int) -> String?)? = nil,
         liveTrackNames: (@Sendable () -> [Int: String]?)? = nil,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        faultSeam: SagaPartialStateFaultSeam? = nil
     ) {
         self.router = router
         self.cache = cache
@@ -130,9 +212,20 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
         self.liveTrackName = liveTrackName
         self.liveTrackNames = liveTrackNames
         self.now = now
+        self.faultSeam = faultSeam
     }
 
     func run(_ step: SagaStep) async -> StepResult {
+        // ADR-004 / issue #287 — QUALIFICATION-ONLY fault seam. Completely dead
+        // unless `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` was set at
+        // construction (faultSeam is nil otherwise, so this whole branch is
+        // skipped and the path below is byte-for-byte today's behaviour). When
+        // engaged for the injected step it returns State C BEFORE any dispatch —
+        // no trace scope, no write, no mutation — so earlier steps' real
+        // compensation can be exercised. Never a product code path.
+        if let faultSeam, let injected = faultSeam.injectionResult(for: step) {
+            return injected
+        }
         // ADR-005: each saga step dispatch gets a NESTED trace context
         // carrying the parent saga trace ID — without it a child's trace
         // start would clobber the parent's registration in the shared box,

--- a/Tests/LogicProMCPTests/SagaExecutionTests.swift
+++ b/Tests/LogicProMCPTests/SagaExecutionTests.swift
@@ -699,4 +699,279 @@ struct SagaExecutionTests {
             }
         }
     }
+
+    // MARK: - ADR-004 / issue #287 qualification-only partial-state fault seam
+
+    private struct SeamFixture: Sendable {
+        let executor: ProductionSagaStepExecutor
+        let channel: SagaRecordingChannel
+        let surface: SagaLiveTrackSurface
+        let registry: TargetRegistry
+        let targets: [TargetReference]
+    }
+
+    /// Builds a one-step-per-track saga environment, optionally arming the
+    /// qualification fault seam. `faultSeam` is nil in the control (env unset)
+    /// case, so the executor is byte-for-byte the production one.
+    private func makeSeamFixture(
+        tracks: [TrackState],
+        faultSeam: SagaPartialStateFaultSeam? = nil
+    ) async -> SeamFixture {
+        let cache = StateCache()
+        await cache.updateTracks(tracks)
+        let surface = SagaLiveTrackSurface(tracks)
+        let registry = TargetRegistry()
+        var targets: [TargetReference] = []
+        for track in tracks {
+            let descriptor = TargetDescriptor(trackIndex: track.id, trackName: track.name)
+            targets.append(await registry.bind(
+                kind: .track,
+                descriptor: descriptor,
+                fingerprint: descriptor.fingerprint
+            ))
+        }
+        let channel = SagaRecordingChannel(cache: cache, surface: surface)
+        let router = ChannelRouter()
+        await router.register(channel)
+        return SeamFixture(
+            executor: ProductionSagaStepExecutor(
+                router: router,
+                cache: cache,
+                targetRegistry: registry,
+                dialogPresent: { false },
+                liveReadback: surface.readback,
+                faultSeam: faultSeam
+            ),
+            channel: channel,
+            surface: surface,
+            registry: registry,
+            targets: targets
+        )
+    }
+
+    private func twoStepTracks() -> [TrackState] {
+        [
+            TrackState(id: 0, name: "Bass", type: .audio, volume: 0.25),
+            TrackState(id: 1, name: "Keys", type: .softwareInstrument),
+        ]
+    }
+
+    /// TEST (c): the seam is a completely dead branch unless the fault env is
+    /// explicitly `partial_state`. Resolution — the ONLY place a seam is
+    /// constructed — returns nil for an unset env, for the transport-only
+    /// `timeout` mode, and for an empty plan; it constructs a seam only for
+    /// `partial_state` with a non-empty plan.
+    @Test("fault seam resolves nil unless partial_state env is explicitly set")
+    func faultSeamResolvesNilUnlessPartialStateEnvSet() async {
+        #expect(SagaPartialStateFaultSeam.resolve(environment: [:], stepCount: 2) == nil)
+        #expect(SagaPartialStateFaultSeam.resolve(
+            environment: ["UNRELATED": "partial_state"],
+            stepCount: 2
+        ) == nil)
+        // `timeout` is the transport probe's mode; it must leave the saga inert.
+        #expect(SagaPartialStateFaultSeam.resolve(
+            environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "timeout"],
+            stepCount: 2
+        ) == nil)
+        #expect(SagaPartialStateFaultSeam.resolve(
+            environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+            stepCount: 0
+        ) == nil)
+        #expect(SagaPartialStateFaultSeam.resolve(
+            environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+            stepCount: 2
+        ) != nil)
+    }
+
+    /// TEST (c): even when armed the seam yields a State-C result for EXACTLY
+    /// one run — the targeted forward step — and nil for every run before and
+    /// after it, so the compensation inverses (which run after) dispatch for
+    /// real. This is what keeps the seam inert on every non-target run.
+    @Test("armed seam injects exactly once at the target forward run")
+    func faultSeamInjectsExactlyOnceAtTargetForwardRun() async throws {
+        let probeStep = SagaStep(
+            operationID: .mixerSetVolume,
+            targetRef: nil,
+            params: [:],
+            expectedInverse: SagaExpectedInverse(
+                operationID: .mixerSetVolume,
+                valueParameter: "value"
+            )
+        )
+
+        // Default target is the LAST step (index 1 of a 2-step plan).
+        let lastSeam = try #require(SagaPartialStateFaultSeam.resolve(
+            environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+            stepCount: 2
+        ))
+        #expect(lastSeam.injectionResult(for: probeStep) == nil) // cursor 0 ≠ 1
+        let injected = try #require(lastSeam.injectionResult(for: probeStep)) // cursor 1
+        #expect(injected.state == .stateC)
+        #expect(!injected.writeBoundaryCrossed)
+        #expect(injected.detail.contains("qualification_fault_injected_partial_state"))
+        #expect(lastSeam.injectionResult(for: probeStep) == nil) // cursor 2 (a compensation run)
+        #expect(lastSeam.injectionResult(for: probeStep) == nil) // cursor 3
+
+        // Explicit override pins the FIRST step (index 0).
+        let firstSeam = try #require(SagaPartialStateFaultSeam.resolve(
+            environment: [
+                "LOGIC_PRO_MCP_FAULT_INJECT": "partial_state",
+                "LOGIC_PRO_MCP_FAULT_INJECT_STEP": "0",
+            ],
+            stepCount: 3
+        ))
+        #expect(try #require(firstSeam.injectionResult(for: probeStep)).state == .stateC) // cursor 0
+        #expect(firstSeam.injectionResult(for: probeStep) == nil) // cursor 1
+
+        // An out-of-range override falls back to the LAST step.
+        let clampedSeam = try #require(SagaPartialStateFaultSeam.resolve(
+            environment: [
+                "LOGIC_PRO_MCP_FAULT_INJECT": "partial_state",
+                "LOGIC_PRO_MCP_FAULT_INJECT_STEP": "99",
+            ],
+            stepCount: 2
+        ))
+        #expect(clampedSeam.injectionResult(for: probeStep) == nil) // cursor 0 ≠ 1
+        #expect(try #require(clampedSeam.injectionResult(for: probeStep)).state == .stateC) // cursor 1
+    }
+
+    /// TEST (a): with the seam absent (env unset) the exact same 2-step plan
+    /// completes normally — both steps apply, nothing compensates. This is the
+    /// control the injected run in the next test is measured against.
+    @Test("seam-absent plan completes normally and applies both steps")
+    func faultSeamAbsentCompletesTwoStepPlanNormally() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let fixture = await makeSeamFixture(tracks: twoStepTracks())
+            let plan = SagaPlan(
+                steps: [
+                    step(.mixerSetVolume, target: fixture.targets[0], value: .double(0.75)),
+                    step(.tracksRename, target: fixture.targets[1], value: .string("Lead")),
+                ],
+                idempotencyKey: "seam-absent-control"
+            )
+
+            let outcome = await MutationSaga(
+                targetRegistry: fixture.registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            ).execute(plan, executor: fixture.executor)
+
+            #expect(outcome.state == .completed)
+            #expect(outcome.complete)
+            let appliedVolume = try #require(outcome.journal[0].executionResult)
+            #expect(appliedVolume.state == .stateA)
+            let appliedRename = try #require(outcome.journal[1].executionResult)
+            #expect(appliedRename.state == .stateA)
+            #expect(await fixture.channel.recordedCalls().map(\.operation)
+                == ["mixer.set_volume", "track.rename"])
+            #expect(fixture.surface.snapshot(0)?.volume == 0.75)
+            #expect(fixture.surface.snapshot(1)?.name == "Lead")
+        }
+    }
+
+    /// TEST (b): with `partial_state` armed on the SAME 2-step plan, the first
+    /// step really applies, the last (injected) step returns State C BEFORE its
+    /// write (no dispatch, no mutation), and the saga's own compensate() runs a
+    /// real inverse over the applied first step — restoring the live surface and
+    /// recording CompensationEvidence for it.
+    @Test("partial_state fault drives real compensation of the applied prefix")
+    func partialStateFaultDrivesRealCompensationOnTwoStepPlan() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let seam = SagaPartialStateFaultSeam.resolve(
+                environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+                stepCount: 2
+            )
+            let fixture = await makeSeamFixture(tracks: twoStepTracks(), faultSeam: seam)
+            let plan = SagaPlan(
+                steps: [
+                    step(.mixerSetVolume, target: fixture.targets[0], value: .double(0.75)),
+                    step(.tracksRename, target: fixture.targets[1], value: .string("Lead")),
+                ],
+                idempotencyKey: "partial-state-two-step"
+            )
+
+            let outcome = await MutationSaga(
+                targetRegistry: fixture.registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            ).execute(plan, executor: fixture.executor)
+
+            // The applied first step, then its inverse — the injected rename
+            // NEVER reached the channel (no "track.rename" forward call).
+            #expect(await fixture.channel.recordedCalls().map(\.operation)
+                == ["mixer.set_volume", "mixer.set_volume"])
+
+            #expect(outcome.state == .fullyCompensated)
+            let applied = try #require(outcome.journal[0].executionResult)
+            #expect(applied.state == .stateA)
+            #expect(outcome.journal[0].verificationEvidence?.disposition == .applied)
+            #expect(outcome.journal[0].compensationEvidence?.disposition == .verified)
+
+            let injected = try #require(outcome.journal[1].executionResult)
+            #expect(injected.state == .stateC)
+            #expect(!injected.writeBoundaryCrossed)
+            #expect(injected.detail.contains("qualification_fault_injected_partial_state"))
+            #expect(outcome.journal[1].verificationEvidence?.disposition == .notApplied)
+            #expect(outcome.journal[1].compensationEvidence?.disposition == .notNeeded)
+
+            // Live surface: volume rolled back, the injected rename never landed.
+            #expect(fixture.surface.snapshot(0)?.volume == 0.25)
+            #expect(fixture.surface.snapshot(1)?.name == "Keys")
+        }
+    }
+
+    /// TEST (b), reverse-order rigor: a 3-step plan with two applied steps proves
+    /// compensation dispatches the inverses in REVERSE order and that the
+    /// injected last step never dispatched (no "mixer.set_pan" anywhere).
+    @Test("partial_state fault compensates the applied prefix in reverse order")
+    func partialStateFaultCompensatesAppliedPrefixInReverse() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let tracks = [
+                TrackState(id: 0, name: "Lead", type: .audio),
+                TrackState(id: 1, name: "Pad", type: .softwareInstrument, volume: 0.2),
+                TrackState(id: 2, name: "FX", type: .audio, pan: 0),
+            ]
+            let seam = SagaPartialStateFaultSeam.resolve(
+                environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+                stepCount: 3
+            )
+            let fixture = await makeSeamFixture(tracks: tracks, faultSeam: seam)
+            let plan = SagaPlan(
+                steps: [
+                    step(.tracksRename, target: fixture.targets[0], value: .string("Lead Vox")),
+                    step(.mixerSetVolume, target: fixture.targets[1], value: .double(0.9)),
+                    step(.mixerSetPan, target: fixture.targets[2], value: .double(-0.5)),
+                ],
+                idempotencyKey: "partial-state-three-step"
+            )
+
+            let outcome = await MutationSaga(
+                targetRegistry: fixture.registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            ).execute(plan, executor: fixture.executor)
+
+            // Forward rename + volume, then inverses in REVERSE order (volume
+            // before rename). The injected pan step is absent from the channel.
+            #expect(await fixture.channel.recordedCalls().map(\.operation) == [
+                "track.rename",
+                "mixer.set_volume",
+                "mixer.set_volume",
+                "track.rename",
+            ])
+
+            #expect(outcome.state == .fullyCompensated)
+            #expect(outcome.journal[0].compensationEvidence?.disposition == .verified)
+            #expect(outcome.journal[1].compensationEvidence?.disposition == .verified)
+            #expect(outcome.journal[2].compensationEvidence?.disposition == .notNeeded)
+            let injected = try #require(outcome.journal[2].executionResult)
+            #expect(injected.state == .stateC)
+            #expect(!injected.writeBoundaryCrossed)
+
+            // Live surface fully restored; the injected pan never landed.
+            #expect(fixture.surface.snapshot(0)?.name == "Lead")
+            #expect(fixture.surface.snapshot(1)?.volume == 0.2)
+            #expect(fixture.surface.snapshot(2)?.pan == 0)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Adds `SagaPartialStateFaultSeam`, a qualification/test affordance that lets a live saga's reverse-order compensation path be exercised end-to-end against real Logic Pro. It is a completely dead branch in every production deployment.

## Behaviour
- Engages **only** when `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` is explicitly set — mirrors the existing transportPlay `QualificationFaultInjection` contract exactly (nil unless the env is set). The executor holds no seam otherwise and `ProductionSagaStepExecutor.run` is byte-identical to today.
- When engaged, fails exactly one forward saga step (default: the last; optional `LOGIC_PRO_MCP_FAULT_INJECT_STEP=<index>`) **before** that step's real write: the injected `StepResult` is State C with `writeBoundaryCrossed=false`, so the step mutates nothing while earlier steps really apply — and the saga's own `compensate()` runs real reverse-order compensation over them.
- Injects at the top of `run` before any dispatch or trace scope; never touches `readState` (the before-state a rollback restores stays truthful); monotonic single-shot cursor so compensation inverses dispatch for real.

## Why
Enables live qualification of ADR-004 saga compensation (issue #287): a two-step saga on a real track where step 1 applies and step 2 fault-injects, driving a full `compensation.started` cycle with live-independent readback — a path that was previously only unit-covered.

## Tests
Resolves nil unless the env is set (dead-branch), injects exactly once at the target run with later (compensation) runs returning nil, honors the step override + clamp, and a seam-absent plan completes applying both steps. Full suite `--no-parallel`: 2978 passed.