### PR TITLE
Coordinate-free track mute/solo/arm actuators (zero mouse/HID-click)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -92,9 +92,9 @@ enum AXLogicProElements {
     /// updates while a blocking sheet is up.
     static func dialogPresent(runtime: Runtime = .production) -> Bool {
         guard let app = appRoot(runtime: runtime) else { return false }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
+        guard let windows: [AXUIElement] = AXHelpers.getAttribute(
             app, kAXWindowsAttribute, runtime: runtime.ax
-        ) ?? []
+        ) else { return true }
         return windows.contains { isBlockingDialogWindow($0, runtime: runtime.ax) }
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -18,6 +18,49 @@ enum AXMouseHelper {
         let postKeyEvent: @Sendable (CGKeyCode) -> Bool
         let postUnicodeScalar: @Sendable (UniChar) -> Bool
         let sleepMicros: @Sendable (useconds_t) -> Void
+        /// Post a key chord WITH modifier flags (e.g. Ctrl+Shift+E). Kept
+        /// separate from `postKeyEvent` (bare key) so callers that never need
+        /// modifiers stay untouched; defaults to a no-op so existing `Runtime`
+        /// constructions compile unchanged. Used by the #106 record-arm path
+        /// (Logic's configurable "Toggle Track Record Enable" key command).
+        let postFlaggedKeyEvent: @Sendable (CGKeyCode, CGEventFlags) -> Bool
+
+        init(
+            postMouseEvent: @escaping @Sendable (CGEventType, CGPoint, Int64) -> Bool,
+            postKeyEvent: @escaping @Sendable (CGKeyCode) -> Bool,
+            postUnicodeScalar: @escaping @Sendable (UniChar) -> Bool,
+            sleepMicros: @escaping @Sendable (useconds_t) -> Void,
+            postFlaggedKeyEvent: @escaping @Sendable (CGKeyCode, CGEventFlags) -> Bool = { _, _ in false }
+        ) {
+            self.postMouseEvent = postMouseEvent
+            self.postKeyEvent = postKeyEvent
+            self.postUnicodeScalar = postUnicodeScalar
+            self.sleepMicros = sleepMicros
+            self.postFlaggedKeyEvent = postFlaggedKeyEvent
+        }
+
+        static func keyboardEvents(
+            source: CGEventSource?,
+            keyCode: CGKeyCode,
+            flags: CGEventFlags,
+            clearModifiersAfter: Bool = false
+        ) -> (down: CGEvent, up: CGEvent, modifierClear: CGEvent?)? {
+            guard
+                let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+                let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+            else { return nil }
+            down.flags = flags
+            up.flags = flags
+
+            guard clearModifiersAfter else { return (down, up, nil) }
+            guard let modifierClear = CGEvent(
+                keyboardEventSource: source,
+                virtualKey: keyCode,
+                keyDown: false
+            ) else { return nil }
+            modifierClear.flags = CGEventFlags(rawValue: 0)
+            return (down, up, modifierClear)
+        }
 
         static let production = Runtime(
             postMouseEvent: { type, point, clickCount in
@@ -34,28 +77,43 @@ enum AXMouseHelper {
             },
             postKeyEvent: { keyCode in
                 let source = CGEventSource(stateID: .combinedSessionState)
-                guard
-                    let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
-                    let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-                else { return false }
-                down.post(tap: .cghidEventTap)
-                up.post(tap: .cghidEventTap)
+                guard let events = keyboardEvents(
+                    source: source,
+                    keyCode: keyCode,
+                    flags: CGEventFlags(rawValue: 0)
+                ) else { return false }
+                events.down.post(tap: .cghidEventTap)
+                events.up.post(tap: .cghidEventTap)
                 return true
             },
             postUnicodeScalar: { scalar in
                 let source = CGEventSource(stateID: .combinedSessionState)
-                guard
-                    let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
-                    let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
-                else { return false }
+                guard let events = keyboardEvents(
+                    source: source,
+                    keyCode: 0,
+                    flags: CGEventFlags(rawValue: 0)
+                ) else { return false }
                 var u16 = [scalar]
-                down.keyboardSetUnicodeString(stringLength: u16.count, unicodeString: &u16)
-                up.keyboardSetUnicodeString(stringLength: u16.count, unicodeString: &u16)
-                down.post(tap: .cghidEventTap)
-                up.post(tap: .cghidEventTap)
+                events.down.keyboardSetUnicodeString(stringLength: u16.count, unicodeString: &u16)
+                events.up.keyboardSetUnicodeString(stringLength: u16.count, unicodeString: &u16)
+                events.down.post(tap: .cghidEventTap)
+                events.up.post(tap: .cghidEventTap)
                 return true
             },
-            sleepMicros: { usleep($0) }
+            sleepMicros: { usleep($0) },
+            postFlaggedKeyEvent: { keyCode, flags in
+                let source = CGEventSource(stateID: .combinedSessionState)
+                guard let events = keyboardEvents(
+                    source: source,
+                    keyCode: keyCode,
+                    flags: flags,
+                    clearModifiersAfter: true
+                ) else { return false }
+                events.down.post(tap: .cghidEventTap)
+                events.up.post(tap: .cghidEventTap)
+                events.modifierClear?.post(tap: .cghidEventTap)
+                return true
+            }
         )
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -108,7 +108,10 @@ extension AccessibilityChannel {
     static func defaultSetTrackToggle(
         params: [String: String],
         button buttonName: String,
-        runtime: AXLogicProElements.Runtime = .production
+        runtime: AXLogicProElements.Runtime = .production,
+        keyRuntime: AXMouseHelper.Runtime = .production,
+        processRuntime: ProcessUtils.Runtime = .production,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> ChannelResult {
         guard let indexStr = params["index"], let index = Int(indexStr) else {
             return .error("Missing or invalid 'index' parameter")
@@ -122,18 +125,7 @@ extension AccessibilityChannel {
         guard let button = finder(index) else {
             return .error("Cannot find \(buttonName) button on track \(index)")
         }
-        // Press toggles state. To make `enabled: true/false` idempotent (the
-        // user-visible contract), read current AXValue — only press when the
-        // target state differs. This fixes the class of bug where `arm off`
-        // was a silent no-op because MCU release-only was being sent and the
-        // AX press was unconditionally toggling regardless of desired state.
         let desired: Bool = (params["enabled"] ?? "true") == "true"
-        let current: Bool? = {
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? Int { return raw != 0 }
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? Bool { return raw }
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? NSNumber { return raw.boolValue }
-            return nil
-        }()
         let baseExtras: [String: Any] = [
             "track": index,
             "button": buttonName,
@@ -141,96 +133,661 @@ extension AccessibilityChannel {
             "verification_source": "ax_value"
         ]
 
-        if let cur = current, cur == desired {
+        // Success is judged ONLY by re-reading this checkbox AXValue (the
+        // observed effect), NEVER by an AX action's return code: on real Logic
+        // 12.x the track-header M/S/R actions return non-zero even when they
+        // no-op (#106 sites-6/7), so trusting the return would fabricate a
+        // State A on a control that never moved.
+        func readValue() -> Bool? {
+            guard let v = AXHelpers.getValue(button, runtime: runtime.ax) else { return nil }
+            if let n = v as? NSNumber { return n.boolValue }
+            if let b = v as? Bool { return b }
+            if let i = v as? Int { return i != 0 }
+            if let s = v as? String {
+                switch s.lowercased() {
+                case "1", "true": return true
+                case "0", "false": return false
+                default: return nil
+                }
+            }
+            return nil
+        }
+
+        // Toggle-from-read: already at the desired state → verified no-op. No
+        // rung runs, so no keyboard/coordinate event is ever fired.
+        if let current = readValue(), current == desired {
             return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
                 "observed": desired,
                 "action": "no-op"
             ]) { _, new in new }))
         }
 
-        func readCurrent() -> Bool? {
-            guard let v = AXHelpers.getValue(button, runtime: runtime.ax) else { return nil }
-            if let n = v as? NSNumber { return n.boolValue }
-            if let b = v as? Bool { return b }
-            if let i = v as? Int { return i != 0 }
-            if let s = v as? String { return s == "1" || s.lowercased() == "true" }
-            return nil
-        }
-
-        // #106: Logic 12.x track-header M/S/R checkboxes are `settable=false`
-        // and ignore `AXPress`/`AXConfirm`/value writes entirely — only a real
-        // mouse click at the control toggles Logic's internal state
-        // (live-confirmed: AXPress leaves the value at 0 indefinitely; a HID
-        // click flips it to 1 within ~350 ms). The earlier fixed 50 ms
-        // read-back was also too fast for Logic to publish the new AX value
-        // after a successful click, so even the arm path (whose locator did
-        // find the checkbox) reported a false `ax_write_failed` *after*
-        // physically toggling the control — a silent malfunction. The write
-        // now polls the read-back up to a per-strategy deadline, and the
-        // mouse-click last resort brings Logic frontmost first so the synthetic
-        // click lands on the (un-occluded) track header.
         func pollMatched(deadlineMs: Int) -> Bool {
             let deadline = Date().addingTimeInterval(Double(deadlineMs) / 1000.0)
             repeat {
-                if let after = readCurrent(), after == desired { return true }
+                if let after = readValue(), after == desired { return true }
                 usleep(40_000)
             } while Date() < deadline
             return false
         }
 
-        let strategies: [(name: String, pollMs: Int, action: () -> Void)] = [
-            ("press", 160, { _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax) }),
-            ("confirm", 160, { _ = AXHelpers.performAction(button, kAXConfirmAction, runtime: runtime.ax) }),
-            ("value-nsnumber", 160, {
-                let n: NSNumber = desired ? 1 : 0
-                AXHelpers.setAttribute(button, kAXValueAttribute, n as CFTypeRef, runtime: runtime.ax)
-            }),
-            ("value-cfbool", 160, {
-                let b: CFBoolean = desired ? kCFBooleanTrue : kCFBooleanFalse
-                AXHelpers.setAttribute(button, kAXValueAttribute, b, runtime: runtime.ax)
-            }),
-            ("mouse-click", 1_000, {
-                _ = ProcessUtils.Runtime.production.activateLogicPro()
-                usleep(120_000)
-                Self.postMouseClickAt(element: button, runtime: runtime.ax)
-            }),
-        ]
-        for strategy in strategies {
-            strategy.action()
-            if pollMatched(deadlineMs: strategy.pollMs) {
-                return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
-                    "observed": desired,
-                    "action": strategy.name
-                ]) { _, new in new }))
+        // #106 / ADR-001: coordinate-free per-op actuator ladder. Every rung
+        // actuates WITHOUT any mouse/coordinate primitive (the former HID-click
+        // last resort is deleted). Live-verified on Logic 12.3: SOLO flips on
+        // AXPress; MUTE needs exclusive-select + key 'm'; ARM needs
+        // exclusive-select + the configurable "Toggle Track Record Enable" key
+        // chord. The read-back — not each rung's return value — decides State A.
+        //
+        // ARM honesty baseline: capture whether transport is ALREADY recording
+        // (nil = UNREADABLE, kept distinct from readable-false) so a mis-assigned
+        // arm key that instead triggers transport Record is caught by the guard
+        // below, and an unreadable transport can never be coerced to "not
+        // recording" under an arm State-A claim (#2).
+        let recordingBaselineState: Bool? =
+            (buttonName == "Record") ? transportRecordingState(runtime: runtime) : nil
+
+        let outcome = runTrackToggleLadder(
+            rungs: trackToggleLadder(
+                button: button,
+                buttonName: buttonName,
+                index: index,
+                desired: desired,
+                readValue: readValue,
+                runtime: runtime,
+                keyRuntime: keyRuntime,
+                processRuntime: processRuntime,
+                environment: environment
+            ),
+            desired: desired,
+            readValue: readValue,
+            pollMatched: { pollMatched(deadlineMs: $0) }
+        )
+
+        switch outcome {
+        case .refused(let refusal):
+            // A refused rung posted NO key, so our action caused no transport
+            // side effect — return the distinct fail-closed reason directly.
+            return .error(HonestContract.encodeStateC(
+                error: refusal.error,
+                hint: refusal.hint,
+                extras: baseExtras.merging(refusal.extras) { _, new in new }
+            ))
+
+        case .landed(let action):
+            // ARM honesty guard — only when we would otherwise claim State A.
+            if buttonName == "Record" {
+                guard let post = transportRecordingState(runtime: runtime) else {
+                    // Transport Record UNREADABLE post-actuate: we cannot prove the
+                    // arm key did not instead start transport recording, so never
+                    // claim a clean arm (#2). Fail closed, distinct from State A.
+                    return .error(HonestContract.encodeStateC(
+                        error: .transportStateUnknown,
+                        hint: armTransportUnknownHint(index: index),
+                        extras: baseExtras.merging(["transport_state": "unknown"]) { _, new in new }
+                    ))
+                }
+                if post, recordingBaselineState != true {
+                    // A mis-assigned key started transport Record instead of
+                    // record-enable — fail closed even if the checkbox reads armed.
+                    return .error(HonestContract.encodeStateC(
+                        error: .axWriteFailed,
+                        hint: armRecordingStartedHint(index: index),
+                        extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+                    ))
+                }
+                if recordingBaselineState == true, !post {
+                    return .error(HonestContract.encodeStateC(
+                        error: .readbackMismatch,
+                        hint: armRecordingStoppedHint(index: index),
+                        extras: baseExtras.merging(["recording_stopped": true]) { _, new in new }
+                    ))
+                }
             }
+            return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
+                "observed": desired,
+                "action": action
+            ]) { _, new in new }))
+
+        case .exhausted:
+            // Even a FAILED arm may have started transport Record via a
+            // mis-assigned key — surface that distinctly when it is readable.
+            if buttonName == "Record",
+               let post = transportRecordingState(runtime: runtime),
+               post, recordingBaselineState != true {
+                return .error(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: armRecordingStartedHint(index: index),
+                    extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+                ))
+            }
+            // Fail closed — NEVER a coordinate fallback.
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: trackToggleFailHint(buttonName: buttonName, index: index, desired: desired),
+                extras: baseExtras
+            ))
         }
