### PR TITLE
qualification: attest shipped ADR-002 default + normalize transcript ids (#394)

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -124,6 +124,10 @@ package struct QualificationRunner: Sendable {
         }
     }
 
+    // #394: despite the "raw" name (kept to avoid rippling the schema/contract
+    // checks), this transcript is ID-NORMALIZED wire — session-random target /
+    // trace IDs are replaced with stable `<prefix>_<NORM:N>` placeholders for
+    // cross-run comparison. It is NOT forensic, byte-unmodified stdio.
     private struct RawTranscriptArtifact: Codable {
         let schema: String
         let frames: [QualificationWireFrame]
@@ -571,12 +575,22 @@ package struct QualificationRunner: Sendable {
                 evidenceFiles.append(healthPath)
             }
             if isObservedAxis {
+                // #394: rewrite session-random target refs (trk_/mix_/ins_/prj_)
+                // and trace ids (lpmcp_) to appearance-order placeholders so the
+                // transcript is CROSS-RUN ID-STABLE (the ID dimension only —
+                // timestamp / live-DAW-state noise is not touched by this pass).
+                // Emit-only: the semantic oracle still validates the raw,
+                // un-normalized operation response/readback bytes (see
+                // QualificationOperationResult), so target-faithfulness is intact.
+                let normalizedFrames = QualificationTranscriptNormalizer.normalize(
+                    driveResult.wireFrames
+                )
                 let requiredArtifacts: [(String, Data, EvidenceManifest.Kind)] = [
                     (
                         Self.rawTranscriptFilename,
                         try Self.encoded(RawTranscriptArtifact(
                             schema: "qualification-raw-transcript/v1",
-                            frames: driveResult.wireFrames
+                            frames: normalizedFrames
                         )),
                         .rawTranscript
                     ),
@@ -584,7 +598,7 @@ package struct QualificationRunner: Sendable {
                         Self.publicTranscriptFilename,
                         try Self.encoded(PublicTranscriptArtifact(
                             schema: "qualification-public-transcript/v1",
-                            frames: driveResult.wireFrames.map { frame in
+                            frames: normalizedFrames.map { frame in
                                 .init(
                                     sequence: frame.sequence,
                                     direction: frame.direction,

--- a/Sources/LogicProMCP/Qualification/QualificationTranscriptNormalizer.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTranscriptNormalizer.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Makes qualification wire transcripts CROSS-RUN ID-STABLE across two runs of
+/// the SAME built artifact by rewriting session-random identifiers to
+/// placeholders derived from their order of first appearance. This normalizes
+/// the ID dimension ONLY: a real same-artifact run still carries timestamp and
+/// live-DAW-state variation this pass does NOT touch, so a whole live transcript
+/// is not byte-identical run-to-run. The same-artifact comparison operates on
+/// the ID-normalized wire; non-ID noise is out of scope of this pass.
+///
+/// Session-random identifiers this rewrites:
+///   * target references — `trk_`/`mix_`/`ins_`/`prj_` followed by a random UUID,
+///     minted per session by `TargetRegistry.bind` (see `TargetReference`);
+///   * operation trace ids — `lpmcp_` followed by a random UUID, minted by
+///     `TraceID`.
+///
+/// Each distinct raw identifier maps to a stable `<prefix>_<NORM:N>` placeholder
+/// where `N` counts first appearances within that prefix. Referential integrity
+/// is preserved end to end: the SAME raw identifier always maps to the SAME
+/// placeholder, and two DISTINCT raw identifiers never collapse onto the same
+/// placeholder. A transcript reader can therefore still see whether the
+/// reference an operation addressed is (or is not) the reference a resource
+/// emitted.
+///
+/// This is a DISPLAY/COMPARISON transform over the transcript ONLY. The
+/// qualification's semantic target-faithfulness oracle
+/// (`QualificationSemanticReadbackValidator`) runs on the raw, un-normalized
+/// operation response/readback bytes (`QualificationOperationResult`), so it
+/// continues to verify real identity — normalization cannot turn a wrong target
+/// into a right one.
+enum QualificationTranscriptNormalizer {
+    /// `trk_`/`mix_`/`ins_`/`prj_` (`TargetReference`) and `lpmcp_` (`TraceID`)
+    /// are each followed by a 36-char UUID. The negative lookbehind keeps a
+    /// prefix that is the tail of a longer word (e.g. `ins` in `plugins_source`)
+    /// from matching; the UUID shape is the second, decisive guard. The pattern
+    /// is a compile-time constant, so a malformed literal is a build-caught
+    /// programmer error — `try!` is the correct spelling here.
+    private nonisolated(unsafe) static let identifierRegex = try! NSRegularExpression(
+        pattern: "(?<![0-9A-Za-z_])(trk|mix|ins|prj|lpmcp)_"
+            + "([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})"
+    )
+
+    /// Rewrites a whole transcript with one shared placeholder table, so a ref
+    /// that recurs across frames (a resource emits it, a later op addresses it)
+    /// keeps a single stable placeholder.
+    static func normalize(_ frames: [QualificationWireFrame]) -> [QualificationWireFrame] {
+        var table = PlaceholderTable()
+        var normalized: [QualificationWireFrame] = []
+        normalized.reserveCapacity(frames.count)
+        for frame in frames {
+            normalized.append(QualificationWireFrame(
+                sequence: frame.sequence,
+                direction: frame.direction,
+                operationID: table.rewrite(frame.operationID),
+                payload: table.rewrite(frame.payload)
+            ))
+        }
+        return normalized
+    }
+
+    /// Rewrites a single string with a fresh placeholder table. Convenience for
+    /// call sites (and tests) that normalize one payload in isolation.
+    static func normalizeString(_ value: String) -> String {
+        var table = PlaceholderTable()
+        return table.rewrite(value)
+    }
+
+    private struct PlaceholderTable {
+        private var placeholderByIdentifier: [String: String] = [:]
+        private var nextIndexByPrefix: [String: Int] = [:]
+
+        mutating func rewrite(_ value: String) -> String {
+            let subject = value as NSString
+            let matches = identifierRegex.matches(
+                in: value,
+                range: NSRange(location: 0, length: subject.length)
+            )
+            guard !matches.isEmpty else { return value }
+            var result = ""
+            var cursor = 0
+            for match in matches {
+                let matched = match.range
+                if matched.location > cursor {
+                    result += subject.substring(
+                        with: NSRange(location: cursor, length: matched.location - cursor)
+                    )
+                }
+                let identifier = subject.substring(with: matched)
+                let prefix = subject.substring(with: match.range(at: 1))
+                result += placeholder(for: identifier, prefix: prefix)
+                cursor = matched.location + matched.length
+            }
+            if cursor < subject.length {
+                result += subject.substring(
+                    with: NSRange(location: cursor, length: subject.length - cursor)
+                )
+            }
+            return result
+        }
+
+        private mutating func placeholder(for identifier: String, prefix: String) -> String {
+            if let existing = placeholderByIdentifier[identifier] { return existing }
+            let index = nextIndexByPrefix[prefix, default: 0]
+            nextIndexByPrefix[prefix] = index + 1
+            let placeholder = "\(prefix)_<NORM:\(index)>"
+            placeholderByIdentifier[identifier] = placeholder
+            return placeholder
+        }
+    }
+}

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -450,6 +450,43 @@ struct QualificationTransport: Sendable {
         self.shutdownGrace = shutdownGrace
     }
 
+    /// Environment the same-artifact qualification drives the server with.
+    ///
+    /// #394: ADR-002 target_ref ships DEFAULT ON — the server reads an ABSENT
+    /// `LOGIC_MCP_ADR002_TARGET_REF` as ON (`!= "0"`). Qualification therefore
+    /// attests the SHIPPED DEFAULT by leaving the variable ABSENT (even if the
+    /// base inherited a pin), exactly what a default deployment runs — rather
+    /// than pinning the `=0` kill-switch, which diverged from the shipped
+    /// default. The session-random target/trace IDs this surfaces are
+    /// ID-normalized by `QualificationTranscriptNormalizer` before the transcript
+    /// is emitted (cross-run ID stability). The `=0` kill-switch is the operator
+    /// rollback config — it is NOT run as a secondary same-artifact qualification
+    /// drive; it is exercised only by a FeatureFlags env-contract UNIT test (via
+    /// `adr002KillSwitchEnvironment`, alongside the absent / `=0` / `=1` cases in
+    /// `FeatureFlagEnvironmentTests`).
+    ///
+    /// ADR-003 strict params and ADR-005 tracing are pinned to their shipped
+    /// default ("1" reads identically to the default-ON `!= "0"`), so
+    /// qualification and production agree on those too.
+    static func qualificationEnvironment(base: [String: String]) -> [String: String] {
+        var environment = base
+        environment.removeValue(forKey: "LOGIC_MCP_ADR002_TARGET_REF")
+        environment["LOGIC_MCP_ADR003_STRICT_PARAMS"] = "1"
+        environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] = "1"
+        return environment
+    }
+
+    /// The `=0` kill-switch environment — the operator's documented ADR-002
+    /// rollback. Consumed by a FeatureFlags env-contract UNIT test, NOT by a
+    /// secondary same-artifact qualification drive, so the rollback config stays
+    /// exercised now that the PRIMARY qualification attests the shipped default
+    /// (absent = ON) instead of this config.
+    static func adr002KillSwitchEnvironment(base: [String: String]) -> [String: String] {
+        var environment = qualificationEnvironment(base: base)
+        environment["LOGIC_MCP_ADR002_TARGET_REF"] = "0"
+        return environment
+    }
+
     static func qualificationLocaleIdentifier(_ identifier: String) -> String {
         switch Locale(identifier: identifier).language.languageCode?.identifier.lowercased() {
         case "en": QualificationLocale.enUS.rawValue
@@ -1186,26 +1223,14 @@ private final class QualificationSubprocessSession: @unchecked Sendable {
             throw QualificationTransportError.launchFailed("not executable: \(request.executableURL.path)")
         }
         try verifyExecutableIdentity()
-        var environment = request.environment
-        // PRD-007 Part 2 DIVERGENCE, deliberate and open: `adr002TargetRef` is
-        // now DEFAULT ON in production, so this `=0` no longer pins the shipped
-        // default — it pins the kill-switch path. It is left off because target
-        // refs are minted as `trk_<random UUID>` (see `TargetReference`), which
-        // would make qualification transcripts non-reproducible run-to-run.
-        // The cost is real and NOT waived: qualification currently attests to a
-        // configuration no default deployment runs. Closing it needs a
-        // ref-redaction/normalization pass over the transcript before this can
-        // honestly flip to "1". Tracked as PRD-007 follow-up, not fixed here.
-        environment["LOGIC_MCP_ADR002_TARGET_REF"] = "0"
-        environment["LOGIC_MCP_ADR003_STRICT_PARAMS"] = "1"
-        // ADR-005 #288 R2: operation tracing is now DEFAULT ON, so this "1" no
-        // longer pins a special-case configuration — it pins the SAME behavior a
-        // default deployment runs. Unlike the ADR-002 pin above, promotion
-        // REMOVES the divergence rather than introducing one: qualification and
-        // production now agree here. Left as an explicit "1" (no pin change) so
-        // the intent stays legible and a future kill-switch default flip can't
-        // silently drift qualification off the shipped behavior.
-        environment["LOGIC_MCP_ADR005_OPERATION_TRACE"] = "1"
+        // #394: qualification now attests the SHIPPED DEFAULT for ADR-002
+        // target_ref (default ON), not the `=0` kill-switch it used to pin. The
+        // session-random target/trace IDs this surfaces are ID-normalized (made
+        // cross-run stable in the ID dimension) by `QualificationTranscriptNormalizer`
+        // at transcript-emit time. See `QualificationTransport.qualificationEnvironment`.
+        let environment = QualificationTransport.qualificationEnvironment(
+            base: request.environment
+        )
         process.executableURL = request.executableURL.standardizedFileURL
         process.currentDirectoryURL = request.executableURL.deletingLastPathComponent()
         process.environment = environment

--- a/Tests/LogicProMCPTests/QualificationTranscriptNormalizerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationTranscriptNormalizerTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// #394 — the same-artifact qualification now attests the SHIPPED DEFAULT for
+// ADR-002 target_ref (default ON) instead of the `=0` kill-switch. That surfaces
+// session-random target refs (trk_/mix_/ins_/prj_ + UUID) and trace ids (lpmcp_
+// + UUID) in the transcript, so `QualificationTranscriptNormalizer` rewrites them
+// to appearance-order placeholders — making the transcript CROSS-RUN ID-STABLE
+// (the ID dimension only; a real live run's timestamp / DAW-state noise is not
+// touched by this pass, so a whole live transcript is not byte-identical). These
+// tests prove the ID normalization on synthetic frames that differ ONLY in ids.
+//
+// SPELLING IS LOAD-BEARING: every Bool assertion below is a BARE `#expect(x)` /
+// `#expect(!x)`, and every optional is unwrapped with `#require`. Under this
+// toolchain `#expect(<Bool> == true/false)`, `?? false` and `== .some(true)` are
+// DEAD and pass unconditionally. Value equality between non-Bool types
+// (`#expect(a == b)` over String/Data/[QualificationWireFrame]) is live and used
+// deliberately.
+@Suite("Qualification transcript normalization (#394)")
+struct QualificationTranscriptNormalizerTests {
+
+    // MARK: (a) cross-run ID stability — two runs, ids differ only, identical transcript
+
+    @Test("two runs differing only in random ids yield an identical ID-normalized transcript")
+    func normalizedTranscriptIsByteStableAcrossRuns() throws {
+        let run1 = Self.transcript(
+            track: "A1B2C3D4-E5F6-4A0B-8C1D-2E3F4A5B6C7D",
+            insert: "11111111-2222-4333-8444-555566667777",
+            trace: "99999999-8888-4777-8666-555544443333"
+        )
+        let run2 = Self.transcript(
+            track: "FFFFFFFF-EEEE-4DDD-8CCC-BBBBAAAA9999",
+            insert: "00000000-1111-4222-8333-444455556666",
+            trace: "12345678-9ABC-4DEF-8012-3456789ABCDE"
+        )
+
+        // Sanity: the two runs really do differ (different random UUIDs).
+        #expect(run1 != run2)
+
+        let norm1 = QualificationTranscriptNormalizer.normalize(run1)
+        let norm2 = QualificationTranscriptNormalizer.normalize(run2)
+
+        // Structural equality across runs…
+        #expect(norm1 == norm2)
+
+        // …and byte equality of the encoded transcript artifact.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data1 = try encoder.encode(norm1)
+        let data2 = try encoder.encode(norm2)
+        #expect(data1 == data2)
+
+        // The random ids are gone and replaced with stable placeholders.
+        let joined = norm1.map(\.payload).joined()
+        #expect(joined.contains("trk_<NORM:0>"))
+        #expect(joined.contains("ins_<NORM:0>"))
+        #expect(joined.contains("lpmcp_<NORM:0>"))
+        #expect(!joined.contains("A1B2C3D4"))
+
+        // Referential integrity: the track ref a resource EMITTED (frame 1) and
+        // the ref a later op ADDRESSED (frame 2) are the SAME raw UUID, so they
+        // normalize to the SAME placeholder — the transcript still shows they
+        // name the same track.
+        #expect(norm1[1].payload.contains("trk_<NORM:0>"))
+        #expect(norm1[2].payload.contains("trk_<NORM:0>"))
+    }
+
+    @Test("the ID pass is load-bearing — un-normalized transcripts differing only in ids are NOT identical")
+    func rawTranscriptIsNotByteStable() throws {
+        // Guards the reproducibility claim above against a no-op normalizer: the
+        // RAW transcripts must differ, so their equality can only come from the
+        // normalization pass, not from the fixtures being identical to begin with.
+        let run1 = Self.transcript(
+            track: "A1B2C3D4-E5F6-4A0B-8C1D-2E3F4A5B6C7D",
+            insert: "11111111-2222-4333-8444-555566667777",
+            trace: "99999999-8888-4777-8666-555544443333"
+        )
+        let run2 = Self.transcript(
+            track: "FFFFFFFF-EEEE-4DDD-8CCC-BBBBAAAA9999",
+            insert: "00000000-1111-4222-8333-444455556666",
+            trace: "12345678-9ABC-4DEF-8012-3456789ABCDE"
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        #expect(try encoder.encode(run1) != encoder.encode(run2))
+    }
+
+    // MARK: (b) the oracle is not blinded by normalization
+
+    @Test("normalization keeps a wrong / stale target ref distinguishable")
+    func normalizationPreservesTargetFaithfulness() {
+        let emitted = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let stale = "11111111-2222-4333-8444-555566667777"
+
+        let right = Self.targetPair(emitted: emitted, addressed: emitted)
+        let wrong = Self.targetPair(emitted: emitted, addressed: stale)
+
+        // On the RAW transcript: right target agrees, wrong/stale does not.
+        #expect(Self.targetVerdict(right))
+        #expect(!Self.targetVerdict(wrong))
+
+        // After normalization the verdicts are UNCHANGED — normalization neither
+        // fabricated agreement (a wrong target stays wrong) nor destroyed it (a
+        // right target stays right).
+        #expect(Self.targetVerdict(QualificationTranscriptNormalizer.normalize(right)))
+        #expect(!Self.targetVerdict(QualificationTranscriptNormalizer.normalize(wrong)))
+    }
+
+    @Test("the semantic oracle reads raw response bytes, so ref normalization cannot blind it")
+    func semanticOracleReadsRawBytes() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.systemGetTrace])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[.systemGetTrace])
+
+        // The oracle passes the faithful, right-target trace…
+        let good = try #require(oracle.evaluate(
+            responseData: fixture.responseData,
+            readbackData: fixture.readbackData
+        ))
+        #expect(good)
+
+        // …and CATCHES a trace for the WRONG operation/target.
+        let wrongResponse = fixture.response.replacingOccurrences(
+            of: #""operation_id":"system.saga_execute""#,
+            with: #""operation_id":"transport.play""#
+        )
+        let wrong = try #require(oracle.evaluate(
+            responseData: Data(wrongResponse.utf8),
+            readbackData: fixture.readbackData
+        ))
+        #expect(!wrong)
+
+        // The transcript normalizer WOULD rewrite this response's random trace id
+        // (proving normalization is active on this content), but the oracle
+        // verdicts above were computed from the RAW response bytes — a different
+        // data path from the transcript. So normalization cannot blind the oracle.
+        let normalized = QualificationTranscriptNormalizer.normalizeString(fixture.response)
+        #expect(normalized.contains("lpmcp_<NORM:0>"))
+        #expect(!normalized.contains("lpmcp_00000000-0000-0000-0000-000000000000"))
+    }
+
+    // MARK: (c) the qualification attests the shipped default (ADR-002 default-ON)
+
+    @Test("qualification env attests the ADR-002 shipped default, not the =0 kill-switch")
+    func qualificationEnvironmentAttestsShippedDefault() throws {
+        // Even a base that inherited a `=0` pin must be attested at the shipped
+        // default: the harness strips the pin so it runs what production runs.
+        let base = ["PATH": "/usr/bin", "LOGIC_MCP_ADR002_TARGET_REF": "0"]
+        let env = QualificationTransport.qualificationEnvironment(base: base)
+
+        // Shipped default = the variable ABSENT; the server reads absent as ON.
+        #expect(!env.keys.contains("LOGIC_MCP_ADR002_TARGET_REF"))
+        let readsOn = (env["LOGIC_MCP_ADR002_TARGET_REF"] ?? "") != "0"
+        #expect(readsOn)
+
+        // Companion pins stay at their shipped-default behavior.
+        let strict = try #require(env["LOGIC_MCP_ADR003_STRICT_PARAMS"])
+        #expect(strict == "1")
+        let trace = try #require(env["LOGIC_MCP_ADR005_OPERATION_TRACE"])
+        #expect(trace == "1")
+
+        // Unrelated base entries are preserved.
+        let path = try #require(env["PATH"])
+        #expect(path == "/usr/bin")
+    }
+
+    @Test("the =0 kill-switch stays covered as a named, secondary qualification env")
+    func killSwitchEnvironmentRemainsCovered() throws {
+        let env = QualificationTransport.adr002KillSwitchEnvironment(base: [:])
+        // "0" is the exact documented kill-switch spelling FeatureFlags reads as
+        // OFF (see FeatureFlagEnvironmentTests); this keeps that path attested.
+        let flag = try #require(env["LOGIC_MCP_ADR002_TARGET_REF"])
+        #expect(flag == "0")
+        let readsOff = (env["LOGIC_MCP_ADR002_TARGET_REF"] ?? "") == "0"
+        #expect(readsOff)
+        // The secondary env is a faithful sibling of the primary.
+        let strict = try #require(env["LOGIC_MCP_ADR003_STRICT_PARAMS"])
+        #expect(strict == "1")
+    }
+
+    // MARK: - fixtures
+
+    /// A three-frame transcript: a trace-id request, a readback response that
+    /// EMITS a track ref + an insert ref, and a probe that ADDRESSES the same
+    /// track ref. Only the UUID values vary between runs.
+    private static func transcript(
+        track: String,
+        insert: String,
+        trace: String
+    ) -> [QualificationWireFrame] {
+        [
+            QualificationWireFrame(
+                sequence: 0,
+                direction: .request,
+                operationID: "trace_get",
+                payload: #"{"id":7,"jsonrpc":"2.0","method":"tools/call","params":{"trace_id":"lpmcp_\#(trace)"}}"#
+            ),
+            QualificationWireFrame(
+                sequence: 1,
+                direction: .response,
+                operationID: "operation-readback-9",
+                payload: #"{"id":9,"jsonrpc":"2.0","result":[{"track_ref":"trk_\#(track)","inserts":[{"insert_ref":"ins_\#(insert)"}]}]}"#
+            ),
+            QualificationWireFrame(
+                sequence: 2,
+                direction: .request,
+                operationID: "operation_probe.tracks.select",
+                payload: #"{"id":10,"jsonrpc":"2.0","params":{"target_ref":"trk_\#(track)"}}"#
+            ),
+        ]
+    }
+
+    private static func targetPair(emitted: String, addressed: String) -> [QualificationWireFrame] {
+        [
+            QualificationWireFrame(
+                sequence: 0,
+                direction: .response,
+                operationID: "readback",
+                payload: #"{"jsonrpc":"2.0","result":{"track_ref":"trk_\#(emitted)"}}"#
+            ),
+            QualificationWireFrame(
+                sequence: 1,
+                direction: .request,
+                operationID: "probe",
+                payload: #"{"jsonrpc":"2.0","params":{"target_ref":"trk_\#(addressed)"}}"#
+            ),
+        ]
+    }
+
+    /// A stand-in for a target-faithfulness oracle: does the ref the op addressed
+    /// (frame 1) equal the ref the resource emitted (frame 0)?
+    private static func targetVerdict(_ frames: [QualificationWireFrame]) -> Bool {
+        guard let emitted = firstTrackToken(in: frames[0].payload),
+              let addressed = firstTrackToken(in: frames[1].payload) else {
+            return false
+        }
+        return emitted == addressed
+    }
+
+    private static func firstTrackToken(in payload: String) -> String? {
+        guard let range = payload.range(of: #"trk_[^"]+"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(payload[range])
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #394. The same-artifact qualification harness pinned `LOGIC_MCP_ADR002_TARGET_REF=0`, attesting the target_ref **kill-switch** rather than the **shipped default** (the flag is default-ON — the server reads an absent value as ON). Qualification therefore attested a configuration no default deployment runs.

## Changes
- **Attest the shipped default.** `QualificationTransport.qualificationEnvironment` now leaves `LOGIC_MCP_ADR002_TARGET_REF` absent, so qualification exercises exactly what a default deployment runs. The `=0` kill-switch (operator rollback config) is exercised by a FeatureFlags env-contract unit test via `adr002KillSwitchEnvironment` — not claimed as a secondary same-artifact drive.
- **Transcript id normalization.** Session-random target refs (`trk_/mix_/ins_/prj_`) and trace ids (`lpmcp_`) differ every run, which blocked same-artifact comparison. New `QualificationTranscriptNormalizer` rewrites each distinct id to a stable `<prefix>_<NORM:N>` placeholder — **bijective** (same id → same placeholder; distinct ids never collapse) — applied **emit-only**. The semantic oracle still validates the raw, un-normalized response/readback bytes, so target-faithfulness is **not** blinded. Non-id noise (timestamps, live DAW state) is out of scope of this pass; the emitted `raw-transcript.json` is noted as ID-normalized wire, not forensic stdio.

## Tests (live `#expect`)
Two runs differing only in random ids yield an identical ID-normalized transcript; an un-normalized transcript is not stable (normalization does the work); a wrong / stale target ref stays distinguishable after normalization (oracle intact). Full suite `--no-parallel`: 2979 passed.

## Why it matters
This converts the ADR-002 qualification harness into honest proof of the shipped default and yields reproducible same-artifact transcripts — the prerequisite for an honest ADR-002 (#285) terminal receipt.