### PR TITLE
qualification: #373 Phase B0 — cross-field oracle constraints

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -16,8 +16,15 @@ import Foundation
 // mutation-tested so an oracle that cannot fail a corrupted payload fails CI.
 //
 // Presence-only oracles are FORBIDDEN: an oracle must carry at least one VALUE
-// constraint (valueEquals / numericRange / enumMember) or be an explicitly
-// reasoned `.custom` escape hatch.
+// constraint (valueEquals / numericRange / enumMember / fieldsEqual /
+// crossCheck) or be an explicitly reasoned `.custom` escape hatch.
+//
+// #373 Phase B0 — extends the model with two RELATIONAL constraints so the
+// safe-mutation surface can be expressed declaratively: `.fieldsEqual` pins the
+// `requested == observed` invariant of a verified write, and `.crossCheck` pins
+// response↔independent-readback agreement (previously only a `.custom` closure
+// could). The 50 concrete safe-mutation oracles land in Phase B1–B3; this file
+// only carries the reusable framework they build on (see `SafeMutationOracle`).
 
 /// A JSON leaf value an oracle can pin exactly.
 enum JSONPrimitive: Sendable, Equatable {
@@ -54,45 +61,82 @@ enum OracleConstraint: Sendable {
     case nonEmptyArray(key: String)
     /// Field must be present with the given JSON type.
     case typedField(key: String, type: JSONType)
+    /// Two key paths WITHIN THE SAME payload resolve to equal leaf values. The
+    /// load-bearing safe-mutation invariant: a verified write echoes what was
+    /// requested as what was observed, so `requested == observed` proves the
+    /// value that LANDED is the value that was ASKED FOR — not merely that some
+    /// value is present. Bool-vs-number safe: a requested `true` is not
+    /// satisfied by an observed `1`.
+    case fieldsEqual(keyA: String, keyB: String)
+    /// A key path in the RESPONSE equals a key path in the INDEPENDENT readback.
+    /// Makes response↔readback agreement declarative instead of a bespoke
+    /// closure. Fails closed when the readback is absent or unparseable — an
+    /// unverifiable cross-check is not a pass. Bool-vs-number safe on both sides.
+    case crossCheck(responseKey: String, readbackKey: String)
 
+    /// The primary RESPONSE-side key path — the one the generic mutator drops
+    /// and error messages cite. For the relational cases it is the response side
+    /// (`keyA` / `responseKey`); the second key is reached case-locally.
     var key: String {
         switch self {
         case .valueEquals(let key, _),
              .numericRange(let key, _, _),
              .enumMember(let key, _),
              .nonEmptyArray(let key),
-             .typedField(let key, _):
+             .typedField(let key, _),
+             .fieldsEqual(let key, _),
+             .crossCheck(let key, _):
             return key
         }
     }
 
     /// VALUE constraints pin meaning; the others only pin shape. The strength
-    /// meta-test uses this to forbid presence-only oracles.
+    /// meta-test uses this to forbid presence-only oracles. The relational cases
+    /// are value-bearing: `fieldsEqual`/`crossCheck` assert a concrete agreement
+    /// between two OBSERVED values, which is stronger than presence — so an
+    /// oracle carrying one is never a checkbox oracle.
     var isValueConstraint: Bool {
         switch self {
-        case .valueEquals, .numericRange, .enumMember:
+        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck:
             return true
         case .nonEmptyArray, .typedField:
             return false
         }
     }
 
-    func isSatisfied(by root: Any) -> Bool {
-        guard let value = JSONPath.resolve(root, keyPath: key) else { return false }
+    /// `readback` is the parsed INDEPENDENT readback payload, read only by
+    /// `.crossCheck`; every other case ignores it. Defaulting it to nil keeps the
+    /// single-payload call sites (and the engine unit tests) unchanged.
+    func isSatisfied(by root: Any, readback: Any? = nil) -> Bool {
         switch self {
-        case .valueEquals(_, let expected):
+        case .valueEquals(let key, let expected):
+            guard let value = JSONPath.resolve(root, keyPath: key) else { return false }
             return JSONInspector.primitive(of: value) == expected
-        case .numericRange(_, let min, let max):
-            guard let number = JSONInspector.number(of: value) else { return false }
+        case .numericRange(let key, let min, let max):
+            guard let value = JSONPath.resolve(root, keyPath: key),
+                  let number = JSONInspector.number(of: value) else { return false }
             return number >= min && number <= max
-        case .enumMember(_, let allowed):
-            guard let token = JSONInspector.enumToken(of: value) else { return false }
+        case .enumMember(let key, let allowed):
+            guard let value = JSONPath.resolve(root, keyPath: key),
+                  let token = JSONInspector.enumToken(of: value) else { return false }
             return allowed.contains(token)
-        case .nonEmptyArray:
-            guard let array = value as? [Any] else { return false }
+        case .nonEmptyArray(let key):
+            guard let array = JSONPath.resolve(root, keyPath: key) as? [Any] else { return false }
             return !array.isEmpty
-        case .typedField(_, let type):
+        case .typedField(let key, let type):
+            guard let value = JSONPath.resolve(root, keyPath: key) else { return false }
             return JSONInspector.type(of: value) == type
+        case .fieldsEqual(let keyA, let keyB):
+            guard let a = JSONPath.resolve(root, keyPath: keyA),
+                  let b = JSONPath.resolve(root, keyPath: keyB) else { return false }
+            return JSONInspector.leavesEqual(a, b)
+        case .crossCheck(let responseKey, let readbackKey):
+            // Fail closed: no readback means nothing to cross-check against,
+            // which is an unverified read — never a pass.
+            guard let readback,
+                  let a = JSONPath.resolve(root, keyPath: responseKey),
+                  let b = JSONPath.resolve(readback, keyPath: readbackKey) else { return false }
+            return JSONInspector.leavesEqual(a, b)
         }
     }
 }
@@ -103,8 +147,10 @@ enum OracleStrength: String, Sendable {
     /// Mixes exact values with domain/shape constraints for the
     /// environment-dependent fields.
     case shapeAndDomain
-    /// Escape hatch: the response is not key-addressable JSON, or the check is
-    /// a response↔readback cross-check the constraint data model cannot express.
+    /// Escape hatch: the response is not key-addressable JSON (prose bodies,
+    /// bare scalars), or the check is a conditional the constraint model cannot
+    /// express. Response↔readback cross-checks are NO LONGER a reason to reach
+    /// for this — `.crossCheck` (Phase B0) expresses them declaratively.
     case custom
 }
 
@@ -156,7 +202,55 @@ struct OperationOracle: Sendable {
             return custom(responseData, readbackData)
         }
         guard let root = JSONInspector.parse(responseData) else { return false }
-        return constraints.allSatisfy { $0.isSatisfied(by: root) }
+        // A missing/unparseable readback is nil; only `.crossCheck` reads it (and
+        // it fails closed on nil). Every non-relational constraint ignores the
+        // readback, so their verdicts are byte-for-byte unchanged.
+        let readback = JSONInspector.parse(readbackData)
+        return constraints.allSatisfy { $0.isSatisfied(by: root, readback: readback) }
+    }
+}
+
+// MARK: - Safe-mutation composition
+
+/// The base every Phase-B *safe-mutation* oracle composes with.
+///
+/// A read-only oracle pins what a query returned; a mutation oracle must first
+/// prove the write was GENUINELY verified before it inspects what changed. The
+/// HonestContract tri-state makes that precise: only State A ("write + read-back
+/// matched") is a verified success. State B ("write landed, could not confirm")
+/// and State C ("write failed") are honest non-verifications and must never be
+/// laundered into a semantic pass.
+///
+/// The envelope is expressed as ordinary declarative constraints — not a bespoke
+/// closure — so each clause is mutation-tested like any other, and a mutation
+/// oracle is just `verifiedEnvelope + <its own invariant>` (typically a
+/// `.fieldsEqual(requested, observed)`). The 50 concrete oracles land in #373
+/// Phase B1–B3; this is only the reusable base they build on.
+enum SafeMutationOracle {
+    /// State A + verified + success, triple-guarded so no single dropped or
+    /// forged field can pass a State B / State C envelope off as a verified
+    /// write. `state == "A"` alone already excludes B and C; `verified == true`
+    /// and `success == true` are kept as independent guards so a handler that
+    /// mislabels its `state` cannot launder an unverified write on one typo.
+    static let verifiedEnvelope: [OracleConstraint] = [
+        .valueEquals(key: "state", expected: .string("A")),
+        .valueEquals(key: "verified", expected: .bool(true)),
+        .valueEquals(key: "success", expected: .bool(true)),
+    ]
+
+    /// Compose the verified envelope with an operation's own semantic clauses.
+    /// The envelope is always FIRST, so a mutation oracle can never assert what
+    /// changed without first proving the change was verified.
+    static func oracle(
+        _ operationID: OperationID,
+        strength: OracleStrength = .shapeAndDomain,
+        semantics: [OracleConstraint]
+    ) -> OperationOracle {
+        OperationOracle(
+            operationID,
+            strength: strength,
+            constraints: verifiedEnvelope + semantics
+        )
     }
 }
 
