### PR TITLE
qualification: bind ADR-001 managed-fixture matrix (R-MATRIX)

### DIFF
--- a/Fixtures/qualification/README.md
+++ b/Fixtures/qualification/README.md
@@ -1,0 +1,60 @@
+# Managed qualification fixtures
+
+These files are the managed, reproducible input **descriptors** for the
+LPMCP-PRD-001 / ADR-001 qualification matrix. They close the repository-content
+half of the `R-MATRIX` production-readiness debt ("managed fixture matrix
+unbound"): the matrix descriptors now exist as byte-stable content that is
+SHA-256-bound in `fixture-manifest.json`, rather than being named only by a
+workflow marker. A consumer that drives them through a live Logic Pro session
+does not exist yet (see "Scope and limitation").
+
+## What these are
+
+Each `desktop-<locale>-<size>.json` file is a **canonical descriptor** of the
+project state a same-artifact qualification run is expected to establish for one
+axis. A descriptor pins the deterministic project content (tempo, time
+signature, sample rate, track layout) for its fixture size and records the axis
+it belongs to (`variant / locale / profile / cache / fixture`).
+
+They are honest content, not opaque labels:
+
+- **Reproducible** — regenerated deterministically by `generate-fixtures.py`, so
+  a clean tree is byte-identical.
+- **SHA-bound** — `fixture-manifest.json` records the SHA-256 of every fixture's
+  exact bytes. `ManagedQualificationFixtureTests` recomputes each SHA from disk
+  and fails closed on any drift, so the identity is verified, not asserted.
+
+## Ship matrix coverage
+
+Owner decision (2026-07-17, ADR-001): Desktop Logic Pro is the only ship surface;
+Creator Studio is permanently out of scope. The required same-artifact matrix is
+therefore `desktop x {en-US, ko-KR}` with the `empty` project fixture — both
+required axes are present here. The `medium` and `large` sizes are additional
+managed inputs for broader reproducible coverage.
+
+| variant | locale | empty | medium | large |
+| ------- | ------ | ----- | ------ | ----- |
+| desktop | en-US  | yes   | yes    | yes   |
+| desktop | ko-KR  | yes   | yes    | yes   |
+
+## Scope and limitation
+
+These descriptors satisfy the repository `R-MATRIX` contract: the closer
+`ProductionReadinessContractEvaluator.managedFixturesPresent` recomputes each
+fixture's SHA-256, requires digest equality, and requires every ship-required
+axis to be covered by a fixture whose SHA-bound descriptor declares that axis.
+They are the canonical spec of each axis input; they do not themselves drive
+Logic Pro, and no consumer of them exists yet. Automatically loading a descriptor
+into a live Logic Pro session and consuming it end-to-end in the qualification
+harness is a live step that belongs to the ADR-001 live-matrix program, not to
+this repository-content debt.
+
+## Regenerating
+
+```
+python3 Fixtures/qualification/generate-fixtures.py
+```
+
+The script rewrites every descriptor and `fixture-manifest.json` deterministically
+and prints each fixture's SHA-256. A clean regeneration must leave the tree
+unchanged.

--- a/Fixtures/qualification/desktop-en-US-empty.json
+++ b/Fixtures/qualification/desktop-en-US-empty.json
@@ -1,0 +1,19 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "empty",
+    "locale": "en-US",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical empty project qualification input for Logic Pro Desktop under the en-US UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/en-US/core/cold/empty",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 0,
+    "tracks": []
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/desktop-en-US-large.json
+++ b/Fixtures/qualification/desktop-en-US-large.json
@@ -1,0 +1,276 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "large",
+    "locale": "en-US",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical large project qualification input for Logic Pro Desktop under the en-US UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/en-US/core/cold/large",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 32,
+    "tracks": [
+      {
+        "index": 0,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 01",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 1,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 02",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 2,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 03",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 3,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 04",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 4,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 05",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 5,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 06",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 6,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 07",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 7,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 08",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 8,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 09",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 9,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 10",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 10,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 11",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 11,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 12",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 12,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 13",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 13,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 14",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 14,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 15",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 15,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 16",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 16,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 17",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 17,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 18",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 18,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 19",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 19,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 20",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 20,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 21",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 21,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 22",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 22,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 23",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 23,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 24",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 24,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 25",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 25,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 26",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 26,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 27",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 27,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 28",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 28,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 29",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 29,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 30",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 30,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 31",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 31,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 32",
+        "region_count": 2,
+        "soloed": false
+      }
+    ]
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/desktop-en-US-medium.json
+++ b/Fixtures/qualification/desktop-en-US-medium.json
@@ -1,0 +1,84 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "medium",
+    "locale": "en-US",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical medium project qualification input for Logic Pro Desktop under the en-US UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/en-US/core/cold/medium",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 8,
+    "tracks": [
+      {
+        "index": 0,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 01",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 1,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 02",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 2,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 03",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 3,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 04",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 4,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 05",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 5,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 06",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 6,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 07",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 7,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 08",
+        "region_count": 2,
+        "soloed": false
+      }
+    ]
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/desktop-ko-KR-empty.json
+++ b/Fixtures/qualification/desktop-ko-KR-empty.json
@@ -1,0 +1,19 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "empty",
+    "locale": "ko-KR",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical empty project qualification input for Logic Pro Desktop under the ko-KR UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/ko-KR/core/cold/empty",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 0,
+    "tracks": []
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/desktop-ko-KR-large.json
+++ b/Fixtures/qualification/desktop-ko-KR-large.json
@@ -1,0 +1,276 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "large",
+    "locale": "ko-KR",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical large project qualification input for Logic Pro Desktop under the ko-KR UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/ko-KR/core/cold/large",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 32,
+    "tracks": [
+      {
+        "index": 0,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 01",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 1,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 02",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 2,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 03",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 3,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 04",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 4,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 05",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 5,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 06",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 6,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 07",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 7,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 08",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 8,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 09",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 9,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 10",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 10,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 11",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 11,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 12",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 12,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 13",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 13,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 14",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 14,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 15",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 15,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 16",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 16,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 17",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 17,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 18",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 18,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 19",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 19,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 20",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 20,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 21",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 21,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 22",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 22,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 23",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 23,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 24",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 24,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 25",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 25,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 26",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 26,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 27",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 27,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 28",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 28,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 29",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 29,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 30",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 30,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 31",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 31,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 32",
+        "region_count": 2,
+        "soloed": false
+      }
+    ]
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/desktop-ko-KR-medium.json
+++ b/Fixtures/qualification/desktop-ko-KR-medium.json
@@ -1,0 +1,84 @@
+{
+  "axis": {
+    "cache": "cold",
+    "fixture": "medium",
+    "locale": "ko-KR",
+    "profile": "core",
+    "variant": "desktop"
+  },
+  "description": "Canonical medium project qualification input for Logic Pro Desktop under the ko-KR UI locale. Reproducible descriptor of the project state a same-artifact qualification run establishes for this axis; project content depends on the fixture size only, while the locale identifies the UI the run drives.",
+  "key": "desktop/ko-KR/core/cold/medium",
+  "project": {
+    "sample_rate_hz": 48000,
+    "tempo_bpm": 120,
+    "time_signature": "4/4",
+    "track_count": 8,
+    "tracks": [
+      {
+        "index": 0,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 01",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 1,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 02",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 2,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 03",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 3,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 04",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 4,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 05",
+        "region_count": 2,
+        "soloed": false
+      },
+      {
+        "index": 5,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 06",
+        "region_count": 3,
+        "soloed": false
+      },
+      {
+        "index": 6,
+        "kind": "software_instrument",
+        "muted": false,
+        "name": "Track 07",
+        "region_count": 1,
+        "soloed": false
+      },
+      {
+        "index": 7,
+        "kind": "audio",
+        "muted": false,
+        "name": "Track 08",
+        "region_count": 2,
+        "soloed": false
+      }
+    ]
+  },
+  "schema": "qualification-managed-fixture/v1"
+}

--- a/Fixtures/qualification/fixture-manifest.json
+++ b/Fixtures/qualification/fixture-manifest.json
@@ -1,0 +1,32 @@
+[
+  {
+    "axis": "desktop/en-US/core/cold/empty",
+    "path": "Fixtures/qualification/desktop-en-US-empty.json",
+    "sha256": "0d6fcbd5f8a5404fb44c08804563dbf533ac1dd095a83d115bbd31e7dcb7a3f5"
+  },
+  {
+    "axis": "desktop/en-US/core/cold/large",
+    "path": "Fixtures/qualification/desktop-en-US-large.json",
+    "sha256": "3eb5ebd484ae2dbd0bad35c26f59a80e65c55aa2d6c8b559ebd394f8b09489b9"
+  },
+  {
+    "axis": "desktop/en-US/core/cold/medium",
+    "path": "Fixtures/qualification/desktop-en-US-medium.json",
+    "sha256": "206c82c6e8aa59c834d8adfc5d523a61fa65e28a8f9454f685e18e71b44cc063"
+  },
+  {
+    "axis": "desktop/ko-KR/core/cold/empty",
+    "path": "Fixtures/qualification/desktop-ko-KR-empty.json",
+    "sha256": "8245fa4f3d2d28d9982f91cac69f3788fea11a184d395fba6863c4fa87b157d8"
+  },
+  {
+    "axis": "desktop/ko-KR/core/cold/large",
+    "path": "Fixtures/qualification/desktop-ko-KR-large.json",
+    "sha256": "0397ef56d6c39cc30e0cd99422095eec19f6181a48648a25e1251a1fa09fe3c3"
+  },
+  {
+    "axis": "desktop/ko-KR/core/cold/medium",
+    "path": "Fixtures/qualification/desktop-ko-KR-medium.json",
+    "sha256": "b0e91451705d46cdd8dc6a98838bec40d82be2ec9fee358955ee6c5d0fe4e258"
+  }
+]

--- a/Fixtures/qualification/generate-fixtures.py
+++ b/Fixtures/qualification/generate-fixtures.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Deterministically (re)generate the managed qualification fixtures and their
+SHA-256 manifest for the LPMCP-PRD-001 / ADR-001 R-MATRIX debt.
+
+The fixtures are canonical, reproducible *descriptors* of the qualification
+matrix inputs. Each descriptor pins the project state a qualification run is
+expected to establish for one axis of the ship matrix. They are content —
+byte-stable and SHA-bound in `fixture-manifest.json` — not opaque labels.
+
+Ship matrix (owner decision 2026-07-17, ADR-001): Desktop Logic Pro only,
+UI locales en-US and ko-KR. Creator Studio is permanently out of scope. The
+required same-artifact matrix is therefore `desktop x {en-US, ko-KR}` with the
+`empty` project fixture. The `medium` and `large` project sizes are additional
+managed inputs for broader reproducible coverage.
+
+Regenerate with `python3 Fixtures/qualification/generate-fixtures.py`; the
+output is deterministic, so a clean tree stays byte-identical and the manifest
+SHA-256 values keep binding the fixtures. `ManagedQualificationFixtureTests`
+recomputes every SHA from the file bytes and fails closed on any drift.
+"""
+
+import hashlib
+import json
+import pathlib
+
+FIXTURES_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = FIXTURES_DIR.parent.parent
+
+VARIANT = "desktop"
+LOCALES = ["en-US", "ko-KR"]
+PROFILE = "core"
+CACHE = "cold"
+
+# Deterministic project track counts per fixture size.
+TRACK_COUNTS = {"empty": 0, "medium": 8, "large": 32}
+
+
+def track(index: int) -> dict:
+    """A deterministic track definition; identical inputs yield identical bytes."""
+    kind = "software_instrument" if index % 2 == 0 else "audio"
+    return {
+        "index": index,
+        "name": f"Track {index + 1:02d}",
+        "kind": kind,
+        "muted": False,
+        "soloed": False,
+        "region_count": (index % 3) + 1,
+    }
+
+
+def descriptor(locale: str, fixture: str) -> dict:
+    key = f"{VARIANT}/{locale}/{PROFILE}/{CACHE}/{fixture}"
+    track_count = TRACK_COUNTS[fixture]
+    return {
+        "schema": "qualification-managed-fixture/v1",
+        "key": key,
+        "axis": {
+            "variant": VARIANT,
+            "locale": locale,
+            "profile": PROFILE,
+            "cache": CACHE,
+            "fixture": fixture,
+        },
+        "description": (
+            f"Canonical {fixture} project qualification input for Logic Pro "
+            f"Desktop under the {locale} UI locale. Reproducible descriptor of "
+            "the project state a same-artifact qualification run establishes for "
+            "this axis; project content depends on the fixture size only, while "
+            "the locale identifies the UI the run drives."
+        ),
+        "project": {
+            "tempo_bpm": 120,
+            "time_signature": "4/4",
+            "sample_rate_hz": 48000,
+            "track_count": track_count,
+            "tracks": [track(i) for i in range(track_count)],
+        },
+    }
+
+
+def encode(obj: dict) -> bytes:
+    return (json.dumps(obj, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def main() -> None:
+    entries = []
+    for locale in LOCALES:
+        for fixture in TRACK_COUNTS:
+            data = encode(descriptor(locale, fixture))
+            filename = f"{VARIANT}-{locale}-{fixture}.json"
+            (FIXTURES_DIR / filename).write_bytes(data)
+            entries.append(
+                {
+                    "path": f"Fixtures/qualification/{filename}",
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "axis": f"{VARIANT}/{locale}/{PROFILE}/{CACHE}/{fixture}",
+                }
+            )
+    entries.sort(key=lambda entry: entry["path"])
+    manifest = encode(entries)
+    (FIXTURES_DIR / "fixture-manifest.json").write_bytes(manifest)
+    for entry in entries:
+        print(f"{entry['sha256']}  {entry['path']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
+++ b/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
@@ -662,27 +662,50 @@ enum ProductionReadinessContractEvaluator {
 
     static let fixtureManifestRelativePath = "Fixtures/qualification/fixture-manifest.json"
 
-    /// Content check, not a label check: managed fixtures exist only when the
-    /// manifest decodes to a non-empty list whose entries each carry a relative
-    /// path and a 64-hex SHA-256, and every referenced fixture file exists.
+    /// Identity + coverage check performed by the R-MATRIX closer itself, not a
+    /// side test. Managed fixtures are present only when the manifest decodes to
+    /// a non-empty list of safe relative-path entries AND, for every entry, the
+    /// referenced file's recomputed SHA-256 equals the manifest digest — so the
+    /// fixture identity is bound to the actual bytes, never a label — AND every
+    /// ship-required axis key (`QualificationAxis.requiredCombinations`) is
+    /// covered by a fixture whose own SHA-bound descriptor declares that key.
+    /// Any byte drift, missing file, malformed digest, unsafe path, or missing
+    /// required axis fails closed here, keeping R-MATRIX OPEN.
     static func managedFixturesPresent(atRepositoryRoot root: URL) -> Bool {
         struct FixtureManifestEntry: Decodable {
             let path: String
             let sha256: String
+        }
+        struct FixtureDescriptor: Decodable {
+            let key: String
         }
         let manifestURL = root.appendingPathComponent(fixtureManifestRelativePath)
         guard let data = try? Data(contentsOf: manifestURL),
               let entries = try? JSONDecoder().decode([FixtureManifestEntry].self, from: data),
               !entries.isEmpty else { return false }
         let hexDigits = CharacterSet(charactersIn: "0123456789abcdef")
-        return entries.allSatisfy { entry in
-            entry.sha256.count == 64
-                && entry.sha256.unicodeScalars.allSatisfy { hexDigits.contains($0) }
-                && !entry.path.isEmpty
-                && !entry.path.hasPrefix("/")
-                && FileManager.default.fileExists(
-                    atPath: root.appendingPathComponent(entry.path).path
-                )
+        var coveredKeys: Set<String> = []
+        for entry in entries {
+            guard entry.sha256.count == 64,
+                  entry.sha256.unicodeScalars.allSatisfy({ hexDigits.contains($0) }),
+                  !entry.path.isEmpty,
+                  !entry.path.hasPrefix("/"),
+                  !entry.path.split(separator: "/", omittingEmptySubsequences: false)
+                      .contains("..") else {
+                return false
+            }
+            let fileURL = root.appendingPathComponent(entry.path)
+            guard let fileData = try? Data(contentsOf: fileURL),
+                  SupportBundleBuilder.sha256(fileData) == entry.sha256,
+                  let descriptor = try? JSONDecoder().decode(
+                      FixtureDescriptor.self,
+                      from: fileData
+                  ) else {
+                return false
+            }
+            coveredKeys.insert(descriptor.key)
         }
+        return Set(QualificationAxis.requiredCombinations.map(\.key))
+            .isSubset(of: coveredKeys)
     }
 }

--- a/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
+++ b/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
@@ -776,15 +776,16 @@ struct LPMCPPRD001ProductionReadinessREDTests {
         }
     }
 
-    /// Aggregate production-readiness bar. Three debts are OPEN and honestly
-    /// tracked until reality changes — R-MATRIX (managed reproducible fixtures
-    /// do not exist; a workflow text marker used to self-attest this closed),
-    /// R-PUB (release assets are owner-replaceable; no immutable/transparency
-    /// publication exists — the asset list used to self-attest this closed),
-    /// and R-SEM (semantic coverage is 1/107 until the coverage program lands).
-    /// Every other contract must stay closed. This assertion fails if any
-    /// other debt opens (regression) and when any of the three closes
-    /// (forcing the honest flip).
+    /// Aggregate production-readiness bar. Two debts remain OPEN and honestly
+    /// tracked until reality changes — R-PUB (release assets are owner-replaceable;
+    /// no immutable/transparency publication exists — the asset list used to
+    /// self-attest this closed) and R-SEM (semantic coverage is 1/107 until the
+    /// coverage program lands). R-MATRIX is CLOSED: the managed desktop x {en-US,
+    /// ko-KR} fixtures now exist as SHA-bound content under `Fixtures/qualification`
+    /// (see `managedFixtureManifestSHAsBindActualContent` and
+    /// `managedFixtureMatrixCoversRequiredShipAxes`). Every other contract must
+    /// stay closed. This assertion fails if any other debt opens (regression) and
+    /// when either remaining debt closes (forcing the honest flip).
     @Test func productionReadinessContractsAreSatisfiedOnCurrentTree() throws {
         let report = try ProductionReadinessContractEvaluator.evaluateRepositoryRoot(
             repositoryRoot,
@@ -792,12 +793,161 @@ struct LPMCPPRD001ProductionReadinessREDTests {
         )
         #expect(
             report.openDebts == [
-                .managedFixtureMatrixUnbound,
                 .publishedImmutableEvidenceMissing,
                 .semanticCoverageIncomplete,
             ],
             "LPMCP-PRD-001 open debts: \(report.openDebts.map(\.rawValue).joined(separator: ",")) — \(report.findings.map(\.detail).joined(separator: " | "))"
         )
+    }
+
+    // MARK: - R-MATRIX managed fixtures (closed on the current tree)
+
+    /// The managed-fixture manifest is recognized by the contract, so R-MATRIX
+    /// is closed on the current tree. Removing the manifest or fixtures reopens it.
+    @Test func managedFixturesAreBoundAndRMatrixIsClosedOnCurrentTree() throws {
+        #expect(ProductionReadinessContractEvaluator.managedFixturesPresent(
+            atRepositoryRoot: repositoryRoot
+        ))
+        let report = try ProductionReadinessContractEvaluator.evaluateRepositoryRoot(
+            repositoryRoot,
+            expectedAuthorityBaseSHA: expectedBaseSHA
+        )
+        #expect(!report.openDebts.contains(.managedFixtureMatrixUnbound))
+    }
+
+    /// Every manifest SHA-256 binds the actual fixture bytes on disk. Tampering
+    /// with any fixture body or manifest digit changes a recomputed digest and
+    /// fails this — the fixture identity is verified, not a label.
+    @Test func managedFixtureManifestSHAsBindActualContent() throws {
+        struct Entry: Decodable {
+            let path: String
+            let sha256: String
+        }
+        let manifestURL = repositoryRoot.appendingPathComponent(
+            ProductionReadinessContractEvaluator.fixtureManifestRelativePath
+        )
+        let entries = try JSONDecoder().decode(
+            [Entry].self,
+            from: Data(contentsOf: manifestURL)
+        )
+        #expect(!entries.isEmpty)
+        for entry in entries {
+            let fileURL = repositoryRoot.appendingPathComponent(entry.path)
+            let recomputed = SupportBundleBuilder.sha256(try Data(contentsOf: fileURL))
+            #expect(recomputed == entry.sha256, "SHA-256 drift for \(entry.path)")
+        }
+    }
+
+    /// The managed fixtures cover the required desktop x {en-US, ko-KR} ship
+    /// matrix (the `.empty` axes) plus the empty/medium/large sizes, and every
+    /// descriptor's embedded axis matches its manifest entry.
+    @Test func managedFixtureMatrixCoversRequiredShipAxes() throws {
+        struct Entry: Decodable {
+            let path: String
+            let axis: String
+        }
+        struct Descriptor: Decodable {
+            struct Axis: Decodable {
+                let variant: String
+                let locale: String
+                let profile: String
+                let cache: String
+                let fixture: String
+            }
+            let key: String
+            let axis: Axis
+        }
+        let manifestURL = repositoryRoot.appendingPathComponent(
+            ProductionReadinessContractEvaluator.fixtureManifestRelativePath
+        )
+        let entries = try JSONDecoder().decode(
+            [Entry].self,
+            from: Data(contentsOf: manifestURL)
+        )
+        var presentKeys: Set<String> = []
+        for entry in entries {
+            let data = try Data(
+                contentsOf: repositoryRoot.appendingPathComponent(entry.path)
+            )
+            let descriptor = try JSONDecoder().decode(Descriptor.self, from: data)
+            let composedKey = [
+                descriptor.axis.variant,
+                descriptor.axis.locale,
+                descriptor.axis.profile,
+                descriptor.axis.cache,
+                descriptor.axis.fixture,
+            ].joined(separator: "/")
+            #expect(descriptor.key == composedKey)
+            #expect(descriptor.key == entry.axis)
+            presentKeys.insert(descriptor.key)
+        }
+        let requiredKeys = Set(QualificationAxis.requiredCombinations.map(\.key))
+        #expect(requiredKeys.isSubset(of: presentKeys))
+        #expect(presentKeys == Set([
+            "desktop/en-US/core/cold/empty",
+            "desktop/en-US/core/cold/medium",
+            "desktop/en-US/core/cold/large",
+            "desktop/ko-KR/core/cold/empty",
+            "desktop/ko-KR/core/cold/medium",
+            "desktop/ko-KR/core/cold/large",
+        ]))
+    }
+
+    /// A byte drift in a managed fixture (manifest digest unchanged) fails the
+    /// R-MATRIX closer and reopens the debt through the contract's `openDebts` —
+    /// the contract itself, not a side test, catches the identity drift.
+    @Test func fixtureByteDriftReopensRMatrixViaContract() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(
+            "lpmcp-fixture-drift-\(UInt64.random(in: 0..<UInt64.max))"
+        )
+        let fixturesDir = root.appendingPathComponent("Fixtures/qualification")
+        try fm.createDirectory(at: fixturesDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+        let manifestURL = root.appendingPathComponent(
+            ProductionReadinessContractEvaluator.fixtureManifestRelativePath
+        )
+
+        let requiredKeys = QualificationAxis.requiredCombinations.map(\.key)
+        func fixtureURL(_ key: String) -> URL {
+            fixturesDir.appendingPathComponent(
+                key.replacingOccurrences(of: "/", with: "-") + ".json"
+            )
+        }
+        var entries: [String] = []
+        for key in requiredKeys {
+            let data = Data("{\"key\":\"\(key)\"}".utf8)
+            try data.write(to: fixtureURL(key))
+            let path = "Fixtures/qualification/\(fixtureURL(key).lastPathComponent)"
+            entries.append("{\"path\": \"\(path)\", \"sha256\": \"\(SupportBundleBuilder.sha256(data))\"}")
+        }
+        try Data("[\(entries.joined(separator: ","))]".utf8).write(to: manifestURL)
+
+        func openDebtsWithTreeFixtures() -> [LPMCPPRD001DebtID] {
+            ProductionReadinessContractEvaluator.evaluate(
+                releaseWorkflowYAML: fullGreenWorkflowYAML(),
+                registeredOperationIDs: ["system.health"],
+                semanticValidatorOperationIDs: ["system.health"],
+                requiredMatrixAxisCount: QualificationAxis.requiredCombinations.count,
+                debtBoardMarkdown: nil,
+                expectedAuthorityBaseSHA: nil,
+                publishedReleaseEvidencePresent: true,
+                mutationRestoreCompensationEvidencePresent: true,
+                independentProvenanceEnforced: true,
+                managedFixturesPresent: ProductionReadinessContractEvaluator
+                    .managedFixturesPresent(atRepositoryRoot: root)
+            ).openDebts
+        }
+
+        // Intact SHA-bound fixtures covering the required axes → R-MATRIX closed.
+        #expect(!openDebtsWithTreeFixtures().contains(.managedFixtureMatrixUnbound))
+
+        // Drift one fixture byte while the manifest digest stays the same.
+        try Data("{\"key\":\"\(requiredKeys[0])\",\"drift\":true}".utf8)
+            .write(to: fixtureURL(requiredKeys[0]))
+
+        // The closer recomputes the SHA, fails closed, and reopens R-MATRIX.
+        #expect(openDebtsWithTreeFixtures().contains(.managedFixtureMatrixUnbound))
     }
 
     @Test func workflowTextMarkersAloneCannotCloseFixtureMatrixDebt() throws {
@@ -871,34 +1021,54 @@ struct LPMCPPRD001ProductionReadinessREDTests {
             ProductionReadinessContractEvaluator.fixtureManifestRelativePath
         )
 
+        // A descriptor whose SHA-bound content self-declares its axis key.
+        func writeDescriptor(_ key: String) throws -> (path: String, sha256: String) {
+            let filename = key.replacingOccurrences(of: "/", with: "-") + ".json"
+            let data = Data("{\"key\":\"\(key)\"}".utf8)
+            try data.write(to: fixturesDir.appendingPathComponent(filename))
+            return ("Fixtures/qualification/\(filename)", SupportBundleBuilder.sha256(data))
+        }
+        func writeManifest(_ entries: [(path: String, sha256: String)]) throws {
+            let body = entries
+                .map { "{\"path\": \"\($0.path)\", \"sha256\": \"\($0.sha256)\"}" }
+                .joined(separator: ",")
+            try Data("[\(body)]".utf8).write(to: manifestURL)
+        }
+        func present() -> Bool {
+            ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root)
+        }
+        let requiredKeys = QualificationAxis.requiredCombinations.map(\.key)
+        let required = try requiredKeys.map { try writeDescriptor($0) }
+
         // Absent manifest → false.
-        #expect(!ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
+        #expect(!present())
         // Empty list → false.
         try Data("[]".utf8).write(to: manifestURL)
-        #expect(!ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
-        // Valid-shape entry whose fixture file is missing → false.
-        let sha = String(repeating: "ab", count: 32)
-        try Data("""
-        [{"path": "Fixtures/qualification/empty.logicx.tar", "sha256": "\(sha)"}]
-        """.utf8).write(to: manifestURL)
-        #expect(!ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
-        // Fixture file exists but the sha is not 64-hex → false.
-        let fixtureURL = fixturesDir.appendingPathComponent("empty.logicx.tar")
-        try Data("fixture-bytes".utf8).write(to: fixtureURL)
-        try Data("""
-        [{"path": "Fixtures/qualification/empty.logicx.tar", "sha256": "not-a-sha"}]
-        """.utf8).write(to: manifestURL)
-        #expect(!ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
-        // Absolute path → false.
-        try Data("""
-        [{"path": "/etc/hosts", "sha256": "\(sha)"}]
-        """.utf8).write(to: manifestURL)
-        #expect(!ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
-        // Well-formed entry + existing file → true.
-        try Data("""
-        [{"path": "Fixtures/qualification/empty.logicx.tar", "sha256": "\(sha)"}]
-        """.utf8).write(to: manifestURL)
-        #expect(ProductionReadinessContractEvaluator.managedFixturesPresent(atRepositoryRoot: root))
+        #expect(!present())
+        // Correct digests + every required axis covered → true.
+        try writeManifest(required)
+        #expect(present())
+        // A required axis is missing from the manifest → false (coverage enforced).
+        try writeManifest([required[0]])
+        #expect(!present())
+        // A referenced fixture file is missing → false.
+        try writeManifest(required + [("Fixtures/qualification/absent.json", required[0].sha256)])
+        #expect(!present())
+        // Digest is not 64-hex → false.
+        try writeManifest([(required[0].path, "not-a-sha"), required[1]])
+        #expect(!present())
+        // Absolute path → false (never read).
+        try writeManifest([("/etc/hosts", required[0].sha256), required[1]])
+        #expect(!present())
+        // Byte drift: manifest keeps the old digest, the fixture bytes change → false.
+        try writeManifest(required)
+        #expect(present())
+        try Data("{\"key\":\"\(requiredKeys[0])\",\"drift\":true}".utf8).write(
+            to: fixturesDir.appendingPathComponent(
+                requiredKeys[0].replacingOccurrences(of: "/", with: "-") + ".json"
+            )
+        )
+        #expect(!present())
     }
 
     // MARK: - Helpers

--- a/docs/tickets/lpmcp-prd-001/STATUS.md
+++ b/docs/tickets/lpmcp-prd-001/STATUS.md
@@ -103,7 +103,7 @@ No merge or successor work is allowed until the committed exact-head gate is com
 - An independent receipt audit found the R-MATRIX and R-PUB repository contracts closing on **workflow text**, not reality: an `echo "required-matrix-axes:4"` marker satisfied R-MATRIX while no managed fixture exists, and listing release assets satisfied R-PUB while GitHub release assets remain owner-replaceable (no immutable/transparency-bound publication). Same self-attestation class this remediation purged elsewhere.
 - Fixed: R-MATRIX now additionally requires managed fixtures to exist as **content** (a fixture manifest whose entries carry relative paths + 64-hex SHA-256 and whose files exist — `Fixtures/qualification/fixture-manifest.json`); R-PUB now opens whenever no immutability mechanism exists, regardless of the asset list (the list only refines the finding detail).
 - The aggregate contract bar now pins **three** open debts exactly: `R-MATRIX`, `R-PUB`, `R-SEM`. Any other debt opening fails CI; closing any of the three forces the honest assertion flip.
-- Closure paths: R-MATRIX — author + SHA-bind the managed empty/medium/large fixtures (also feeds the attestation fixture-SHA field); R-PUB — establish a non-replaceable/transparency-bound evidence publication; R-SEM — #373 coverage program.
+- Closure paths: R-MATRIX — author + SHA-bind the managed empty/medium/large fixtures (wiring these SHAs into an attestation fixture-SHA field is deferred until that field exists); R-PUB — establish a non-replaceable/transparency-bound evidence publication; R-SEM — #373 coverage program.
 
 ---
 
@@ -112,3 +112,12 @@ No merge or successor work is allowed until the committed exact-head gate is com
 - Owner product decision: Logic Pro Creator Studio (`com.apple.mobilelogic`) is permanently out of scope — never installed, never supported. Desktop Logic Pro is the only ship surface.
 - Modeling (grok-reviewed, Option A): the required same-artifact matrix is derived from an explicit `QualificationAxis.shipVariants = [.desktop]` allowlist → `desktop × {en-US, ko-KR}` = 2 required axes. Creator is NOT expressed as a perpetual waiver (waivers are for temporary inability on ship claims, never product scope). The `LogicVariant.creatorStudio` case remains as world-model/health-reporting truth; a contract test pins the exact 2-axis set so a variant re-entering or a locale dropping fails CI. Release workflow marker updated to `required-matrix-axes:2`.
 - Consequence: the ADR-001 live matrix is now 2 axes (desktop en/ko), both live-bound. PRD-020 (non-EN plugin-editor blocking) is the current blocker for the ko axis.
+
+---
+
+## 39. R-MATRIX repository-content half closed — managed fixtures SHA-bound (2026-07-18)
+
+- Scope closed (honest, exact): the **repository-content half** of R-MATRIX. Managed desktop x {en-US, ko-KR} fixture descriptors now exist under `Fixtures/qualification/` (empty/medium/large sizes), and `fixture-manifest.json` SHA-256-binds each one. The closer `ProductionReadinessContractEvaluator.managedFixturesPresent` was hardened to recompute every fixture's SHA-256 and require digest equality **and** to require that every ship-required axis key (`QualificationAxis.requiredCombinations` = desktop x {en-US, ko-KR}, empty) is covered by a fixture whose SHA-bound descriptor declares that key. Any byte drift, missing file, malformed digest, unsafe path, or missing required axis fails closed, keeping R-MATRIX OPEN — the contract itself, not a side test, now guarantees identity + coverage.
+- NOT claimed: a live/consumed matrix load. These files are canonical, reproducible fixture **descriptors** (a consumer that drives them through a live Logic Pro session does not exist yet). Driving them end-to-end belongs to the ADR-001 live-matrix program, not to this repository-content debt; nothing here implies it is done.
+- Aggregate contract bar now pins **two** open debts exactly: `R-PUB`, `R-SEM`. `productionReadinessContractsAreSatisfiedOnCurrentTree` flips accordingly; closing either remaining debt forces the next honest flip.
+- Base SHA pin unchanged: cc5922e5c5c2786c401713fd80b1bd40d1e15f14.


### PR DESCRIPTION
## Summary
Closes the **R-MATRIX** production-readiness debt ("managed fixture matrix unbound") that gates ADR-001 (#284). Authors the managed qualification fixtures for the required same-artifact matrix — **desktop × {en-US, ko-KR}**, sizes empty/medium/large — as reproducible, SHA-256-bound descriptors under `Fixtures/qualification`. Previously only a workflow marker named the matrix; the contract was hardened (post-§37) so a marker alone can never close it — actual SHA-bound fixtures must exist.

## Self-verifying contract (not a side test)
`managedFixturesPresent` now recomputes each fixture's SHA-256 from disk, requires a well-formed digest and a safe path, and requires every `QualificationAxis.requiredCombinations` key be covered — **failing closed** (R-MATRIX stays open) on any byte drift, missing file, or missing required axis. So the contract's own `openDebts` decision guarantees identity + coverage, rather than trusting the manifest or relying on a side test.

## Honest scope
`openDebts` drops to `[R-PUB, R-SEM]`. **Consumption** of the fixtures by a live matrix run is **not** claimed here — that remains under R-SEM (the #373 coverage program). This closes the repository-content half of R-MATRIX only, and STATUS.md is worded accordingly.

## Tests (live `#expect`)
Fixtures load and every manifest SHA binds actual bytes; required ship axes covered; **mutating a fixture byte reopens R-MATRIX** via the contract's `openDebts` (mutation-checked). Full suite `--no-parallel`: **2988 passed**.

Part of ADR-001 (#284); R-PUB and R-SEM remain open.