### PR TITLE
ax: eliminate clear-win coordinate actuations (8 sites) with live-verified AX paths

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -137,19 +137,13 @@ extension AXLogicProElements {
             }
         }
 
-        // Step 5 — last resort: coord click at the header's name area.
-        var posRaw: AnyObject?
-        var sizeRaw: AnyObject?
-        guard
-            AXUIElementCopyAttributeValue(header, kAXPositionAttribute as CFString, &posRaw) == .success,
-            AXUIElementCopyAttributeValue(header, kAXSizeAttribute as CFString, &sizeRaw) == .success,
-            // H2 (P2-5): fail-closed on non-AXValue / wrong-subtype rather than
-            // a (0,0) misclick.
-            let pt = AXHelpers.point(fromRawAttribute: posRaw),
-            let sz = AXHelpers.size(fromRawAttribute: sizeRaw)
-        else { return false }
-        let clickPoint = CGPoint(x: pt.x + min(60, sz.width / 4), y: pt.y + sz.height / 2)
-        return LibraryAccessor.productionMouseClick(at: clickPoint)
+        // ADR-001 coordinate ban: the former Step 5 (element-derived HID click on
+        // the header's name area) is removed. Step 1 (AXSelectedChildren on the
+        // parent group) is the live-verified primary that actually moves Logic's
+        // selection (v3.0.9, 10/10 indices on a 10-track project), and
+        // `track.select` also routes to the MCU channel — so failing closed here
+        // preserves function without a coordinate fallback.
+        return false
     }
 
     /// Enumerate all track header rows.

--- a/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
+++ b/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
@@ -758,18 +758,15 @@ enum LibraryAccessor {
             )
             guard orientation == kAXHorizontalOrientationValue as String else { continue }
             guard horizontallyOverlaps(scrollBar, browserFrame: browserFrame, runtime: runtime) else { continue }
+            // ADR-001 coordinate ban: reset the stuck horizontal scrollbar by
+            // writing AXValue 0 only; the former element-derived cliclick nudge
+            // is removed.
             didReset = AXHelpers.setAttribute(
                 scrollBar,
                 kAXValueAttribute,
                 NSNumber(value: 0),
                 runtime: runtime
             ) || didReset