@@ -208,6 +302,39 @@ enum JSONInspector {
         case .string: return value as? String
         case .bool: return ((value as? NSNumber)?.boolValue ?? false) ? "true" : "false"
         default: return nil
+        }
+    }
+
+    /// Leaf/structural equality with the SAME bool-vs-number discipline as
+    /// `primitive(of:)`: a `true` never equals a `1`, because the two are
+    /// distinguished by CFBooleanGetTypeID before any numeric bridge can conflate
+    /// them. Arrays and objects compare recursively so the discipline holds at
+    /// every depth. Used by the relational constraints (`fieldsEqual` /
+    /// `crossCheck`) — the load-bearing safe-mutation checks.
+    static func leavesEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+        let lhsType = type(of: lhs)
+        guard lhsType == type(of: rhs) else { return false }
+        switch lhsType {
+        case .bool:
+            return (lhs as? NSNumber)?.boolValue == (rhs as? NSNumber)?.boolValue
+        case .number:
+            return number(of: lhs) == number(of: rhs)
+        case .string:
+            return (lhs as? String) == (rhs as? String)
+        case .null:
+            return true
+        case .array:
+            guard let la = lhs as? [Any], let ra = rhs as? [Any], la.count == ra.count else {
+                return false
+            }
+            return zip(la, ra).allSatisfy { leavesEqual($0, $1) }
+        case .object:
+            guard let lo = lhs as? [String: Any], let ro = rhs as? [String: Any],
+                  lo.count == ro.count else { return false }
+            return lo.allSatisfy { key, value in
+                guard let other = ro[key] else { return false }
+                return leavesEqual(value, other)
+            }
         }
     }
 }

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -85,6 +85,75 @@ struct SemanticOracleEngineTests {
         #expect(!OracleConstraint.typedField(key: "missing", type: .string).isSatisfied(by: object))
     }
 