-        return .error(HonestContract.encodeStateC(
-            error: .axWriteFailed,
-            hint: "tried press/confirm/value-nsnumber/value-cfbool/mouse-click; read-back never matched on track \(index) \(buttonName)=\(desired)",
-            extras: baseExtras
-        ))
     }
 
-    /// Simulate a real user mouse-click at the screen center of an AX element.
-    /// Used as a last resort when AXPress / AXValue writes don't propagate to
-    /// Logic Pro's internal handlers (observed with Logic 12 rec-arm checkboxes).
-    private static func postMouseClickAt(element: AXUIElement, runtime: AXHelpers.Runtime) {
-        var posValue: AnyObject?
-        var sizeValue: AnyObject?
-        let pr = AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posValue)
-        let sr = AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue)
-        // H2 (P2-5): fail-closed on non-AXValue / wrong-subtype rather than
-        // posting a click at (0,0).
-        guard pr == .success, sr == .success,
-              let pt = AXHelpers.point(fromRawAttribute: posValue),
-              let sz = AXHelpers.size(fromRawAttribute: sizeValue) else { return }
-        let center = CGPoint(x: pt.x + sz.width / 2, y: pt.y + sz.height / 2)
-        let src = CGEventSource(stateID: .hidSystemState)
-        if let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
-           let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) {
-            down.post(tap: .cghidEventTap)
-            up.post(tap: .cghidEventTap)
+    // MARK: - Ladder runner (#3 double-toggle halt barrier)
+
+    enum RungOutcome {
+        case actuated
+        case alreadyLanded
+        case landed
+        case refused(RungRefusal)
+        case exhausted
+    }
+
+    /// A fail-closed refusal from a rung: a distinct Honest-Contract error, an
+    /// operator-facing hint, and structured extras merged into the State C body.
+    struct RungRefusal {
+        let error: HonestContract.FailureError
+        let hint: String
+        let extras: [String: Any]
+    }
+
+    /// Terminal result of running the actuator ladder.
+    enum LadderOutcome {
+        case landed(action: String)
+        case refused(RungRefusal)
+        case exhausted
+    }
+
+    /// Run the actuator ladder with a HALT BARRIER between rungs (#3). Every rung
+    /// is a TOGGLE, not a set: if an earlier rung actually flipped the control but
+    /// its AXValue published only AFTER that rung's poll window closed, firing the
+    /// next toggle rung would flip it straight BACK. So BEFORE actuating each rung
+    /// (which includes re-reading after a prior rung's poll failed) we re-read the
+    /// live value; if it ALREADY equals `desired`, we STOP and report State A
+    /// attributed to the rung that actually moved it — never actuating again.
+    /// `readValue` / `pollMatched` are injected so the barrier is unit-testable
+    /// without live timing.
+    static func runTrackToggleLadder(
+        rungs: [TrackToggleRung],
+        desired: Bool,
+        readValue: () -> Bool?,
+        pollMatched: (Int) -> Bool
+    ) -> LadderOutcome {
+        var lastActuated: String?
+        for rung in rungs {
+            // #3 halt barrier — re-read before EVERY actuation.
+            if let current = readValue(), current == desired {
+                return .landed(action: lastActuated ?? rung.name)
+            }
+            switch rung.actuate(pollMatched) {
+            case .refused(let refusal):
+                return .refused(refusal)
+            case .alreadyLanded:
+                return .landed(action: lastActuated ?? rung.name)
+            case .landed:
+                return .landed(action: rung.name)
+            case .exhausted:
+                return .exhausted
+            case .actuated:
+                lastActuated = rung.name
+                if pollMatched(rung.pollMs) {
+                    return .landed(action: rung.name)
+                }
+            }
         }
+        return .exhausted
+    }
+
+    // MARK: - Coordinate-free track-toggle actuator (#106 / ADR-001)
+
+    /// `kVK_ANSI_M` (46) — Logic's default "Mute selected tracks" key command.
+    /// With the target track exclusively selected, pressing it flips that
+    /// track-header Mute checkbox (live-verified on Logic 12.3); AXPress on the
+    /// checkbox itself is a no-op.
+    static let trackMuteKeyCode: CGKeyCode = 46
+
+    /// `kVK_ANSI_S` (1) — Logic's default "Solo selected tracks" key command.
+    /// AXPress on the track-header Solo checkbox is a live no-op on Logic 12.3.
+    static let trackSoloKeyCode: CGKeyCode = 1
+
+    static let logicFrontmostPollIntervalMicros: useconds_t = 100_000
+    static let logicFrontmostStabilityPollCount = 4
+    static let logicFrontmostStabilityTimeoutMicros: useconds_t = 2_000_000
+    static let logicKeyWindowSettleMicros: useconds_t = 800_000
+    static let syntheticKeyRetryAttempts = 3
+    static let syntheticKeyRetryPollMs = 600
+    static let syntheticKeyRetrySettleMicros: useconds_t = 200_000
+
+    /// `kVK_ANSI_R` (15) — bare 'r' IS transport Record. NEVER post it for arm
+    /// (it would start recording instead of toggling record-enable).
+    static let transportRecordKeyCode: CGKeyCode = 15
+
+    /// Default key CHORD for the record-ARM key command: Ctrl+Shift+E
+    /// (`kVK_ANSI_E` (14) + control + shift). Live-confirmed target: Logic's
+    /// "Toggle Track Record Enable" command, which toggles record-enable on the
+    /// SELECTED track (distinct from transport Record). It ships UNASSIGNED, so
+    /// the operator assigns it to this chord (or overrides via
+    /// `LOGIC_PRO_MCP_ARM_KEYCODE` / `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`).
+    static let defaultArmKeyCode: CGKeyCode = 14
+    static let defaultArmModifiers: CGEventFlags = [.maskControl, .maskShift]
+
+    /// Environment override keys for the record-arm chord.
+    static let armKeyCodeEnvVar = "LOGIC_PRO_MCP_ARM_KEYCODE"
+    static let armKeyModifiersEnvVar = "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS"
+
+    /// Outcome of resolving the record-arm key chord from the environment. A
+    /// PRESENT-but-unparseable override is a CONFIGURATION ERROR — surfaced so the
+    /// arm path fails closed with `arm_key_config_invalid` instead of silently
+    /// falling back to the default chord or dropping unknown modifier tokens (#7).
+    /// An ABSENT override still uses the built-in default.
+    enum ArmChordResolution: Equatable {
+        case resolved(code: CGKeyCode, flags: CGEventFlags)
+        case invalidKeyCode(String)
+        case invalidModifierToken(String)
+    }
+
+    /// Resolve the record-arm chord. `LOGIC_PRO_MCP_ARM_KEYCODE` (decimal virtual
+    /// keycode) and `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS` (comma list of
+    /// control/shift/option/command) override the Ctrl+Shift+E default:
+    ///   - ABSENT var → the built-in default (correct, silent).
+    ///   - present + valid → parsed value.
+    ///   - present keycode that does not parse → `.invalidKeyCode` (NO silent
+    ///     fallback to 14).
+    ///   - present modifiers with an unknown token → `.invalidModifierToken` (NO
+    ///     silently dropped token).
+    ///   - present-but-EMPTY modifiers → `.resolved` with no flags (a bare key),
+    ///     which the arm path then refuses as unsafe.
+    /// Injectable environment for deterministic tests.
+    static func resolveArmChord(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> ArmChordResolution {
+        let code: CGKeyCode
+        if let raw = environment[armKeyCodeEnvVar] {
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            guard let parsed = UInt16(trimmed) else { return .invalidKeyCode(trimmed) }
+            code = CGKeyCode(parsed)
+        } else {
+            code = defaultArmKeyCode
+        }
+
+        let flags: CGEventFlags
+        if let raw = environment[armKeyModifiersEnvVar] {
+            var parsed: CGEventFlags = []
+            for token in raw.split(separator: ",") {
+                let name = token.trimmingCharacters(in: .whitespaces).lowercased()
+                if name.isEmpty { continue }
+                switch name {
+                case "control", "ctrl": parsed.insert(.maskControl)
+                case "shift": parsed.insert(.maskShift)
+                case "option", "opt", "alt": parsed.insert(.maskAlternate)
+                case "command", "cmd": parsed.insert(.maskCommand)
+                default: return .invalidModifierToken(name)
+                }
+            }
+            flags = parsed
+        } else {
+            flags = defaultArmModifiers
+        }
+        return .resolved(code: code, flags: flags)
+    }
+
+    /// Read whether Logic's transport is currently RECORDING (control-bar Record
+    /// checkbox), returning nil when it is UNREADABLE. The arm honesty guard MUST
+    /// keep nil DISTINCT from a readable `false`: coercing nil→false would let an
+    /// unreadable transport masquerade as "not recording" under a State-A arm
+    /// claim (#2).
+    static func transportRecordingState(runtime: AXLogicProElements.Runtime) -> Bool? {
+        AXLogicProElements.readControlBarCheckboxValue(
+            named: "녹음", englishName: "Record", runtime: runtime
+        )
+    }
+
+    typealias TrackToggleRung = (
+        name: String,
+        pollMs: Int,
+        actuate: (_ pollMatched: (Int) -> Bool) -> RungOutcome
+    )
+
+    /// Per-op coordinate-free ladder. AXPress is always the natural primary
+    /// (cheap; its return code is ignored and only read-back decides success).
+    /// Mute/solo/arm add an exclusive-select-then-keyboard rung whose
+    /// synthetic key is gated by: exclusive selection re-confirmed ATOMICALLY
+    /// before the post (#4/#5), a safe keyboard focus (#6), and — for arm — a
+    /// valid, non-bare key chord (#7). Any gate failing ⇒ the rung REFUSES (fails
+    /// closed) without posting a key.
+    static func trackToggleLadder(
+        button: AXUIElement,
+        buttonName: String,
+        index: Int,
+        desired: Bool,
+        readValue: @escaping () -> Bool?,
+        runtime: AXLogicProElements.Runtime,
+        keyRuntime: AXMouseHelper.Runtime,
+        processRuntime: ProcessUtils.Runtime,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [TrackToggleRung] {
+        let pressRung: TrackToggleRung = ("press", 250, { _ in
+            _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax)
+            return .actuated
+        })
+
+        func retryingKeyOutcome(
+            pollMatched: (Int) -> Bool,
+            postKey: () -> Void
+        ) -> RungOutcome {
+            if let refusal = syntheticKeyFocusRefusal(runtime: runtime) {
+                return .refused(refusal)
+            }
+            if let refusal = confirmExclusiveSelectionRefusal(
+                index: index,
+                runtime: runtime,
+                processRuntime: processRuntime,
+                sleepMicros: keyRuntime.sleepMicros
+            ) { return .refused(refusal) }
+
+            for attempt in 0..<syntheticKeyRetryAttempts {
+                // Fresh live halt barrier before EVERY post: a late read-back
+                // must never turn a successful toggle into a second toggle.
+                if readValue() == desired {
+                    return attempt == 0 ? .alreadyLanded : .landed
+                }
+                guard processRuntime.logicIsFrontmost() else {
+                    return .refused(logicNotFrontmostRefusal(index: index))
+                }
+                guard selectionIsExclusive(index: index, runtime: runtime) else {
+                    return .refused(selectionNotExclusiveRefusal(index: index))
+                }
+                if let refusal = syntheticKeyFocusRefusal(runtime: runtime) {
+                    return .refused(refusal)
+                }
+                postKey()
+                if pollMatched(syntheticKeyRetryPollMs) { return .landed }
+                if attempt < syntheticKeyRetryAttempts - 1 {
+                    keyRuntime.sleepMicros(syntheticKeyRetrySettleMicros)
+                }
+            }
+            return .exhausted
+        }
+
+        switch buttonName {
+        case "Solo":
+            let keyRung: TrackToggleRung = ("keyboard-solo", syntheticKeyRetryPollMs, { poll in
+                retryingKeyOutcome(pollMatched: poll) {
+                    _ = keyRuntime.postKeyEvent(trackSoloKeyCode)
+                }
+            })
+            return [pressRung, keyRung]
+        case "Mute":
+            let keyRung: TrackToggleRung = ("keyboard-mute", syntheticKeyRetryPollMs, { poll in
+                retryingKeyOutcome(pollMatched: poll) {
+                    _ = keyRuntime.postKeyEvent(trackMuteKeyCode)
+                }
+            })
+            return [pressRung, keyRung]
+        case "Record":
+            let keyRung: TrackToggleRung = ("keyboard-arm", syntheticKeyRetryPollMs, { poll in
+                // #7 configurable chord — a present-but-invalid override is a
+                // config error, never a silent fallback to the default chord.
+                let code: CGKeyCode
+                let flags: CGEventFlags
+                switch resolveArmChord(environment: environment) {
+                case .resolved(let resolvedCode, let resolvedFlags):
+                    code = resolvedCode
+                    flags = resolvedFlags
+                case .invalidKeyCode(let bad):
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "\(armKeyCodeEnvVar)=\"\(bad)\" is not a valid decimal virtual keycode"
+                    ))
+                case .invalidModifierToken(let bad):
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "\(armKeyModifiersEnvVar) contains an unknown modifier token \"\(bad)\""
+                    ))
+                }
+                // A bare (no-modifier) arm key is unsafe: bare 'r' IS transport
+                // Record, and any bare key is a global single-key command. Refuse
+                // it — the default chord (Ctrl+Shift+E) carries modifiers, so only
+                // an explicit empty-modifier override reaches here.
+                if flags.isEmpty {
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "a bare arm key with no modifiers is unsafe (bare 'r' starts transport "
+                            + "recording; any bare key triggers a global command) — configure a modifier chord"
+                    ))
+                }
+                return retryingKeyOutcome(pollMatched: poll) {
+                    _ = keyRuntime.postFlaggedKeyEvent(code, flags)
+                }
+            })
+            return [pressRung, keyRung]
+        default:
+            return [pressRung]
+        }
+    }
+
+    /// Exclusive single-track selection guard. Keyboard mute/solo/arm act on the
+    /// SELECTED track, so before posting any key we (1) activate Logic, (2) drive
+    /// the AX `AXSelectedChildren` selection path, and (3) READ BACK that the target —
+    /// and ONLY the target — is selected. Returns false (⇒ the key is NOT
+    /// posted, so a wrong/multi selection can never toggle the wrong track)
+    /// until exclusivity is confirmed within a bounded settle budget.
+    static func confirmExclusiveSelection(
+        index: Int,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        _ = AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime)
+        for attempt in 0..<4 {
+            if selectionIsExclusive(index: index, runtime: runtime) { return true }
+            if attempt < 3 { usleep(80_000) }
+        }
+        return false
+    }
+
+    /// Read-only exclusivity predicate: the target — and ONLY the target — is
+    /// selected. #5 fail-closed on uncertainty: EVERY non-target header must
+    /// report a DEFINITIVE `AXSelected == false`; any nil/unreadable non-target
+    /// selection state means we cannot PROVE it is unselected, so exclusivity is
+    /// treated as UNPROVEN (returns false) rather than optimistically ignored. The
+    /// target itself must read a definitive `true`.
+    static func selectionIsExclusive(
+        index: Int,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+        guard index >= 0, index < headers.count else { return false }
+        let states = headers.map { AXValueExtractors.extractSelectedState($0, runtime: runtime.ax) }
+        guard states[index] == true else { return false }
+        return states.enumerated().allSatisfy { offset, state in
+            offset == index || state == false
+        }
+    }
+
+    /// Confirm exclusive selection with an ATOMIC re-check immediately before the
+    /// key post (#4 TOCTOU): a second `confirmExclusiveSelection` right before the
+    /// caller posts the key. Returns a distinct `selection_not_exclusive` refusal
+    /// (#9) — NOT the generic write-fail hint — when exclusivity cannot be
+    /// (re)proven, so the key is never posted onto a wrong/multi selection.
+    /// nil ⇒ safe to post.
+    static func confirmExclusiveSelectionRefusal(
+        index: Int,
+        runtime: AXLogicProElements.Runtime,
+        processRuntime: ProcessUtils.Runtime,
+        sleepMicros: (useconds_t) -> Void
+    ) -> RungRefusal? {
+        _ = ProcessUtils.activateLogicPro(runtime: processRuntime)
+
+        var stablePolls = 0
+        var elapsedMicros: useconds_t = 0
+        var frontmostSettled = false
+        while elapsedMicros < logicFrontmostStabilityTimeoutMicros {
+            stablePolls = processRuntime.logicIsFrontmost() ? stablePolls + 1 : 0
+            sleepMicros(logicFrontmostPollIntervalMicros)
+            elapsedMicros += logicFrontmostPollIntervalMicros
+            if stablePolls == logicFrontmostStabilityPollCount {
+                guard processRuntime.logicIsFrontmost() else {
+                    stablePolls = 0
+                    continue
+                }
+                sleepMicros(logicKeyWindowSettleMicros)
+                frontmostSettled = processRuntime.logicIsFrontmost()
+                if frontmostSettled { break }
+                stablePolls = 0
+            }
+        }
+        guard frontmostSettled else { return logicNotFrontmostRefusal(index: index) }
+        guard confirmExclusiveSelection(index: index, runtime: runtime) else {
+            return selectionNotExclusiveRefusal(index: index)
+        }
+        // Re-confirm atomically right before the key — selection can change
+        // between the first confirm and the post (multi-select, user shift-click,
+        // Logic reselection). If it no longer holds, fail closed without posting.
+        guard confirmExclusiveSelection(index: index, runtime: runtime) else {
+            return selectionNotExclusiveRefusal(index: index)
+        }
+        guard processRuntime.logicIsFrontmost() else {
+            return logicNotFrontmostRefusal(index: index)
+        }
+        return nil
+    }
+
+    /// #6 — refuse a synthetic global command key when Logic's keyboard focus is
+    /// NOT known-safe: a modal/sheet is present, or the focused element is an
+    /// editable text surface (rename field, Notes, search/combo box, or any
+    /// element exposing a text insertion point). Posting 'm', 's', or the arm chord into
+    /// such focus would type text or trigger the wrong command. Returns a refusal
+    /// (⇒ do NOT post the key) on POSITIVE danger; nil ⇒ no unsafe focus detected
+    /// (a nil focus is the common non-text case — the modal check covers sheets).
+    /// Mute, Solo, and arm all use this gate before their synthetic key rung.
+    static func syntheticKeyFocusRefusal(
+        runtime: AXLogicProElements.Runtime
+    ) -> RungRefusal? {
+        if AXLogicProElements.dialogPresent(runtime: runtime) {
+            return unsafeFocusRefusal(reason: "a modal dialog or sheet is present", focus: "modal")
+        }
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return unsafeFocusRefusal(
+                reason: "the Logic application root is unreadable — focus safety cannot be proven",
+                focus: "app_root_unreadable"
+            )
+        }
+        guard let focused: AXUIElement = AXHelpers.getAttribute(
+            app, kAXFocusedUIElementAttribute, runtime: runtime.ax
+        ) else {
+            return unsafeFocusRefusal(
+                reason: "Logic's focused element is unreadable — focus safety cannot be proven",
+                focus: "focus_unreadable"
+            )
+        }
+        guard let role = AXHelpers.getRole(focused, runtime: runtime.ax) else {
+            return unsafeFocusRefusal(
+                reason: "the focused element's role is unreadable — focus safety cannot be proven",
+                focus: "role_unreadable"
+            )
+        }
+        let editableRoles: Set<String> = [
+            kAXTextFieldRole as String,
+            kAXTextAreaRole as String,
+            kAXComboBoxRole as String
+        ]
+        if editableRoles.contains(role) {
+            return unsafeFocusRefusal(
+                reason: "an editable text field is focused (role \(role))", focus: role
+            )
+        }
+        // A text insertion point marks an editable text surface even when the role
+        // is unusual — a synthetic key would type into it.
+        if let _: NSNumber = AXHelpers.getAttribute(
+            focused, kAXInsertionPointLineNumberAttribute, runtime: runtime.ax
+        ) {
+            return unsafeFocusRefusal(
+                reason: "a text-editing surface with an insertion point is focused",
+                focus: role
+            )
+        }
+        return nil
+    }
+
+    /// Fail-closed hint (read-back never flipped). Arm points the operator at
+    /// the required "Toggle Track Record Enable" key-command assignment — the
+    /// only coordinate-free arm path on Logic 12.x.
+    static func trackToggleFailHint(buttonName: String, index: Int, desired: Bool) -> String {
+        switch buttonName {
+        case "Record":
+            return "arm requires the Logic key command 'Toggle Track Record Enable' assigned to the "
+                + "configured key (default Ctrl+Shift+E); assign it in Logic ▸ Key Commands, or set "
+                + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
+        case "Mute":
+            return "track \(index) Mute=\(desired): read-back never matched after AXPress + "
+                + "exclusive-select then key 'm' (coordinate-free actuators only)."
+        case "Solo":
+            return "track \(index) Solo=\(desired): read-back never matched after AXPress + "
+                + "exclusive-select then key 's' (coordinate-free actuators only)."
+        default:
+            return "track \(index) \(buttonName)=\(desired): read-back never matched after AXPress "
+                + "on the checkbox (coordinate-free actuators only)."
+        }
+    }
+
+    /// Arm fail-closed hint for the mis-assignment case: the configured key
+    /// started transport RECORDING instead of toggling record-enable.
+    static func armRecordingStartedHint(index: Int) -> String {
+        "arm aborted: the configured key started transport recording instead of arming track "
+            + "\(index) — it is not assigned to 'Toggle Track Record Enable'. Stop the recording, then "
+            + "assign that command (default Ctrl+Shift+E) in Logic ▸ Key Commands, or set "
+            + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
+    }
+
+    static func armRecordingStoppedHint(index: Int) -> String {
+        "arm aborted: the configured key stopped active transport recording instead of only arming track "
+            + "\(index) — it is not assigned to 'Toggle Track Record Enable'. Restore recording as needed, then "
+            + "assign that command (default Ctrl+Shift+E) in Logic ▸ Key Commands, or set "
+            + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
+    }
+
+    /// #2 — arm fail-closed hint when the transport Record state is UNREADABLE at
+    /// the post-actuate check, so a clean arm cannot be honestly claimed.
+    static func armTransportUnknownHint(index: Int) -> String {
+        "arm could not be confirmed for track \(index): the transport Record state was UNREADABLE, so "
+            + "the server cannot prove the arm key did not instead start transport recording. Fail-closed "
+            + "(no State A) — make Logic's control bar (with the Record button) visible, then retry."
+    }
+
+    /// #5/#9 — fail closed when exclusive selection cannot be proven.
+    static func selectionNotExclusiveRefusal(index: Int) -> RungRefusal {
+        RungRefusal(
+            error: .selectionNotExclusive,
+            hint: "track \(index) could not be exclusively selected before the key command "
+                + "(another track is selected, or a header's selection state was unreadable). "
+                + "Deselect other tracks and retry — the key was NOT posted.",
+            extras: ["selection_error": "selection_not_exclusive"]
+        )
+    }
+
+    static func logicNotFrontmostRefusal(index: Int) -> RungRefusal {
+        RungRefusal(
+            error: .logicNotFrontmost,
+            hint: "track \(index) is exclusively selected, but Logic could not be confirmed frontmost. "
+                + "Bring Logic frontmost and retry — the key was NOT posted.",
+            extras: ["frontmost_error": "logic_not_frontmost"]
+        )
+    }
+
+    /// #6 — refusal when Logic's keyboard focus is not known-safe for a synthetic
+    /// global command key. The key was never posted.
+    static func unsafeFocusRefusal(reason: String, focus: String) -> RungRefusal {
+        RungRefusal(
+            error: .unsafeFocusForSyntheticKey,
+            hint: "refused to post the track key command: \(reason). Click the arrange/tracks area "
+                + "(or dismiss the dialog) so keyboard focus is safe, then retry — the key was NOT posted.",
+            extras: ["focus_guard": focus]
+        )
+    }
+
+    /// #7 — refusal when the record-arm key override is present but invalid
+    /// (unparseable keycode, unknown modifier token, or a bare no-modifier key).
+    /// The key was never posted.
+    static func armConfigInvalidRefusal(reason: String) -> RungRefusal {
+        RungRefusal(
+            error: .armKeyConfigInvalid,
+            hint: "record-arm key configuration is invalid: \(reason). Fix "
+                + "\(armKeyCodeEnvVar)/\(armKeyModifiersEnvVar) (or unset them to use the default "
+                + "Ctrl+Shift+E) — the key was NOT posted.",
+            extras: ["arm_key_config": "invalid"]
+        )
     }
 
     static func defaultRenameTrack(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -184,6 +184,7 @@ actor AccessibilityChannel: Channel {
             logicRuntime: AXLogicProElements.Runtime = .production,
             controlBarMouseRuntime: AXMouseHelper.Runtime = .production,
             trackRenameMouseRuntime: AXMouseHelper.Runtime = .production,
+            trackToggleKeyRuntime: AXMouseHelper.Runtime = .production,
             processRuntime: ProcessUtils.Runtime = .production,
             confirmNewTrackDialog: @escaping @Sendable () -> Void = {
                 AccessibilityChannel.sendReturnKey()
@@ -224,7 +225,15 @@ actor AccessibilityChannel: Channel {
                 trackStates: { AccessibilityChannel.defaultGetTrackStates(runtime: logicRuntime) },
                 selectedTrack: { AccessibilityChannel.defaultGetSelectedTrack(runtime: logicRuntime) },
                 selectTrack: { await AccessibilityChannel.defaultSelectTrack(params: $0, runtime: logicRuntime) },
-                setTrackToggle: { AccessibilityChannel.defaultSetTrackToggle(params: $0, button: $1, runtime: logicRuntime) },
+                setTrackToggle: {
+                    AccessibilityChannel.defaultSetTrackToggle(
+                        params: $0,
+                        button: $1,
+                        runtime: logicRuntime,
+                        keyRuntime: trackToggleKeyRuntime,
+                        processRuntime: processRuntime
+                    )
+                },
                 renameTrack: {
                     AccessibilityChannel.defaultRenameTrack(
                         params: $0,

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -800,11 +800,15 @@ enum SemanticOracleTable {
         ]
     )
 
-    /// The `defaultSetTrackToggle` write strategies — the `action` a State-A
-    /// toggle records as the path that actually landed the write. Pinned as a
+    /// The `defaultSetTrackToggle` coordinate-free actuator rungs — the
+    /// `action` a State-A toggle records as the path that actually landed the
+    /// write (#106 / ADR-001: the former value-write / HID `mouse-click` rungs
+    /// are removed). `no-op` = already at desired (toggle-from-read); `press` =
+    /// AXPress on the checkbox; `keyboard-mute` / `keyboard-solo` /
+    /// `keyboard-arm` = exclusive-select then a CGEvent key command. Pinned as a
     /// domain so a toggle claiming an unknown strategy is caught.
     static let trackToggleActions = [
-        "no-op", "press", "confirm", "value-nsnumber", "value-cfbool", "mouse-click",
+        "no-op", "press", "keyboard-mute", "keyboard-solo", "keyboard-arm",
     ]
 
     // AccessibilityChannel+Tracks `defaultSetTrackToggle` (button "Mute") →

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -241,6 +241,33 @@ enum HonestContract {
         case sagaOutcomeUnavailable = "saga_outcome_unavailable"
         case notSupported = "not_supported"
         case sagaExecutionFailed = "saga_execution_failed"
+
+        // #106 coordinate-free track M/S/R actuator — fail-closed honesty codes.
+        /// The transport Record state was UNREADABLE at the arm post-actuate
+        /// check, so the server cannot prove the arm key did not instead start
+        /// transport recording. Distinct from `.axWriteFailed`: the write may have
+        /// landed on the checkbox, but the honesty claim is unverifiable, so arm
+        /// fails closed instead of returning State A (#2). NOT terminal — another
+        /// channel (e.g. MCU) may arm through a different mechanism.
+        case transportStateUnknown = "transport_state_unknown"
+        /// A mute/arm key command was refused because the target track could not
+        /// be proven EXCLUSIVELY selected (another track selected, or a header's
+        /// selection state unreadable). Distinct from the generic write-fail hint
+        /// so an operator is not misdirected to the key binding when selection is
+        /// the problem (#5/#9). The key was never posted.
+        case selectionNotExclusive = "selection_not_exclusive"
+        case logicNotFrontmost = "logic_not_frontmost"
+        /// A mute/arm synthetic key was refused because Logic's keyboard focus is
+        /// not known-safe (an editable text field/sheet/combo box is focused), so
+        /// posting the key would corrupt text or hit the wrong command (#6). The
+        /// key was never posted.
+        case unsafeFocusForSyntheticKey = "unsafe_focus_for_synthetic_key"
+        /// The record-arm key override (`LOGIC_PRO_MCP_ARM_KEYCODE` /
+        /// `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`) is present but invalid (unparseable
+        /// keycode, unknown modifier token, or a bare no-modifier key). The arm
+        /// path fails closed rather than silently posting the default or a partial
+        /// chord (#7). The key was never posted.
+        case armKeyConfigInvalid = "arm_key_config_invalid"
     }
 
     // MARK: - Encoding primitives

--- a/Sources/LogicProMCP/Utilities/ProcessUtils.swift
+++ b/Sources/LogicProMCP/Utilities/ProcessUtils.swift
@@ -9,6 +9,7 @@ enum ProcessUtils {
         let fallbackLogicProPID: @Sendable () -> pid_t?
         let logicProRunning: @Sendable () -> Bool
         let activateLogicPro: @Sendable () -> Bool
+        let logicIsFrontmost: @Sendable () -> Bool
         let logicProBundleURL: @Sendable () -> URL?
 
         static let production = Runtime(
@@ -39,6 +40,11 @@ enum ProcessUtils {
                         ProcessUtils.activateLogicProViaAppleScript()
                     }
                 )
+            },
+            logicIsFrontmost: {
+                guard let app = NSWorkspace.shared.frontmostApplication,
+                      app.bundleIdentifier != nil else { return false }
+                return ProcessUtils.isKnownLogicPID(app.processIdentifier)
             },
             logicProBundleURL: {
                 // RB-2 (v3.4.0): same rationale as `logicProApp()` — both

--- a/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
@@ -210,12 +210,18 @@ import Testing
     #expect(!(AXLogicProElements.dialogPresent(runtime: runtime)))
 }
 
-@Test func testDialogPresentReturnsFalseWhenNoWindowsExposed() {
-    // No kAXWindowsAttribute set — treated as "no dialogs known".
+@Test func testDialogPresentFailsClosedWhenWindowsAreUnreadable() {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(1)
-    let runtime = builder.makeLogicRuntime(appElement: app)
-    #expect(!(AXLogicProElements.dialogPresent(runtime: runtime)))
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        attributeValueHandler: { _, attribute in
+            attribute == kAXWindowsAttribute as String ? .some(nil) : nil
+        },
+        setAttributeHandler: nil,
+        performActionHandler: nil
+    )
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
 }
 
 // MARK: - #234 plugin-editor window classification

--- a/Tests/LogicProMCPTests/AXMouseHelperTests.swift
+++ b/Tests/LogicProMCPTests/AXMouseHelperTests.swift
@@ -88,3 +88,26 @@ private final class AXMouseHelperRecorder: @unchecked Sendable {
     #expect(recorder.unicodeEvents == [0xD83C, 0xDFB9])
     #expect(recorder.sleeps == [12_000, 12_000])
 }
+
+@Test func axMouseHelperKeyboardEventsCarryExplicitFlagsAndClearChordState() throws {
+    let source = try #require(CGEventSource(stateID: .combinedSessionState))
+    let chordFlags: CGEventFlags = [.maskControl, .maskShift]
+    let chord = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x0E,
+        flags: chordFlags,
+        clearModifiersAfter: true
+    ))
+    let bare = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x2E,
+        flags: CGEventFlags(rawValue: 0)
+    ))
+
+    #expect(chord.down.flags == chordFlags)
+    #expect(chord.up.flags == chordFlags)
+    #expect(chord.modifierClear?.flags == CGEventFlags(rawValue: 0))
+    #expect(bare.down.flags == CGEventFlags(rawValue: 0))
+    #expect(bare.up.flags == CGEventFlags(rawValue: 0))
+    #expect(bare.modifierClear == nil)
+}

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -203,6 +203,7 @@ private func makeProcessRuntime(isRunning: Bool = true) -> ProcessUtils.Runtime 
         fallbackLogicProPID: { 4242 },
         logicProRunning: { isRunning },
         activateLogicPro: { true },
+        logicIsFrontmost: { true },
         logicProBundleURL: { nil }
     )
 }
