### PR TITLE
qualification: #373 Phase B1 — 12 verified-write semantic oracles

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -49,8 +49,9 @@ enum SemanticOracleTable {
     /// resource returns the identical payload by construction.
     static let bespokeOperationIDs: Set<OperationID> = [.systemHealth]
 
-    /// The read-only surface this table must cover, derived from the registry
-    /// (the registry is truth — never a hand-maintained name list).
+    /// The read-only surface this table must FULLY cover, derived from the
+    /// registry (the registry is truth — never a hand-maintained name list).
+    /// Phase A/B0 invariant, unchanged: every read-only spec here has an oracle.
     static var coveredSpecIDs: Set<OperationID> {
         Set(
             OperationRegistry.specs
@@ -59,6 +60,73 @@ enum SemanticOracleTable {
         )
         .subtracting(bespokeOperationIDs)
     }
+
+    // ── #373 Phase B1 — DUAL census (generalize the census FIRST) ────────────
+    //
+    // Phase A/B0 covered ONLY the read-only surface, and the census pinned it
+    // exactly: every read-only spec had an oracle, and every oracle mapped back
+    // to a read-only spec. B1 begins the MUTATING surface, so a read-only-only
+    // census can no longer be sound — a mutating oracle has no read-only spec to
+    // map back to. The census is therefore generalized to two axes with DELIBER-
+    // ATELY DIFFERENT completeness contracts:
+    //
+    //   * read-only  — FULLY covered (all 20; `coveredSpecIDs`), unchanged.
+    //   * mutating   — covered INCREMENTALLY. B1 lands the verified-write oracles
+    //                  below; B2/B3 add the rest. Full 51-op mutating coverage is
+    //                  NOT required yet, so the census must not demand it.
+    //
+    // Soundness is kept by pinning the mutating increment EXACTLY
+    // (`phaseB1MutatingOperationIDs`) and by proving every id in it is a real
+    // `.mutating`, non-`.unsupported` registry spec — a read-only id or a typo
+    // cannot masquerade as mutating coverage, and the read-only 20 stay pinned.
+
+    /// The mutating operations B1 covers with a verified-write (State A) oracle.
+    /// Each was derived by READING its dispatcher/channel handler and pinning
+    /// what its `encodeStateA` / `encodeV2StateA` envelope actually emits (cited
+    /// per oracle below). NOT the whole mutating surface — an explicit increment.
+    ///
+    /// mixer.set_plugin_param is DELIBERATELY ABSENT: it routes to `[.scripter]`,
+    /// whose handler emits only State B (`readback_unavailable`,
+    /// `scripter_send_only`) — a send-only write that never reaches State A, so it
+    /// has no verified envelope to pin and cannot be an honest B1 oracle. It stays
+    /// uncovered until a State-B honest-contract oracle class exists.
+    static let phaseB1MutatingOperationIDs: Set<OperationID> = [
+        .mixerSetVolume, .mixerSetPan, .mixerSetMasterVolume,
+        .tracksSelect, .tracksRename, .tracksMute, .tracksSolo, .tracksArm,
+        .tracksArmOnly, .tracksSetAutomation, .tracksSetInstrument,
+        .pluginsSetParamVerified,
+    ]
+
+    /// The mutating surface (non-`.unsupported`), from the registry. Coverage is
+    /// INCREMENTAL — unlike `coveredSpecIDs`, the table need not cover all of this
+    /// yet; `phaseB1MutatingOperationIDs` is the covered subset.
+    static var mutatingSpecIDs: Set<OperationID> {
+        Set(
+            OperationRegistry.specs
+                .filter { $0.mutability == .mutating && $0.availability != .unsupported }
+                .map(\.id)
+        )
+    }
+
+    /// Every operation the table may legitimately carry an oracle for: the FULLY
+    /// covered read-only surface UNION the mutating surface. An oracle outside
+    /// this union is dead weight (no spec) or bound to an unsupported spec — the
+    /// census forbids both.
+    static var supportedOracleSurface: Set<OperationID> {
+        coveredSpecIDs.union(mutatingSpecIDs)
+    }
+
+    /// Mutating ops AUDITED in B1 and found to have NO verifiable State-A envelope
+    /// — deliberately, STRUCTURALLY excluded from the verified-write oracle set
+    /// (not merely "not yet phased in"), each with the reason. Kept EXPLICIT so
+    /// the exclusion is a reviewed decision, not an accidental gap: the census
+    /// asserts each is a real mutating spec, is DISJOINT from the covered set, and
+    /// carries a reason — so the uncovered complement is never fully implicit.
+    static let structurallyUnverifiedMutatingOperationIDs: [OperationID: String] = [
+        .mixerSetPluginParam:
+            "send-only State B — routes to [.scripter], whose handler emits only "
+            + "readback_unavailable / scripter_send_only; there is no State A to verify",
+    ]
 
     static let all: [OperationOracle] = [
         systemPermissions,
@@ -81,6 +149,19 @@ enum SemanticOracleTable {
         tracksScanLibrary,
         tracksResolvePath,
         tracksScanPluginPresets,
+        // #373 Phase B1 — verified-write safe-mutation oracles (State A).
+        mixerSetVolume,
+        mixerSetPan,
+        mixerSetMasterVolume,
+        tracksSelect,
+        tracksRename,
+        tracksMute,
+        tracksSolo,
+        tracksArm,
+        tracksArmOnly,
+        tracksSetAutomation,
+        tracksSetInstrument,
+        pluginsSetParamVerified,
     ]
 
     static let byOperationID: [OperationID: OperationOracle] = Dictionary(
@@ -608,6 +689,263 @@ enum SemanticOracleTable {
             .numericRange(key: "nodeCount", min: 0, max: 10_000_000),
             .numericRange(key: "leafCount", min: 0, max: 10_000_000),
             .numericRange(key: "scanDurationMs", min: 0, max: 3_600_000),
+        ]
+    )
+
+    // MARK: - #373 Phase B1 — verified-write safe-mutation oracles
+
+    // Each composes `SafeMutationOracle.verifiedEnvelope` (State A + verified +
+    // success — the honest-contract proof the write was CONFIRMED) with the
+    // operation's own semantic invariant, derived by READING the handler and
+    // pinning what its `encodeStateA` extras actually emit. The envelope is
+    // always FIRST, so no oracle asserts what changed before proving it was
+    // verified.
+
+    // mixer
+
+    // AccessibilityChannel+Mixer `defaultSetMixerValue` (target .volume) →
+    // encodeStateA(baseExtras). WHY NOT fieldsEqual(requested, observed): this
+    // fader is driven by AXIncrement/AXDecrement in ~10-raw-unit DETENTS, so the
+    // handler converges to the NEAREST representable detent — `observed` is
+    // deliberately ≠ `requested` in general. The write-LANDED proof is the
+    // handler's OWN State-A gate, `abs(observedRaw − targetRaw) <= 6.0`
+    // (AccessibilityChannel+Mixer.swift line 174), pinned as `.numericNear` on the
+    // raw AX values it emits: `observed_raw` is the achieved slider position and
+    // `target_raw` the REQUESTED value mapped to raw — DIFFERENT sources, so this
+    // is a genuine request↔readback bound, not a same-source echo. (The prior
+    // `fieldsEqual(observed, observed_after)` was a tautology — both keys are the
+    // same post-write read-back.) Plus the hardcoded write/verify method echoes;
+    // requested is domain-pinned; observed is shape-typed only.
+    static let mixerSetVolume = SafeMutationOracle.oracle(
+        .mixerSetVolume,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("mixer.set_volume")),
+            .valueEquals(key: "control", expected: .string("volume")),
+            .valueEquals(key: "verify_source", expected: .string("ax_slider")),
+            .valueEquals(key: "write_method", expected: .string("ax_increment_decrement")),
+            .numericNear(keyA: "observed_raw", keyB: "target_raw", within: .absolute(6.0)),
+            .numericRange(key: "requested", min: 0, max: 1),
+            .typedField(key: "observed", type: .number),
+        ]
+    )
+
+    // AccessibilityChannel+Mixer `defaultSetMixerValue` (target .pan) — same
+    // detent-quantized AX-slider path as set_volume (the `<= 6.0` raw convergence
+    // gate is shared code); `control` is "pan" and requested is the centered −1..1.
+    static let mixerSetPan = SafeMutationOracle.oracle(
+        .mixerSetPan,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("mixer.set_pan")),
+            .valueEquals(key: "control", expected: .string("pan")),
+            .valueEquals(key: "verify_source", expected: .string("ax_slider")),
+            .valueEquals(key: "write_method", expected: .string("ax_increment_decrement")),
+            .numericNear(keyA: "observed_raw", keyB: "target_raw", within: .absolute(6.0)),
+            .numericRange(key: "requested", min: -1, max: 1),
+            .typedField(key: "observed", type: .number),
+        ]
+    )
+
+    // MCUChannel `executeSetMasterVolume` → encodeStateA(extras). The master fader
+    // has NO AX track-header equivalent (#142), so an MCU echo on strip 8 is the
+    // ONLY readback and State A gates on `abs(observed − value) <= 2.0/16383.0`
+    // (14-bit echo resolution; MCUChannel.swift line 509). That handler tolerance
+    // is pinned as `.numericNear(observed, requested, 2/16383)` — a genuine
+    // request↔echo bound (observed is the decoded MCU echo, requested the input) —
+    // alongside the constant `track:"master"` (a STRING, not an index — uniquely
+    // marks the master-strip write) and `readback_source:"mcu_echo"`.
+    static let mixerSetMasterVolume = SafeMutationOracle.oracle(
+        .mixerSetMasterVolume,
+        semantics: [
+            .valueEquals(key: "track", expected: .string("master")),
+            .valueEquals(key: "readback_source", expected: .string("mcu_echo")),
+            .numericNear(keyA: "observed", keyB: "requested", within: .absolute(2.0 / 16383.0)),
+            .numericRange(key: "requested", min: 0, max: 1),
+        ]
+    )
+
+    // tracks
+
+    // AccessibilityChannel+Tracks `defaultSelectTrack` → encodeStateA(base +
+    // observed). base = {requested: index, selected: index}; State A merges
+    // observed: index — so all THREE are the same input `index`, re-echoed. The
+    // real verification is STRUCTURAL: the handler emits State A only in the
+    // `.verified` switch case (the AX readback confirmed selection landed on the
+    // requested track), so the ENVELOPE is the load-bearing proof. The
+    // requested/selected/observed equalities are therefore ECHO-INTEGRITY (the
+    // wire consistently carried the one index; a serialization that corrupted one
+    // side is caught), NOT a request↔readback semantic pin — the payload carries
+    // no independent readback value to pin. requested is domain-pinned.
+    static let tracksSelect = SafeMutationOracle.oracle(
+        .tracksSelect,
+        semantics: [
+            // Echo-integrity (same-source index), not a write-verification claim.
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .fieldsEqual(keyA: "selected", keyB: "observed"),
+            .numericRange(key: "requested", min: 0, max: 100_000),
+        ]
+    )
+
+    // AccessibilityChannel+Tracks `defaultRenameTrack` → encodeStateA(baseExtras
+    // + observed + via). State A is reached ONLY when the AX read-back name equals
+    // the requested name (`observed == truncatedName == requested`), so
+    // requested==observed is the load-bearing invariant (both strings; the keys
+    // are `requested`/`observed`, NOT `requested_name`/`observed_name` — pinned by
+    // reading the handler). `via` records the write path; `track` the index.
+    static let tracksRename = SafeMutationOracle.oracle(
+        .tracksRename,
+        semantics: [
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "track", type: .number),
+            .typedField(key: "via", type: .string),
+        ]
+    )
+
+    /// The `defaultSetTrackToggle` write strategies — the `action` a State-A
+    /// toggle records as the path that actually landed the write. Pinned as a
+    /// domain so a toggle claiming an unknown strategy is caught.
+    static let trackToggleActions = [
+        "no-op", "press", "confirm", "value-nsnumber", "value-cfbool", "mouse-click",
+    ]
+
+    // AccessibilityChannel+Tracks `defaultSetTrackToggle` (button "Mute") →
+    // encodeStateA(baseExtras + observed + action). The handler emits
+    // `observed: desired` — the SAME input value as `requested: desired` — so
+    // requested==observed is ECHO-INTEGRITY, not a readback pin: the real readback
+    // is STRUCTURAL (State A is reached only when `pollMatched` confirmed the AX
+    // value equals `desired`), carried by the envelope. The NON-tautological
+    // content is the constant `button` (which control), `verification_source` (how
+    // it was read), and `action` (which write strategy landed — a genuine effect
+    // record).
+    static let tracksMute = SafeMutationOracle.oracle(
+        .tracksMute,
+        semantics: [
+            .valueEquals(key: "button", expected: .string("Mute")),
+            .valueEquals(key: "verification_source", expected: .string("ax_value")),
+            .enumMember(key: "action", allowed: trackToggleActions),
+            // Echo-integrity (same-source desired), not a write-verification claim.
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "track", type: .number),
+        ]
+    )
+
+    // AccessibilityChannel+Tracks `defaultSetTrackToggle` (button "Solo") — same
+    // echo-integrity + genuine `action`/`button`/`verification_source` shape as mute.
+    static let tracksSolo = SafeMutationOracle.oracle(
+        .tracksSolo,
+        semantics: [
+            .valueEquals(key: "button", expected: .string("Solo")),
+            .valueEquals(key: "verification_source", expected: .string("ax_value")),
+            .enumMember(key: "action", allowed: trackToggleActions),
+            // Echo-integrity (same-source desired), not a write-verification claim.
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "track", type: .number),
+        ]
+    )
+
+    // AccessibilityChannel+Tracks `defaultSetTrackToggle` (button "Record" — the
+    // record-ARM checkbox; Logic labels the arm control "Record").
+    static let tracksArm = SafeMutationOracle.oracle(
+        .tracksArm,
+        semantics: [
+            .valueEquals(key: "button", expected: .string("Record")),
+            .valueEquals(key: "verification_source", expected: .string("ax_value")),
+            .enumMember(key: "action", allowed: trackToggleActions),
+            // Echo-integrity (same-source desired), not a write-verification claim.
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "track", type: .number),
+        ]
+    )
+
+    // TrackDispatcher `arm_only` → encodeStateA(armOnlyExtras(...)). arm_only's
+    // whole effect is "disarm every OTHER track + arm the target". It reaches
+    // State A only when the target arm is verified AND the disarm sweep left no
+    // failures/uncertainties — the dispatcher passes armedSuccess:true with
+    // failedDisarm:[] and unverifiedDisarm:[]. The MULTI-TRACK gate is pinned via
+    // `.emptyArray` on both lists (FIX 4) so the sweep effect is checked, not just
+    // the target arm. NOTE requested_enabled==observed_enabled and
+    // armed==target_track are ECHO-INTEGRITY: observed_enabled is forwarded from
+    // set_arm's `observed`, itself a re-echo of `desired` (see tracks.mute), and
+    // armed/target_track are the same index — neither is an independent readback.
+    // The genuine content is the op identity, armedSuccess, the always-arm intent
+    // (requested_enabled:true), and the empty failure lists. verification_source
+    // is NOT pinned — it is channel-dependent (forwarded from set_arm).
+    static let tracksArmOnly = SafeMutationOracle.oracle(
+        .tracksArmOnly,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("track.arm_only")),
+            .valueEquals(key: "armedSuccess", expected: .bool(true)),
+            .valueEquals(key: "requested_enabled", expected: .bool(true)),
+            // Multi-track gate: the disarm sweep left nothing failed or unverified.
+            .emptyArray(key: "failedDisarm"),
+            .emptyArray(key: "unverifiedDisarm"),
+            // Echo-integrity (forwarded/same-source), not a readback pin.
+            .fieldsEqual(keyA: "requested_enabled", keyB: "observed_enabled"),
+            .fieldsEqual(keyA: "armed", keyB: "target_track"),
+        ]
+    )
+
+    // MCUChannel `executeAutomation` → encodeStateA(extras). BOTH State-A branches
+    // (already-in-mode fast path, and the write path) emit function:"set_automation",
+    // the requested `mode`, and `observed_mode` == requested mode (State A gates on
+    // observedMode == requestedMode). The write-phase flags differ between the two
+    // branches, so ONLY the common keys are pinned: the hardcoded function echo,
+    // the legal mode domain, and the load-bearing mode==observed_mode agreement.
+    static let tracksSetAutomation = SafeMutationOracle.oracle(
+        .tracksSetAutomation,
+        semantics: [
+            .valueEquals(key: "function", expected: .string("set_automation")),
+            .enumMember(key: "mode", allowed: ["read", "write", "touch", "latch", "trim"]),
+            .fieldsEqual(keyA: "mode", keyB: "observed_mode"),
+        ]
+    )
+
+    // AccessibilityChannel+Library `setTrackInstrument` → encodeStateA(base +
+    // observed/observed_patch_name + verify_source + readback_state:"verified").
+    // State A is reached ONLY when the Library panel's selected-preset read-back
+    // equals the requested preset (`observed == preset`), so requested==observed
+    // is the load-bearing invariant (base sets requested==preset and
+    // observed_patch_name==observed). verify_source/readback_state are the
+    // hardcoded honest-read markers.
+    static let tracksSetInstrument = SafeMutationOracle.oracle(
+        .tracksSetInstrument,
+        semantics: [
+            .valueEquals(key: "verify_source", expected: .string("library_selected_children")),
+            .valueEquals(key: "readback_state", expected: .string("verified")),
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .fieldsEqual(keyA: "preset", keyB: "observed_patch_name"),
+        ]
+    )
+
+    // plugins
+
+    // AccessibilityChannel+VerifiedPlugins `defaultSetParamVerified` →
+    // encodeV2StateA(extras). HC v2 (the verified-plugin superset): the envelope
+    // additionally carries `hc_schema:2`, pinned here. State A is the tolerance
+    // gate `abs(after − requested) <= tolerance` (VerifiedPlugins line 1056), and
+    // `tolerance` is PER-PARAMETER in the parameter's OWN unit (0..1 for some
+    // controls, 0..100 for others — e.g. Compressor Threshold, tolerance 1.0), so
+    // no single constant could bound it. It is pinned as
+    // `.numericNear(observed_normalized, requested_normalized, .field("tolerance"))`
+    // — reading the bound from the payload's OWN emitted tolerance, the faithful
+    // request↔readback proof (observed_normalized is the achieved slider read,
+    // requested_normalized the input). Plus the hardcoded same-surface
+    // write/verify (no cross-surface laundering), display_unit, operation
+    // identity, and target_identity/param shapes.
+    static let pluginsSetParamVerified = SafeMutationOracle.oracle(
+        .pluginsSetParamVerified,
+        semantics: [
+            .valueEquals(key: "hc_schema", expected: .number(2)),
+            .valueEquals(key: "operation", expected: .string("logic_plugins.set_param_verified")),
+            .valueEquals(key: "write_source", expected: .string("ax_plugin_window")),
+            .valueEquals(key: "verify_source", expected: .string("ax_plugin_window")),
+            .valueEquals(key: "display_unit", expected: .string("%")),
+            .numericNear(
+                keyA: "observed_normalized",
+                keyB: "requested_normalized",
+                within: .field("tolerance")
+            ),
+            .typedField(key: "target_identity", type: .object),
+            .typedField(key: "param", type: .string),
         ]
     )
 }

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -44,6 +44,20 @@ enum JSONType: String, Sendable, Equatable {
     case null
 }
 