+    // MARK: - relational constraints (Phase B0)
+
+    @Test func fieldsEqualHoldsWhenTwoKeyPathsAgreeAndFailsWhenTheyDiverge() {
+        let object = root(#"{"requested":-6.0,"observed":-6.0,"other":-3.0}"#)
+        #expect(OracleConstraint.fieldsEqual(keyA: "requested", keyB: "observed").isSatisfied(by: object))
+        #expect(!OracleConstraint.fieldsEqual(keyA: "requested", keyB: "other").isSatisfied(by: object))
+        // A missing side can never agree — corrupt inputs fail closed, not open.
+        #expect(!OracleConstraint.fieldsEqual(keyA: "requested", keyB: "absent").isSatisfied(by: object))
+        #expect(!OracleConstraint.fieldsEqual(keyA: "absent", keyB: "observed").isSatisfied(by: object))
+    }
+
+    /// The same bool-vs-number discipline valueEquals enforces: a requested
+    /// boolean `true` must not be satisfied by an observed numeric `1`, or a
+    /// mute/arm write's `requested == observed` invariant becomes forgeable.
+    @Test func fieldsEqualDoesNotConflateBooleanAndNumericOne() {
+        let object = root(#"{"reqBool":true,"obsOne":1,"reqTrue":true,"obsTrue":true}"#)
+        #expect(!OracleConstraint.fieldsEqual(keyA: "reqBool", keyB: "obsOne").isSatisfied(by: object))
+        #expect(OracleConstraint.fieldsEqual(keyA: "reqTrue", keyB: "obsTrue").isSatisfied(by: object))
+    }
+
+    @Test func fieldsEqualComparesStringsAndNestedStructuresPreservingTheDiscipline() {
+        let strings = root(#"{"a":"Kick 1","b":"Kick 1","c":"Kick 2"}"#)
+        #expect(OracleConstraint.fieldsEqual(keyA: "a", keyB: "b").isSatisfied(by: strings))
+        #expect(!OracleConstraint.fieldsEqual(keyA: "a", keyB: "c").isSatisfied(by: strings))
+        // Nested containers compare structurally; the bool≠1 rule holds at depth.
+        let nested = root(#"{"x":{"v":1,"on":true},"y":{"v":1,"on":true},"z":{"v":1,"on":1}}"#)
+        #expect(OracleConstraint.fieldsEqual(keyA: "x", keyB: "y").isSatisfied(by: nested))
+        #expect(!OracleConstraint.fieldsEqual(keyA: "x", keyB: "z").isSatisfied(by: nested))
+    }
+
+    @Test func crossCheckAgreesAcrossPayloadsAndFailsOnDivergenceOrMissingReadback() {
+        let response = root(#"{"value":-6.0,"name":"Bass"}"#)
+        let constraint = OracleConstraint.crossCheck(responseKey: "value", readbackKey: "observed_value")
+        #expect(constraint.isSatisfied(by: response, readback: root(#"{"observed_value":-6.0}"#)))
+        #expect(!constraint.isSatisfied(by: response, readback: root(#"{"observed_value":-3.0}"#)))
+        // Fail closed: an absent readback is not a pass.
+        #expect(!constraint.isSatisfied(by: response, readback: nil))
+        // A readback missing the cross-checked key is a divergence, not a pass.
+        #expect(!constraint.isSatisfied(by: response, readback: root(#"{"other":-6.0}"#)))
+    }
+
+    @Test func crossCheckDoesNotConflateBooleanAndNumericOneAcrossPayloads() {
+        let response = root(#"{"flag":true}"#)
+        let constraint = OracleConstraint.crossCheck(responseKey: "flag", readbackKey: "mirror")
+        #expect(!constraint.isSatisfied(by: response, readback: root(#"{"mirror":1}"#)))
+        #expect(constraint.isSatisfied(by: response, readback: root(#"{"mirror":true}"#)))
+    }
+
+    /// Through the full Data path: `evaluate` parses the readback, so an
+    /// unparseable readback resolves to nil and `.crossCheck` fails closed rather
+    /// than laundering an unverifiable read into a pass.
+    @Test func crossCheckOracleFailsClosedWhenReadbackIsUnparseable() throws {
+        let oracle = OperationOracle(
+            .transportPlay,
+            strength: .shapeAndDomain,
+            constraints: [.crossCheck(responseKey: "value", readbackKey: "value")]
+        )
+        let agreed = try #require(oracle.evaluate(
+            responseData: Data(#"{"value":1}"#.utf8),
+            readbackData: Data(#"{"value":1}"#.utf8)
+        ))
+        #expect(agreed)
+        let failedClosed: Bool = oracle.evaluate(
+            responseData: Data(#"{"value":1}"#.utf8),
+            readbackData: Data("not json".utf8)
+        ) == true
+        #expect(!failedClosed)
+    }
+
     // MARK: - key paths
 
     @Test func keyPathsResolveNestingIndexingAndTheRoot() {
@@ -217,6 +286,33 @@ struct SemanticOracleStrengthTests {
             let allExact = oracle.constraints.allSatisfy(Self.isExactValue)
             #expect(allExact, "\(oracle.operationID.rawValue) claims .value strength inexactly")
         }
+    }
+
+    /// Phase B0: the relational constraints are VALUE-bearing, so an oracle
+    /// carrying only a `fieldsEqual` or `crossCheck` (and no `valueEquals`) still
+    /// passes the anti-checkbox gate — the gate must not force a redundant
+    /// constant onto a mutation oracle whose real check is the agreement.
+    @Test func relationalConstraintsAreValueBearingAndSurviveTheStrengthGate() {
+        #expect(OracleConstraint.fieldsEqual(keyA: "a", keyB: "b").isValueConstraint)
+        #expect(OracleConstraint.crossCheck(responseKey: "a", readbackKey: "b").isValueConstraint)
+
+        let fieldsEqualOnly = OperationOracle(
+            .transportPlay,
+            strength: .shapeAndDomain,
+            constraints: [.fieldsEqual(keyA: "requested", keyB: "observed")]
+        )
+        #expect(fieldsEqualOnly.isSemanticallyLoadBearing)
+
+        let crossCheckOnly = OperationOracle(
+            .transportPlay,
+            strength: .shapeAndDomain,
+            constraints: [.crossCheck(responseKey: "value", readbackKey: "value")]
+        )
+        #expect(crossCheckOnly.isSemanticallyLoadBearing)
+
+        // Shape-only constraints remain non-value-bearing — the gate still bites.
+        #expect(!OracleConstraint.typedField(key: "a", type: .string).isValueConstraint)
+        #expect(!OracleConstraint.nonEmptyArray(key: "a").isValueConstraint)
     }
 
     private static func isExactValue(_ constraint: OracleConstraint) -> Bool {
@@ -401,6 +497,150 @@ struct SemanticOracleMutationTests {
     }
 }
 
+// MARK: - safe-mutation base (Phase B0)
+
+@Suite("#373 Phase B0 safe-mutation oracle base")
+struct SafeMutationOracleTests {
+    private func passes(_ oracle: OperationOracle, _ response: String, readback: String = "{}") -> Bool {
+        oracle.evaluate(responseData: Data(response.utf8), readbackData: Data(readback.utf8)) == true
+    }
+
+    /// A genuine State A verified write passes the base envelope; the honest
+    /// non-verifications (B, C) do not, so "I couldn't verify" can never be
+    /// laundered into a semantic pass.
+    @Test func verifiedEnvelopePassesStateAAndRejectsStateBAndC() {
+        let oracle = SafeMutationOracle.oracle(.transportPlay, semantics: [])
+        #expect(passes(oracle, #"{"success":true,"verified":true,"state":"A"}"#))
+        #expect(!passes(oracle, #"{"success":true,"verified":false,"state":"B","reason":"ax_readback_unavailable"}"#))
+        #expect(!passes(oracle, #"{"success":false,"verified":false,"state":"C","error":"invalid_params"}"#))
+    }
+
+    /// Each envelope clause is independently load-bearing: forging or dropping
+    /// any ONE must sink the verdict, so a single mislabeled field cannot pass a
+    /// State B envelope off as a verified write.
+    @Test func eachEnvelopeClauseIsIndependentlyLoadBearing() {
+        let oracle = SafeMutationOracle.oracle(.transportPlay, semantics: [])
+        // `state` forged to A while `verified` is still false (B wearing A's tag).
+        #expect(!passes(oracle, #"{"success":true,"verified":false,"state":"A"}"#))
+        // `verified` forged true while `state` is still B.
+        #expect(!passes(oracle, #"{"success":true,"verified":true,"state":"B"}"#))
+        // `success` false under an otherwise A-looking envelope.
+        #expect(!passes(oracle, #"{"success":false,"verified":true,"state":"A"}"#))
+        // A dropped field is absent → its valueEquals fails closed.
+        #expect(!passes(oracle, #"{"verified":true,"state":"A"}"#))
+    }
+
+    /// The base composes: envelope FIRST, then the op's own invariant. A verified
+    /// envelope whose requested≠observed is still not a semantic pass, and an
+    /// unverified envelope fails before the invariant is even consulted.
+    @Test func envelopeComposesWithASafeMutationInvariant() {
+        let oracle = SafeMutationOracle.oracle(.transportPlay, semantics: [
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+        ])
+        #expect(passes(oracle, #"{"success":true,"verified":true,"state":"A","requested":-6.0,"observed":-6.0}"#))
+        // Verified write, but what landed is not what was asked for.
+        #expect(!passes(oracle, #"{"success":true,"verified":true,"state":"A","requested":-6.0,"observed":-3.0}"#))
+        // Unverified (State B) — fails on the envelope regardless of the invariant.
+        #expect(!passes(oracle, #"{"success":true,"verified":false,"state":"B","requested":-6.0,"observed":-6.0}"#))
+    }
+
+    @Test func verifiedEnvelopeIsThreeValueConstraintsAndComposesLoadBearing() {
+        #expect(SafeMutationOracle.verifiedEnvelope.count == 3)
+        #expect(SafeMutationOracle.verifiedEnvelope.allSatisfy { $0.isValueConstraint })
+        let composed = SafeMutationOracle.oracle(.transportPlay, semantics: [
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+        ])
+        #expect(composed.isSemanticallyLoadBearing)
+        #expect(composed.strength == .shapeAndDomain)
+        #expect(composed.constraints.count == 4)
+    }
+}
+
+// MARK: - relational mutation harness (Phase B0)
+
+@Suite("#373 Phase B0 relational mutation")
+struct SemanticOracleRelationalMutationTests {
+    /// The relational constraints are load-bearing under the SAME generic
+    /// mutation harness the B1–B3 mutating oracles will run through: every mutant
+    /// the mutator derives for a `fieldsEqual` must sink the oracle. Proven on a
+    /// synthetic oracle because the table carries no mutating oracle yet — the
+    /// read-only census stays at 20 (see SemanticOracleB0CensusTests).
+    @Test func fieldsEqualMutantsAreAllRejected() throws {
+        let response = #"{"requested":-6.0,"observed":-6.0}"#
+        let root = try #require(JSONInspector.parse(Data(response.utf8)))
+        let constraint = OracleConstraint.fieldsEqual(keyA: "requested", keyB: "observed")
+        let oracle = OperationOracle(.transportPlay, strength: .shapeAndDomain, constraints: [constraint])
+
+        // Guard: the pristine fixture passes, so a rejection below is the
+        // mutation's doing, not a broken baseline.
+        let baseline = try #require(oracle.evaluate(
+            responseData: Data(response.utf8), readbackData: Data("{}".utf8)))
+        #expect(baseline)
+
+        let mutants = JSONMutator.mutants(for: constraint, in: root)
+        #expect(mutants.count >= 3, "expected drop + two divergence mutants, got \(mutants.count)")
+        for mutant in mutants {
+            let data = try #require(JSONMutator.encode(mutant.json))
+            let survived: Bool = oracle.evaluate(
+                responseData: data, readbackData: Data("{}".utf8)) == true
+            #expect(!survived, "fieldsEqual survived mutant [\(mutant.label)]")
+        }
+    }
+
+    @Test func crossCheckResponseMutantsAndReadbackDivergenceAreRejected() throws {
+        let response = #"{"value":-6.0}"#
+        let readback = #"{"observed":-6.0}"#
+        let root = try #require(JSONInspector.parse(Data(response.utf8)))
+        let constraint = OracleConstraint.crossCheck(responseKey: "value", readbackKey: "observed")
+        let oracle = OperationOracle(.transportPlay, strength: .shapeAndDomain, constraints: [constraint])
+
+        let baseline = try #require(oracle.evaluate(
+            responseData: Data(response.utf8), readbackData: Data(readback.utf8)))
+        #expect(baseline)
+
+        // Response-side mutants — exactly what the table-driven harness runs
+        // (readback held fixed, response corrupted).
+        let mutants = JSONMutator.mutants(for: constraint, in: root)
+        #expect(mutants.count >= 2, "expected drop + divergence mutants, got \(mutants.count)")
+        for mutant in mutants {
+            let data = try #require(JSONMutator.encode(mutant.json))
+            let survived: Bool = oracle.evaluate(
+                responseData: data, readbackData: Data(readback.utf8)) == true
+            #expect(!survived, "crossCheck survived response mutant [\(mutant.label)]")
+        }
+
+        // Readback-side divergence: pristine response, corrupted readback.
+        let diverged: Bool = oracle.evaluate(
+            responseData: Data(response.utf8),
+            readbackData: Data(#"{"observed":-3.0}"#.utf8)) == true
+        #expect(!diverged)
+    }
+}
+
+// MARK: - census non-regression (Phase B0)
+
+@Suite("#373 Phase B0 census non-regression")
+struct SemanticOracleB0CensusTests {
+    /// B0 adds FRAMEWORK ONLY — no oracle was added to the table, so the
+    /// read-only census is unchanged and the mutating surface stays UNCOVERED
+    /// (its 50 oracles land in B1–B3). Pinning this catches a premature mutating
+    /// oracle and proves the mutating-census scaffold stays satisfiable at zero.
+    @Test func b0AddsNoTableOracleAndLeavesTheReadOnlyCensusAtTwenty() {
+        #expect(SemanticOracleTable.all.count == 20)
+        #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
+
+        let mutatingSpecIDs = Set(
+            OperationRegistry.specs.filter { $0.mutability == .mutating }.map(\.id)
+        )
+        let mutatingOraclesPresent = Set(SemanticOracleTable.byOperationID.keys)
+            .intersection(mutatingSpecIDs)
+        #expect(
+            mutatingOraclesPresent.isEmpty,
+            "B0 must not author mutating oracles: \(mutatingOraclesPresent.map(\.rawValue).sorted())"
+        )
+    }
+}
+
 // MARK: - mutator
 
 enum JSONMutator {
@@ -437,6 +677,22 @@ enum JSONMutator {
             mutants.append(contentsOf: replacements(root, key, [("emptied", [Any]())]))
         case .typedField(_, let type):
             mutants.append(contentsOf: replacements(root, key, [("wrong type", wrongTyped(type))]))
+        case .fieldsEqual(let keyA, let keyB):
+            // Break the equality by diverging EITHER side; each must sink the
+            // oracle. (`drop keyA` is already added generically via `key`.)
+            if let currentA = JSONPath.resolve(root, keyPath: keyA) {
+                mutants.append(contentsOf: replacements(root, keyA, [("diverge", divergent(from: currentA))]))
+            }
+            if let currentB = JSONPath.resolve(root, keyPath: keyB) {
+                mutants.append(contentsOf: replacements(root, keyB, [("diverge", divergent(from: currentB))]))
+            }
+        case .crossCheck(let responseKey, _):
+            // The harness holds the readback fixed and mutates the response, so
+            // diverging the response side breaks response==readback. (Readback-
+            // side divergence is exercised directly in the engine unit tests.)
+            if let current = JSONPath.resolve(root, keyPath: responseKey) {
+                mutants.append(contentsOf: replacements(root, responseKey, [("diverge", divergent(from: current))]))
+            }
         }
         return mutants
     }
@@ -457,6 +713,19 @@ enum JSONMutator {
         case .number(let value): return value + 1
         case .bool(let value): return !value
         case .null: return "no longer null"
+        }
+    }
+
+    /// A value guaranteed to differ from `value` under `JSONInspector.leavesEqual`
+    /// — used to break a relational constraint (fieldsEqual / crossCheck) by
+    /// corrupting one side. Mirrors the type discipline: a bool flips, a number
+    /// increments, a string is suffixed, a container/null becomes a sentinel.
+    private static func divergent(from value: Any) -> Any {
+        switch JSONInspector.type(of: value) {
+        case .string: return (value as? String ?? "") + "__oracle_mutant__"
+        case .number: return (JSONInspector.number(of: value) ?? 0) + 1
+        case .bool: return !((value as? NSNumber)?.boolValue ?? false)
+        case .array, .object, .null: return "__oracle_divergent__"
         }
     }
 


### PR DESCRIPTION
## Summary
The constraint-model prerequisite for #373 Phase B (the 50 safe-mutation semantic oracles). Extends `OracleConstraint` with two **cross-field** cases so safe-mutation invariants are declarative, not custom closures:
- **`.fieldsEqual(keyA, keyB)`** — the JSON values at two keypaths are equal (pins the `requested == observed` invariant of a verified write), with the framework's bool-vs-number discipline (a JSON `true` is never equal to a JSON `1`).
- **`.crossCheck(responseKey, readbackKey)`** — response equals the independent readback (declarative independent-readback agreement); a missing/unparseable readback **fails closed**.

Both are value-bearing (satisfy the anti-checkbox rule). Adds a **`verifiedEnvelope`** constraint set (`state==A` + `verified==true` + `success==true`) so a Phase-B oracle is `verifiedEnvelope + <its invariant>` and a State-B ("couldn't verify") response can never be laundered into a semantic pass. `JSONMutator` gains mutants for both cases so oracles using them are proven load-bearing.

## Scope
No mutating oracles are authored here — B1–B3 do that. The existing 20 read-only oracles + census are unchanged (no regression, no premature mutating-coverage requirement).

## Tests (live `#expect`, mutation-checked)
fieldsEqual agree→true, diverge/absent→false, **bool-vs-numeric-1→false**, strings/nested; crossCheck agree→true, diverge/missing/unparseable-readback→false; both cases' JSONMutator mutants all rejected; resolver/routing pins. Full suite `--no-parallel`: **3002 passed**. Adversarial gate: PROCEED.

First step of #373 Phase B; ADR-001 (#284).