@@ -288,6 +289,12 @@ private func makeAXBackedAccessibilityChannel(
         postUnicodeScalar: { _ in false },
         sleepMicros: { _ in }
     ),
+    trackToggleKeyRuntime: AXMouseHelper.Runtime = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in false },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    ),
     processRuntime: ProcessUtils.Runtime = makeProcessRuntime(),
     confirmNewTrackDialog: @escaping @Sendable () -> Void = {},
     canPostEvents: @escaping @Sendable () -> Bool = { true },
@@ -299,6 +306,7 @@ private func makeAXBackedAccessibilityChannel(
         logicRuntime: logicRuntime ?? builder.makeLogicRuntime(appElement: app),
         controlBarMouseRuntime: controlBarMouseRuntime,
         trackRenameMouseRuntime: trackRenameMouseRuntime,
+        trackToggleKeyRuntime: trackToggleKeyRuntime,
         processRuntime: processRuntime,
         confirmNewTrackDialog: confirmNewTrackDialog,
         canPostEvents: canPostEvents,
@@ -2631,6 +2639,7 @@ private func makeTempoSliderFixture(
     builder.setChildren(window, [trackList])
     builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
     builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, trackList)
     builder.setChildren(trackList, [header])
 
     // v3.1.8 (Issue #7) — strict allTrackHeaders requires AXLayoutItem role
@@ -2657,7 +2666,18 @@ private func makeTempoSliderFixture(
     builder.setAttribute(armButton, kAXDescriptionAttribute as String, "Record Track 1")
     builder.setAttribute(armButton, kAXValueAttribute as String, 1)
 
-    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    // #106 / ADR-001: mute is coordinate-free-actuated — AXPress no-ops on the
+    // real Logic checkbox, so the primary is exclusive-select + CGEvent key 'm'
+    // (keycode 46). Model that faithfully: pressing key 46 toggles muteButton.
+    let muteKeyRecorder = ControlBarMouseRecorder()
+    muteKeyRecorder.onKeyEvent = { code in
+        guard code == AccessibilityChannel.trackMuteKeyCode else { return }
+        let current = (builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue ?? false
+        builder.setAttribute(muteButton, kAXValueAttribute as String, NSNumber(value: !current))
+    }
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, trackToggleKeyRuntime: muteKeyRecorder.runtime()
+    )
 
     let tracksResult = await channel.execute(operation: "track.get_tracks", params: [:])
     #expect(tracksResult.isSuccess)
@@ -2683,10 +2703,17 @@ private func makeTempoSliderFixture(
     #expect(muteNoopResult.isSuccess)
     #expect(muteNoopResult.message.contains("\"action\":\"no-op\""))
     #expect(!builder.actionCalls.contains { $0.elementID == builder.elementID(muteButton) && $0.action == kAXPressAction as String })
-    // Explicitly request disable (enabled=false) — current=true, desired=false → press.
+    // Explicitly request disable (enabled=false) — current=true, desired=false.
+    // AXPress runs first (natural primary; a no-op on the real control), then
+    // the exclusive-select + key 'm' rung flips the value → verified State A.
     let muteOffResult = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "false"])
     #expect(muteOffResult.isSuccess)
+    #expect(muteOffResult.message.contains("\"action\":\"keyboard-mute\""))
+    #expect(muteKeyRecorder.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+    // ADR-001: zero mouse/coordinate events — the actuator is keyboard-only.
+    #expect(muteKeyRecorder.mouseEvents.isEmpty)
     #expect(builder.actionCalls.contains { $0.elementID == builder.elementID(muteButton) && $0.action == kAXPressAction as String })
+    #expect((builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue == false)
 
     let renameResult = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Lead"])
     #expect(renameResult.isSuccess)
@@ -3420,17 +3447,13 @@ private final class LockedFlag: @unchecked Sendable {
     builder.setChildren(header, [soloButton])
     builder.setAttribute(soloButton, kAXRoleAttribute as String, kAXButtonRole as String)
     builder.setAttribute(soloButton, kAXDescriptionAttribute as String, "Solo Track 1")
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, trackList)
+    builder.setAttribute(header, kAXSelectedAttribute as String, true)
 
-    // With performAction disabled, the fallback to direct AXValue write still
-    // succeeds (fake builder stores the value and read-back matches). New
-    // post-hardening contract: the handler reports success via "value-written"
-    // action marker rather than erroring out, because the desired state was
-    // actually reached through the alternate write path.
     let soloFailure = await failingChannel.execute(operation: "track.set_solo", params: ["index": "0"])
-    #expect(soloFailure.isSuccess)
-    // Strategy name: "value-nsnumber" is the first write-based strategy that
-    // succeeds in the fake builder (NSNumber round-trip works, press doesn't).
-    #expect(soloFailure.message.contains("\"action\":\"value-nsnumber\""))
+    #expect(!soloFailure.isSuccess)
+    #expect(soloFailure.message.contains("\"error\":\"ax_write_failed\""))
+    #expect(soloFailure.message.contains("\"state\":\"C\""))
 }
 
 @Test func testAccessibilityChannelAXBackedMixerAndProjectDefaultsUseFakeAXTree() async throws {

--- a/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
+++ b/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
@@ -56,6 +56,10 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
                 if let handled = attributeValueHandler?(element, attribute) {
                     return handled
                 }
+                if attribute == kAXWindowsAttribute as String,
+                   attributes[key(for: element)]?[attribute] == nil {
+                    return NSArray()
+                }
                 return bridge(attributes[key(for: element)]?[attribute])
             },
             setAttributeValue: { [self] element, attribute, value in

--- a/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
+++ b/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
@@ -1,0 +1,1338 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #106 / ADR-001 — the track mute/solo/arm actuator ladder is COORDINATE-FREE.
+/// Each op actuates via AX/keyboard only (no mouse click), determines success by
+/// RE-READING the checkbox AXValue (never the AX action's return code), and fails
+/// closed (never a coordinate fallback) when the read-back never reaches the
+/// desired state. Every test is deterministic (fakes, no live Logic) and each
+/// asserts ZERO mouse events — the coordinate rung is gone.
+@Suite("#106 coordinate-free track toggle actuator")
+struct CoordFreeTrackToggleTests {
+
+    // MARK: - Fixtures / doubles
+
+    /// Records the CGEvent keyboard + mouse posts a coordinate-free actuator
+    /// makes, and (optionally) mutates the fake AX tree when a key lands — the
+    /// deterministic stand-in for "Logic honoured the key command".
+    private final class KeyMouseRecorder: @unchecked Sendable {
+        var keyEvents: [CGKeyCode] = []
+        var flaggedKeyEvents: [(code: CGKeyCode, flags: CGEventFlags)] = []
+        var mouseEvents: [(type: CGEventType, point: CGPoint, clickCount: Int64)] = []
+        var onKeyEvent: ((CGKeyCode) -> Void)?
+        var onFlaggedKey: ((CGKeyCode, CGEventFlags) -> Void)?
+
+        func runtime() -> AXMouseHelper.Runtime {
+            AXMouseHelper.Runtime(
+                postMouseEvent: { type, point, clickCount in
+                    self.mouseEvents.append((type, point, clickCount))
+                    return true
+                },
+                postKeyEvent: { code in
+                    self.keyEvents.append(code)
+                    self.onKeyEvent?(code)
+                    return true
+                },
+                postUnicodeScalar: { _ in false },
+                sleepMicros: { _ in },
+                postFlaggedKeyEvent: { code, flags in
+                    self.flaggedKeyEvents.append((code, flags))
+                    self.onFlaggedKey?(code, flags)
+                    return true
+                }
+            )
+        }
+    }
+
+    private final class FrontmostProbe: @unchecked Sendable {
+        var falseReadsRemaining: Int
+        var checks = 0
+
+        init(falseReads: Int) {
+            falseReadsRemaining = falseReads
+        }
+
+        func read() -> Bool {
+            checks += 1
+            if falseReadsRemaining > 0 {
+                falseReadsRemaining -= 1
+                return false
+            }
+            return true
+        }
+    }
+
+    private final class ActivationProbe: @unchecked Sendable {
+        var calls = 0
+
+        func activate() -> Bool {
+            calls += 1
+            return true
+        }
+    }
+
+    private struct ToggleFixture {
+        let builder: FakeAXRuntimeBuilder
+        let app: AXUIElement
+        let headers: [AXUIElement]
+        let mute: [AXUIElement]
+        let solo: [AXUIElement]
+        let arm: [AXUIElement]
+        let recordCheckbox: AXUIElement // control-bar transport Record (arm honesty guard)
+    }
+
+    /// A Logic-12-shaped fake: an AXList("Track Headers") of AXLayoutItem rows,
+    /// each carrying Mute/Solo/Record-Enable AXCheckBoxes (value 0) plus an
+    /// AXSelected flag. `selected` seeds which rows report AXSelected == true.
+    private func makeToggleFixture(
+        trackCount: Int = 1,
+        selected: Set<Int> = [0],
+        nilSelected: Set<Int> = []
+    ) -> ToggleFixture {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(9000)
+        let window = b.element(9001)
+        let trackList = b.element(9002)
+        let controlBar = b.element(9003)
+        let recordCheckbox = b.element(9004)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        b.setChildren(window, [trackList, controlBar])
+        b.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+        b.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+        b.setAttribute(app, kAXFocusedUIElementAttribute as String, trackList)
+        b.setAttribute(app, kAXWindowsAttribute as String, [AXUIElement]())
+        // Control bar with the transport Record checkbox (value 0 = not
+        // recording) so `transportRecordingState` can read it in arm tests.
+        b.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+        b.setChildren(controlBar, [recordCheckbox])
+        b.setAttribute(recordCheckbox, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        b.setAttribute(recordCheckbox, kAXTitleAttribute as String, "Record")
+        b.setAttribute(recordCheckbox, kAXValueAttribute as String, 0)
+
+        var headers: [AXUIElement] = []
+        var mutes: [AXUIElement] = []
+        var solos: [AXUIElement] = []
+        var arms: [AXUIElement] = []
+        for i in 0..<trackCount {
+            let base = 9100 + i * 10
+            let header = b.element(base)
+            let mute = b.element(base + 1)
+            let solo = b.element(base + 2)
+            let arm = b.element(base + 3)
+            b.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            b.setAttribute(header, kAXTitleAttribute as String, "Track \(i + 1)")
+            // `nilSelected` leaves AXSelected UNSET (nil/unreadable) for those rows,
+            // modelling headers that omit the attribute (#5 fail-closed input).
+            if !nilSelected.contains(i) {
+                b.setAttribute(header, kAXSelectedAttribute as String, selected.contains(i))
+            }
+            for (control, desc) in [(mute, "Mute"), (solo, "Solo"), (arm, "Record Enable")] {
+                b.setAttribute(control, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                b.setAttribute(control, kAXDescriptionAttribute as String, desc)
+                b.setAttribute(control, kAXValueAttribute as String, 0)
+            }
+            b.setChildren(header, [mute, solo, arm])
+            headers.append(header); mutes.append(mute); solos.append(solo); arms.append(arm)
+        }
+        b.setChildren(trackList, headers)
+        return ToggleFixture(
+            builder: b, app: app, headers: headers,
+            mute: mutes, solo: solos, arm: arms, recordCheckbox: recordCheckbox
+        )
+    }
+
+    /// A process runtime whose `activateLogicPro` is a no-op — keeps the
+    /// coordinate-free path from reaching for the real Logic app under test.
+    private func noopProcessRuntime(
+        activateLogicPro: @escaping @Sendable () -> Bool = { true },
+        logicIsFrontmost: @escaping @Sendable () -> Bool = { true }
+    ) -> ProcessUtils.Runtime {
+        ProcessUtils.Runtime(
+            logicProPID: { 4242 },
+            fallbackLogicProPID: { 4242 },
+            logicProRunning: { true },
+            activateLogicPro: activateLogicPro,
+            logicIsFrontmost: logicIsFrontmost,
+            logicProBundleURL: { nil }
+        )
+    }
+
+    private func makeChannel(
+        _ fixture: ToggleFixture,
+        keyRuntime: AXMouseHelper.Runtime,
+        performAction: (@Sendable (AXUIElement, String) -> Bool)? = nil,
+        logicProPID: @escaping @Sendable () -> pid_t? = { 4242 },
+        activateLogicPro: @escaping @Sendable () -> Bool = { true },
+        logicIsFrontmost: @escaping @Sendable () -> Bool = { true },
+        attributeValueHandler: (@Sendable (AXUIElement, String) -> AnyObject??)? = nil
+    ) -> AccessibilityChannel {
+        let logic = AXLogicProElements.Runtime(
+            logicProPID: logicProPID,
+            ax: fixture.builder.makeAXRuntime(
+                appElement: fixture.app,
+                attributeValueHandler: attributeValueHandler,
+                setAttributeHandler: nil,
+                performActionHandler: performAction
+            )
+        )
+        return AccessibilityChannel(runtime: .axBacked(
+            isTrusted: { true },
+            isLogicProRunning: { true },
+            logicRuntime: logic,
+            trackToggleKeyRuntime: keyRuntime,
+            processRuntime: noopProcessRuntime(
+                activateLogicPro: activateLogicPro,
+                logicIsFrontmost: logicIsFrontmost
+            )
+        ))
+    }
+
+    private func object(_ raw: String) -> [String: Any]? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private func boolValue(_ fixture: ToggleFixture, _ element: AXUIElement) -> Bool? {
+        (fixture.builder.attributeValue(element, kAXValueAttribute as String) as? NSNumber)?.boolValue
+    }
+
+    // MARK: - Solo
+
+    @Test("solo flips on AXPress → verified State A via press, ZERO mouse/key")
+    func soloAXPressFlipsVerifiedStateA() async throws {
+        let f = makeToggleFixture()
+        let solo = f.solo[0]
+        let key = KeyMouseRecorder()
+        // Real Logic: AXPress on the Solo checkbox flips it directly.
+        let channel = makeChannel(f, keyRuntime: key.runtime()) { element, action in
+            if element == solo, action == kAXPressAction as String {
+                f.builder.setAttribute(solo, kAXValueAttribute as String, 1)
+            }
+            return true
+        }
+
+        let result = await channel.execute(operation: "track.set_solo", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["verified"] as? Bool == true)
+        #expect(obj?["action"] as? String == "press")
+        #expect(obj?["button"] as? String == "Solo")
+        #expect(boolValue(f, solo) == true)
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("success is judged by the read-back, not the AX return code (#106 sites-6/7)")
+    func soloReadbackBeatsReturnCode() async throws {
+        let f = makeToggleFixture()
+        let solo = f.solo[0]
+        let key = KeyMouseRecorder()
+        // The action REPORTS failure (false) yet the control actually moved —
+        // exactly the live #106 sites-6/7 signature. Only a read-back-driven
+        // ladder reaches State A here; a return-code-gated one would State C.
+        let channel = makeChannel(f, keyRuntime: key.runtime()) { element, action in
+            if element == solo, action == kAXPressAction as String {
+                f.builder.setAttribute(solo, kAXValueAttribute as String, 1)
+                return false
+            }
+            return true
+        }
+
+        let result = await channel.execute(operation: "track.set_solo", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "press")
+        #expect(boolValue(f, solo) == true)
+    }
+
+    @Test("solo: AXPress no-ops, exclusive-select + key 's' flips → State A keyboard-solo")
+    func soloKeyboardActuatorFlipsStateA() async throws {
+        let f = makeToggleFixture()
+        let solo = f.solo[0]
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackSoloKeyCode {
+                f.builder.setAttribute(solo, kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_solo", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["state"] as? String)! == "A")
+        #expect(obj?["action"] as? String == "keyboard-solo")
+        #expect(boolValue(f, solo)!)
+        #expect(key.keyEvents == [AccessibilityChannel.trackSoloKeyCode])
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("solo keyboard rung refuses unsafe focus and posts no key")
+    func soloRefusesWhenFocusIsEditableText() async throws {
+        let f = makeToggleFixture()
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_solo", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["state"] as? String)! == "C")
+        #expect((obj?["error"] as? String)! == "unsafe_focus_for_synthetic_key")
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.solo[0])!)
+    }
+
+    @Test("solo keyboard rung refuses non-exclusive selection and posts no key")
+    func soloRefusesWhenSelectionIsNotExclusive() async throws {
+        let f = makeToggleFixture(trackCount: 2, selected: [0, 1])
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_solo", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["state"] as? String)! == "C")
+        #expect((obj?["error"] as? String)! == "selection_not_exclusive")
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.solo[0])!)
+    }
+
+    // MARK: - Mute: select + key 'm'
+
+    @Test("mute: AXPress no-ops, exclusive-select + key 'm' flips → State A keyboard-mute, ZERO mouse")
+    func muteKeyboardActuatorFlipsStateA() async throws {
+        let f = makeToggleFixture()
+        let mute = f.mute[0]
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(mute, kAXValueAttribute as String, 1)
+            }
+        }
+        // Default performAction (nil): AXPress records + returns true but NEVER
+        // flips a checkbox — modelling Logic's no-op mute press.
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "keyboard-mute")
+        #expect(boolValue(f, mute) == true)
+        // The natural-primary AXPress was still tried first (its return ignored)…
+        #expect(f.builder.actionCalls.contains {
+            $0.elementID == f.builder.elementID(mute) && $0.action == kAXPressAction as String
+        })
+        // …and the rung that LANDED it was the 'm' key command, ZERO mouse.
+        #expect(key.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("mute fails closed (State C) when the keyboard rung does not flip — no coordinate fallback")
+    func muteFailsClosedNoCoordinateFallback() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder() // records the key but never flips the value
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        #expect(boolValue(f, f.mute[0]) == false)
+        // The key WAS attempted (selection was exclusive) but nothing flipped —
+        // and CRUCIALLY no coordinate rung ran to "rescue" it.
+        #expect(key.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    // MARK: - Arm: user-assigned "Toggle Track Record Enable" key command
+
+    @Test("arm: exclusive-select + configurable Ctrl+Shift+E chord flips → State A keyboard-arm, ZERO mouse")
+    func armKeyboardActuatorFlipsStateA() async throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        guard case let .resolved(armCode, armFlags) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve to a valid code + modifier flags")
+            return
+        }
+        let key = KeyMouseRecorder()
+        // Correct "Toggle Track Record Enable": flips the track's record-enable,
+        // does NOT touch the transport Record checkbox.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(arm, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "keyboard-arm")
+        #expect(obj?["button"] as? String == "Record")
+        #expect(boolValue(f, arm) == true)
+        // The RESOLVED chord (code + modifier flags) was posted, ZERO mouse, and
+        // no bare-key path was used.
+        #expect(key.flaggedKeyEvents.contains { $0.code == armCode && $0.flags == armFlags })
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+        // Honesty: transport did not start recording.
+        #expect(boolValue(f, f.recordCheckbox) == false)
+    }
+
+    @Test("arm fails closed (State C) with the exact 'Toggle Track Record Enable' key-command hint")
+    func armFailClosedWithKeyCommandHint() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder() // records the chord but never flips arm
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        // Must say EXACTLY the operator-facing key-command guidance.
+        #expect(obj?["hint"] as? String == "arm requires the Logic key command 'Toggle Track Record "
+            + "Enable' assigned to the configured key (default Ctrl+Shift+E); assign it in Logic ▸ Key "
+            + "Commands, or set LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key.")
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("arm honesty: a key that starts transport RECORDING fails closed, never a false arm")
+    func armFailsClosedWhenKeyStartsRecording() async throws {
+        let f = makeToggleFixture()
+        guard case let .resolved(armCode, _) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve")
+            return
+        }
+        let key = KeyMouseRecorder()
+        // Mis-assigned key = transport Record: it starts recording (control-bar
+        // Record → 1) and does NOT arm the track.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        #expect(obj?["recording_started"] as? Bool == true)
+        let hint = obj?["hint"] as? String ?? ""
+        #expect(hint.contains("transport recording"))
+        #expect(hint.contains("Toggle Track Record Enable"))
+        // The arm checkbox was never (falsely) claimed armed.
+        #expect(boolValue(f, f.arm[0]) == false)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    // MARK: - Toggle-from-read + selection guard
+
+    @Test("toggle-from-read: already at desired → verified no-op with ZERO actuation")
+    func toggleFromReadIsVerifiedNoOp() async throws {
+        let f = makeToggleFixture()
+        f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1) // already muted
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "no-op")
+        // No rung ran: no AXPress on the checkbox, no key, no mouse.
+        // Mutation-check: dropping the toggle-from-read short-circuit would fire
+        // the ladder and populate these.
+        #expect(!f.builder.actionCalls.contains {
+            $0.elementID == f.builder.elementID(f.mute[0]) && $0.action == kAXPressAction as String
+        })
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("toggle-from-read: unknown string is unreadable, never a false no-op State A")
+    func unknownStringTrackValueFailsClosed() async throws {
+        let f = makeToggleFixture()
+        f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, "unavailable")
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "false"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        #expect(key.keyEvents.count == 3)
+        #expect(key.flaggedKeyEvents.count == 0)
+    }
+
+    @Test("exclusive-selection guard: ambiguous selection blocks the key (no wrong-track toggle)")
+    func exclusiveSelectionGuardBlocksKey() async throws {
+        // Two tracks, BOTH reporting selected. Keyboard mute would act on the
+        // selected track(s) — so with selection non-exclusive the guard MUST
+        // refuse to post the key, and the op fails closed.
+        let f = makeToggleFixture(trackCount: 2, selected: [0, 1])
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            // If the guard were broken and this fired, it would fabricate a flip.
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        // The load-bearing guard assertion: the key was NEVER posted because
+        // selection could not be proven exclusive, so no track was toggled.
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+        #expect(boolValue(f, f.mute[0]) == false)
+    }
+
+    @Test("frontmost guard: mute, solo, and arm refuse when Logic never becomes frontmost")
+    func syntheticTrackKeysRefuseWhenLogicIsNotFrontmost() async throws {
+        for operation in ["track.set_mute", "track.set_solo", "track.set_arm"] {
+            let f = makeToggleFixture()
+            let key = KeyMouseRecorder()
+            let target: AXUIElement
+            switch operation {
+            case "track.set_mute": target = f.mute[0]
+            case "track.set_solo": target = f.solo[0]
+            default: target = f.arm[0]
+            }
+            key.onKeyEvent = { _ in
+                f.builder.setAttribute(target, kAXValueAttribute as String, 1)
+            }
+            key.onFlaggedKey = { _, _ in
+                f.builder.setAttribute(target, kAXValueAttribute as String, 1)
+            }
+            let channel = makeChannel(
+                f, keyRuntime: key.runtime(), logicIsFrontmost: { false }
+            )
+
+            let result = await channel.execute(
+                operation: operation, params: ["index": "0", "enabled": "true"]
+            )
+
+            #expect(!result.isSuccess)
+            let obj = object(result.message)
+            #expect((obj?["state"] as? String)! == "C")
+            #expect((obj?["error"] as? String)! == "logic_not_frontmost")
+            #expect(key.keyEvents.isEmpty)
+            #expect(key.flaggedKeyEvents.isEmpty)
+            #expect(!boolValue(f, target)!)
+        }
+    }
+
+    @Test("frontmost settle: delayed frontmost stabilizes, activates once, then mute lands State A")
+    func delayedStableFrontmostAllowsSyntheticTrackKeyAfterOneActivation() async throws {
+        let f = makeToggleFixture()
+        let frontmost = FrontmostProbe(falseReads: 3)
+        let activation = ActivationProbe()
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            activateLogicPro: { activation.activate() },
+            logicIsFrontmost: { frontmost.read() }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["state"] as? String)! == "A")
+        #expect((obj?["action"] as? String)! == "keyboard-mute")
+        #expect(key.keyEvents == [AccessibilityChannel.trackMuteKeyCode])
+        #expect(activation.calls == 1)
+        #expect(frontmost.checks >= 8)
+        #expect(boolValue(f, f.mute[0])!)
+    }
+
+    // MARK: - Configurable arm keycode
+
+    // MARK: - #7 configurable arm chord: config errors fail closed, never fall open
+
+    /// Helper: does `resolveArmChord` return `.resolved` satisfying `check`?
+    private func resolvedChord(
+        _ env: [String: String],
+        _ check: (CGKeyCode, CGEventFlags) -> Bool
+    ) -> Bool {
+        if case let .resolved(code, flags) = AccessibilityChannel.resolveArmChord(environment: env) {
+            return check(code, flags)
+        }
+        return false
+    }
+
+    @Test("#7 arm chord resolution: absent→default; valid→parsed; bad keycode / unknown modifier → config error; empty → bare")
+    func armChordResolutionContract() {
+        #expect(AccessibilityChannel.defaultArmKeyCode == 14)
+
+        // Row: ABSENT → default Ctrl+Shift+E (14). Force-unwrapped via closure so
+        // the assertion is live (never a DEAD `optionalBool == true`).
+        #expect(resolvedChord([:]) { code, flags in
+            code == 14 && flags.contains(.maskControl) && flags.contains(.maskShift)
+                && !flags.contains(.maskCommand) && !flags.contains(.maskAlternate)
+        })
+        #expect(AccessibilityChannel.defaultArmModifiers == [.maskControl, .maskShift])
+
+        // Row: present + valid keycode + valid modifier list → parsed.
+        #expect(resolvedChord([
+            "LOGIC_PRO_MCP_ARM_KEYCODE": "60",
+            "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "command, option"
+        ]) { code, flags in
+            code == 60 && flags.contains(.maskCommand) && flags.contains(.maskAlternate)
+                && !flags.contains(.maskControl)
+        })
+
+        // Row: `ARM_KEYCODE=not-a-number` → INVALID (no silent fallback to 14).
+        #expect({
+            if case .invalidKeyCode = AccessibilityChannel.resolveArmChord(
+                environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
+            ) { return true }
+            return false
+        }())
+
+        // Row: `ARM_KEY_MODIFIERS=controle,shft` (typos) → INVALID (no dropped tokens).
+        #expect({
+            if case .invalidModifierToken = AccessibilityChannel.resolveArmChord(
+                environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "controle,shft"]
+            ) { return true }
+            return false
+        }())
+
+        // Row: `ARM_KEY_MODIFIERS=` (present-empty) → resolved as a BARE key (no
+        // flags). The arm PATH then refuses this as unsafe (see behavioral test).
+        #expect(resolvedChord(["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]) { _, flags in
+            flags.isEmpty
+        })
+    }
+
+    @Test("#7 arm path fails closed (arm_key_config_invalid) on an unparseable keycode override — key NOT posted")
+    func armRefusesInvalidKeycodeConfig() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let result = AccessibilityChannel.defaultSetTrackToggle(
+            params: ["index": "0", "enabled": "true"],
+            button: "Record",
+            runtime: logic,
+            keyRuntime: key.runtime(),
+            processRuntime: noopProcessRuntime(),
+            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
+        )
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "arm_key_config_invalid")
+        // The chord was never posted — a fail-open default would have posted 14.
+        #expect(key.flaggedKeyEvents.isEmpty)
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    @Test("#7 arm path refuses a BARE (no-modifier) key override as unsafe — key NOT posted")
+    func armRefusesBareKeyConfig() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let result = AccessibilityChannel.defaultSetTrackToggle(
+            params: ["index": "0", "enabled": "true"],
+            button: "Record",
+            runtime: logic,
+            keyRuntime: key.runtime(),
+            processRuntime: noopProcessRuntime(),
+            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]  // present-empty → bare
+        )
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "arm_key_config_invalid")
+        #expect(key.flaggedKeyEvents.isEmpty)
+        #expect(key.keyEvents.isEmpty)
+    }
+
+    // MARK: - #3 double-toggle halt barrier
+
+    @Test("#3 halt barrier: rung-1 flips but its poll misses ⇒ rung-2 is NOT fired, result State A (no toggle-back)")
+    func haltBarrierStopsSecondRungAfterLatePress() {
+        // Scripted read-back: the barrier BEFORE the press reads 0 (proceed); the
+        // press's poll MISSES (injected false); then — modelling an AXValue that
+        // published only after the press poll window — the barrier BEFORE the
+        // keyboard rung reads 1 (== desired) and HALTS. A ladder without the
+        // barrier would advance and fire (toggle back) the keyboard rung.
+        var pressFired = false
+        var keyboardFired = false
+        let press: AccessibilityChannel.TrackToggleRung = ("press", 250, { _ in
+            pressFired = true
+            return .actuated
+        })
+        let keyboard: AccessibilityChannel.TrackToggleRung = ("keyboard-mute", 600, { _ in
+            keyboardFired = true
+            return .actuated
+        })
+        let reads: [Bool?] = [false, true]  // barrier-before-press, barrier-before-keyboard
+        var idx = 0
+        let outcome = AccessibilityChannel.runTrackToggleLadder(
+            rungs: [press, keyboard],
+            desired: true,
+            readValue: {
+                defer { idx += 1 }
+                return reads[min(idx, reads.count - 1)]
+            },
+            pollMatched: { _ in false }  // press poll MISSES
+        )
+
+        #expect(pressFired)
+        #expect(!keyboardFired)  // ← load-bearing: barrier halted before rung-2
+        #expect({
+            if case .landed(let action) = outcome { return action == "press" }
+            return false
+        }())
+    }
+
+    @Test("cold-start retry: first synthetic key misses, second lands → State A")
+    func syntheticKeyRetryRecoversColdStartMiss() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let activation = ActivationProbe()
+        key.onKeyEvent = { _ in
+            if key.keyEvents.count == 2 {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let runtime = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let readValue = { boolValue(f, f.mute[0]) }
+        let outcome = AccessibilityChannel.runTrackToggleLadder(
+            rungs: AccessibilityChannel.trackToggleLadder(
+                button: f.mute[0],
+                buttonName: "Mute",
+                index: 0,
+                desired: true,
+                readValue: readValue,
+                runtime: runtime,
+                keyRuntime: key.runtime(),
+                processRuntime: noopProcessRuntime(activateLogicPro: { activation.activate() })
+            ),
+            desired: true,
+            readValue: readValue,
+            pollMatched: { _ in readValue() == true }
+        )
+
+        #expect({
+            if case .landed(let action) = outcome { return action == "keyboard-mute" }
+            return false
+        }())
+        #expect(key.keyEvents.count == 2)
+        #expect(activation.calls == 1)
+    }
+
+    @Test("retry halt barrier: late first post lands → no second synthetic key")
+    func syntheticKeyRetryFreshReadPreventsDoubleToggle() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let activation = ActivationProbe()
+        key.onKeyEvent = { _ in
+            f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+        }
+        let runtime = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let readValue = { boolValue(f, f.mute[0]) }
+        let outcome = AccessibilityChannel.runTrackToggleLadder(
+            rungs: AccessibilityChannel.trackToggleLadder(
+                button: f.mute[0],
+                buttonName: "Mute",
+                index: 0,
+                desired: true,
+                readValue: readValue,
+                runtime: runtime,
+                keyRuntime: key.runtime(),
+                processRuntime: noopProcessRuntime(activateLogicPro: { activation.activate() })
+            ),
+            desired: true,
+            readValue: readValue,
+            pollMatched: { _ in false }
+        )
+
+        #expect({
+            if case .landed(let action) = outcome { return action == "keyboard-mute" }
+            return false
+        }())
+        #expect(key.keyEvents.count == 1)
+        #expect(activation.calls == 1)
+        #expect(readValue() == true)
+    }
+
+    @Test("synthetic key retry is bounded at three attempts when value never flips")
+    func syntheticKeyRetryExhaustsAfterThreeAttempts() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let activation = ActivationProbe()
+        let runtime = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let readValue = { boolValue(f, f.mute[0]) }
+        let outcome = AccessibilityChannel.runTrackToggleLadder(
+            rungs: AccessibilityChannel.trackToggleLadder(
+                button: f.mute[0],
+                buttonName: "Mute",
+                index: 0,
+                desired: true,
+                readValue: readValue,
+                runtime: runtime,
+                keyRuntime: key.runtime(),
+                processRuntime: noopProcessRuntime(activateLogicPro: { activation.activate() })
+            ),
+            desired: true,
+            readValue: readValue,
+            pollMatched: { _ in false }
+        )
+
+        #expect({
+            if case .exhausted = outcome { return true }
+            return false
+        }())
+        #expect(key.keyEvents.count == 3)
+        #expect(activation.calls == 1)
+    }
+
+    private final class LateTrackValuePublication: @unchecked Sendable {
+        let app: AXUIElement
+        let button: AXUIElement
+        var value = false
+
+        init(app: AXUIElement, button: AXUIElement) {
+            self.app = app
+            self.button = button
+        }
+
+        func attributeValue(_ element: AXUIElement, _ attribute: String) -> AnyObject?? {
+            if element == app, attribute == kAXFocusedUIElementAttribute as String {
+                value = true
+                return nil
+            }
+            if element == button, attribute == kAXValueAttribute as String {
+                return .some(NSNumber(value: value))
+            }
+            return nil
+        }
+    }
+
+    @Test("halt barrier: mute value publishes during gates ⇒ no reverse key post, prior press lands")
+    func mutePrePostBarrierStopsReverseToggle() async throws {
+        let f = makeToggleFixture()
+        let late = LateTrackValuePublication(app: f.app, button: f.mute[0])
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { _ in late.value.toggle() }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { late.attributeValue($0, $1) }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "press")
+        #expect(late.value)
+        #expect(key.keyEvents.count == 0)
+        #expect(key.flaggedKeyEvents.count == 0)
+    }
+
+    @Test("halt barrier: arm value publishes during gates ⇒ no reverse chord post, prior press lands")
+    func armPrePostBarrierStopsReverseToggle() async throws {
+        let f = makeToggleFixture()
+        let late = LateTrackValuePublication(app: f.app, button: f.arm[0])
+        let key = KeyMouseRecorder()
+        key.onFlaggedKey = { _, _ in late.value.toggle() }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { late.attributeValue($0, $1) }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_arm", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "press")
+        #expect(late.value)
+        #expect(key.keyEvents.count == 0)
+        #expect(key.flaggedKeyEvents.count == 0)
+    }
+
+    // MARK: - #5 nil AXSelected is not proof of "unselected"
+
+    @Test("#5 exclusive-select confirm: a non-target header with nil/unreadable AXSelected ⇒ NOT exclusive (fail closed)")
+    func nonTargetNilSelectedIsNotExclusive() {
+        // Target (0) selected; header 1 omits AXSelected entirely (nil). We cannot
+        // PROVE header 1 is unselected, so exclusivity is unproven → refuse.
+        let f = makeToggleFixture(trackCount: 2, selected: [0], nilSelected: [1])
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let exclusive = AccessibilityChannel.confirmExclusiveSelection(
+            index: 0, runtime: logic
+        )
+        #expect(!exclusive)
+    }
+
+    // MARK: - #4 select→key TOCTOU
+
+    /// Marks a second header selected on the Nth AXPress of a watched header —
+    /// modelling a concurrent multi-select that appears between the first exclusive
+    /// confirm and the atomic re-confirm right before the key post.
+    private final class HeaderPressFlip: @unchecked Sendable {
+        let builder: FakeAXRuntimeBuilder
+        let watch: AXUIElement
+        let onNthPress: Int
+        let select: AXUIElement
+        var presses = 0
+        init(builder: FakeAXRuntimeBuilder, watch: AXUIElement, onNthPress: Int, select: AXUIElement) {
+            self.builder = builder
+            self.watch = watch
+            self.onNthPress = onNthPress
+            self.select = select
+        }
+        func handler(_ element: AXUIElement, _ action: String) -> Bool {
+            if action == (kAXPressAction as String), element == watch {
+                presses += 1
+                if presses == onNthPress {
+                    builder.setAttribute(select, kAXSelectedAttribute as String, true)
+                }
+            }
+            return true
+        }
+    }
+
+    @Test("select→key TOCTOU: selection changes during focus read ⇒ final gate refuses, key NOT posted")
+    func selectionChangeDuringFocusReadFailsClosed() async throws {
+        let f = makeToggleFixture(trackCount: 2, selected: [0])
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { _ in
+            f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+        }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { element, attribute in
+                if element == f.app, attribute == kAXFocusedUIElementAttribute as String {
+                    f.builder.setAttribute(f.headers[1], kAXSelectedAttribute as String, true)
+                }
+                return nil
+            }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "selection_not_exclusive")
+        #expect(!boolValue(f, f.mute[0])!)
+        #expect(key.keyEvents.count == 0)
+        #expect(key.flaggedKeyEvents.count == 0)
+    }
+
+    @Test("focus safe before activation but unsafe after activation refuses the key")
+    func focusBecomingUnsafeDuringActivationFailsClosed() async throws {
+        let f = makeToggleFixture()
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { _ in
+            f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+        }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            activateLogicPro: {
+                f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+                return true
+            }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["error"] as? String)! == "unsafe_focus_for_synthetic_key")
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#4 select→key TOCTOU: selection lost between confirm and post ⇒ fail closed, key NOT posted")
+    func selectionLostBeforeKeyFailsClosed() async throws {
+        let f = makeToggleFixture(trackCount: 2, selected: [0])  // header 1 starts unselected
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        // The keyboard rung re-confirms exclusivity IMMEDIATELY before the key. The
+        // SECOND confirm's own selectTrackViaAX presses header 0 (press #2 overall),
+        // and at that instant header 1 becomes selected too — so the re-check sees a
+        // non-exclusive selection and must refuse without posting.
+        let flip = HeaderPressFlip(builder: f.builder, watch: f.headers[0], onNthPress: 2, select: f.headers[1])
+        let channel = makeChannel(f, keyRuntime: key.runtime(), performAction: { flip.handler($0, $1) })
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "selection_not_exclusive")
+        // Load-bearing: the TOCTOU re-check caught the change → key NEVER posted.
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.mute[0])!)  // live force-unwrap (fixture always sets 0/1)
+    }
+
+    // MARK: - #6 keyboard-focus gate
+
+    private final class AppRootDropDuringFocusGate: @unchecked Sendable {
+        let app: AXUIElement
+        var dropDuringFocusGate = false
+        var readable = true
+
+        init(app: AXUIElement) {
+            self.app = app
+        }
+
+        func pid() -> pid_t? {
+            readable ? 4242 : nil
+        }
+
+        func attributeValue(_ element: AXUIElement, _ attribute: String) -> AnyObject?? {
+            if dropDuringFocusGate,
+               element == app,
+               attribute == kAXWindowsAttribute as String {
+                readable = false
+            }
+            return nil
+        }
+    }
+
+    @Test("#6 focus gate: unreadable app root ⇒ mute refuses the synthetic key")
+    func muteRefusesWhenAppRootIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let appRoot = AppRootDropDuringFocusGate(app: f.app)
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            performAction: { element, _ in
+                if element == f.mute[0] { appRoot.dropDuringFocusGate = true }
+                return true
+            },
+            logicProPID: { appRoot.pid() },
+            attributeValueHandler: { appRoot.attributeValue($0, $1) }
+        )
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(obj?["focus_guard"] as? String == "app_root_unreadable")
+        #expect(key.keyEvents.count + key.flaggedKeyEvents.count == 0)
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: unreadable app root ⇒ arm refuses the synthetic chord")
+    func armRefusesWhenAppRootIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let appRoot = AppRootDropDuringFocusGate(app: f.app)
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            performAction: { element, _ in
+                if element == f.arm[0] { appRoot.dropDuringFocusGate = true }
+                return true
+            },
+            logicProPID: { appRoot.pid() },
+            attributeValueHandler: { appRoot.attributeValue($0, $1) }
+        )
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(obj?["focus_guard"] as? String == "app_root_unreadable")
+        #expect(key.keyEvents.count + key.flaggedKeyEvents.count == 0)
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    @Test("#6 focus gate: unreadable focused element ⇒ mute refuses the synthetic key")
+    func muteRefusesWhenFocusedElementIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { element, attribute in
+                if element == f.app, attribute == kAXFocusedUIElementAttribute as String {
+                    return .some(nil)
+                }
+                return nil
+            }
+        )
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(obj?["focus_guard"] as? String == "focus_unreadable")
+        #expect(key.keyEvents.count + key.flaggedKeyEvents.count == 0)
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: unreadable focused element ⇒ arm refuses the synthetic chord")
+    func armRefusesWhenFocusedElementIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { element, attribute in
+                if element == f.app, attribute == kAXFocusedUIElementAttribute as String {
+                    return .some(nil)
+                }
+                return nil
+            }
+        )
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(obj?["focus_guard"] as? String == "focus_unreadable")
+        #expect(key.keyEvents.count + key.flaggedKeyEvents.count == 0)
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    @Test("#6 focus gate: unreadable focused role refuses the synthetic key")
+    func muteRefusesWhenFocusedRoleIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let unknown = f.builder.element(9501)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, unknown)
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { _ in
+            f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["error"] as? String)! == "unsafe_focus_for_synthetic_key")
+        #expect((obj?["focus_guard"] as? String)! == "role_unreadable")
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: unreadable window list refuses the synthetic key")
+    func muteRefusesWhenWindowListIsUnreadable() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { _ in
+            f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+        }
+        let channel = makeChannel(
+            f,
+            keyRuntime: key.runtime(),
+            attributeValueHandler: { element, attribute in
+                if element == f.app, attribute == kAXWindowsAttribute as String {
+                    return .some(nil)
+                }
+                return nil
+            }
+        )
+
+        let result = await channel.execute(
+            operation: "track.set_mute", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect((obj?["error"] as? String)! == "unsafe_focus_for_synthetic_key")
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: a focused editable text field ⇒ mute refuses the synthetic key (unsafe_focus_for_synthetic_key)")
+    func muteRefusesWhenFocusIsEditableText() async throws {
+        let f = makeToggleFixture()
+        // Focus is on a rename/search text field — a synthetic 'm' would type text.
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(key.keyEvents.isEmpty)  // key NEVER posted
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: a focused editable text field ⇒ arm refuses the synthetic chord")
+    func armRefusesWhenFocusIsEditableText() async throws {
+        let f = makeToggleFixture()
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(key.flaggedKeyEvents.isEmpty)  // chord NEVER posted
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    // MARK: - #2 transport unreadable ⇒ arm fails closed (never State A while maybe recording)
+
+    @Test("#2 arm honesty: transport Record UNREADABLE at post-actuate ⇒ transport_state_unknown, not State A")
+    func armFailsClosedWhenTransportUnreadable() async throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        guard case let .resolved(armCode, _) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve")
+            return
+        }
+        // Make the control-bar Record checkbox UNREADABLE (a non-numeric AXValue →
+        // readControlBarCheckboxValue returns nil), so transport state is unknown.
+        f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, "unreadable")
+        let key = KeyMouseRecorder()
+        // The arm key genuinely flips the record-enable checkbox — but with the
+        // transport state unreadable we still cannot honestly claim a clean arm.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(arm, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "transport_state_unknown")
+        // The checkbox DID flip, yet arm is NOT claimed as State A (success:false
+        // + State C error above prove it was never a verified clean arm).
+        #expect(boolValue(f, arm)!)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("arm honesty: a key that stops active transport recording fails closed, never State A")
+    func armFailsClosedWhenKeyStopsRecording() async throws {
+        let f = makeToggleFixture()
+        f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, 1)
+        guard case let .resolved(armCode, _) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve")
+            return
+        }
+        let key = KeyMouseRecorder()
+        key.onFlaggedKey = { code, _ in
+            guard code == armCode else { return }
+            f.builder.setAttribute(f.arm[0], kAXValueAttribute as String, 1)
+            f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, 0)
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(
+            operation: "track.set_arm", params: ["index": "0", "enabled": "true"]
+        )
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "readback_mismatch")
+        #expect(obj?["recording_stopped"] as? Bool == true)
+        #expect(boolValue(f, f.arm[0])!)
+        #expect(!boolValue(f, f.recordCheckbox)!)
+        #expect(key.keyEvents.count == 0)
+        #expect(key.flaggedKeyEvents.count == 1)
+    }
+}