-            if let scrollFrame = frame(of: scrollBar, runtime: runtime) {
-                let resetPoint = CGPoint(x: scrollFrame.minX + 6, y: scrollFrame.midY)
-                debugLibraryClick("reset scrollbar frame=\(scrollFrame) point=\(resetPoint)")
-                _ = postCliclick(command: "c", at: resetPoint)
-                didReset = true
-            }
         }
         if didReset {
             Thread.sleep(forTimeInterval: 0.10)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
@@ -67,11 +67,11 @@ extension AccessibilityChannel {
             return .error("Logic Pro is not running")
         }
         // 2. Find focused plugin window (heuristic: has AXPopUpButton with "Preset"/"기본" value)
-        guard let pluginWin = PluginInspector.findFocusedPluginWindowAX(in: appRoot) else {
+        guard let pluginWin = PluginInspector.findFocusedPluginWindowAX(in: appRoot, runtime: runtime.ax) else {
             return .error("No plugin window with Setting dropdown found. Open an instrument plugin window first.")
         }
         // 3. Locate Setting popup
-        guard let popup = PluginInspector.findSettingPopupAX(in: pluginWin) else {
+        guard let popup = PluginInspector.findSettingPopupAX(in: pluginWin, runtime: runtime.ax) else {
             return .error("Setting popup not found in plugin window")
         }
         // 4. Open the menu — AX-only ladder (ADR-001: no CGEvent last-resort).
@@ -82,12 +82,19 @@ extension AccessibilityChannel {
         var menu: AXUIElement?
         let axOpenActions = [kAXShowMenuAction, kAXPressAction]
         for action in axOpenActions {
-            if AXHelpers.performAction(popup, action, runtime: runtime.ax) {
-                try? await Task.sleep(nanoseconds: 350_000_000)
-                if let found = PluginInspector.findOpenSettingMenuAX(in: appRoot) {
-                    menu = found
-                    break
-                }
+            // Fire the action but IGNORE its return code, then poll the AX tree
+            // for the actually-open AXMenu. On real Logic 12.3 the Setting
+            // AXPopUpButton returns a NON-ZERO AX status even when the action
+            // succeeds (AXShowMenu → -25206 actionUnsupported; AXPress → -25204
+            // cannotComplete WHILE the menu still opens). Gating the poll on the
+            // performAction return therefore fails closed on a menu that is in
+            // fact open. Honest-contract: trust the OBSERVED state, not the
+            // unreliable return code — fire, settle, then observe.
+            _ = AXHelpers.performAction(popup, action, runtime: runtime.ax)
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            if let found = PluginInspector.findOpenSettingMenuAX(in: appRoot, runtime: runtime.ax) {
+                menu = found
+                break
             }
         }
         // ADR-001 coordinate ban: the Setting popup is opened via the AXShowMenu →
@@ -99,7 +106,7 @@ extension AccessibilityChannel {
             return .error("Setting menu did not appear after AXShowMenu/AXPress (or already dismissed)")
         }
         // 6. Build live probe + walk
-        let probe = PluginInspector.liveMenuProbe(rootMenu: menu, settleMs: settleMs)
+        let probe = PluginInspector.liveMenuProbe(rootMenu: menu, settleMs: settleMs, runtime: runtime.ax)
         let scanStart = Date()
         do {
             let (root, cycleCount) = try await PluginInspector.enumerateMenuTree(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
@@ -53,10 +53,11 @@ extension AccessibilityChannel {
     // MARK: - F2 plugin.scan_presets minimal handler (T0 verdict MIXED)
 
     /// Production `plugin.scan_presets` path — relies on currently-focused plugin
-    /// window. CGEvent-clicks the Setting popup to open the menu, then walks via
-    /// AXPress on AXMenuItems (T0 v0.6 empirical — popup AXPress unreliable, menu
-    /// item AXPress 100% reliable). Returns serialized PluginPresetNode tree.
-    /// Full T6 (cache, persistence, identity gate) is follow-up.
+    /// window. Opens the Setting popup via the AXShowMenu→AXPress ladder (ADR-001:
+    /// no CGEvent last-resort), then walks via AXPress on AXMenuItems (T0 v0.6
+    /// empirical — popup AXPress unreliable, menu item AXPress 100% reliable).
+    /// Returns serialized PluginPresetNode tree. Full T6 (cache, persistence,
+    /// identity gate) is follow-up.
     static func runLivePluginPresetScan(
         runtime: AXLogicProElements.Runtime,
         settleMs: Int = 250
@@ -73,12 +74,11 @@ extension AccessibilityChannel {
         guard let popup = PluginInspector.findSettingPopupAX(in: pluginWin) else {
             return .error("Setting popup not found in plugin window")
         }
-        // 4. Open the menu — AX-first ladder. AXShowMenu is the canonical popup
-        //    action per NSAccessibility; AXPress sometimes works on Logic's
-        //    custom popups; CGEvent click is the last-resort fallback.
-        //    T0 verdict (v0.6) said raw AXPress was unreliable — we re-test here
-        //    and only fall through to CGEvent if both AX actions fail to surface
-        //    the AXMenu within the settle window.
+        // 4. Open the menu — AX-only ladder (ADR-001: no CGEvent last-resort).
+        //    AXShowMenu is the canonical popup action per NSAccessibility; AXPress
+        //    is the secondary. T0 verdict (v0.6) said raw AXPress was unreliable,
+        //    so AXShowMenu leads; if neither surfaces the AXMenu within the settle
+        //    window the scan fails closed rather than reaching a coordinate click.
         var menu: AXUIElement?
         let axOpenActions = [kAXShowMenuAction, kAXPressAction]
         for action in axOpenActions {
@@ -90,18 +90,13 @@ extension AccessibilityChannel {
                 }
             }
         }
-        if menu == nil {
-            guard let center = PluginInspector.centerPoint(of: popup) else {
-                return .error("Setting popup has no readable position/size; AXShowMenu/AXPress also failed")
-            }
-            guard LibraryAccessor.productionMouseClick(at: center) else {
-                return .error("AXShowMenu/AXPress failed and CGEvent click on Setting popup also failed (Post-Event permission?)")
-            }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            menu = PluginInspector.findOpenSettingMenuAX(in: appRoot)
-        }
+        // ADR-001 coordinate ban: the Setting popup is opened via the AXShowMenu →
+        // AXPress ladder only (AXShowMenu is the canonical NSAccessibility popup
+        // action and is the primary here). The former element-derived CGEvent
+        // click last-resort is removed; if neither AX action surfaces the menu,
+        // fail closed rather than reaching a coordinate primitive.
         guard let menu = menu else {
-            return .error("Setting menu did not appear after AXShowMenu/AXPress/CGEvent (or already dismissed)")
+            return .error("Setting menu did not appear after AXShowMenu/AXPress (or already dismissed)")
         }
         // 6. Build live probe + walk
         let probe = PluginInspector.liveMenuProbe(rootMenu: menu, settleMs: settleMs)
@@ -535,8 +530,9 @@ extension AccessibilityChannel {
             return false
         }
 
-        if !clickAXElementCenter(viewMenu, runtime: runtime.ax),
-           !AXHelpers.performAction(viewMenu, kAXPressAction as String, runtime: runtime.ax) {
+        // ADR-001 coordinate ban: open the View menu via AXPress only (menu-bar
+        // items respond to AXPress); no element-derived click fallback.
+        if !AXHelpers.performAction(viewMenu, kAXPressAction as String, runtime: runtime.ax) {
             return false
         }
         try? await Task.sleep(nanoseconds: 120_000_000)
@@ -562,23 +558,13 @@ extension AccessibilityChannel {
             return false
         }
 
-        if clickAXElementCenter(item, runtime: runtime.ax)
-            || AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) {
+        // ADR-001 coordinate ban: activate the Show Library menu item via AXPress
+        // only; fail closed (Escape) if it does not respond.
+        if AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) {
             return true
         }
         AXMouseHelper.pressEscape()
         return false
-    }
-
-    private static func clickAXElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
-        guard let pos = AXHelpers.getPosition(element, runtime: runtime),
-              let size = AXHelpers.getSize(element, runtime: runtime),
-              size.width > 0, size.height > 0 else {
-            return false
-        }
-        return LibraryAccessor.productionMouseClick(
-            at: CGPoint(x: pos.x + size.width / 2, y: pos.y + size.height / 2)
-        )
     }
 
     /// One-shot, thread-safe latch so a deadline race resumes its continuation

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -46,14 +46,15 @@ extension AccessibilityChannel {
                 extras: ["requested": index]
             ))
         }
-        // v3.0.3+ — activate Logic so any coord-click fallback can land, then
-        // go through the AX-native selection ladder.
+        // v3.0.3+ — activate Logic so the frontmost-dependent AX selection can
+        // land, then go through the AX-native selection ladder (ADR-001: no
+        // coordinate fallback — fail closed if every AX step is rejected).
         _ = ProcessUtils.Runtime.production.activateLogicPro()
         try? await Task.sleep(nanoseconds: 150_000_000)
         guard AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime) else {
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
-                hint: "Failed to select track \(index) via AX or coord click",
+                hint: "Failed to select track \(index) via the AX selection ladder",
                 extras: ["requested": index]
             ))
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1065,7 +1065,7 @@ extension AccessibilityChannel {
         if let before {
             return .error(HonestContract.encodeStateC(
                 error: .readbackMismatch,
-                hint: "control-bar checkbox '\(english)' did not change after real click / AXPress attempts",
+                hint: "control-bar checkbox '\(english)' did not change after AXPress / AXConfirm attempts",
                 extras: [
                     "button": english,
                     "control": korean,
@@ -1157,7 +1157,7 @@ extension AccessibilityChannel {
         let observed = controlBarCheckboxValue(cb, runtime: runtime) as Any
         return .error(HonestContract.encodeStateC(
             error: .readbackMismatch,
-            hint: "control-bar checkbox '\(english)' did not reach desired=\(desired) after real click / AXPress attempts",
+            hint: "control-bar checkbox '\(english)' did not reach desired=\(desired) after AXPress / AXConfirm attempts",
             extras: baseExtras.merging([
                 "observed": observed,
                 "attempts": attempts,
@@ -1176,24 +1176,15 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime,
         mouseRuntime: AXMouseHelper.Runtime
     ) -> [ControlBarClickStrategy] {
-        [
-            ControlBarClickStrategy(name: "mouse-click", action: {
-                guard let position = AXHelpers.getPosition(element, runtime: runtime.ax),
-                      let size = AXHelpers.getSize(element, runtime: runtime.ax),
-                      position.x.isFinite,
-                      position.y.isFinite,
-                      size.width.isFinite,
-                      size.height.isFinite,
-                      size.width > 0,
-                      size.height > 0 else {
-                    return false
-                }
-                let center = CGPoint(
-                    x: position.x + size.width / 2,
-                    y: position.y + size.height / 2
-                )
-                return AXMouseHelper.click(at: center, runtime: mouseRuntime)
-            }),
+        // ADR-001 coordinate ban: the control-bar checkboxes are actuated by
+        // AXPress/AXConfirm only. The former mouse-click (element-derived HID
+        // click) rung is removed — Cycle/Metronome retain keycmd (C/K) channel
+        // fallbacks and Count-In routes native AXPress-first (#255), so the
+        // non-coordinate paths preserve full function. `mouseRuntime` is left in
+        // the signature (still threaded by the test doubles) but is no longer
+        // read here; a clear-win control-bar toggle must never post a mouse event.
+        _ = mouseRuntime
+        return [
             ControlBarClickStrategy(name: "axpress", action: {
                 AXHelpers.performAction(element, kAXPressAction, runtime: runtime.ax)
             }),

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1207,7 +1207,7 @@ extension AccessibilityChannel {
             + [targetSlot]
             + rankedControls.filter { $0.rank != 0 }.map(\.element)
         for element in attempts {
-            guard pressOrClick(element, runtime: runtime.ax) else { continue }
+            guard pressElement(element, runtime: runtime.ax) else { continue }
             switch await pollOpenPluginWindow(
                 trackName: trackName,
                 axDescription: axDescription,
@@ -1334,11 +1334,12 @@ extension AccessibilityChannel {
         return .none
     }
 
-    private static func pressOrClick(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
-        if AXHelpers.performAction(element, kAXPressAction as String, runtime: runtime) {
-            return true
-        }
-        return clickElementCenter(element, runtime: runtime)
+    /// ADR-001 coordinate ban: open the plugin window from its slot control via
+    /// AXPress only. The former element-derived `clickElementCenter` fallback is
+    /// removed; `openPluginWindowFromTargetSlot` fails closed (`window_open_failed`)
+    /// when no ranked control responds to AXPress, never a coordinate click.
+    private static func pressElement(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
+        AXHelpers.performAction(element, kAXPressAction as String, runtime: runtime)
     }
 
     private static func pluginWindowAcquisitionDiagnostics(
@@ -2063,10 +2064,12 @@ extension AccessibilityChannel {
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> Bool {
-        if clickElementCenter(item, runtime: runtime) {
-            return true
-        }
-        return AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime)
+        // ADR-001 coordinate ban: open the menu-bar item via AXPress only
+        // (menu-bar items respond to AXPress). The former element-derived
+        // clickElementCenter-first rung is removed. The features this serves keep
+        // non-coordinate fallbacks — mixer reveal falls back to the cgevent key-7
+        // channel and Edit▸Undo to Cmd+Z — so no feature is degraded.
+        AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime)
     }
 
     private static func menuItem(
@@ -2686,8 +2689,9 @@ extension AccessibilityChannel {
                 maxDepth: 4,
                 runtime: runtime.ax
             ) {
-                if AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax)
-                    || clickElementCenter(cancel, runtime: runtime.ax) {
+                // ADR-001 coordinate ban: dismiss via AXPress only (Escape remains
+                // the terminal non-coordinate fallback below).
+                if AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax) {
                     continue
                 }
             }
@@ -2699,8 +2703,8 @@ extension AccessibilityChannel {
                 )
                 return subrole == kAXCloseButtonSubrole as String
             }) {
+                // ADR-001 coordinate ban: AXPress only; no element-derived click.
                 _ = AXHelpers.performAction(close, kAXPressAction as String, runtime: runtime.ax)
-                    || clickElementCenter(close, runtime: runtime.ax)
             } else {
                 AXMouseHelper.pressEscape()
             }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1207,7 +1207,14 @@ extension AccessibilityChannel {
             + [targetSlot]
             + rankedControls.filter { $0.rank != 0 }.map(\.element)
         for element in attempts {
-            guard pressElement(element, runtime: runtime.ax) else { continue }
+            // Fire AXPress but IGNORE its return code, then consult the observed
+            // window poll REGARDLESS of that return. On real Logic 12.3 an AXPress
+            // that actually opens the plugin window can still report a NON-ZERO AX
+            // status; gating the poll on the return (the former `guard … else
+            // continue`) skips past a control that DID open the window. Honest-
+            // contract: trust the OBSERVED window, not the unreliable return —
+            // only advance to the next ranked control if the poll shows no window.
+            _ = pressElement(element, runtime: runtime.ax)
             switch await pollOpenPluginWindow(
                 trackName: trackName,
                 axDescription: axDescription,

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -236,7 +236,7 @@ extension ChannelRouter {
         // reintroduced only through an allowlisted AX mixer-slot path.
         "plugin.list":                [.accessibility],
         "plugin.set_param":           [.scripter],  // deterministic plugin parameter path
-        "plugin.scan_presets":        [.accessibility],  // F2 — empirical T0 verdict MIXED (CGEvent popup + AXPress menu)
+        "plugin.scan_presets":        [.accessibility],  // F2 — AX-only ladder (AXShowMenu→AXPress); ADR-001 removed the CGEvent popup last-resort
 
         // Automation
         "automation.get_mode":        [.accessibility],

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1407,7 +1407,11 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
     #expect(state.tempo == 127.0)
 }
 
-@Test func testAccessibilityChannelControlBarToggleUsesMouseClickAndVerifiesReadback() async {
+@Test func testAccessibilityChannelControlBarToggleUsesAXPressAndPostsNoMouseEvents() async throws {
+    // ADR-001 coordinate ban: control-bar toggles are actuated by AXPress only.
+    // Even with a fully wired mouse runtime available, a clear-win toggle must
+    // post ZERO mouse events (the element-derived mouse-click rung was removed)
+    // and still verify its read-back via the AX path.
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(120)
     let window = builder.element(121)
@@ -1423,18 +1427,28 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
     builder.setAttribute(cycle, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     builder.setAttribute(cycle, kAXTitleAttribute as String, "Cycle")
     builder.setAttribute(cycle, kAXValueAttribute as String, NSNumber(value: false))
+    // Position/size ARE present: a re-introduced mouse-click rung would fire
+    // here, so `mouse.mouseEvents.isEmpty` is a real regression guard.
     builder.setAttribute(cycle, kAXPositionAttribute as String, axPoint(100, 200))
     builder.setAttribute(cycle, kAXSizeAttribute as String, axSize(24, 18))
 
-    let mouse = ControlBarMouseRecorder()
-    mouse.onMouseEvent = { type, _, _ in
-        if type == .leftMouseUp {
-            builder.setAttribute(cycle, kAXValueAttribute as String, NSNumber(value: true))
+    // Real Logic control-bar checkboxes flip on AXPress (unlike track-header M/S/R).
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if element == cycle && action == kAXPressAction as String {
+                builder.setAttribute(cycle, kAXValueAttribute as String, NSNumber(value: true))
+                return true
+            }
+            return true
         }
-    }
+    )
+    let mouse = ControlBarMouseRecorder()
     let channel = makeAXBackedAccessibilityChannel(
         builder: builder,
         app: app,
+        logicRuntime: logicRuntime,
         controlBarMouseRuntime: mouse.runtime()
     )
 
@@ -1442,11 +1456,195 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
     let object = decodeAccessibilityJSON(result.message)
 
     #expect(result.isSuccess)
-    #expect((object["verified"] as? Bool)!)
-    #expect(object["action"] as? String == "mouse-click")
-    #expect(mouse.mouseEvents.map(\.type) == [.leftMouseDown, .leftMouseUp])
-    #expect(builder.actionCalls.isEmpty)
-    #expect(((builder.attributeValue(cycle, kAXValueAttribute as String) as? NSNumber)?.boolValue)!)
+    #expect(try #require(object["verified"] as? Bool))
+    // The successful strategy was AXPress (not "mouse-click"), and the checkbox
+    // actually flipped — together proving the AX path actuated the control.
+    #expect(try #require(object["action"] as? String) == "axpress")
+    #expect(try #require(builder.attributeValue(cycle, kAXValueAttribute as String) as? NSNumber).boolValue)
+    // Load-bearing (ADR-001): the coordinate rung is gone — zero mouse events,
+    // even though a live mouse runtime and a clickable frame were available.
+    #expect(mouse.mouseEvents.isEmpty)
+}
+
+@Test func testAccessibilityChannelCountInToggleUsesAXPressAndPostsNoMouseEvents() async throws {
+    // ADR-001: Count-In is actuated by AXPress (native toggle, #255). Its route is
+    // [.accessibility, .midiKeyCommands, .cgEvent] — midiKeyCommands carries CC99
+    // as a fallback; only the cgEvent channel lacks a key mapping. This proves the
+    // AX path carries the toggle with ZERO mouse events even when a live mouse
+    // runtime and a clickable frame are present.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(150)
+    let window = builder.element(151)
+    let controlBar = builder.element(152)
+    let countIn = builder.element(153)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [countIn])
+
+    builder.setAttribute(countIn, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(countIn, kAXTitleAttribute as String, "Count In")
+    builder.setAttribute(countIn, kAXValueAttribute as String, NSNumber(value: false))
+    builder.setAttribute(countIn, kAXPositionAttribute as String, axPoint(140, 200))
+    builder.setAttribute(countIn, kAXSizeAttribute as String, axSize(24, 18))
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if element == countIn && action == kAXPressAction as String {
+                builder.setAttribute(countIn, kAXValueAttribute as String, NSNumber(value: true))
+                return true
+            }
+            return true
+        }
+    )
+    let mouse = ControlBarMouseRecorder()
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder,
+        app: app,
+        logicRuntime: logicRuntime,
+        controlBarMouseRuntime: mouse.runtime()
+    )
+
+    let result = await channel.execute(operation: "transport.toggle_count_in", params: [:])
+    let object = decodeAccessibilityJSON(result.message)
+
+    #expect(result.isSuccess)
+    #expect(try #require(object["verified"] as? Bool))
+    #expect(try #require(object["action"] as? String) == "axpress")
+    #expect(try #require(builder.attributeValue(countIn, kAXValueAttribute as String) as? NSNumber).boolValue)
+    // Load-bearing (ADR-001): no coordinate rung remains for Count-In.
+    #expect(mouse.mouseEvents.isEmpty)
+}
+
+@Test func testAccessibilityChannelControlBarToggleReturnsHonestStateBWhenValueUnreadable() async throws {
+    // ADR-001 + honesty edge case: a control-bar checkbox that exposes NO readable
+    // value but accepts AXPress is reported as State B readback_unavailable (never
+    // a fabricated State A), and still posts ZERO mouse events.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(160)
+    let window = builder.element(161)
+    let controlBar = builder.element(162)
+    let cycle = builder.element(163)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [cycle])
+
+    builder.setAttribute(cycle, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(cycle, kAXTitleAttribute as String, "Cycle")
+    // Deliberately NO kAXValueAttribute → controlBarCheckboxValue == nil.
+    builder.setAttribute(cycle, kAXPositionAttribute as String, axPoint(100, 200))
+    builder.setAttribute(cycle, kAXSizeAttribute as String, axSize(24, 18))
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            element == cycle && action == kAXPressAction as String
+        }
+    )
+    let mouse = ControlBarMouseRecorder()
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, logicRuntime: logicRuntime, controlBarMouseRuntime: mouse.runtime()
+    )
+
+    let result = await channel.execute(operation: "transport.toggle_cycle", params: [:])
+    let object = decodeAccessibilityJSON(result.message)
+
+    #expect(result.isSuccess)   // State B is success:true, verified:false
+    #expect(try #require(object["state"] as? String) == "B")
+    #expect(try #require(object["reason"] as? String) == "readback_unavailable")
+    #expect(try #require(object["action"] as? String) == "axpress")
+    // Load-bearing (ADR-001): no coordinate rung even on the unverifiable path.
+    #expect(mouse.mouseEvents.isEmpty)
+}
+
+@Test func testAccessibilityChannelControlBarToggleFailsClosedWhenAllAXActionsRejected() async throws {
+    // ADR-001 CORE guarantee: with the coordinate rung gone, a checkbox whose
+    // value is unreadable AND which rejects EVERY AX action fails CLOSED (State C
+    // ax_write_failed). It must never silently "succeed" via a mouse click, and
+    // must post ZERO mouse events even though a clickable frame + mouse runtime
+    // are both present.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(170)
+    let window = builder.element(171)
+    let controlBar = builder.element(172)
+    let cycle = builder.element(173)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [cycle])
+
+    builder.setAttribute(cycle, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(cycle, kAXTitleAttribute as String, "Cycle")
+    // Clickable frame present (a re-introduced mouse rung would fire); no value.
+    builder.setAttribute(cycle, kAXPositionAttribute as String, axPoint(100, 200))
+    builder.setAttribute(cycle, kAXSizeAttribute as String, axSize(24, 18))
+
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { _, _ in false }   // every AX action rejected
+    )
+    let mouse = ControlBarMouseRecorder()
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, logicRuntime: logicRuntime, controlBarMouseRuntime: mouse.runtime()
+    )
+
+    let result = await channel.execute(operation: "transport.toggle_cycle", params: [:])
+    let object = decodeAccessibilityJSON(result.message)
+
+    #expect(!result.isSuccess)
+    #expect(try #require(object["state"] as? String) == "C")
+    #expect(try #require(object["error"] as? String) == "ax_write_failed")
+    // Load-bearing (ADR-001): fail-closed, never a silent coordinate "success".
+    #expect(mouse.mouseEvents.isEmpty)
+}
+
+@Test func testAccessibilityChannelTrackSelectFailsClosedWhenEveryAXStepRejected() async throws {
+    // ADR-001: track.select's Step-5 coordinate click is gone. When the header's
+    // parent group is not AXSelectedChildren-writable AND Steps 2-4 (AXSelected /
+    // AXPress) are all rejected, selectTrackViaAX fails and the op returns honest
+    // State C ax_write_failed — never a silent success, never a coordinate click.
+    // The header carries a real frame so a re-introduced Step-5 would actuate it.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(620)
+    let window = builder.element(621)
+    let trackList = builder.element(622)
+    let header = builder.element(623)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [header])
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header, kAXTitleAttribute as String, "Track 1")
+    builder.setAttribute(header, kAXPositionAttribute as String, axPoint(10, 100))
+    builder.setAttribute(header, kAXSizeAttribute as String, axSize(180, 40))
+
+    // Every AX action (AXPress on header/children) is rejected.
+    let logicRuntime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { _, _ in false }
+    )
+    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app, logicRuntime: logicRuntime)
+
+    let result = await channel.execute(operation: "track.select", params: ["index": "0"])
+    let object = decodeAccessibilityJSON(result.message)
+
+    #expect(!result.isSuccess)
+    #expect(try #require(object["state"] as? String) == "C")
+    #expect(try #require(object["error"] as? String) == "ax_write_failed")
 }
 
 @Test func testAccessibilityChannelControlBarToggleDoesNotTrustNoopAXPress() async {

--- a/Tests/LogicProMCPTests/PluginScanPresetsObservedMenuTests.swift
+++ b/Tests/LogicProMCPTests/PluginScanPresetsObservedMenuTests.swift
@@ -1,0 +1,101 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// Regression guard for the coord-removal feature-loss bug in
+// `runLivePluginPresetScan` (plugin.scan_presets).
+//
+// LIVE ROOT CAUSE (verified against real Logic 12.3): the Setting AXPopUpButton
+// returns a NON-ZERO AX status even when the action actually opens the menu
+// (AXShowMenu → -25206 actionUnsupported; AXPress → -25204 cannotComplete WHILE
+// ~141 AXMenuItems appear). The old loop gated the observed-menu poll on the
+// performAction return code, so it skipped the poll and fail-closed with
+// "Setting menu did not appear" — even though the menu was open. Unit fakes
+// returned true, so they never caught it.
+//
+// These tests drive the fake `performAction` to return FALSE for the Setting
+// popup (the exact live behavior) while the observed AX tree DOES expose the
+// open AXMenu. The op MUST now scan the menu (success), not fail-closed.
+
+/// Builds the AX tree `runLivePluginPresetScan` walks:
+///   app
+///     ├─ kAXWindows   = [pluginWindow]           (findFocusedPluginWindowAX)
+///     │     pluginWindow ── Setting AXPopUpButton (value "Default Preset")
+///     └─ kAXChildren  = [settingMenu?]           (findOpenSettingMenuAX)
+///           settingMenu ── N AXMenuItem leaves
+///
+/// `menuIsOpen` models whether the menu actually surfaced in the tree; the
+/// popup's `performAction` always returns FALSE, mirroring live Logic.
+private struct ScanPresetsFixture {
+    let runtime: AXLogicProElements.Runtime
+
+    init(menuIsOpen: Bool, menuItemCount: Int = 5) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(1)
+        let pluginWindow = b.element(2)
+        let popup = b.element(3)
+        let menu = b.element(4)
+
+        // Plugin window: title has no ".logicx"; holds the Setting popup.
+        b.setAttribute(pluginWindow, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(pluginWindow, kAXTitleAttribute as String, "Compressor")
+        b.setChildren(pluginWindow, [popup])
+
+        // Setting popup: AXPopUpButton whose value matches settingPopupValue.
+        b.setAttribute(popup, kAXRoleAttribute as String, kAXPopUpButtonRole as String)
+        b.setAttribute(popup, kAXValueAttribute as String, "Default Preset")
+
+        b.setAttribute(app, kAXWindowsAttribute as String, [pluginWindow])
+
+        if menuIsOpen {
+            b.setAttribute(menu, kAXRoleAttribute as String, kAXMenuRole as String)
+            var items: [AXUIElement] = []
+            for i in 0..<menuItemCount {
+                let item = b.element(100 + i)
+                b.setAttribute(item, kAXRoleAttribute as String, kAXMenuItemRole as String)
+                b.setAttribute(item, kAXTitleAttribute as String, "Preset \(i)")
+                items.append(item)
+            }
+            b.setChildren(menu, items)
+            // The open menu appears as a top-level child of the app root.
+            b.setChildren(app, [menu])
+        } else {
+            b.setChildren(app, [])
+        }
+
+        // The Setting popup's action ALWAYS returns false — the live bug.
+        let popupKey = b.elementID(popup)
+        runtime = b.makeLogicRuntime(
+            appElement: app,
+            setAttributeHandler: nil,
+            performActionHandler: { [b] element, _ in
+                b.elementID(element) != popupKey
+            }
+        )
+    }
+}
+
+@Test func testScanPresetsSucceedsWhenPopupActionFailsButMenuObserved() async {
+    // Live scenario: popup AXShowMenu/AXPress both return false, yet the menu is
+    // open in the AX tree. The scan MUST trust the observed menu and succeed.
+    let fixture = ScanPresetsFixture(menuIsOpen: true, menuItemCount: 6)
+    let result = await AccessibilityChannel.runLivePluginPresetScan(
+        runtime: fixture.runtime, settleMs: 0
+    )
+    #expect(result.isSuccess)
+    #expect(result.message.contains("Preset 0"))
+    #expect(result.message.contains("Preset 5"))
+    #expect(!result.message.contains("Setting menu did not appear"))
+}
+
+@Test func testScanPresetsFailsClosedWhenActionFiresButNoMenuOpens() async {
+    // Complement: popup action fires but NOTHING opens (no menu in the tree).
+    // The fix must remain fail-closed — never fabricate a State-A success.
+    let fixture = ScanPresetsFixture(menuIsOpen: false)
+    let result = await AccessibilityChannel.runLivePluginPresetScan(
+        runtime: fixture.runtime, settleMs: 0
+    )
+    #expect(!result.isSuccess)
+    #expect(result.message.contains("Setting menu did not appear"))
+}

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -49,7 +49,8 @@ private final class LiveFixture: @unchecked Sendable {
         otherTracks: Int = 0,
         duplicateTrackNameAt: Int? = nil,
         emptyInsertChain: Bool = false,
-        pluginWindowRejectsDirectDemotion: Bool = false
+        pluginWindowRejectsDirectDemotion: Bool = false,
+        slotPressReturnsFalse: Bool = false
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
@@ -195,7 +196,10 @@ private final class LiveFixture: @unchecked Sendable {
                 }
                 b.setAttribute(pluginWindow, kAXMainAttribute as String, true)
                 b.setAttribute(pluginWindow, kAXFocusedAttribute as String, true)
-                return true
+                // Model real Logic 12.3: the slot/open-control AXPress opens the
+                // window but reports a NON-ZERO AX status. The observed-window
+                // poll must succeed regardless of this return.
+                return !slotPressReturnsFalse
             }
         )
         self.app = app
@@ -572,6 +576,44 @@ private func runChannelEQFixture(
     #expect(obj["state"] as? String == "A")
     #expect(obj["observed_normalized"] as? Double == 60)
     #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testOpenerReachesStateAWhenSlotPressReturnsFalseButWindowOpens() async {
+    // Regression guard for the coord-removal feature-loss bug. On real Logic
+    // 12.3 the slot/open-control AXPress can open the plugin window while
+    // reporting a NON-ZERO AX status. The old loop did `guard pressElement …
+    // else { continue }`, skipping the observed-window poll on that false
+    // return, so the window that DID open was never claimed → window_open_failed.
+    // The fix consults `pollOpenPluginWindow` regardless of the press return; the
+    // op MUST now reach State A.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        slotPressReturnsFalse: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(obj["observed_normalized"] as? Double == 60)
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testOpenerStaysFailClosedWhenSlotPressReturnsFalseAndNoWindowOpens() async {
+    // Complement: the press fires (and returns false) but NOTHING opens. The fix
+    // must remain fail-closed (window_open_failed), never fabricate State A.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: false,
+        slotPressReturnsFalse: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(!((obj["write_attempted"] as? Bool)!))
+    #expect(fixture.currentSliderValue == 51)
 }
 
 @Test func testManualPreopenFallsBackToRaisingArrangeWhenFocusedCannotBeClearedDirectly() async {


### PR DESCRIPTION
## Summary
Removes 8 fixed-coordinate / mouse-click actuation sites in favor of accessibility-native equivalents, each **fail-closed** (honest State C on failure — never a silent no-op or coordinate fallback). Every site is live-verified against real Logic Pro 12.3 or covered by the fix + regression tests below.

## The 8 sites
1. control-bar Cycle / Metronome / **Count-In** — coord → AXPress + confirm/readback (**Count-In live-verified State A**)
2. **track.select** last-resort — coord → AXSelectedChildren (**live State A**)
3. **ensure-library-open** — coord → View ▸ Show Library AXPress (**live State A** via set_instrument)
4. openMenuBarItem — coord → AXPress (**live** via the View menu)
5. set_param plugin **window-open** — coord → AXPress (see fix below)
6. plugin **scan_presets** Setting menu — CGEvent popup → AXShowMenu→AXPress (see fix below)
7. resetHorizontalScroll — coord → AXValue = 0
8. closeGoToPositionDialog — coord → AXPress/Escape

## Live-caught feature-loss bug + fix (commit 2)
Live verification proved AXPress **opens a plugin editor window** (window count +1) and **opens the Setting menu** (0→141 AXMenuItems) — but `AXUIElementPerformAction` returns a **non-zero error even when it succeeds** (the Setting popup AXPress returns `-25204` while the menu opens; AXShowMenu is `-25206`/unsupported). The first-pass removal gated its success-poll on the AX return code (`if performAction { poll }` / `guard pressElement else { continue }`), so it **fail-closed on an effect that actually happened** — a dead feature. Unit tests missed it (fakes return true).

**Fix:** fire the AX action, **ignore its return code**, and determine success by polling the **observed effect** (the open AXMenu / the open plugin window). Fail closed only when the effect genuinely does not appear.

**Regression tests:** `testOpenerReachesStateAWhenSlotPressReturnsFalseButWindowOpens` (+ scan_presets analogue) — action returns false but the window/menu opens → State A (was: fail-closed); and the fail-closed-when-nothing-opens counterpart.

## Verification
Full suite `--no-parallel`: **2981 passed**. Adversarial gate: **PROCEED** (prior zero-feature-loss BLOCK on sites 6/7 explicitly lifted after live mechanism proof + the observe-the-effect fix + regression tests). mute/solo/arm and exact-BPM set_tempo intentionally retain their actuators pending their own coordinate-free replacements (tracked). Side finding filed: #405 (DMD Smart Controls AXDialog).