+/// How `.numericNear` bounds the gap between its two keys.
+///
+/// `.absolute` is right where the handler's convergence tolerance is a HARD-CODED
+/// constant — the mixer AX-slider detent gate (`|observed_raw − target_raw| ≤ 6`)
+/// and the MCU 14-bit echo tolerance (`2/16383`). `.field` reads the bound from
+/// the payload's OWN tolerance key, which is the only faithful choice where the
+/// handler's tolerance is DATA-DRIVEN and unit-specific: `set_param_verified`
+/// carries a per-parameter `tolerance` in the parameter's own unit (0..1 for some
+/// controls, 0..100 for others), so no single constant could bound it soundly.
+enum NearnessBound: Sendable, Equatable {
+    case absolute(Double)
+    case field(String)
+}
+
 /// One declarative check against an operation's response payload.
 ///
 /// `key` is a dotted key path resolved against the parsed response:
@@ -73,6 +87,21 @@ enum OracleConstraint: Sendable {
     /// closure. Fails closed when the readback is absent or unparseable — an
     /// unverifiable cross-check is not a pass. Bool-vs-number safe on both sides.
     case crossCheck(responseKey: String, readbackKey: String)
+    /// Two numeric key paths WITHIN THE SAME payload agree to within a tolerance:
+    /// `|value(keyA) − value(keyB)| ≤ bound`. The honest form of "the write landed
+    /// near what was requested" for QUANTIZED writes, where an exact `fieldsEqual`
+    /// would false-reject a legitimate verified write: an AX fader converges to
+    /// the nearest ~10-raw-unit detent, an MCU echo to 14-bit resolution, a plugin
+    /// slider to a per-parameter tolerance. NUMBERS ONLY, with the same
+    /// bool-vs-number discipline as the rest of the model — a bool is never "near"
+    /// a number (`number(of:)` rejects booleans) — and fails closed on a missing
+    /// key, a non-number, or (for `.field`) a missing/negative tolerance.
+    case numericNear(keyA: String, keyB: String, within: NearnessBound)
+    /// Field must be an array with EXACTLY zero elements. The mirror of
+    /// `.nonEmptyArray`, for pinning a "nothing went wrong" gate in the payload —
+    /// e.g. a multi-step op that reaches State A only when its failure/uncertainty
+    /// lists are empty. Fails closed on a missing key or a non-array.
+    case emptyArray(key: String)
 
     /// The primary RESPONSE-side key path — the one the generic mutator drops
     /// and error messages cite. For the relational cases it is the response side
@@ -85,7 +114,9 @@ enum OracleConstraint: Sendable {
              .nonEmptyArray(let key),
              .typedField(let key, _),
              .fieldsEqual(let key, _),
-             .crossCheck(let key, _):
+             .crossCheck(let key, _),
+             .numericNear(let key, _, _),
+             .emptyArray(let key):
             return key
         }
     }