--- a/Tests/LogicProMCPTests/ProcessUtilsTests.swift
+++ b/Tests/LogicProMCPTests/ProcessUtilsTests.swift
@@ -21,6 +21,7 @@ private final class ProcessRuntimeHarness: @unchecked Sendable {
                 self.activateCalls += 1
                 return self.activateResult
             },
+            logicIsFrontmost: { true },
             logicProBundleURL: { self.bundleURL }
         )
     }

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -523,11 +523,12 @@ enum SemanticOracleFixtures {
             readback: "{}"
         ),
         // AccessibilityChannel+Tracks.defaultSetTrackToggle (Mute): requested==observed bool.
+        // Mute's coordinate-free primary is exclusive-select + key 'm' (#106).
         .tracksMute: SemanticOracleFixture(
             response: """
                 {"success":true,"verified":true,"state":"A","track":1,\
                 "button":"Mute","requested":true,"verification_source":"ax_value",\
-                "observed":true,"action":"press"}
+                "observed":true,"action":"keyboard-mute"}
                 """,
             readback: "{}"
         ),
@@ -535,15 +536,17 @@ enum SemanticOracleFixtures {
             response: """
                 {"success":true,"verified":true,"state":"A","track":1,\
                 "button":"Solo","requested":true,"verification_source":"ax_value",\
-                "observed":true,"action":"press"}
+                "observed":true,"action":"keyboard-solo"}
                 """,
             readback: "{}"
         ),
+        // Arm's coordinate-free path is exclusive-select + a user-assigned
+        // "Toggle Track Record Enable" key command (#106; 'r' is transport Record).
         .tracksArm: SemanticOracleFixture(
             response: """
                 {"success":true,"verified":true,"state":"A","track":1,\
                 "button":"Record","requested":true,"verification_source":"ax_value",\
-                "observed":true,"action":"mouse-click"}
+                "observed":true,"action":"keyboard-arm"}
                 """,
             readback: "{}"
         ),

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -482,6 +482,16 @@ struct SemanticOracleMutationTests {
         #expect(verdict, "\(operationID.rawValue) rejected its own realistic fixture")
     }
 
+    @Test("Solo keyboard State A passes qualification")
+    func soloKeyboardStateAPassesQualification() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.tracksSolo])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[.tracksSolo])
+        #expect(oracle.evaluate(
+            responseData: fixture.responseData,
+            readbackData: fixture.readbackData
+        )!)
+    }
+
     /// The anti-checkbox tool. For every constraint of every declarative oracle,
     /// corrupt the fixture the way that constraint exists to catch (drop the
     /// key, push the value out of domain, wrong-type it) and require the oracle


### PR DESCRIPTION
## Coordinate-free track mute/solo/arm actuators (zero mouse/HID-click)