@@ -97,9 +128,9 @@ enum OracleConstraint: Sendable {
     /// oracle carrying one is never a checkbox oracle.
     var isValueConstraint: Bool {
         switch self {
-        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck:
+        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck, .numericNear:
             return true
-        case .nonEmptyArray, .typedField:
+        case .nonEmptyArray, .typedField, .emptyArray:
             return false
         }
     }
@@ -137,6 +168,28 @@ enum OracleConstraint: Sendable {
                   let a = JSONPath.resolve(root, keyPath: responseKey),
                   let b = JSONPath.resolve(readback, keyPath: readbackKey) else { return false }
             return JSONInspector.leavesEqual(a, b)
+        case .numericNear(let keyA, let keyB, let within):
+            // NUMBERS ONLY: `number(of:)` rejects booleans, so a bool is never
+            // "near" a number. A missing key, a non-number, or (for `.field`) a
+            // missing/negative tolerance all fail closed.
+            guard let aValue = JSONPath.resolve(root, keyPath: keyA),
+                  let bValue = JSONPath.resolve(root, keyPath: keyB),
+                  let a = JSONInspector.number(of: aValue),
+                  let b = JSONInspector.number(of: bValue) else { return false }
+            let bound: Double
+            switch within {
+            case .absolute(let value):
+                bound = value
+            case .field(let toleranceKey):
+                guard let raw = JSONPath.resolve(root, keyPath: toleranceKey),
+                      let tolerance = JSONInspector.number(of: raw),
+                      tolerance >= 0 else { return false }
+                bound = tolerance
+            }
+            return abs(a - b) <= bound
+        case .emptyArray(let key):
+            guard let array = JSONPath.resolve(root, keyPath: key) as? [Any] else { return false }
+            return array.isEmpty
         }
     }
 }

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -459,5 +459,142 @@ enum SemanticOracleFixtures {
                 "ax_occluded":false,"data":{"categories":["Bass"],"source":"ax"}}
                 """
         ),
+
+        // ── #373 Phase B1 — verified-write State-A fixtures ──────────────────
+        // Each is a faithful State-A payload from the op's `encodeStateA` /
+        // `encodeV2StateA` path. `observed` is the DETENT/TOLERANCE-quantized
+        // read-back where the handler quantizes (mixer sliders, set_param_verified)
+        // — deliberately ≠ `requested` — so the fixtures model the real verified
+        // shape, not an idealized requested==observed. Readback is unused (no
+        // oracle here cross-checks), so it is a bare `{}`.
+
+        // AccessibilityChannel+Mixer.defaultSetMixerValue (.volume): requested
+        // 0.5 lands on the nearest AX detent, observed 0.48 == observed_after.
+        .mixerSetVolume: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"mixer.set_volume","track":0,"control":"volume",\
+                "requested":0.5,"target_identity":{"track_index":0,"control":"volume"},\
+                "observed_before":0.30,"observed_after":0.48,"observed":0.48,\
+                "observed_raw":48.0,"target_raw":50.0,"detent_raw_step":10,\
+                "verify_source":"ax_slider","write_method":"ax_increment_decrement",\
+                "nudge_steps":3,"quantization_note":"nearest representable level"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Mixer.defaultSetMixerValue (.pan): centered range.
+        .mixerSetPan: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"mixer.set_pan","track":1,"control":"pan",\
+                "requested":-0.30,"target_identity":{"track_index":1,"control":"pan"},\
+                "observed_before":0.0,"observed_after":-0.28,"observed":-0.28,\
+                "observed_raw":36.0,"target_raw":35.0,"detent_raw_step":10,\
+                "verify_source":"ax_slider","write_method":"ax_increment_decrement",\
+                "nudge_steps":2,"quantization_note":"nearest representable level"}
+                """,
+            readback: "{}"
+        ),
+        // MCUChannel.executeSetMasterVolume: track "master" (string), MCU echo.
+        // observed is 14-bit-echo-quantized ≈ requested (0.5001 vs 0.5, within
+        // 2/16383 ≈ 0.000122) — near, deliberately not equal.
+        .mixerSetMasterVolume: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "requested":0.5,"observed":0.5001,"track":"master",\
+                "readback_source":"mcu_echo"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Tracks.defaultSelectTrack: requested==selected==observed.
+        .tracksSelect: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "requested":2,"selected":2,"observed":2}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Tracks.defaultRenameTrack: observed name == requested.
+        .tracksRename: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","track":2,\
+                "requested":"Lead Synth","observed":"Lead Synth","via":"ax_set_value"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Tracks.defaultSetTrackToggle (Mute): requested==observed bool.
+        .tracksMute: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","track":1,\
+                "button":"Mute","requested":true,"verification_source":"ax_value",\
+                "observed":true,"action":"press"}
+                """,
+            readback: "{}"
+        ),
+        .tracksSolo: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","track":1,\
+                "button":"Solo","requested":true,"verification_source":"ax_value",\
+                "observed":true,"action":"press"}
+                """,
+            readback: "{}"
+        ),
+        .tracksArm: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","track":1,\
+                "button":"Record","requested":true,"verification_source":"ax_value",\
+                "observed":true,"action":"mouse-click"}
+                """,
+            readback: "{}"
+        ),
+        // TrackDispatcher.arm_only: armed==target_track, requested_enabled==observed_enabled.
+        .tracksArmOnly: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"track.arm_only","armed":2,"target_track":2,\
+                "armedSuccess":true,"requested_enabled":true,"observed_enabled":true,\
+                "verification_source":"ax_value","disarmed":[0,1],\
+                "unverifiedDisarm":[],"failedDisarm":[],"detail":"track 2 armed"}
+                """,
+            readback: "{}"
+        ),
+        // MCUChannel.executeAutomation (fast path): mode == observed_mode.
+        .tracksSetAutomation: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "function":"set_automation","track":1,"mode":"read",\
+                "observed_mode":"read","write_attempted":false}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Library.setTrackInstrument: observed preset == requested.
+        .tracksSetInstrument: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "requested":"Deep Sub","requested_patch_name":"Deep Sub",\
+                "requested_category":"Bass","requested_path":"Bass/Deep Sub",\
+                "category":"Bass","preset":"Deep Sub","path":"Bass/Deep Sub",\
+                "target_track_index":1,"target_track_name":"Bass",\
+                "observed":"Deep Sub","observed_patch_name":"Deep Sub",\
+                "verify_source":"library_selected_children","readback_state":"verified"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+VerifiedPlugins.defaultSetParamVerified (HC v2):
+        // hc_schema 2, same-surface write/verify. Compressor Threshold — a real
+        // catalog param whose unit is 0..100 (normalized %) with tolerance 1.0, so
+        // observed_normalized 60.5 is within the payload's OWN tolerance of the
+        // requested 60.0 (|0.5| ≤ 1.0) — exercising the data-driven `.field` bound.
+        .pluginsSetParamVerified: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","hc_schema":2,\
+                "operation":"logic_plugins.set_param_verified",\
+                "target_identity":{"track":0,"insert":0,"plugin_id":"logic.stock.compressor"},\
+                "param":"threshold","requested_normalized":60.0,"observed_normalized":60.5,\
+                "observed_display":"60.5 %","display_unit":"%","tolerance":1.0,\
+                "write_source":"ax_plugin_window","verify_source":"ax_plugin_window"}
+                """,
+            readback: "{}"
+        ),
     ]
 }

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -115,6 +115,80 @@ struct SemanticOracleEngineTests {
         #expect(!OracleConstraint.fieldsEqual(keyA: "x", keyB: "z").isSatisfied(by: nested))
     }
 
+    /// #373 B1 equality-matrix — pins the exact `.fieldsEqual` contract every
+    /// safe-mutation oracle's requested==observed leans on (grok-ratified). It
+    /// must accept `3`/`3.0` (JSON does not distinguish int/double), reject a
+    /// number-vs-string `3`/`"3"`, and — crucially — never read an ABSENT key as
+    /// agreement: `null`/missing and `""`/missing both fail closed.
+    @Test func fieldsEqualEqualityMatrixPinsTheSafeMutationContract() {
+        let eq = OracleConstraint.fieldsEqual(keyA: "a", keyB: "b")
+        // 3 / 3.0 → pass.
+        #expect(eq.isSatisfied(by: root(#"{"a":3,"b":3.0}"#)))
+        // 3 / "3" → fail (a number is not the string "3").
+        #expect(!eq.isSatisfied(by: root(#"{"a":3,"b":"3"}"#)))
+        // null / missing → fail (a present null cannot agree with an absent key).
+        #expect(!eq.isSatisfied(by: root(#"{"a":null}"#)))
+        // "" / missing → fail (empty string present; other side absent).
+        #expect(!eq.isSatisfied(by: root(#"{"a":""}"#)))
+        // The boundary the matrix protects is ABSENCE and TYPE, not a blanket
+        // rejection: two PRESENT equal leaves agree — including null==null.
+        #expect(eq.isSatisfied(by: root(#"{"a":null,"b":null}"#)))
+        #expect(eq.isSatisfied(by: root(#"{"a":"","b":""}"#)))
+    }
+
+    // MARK: - numericNear / emptyArray (Phase B1)
+
+    /// The quantized-write invariant: `|observed − requested| ≤ ε`. Equal, within
+    /// ε, and exactly on the boundary pass; beyond ε fails. Replaces the
+    /// tautological `fieldsEqual(observed, observed_after)` for detent/echo writes.
+    @Test func numericNearHoldsWithinToleranceAndFailsBeyondIt() {
+        let near = OracleConstraint.numericNear(keyA: "observed", keyB: "requested", within: .absolute(6.0))
+        #expect(near.isSatisfied(by: root(#"{"observed":50,"requested":50}"#)))
+        #expect(near.isSatisfied(by: root(#"{"observed":48,"requested":50}"#)))
+        #expect(near.isSatisfied(by: root(#"{"observed":56,"requested":50}"#)))   // |56−50|=6 ≤ 6
+        #expect(!near.isSatisfied(by: root(#"{"observed":57,"requested":50}"#)))  // |57−50|=7 > 6
+    }
+
+    /// Same bool-vs-number discipline as the rest of the model: a bool is never
+    /// "near" a number, and a non-number / missing key fails closed.
+    @Test func numericNearRejectsBoolsNonNumbersAndMissingKeys() {
+        let near = OracleConstraint.numericNear(keyA: "a", keyB: "b", within: .absolute(1.0))
+        #expect(!near.isSatisfied(by: root(#"{"a":true,"b":1}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"a":1,"b":true}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"a":1,"b":"1"}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"a":1}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"b":1}"#)))
+    }
+
+    /// `.field` reads the tolerance from the payload's OWN key — the faithful
+    /// choice for set_param_verified's per-parameter, unit-specific `tolerance`.
+    /// A tighter tolerance fails the same gap; a missing/negative one fails closed.
+    @Test func numericNearFieldBoundReadsToleranceFromThePayload() {
+        let near = OracleConstraint.numericNear(
+            keyA: "observed_normalized", keyB: "requested_normalized", within: .field("tolerance")
+        )
+        #expect(near.isSatisfied(by: root(#"{"observed_normalized":60.5,"requested_normalized":60,"tolerance":1.0}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"observed_normalized":62,"requested_normalized":60,"tolerance":1.0}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"observed_normalized":60.5,"requested_normalized":60,"tolerance":0.1}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"observed_normalized":60,"requested_normalized":60}"#)))
+        #expect(!near.isSatisfied(by: root(#"{"observed_normalized":60,"requested_normalized":60,"tolerance":-1}"#)))
+    }
+
+    @Test func emptyArrayAcceptsEmptyAndRejectsNonEmptyMissingAndNonArrays() {
+        #expect(OracleConstraint.emptyArray(key: "x").isSatisfied(by: root(#"{"x":[]}"#)))
+        #expect(!OracleConstraint.emptyArray(key: "x").isSatisfied(by: root(#"{"x":[1]}"#)))
+        #expect(!OracleConstraint.emptyArray(key: "x").isSatisfied(by: root(#"{"x":{}}"#)))
+        #expect(!OracleConstraint.emptyArray(key: "x").isSatisfied(by: root(#"{"y":[]}"#)))
+    }
+
+    /// numericNear is a VALUE constraint (it asserts a concrete agreement between
+    /// two observed numbers); emptyArray is a shape/cardinality check like
+    /// nonEmptyArray, so the strength gate still bites on a presence-only oracle.
+    @Test func numericNearIsValueBearingAndEmptyArrayIsNot() {
+        #expect(OracleConstraint.numericNear(keyA: "a", keyB: "b", within: .absolute(1)).isValueConstraint)
+        #expect(!OracleConstraint.emptyArray(key: "a").isValueConstraint)
+    }
+
     @Test func crossCheckAgreesAcrossPayloadsAndFailsOnDivergenceOrMissingReadback() {
         let response = root(#"{"value":-6.0,"name":"Bass"}"#)
         let constraint = OracleConstraint.crossCheck(responseKey: "value", readbackKey: "observed_value")
@@ -211,12 +285,17 @@ struct SemanticOracleCensusTests {
         #expect(missing.isEmpty, "read-only specs with no oracle: \(missing.map(\.rawValue).sorted())")
     }
 
-    /// The mirror image: an oracle for something that is not a qualifying
-    /// read-only spec is dead weight that would never run.
-    @Test func everyOracleMapsToAReadOnlySpec() {
+    /// The mirror image, generalized for the #373 B1 DUAL census: an oracle must
+    /// map to a SUPPORTED spec — the fully-covered read-only surface UNION the
+    /// mutating surface. An oracle outside that union is dead weight (no spec) or
+    /// bound to an `.unsupported` spec, either of which would never run.
+    @Test func everyOracleMapsToASupportedSpec() {
         let extra = Set(SemanticOracleTable.byOperationID.keys)
-            .subtracting(SemanticOracleTable.coveredSpecIDs)
-        #expect(extra.isEmpty, "oracles with no read-only spec: \(extra.map(\.rawValue).sorted())")
+            .subtracting(SemanticOracleTable.supportedOracleSurface)
+        #expect(
+            extra.isEmpty,
+            "oracles with no supported (read-only or mutating) spec: \(extra.map(\.rawValue).sorted())"
+        )
     }
 
     @Test func healthKeepsItsBespokeValidatorAndIsNotInTheTable() {
@@ -243,6 +322,64 @@ struct SemanticOracleCensusTests {
         #expect(clearTraces?.mutability == .readOnly)
         let refreshCache = OperationRegistry.specs.first { $0.id == .systemRefreshCache }
         #expect(refreshCache?.mutability == .readOnly)
+    }
+
+    // MARK: - #373 Phase B1 — mutating-surface increment (dual census)
+
+    /// The mutating oracles present are EXACTLY the declared Phase-B1 increment —
+    /// no accidental add or drop. Pinning the set (not just a count) is what makes
+    /// the increment a deliberate, reviewable diff.
+    @Test func mutatingOraclesAreExactlyThePhaseB1Increment() {
+        let mutatingOracles = Set(SemanticOracleTable.byOperationID.keys)
+            .intersection(SemanticOracleTable.mutatingSpecIDs)
+        #expect(mutatingOracles == SemanticOracleTable.phaseB1MutatingOperationIDs)
+        #expect(SemanticOracleTable.phaseB1MutatingOperationIDs.count == 12)
+    }
+
+    /// Soundness of the increment: every id it names is a REAL `.mutating`,
+    /// non-`.unsupported` registry spec — a read-only id or a typo cannot
+    /// masquerade as mutating coverage.
+    @Test func everyPhaseB1IDIsARealMutatingSpec() {
+        #expect(
+            SemanticOracleTable.phaseB1MutatingOperationIDs
+                .isSubset(of: SemanticOracleTable.mutatingSpecIDs)
+        )
+        for id in SemanticOracleTable.phaseB1MutatingOperationIDs {
+            let spec = OperationRegistry.specs.first { $0.id == id }
+            #expect(spec?.mutability == .mutating, "\(id.rawValue) is not mutating")
+            #expect(spec?.availability != .unsupported, "\(id.rawValue) is unsupported")
+        }
+    }
+
+    /// The census DELIBERATELY does not yet require full mutating coverage: B1 is
+    /// an increment, and B2/B3 add the rest. If this ever reaches parity, the
+    /// mutating census contract must flip from "incremental" to "complete".
+    @Test func mutatingCoverageIsIncrementalNotYetComplete() {
+        let covered = Set(SemanticOracleTable.byOperationID.keys)
+            .intersection(SemanticOracleTable.mutatingSpecIDs)
+        #expect(covered.count < SemanticOracleTable.mutatingSpecIDs.count)
+        // mixer.set_plugin_param is the canonical NOT-yet-covered case: it is a
+        // send-only State-B write (Scripter), so it has no State A to verify and
+        // deliberately carries no B1 verified-write oracle.
+        #expect(!covered.contains(.mixerSetPluginParam))
+        #expect(SemanticOracleTable.mutatingSpecIDs.contains(.mixerSetPluginParam))
+    }
+
+    /// FIX 5 — the structural-exclusion allowlist is EXPLICIT: every entry is a
+    /// real mutating spec, is DISJOINT from the covered increment, and carries a
+    /// reason, so the uncovered surface is a reviewed decision, not implicit.
+    @Test func structuralExclusionsAreExplicitDisjointAndReasoned() {
+        let exclusions = SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs
+        #expect(!exclusions.isEmpty)
+        #expect(exclusions[.mixerSetPluginParam] != nil)
+        for (id, reason) in exclusions {
+            #expect(SemanticOracleTable.mutatingSpecIDs.contains(id), "\(id.rawValue) is not a mutating spec")
+            #expect(
+                !SemanticOracleTable.phaseB1MutatingOperationIDs.contains(id),
+                "\(id.rawValue) is both covered and excluded"
+            )
+            #expect(reason.count > 20, "\(id.rawValue) exclusion reason is too thin")
+        }
     }
 }
 
@@ -436,9 +573,12 @@ struct SemanticOracleMutationTests {
         #expect(!declined, "\(operationID.rawValue) declined to render a verdict on its own fixture")
     }
 
-    /// Wiring: the validator must actually consult the table, not just own it.
+    /// Wiring: the validator must actually consult the table, not just own it —
+    /// for EVERY oracle it carries (read-only AND the B1 mutating oracles; the
+    /// validator routes both, even though the offline runner only live-runs the
+    /// read-only surface).
     @Test(arguments: SemanticOracleTable.all.map(\.operationID))
-    func validatorRoutesEachReadOnlyOperationToItsOracle(operationID: OperationID) throws {
+    func validatorRoutesEachOracleOperationToItsOracle(operationID: OperationID) throws {
         let fixture = try #require(SemanticOracleFixtures.byOperationID[operationID])
         let routed = try #require(QualificationSemanticReadbackValidator.validate(
             operationID: operationID.rawValue,
@@ -561,10 +701,10 @@ struct SafeMutationOracleTests {
 @Suite("#373 Phase B0 relational mutation")
 struct SemanticOracleRelationalMutationTests {
     /// The relational constraints are load-bearing under the SAME generic
-    /// mutation harness the B1–B3 mutating oracles will run through: every mutant
-    /// the mutator derives for a `fieldsEqual` must sink the oracle. Proven on a
-    /// synthetic oracle because the table carries no mutating oracle yet — the
-    /// read-only census stays at 20 (see SemanticOracleB0CensusTests).
+    /// mutation harness the B1 mutating oracles run through: every mutant the
+    /// mutator derives for a `fieldsEqual` must sink the oracle. Kept as a focused
+    /// engine-level proof on a synthetic oracle; the table-driven proof for the
+    /// real B1 verified-write oracles is `everyConstraintRejectsItsMutants`.
     @Test func fieldsEqualMutantsAreAllRejected() throws {
         let response = #"{"requested":-6.0,"observed":-6.0}"#
         let root = try #require(JSONInspector.parse(Data(response.utf8)))
@@ -617,26 +757,23 @@ struct SemanticOracleRelationalMutationTests {
     }
 }
 
-// MARK: - census non-regression (Phase B0)
+// MARK: - read-only census non-regression (Phase B0 → B1)
 
-@Suite("#373 Phase B0 census non-regression")
+@Suite("#373 read-only census non-regression")
 struct SemanticOracleB0CensusTests {
-    /// B0 adds FRAMEWORK ONLY — no oracle was added to the table, so the
-    /// read-only census is unchanged and the mutating surface stays UNCOVERED
-    /// (its 50 oracles land in B1–B3). Pinning this catches a premature mutating
-    /// oracle and proves the mutating-census scaffold stays satisfiable at zero.
-    @Test func b0AddsNoTableOracleAndLeavesTheReadOnlyCensusAtTwenty() {
-        #expect(SemanticOracleTable.all.count == 20)
+    /// The read-only census is a STANDING invariant across phases. B0 added
+    /// framework only; B1 adds the mutating increment WITHOUT perturbing the
+    /// fully-covered read-only surface. So the read-only census stays exactly 20,
+    /// and the table's total is the read-only 20 plus the pinned B1 increment — a
+    /// premature or miscounted mutating oracle fails here.
+    @Test func readOnlyCensusStaysTwentyAndB1AddsTheMutatingIncrement() {
         #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
-
-        let mutatingSpecIDs = Set(
-            OperationRegistry.specs.filter { $0.mutability == .mutating }.map(\.id)
-        )
-        let mutatingOraclesPresent = Set(SemanticOracleTable.byOperationID.keys)
-            .intersection(mutatingSpecIDs)
+        let readOnlyOracles = Set(SemanticOracleTable.byOperationID.keys)
+            .intersection(SemanticOracleTable.coveredSpecIDs)
+        #expect(readOnlyOracles.count == 20)
         #expect(
-            mutatingOraclesPresent.isEmpty,
-            "B0 must not author mutating oracles: \(mutatingOraclesPresent.map(\.rawValue).sorted())"
+            SemanticOracleTable.all.count
+                == 20 + SemanticOracleTable.phaseB1MutatingOperationIDs.count
         )
     }
 }
@@ -693,6 +830,30 @@ enum JSONMutator {
             if let current = JSONPath.resolve(root, keyPath: responseKey) {
                 mutants.append(contentsOf: replacements(root, responseKey, [("diverge", divergent(from: current))]))
             }
+        case .numericNear(let keyA, let keyB, let within):
+            // Break nearness by pushing EITHER side clearly beyond the bound
+            // (distance bound+1, so it exceeds even a tiny tolerance), plus a
+            // non-number to exercise the numbers-only rule. (drop keyA is added
+            // generically via `key`.)
+            let bound: Double
+            switch within {
+            case .absolute(let value):
+                bound = value
+            case .field(let toleranceKey):
+                bound = JSONPath.resolve(root, keyPath: toleranceKey)
+                    .flatMap(JSONInspector.number(of:)) ?? 0
+            }
+            if let aValue = JSONPath.resolve(root, keyPath: keyA),
+               let a = JSONInspector.number(of: aValue) {
+                mutants.append(contentsOf: replacements(root, keyB, [("beyond-near", a + bound + 1.0)]))
+                mutants.append(contentsOf: replacements(root, keyA, [("non-number", "not-a-number")]))
+            }
+            if let bValue = JSONPath.resolve(root, keyPath: keyB),
+               let b = JSONInspector.number(of: bValue) {
+                mutants.append(contentsOf: replacements(root, keyA, [("beyond-near", b + bound + 1.0)]))
+            }
+        case .emptyArray(let key):
+            mutants.append(contentsOf: replacements(root, key, [("non-empty", [1] as [Any])]))
         }
         return mutants
     }


### PR DESCRIPTION
## Summary
The first oracle chunk of #373 Phase B: 12 verified-write safe-mutation semantic oracles, advancing R-SEM coverage from 21/107 toward closure. Each composes `verifiedEnvelope` (state A + verified + success — a State-B "couldn't verify" can never pass) with an op-specific invariant read from the dispatcher handler.

**Ops:** mixer set_volume/set_pan/set_master_volume; tracks select/rename/mute/solo/arm/arm_only/set_automation/set_instrument; plugins.set_param_verified.

## New primitive: `.numericNear`
AX-quantized writes can't pin `requested == observed` (fader detents), and `observed == observed_after` is a same-source echo (tautology). `.numericNear(keyA, keyB, within:)` pins **intent within tolerance**: set_volume/set_pan assert `observed_raw ≈ target_raw` (the readback's raw value near the requested value's raw mapping) within one detent — genuinely different sources. `NearnessBound` supports an absolute bound or a payload tolerance field.

## Honesty
Exact-op equalities (select, toggles — same source) are labelled **echo-integrity**, not write-verification; the real semantic weight sits on the envelope + genuine request↔readback pairs (rename, set_instrument, set_automation, and arm_only's empty `failedDisarm`/`unverifiedDisarm` multi-track gate). `mixer.set_plugin_param` is **explicitly listed uncovered** (Scripter → unverified State B) so the complement is never implicit.

## Census
Generalized to the mutating surface: the 20 read-only oracles stay pinned, the 12 are counted, and full 51-op coverage is not required until B2/B3.

## Tests (live `#expect`, mutation-checked)
numericNear within/beyond/bool/non-number/missing; every oracle's mutants (drop/out-of-domain/wrong-type/near-diverge) rejected; census/strength/routing extended. Full suite `--no-parallel`: **3012 passed**. Adversarial gate: PROCEED-WITH-FIXES applied (de-tautologized the quantized invariant).

Part of #373 Phase B; ADR-001 (#284). Next: B2 (transport+navigate).