Replaces the track-header mute/solo/arm toggle path's mouse/coordinate last-resort with a coordinate-free actuation ladder. Part of the coordinate-actuation-removal effort: the server must never actuate Logic via screen coordinates or synthetic mouse events.

### What changed
- **SOLO** — AXPress on the checkbox (live-verified to flip on Logic 12.3).
- **MUTE** — exclusive-select the track, then key `m` (kVK_ANSI_M).
- **ARM** — exclusive-select, then the configurable "Toggle Track Record Enable" chord (default Ctrl+Shift+E; `LOGIC_PRO_MCP_ARM_KEYCODE` / `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS` override). Record-side-effect guard fails closed if the transport starts recording.
- The former HID-click last resort is deleted. **Zero mouse/coordinate/cliclick actuation** in this path.

### Correctness law
Success is decided **only** by polling the observed effect (the checkbox AXValue changed), **never** by an AX action's return code — on real Logic 12.3 `AXUIElementPerformAction` returns non-zero even when the action succeeds. Every path **fails closed** on uncertainty (no coordinate fallback ever).

### Hardening (adversarial-review findings closed)
- Double-toggle halt-barrier: re-read the control before every rung; stop the instant it equals the desired state (never fire the next toggle).
- Transport-unreadable → fail closed (`transport_state_unknown`), never coerced to "not recording".
- Exclusive selection requires a definitive `false` on every non-target header; any nil/unreadable → refuse (fail closed).
- Selection re-confirmed atomically immediately before the key post (TOCTOU).
- Keyboard-focus gate: refuse synthetic mute/arm keys when a modal/sheet is present or focus is an editable text surface.
- Env-parse: present-but-unparseable keycode/modifier → `arm_key_config_invalid` (no silent default); bare no-modifier key refused.
- Distinct `selection_not_exclusive` error.

### Evidence
- Full suite: **3038 tests green** (`swift test --no-parallel`), 0 non-skipped failures.
- 9 new regression tests, each fails before its fix (live `#expect`, force-unwrap — no dead-expect).
- Live-verified on Logic 12.3: mute (keyboard `m`), solo (AXPress), arm (Ctrl+Shift+E) each flip the observed track-header state; fail-closed negatives confirmed.

Note: the consent-based arm key-command auto-setup (which assigns the arm chord in Logic's Key Commands GUI) is a **separate follow-up PR** — this PR is the actuator only.
