### PR TITLE
Consent-based arm key-command auto-setup (system.setup_arm_key)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -18,6 +18,26 @@ enum AXMouseHelper {
         let postKeyEvent: @Sendable (CGKeyCode) -> Bool
         let postUnicodeScalar: @Sendable (UniChar) -> Bool
         let sleepMicros: @Sendable (useconds_t) -> Void
+        /// Post a key chord WITH modifier flags (e.g. Ctrl+Shift+E). Kept
+        /// separate from `postKeyEvent` (bare key) so callers that never need
+        /// modifiers stay untouched; defaults to a no-op so existing `Runtime`
+        /// constructions compile unchanged. Used by the #106 record-arm path
+        /// (Logic's configurable "Toggle Track Record Enable" key command).
+        let postFlaggedKeyEvent: @Sendable (CGKeyCode, CGEventFlags) -> Bool
+
+        init(
+            postMouseEvent: @escaping @Sendable (CGEventType, CGPoint, Int64) -> Bool,
+            postKeyEvent: @escaping @Sendable (CGKeyCode) -> Bool,
+            postUnicodeScalar: @escaping @Sendable (UniChar) -> Bool,
+            sleepMicros: @escaping @Sendable (useconds_t) -> Void,
+            postFlaggedKeyEvent: @escaping @Sendable (CGKeyCode, CGEventFlags) -> Bool = { _, _ in false }
+        ) {
+            self.postMouseEvent = postMouseEvent
+            self.postKeyEvent = postKeyEvent
+            self.postUnicodeScalar = postUnicodeScalar
+            self.sleepMicros = sleepMicros
+            self.postFlaggedKeyEvent = postFlaggedKeyEvent
+        }
 
         static let production = Runtime(
             postMouseEvent: { type, point, clickCount in
@@ -55,7 +75,19 @@ enum AXMouseHelper {
                 up.post(tap: .cghidEventTap)
                 return true
             },
-            sleepMicros: { usleep($0) }
+            sleepMicros: { usleep($0) },
+            postFlaggedKeyEvent: { keyCode, flags in
+                let source = CGEventSource(stateID: .combinedSessionState)
+                guard
+                    let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+                    let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+                else { return false }
+                down.flags = flags
+                up.flags = flags
+                down.post(tap: .cghidEventTap)
+                up.post(tap: .cghidEventTap)
+                return true
+            }
         )
     }
 

--- a/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
+++ b/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
@@ -1,0 +1,312 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Consent-based server automation of the one-time key-command assignment that
+/// the coordinate-free record-arm path requires.
+///
+/// Why this exists: on real Logic 12.3 the track-header "Record Enable"
+/// checkbox advertises AXPress but AXPress is a **no-op** (returns success yet
+/// the value never flips — unlike Solo, which does flip on AXPress), the value
+/// is not settable, and no menu item record-enables a track. The only
+/// coordinate-free way to arm is Logic's "Toggle Track Record Enable" key
+/// command — which ships **unassigned**, and Logic 12.2+ blocks programmatic
+/// key-command *import*. So the assignment must be made through the Key Commands
+/// GUI. This type does that entirely coordinate-free (no mouse/CGEvent-mouse):
+///   1. Option+K keystroke opens the Key Commands window.
+///   2. The command list is collapsed with a **search-field AXValue write**
+///      (avoids walking the ~2200-row outline, which times out).
+///   3. The command row is selected via `AXSelected`.
+///   4. The "Learn by Key Label" **AXCheckBox** is driven via AXPress (it is a
+///      checkbox, not a button — the reason an earlier button-only hunt missed
+///      it), the chord is sent as a CGEvent **keyboard** chord (keystrokes are
+///      not coordinates), then Learn is toggled back off.
+///   5. The window is closed via **AXPress on its close button** — never a
+///      second Option+K, which would type into the focused search field and
+///      leave the window open (starving track reads).
+///
+/// Consent is mandatory (Isaac's rule: never modify the user's Logic config
+/// without consent). Every step's success is judged by a polled OBSERVED effect
+/// (window appeared / command row appeared / checkbox value changed), never by
+/// an AX action's return code. On any step whose effect does not materialise it
+/// fails closed with an actionable manual-fallback hint. Idempotent: re-running
+/// re-learns the same chord.
+enum ArmKeyCommandSetup {
+    /// EN command name / checkbox title. Locale-dependent: non-EN Logic shows
+    /// localised strings, so a non-EN run fails closed at `commandNotFound`
+    /// with a manual hint rather than mis-assigning. (Future: AXLocalePolicy.)
+    static let commandName = "Toggle Track Record Enable"
+    static let learnCheckboxTitle = "Learn by Key Label"
+
+    enum Outcome: Equatable {
+        case consentRequired
+        case configuredAndVerified               // State A — assignment made AND a live arm flip observed
+        case configuredUnverified(why: String)   // State B — assignment made, could not confirm a flip
+        case failed(stage: String, hint: String) // State C — a step's observed effect never materialised
+    }
+
+    struct Runtime {
+        /// Bring Logic frontmost so synthetic keystrokes route to it.
+        var activateLogic: @Sendable () -> Void
+        /// Post a modified key chord (used for Option+K and the arm chord).
+        var postChord: @Sendable (CGKeyCode, CGEventFlags) -> Void
+        /// Type text as real keystrokes into the focused element. Used to fill
+        /// the KC search field: a programmatic AXValue set does NOT trigger
+        /// Logic's list filter, but typed keystrokes do (collapsing ~2200 rows
+        /// to a handful, so the command lookup is fast instead of a ~26s walk).
+        var typeText: @Sendable (String) -> Void
+        /// Sleep seconds (injected so tests don't wall-clock).
+        var sleep: @Sendable (Double) -> Void
+        var ax: AXHelpers.Runtime
+        var elements: AXLogicProElements.Runtime
+        /// Ground-truth verification: drive a real record-arm and report whether
+        /// the observed record-enable state flipped. nil ⇒ could not verify
+        /// (e.g. no track). Wired by the dispatcher to the arm actuator.
+        var verifyArmFlip: @Sendable () -> Bool?
+
+        static func production(verifyArmFlip: @escaping @Sendable () -> Bool?) -> Runtime {
+            Runtime(
+                activateLogic: {
+                    if let pid = ProcessUtils.logicProPID(),
+                       let app = NSRunningApplication(processIdentifier: pid) {
+                        app.activate(options: [])
+                    }
+                },
+                postChord: { keyCode, flags in
+                    _ = AXMouseHelper.Runtime.production.postFlaggedKeyEvent(keyCode, flags)
+                },
+                typeText: { AXMouseHelper.typeText($0) },
+                sleep: { Thread.sleep(forTimeInterval: $0) },
+                ax: .production,
+                elements: .production,
+                verifyArmFlip: verifyArmFlip
+            )
+        }
+    }
+
+    private static let optionKKeyCode: CGKeyCode = 40          // kVK_ANSI_K
+    private static let optionFlag: CGEventFlags = .maskAlternate
+
+    /// Run the consent-gated assignment. `keyCode`/`modifiers` default to
+    /// Ctrl+Shift+E (the shipped arm chord); pass the resolved chord so setup
+    /// and the runtime actuator stay in lockstep.
+    static func run(
+        consent: Bool,
+        keyCode: CGKeyCode,
+        modifiers: CGEventFlags,
+        runtime: Runtime
+    ) -> Outcome {
+        guard consent else { return .consentRequired }
+
+        runtime.activateLogic()
+        runtime.sleep(0.4)
+
+        // 1. Open the Key Commands window (Option+K), polling for the window.
+        var window = keyCommandsWindow(runtime: runtime)
+        if window == nil {
+            runtime.postChord(optionKKeyCode, optionFlag)
+            window = poll(runtime: runtime, deadline: 4.0) { keyCommandsWindow(runtime: runtime) }
+        }
+        guard let kcWindow = window else {
+            return .failed(
+                stage: "open_key_commands",
+                hint: "The Key Commands window did not open (Option+K). Open it manually "
+                    + "(Logic Pro ▸ Key Commands ▸ Edit) and assign \"\(commandName)\" to a shortcut."
+            )
+        }
+
+        // 2. Collapse the list with the search field (never a full-tree walk).
+        guard let searchField = firstDescendant(in: kcWindow, runtime: runtime, where: { el in
+            let role = AXHelpers.getRole(el, runtime: runtime.ax) ?? ""
+            return role == (kAXTextFieldRole as String) || role == "AXSearchField"
+        }) else {
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "search_field",
+                hint: "Could not find the Key Commands search field. Assign \"\(commandName)\" manually."
+            )
+        }
+        // Type the command name into the search field. Keystrokes trigger Logic's
+        // list filter (collapsing ~2200 rows to a handful → fast lookup); a
+        // programmatic AXValue set does NOT filter and leaves a ~26s full walk.
+        _ = AXHelpers.setAttribute(searchField, kAXValueAttribute, "" as CFTypeRef, runtime: runtime.ax)
+        _ = AXHelpers.setAttribute(searchField, kAXFocusedAttribute, kCFBooleanTrue, runtime: runtime.ax)
+        runtime.sleep(0.3)
+        runtime.typeText(commandName)
+        runtime.sleep(1.0)  // let the filter collapse the list
+
+        // 3. Poll for the filtered command element (fast on the collapsed list),
+        //    then select its row. Exclude the search field itself — it now also
+        //    contains the command name.
+        guard let commandEl = poll(runtime: runtime, deadline: 4.0, {
+            firstDescendant(in: kcWindow, runtime: runtime, where: { el in
+                !CFEqual(el, searchField) && matchesCommand(el, runtime: runtime)
+            })
+        }) else {
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "command_not_found",
+                hint: "Could not find the \"\(commandName)\" command — Logic may be non-English. "
+                    + "Assign the record-arm command to \(chordLabel(keyCode: keyCode, modifiers: modifiers)) manually."
+            )
+        }
+        selectEnclosingRow(commandEl, runtime: runtime)
+
+        // 4. Drive "Learn by Key Label" (an AXCheckBox), send the chord, stop learning.
+        guard let learn = firstDescendant(in: kcWindow, runtime: runtime, where: { el in
+            AXHelpers.getRole(el, runtime: runtime.ax) == (kAXCheckBoxRole as String)
+                && (AXHelpers.getTitle(el, runtime: runtime.ax) ?? "") == learnCheckboxTitle
+        }) else {
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "learn_checkbox",
+                hint: "Could not find the \"\(learnCheckboxTitle)\" control. Assign \"\(commandName)\" manually."
+            )
+        }
+        _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
+        // Observed effect: the checkbox reports learning (value 1). Poll, don't
+        // trust the AXPress return.
+        _ = poll(runtime: runtime, deadline: 1.5) { checkboxOn(learn, runtime: runtime) ? true : nil }
+
+        runtime.postChord(keyCode, modifiers)
+        runtime.sleep(0.3)
+
+        // Turn Learn back off if it is still on (idempotent).
+        if checkboxOn(learn, runtime: runtime) {
+            _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
+            runtime.sleep(0.2)
+        }
+
+        // 5. Close the window via its close button (NOT Option+K).
+        closeWindow(kcWindow, runtime: runtime)
+        runtime.sleep(0.3)
+
+        // Re-focus Logic's main window and let focus settle BEFORE verifying.
+        // Driving the arm immediately after the KC window closes hits a transient
+        // focus state (the arm actuator's focus gate / exclusive-select needs the
+        // tracks area focused, not the just-closed floating KC window) — that made
+        // an otherwise-good assignment self-report as unverified.
+        runtime.activateLogic()
+        runtime.sleep(0.9)
+
+        // 6. Ground-truth verify by driving a real arm.
+        switch runtime.verifyArmFlip() {
+        case .some(true):
+            return .configuredAndVerified
+        case .some(false):
+            return .failed(
+                stage: "verify",
+                hint: "Assigned \(chordLabel(keyCode: keyCode, modifiers: modifiers)) but a test arm did not "
+                    + "flip record-enable — the assignment may not have taken. Re-run, or assign \"\(commandName)\" manually."
+            )
+        case .none:
+            return .configuredUnverified(
+                why: "no selectable track to test on; arm a track to confirm "
+                    + "\(chordLabel(keyCode: keyCode, modifiers: modifiers)) works"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    static func keyCommandsWindow(runtime: Runtime) -> AXUIElement? {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime.elements) else { return nil }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(app, kAXWindowsAttribute, runtime: runtime.ax) ?? []
+        return windows.first { win in
+            (AXHelpers.getTitle(win, runtime: runtime.ax) ?? "").contains("Key Command")
+        }
+    }
+
+    private static func matchesCommand(_ el: AXUIElement, runtime: Runtime) -> Bool {
+        // `.contains`, not `==`: Logic suffixes an edited/assigned command's cell
+        // with " *" (e.g. "Toggle Track Record Enable *").
+        let value = AXHelpers.getValue(el, runtime: runtime.ax) as? String ?? ""
+        if value.contains(commandName) { return true }
+        return (AXHelpers.getTitle(el, runtime: runtime.ax) ?? "").contains(commandName)
+    }
+
+    /// Select the command's enclosing AXRow (falls back to selecting the element
+    /// itself when the list is flat).
+    private static func selectEnclosingRow(_ el: AXUIElement, runtime: Runtime) {
+        var node: AXUIElement? = el
+        for _ in 0..<8 {
+            guard let cur = node else { break }
+            if AXHelpers.getRole(cur, runtime: runtime.ax) == (kAXRowRole as String) {
+                _ = AXHelpers.setAttribute(cur, kAXSelectedAttribute, kCFBooleanTrue, runtime: runtime.ax)
+                return
+            }
+            node = AXHelpers.getAttribute(cur, kAXParentAttribute, runtime: runtime.ax)
+        }
+        _ = AXHelpers.setAttribute(el, kAXSelectedAttribute, kCFBooleanTrue, runtime: runtime.ax)
+    }
+
+    private static func checkboxOn(_ el: AXUIElement, runtime: Runtime) -> Bool {
+        (AXHelpers.getValue(el, runtime: runtime.ax) as? NSNumber)?.intValue ?? 0 != 0
+    }
+
+    private static func closeWindow(_ window: AXUIElement, runtime: Runtime) {
+        if let closeButton: AXUIElement = AXHelpers.getAttribute(window, "AXCloseButton", runtime: runtime.ax) {
+            _ = AXHelpers.performAction(closeButton, kAXPressAction as String, runtime: runtime.ax)
+        }
+    }
+
+    /// BFS for the first descendant satisfying `predicate` (AXHelpers'
+    /// findAllDescendants only filters by role, so we walk with getChildren).
+    /// `maxNodes` bounds the walk: the Key Commands outline holds ~2200 rows
+    /// (~28k nodes to depth 18, ~26s), so an unbounded walk before the filter
+    /// collapses the list would hang. Bounding each call keeps it cheap and lets
+    /// the caller poll until the (typed) filter collapses the tree.
+    private static func firstDescendant(
+        in root: AXUIElement,
+        runtime: Runtime,
+        maxDepth: Int = 18,
+        maxNodes: Int = 6000,
+        where predicate: (AXUIElement) -> Bool
+    ) -> AXUIElement? {
+        var queue: [(AXUIElement, Int)] = [(root, 0)]
+        var visited = 0
+        while !queue.isEmpty, visited < maxNodes {
+            let (node, depth) = queue.removeFirst()
+            visited += 1
+            if predicate(node) { return node }
+            if depth < maxDepth {
+                for child in AXHelpers.getChildren(node, runtime: runtime.ax) {
+                    queue.append((child, depth + 1))
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Poll `probe` until it returns non-nil or the deadline elapses.
+    private static func poll<T>(runtime: Runtime, deadline: Double, _ probe: () -> T?) -> T? {
+        let step = 0.2
+        var elapsed = 0.0
+        while elapsed <= deadline {
+            if let v = probe() { return v }
+            runtime.sleep(step)
+            elapsed += step
+        }
+        return nil
+    }
+
+    /// Human-readable chord label (⌃⇧E etc.) for hints.
+    static func chordLabel(keyCode: CGKeyCode, modifiers: CGEventFlags) -> String {
+        var s = ""
+        if modifiers.contains(.maskControl) { s += "⌃" }
+        if modifiers.contains(.maskAlternate) { s += "⌥" }
+        if modifiers.contains(.maskShift) { s += "⇧" }
+        if modifiers.contains(.maskCommand) { s += "⌘" }
+        s += keyLetter(keyCode)
+        return s
+    }
+
+    private static func keyLetter(_ keyCode: CGKeyCode) -> String {
+        // Minimal map for the letters we assign; falls back to the raw code.
+        switch keyCode {
+        case 14: return "E"
+        case 15: return "R"
+        default: return "key(\(keyCode))"
+        }
+    }
+}

--- a/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
+++ b/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
@@ -14,23 +14,32 @@ import Foundation
 /// key-command *import*. So the assignment must be made through the Key Commands
 /// GUI. This type does that entirely coordinate-free (no mouse/CGEvent-mouse):
 ///   1. Option+K keystroke opens the Key Commands window.
-///   2. The command list is collapsed with a **search-field AXValue write**
-///      (avoids walking the ~2200-row outline, which times out).
-///   3. The command row is selected via `AXSelected`.
-///   4. The "Learn by Key Label" **AXCheckBox** is driven via AXPress (it is a
-///      checkbox, not a button — the reason an earlier button-only hunt missed
-///      it), the chord is sent as a CGEvent **keyboard** chord (keystrokes are
-///      not coordinates), then Learn is toggled back off.
+///   2. The command list is collapsed by **typing the command name** into the
+///      search field (typed keystrokes trigger Logic's list filter; a bare
+///      AXValue write does NOT filter and leaves a ~26s full-outline walk).
+///      Typing is gated on OBSERVED focus: Logic must be frontmost and the
+///      search field must not read as unfocused, else we fail closed.
+///   3. The command row is selected via `AXSelected`, and the selection is READ
+///      BACK before proceeding (an unconfirmed selection would let Learn bind
+///      the previously-selected command).
+///   4. The "Learn by Key Label" **AXCheckBox** is driven to ON via AXPress (it
+///      is a checkbox, not a button — the reason an earlier button-only hunt
+///      missed it). Learn is ENSURED on (pressed only when observed off) and its
+///      ON state is READ BACK before the chord is sent; if Learn never reports
+///      on, we FAIL CLOSED without sending the chord (never bind to nothing/the
+///      wrong focus). The chord is a CGEvent **keyboard** chord (keystrokes are
+///      not coordinates); afterwards Learn is restored to its prior state.
 ///   5. The window is closed via **AXPress on its close button** — never a
 ///      second Option+K, which would type into the focused search field and
-///      leave the window open (starving track reads).
+///      leave the window open (starving track reads) — and the close is READ
+///      BACK (poll until the window is gone).
 ///
 /// Consent is mandatory (Isaac's rule: never modify the user's Logic config
 /// without consent). Every step's success is judged by a polled OBSERVED effect
-/// (window appeared / command row appeared / checkbox value changed), never by
-/// an AX action's return code. On any step whose effect does not materialise it
-/// fails closed with an actionable manual-fallback hint. Idempotent: re-running
-/// re-learns the same chord.
+/// (window appeared / command row appeared+selected / Learn value on / window
+/// gone), never by an AX action's return code. On any step whose effect does not
+/// materialise it fails closed with an actionable manual-fallback hint.
+/// Idempotent: re-running re-learns the same chord.
 enum ArmKeyCommandSetup {
     /// EN command name / checkbox title. Locale-dependent: non-EN Logic shows
     /// localised strings, so a non-EN run fails closed at `commandNotFound`
@@ -41,13 +50,18 @@ enum ArmKeyCommandSetup {
     enum Outcome: Equatable {
         case consentRequired
         case configuredAndVerified               // State A — assignment made AND a live arm flip observed
-        case configuredUnverified(why: String)   // State B — assignment made, could not confirm a flip
+        case configuredUnverified(why: String)   // State B — steps ran, no track to confirm a flip on
         case failed(stage: String, hint: String) // State C — a step's observed effect never materialised
     }
 
     struct Runtime {
-        /// Bring Logic frontmost so synthetic keystrokes route to it.
-        var activateLogic: @Sendable () -> Void
+        /// Bring Logic frontmost (strong activation) so synthetic keystrokes
+        /// route to it. Returns the activation actuation result; frontmost is
+        /// separately OBSERVED via `logicIsFrontmost` (never trust this return).
+        var activateLogic: @Sendable () -> Bool
+        /// OBSERVED: Logic is the frontmost application right now. Gates every
+        /// keystroke burst so typing can never land on another app / surface.
+        var logicIsFrontmost: @Sendable () -> Bool
         /// Post a modified key chord (used for Option+K and the arm chord).
         var postChord: @Sendable (CGKeyCode, CGEventFlags) -> Void
         /// Type text as real keystrokes into the focused element. Used to fill
@@ -66,11 +80,12 @@ enum ArmKeyCommandSetup {
 
         static func production(verifyArmFlip: @escaping @Sendable () -> Bool?) -> Runtime {
             Runtime(
-                activateLogic: {
-                    if let pid = ProcessUtils.logicProPID(),
-                       let app = NSRunningApplication(processIdentifier: pid) {
-                        app.activate(options: [])
-                    }
+                // HIGH#5: the stronger AppleScript+AppKit activation, not a bare
+                // NSRunningApplication.activate(options: []).
+                activateLogic: { ProcessUtils.Runtime.production.activateLogicPro() },
+                logicIsFrontmost: {
+                    guard let pid = ProcessUtils.logicProPID() else { return false }
+                    return NSWorkspace.shared.frontmostApplication?.processIdentifier == pid
                 },
                 postChord: { keyCode, flags in
                     _ = AXMouseHelper.Runtime.production.postFlaggedKeyEvent(keyCode, flags)
@@ -98,7 +113,7 @@ enum ArmKeyCommandSetup {
     ) -> Outcome {
         guard consent else { return .consentRequired }
 
-        runtime.activateLogic()
+        _ = runtime.activateLogic()
         runtime.sleep(0.4)
 
         // 1. Open the Key Commands window (Option+K), polling for the window.
@@ -132,6 +147,17 @@ enum ArmKeyCommandSetup {
         _ = AXHelpers.setAttribute(searchField, kAXValueAttribute, "" as CFTypeRef, runtime: runtime.ax)
         _ = AXHelpers.setAttribute(searchField, kAXFocusedAttribute, kCFBooleanTrue, runtime: runtime.ax)
         runtime.sleep(0.3)
+        // HIGH#5: prove focus BEFORE typing — otherwise the command name lands on
+        // another app or the wrong Logic surface (piano roll / notes / another
+        // field). Fail closed if focus cannot be established.
+        guard focusEstablished(on: searchField, runtime: runtime) else {
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "focus_search_field",
+                hint: "Could not confirm Logic is frontmost with the Key Commands search field focused; "
+                    + "refused to type (the command name could have gone elsewhere). Assign \"\(commandName)\" manually."
+            )
+        }
         runtime.typeText(commandName)
         runtime.sleep(1.0)  // let the filter collapse the list
 
@@ -150,9 +176,22 @@ enum ArmKeyCommandSetup {
                     + "Assign the record-arm command to \(chordLabel(keyCode: keyCode, modifiers: modifiers)) manually."
             )
         }
-        selectEnclosingRow(commandEl, runtime: runtime)
+        let selectedRow = selectEnclosingRow(commandEl, runtime: runtime)
+        // HIGH#4: confirm the row is ACTUALLY selected (observed) before Learn —
+        // a fire-and-forget AXSelected set that silently failed would let Learn
+        // bind onto the PREVIOUSLY selected command. Fail closed if unconfirmed.
+        guard poll(runtime: runtime, deadline: 1.5, {
+            elementSelected(selectedRow, runtime: runtime) ? true : nil
+        }) != nil else {
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "select_command",
+                hint: "Found the \"\(commandName)\" command but Logic did not confirm its row selected; "
+                    + "refused to Learn onto an unconfirmed selection. Assign \"\(commandName)\" manually."
+            )
+        }
 
-        // 4. Drive "Learn by Key Label" (an AXCheckBox), send the chord, stop learning.
+        // 4. Drive "Learn by Key Label" (an AXCheckBox) to ON, then send the chord.
         guard let learn = firstDescendant(in: kcWindow, runtime: runtime, where: { el in
             AXHelpers.getRole(el, runtime: runtime.ax) == (kAXCheckBoxRole as String)
                 && (AXHelpers.getTitle(el, runtime: runtime.ax) ?? "") == learnCheckboxTitle
@@ -163,22 +202,52 @@ enum ArmKeyCommandSetup {
                 hint: "Could not find the \"\(learnCheckboxTitle)\" control. Assign \"\(commandName)\" manually."
             )
         }
-        _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
-        // Observed effect: the checkbox reports learning (value 1). Poll, don't
-        // trust the AXPress return.
-        _ = poll(runtime: runtime, deadline: 1.5) { checkboxOn(learn, runtime: runtime) ? true : nil }
+        // HIGH#2: ENSURE on, do not blind-toggle — a press on an already-on Learn
+        // would turn it OFF and the chord would post while NOT learning.
+        let learnWasOn = checkboxOn(learn, runtime: runtime)
+        if !learnWasOn {
+            _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
+        }
+        // HIGH#1: the chord is only safe to send while Learn is OBSERVED on (poll
+        // the value; never trust the AXPress return). If Learn never engages, FAIL
+        // CLOSED before the chord — do not bind to nothing / the wrong focus.
+        guard poll(runtime: runtime, deadline: 1.5, {
+            checkboxOn(learn, runtime: runtime) ? true : nil
+        }) != nil else {
+            restoreLearn(learn, wasOn: learnWasOn, runtime: runtime)
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "learn_engage",
+                hint: "Could not confirm Logic's \"\(learnCheckboxTitle)\" mode engaged; refused to send "
+                    + "\(chordLabel(keyCode: keyCode, modifiers: modifiers)) (nothing was assigned). "
+                    + "Assign \"\(commandName)\" manually."
+            )
+        }
+        // HIGH#5: re-confirm Logic is frontmost right before the chord — focus can
+        // shift between engaging Learn and posting the key.
+        guard runtime.logicIsFrontmost() else {
+            restoreLearn(learn, wasOn: learnWasOn, runtime: runtime)
+            closeWindow(kcWindow, runtime: runtime)
+            return .failed(
+                stage: "focus_chord",
+                hint: "Logic left the foreground before \(chordLabel(keyCode: keyCode, modifiers: modifiers)) "
+                    + "could be sent; refused to post it. Re-run, or assign \"\(commandName)\" manually."
+            )
+        }
 
         runtime.postChord(keyCode, modifiers)
         runtime.sleep(0.3)
 
-        // Turn Learn back off if it is still on (idempotent).
-        if checkboxOn(learn, runtime: runtime) {
-            _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
-            runtime.sleep(0.2)
-        }
+        // Restore Learn to its prior state (idempotent): only turn it off if it
+        // was off before AND is still on.
+        restoreLearn(learn, wasOn: learnWasOn, runtime: runtime)
 
-        // 5. Close the window via its close button (NOT Option+K).
+        // 5. Close the window via its close button (NOT Option+K), then MEDIUM#7
+        //    confirm it actually closed — a stuck KC window starves track reads.
         closeWindow(kcWindow, runtime: runtime)
+        _ = poll(runtime: runtime, deadline: 2.0) {
+            keyCommandsWindow(runtime: runtime) == nil ? true : nil
+        }
         runtime.sleep(0.3)
 
         // Re-focus Logic's main window and let focus settle BEFORE verifying.
@@ -186,7 +255,7 @@ enum ArmKeyCommandSetup {
         // focus state (the arm actuator's focus gate / exclusive-select needs the
         // tracks area focused, not the just-closed floating KC window) — that made
         // an otherwise-good assignment self-report as unverified.
-        runtime.activateLogic()
+        _ = runtime.activateLogic()
         runtime.sleep(0.9)
 
         // 6. Ground-truth verify by driving a real arm.
@@ -201,7 +270,7 @@ enum ArmKeyCommandSetup {
             )
         case .none:
             return .configuredUnverified(
-                why: "no selectable track to test on; arm a track to confirm "
+                why: "no selectable track to test on; arm a track and re-run to confirm "
                     + "\(chordLabel(keyCode: keyCode, modifiers: modifiers)) works"
             )
         }
@@ -226,22 +295,57 @@ enum ArmKeyCommandSetup {
     }
 
     /// Select the command's enclosing AXRow (falls back to selecting the element
-    /// itself when the list is flat).
-    private static func selectEnclosingRow(_ el: AXUIElement, runtime: Runtime) {
+    /// itself when the list is flat). Returns the node AXSelected was set on so
+    /// the caller can READ BACK that the selection actually took (HIGH#4).
+    private static func selectEnclosingRow(_ el: AXUIElement, runtime: Runtime) -> AXUIElement {
         var node: AXUIElement? = el
         for _ in 0..<8 {
             guard let cur = node else { break }
             if AXHelpers.getRole(cur, runtime: runtime.ax) == (kAXRowRole as String) {
                 _ = AXHelpers.setAttribute(cur, kAXSelectedAttribute, kCFBooleanTrue, runtime: runtime.ax)
-                return
+                return cur
             }
             node = AXHelpers.getAttribute(cur, kAXParentAttribute, runtime: runtime.ax)
         }
         _ = AXHelpers.setAttribute(el, kAXSelectedAttribute, kCFBooleanTrue, runtime: runtime.ax)
+        return el
+    }
+
+    /// HIGH#5: focus is "established" when Logic is OBSERVED frontmost and the
+    /// search field does not READ as unfocused. A nil (unreadable) focus state
+    /// does not fail closed — some Logic builds do not surface AXFocused on the
+    /// KC search field, and frontmost + the explicit focus set above carry it;
+    /// only a definitive `focused == false` is treated as wrong focus.
+    private static func focusEstablished(on field: AXUIElement, runtime: Runtime) -> Bool {
+        guard runtime.logicIsFrontmost() else { return false }
+        return poll(runtime: runtime, deadline: 1.0) {
+            elementFocusedState(field, runtime: runtime) == false ? nil : true
+        } ?? false
+    }
+
+    /// Restore Learn to its prior state: turn it back off ONLY if it was off
+    /// before AND currently reads on (idempotent; never leaves Learn stuck on).
+    private static func restoreLearn(_ learn: AXUIElement, wasOn: Bool, runtime: Runtime) {
+        guard !wasOn, checkboxOn(learn, runtime: runtime) else { return }
+        _ = AXHelpers.performAction(learn, kAXPressAction as String, runtime: runtime.ax)
+        runtime.sleep(0.2)
     }
 
     private static func checkboxOn(_ el: AXUIElement, runtime: Runtime) -> Bool {
         (AXHelpers.getValue(el, runtime: runtime.ax) as? NSNumber)?.intValue ?? 0 != 0
+    }
+
+    /// Observed AXSelected (definitively true), used to confirm a selection took.
+    private static func elementSelected(_ el: AXUIElement, runtime: Runtime) -> Bool {
+        let n: NSNumber? = AXHelpers.getAttribute(el, kAXSelectedAttribute, runtime: runtime.ax)
+        return (n?.intValue ?? 0) != 0
+    }
+
+    /// Observed AXFocused as an optional: true/false when readable, nil when the
+    /// element does not expose focus state.
+    private static func elementFocusedState(_ el: AXUIElement, runtime: Runtime) -> Bool? {
+        let n: NSNumber? = AXHelpers.getAttribute(el, kAXFocusedAttribute, runtime: runtime.ax)
+        return n.map { $0.intValue != 0 }
     }
 
     private static func closeWindow(_ window: AXUIElement, runtime: Runtime) {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -422,6 +422,14 @@ extension AccessibilityChannel {
             return nil
         }
         let current = curNum.intValue != 0
+
+        // HIGH#6: the arm actuator exclusive-selects track 0, which would silently
+        // clobber whatever track the user had selected. Capture the prior single
+        // selection (the one header that OBSERVED-reads selected) so we can put it
+        // back afterwards. Multi/none/unreadable selection → nil (nothing to
+        // deterministically restore).
+        let priorSelection = observedSingleSelectedTrackIndex(runtime: runtime)
+
         let toggle = defaultSetTrackToggle(
             params: ["index": "0", "enabled": String(!current)],
             button: "Record",
@@ -430,14 +438,53 @@ extension AccessibilityChannel {
         )
         let flipped: Bool
         if case .success = toggle { flipped = true } else { flipped = false }
-        // Restore the original arm state regardless of the verify outcome.
-        _ = defaultSetTrackToggle(
+
+        // HIGH#6: restore track 0's ORIGINAL arm state and VERIFY the restore took
+        // (defaultSetTrackToggle returns .success only on an OBSERVED read-back),
+        // not fire-and-forget. One retry: a single missed read-back must not leave
+        // track 0 armed the wrong way.
+        var restore = defaultSetTrackToggle(
             params: ["index": "0", "enabled": String(current)],
             button: "Record",
             runtime: runtime,
             environment: environment
         )
+        if case .success = restore {} else {
+            restore = defaultSetTrackToggle(
+                params: ["index": "0", "enabled": String(current)],
+                button: "Record",
+                runtime: runtime,
+                environment: environment
+            )
+        }
+        _ = restore
+
+        // HIGH#6: restore the user's prior track selection (best-effort, confirmed
+        // exclusive) — driving the verify exclusive-selected track 0. Re-selection
+        // is AX-only (AXSelectedChildren), so it posts no key/chord.
+        if let priorSelection, priorSelection != 0 {
+            _ = confirmExclusiveSelection(
+                index: priorSelection,
+                runtime: runtime,
+                processRuntime: .production
+            )
+        }
+
         return flipped
+    }
+
+    /// The index of the single OBSERVED-selected track header, or nil when zero
+    /// or more than one reads selected (or none is readable). Captures the
+    /// caller's selection before an exclusive-select side effect so it can be
+    /// restored (HIGH#6).
+    private static func observedSingleSelectedTrackIndex(
+        runtime: AXLogicProElements.Runtime
+    ) -> Int? {
+        let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+        let selected = headers.indices.filter {
+            AXValueExtractors.extractSelectedState(headers[$0], runtime: runtime.ax) == true
+        }
+        return selected.count == 1 ? selected[0] : nil
     }
 
     /// A single coordinate-free actuation rung: `actuate` either fires (then the

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -108,7 +108,9 @@ extension AccessibilityChannel {
     static func defaultSetTrackToggle(
         params: [String: String],
         button buttonName: String,
-        runtime: AXLogicProElements.Runtime = .production
+        runtime: AXLogicProElements.Runtime = .production,
+        keyRuntime: AXMouseHelper.Runtime = .production,
+        processRuntime: ProcessUtils.Runtime = .production
     ) -> ChannelResult {
         guard let indexStr = params["index"], let index = Int(indexStr) else {
             return .error("Missing or invalid 'index' parameter")
@@ -122,18 +124,7 @@ extension AccessibilityChannel {
         guard let button = finder(index) else {
             return .error("Cannot find \(buttonName) button on track \(index)")
         }
-        // Press toggles state. To make `enabled: true/false` idempotent (the
-        // user-visible contract), read current AXValue — only press when the
-        // target state differs. This fixes the class of bug where `arm off`
-        // was a silent no-op because MCU release-only was being sent and the
-        // AX press was unconditionally toggling regardless of desired state.
         let desired: Bool = (params["enabled"] ?? "true") == "true"
-        let current: Bool? = {
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? Int { return raw != 0 }
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? Bool { return raw }
-            if let raw = AXHelpers.getValue(button, runtime: runtime.ax) as? NSNumber { return raw.boolValue }
-            return nil
-        }()
         let baseExtras: [String: Any] = [
             "track": index,
             "button": buttonName,
@@ -141,14 +132,12 @@ extension AccessibilityChannel {
             "verification_source": "ax_value"
         ]
 
-        if let cur = current, cur == desired {
-            return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
-                "observed": desired,
-                "action": "no-op"
-            ]) { _, new in new }))
-        }
-
-        func readCurrent() -> Bool? {
+        // Success is judged ONLY by re-reading this checkbox AXValue (the
+        // observed effect), NEVER by an AX action's return code: on real Logic
+        // 12.x the track-header M/S/R actions return non-zero even when they
+        // no-op (#106 sites-6/7), so trusting the return would fabricate a
+        // State A on a control that never moved.
+        func readValue() -> Bool? {
             guard let v = AXHelpers.getValue(button, runtime: runtime.ax) else { return nil }
             if let n = v as? NSNumber { return n.boolValue }
             if let b = v as? Bool { return b }
@@ -157,80 +146,251 @@ extension AccessibilityChannel {
             return nil
         }
 
-        // #106: Logic 12.x track-header M/S/R checkboxes are `settable=false`
-        // and ignore `AXPress`/`AXConfirm`/value writes entirely — only a real
-        // mouse click at the control toggles Logic's internal state
-        // (live-confirmed: AXPress leaves the value at 0 indefinitely; a HID
-        // click flips it to 1 within ~350 ms). The earlier fixed 50 ms
-        // read-back was also too fast for Logic to publish the new AX value
-        // after a successful click, so even the arm path (whose locator did
-        // find the checkbox) reported a false `ax_write_failed` *after*
-        // physically toggling the control — a silent malfunction. The write
-        // now polls the read-back up to a per-strategy deadline, and the
-        // mouse-click last resort brings Logic frontmost first so the synthetic
-        // click lands on the (un-occluded) track header.
+        // Toggle-from-read: already at the desired state → verified no-op. No
+        // rung runs, so no keyboard/coordinate event is ever fired.
+        if let current = readValue(), current == desired {
+            return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
+                "observed": desired,
+                "action": "no-op"
+            ]) { _, new in new }))
+        }
+
         func pollMatched(deadlineMs: Int) -> Bool {
             let deadline = Date().addingTimeInterval(Double(deadlineMs) / 1000.0)
             repeat {
-                if let after = readCurrent(), after == desired { return true }
+                if let after = readValue(), after == desired { return true }
                 usleep(40_000)
             } while Date() < deadline
             return false
         }
 
-        let strategies: [(name: String, pollMs: Int, action: () -> Void)] = [
-            ("press", 160, { _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax) }),
-            ("confirm", 160, { _ = AXHelpers.performAction(button, kAXConfirmAction, runtime: runtime.ax) }),
-            ("value-nsnumber", 160, {
-                let n: NSNumber = desired ? 1 : 0
-                AXHelpers.setAttribute(button, kAXValueAttribute, n as CFTypeRef, runtime: runtime.ax)
-            }),
-            ("value-cfbool", 160, {
-                let b: CFBoolean = desired ? kCFBooleanTrue : kCFBooleanFalse
-                AXHelpers.setAttribute(button, kAXValueAttribute, b, runtime: runtime.ax)
-            }),
-            ("mouse-click", 1_000, {
-                _ = ProcessUtils.Runtime.production.activateLogicPro()
-                usleep(120_000)
-                Self.postMouseClickAt(element: button, runtime: runtime.ax)
-            }),
-        ]
-        for strategy in strategies {
-            strategy.action()
-            if pollMatched(deadlineMs: strategy.pollMs) {
-                return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
-                    "observed": desired,
-                    "action": strategy.name
-                ]) { _, new in new }))
+        // #106 / ADR-001: coordinate-free per-op actuator ladder. Every rung
+        // actuates WITHOUT any mouse/coordinate primitive (the former HID-click
+        // last resort is deleted). Live-verified on Logic 12.3: SOLO flips on
+        // AXPress; MUTE needs exclusive-select + key 'm'; ARM needs
+        // exclusive-select + the configurable "Toggle Track Record Enable" key
+        // chord. The read-back below — not each rung's return value — decides
+        // State A.
+        //
+        // ARM honesty baseline: capture whether transport is ALREADY recording
+        // so a (mis-assigned) arm key that instead triggers transport Record can
+        // be detected as a state CHANGE by the guard below.
+        let recordingBaseline = (buttonName == "Record") && isTransportRecording(runtime: runtime)
+
+        var landedAction: String?
+        for rung in trackToggleLadder(
+            button: button,
+            buttonName: buttonName,
+            index: index,
+            desired: desired,
+            runtime: runtime,
+            keyRuntime: keyRuntime,
+            processRuntime: processRuntime
+        ) {
+            rung.actuate()
+            if pollMatched(deadlineMs: rung.pollMs) {
+                landedAction = rung.name
+                break
             }
         }
+
+        // ARM honesty guard: a mis-assigned key can fire transport Record rather
+        // than record-enable. If recording STARTED as a side effect, fail closed
+        // even if the checkbox reads "armed" — never claim a clean arm.
+        if buttonName == "Record", !recordingBaseline, isTransportRecording(runtime: runtime) {
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: armRecordingStartedHint(index: index),
+                extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+            ))
+        }
+
+        if let landedAction {
+            return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
+                "observed": desired,
+                "action": landedAction
+            ]) { _, new in new }))
+        }
+
+        // Fail closed — NEVER a coordinate fallback.
         return .error(HonestContract.encodeStateC(
             error: .axWriteFailed,
-            hint: "tried press/confirm/value-nsnumber/value-cfbool/mouse-click; read-back never matched on track \(index) \(buttonName)=\(desired)",
+            hint: trackToggleFailHint(buttonName: buttonName, index: index, desired: desired),
             extras: baseExtras
         ))
     }
 
-    /// Simulate a real user mouse-click at the screen center of an AX element.
-    /// Used as a last resort when AXPress / AXValue writes don't propagate to
-    /// Logic Pro's internal handlers (observed with Logic 12 rec-arm checkboxes).
-    private static func postMouseClickAt(element: AXUIElement, runtime: AXHelpers.Runtime) {
-        var posValue: AnyObject?
-        var sizeValue: AnyObject?
-        let pr = AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posValue)
-        let sr = AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue)
-        // H2 (P2-5): fail-closed on non-AXValue / wrong-subtype rather than
-        // posting a click at (0,0).
-        guard pr == .success, sr == .success,
-              let pt = AXHelpers.point(fromRawAttribute: posValue),
-              let sz = AXHelpers.size(fromRawAttribute: sizeValue) else { return }
-        let center = CGPoint(x: pt.x + sz.width / 2, y: pt.y + sz.height / 2)
-        let src = CGEventSource(stateID: .hidSystemState)
-        if let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
-           let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) {
-            down.post(tap: .cghidEventTap)
-            up.post(tap: .cghidEventTap)
+    // MARK: - Coordinate-free track-toggle actuator (#106 / ADR-001)
+
+    /// `kVK_ANSI_M` (46) — Logic's default "Mute selected tracks" key command.
+    /// With the target track exclusively selected, pressing it flips that
+    /// track-header Mute checkbox (live-verified on Logic 12.3); AXPress on the
+    /// checkbox itself is a no-op.
+    static let trackMuteKeyCode: CGKeyCode = 46
+
+    /// `kVK_ANSI_R` (15) — bare 'r' IS transport Record. NEVER post it for arm
+    /// (it would start recording instead of toggling record-enable).
+    static let transportRecordKeyCode: CGKeyCode = 15
+
+    /// Default key CHORD for the record-ARM key command: Ctrl+Shift+E
+    /// (`kVK_ANSI_E` (14) + control + shift). Live-confirmed target: Logic's
+    /// "Toggle Track Record Enable" command, which toggles record-enable on the
+    /// SELECTED track (distinct from transport Record). It ships UNASSIGNED, so
+    /// the operator assigns it to this chord (or overrides via
+    /// `LOGIC_PRO_MCP_ARM_KEYCODE` / `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`).
+    static let defaultArmKeyCode: CGKeyCode = 14
+    static let defaultArmModifiers: CGEventFlags = [.maskControl, .maskShift]
+
+    /// Environment override keys for the record-arm chord.
+    static let armKeyCodeEnvVar = "LOGIC_PRO_MCP_ARM_KEYCODE"
+    static let armKeyModifiersEnvVar = "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS"
+
+    /// Resolve the record-arm keycode: `LOGIC_PRO_MCP_ARM_KEYCODE` (decimal
+    /// virtual keycode) when set and parseable, else `defaultArmKeyCode`. The
+    /// environment is injectable so the override is deterministically testable
+    /// without mutating the process-global environment.
+    static func resolvedArmKeyCode(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> CGKeyCode {
+        if let raw = environment[armKeyCodeEnvVar],
+           let parsed = UInt16(raw.trimmingCharacters(in: .whitespaces)) {
+            return CGKeyCode(parsed)
         }
+        return defaultArmKeyCode
+    }
+
+    /// Resolve the record-arm modifier flags from `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`
+    /// (comma list of control/shift/option/command). An ABSENT var → the
+    /// Ctrl+Shift default; a PRESENT-but-empty var → no modifiers (an explicit
+    /// bare key). Unknown tokens are ignored. Injectable for deterministic tests.
+    static func resolvedArmModifiers(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> CGEventFlags {
+        guard let raw = environment[armKeyModifiersEnvVar] else { return defaultArmModifiers }
+        var flags: CGEventFlags = []
+        for token in raw.split(separator: ",") {
+            switch token.trimmingCharacters(in: .whitespaces).lowercased() {
+            case "control", "ctrl": flags.insert(.maskControl)
+            case "shift": flags.insert(.maskShift)
+            case "option", "opt", "alt": flags.insert(.maskAlternate)
+            case "command", "cmd": flags.insert(.maskCommand)
+            default: break
+            }
+        }
+        return flags
+    }
+
+    /// Read whether Logic's transport is currently RECORDING (control-bar
+    /// Record checkbox). Used by the arm honesty guard to detect a mis-assigned
+    /// key that triggers transport Record instead of record-enable.
+    static func isTransportRecording(runtime: AXLogicProElements.Runtime) -> Bool {
+        AXLogicProElements.readControlBarCheckboxValue(
+            named: "녹음", englishName: "Record", runtime: runtime
+        ) ?? false
+    }
+
+    /// A single coordinate-free actuation rung: perform `actuate`, then the
+    /// caller polls the AX read-back up to `pollMs` to decide State A.
+    typealias TrackToggleRung = (name: String, pollMs: Int, actuate: () -> Void)
+
+    /// Per-op coordinate-free ladder. AXPress is always the natural primary
+    /// (cheap; flips solo, no-ops mute/arm on 12.x — we never depend on its
+    /// return code). Mute/arm add an exclusive-select-then-keyboard rung.
+    static func trackToggleLadder(
+        button: AXUIElement,
+        buttonName: String,
+        index: Int,
+        desired: Bool,
+        runtime: AXLogicProElements.Runtime,
+        keyRuntime: AXMouseHelper.Runtime,
+        processRuntime: ProcessUtils.Runtime
+    ) -> [TrackToggleRung] {
+        let pressRung: TrackToggleRung = ("press", 250, {
+            _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax)
+        })
+        switch buttonName {
+        case "Solo":
+            // AXPress on the Solo checkbox flips it directly; keyboard 's' is a
+            // no-op for the track-header control, so there is no keyboard rung.
+            return [pressRung]
+        case "Mute":
+            let keyRung: TrackToggleRung = ("keyboard-mute", 600, {
+                guard confirmExclusiveSelection(
+                    index: index, runtime: runtime, processRuntime: processRuntime
+                ) else { return }
+                _ = keyRuntime.postKeyEvent(trackMuteKeyCode)
+            })
+            return [pressRung, keyRung]
+        case "Record":
+            let armCode = resolvedArmKeyCode()
+            let armFlags = resolvedArmModifiers()
+            let keyRung: TrackToggleRung = ("keyboard-arm", 600, {
+                guard confirmExclusiveSelection(
+                    index: index, runtime: runtime, processRuntime: processRuntime
+                ) else { return }
+                // Never fire bare 'r' — that IS transport Record. A MODIFIED 'r'
+                // is a distinct command and is allowed; the recording guard in
+                // defaultSetTrackToggle is the runtime backstop for a mis-assign.
+                if armCode == transportRecordKeyCode, armFlags.isEmpty { return }
+                _ = keyRuntime.postFlaggedKeyEvent(armCode, armFlags)
+            })
+            return [pressRung, keyRung]
+        default:
+            return [pressRung]
+        }
+    }
+
+    /// Exclusive single-track selection guard. Keyboard mute/arm act on the
+    /// SELECTED track, so before posting any key we (1) bring Logic frontmost
+    /// (synthetic keystrokes only land on the focused app), (2) drive the AX
+    /// `AXSelectedChildren` selection path, and (3) READ BACK that the target —
+    /// and ONLY the target — is selected. Returns false (⇒ the key is NOT
+    /// posted, so a wrong/multi selection can never toggle the wrong track)
+    /// until exclusivity is confirmed within a bounded settle budget.
+    static func confirmExclusiveSelection(
+        index: Int,
+        runtime: AXLogicProElements.Runtime,
+        processRuntime: ProcessUtils.Runtime
+    ) -> Bool {
+        _ = ProcessUtils.activateLogicPro(runtime: processRuntime)
+        _ = AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime)
+        for attempt in 0..<4 {
+            let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+            guard index >= 0, index < headers.count else { return false }
+            let states = headers.map { AXValueExtractors.extractSelectedState($0, runtime: runtime.ax) }
+            let targetSelected = states[index] == true
+            let anyOtherSelected = states.enumerated().contains { $0.offset != index && $0.element == true }
+            if targetSelected && !anyOtherSelected { return true }
+            if attempt < 3 { usleep(80_000) }
+        }
+        return false
+    }
+
+    /// Fail-closed hint (read-back never flipped). Arm points the operator at
+    /// the required "Toggle Track Record Enable" key-command assignment — the
+    /// only coordinate-free arm path on Logic 12.x.
+    static func trackToggleFailHint(buttonName: String, index: Int, desired: Bool) -> String {
+        switch buttonName {
+        case "Record":
+            return "arm requires the Logic key command 'Toggle Track Record Enable' assigned to the "
+                + "configured key (default Ctrl+Shift+E); assign it in Logic ▸ Key Commands, or set "
+                + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
+        case "Mute":
+            return "track \(index) Mute=\(desired): read-back never matched after AXPress + "
+                + "exclusive-select then key 'm' (coordinate-free actuators only)."
+        default:
+            return "track \(index) \(buttonName)=\(desired): read-back never matched after AXPress "
+                + "on the checkbox (coordinate-free actuators only)."
+        }
+    }
+
+    /// Arm fail-closed hint for the mis-assignment case: the configured key
+    /// started transport RECORDING instead of toggling record-enable.
+    static func armRecordingStartedHint(index: Int) -> String {
+        "arm aborted: the configured key started transport recording instead of arming track "
+            + "\(index) — it is not assigned to 'Toggle Track Record Enable'. Stop the recording, then "
+            + "assign that command (default Ctrl+Shift+E) in Logic ▸ Key Commands, or set "
+            + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
     }
 
     static func defaultRenameTrack(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -110,7 +110,8 @@ extension AccessibilityChannel {
         button buttonName: String,
         runtime: AXLogicProElements.Runtime = .production,
         keyRuntime: AXMouseHelper.Runtime = .production,
-        processRuntime: ProcessUtils.Runtime = .production
+        processRuntime: ProcessUtils.Runtime = .production,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> ChannelResult {
         guard let indexStr = params["index"], let index = Int(indexStr) else {
             return .error("Missing or invalid 'index' parameter")
@@ -169,55 +170,148 @@ extension AccessibilityChannel {
         // last resort is deleted). Live-verified on Logic 12.3: SOLO flips on
         // AXPress; MUTE needs exclusive-select + key 'm'; ARM needs
         // exclusive-select + the configurable "Toggle Track Record Enable" key
-        // chord. The read-back below — not each rung's return value — decides
-        // State A.
+        // chord. The read-back — not each rung's return value — decides State A.
         //
         // ARM honesty baseline: capture whether transport is ALREADY recording
-        // so a (mis-assigned) arm key that instead triggers transport Record can
-        // be detected as a state CHANGE by the guard below.
-        let recordingBaseline = (buttonName == "Record") && isTransportRecording(runtime: runtime)
+        // (nil = UNREADABLE, kept distinct from readable-false) so a mis-assigned
+        // arm key that instead triggers transport Record is caught by the guard
+        // below, and an unreadable transport can never be coerced to "not
+        // recording" under an arm State-A claim (#2).
+        let recordingBaselineState: Bool? =
+            (buttonName == "Record") ? transportRecordingState(runtime: runtime) : nil
 
-        var landedAction: String?
-        for rung in trackToggleLadder(
-            button: button,
-            buttonName: buttonName,
-            index: index,
+        let outcome = runTrackToggleLadder(
+            rungs: trackToggleLadder(
+                button: button,
+                buttonName: buttonName,
+                index: index,
+                runtime: runtime,
+                keyRuntime: keyRuntime,
+                processRuntime: processRuntime,
+                environment: environment
+            ),
             desired: desired,
-            runtime: runtime,
-            keyRuntime: keyRuntime,
-            processRuntime: processRuntime
-        ) {
-            rung.actuate()
-            if pollMatched(deadlineMs: rung.pollMs) {
-                landedAction = rung.name
-                break
-            }
-        }
+            readValue: readValue,
+            pollMatched: { pollMatched(deadlineMs: $0) }
+        )
 
-        // ARM honesty guard: a mis-assigned key can fire transport Record rather
-        // than record-enable. If recording STARTED as a side effect, fail closed
-        // even if the checkbox reads "armed" — never claim a clean arm.
-        if buttonName == "Record", !recordingBaseline, isTransportRecording(runtime: runtime) {
+        switch outcome {
+        case .refused(let refusal):
+            // A refused rung posted NO key, so our action caused no transport
+            // side effect — return the distinct fail-closed reason directly.
             return .error(HonestContract.encodeStateC(
-                error: .axWriteFailed,
-                hint: armRecordingStartedHint(index: index),
-                extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+                error: refusal.error,
+                hint: refusal.hint,
+                extras: baseExtras.merging(refusal.extras) { _, new in new }
             ))
-        }
 
-        if let landedAction {
+        case .landed(let action):
+            // ARM honesty guard — only when we would otherwise claim State A.
+            if buttonName == "Record" {
+                guard let post = transportRecordingState(runtime: runtime) else {
+                    // Transport Record UNREADABLE post-actuate: we cannot prove the
+                    // arm key did not instead start transport recording, so never
+                    // claim a clean arm (#2). Fail closed, distinct from State A.
+                    return .error(HonestContract.encodeStateC(
+                        error: .transportStateUnknown,
+                        hint: armTransportUnknownHint(index: index),
+                        extras: baseExtras.merging(["transport_state": "unknown"]) { _, new in new }
+                    ))
+                }
+                if post, recordingBaselineState != true {
+                    // A mis-assigned key started transport Record instead of
+                    // record-enable — fail closed even if the checkbox reads armed.
+                    return .error(HonestContract.encodeStateC(
+                        error: .axWriteFailed,
+                        hint: armRecordingStartedHint(index: index),
+                        extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+                    ))
+                }
+            }
             return .success(HonestContract.encodeStateA(extras: baseExtras.merging([
                 "observed": desired,
-                "action": landedAction
+                "action": action
             ]) { _, new in new }))
-        }
 
-        // Fail closed — NEVER a coordinate fallback.
-        return .error(HonestContract.encodeStateC(
-            error: .axWriteFailed,
-            hint: trackToggleFailHint(buttonName: buttonName, index: index, desired: desired),
-            extras: baseExtras
-        ))
+        case .exhausted:
+            // Even a FAILED arm may have started transport Record via a
+            // mis-assigned key — surface that distinctly when it is readable.
+            if buttonName == "Record",
+               let post = transportRecordingState(runtime: runtime),
+               post, recordingBaselineState != true {
+                return .error(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: armRecordingStartedHint(index: index),
+                    extras: baseExtras.merging(["recording_started": true]) { _, new in new }
+                ))
+            }
+            // Fail closed — NEVER a coordinate fallback.
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: trackToggleFailHint(buttonName: buttonName, index: index, desired: desired),
+                extras: baseExtras
+            ))
+        }
+    }
+
+    // MARK: - Ladder runner (#3 double-toggle halt barrier)
+
+    /// One coordinate-free actuation rung's result: either it actuated (poll the
+    /// read-back to decide State A) or it REFUSED to actuate and fails closed with
+    /// a distinct reason (selection unproven, unsafe key focus, bad arm-key
+    /// config). A refusal NEVER posts a key.
+    enum RungOutcome {
+        case actuated
+        case refused(RungRefusal)
+    }
+
+    /// A fail-closed refusal from a rung: a distinct Honest-Contract error, an
+    /// operator-facing hint, and structured extras merged into the State C body.
+    struct RungRefusal {
+        let error: HonestContract.FailureError
+        let hint: String
+        let extras: [String: Any]
+    }
+
+    /// Terminal result of running the actuator ladder.
+    enum LadderOutcome {
+        case landed(action: String)
+        case refused(RungRefusal)
+        case exhausted
+    }
+
+    /// Run the actuator ladder with a HALT BARRIER between rungs (#3). Every rung
+    /// is a TOGGLE, not a set: if an earlier rung actually flipped the control but
+    /// its AXValue published only AFTER that rung's poll window closed, firing the
+    /// next toggle rung would flip it straight BACK. So BEFORE actuating each rung
+    /// (which includes re-reading after a prior rung's poll failed) we re-read the
+    /// live value; if it ALREADY equals `desired`, we STOP and report State A
+    /// attributed to the rung that actually moved it — never actuating again.
+    /// `readValue` / `pollMatched` are injected so the barrier is unit-testable
+    /// without live timing.
+    static func runTrackToggleLadder(
+        rungs: [TrackToggleRung],
+        desired: Bool,
+        readValue: () -> Bool?,
+        pollMatched: (Int) -> Bool
+    ) -> LadderOutcome {
+        var lastActuated: String?
+        for rung in rungs {
+            // #3 halt barrier — re-read before EVERY actuation.
+            if let current = readValue(), current == desired {
+                return .landed(action: lastActuated ?? rung.name)
+            }
+            switch rung.actuate() {
+            case .refused(let refusal):
+                return .refused(refusal)
+            case .actuated:
+                lastActuated = rung.name
+                if pollMatched(rung.pollMs) {
+                    return .landed(action: rung.name)
+                }
+            }
+        }
+        return .exhausted
     }
 
     // MARK: - Coordinate-free track-toggle actuator (#106 / ADR-001)
@@ -245,94 +339,155 @@ extension AccessibilityChannel {
     static let armKeyCodeEnvVar = "LOGIC_PRO_MCP_ARM_KEYCODE"
     static let armKeyModifiersEnvVar = "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS"
 
-    /// Resolve the record-arm keycode: `LOGIC_PRO_MCP_ARM_KEYCODE` (decimal
-    /// virtual keycode) when set and parseable, else `defaultArmKeyCode`. The
-    /// environment is injectable so the override is deterministically testable
-    /// without mutating the process-global environment.
-    static func resolvedArmKeyCode(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> CGKeyCode {
-        if let raw = environment[armKeyCodeEnvVar],
-           let parsed = UInt16(raw.trimmingCharacters(in: .whitespaces)) {
-            return CGKeyCode(parsed)
-        }
-        return defaultArmKeyCode
+    /// Outcome of resolving the record-arm key chord from the environment. A
+    /// PRESENT-but-unparseable override is a CONFIGURATION ERROR — surfaced so the
+    /// arm path fails closed with `arm_key_config_invalid` instead of silently
+    /// falling back to the default chord or dropping unknown modifier tokens (#7).
+    /// An ABSENT override still uses the built-in default.
+    enum ArmChordResolution: Equatable {
+        case resolved(code: CGKeyCode, flags: CGEventFlags)
+        case invalidKeyCode(String)
+        case invalidModifierToken(String)
     }
 
-    /// Resolve the record-arm modifier flags from `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`
-    /// (comma list of control/shift/option/command). An ABSENT var → the
-    /// Ctrl+Shift default; a PRESENT-but-empty var → no modifiers (an explicit
-    /// bare key). Unknown tokens are ignored. Injectable for deterministic tests.
-    static func resolvedArmModifiers(
+    /// Resolve the record-arm chord. `LOGIC_PRO_MCP_ARM_KEYCODE` (decimal virtual
+    /// keycode) and `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS` (comma list of
+    /// control/shift/option/command) override the Ctrl+Shift+E default:
+    ///   - ABSENT var → the built-in default (correct, silent).
+    ///   - present + valid → parsed value.
+    ///   - present keycode that does not parse → `.invalidKeyCode` (NO silent
+    ///     fallback to 14).
+    ///   - present modifiers with an unknown token → `.invalidModifierToken` (NO
+    ///     silently dropped token).
+    ///   - present-but-EMPTY modifiers → `.resolved` with no flags (a bare key),
+    ///     which the arm path then refuses as unsafe.
+    /// Injectable environment for deterministic tests.
+    static func resolveArmChord(
         environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> CGEventFlags {
-        guard let raw = environment[armKeyModifiersEnvVar] else { return defaultArmModifiers }
-        var flags: CGEventFlags = []
-        for token in raw.split(separator: ",") {
-            switch token.trimmingCharacters(in: .whitespaces).lowercased() {
-            case "control", "ctrl": flags.insert(.maskControl)
-            case "shift": flags.insert(.maskShift)
-            case "option", "opt", "alt": flags.insert(.maskAlternate)
-            case "command", "cmd": flags.insert(.maskCommand)
-            default: break
+    ) -> ArmChordResolution {
+        let code: CGKeyCode
+        if let raw = environment[armKeyCodeEnvVar] {
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            guard let parsed = UInt16(trimmed) else { return .invalidKeyCode(trimmed) }
+            code = CGKeyCode(parsed)
+        } else {
+            code = defaultArmKeyCode
+        }
+
+        let flags: CGEventFlags
+        if let raw = environment[armKeyModifiersEnvVar] {
+            var parsed: CGEventFlags = []
+            for token in raw.split(separator: ",") {
+                let name = token.trimmingCharacters(in: .whitespaces).lowercased()
+                if name.isEmpty { continue }
+                switch name {
+                case "control", "ctrl": parsed.insert(.maskControl)
+                case "shift": parsed.insert(.maskShift)
+                case "option", "opt", "alt": parsed.insert(.maskAlternate)
+                case "command", "cmd": parsed.insert(.maskCommand)
+                default: return .invalidModifierToken(name)
+                }
             }
+            flags = parsed
+        } else {
+            flags = defaultArmModifiers
         }
-        return flags
+        return .resolved(code: code, flags: flags)
     }
 
-    /// Read whether Logic's transport is currently RECORDING (control-bar
-    /// Record checkbox). Used by the arm honesty guard to detect a mis-assigned
-    /// key that triggers transport Record instead of record-enable.
-    static func isTransportRecording(runtime: AXLogicProElements.Runtime) -> Bool {
+    /// Read whether Logic's transport is currently RECORDING (control-bar Record
+    /// checkbox), returning nil when it is UNREADABLE. The arm honesty guard MUST
+    /// keep nil DISTINCT from a readable `false`: coercing nil→false would let an
+    /// unreadable transport masquerade as "not recording" under a State-A arm
+    /// claim (#2).
+    static func transportRecordingState(runtime: AXLogicProElements.Runtime) -> Bool? {
         AXLogicProElements.readControlBarCheckboxValue(
             named: "녹음", englishName: "Record", runtime: runtime
-        ) ?? false
+        )
     }
 
-    /// A single coordinate-free actuation rung: perform `actuate`, then the
-    /// caller polls the AX read-back up to `pollMs` to decide State A.
-    typealias TrackToggleRung = (name: String, pollMs: Int, actuate: () -> Void)
+    /// A single coordinate-free actuation rung: `actuate` either fires (then the
+    /// caller polls the AX read-back up to `pollMs` to decide State A) or REFUSES
+    /// and fails closed. A refusal NEVER posts a key.
+    typealias TrackToggleRung = (name: String, pollMs: Int, actuate: () -> RungOutcome)
 
     /// Per-op coordinate-free ladder. AXPress is always the natural primary
     /// (cheap; flips solo, no-ops mute/arm on 12.x — we never depend on its
-    /// return code). Mute/arm add an exclusive-select-then-keyboard rung.
+    /// return code). Mute/arm add an exclusive-select-then-keyboard rung whose
+    /// synthetic key is gated by: exclusive selection re-confirmed ATOMICALLY
+    /// before the post (#4/#5), a safe keyboard focus (#6), and — for arm — a
+    /// valid, non-bare key chord (#7). Any gate failing ⇒ the rung REFUSES (fails
+    /// closed) without posting a key.
     static func trackToggleLadder(
         button: AXUIElement,
         buttonName: String,
         index: Int,
-        desired: Bool,
         runtime: AXLogicProElements.Runtime,
         keyRuntime: AXMouseHelper.Runtime,
-        processRuntime: ProcessUtils.Runtime
+        processRuntime: ProcessUtils.Runtime,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> [TrackToggleRung] {
         let pressRung: TrackToggleRung = ("press", 250, {
             _ = AXHelpers.performAction(button, kAXPressAction, runtime: runtime.ax)
+            return .actuated
         })
         switch buttonName {
         case "Solo":
             // AXPress on the Solo checkbox flips it directly; keyboard 's' is a
-            // no-op for the track-header control, so there is no keyboard rung.
+            // no-op for the track-header control, so there is no keyboard rung
+            // (and thus no synthetic-key focus/selection gate to apply).
             return [pressRung]
         case "Mute":
             let keyRung: TrackToggleRung = ("keyboard-mute", 600, {
-                guard confirmExclusiveSelection(
+                if let refusal = confirmExclusiveSelectionRefusal(
                     index: index, runtime: runtime, processRuntime: processRuntime
-                ) else { return }
+                ) { return .refused(refusal) }
+                // #6 keyboard-focus gate — never type 'm' into a text field / sheet.
+                if let refusal = syntheticKeyFocusRefusal(runtime: runtime) {
+                    return .refused(refusal)
+                }
                 _ = keyRuntime.postKeyEvent(trackMuteKeyCode)
+                return .actuated
             })
             return [pressRung, keyRung]
         case "Record":
-            let armCode = resolvedArmKeyCode()
-            let armFlags = resolvedArmModifiers()
             let keyRung: TrackToggleRung = ("keyboard-arm", 600, {
-                guard confirmExclusiveSelection(
+                if let refusal = confirmExclusiveSelectionRefusal(
                     index: index, runtime: runtime, processRuntime: processRuntime
-                ) else { return }
-                // Never fire bare 'r' — that IS transport Record. A MODIFIED 'r'
-                // is a distinct command and is allowed; the recording guard in
-                // defaultSetTrackToggle is the runtime backstop for a mis-assign.
-                if armCode == transportRecordKeyCode, armFlags.isEmpty { return }
-                _ = keyRuntime.postFlaggedKeyEvent(armCode, armFlags)
+                ) { return .refused(refusal) }
+                // #7 configurable chord — a present-but-invalid override is a
+                // config error, never a silent fallback to the default chord.
+                let code: CGKeyCode
+                let flags: CGEventFlags
+                switch resolveArmChord(environment: environment) {
+                case .resolved(let resolvedCode, let resolvedFlags):
+                    code = resolvedCode
+                    flags = resolvedFlags
+                case .invalidKeyCode(let bad):
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "\(armKeyCodeEnvVar)=\"\(bad)\" is not a valid decimal virtual keycode"
+                    ))
+                case .invalidModifierToken(let bad):
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "\(armKeyModifiersEnvVar) contains an unknown modifier token \"\(bad)\""
+                    ))
+                }
+                // A bare (no-modifier) arm key is unsafe: bare 'r' IS transport
+                // Record, and any bare key is a global single-key command. Refuse
+                // it — the default chord (Ctrl+Shift+E) carries modifiers, so only
+                // an explicit empty-modifier override reaches here.
+                if flags.isEmpty {
+                    return .refused(armConfigInvalidRefusal(
+                        reason: "a bare arm key with no modifiers is unsafe (bare 'r' starts transport "
+                            + "recording; any bare key triggers a global command) — configure a modifier chord"
+                    ))
+                }
+                // #6 keyboard-focus gate before the synthetic chord.
+                if let refusal = syntheticKeyFocusRefusal(runtime: runtime) {
+                    return .refused(refusal)
+                }
+                _ = keyRuntime.postFlaggedKeyEvent(code, flags)
+                return .actuated
             })
             return [pressRung, keyRung]
         default:
@@ -355,15 +510,96 @@ extension AccessibilityChannel {
         _ = ProcessUtils.activateLogicPro(runtime: processRuntime)
         _ = AXLogicProElements.selectTrackViaAX(at: index, runtime: runtime)
         for attempt in 0..<4 {
-            let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
-            guard index >= 0, index < headers.count else { return false }
-            let states = headers.map { AXValueExtractors.extractSelectedState($0, runtime: runtime.ax) }
-            let targetSelected = states[index] == true
-            let anyOtherSelected = states.enumerated().contains { $0.offset != index && $0.element == true }
-            if targetSelected && !anyOtherSelected { return true }
+            if selectionIsExclusive(index: index, runtime: runtime) { return true }
             if attempt < 3 { usleep(80_000) }
         }
         return false
+    }
+
+    /// Read-only exclusivity predicate: the target — and ONLY the target — is
+    /// selected. #5 fail-closed on uncertainty: EVERY non-target header must
+    /// report a DEFINITIVE `AXSelected == false`; any nil/unreadable non-target
+    /// selection state means we cannot PROVE it is unselected, so exclusivity is
+    /// treated as UNPROVEN (returns false) rather than optimistically ignored. The
+    /// target itself must read a definitive `true`.
+    static func selectionIsExclusive(
+        index: Int,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+        guard index >= 0, index < headers.count else { return false }
+        let states = headers.map { AXValueExtractors.extractSelectedState($0, runtime: runtime.ax) }
+        guard states[index] == true else { return false }
+        return states.enumerated().allSatisfy { offset, state in
+            offset == index || state == false
+        }
+    }
+
+    /// Confirm exclusive selection with an ATOMIC re-check immediately before the
+    /// key post (#4 TOCTOU): a second `confirmExclusiveSelection` right before the
+    /// caller posts the key. Returns a distinct `selection_not_exclusive` refusal
+    /// (#9) — NOT the generic write-fail hint — when exclusivity cannot be
+    /// (re)proven, so the key is never posted onto a wrong/multi selection.
+    /// nil ⇒ safe to post.
+    static func confirmExclusiveSelectionRefusal(
+        index: Int,
+        runtime: AXLogicProElements.Runtime,
+        processRuntime: ProcessUtils.Runtime
+    ) -> RungRefusal? {
+        guard confirmExclusiveSelection(
+            index: index, runtime: runtime, processRuntime: processRuntime
+        ) else { return selectionNotExclusiveRefusal(index: index) }
+        // Re-confirm atomically right before the key — selection can change
+        // between the first confirm and the post (multi-select, user shift-click,
+        // Logic reselection). If it no longer holds, fail closed without posting.
+        guard confirmExclusiveSelection(
+            index: index, runtime: runtime, processRuntime: processRuntime
+        ) else { return selectionNotExclusiveRefusal(index: index) }
+        return nil
+    }
+
+    /// #6 — refuse a synthetic global command key when Logic's keyboard focus is
+    /// NOT known-safe: a modal/sheet is present, or the focused element is an
+    /// editable text surface (rename field, Notes, search/combo box, or any
+    /// element exposing a text insertion point). Posting 'm' / the arm chord into
+    /// such focus would type text or trigger the wrong command. Returns a refusal
+    /// (⇒ do NOT post the key) on POSITIVE danger; nil ⇒ no unsafe focus detected
+    /// (a nil focus is the common non-text case — the modal check covers sheets).
+    /// Solo (AXPress, not a synthetic global key) does not use this gate.
+    static func syntheticKeyFocusRefusal(
+        runtime: AXLogicProElements.Runtime
+    ) -> RungRefusal? {
+        if AXLogicProElements.dialogPresent(runtime: runtime) {
+            return unsafeFocusRefusal(reason: "a modal dialog or sheet is present", focus: "modal")
+        }
+        guard let app = AXLogicProElements.appRoot(runtime: runtime),
+              let focused: AXUIElement = AXHelpers.getAttribute(
+                app, kAXFocusedUIElementAttribute, runtime: runtime.ax
+              ) else {
+            return nil
+        }
+        let role = AXHelpers.getRole(focused, runtime: runtime.ax) ?? ""
+        let editableRoles: Set<String> = [
+            kAXTextFieldRole as String,
+            kAXTextAreaRole as String,
+            kAXComboBoxRole as String
+        ]
+        if editableRoles.contains(role) {
+            return unsafeFocusRefusal(
+                reason: "an editable text field is focused (role \(role))", focus: role
+            )
+        }
+        // A text insertion point marks an editable text surface even when the role
+        // is unusual — a synthetic key would type into it.
+        if let _: NSNumber = AXHelpers.getAttribute(
+            focused, kAXInsertionPointLineNumberAttribute, runtime: runtime.ax
+        ) {
+            return unsafeFocusRefusal(
+                reason: "a text-editing surface with an insertion point is focused",
+                focus: role.isEmpty ? "insertion_point" : role
+            )
+        }
+        return nil
     }
 
     /// Fail-closed hint (read-back never flipped). Arm points the operator at
@@ -391,6 +627,51 @@ extension AccessibilityChannel {
             + "\(index) — it is not assigned to 'Toggle Track Record Enable'. Stop the recording, then "
             + "assign that command (default Ctrl+Shift+E) in Logic ▸ Key Commands, or set "
             + "LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key."
+    }
+
+    /// #2 — arm fail-closed hint when the transport Record state is UNREADABLE at
+    /// the post-actuate check, so a clean arm cannot be honestly claimed.
+    static func armTransportUnknownHint(index: Int) -> String {
+        "arm could not be confirmed for track \(index): the transport Record state was UNREADABLE, so "
+            + "the server cannot prove the arm key did not instead start transport recording. Fail-closed "
+            + "(no State A) — make Logic's control bar (with the Record button) visible, then retry."
+    }
+
+    /// #5/#9 — distinct refusal when exclusive selection cannot be (re)proven, so
+    /// an operator is not misdirected to the key binding when SELECTION is the
+    /// problem. The key was never posted.
+    static func selectionNotExclusiveRefusal(index: Int) -> RungRefusal {
+        RungRefusal(
+            error: .selectionNotExclusive,
+            hint: "track \(index) could not be exclusively selected before the key command "
+                + "(another track is selected, or a header's selection state was unreadable). "
+                + "Deselect other tracks and retry — the key was NOT posted.",
+            extras: ["selection_error": "selection_not_exclusive"]
+        )
+    }
+
+    /// #6 — refusal when Logic's keyboard focus is not known-safe for a synthetic
+    /// global command key. The key was never posted.
+    static func unsafeFocusRefusal(reason: String, focus: String) -> RungRefusal {
+        RungRefusal(
+            error: .unsafeFocusForSyntheticKey,
+            hint: "refused to post the track key command: \(reason). Click the arrange/tracks area "
+                + "(or dismiss the dialog) so keyboard focus is safe, then retry — the key was NOT posted.",
+            extras: ["focus_guard": focus]
+        )
+    }
+
+    /// #7 — refusal when the record-arm key override is present but invalid
+    /// (unparseable keycode, unknown modifier token, or a bare no-modifier key).
+    /// The key was never posted.
+    static func armConfigInvalidRefusal(reason: String) -> RungRefusal {
+        RungRefusal(
+            error: .armKeyConfigInvalid,
+            hint: "record-arm key configuration is invalid: \(reason). Fix "
+                + "\(armKeyCodeEnvVar)/\(armKeyModifiersEnvVar) (or unset them to use the default "
+                + "Ctrl+Shift+E) — the key was NOT posted.",
+            extras: ["arm_key_config": "invalid"]
+        )
     }
 
     static func defaultRenameTrack(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -406,6 +406,40 @@ extension AccessibilityChannel {
         )
     }
 
+    /// Ground-truth verification for the arm-key auto-setup: drive a real
+    /// record-arm on track 0 through the configured chord and report whether
+    /// record-enable actually flipped (State A from the coordinate-free arm
+    /// ladder means the observed flip happened). Returns nil when there is no
+    /// track to test on. Restores track 0's original arm state either way.
+    /// ArmKeyCommandSetup calls this after assigning the key command — if the
+    /// chord flips arm here, the assignment took; if not, setup fails closed.
+    static func armSetupVerify(
+        runtime: AXLogicProElements.Runtime = .production,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool? {
+        guard let armButton = AXLogicProElements.findTrackArmButton(trackIndex: 0, runtime: runtime),
+              let curNum = AXHelpers.getValue(armButton, runtime: runtime.ax) as? NSNumber else {
+            return nil
+        }
+        let current = curNum.intValue != 0
+        let toggle = defaultSetTrackToggle(
+            params: ["index": "0", "enabled": String(!current)],
+            button: "Record",
+            runtime: runtime,
+            environment: environment
+        )
+        let flipped: Bool
+        if case .success = toggle { flipped = true } else { flipped = false }
+        // Restore the original arm state regardless of the verify outcome.
+        _ = defaultSetTrackToggle(
+            params: ["index": "0", "enabled": String(current)],
+            button: "Record",
+            runtime: runtime,
+            environment: environment
+        )
+        return flipped
+    }
+
     /// A single coordinate-free actuation rung: `actuate` either fires (then the
     /// caller polls the AX read-back up to `pollMs` to decide State A) or REFUSES
     /// and fails closed. A refusal NEVER posts a key.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -184,6 +184,7 @@ actor AccessibilityChannel: Channel {
             logicRuntime: AXLogicProElements.Runtime = .production,
             controlBarMouseRuntime: AXMouseHelper.Runtime = .production,
             trackRenameMouseRuntime: AXMouseHelper.Runtime = .production,
+            trackToggleKeyRuntime: AXMouseHelper.Runtime = .production,
             processRuntime: ProcessUtils.Runtime = .production,
             confirmNewTrackDialog: @escaping @Sendable () -> Void = {
                 AccessibilityChannel.sendReturnKey()
@@ -224,7 +225,15 @@ actor AccessibilityChannel: Channel {
                 trackStates: { AccessibilityChannel.defaultGetTrackStates(runtime: logicRuntime) },
                 selectedTrack: { AccessibilityChannel.defaultGetSelectedTrack(runtime: logicRuntime) },
                 selectTrack: { await AccessibilityChannel.defaultSelectTrack(params: $0, runtime: logicRuntime) },
-                setTrackToggle: { AccessibilityChannel.defaultSetTrackToggle(params: $0, button: $1, runtime: logicRuntime) },
+                setTrackToggle: {
+                    AccessibilityChannel.defaultSetTrackToggle(
+                        params: $0,
+                        button: $1,
+                        runtime: logicRuntime,
+                        keyRuntime: trackToggleKeyRuntime,
+                        processRuntime: processRuntime
+                    )
+                },
                 renameTrack: {
                     AccessibilityChannel.defaultRenameTrack(
                         params: $0,

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -176,7 +176,7 @@ struct SystemDispatcher: OperationTraceDispatching {
             Diagnostics, help, and saga coordination for the Logic Pro MCP server. \
             Commands: health, permissions, refresh_cache, export_support_bundle, saga_preflight, \
             saga_execute, saga_status, saga_cancel, list_recent_traces, get_trace, clear_traces, \
-            help. \
+            help, setup_arm_key. \
             Params by command: \
             help -> { category: String } (returns full param docs for a dispatcher); \
             refresh_cache -> {} (force AX re-poll); \
@@ -185,7 +185,9 @@ struct SystemDispatcher: OperationTraceDispatching {
             clear_traces -> { confirmed: Bool }; \
             export_support_bundle -> { dir?: String } (local files only; never uploaded); \
             saga_preflight/saga_execute -> { steps: [step], idempotency_key: String }; \
-            saga_status/saga_cancel -> { idempotency_key: String }. \
+            saga_status/saga_cancel -> { idempotency_key: String }; \
+            setup_arm_key -> { consent: "true" } (one-time consent-gated Key Commands GUI \
+            drive that assigns the coordinate-free record-arm chord; no mouse). \
             Saga work is ordered best-effort work with compensation; it does not promise \
             all-or-nothing completion or durable recovery. The journal is session-only and \
             cleared when the server session ends, including process restart. \
@@ -342,6 +344,9 @@ struct SystemDispatcher: OperationTraceDispatching {
             // key command (the track-header Record-Enable AXPress is a no-op, so a
             // key command is the only coord-free arm; it ships unassigned and
             // Logic 12.2+ blocks programmatic import). Fails closed without consent.
+            // ADR-005: a mutating op, so it emits an operation trace like every
+            // other mutating system command (started here, finalized on each exit).
+            let armTraceID = await startTraceIfEnabled(command: command)
             let consent = params["consent"]?.stringValue == "true"
             let keyCode: CGKeyCode
             let modifiers: CGEventFlags
@@ -350,17 +355,17 @@ struct SystemDispatcher: OperationTraceDispatching {
                 keyCode = code
                 modifiers = flags
             case .invalidKeyCode(let raw):
-                return toolTextResult(HonestContract.encodeStateC(
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateC(
                     error: .armKeyConfigInvalid,
                     hint: "LOGIC_PRO_MCP_ARM_KEYCODE '\(raw)' is not a valid decimal keycode.",
                     extras: ["stage": "resolve_chord"]
-                ), isError: true)
+                ), isError: true), traceID: armTraceID)
             case .invalidModifierToken(let token):
-                return toolTextResult(HonestContract.encodeStateC(
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateC(
                     error: .armKeyConfigInvalid,
                     hint: "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS has an unknown modifier token '\(token)'.",
                     extras: ["stage": "resolve_chord"]
-                ), isError: true)
+                ), isError: true), traceID: armTraceID)
             }
             let chordText = ArmKeyCommandSetup.chordLabel(keyCode: keyCode, modifiers: modifiers)
             let armSetupOutcome = ArmKeyCommandSetup.run(
@@ -371,35 +376,38 @@ struct SystemDispatcher: OperationTraceDispatching {
             )
             switch armSetupOutcome {
             case .consentRequired:
-                return toolTextResult(HonestContract.encodeStateC(
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateC(
                     error: .invalidParams,
                     hint: "One-time setup assigns Logic's \"\(ArmKeyCommandSetup.commandName)\" command to "
                         + "\(chordText) so tracks arm coordinate-free. The server drives the Key Commands "
                         + "window on your behalf (no mouse). Re-run with consent:\"true\" to proceed.",
                     extras: ["stage": "consent", "chord": chordText, "command": ArmKeyCommandSetup.commandName]
-                ), isError: true)
+                ), isError: true), traceID: armTraceID)
             case .configuredAndVerified:
-                return toolTextResult(HonestContract.encodeStateA(extras: [
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateA(extras: [
                     "chord": chordText,
                     "command": ArmKeyCommandSetup.commandName,
                     "verified": true,
                     "detail": "Key command assigned and confirmed by a live record-arm flip.",
-                ]))
+                ])), traceID: armTraceID)
             case .configuredUnverified(let why):
-                return toolTextResult(HonestContract.encodeStateB(
+                // HIGH#3: nothing observed the assignment on this path (no track to
+                // test), so we must NOT claim "assigned" — report the steps ran but
+                // the assignment is unproven.
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateB(
                     reason: .readbackUnavailable,
                     extras: [
                         "chord": chordText,
                         "command": ArmKeyCommandSetup.commandName,
-                        "detail": "Key command assigned; could not confirm a live flip (\(why)).",
+                        "detail": "Setup steps ran, but the assignment is UNPROVEN — \(why).",
                     ]
-                ))
+                )), traceID: armTraceID)
             case .failed(let stage, let hint):
-                return toolTextResult(HonestContract.encodeStateC(
+                return await finalizeTrace(toolTextResult(HonestContract.encodeStateC(
                     error: .axWriteFailed,
                     hint: hint,
                     extras: ["stage": stage, "chord": chordText]
-                ), isError: true)
+                ), isError: true), traceID: armTraceID)
             }
 
         case "export_support_bundle":

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -337,6 +337,71 @@ struct SystemDispatcher: OperationTraceDispatching {
             }
             return toolTextResult("State refresh triggered. Cache will be updated on next poll cycle.")
 
+        case "setup_arm_key":
+            // Consent-based one-time automation of the coordinate-free record-arm
+            // key command (the track-header Record-Enable AXPress is a no-op, so a
+            // key command is the only coord-free arm; it ships unassigned and
+            // Logic 12.2+ blocks programmatic import). Fails closed without consent.
+            let consent = params["consent"]?.stringValue == "true"
+            let keyCode: CGKeyCode
+            let modifiers: CGEventFlags
+            switch AccessibilityChannel.resolveArmChord() {
+            case .resolved(let code, let flags):
+                keyCode = code
+                modifiers = flags
+            case .invalidKeyCode(let raw):
+                return toolTextResult(HonestContract.encodeStateC(
+                    error: .armKeyConfigInvalid,
+                    hint: "LOGIC_PRO_MCP_ARM_KEYCODE '\(raw)' is not a valid decimal keycode.",
+                    extras: ["stage": "resolve_chord"]
+                ), isError: true)
+            case .invalidModifierToken(let token):
+                return toolTextResult(HonestContract.encodeStateC(
+                    error: .armKeyConfigInvalid,
+                    hint: "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS has an unknown modifier token '\(token)'.",
+                    extras: ["stage": "resolve_chord"]
+                ), isError: true)
+            }
+            let chordText = ArmKeyCommandSetup.chordLabel(keyCode: keyCode, modifiers: modifiers)
+            let armSetupOutcome = ArmKeyCommandSetup.run(
+                consent: consent,
+                keyCode: keyCode,
+                modifiers: modifiers,
+                runtime: .production(verifyArmFlip: { AccessibilityChannel.armSetupVerify() })
+            )
+            switch armSetupOutcome {
+            case .consentRequired:
+                return toolTextResult(HonestContract.encodeStateC(
+                    error: .invalidParams,
+                    hint: "One-time setup assigns Logic's \"\(ArmKeyCommandSetup.commandName)\" command to "
+                        + "\(chordText) so tracks arm coordinate-free. The server drives the Key Commands "
+                        + "window on your behalf (no mouse). Re-run with consent:\"true\" to proceed.",
+                    extras: ["stage": "consent", "chord": chordText, "command": ArmKeyCommandSetup.commandName]
+                ), isError: true)
+            case .configuredAndVerified:
+                return toolTextResult(HonestContract.encodeStateA(extras: [
+                    "chord": chordText,
+                    "command": ArmKeyCommandSetup.commandName,
+                    "verified": true,
+                    "detail": "Key command assigned and confirmed by a live record-arm flip.",
+                ]))
+            case .configuredUnverified(let why):
+                return toolTextResult(HonestContract.encodeStateB(
+                    reason: .readbackUnavailable,
+                    extras: [
+                        "chord": chordText,
+                        "command": ArmKeyCommandSetup.commandName,
+                        "detail": "Key command assigned; could not confirm a live flip (\(why)).",
+                    ]
+                ))
+            case .failed(let stage, let hint):
+                return toolTextResult(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: hint,
+                    extras: ["stage": stage, "chord": chordText]
+                ), isError: true)
+            }
+
         case "export_support_bundle":
             let createdAt = Date()
             let directory: URL

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -800,11 +800,15 @@ enum SemanticOracleTable {
         ]
     )
 
-    /// The `defaultSetTrackToggle` write strategies — the `action` a State-A
-    /// toggle records as the path that actually landed the write. Pinned as a
+    /// The `defaultSetTrackToggle` coordinate-free actuator rungs — the
+    /// `action` a State-A toggle records as the path that actually landed the
+    /// write (#106 / ADR-001: the former value-write / HID `mouse-click` rungs
+    /// are removed). `no-op` = already at desired (toggle-from-read); `press` =
+    /// AXPress on the checkbox (solo's direct flip); `keyboard-mute` /
+    /// `keyboard-arm` = exclusive-select then a CGEvent key command. Pinned as a
     /// domain so a toggle claiming an unknown strategy is caught.
     static let trackToggleActions = [
-        "no-op", "press", "confirm", "value-nsnumber", "value-cfbool", "mouse-click",
+        "no-op", "press", "keyboard-mute", "keyboard-arm",
     ]
 
     // AccessibilityChannel+Tracks `defaultSetTrackToggle` (button "Mute") →

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -38,6 +38,7 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case systemSagaExecute = "system.saga_execute"
     case systemSagaStatus = "system.saga_status"
     case systemSagaCancel = "system.saga_cancel"
+    case systemSetupArmKey = "system.setup_arm_key"
     case pluginsGetInventory = "plugins.get_inventory"
     case pluginsSetParamVerified = "plugins.set_param_verified"
     case pluginsInsertVerified = "plugins.insert_verified"
@@ -300,6 +301,7 @@ enum OperationRegistry {
             "system.list_recent_traces", "system.get_trace", "system.clear_traces",
             "system.export_support_bundle", "system.help", "system.saga_preflight",
             "system.saga_execute", "system.saga_status", "system.saga_cancel",
+            "system.setup_arm_key",
         ],
         ToolID.logicPlugins.rawValue: [
             "plugins.get_inventory", "plugins.set_param_verified", "plugins.insert_verified",
@@ -353,6 +355,7 @@ enum OperationRegistry {
             "health", "permissions", "refresh_cache", "export_support_bundle", "help",
             "list_recent_traces", "get_trace", "clear_traces",
             "saga_preflight", "saga_execute", "saga_status", "saga_cancel",
+            "setup_arm_key",
         ],
         ToolID.logicPlugins.rawValue: [
             "get_inventory", "set_param_verified", "insert_verified",
@@ -636,6 +639,10 @@ enum OperationRegistry {
         (.systemSagaExecute, "saga_execute", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired, ["idempotency_key", "steps"]),
         (.systemSagaStatus, "saga_status", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, ["idempotency_key"]),
         (.systemSagaCancel, "saga_cancel", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, ["idempotency_key"]),
+        // Consent-gated one-time Key-Commands GUI automation for the coord-free
+        // arm chord; long deadline (opens/searches/learns/closes the KC window),
+        // self-verifies via a live record-arm flip.
+        (.systemSetupArmKey, "setup_arm_key", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired, ["consent"]),
     ] as [(OperationID, String, Mutability, DeadlineClass, VerificationPolicy, Set<String>)]).map { entry in
         OperationSpec(
             id: entry.0,

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -241,6 +241,32 @@ enum HonestContract {
         case sagaOutcomeUnavailable = "saga_outcome_unavailable"
         case notSupported = "not_supported"
         case sagaExecutionFailed = "saga_execution_failed"
+
+        // #106 coordinate-free track M/S/R actuator — fail-closed honesty codes.
+        /// The transport Record state was UNREADABLE at the arm post-actuate
+        /// check, so the server cannot prove the arm key did not instead start
+        /// transport recording. Distinct from `.axWriteFailed`: the write may have
+        /// landed on the checkbox, but the honesty claim is unverifiable, so arm
+        /// fails closed instead of returning State A (#2). NOT terminal — another
+        /// channel (e.g. MCU) may arm through a different mechanism.
+        case transportStateUnknown = "transport_state_unknown"
+        /// A mute/arm key command was refused because the target track could not
+        /// be proven EXCLUSIVELY selected (another track selected, or a header's
+        /// selection state unreadable). Distinct from the generic write-fail hint
+        /// so an operator is not misdirected to the key binding when selection is
+        /// the problem (#5/#9). The key was never posted.
+        case selectionNotExclusive = "selection_not_exclusive"
+        /// A mute/arm synthetic key was refused because Logic's keyboard focus is
+        /// not known-safe (an editable text field/sheet/combo box is focused), so
+        /// posting the key would corrupt text or hit the wrong command (#6). The
+        /// key was never posted.
+        case unsafeFocusForSyntheticKey = "unsafe_focus_for_synthetic_key"
+        /// The record-arm key override (`LOGIC_PRO_MCP_ARM_KEYCODE` /
+        /// `LOGIC_PRO_MCP_ARM_KEY_MODIFIERS`) is present but invalid (unparseable
+        /// keycode, unknown modifier token, or a bare no-modifier key). The arm
+        /// path fails closed rather than silently posting the default or a partial
+        /// chord (#7). The key was never posted.
+        case armKeyConfigInvalid = "arm_key_config_invalid"
     }
 
     // MARK: - Encoding primitives

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -547,7 +547,7 @@ enum WorkflowSkillCatalog {
         ],
         "logic_system": [
             "health", "permissions", "refresh_cache", "export_support_bundle", "help",
-            "list_recent_traces", "get_trace", "clear_traces",
+            "list_recent_traces", "get_trace", "clear_traces", "setup_arm_key",
             "saga_preflight", "saga_execute", "saga_status", "saga_cancel",
         ],
         "logic_audio": [

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -288,6 +288,12 @@ private func makeAXBackedAccessibilityChannel(
         postUnicodeScalar: { _ in false },
         sleepMicros: { _ in }
     ),
+    trackToggleKeyRuntime: AXMouseHelper.Runtime = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in false },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    ),
     processRuntime: ProcessUtils.Runtime = makeProcessRuntime(),
     confirmNewTrackDialog: @escaping @Sendable () -> Void = {},
     canPostEvents: @escaping @Sendable () -> Bool = { true },
@@ -299,6 +305,7 @@ private func makeAXBackedAccessibilityChannel(
         logicRuntime: logicRuntime ?? builder.makeLogicRuntime(appElement: app),
         controlBarMouseRuntime: controlBarMouseRuntime,
         trackRenameMouseRuntime: trackRenameMouseRuntime,
+        trackToggleKeyRuntime: trackToggleKeyRuntime,
         processRuntime: processRuntime,
         confirmNewTrackDialog: confirmNewTrackDialog,
         canPostEvents: canPostEvents,
@@ -2657,7 +2664,18 @@ private func makeTempoSliderFixture(
     builder.setAttribute(armButton, kAXDescriptionAttribute as String, "Record Track 1")
     builder.setAttribute(armButton, kAXValueAttribute as String, 1)
 
-    let channel = makeAXBackedAccessibilityChannel(builder: builder, app: app)
+    // #106 / ADR-001: mute is coordinate-free-actuated — AXPress no-ops on the
+    // real Logic checkbox, so the primary is exclusive-select + CGEvent key 'm'
+    // (keycode 46). Model that faithfully: pressing key 46 toggles muteButton.
+    let muteKeyRecorder = ControlBarMouseRecorder()
+    muteKeyRecorder.onKeyEvent = { code in
+        guard code == AccessibilityChannel.trackMuteKeyCode else { return }
+        let current = (builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue ?? false
+        builder.setAttribute(muteButton, kAXValueAttribute as String, NSNumber(value: !current))
+    }
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app, trackToggleKeyRuntime: muteKeyRecorder.runtime()
+    )
 
     let tracksResult = await channel.execute(operation: "track.get_tracks", params: [:])
     #expect(tracksResult.isSuccess)
@@ -2683,10 +2701,17 @@ private func makeTempoSliderFixture(
     #expect(muteNoopResult.isSuccess)
     #expect(muteNoopResult.message.contains("\"action\":\"no-op\""))
     #expect(!builder.actionCalls.contains { $0.elementID == builder.elementID(muteButton) && $0.action == kAXPressAction as String })
-    // Explicitly request disable (enabled=false) — current=true, desired=false → press.
+    // Explicitly request disable (enabled=false) — current=true, desired=false.
+    // AXPress runs first (natural primary; a no-op on the real control), then
+    // the exclusive-select + key 'm' rung flips the value → verified State A.
     let muteOffResult = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "false"])
     #expect(muteOffResult.isSuccess)
+    #expect(muteOffResult.message.contains("\"action\":\"keyboard-mute\""))
+    #expect(muteKeyRecorder.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+    // ADR-001: zero mouse/coordinate events — the actuator is keyboard-only.
+    #expect(muteKeyRecorder.mouseEvents.isEmpty)
     #expect(builder.actionCalls.contains { $0.elementID == builder.elementID(muteButton) && $0.action == kAXPressAction as String })
+    #expect((builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue == false)
 
     let renameResult = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Lead"])
     #expect(renameResult.isSuccess)
@@ -3421,16 +3446,14 @@ private final class LockedFlag: @unchecked Sendable {
     builder.setAttribute(soloButton, kAXRoleAttribute as String, kAXButtonRole as String)
     builder.setAttribute(soloButton, kAXDescriptionAttribute as String, "Solo Track 1")
 
-    // With performAction disabled, the fallback to direct AXValue write still
-    // succeeds (fake builder stores the value and read-back matches). New
-    // post-hardening contract: the handler reports success via "value-written"
-    // action marker rather than erroring out, because the desired state was
-    // actually reached through the alternate write path.
+    // #106 / ADR-001: Solo is actuated by AXPress on the checkbox ONLY — the
+    // value-write and coordinate fallbacks are removed. With AXPress rejected
+    // and the control's AX value never reaching the desired state, the op fails
+    // closed as an honest State C (never a fabricated success).
     let soloFailure = await failingChannel.execute(operation: "track.set_solo", params: ["index": "0"])
-    #expect(soloFailure.isSuccess)
-    // Strategy name: "value-nsnumber" is the first write-based strategy that
-    // succeeds in the fake builder (NSNumber round-trip works, press doesn't).
-    #expect(soloFailure.message.contains("\"action\":\"value-nsnumber\""))
+    #expect(!soloFailure.isSuccess)
+    #expect(soloFailure.message.contains("\"error\":\"ax_write_failed\""))
+    #expect(soloFailure.message.contains("\"state\":\"C\""))
 }
 
 @Test func testAccessibilityChannelAXBackedMixerAndProjectDefaultsUseFakeAXTree() async throws {

--- a/Tests/LogicProMCPTests/ArmKeyCommandSetupTests.swift
+++ b/Tests/LogicProMCPTests/ArmKeyCommandSetupTests.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Testing
+@testable import LogicProMCP
+
+/// The live Key-Commands GUI automation itself is validated live (mocks cannot
+/// reproduce real Logic KC behavior). These pin the mockable safety contract:
+/// consent MUST gate before any action, and the chord label is correct.
+@Suite struct ArmKeyCommandSetupTests {
+    /// A runtime whose every side-effecting hook trips a flag — so we can assert
+    /// consent=false performs NONE of them.
+    private static func trippingRuntime(_ trip: @escaping @Sendable () -> Void) -> ArmKeyCommandSetup.Runtime {
+        ArmKeyCommandSetup.Runtime(
+            activateLogic: { trip() },
+            postChord: { _, _ in trip() },
+            typeText: { _ in trip() },
+            sleep: { _ in },
+            ax: .production,      // unreached under consent=false (asserted below)
+            elements: .production,
+            verifyArmFlip: { trip(); return true }
+        )
+    }
+
+    @Test func consentFalseRefusesBeforeAnyAction() {
+        final class Box: @unchecked Sendable { var tripped = false }
+        let box = Box()
+        let runtime = Self.trippingRuntime { box.tripped = true }
+        let outcome = ArmKeyCommandSetup.run(
+            consent: false,
+            keyCode: 14,
+            modifiers: [.maskControl, .maskShift],
+            runtime: runtime
+        )
+        #expect(outcome == ArmKeyCommandSetup.Outcome.consentRequired)
+        // No activation, no keystroke, no verify may have happened without consent.
+        #expect(box.tripped == false)
+    }
+
+    @Test func chordLabelRendersControlShiftE() {
+        let label = ArmKeyCommandSetup.chordLabel(keyCode: 14, modifiers: [.maskControl, .maskShift])
+        #expect(label == "⌃⇧E")
+    }
+
+    @Test func chordLabelRendersAllModifiers() {
+        let label = ArmKeyCommandSetup.chordLabel(
+            keyCode: 15,
+            modifiers: [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+        )
+        #expect(label == "⌃⌥⇧⌘R")
+    }
+}

--- a/Tests/LogicProMCPTests/ArmKeyCommandSetupTests.swift
+++ b/Tests/LogicProMCPTests/ArmKeyCommandSetupTests.swift
@@ -1,16 +1,22 @@
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Testing
 @testable import LogicProMCP
 
 /// The live Key-Commands GUI automation itself is validated live (mocks cannot
-/// reproduce real Logic KC behavior). These pin the mockable safety contract:
-/// consent MUST gate before any action, and the chord label is correct.
+/// reproduce real Logic KC behavior). These pin the MOCKABLE safety contract:
+/// consent MUST gate before any action; the chord is only sent once Learn is
+/// OBSERVED engaged; an already-on Learn is never blind-toggled off; focus must
+/// be established before typing; and the verify result maps to an honest Outcome.
 @Suite struct ArmKeyCommandSetupTests {
+    // MARK: - Consent gate
+
     /// A runtime whose every side-effecting hook trips a flag — so we can assert
     /// consent=false performs NONE of them.
     private static func trippingRuntime(_ trip: @escaping @Sendable () -> Void) -> ArmKeyCommandSetup.Runtime {
         ArmKeyCommandSetup.Runtime(
-            activateLogic: { trip() },
+            activateLogic: { trip(); return true },
+            logicIsFrontmost: { trip(); return true },
             postChord: { _, _ in trip() },
             typeText: { _ in trip() },
             sleep: { _ in },
@@ -46,5 +52,145 @@ import Testing
             modifiers: [.maskControl, .maskAlternate, .maskShift, .maskCommand]
         )
         #expect(label == "⌃⌥⇧⌘R")
+    }
+
+    // MARK: - Fake Key-Commands tree (the mockable slice of the GUI drive)
+
+    private final class PostedChords: @unchecked Sendable {
+        var codes: [CGKeyCode] = []
+    }
+
+    private struct Harness {
+        let runtime: ArmKeyCommandSetup.Runtime
+        let posted: PostedChords
+        let builder: FakeAXRuntimeBuilder
+        let learn: AXUIElement
+    }
+
+    private static let ctrlShiftE: (code: CGKeyCode, mods: CGEventFlags) = (14, [.maskControl, .maskShift])
+
+    /// A minimal Key-Commands window tree every hard step can traverse: the
+    /// window is found immediately (so Option+K is never posted — a clean signal
+    /// that `posted` holds ONLY the arm chord), a search field, a selectable
+    /// command row for the record-arm command, a "Learn by Key Label" checkbox,
+    /// and a close button. `learnOn` seeds the checkbox; the fake's AXPress is a
+    /// no-op on the value, so a Learn that starts off never reads on (modelling
+    /// the "Learn did not engage" failure).
+    private static func makeHarness(
+        learnOn: Bool,
+        frontmost: Bool = true,
+        verifyArmFlip: Bool?
+    ) -> Harness {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(0)
+        let kcWindow = builder.element(1)
+        let searchField = builder.element(2)
+        let commandRow = builder.element(3)
+        let commandCell = builder.element(4)
+        let learn = builder.element(5)
+        let closeButton = builder.element(6)
+
+        builder.setAttribute(kcWindow, kAXTitleAttribute as String, "Key Commands")
+        builder.setAttribute(kcWindow, "AXCloseButton", closeButton)
+        builder.setRole(searchField, kAXTextFieldRole as String)
+        builder.setAttribute(searchField, kAXValueAttribute as String, "")
+        builder.setRole(commandRow, kAXRowRole as String)
+        builder.setRole(commandCell, kAXStaticTextRole as String)
+        builder.setAttribute(commandCell, kAXValueAttribute as String, ArmKeyCommandSetup.commandName)
+        builder.setAttribute(commandCell, kAXParentAttribute as String, commandRow)
+        builder.setRole(learn, kAXCheckBoxRole as String)
+        builder.setAttribute(learn, kAXTitleAttribute as String, ArmKeyCommandSetup.learnCheckboxTitle)
+        builder.setAttribute(learn, kAXValueAttribute as String, learnOn ? 1 : 0)
+
+        builder.setAttribute(app, kAXWindowsAttribute as String, [kcWindow])
+        builder.setChildren(kcWindow, [searchField, commandRow, learn])
+        builder.setChildren(commandRow, [commandCell])
+
+        let posted = PostedChords()
+        let runtime = ArmKeyCommandSetup.Runtime(
+            activateLogic: { true },
+            logicIsFrontmost: { frontmost },
+            postChord: { code, _ in posted.codes.append(code) },
+            typeText: { _ in },
+            sleep: { _ in },
+            ax: builder.makeAXRuntime(appElement: app),
+            elements: builder.makeLogicRuntime(appElement: app),
+            verifyArmFlip: { verifyArmFlip }
+        )
+        return Harness(runtime: runtime, posted: posted, builder: builder, learn: learn)
+    }
+
+    private static func run(_ h: Harness) -> ArmKeyCommandSetup.Outcome {
+        ArmKeyCommandSetup.run(
+            consent: true,
+            keyCode: Self.ctrlShiftE.code,
+            modifiers: Self.ctrlShiftE.mods,
+            runtime: h.runtime
+        )
+    }
+
+    /// HIGH#1: a Learn that never reports on must FAIL CLOSED before the chord —
+    /// no chord is posted, so nothing is bound to the wrong/empty focus.
+    @Test func learnThatNeverEngagesFailsClosedWithoutSendingAnyChord() {
+        let h = Self.makeHarness(learnOn: false, verifyArmFlip: true)
+        let outcome = Self.run(h)
+        guard case .failed(let stage, _) = outcome else {
+            Issue.record("expected .failed, got \(outcome)")
+            return
+        }
+        #expect(stage == "learn_engage")
+        #expect(h.posted.codes.isEmpty)
+    }
+
+    /// HIGH#2: an already-on Learn must NOT be blind-toggled off; the chord is
+    /// still sent exactly once and Learn is left on (its prior state).
+    @Test func alreadyOnLearnIsNotToggledOffAndTheChordIsSentOnce() throws {
+        let h = Self.makeHarness(learnOn: true, verifyArmFlip: true)
+        let outcome = Self.run(h)
+        #expect(outcome == ArmKeyCommandSetup.Outcome.configuredAndVerified)
+        #expect(h.posted.codes == [Self.ctrlShiftE.code])
+        let learnValue = try #require(
+            h.builder.attributeValue(h.learn, kAXValueAttribute as String) as? Int
+        )
+        #expect(learnValue == 1)
+    }
+
+    /// Outcome mapping + HIGH#3: with the chord sent but no track to verify on,
+    /// the outcome is `configuredUnverified` and its wording must NOT claim the
+    /// key command was "assigned" (nothing observed the assignment).
+    @Test func noSelectableTrackMapsToHonestUnverifiedOutcome() {
+        let h = Self.makeHarness(learnOn: true, verifyArmFlip: nil)
+        let outcome = Self.run(h)
+        guard case .configuredUnverified(let why) = outcome else {
+            Issue.record("expected .configuredUnverified, got \(outcome)")
+            return
+        }
+        #expect(!why.lowercased().contains("assigned"))
+        #expect(h.posted.codes == [Self.ctrlShiftE.code])
+    }
+
+    /// Outcome mapping: an observed NON-flip (verify drove an arm and it did not
+    /// move) is a hard failure, never a success.
+    @Test func observedNonFlipMapsToFailedVerify() {
+        let h = Self.makeHarness(learnOn: true, verifyArmFlip: false)
+        let outcome = Self.run(h)
+        guard case .failed(let stage, _) = outcome else {
+            Issue.record("expected .failed, got \(outcome)")
+            return
+        }
+        #expect(stage == "verify")
+    }
+
+    /// HIGH#5: if Logic cannot be confirmed frontmost, typing is refused before it
+    /// starts — no chord is posted.
+    @Test func focusNotEstablishedFailsClosedBeforeTyping() {
+        let h = Self.makeHarness(learnOn: true, frontmost: false, verifyArmFlip: true)
+        let outcome = Self.run(h)
+        guard case .failed(let stage, _) = outcome else {
+            Issue.record("expected .failed, got \(outcome)")
+            return
+        }
+        #expect(stage == "focus_search_field")
+        #expect(h.posted.codes.isEmpty)
     }
 }

--- a/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
+++ b/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
@@ -1,0 +1,421 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #106 / ADR-001 — the track mute/solo/arm actuator ladder is COORDINATE-FREE.
+/// Each op actuates via AX/keyboard only (no mouse click), determines success by
+/// RE-READING the checkbox AXValue (never the AX action's return code), and fails
+/// closed (never a coordinate fallback) when the read-back never reaches the
+/// desired state. Every test is deterministic (fakes, no live Logic) and each
+/// asserts ZERO mouse events — the coordinate rung is gone.
+@Suite("#106 coordinate-free track toggle actuator")
+struct CoordFreeTrackToggleTests {
+
+    // MARK: - Fixtures / doubles
+
+    /// Records the CGEvent keyboard + mouse posts a coordinate-free actuator
+    /// makes, and (optionally) mutates the fake AX tree when a key lands — the
+    /// deterministic stand-in for "Logic honoured the key command".
+    private final class KeyMouseRecorder: @unchecked Sendable {
+        var keyEvents: [CGKeyCode] = []
+        var flaggedKeyEvents: [(code: CGKeyCode, flags: CGEventFlags)] = []
+        var mouseEvents: [(type: CGEventType, point: CGPoint, clickCount: Int64)] = []
+        var onKeyEvent: ((CGKeyCode) -> Void)?
+        var onFlaggedKey: ((CGKeyCode, CGEventFlags) -> Void)?
+
+        func runtime() -> AXMouseHelper.Runtime {
+            AXMouseHelper.Runtime(
+                postMouseEvent: { type, point, clickCount in
+                    self.mouseEvents.append((type, point, clickCount))
+                    return true
+                },
+                postKeyEvent: { code in
+                    self.keyEvents.append(code)
+                    self.onKeyEvent?(code)
+                    return true
+                },
+                postUnicodeScalar: { _ in false },
+                sleepMicros: { _ in },
+                postFlaggedKeyEvent: { code, flags in
+                    self.flaggedKeyEvents.append((code, flags))
+                    self.onFlaggedKey?(code, flags)
+                    return true
+                }
+            )
+        }
+    }
+
+    private struct ToggleFixture {
+        let builder: FakeAXRuntimeBuilder
+        let app: AXUIElement
+        let headers: [AXUIElement]
+        let mute: [AXUIElement]
+        let solo: [AXUIElement]
+        let arm: [AXUIElement]
+        let recordCheckbox: AXUIElement // control-bar transport Record (arm honesty guard)
+    }
+
+    /// A Logic-12-shaped fake: an AXList("Track Headers") of AXLayoutItem rows,
+    /// each carrying Mute/Solo/Record-Enable AXCheckBoxes (value 0) plus an
+    /// AXSelected flag. `selected` seeds which rows report AXSelected == true.
+    private func makeToggleFixture(trackCount: Int = 1, selected: Set<Int> = [0]) -> ToggleFixture {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(9000)
+        let window = b.element(9001)
+        let trackList = b.element(9002)
+        let controlBar = b.element(9003)
+        let recordCheckbox = b.element(9004)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+        b.setChildren(window, [trackList, controlBar])
+        b.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+        b.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+        // Control bar with the transport Record checkbox (value 0 = not
+        // recording) so `isTransportRecording` can read it in arm tests.
+        b.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+        b.setChildren(controlBar, [recordCheckbox])
+        b.setAttribute(recordCheckbox, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        b.setAttribute(recordCheckbox, kAXTitleAttribute as String, "Record")
+        b.setAttribute(recordCheckbox, kAXValueAttribute as String, 0)
+
+        var headers: [AXUIElement] = []
+        var mutes: [AXUIElement] = []
+        var solos: [AXUIElement] = []
+        var arms: [AXUIElement] = []
+        for i in 0..<trackCount {
+            let base = 9100 + i * 10
+            let header = b.element(base)
+            let mute = b.element(base + 1)
+            let solo = b.element(base + 2)
+            let arm = b.element(base + 3)
+            b.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            b.setAttribute(header, kAXTitleAttribute as String, "Track \(i + 1)")
+            b.setAttribute(header, kAXSelectedAttribute as String, selected.contains(i))
+            for (control, desc) in [(mute, "Mute"), (solo, "Solo"), (arm, "Record Enable")] {
+                b.setAttribute(control, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                b.setAttribute(control, kAXDescriptionAttribute as String, desc)
+                b.setAttribute(control, kAXValueAttribute as String, 0)
+            }
+            b.setChildren(header, [mute, solo, arm])
+            headers.append(header); mutes.append(mute); solos.append(solo); arms.append(arm)
+        }
+        b.setChildren(trackList, headers)
+        return ToggleFixture(
+            builder: b, app: app, headers: headers,
+            mute: mutes, solo: solos, arm: arms, recordCheckbox: recordCheckbox
+        )
+    }
+
+    /// A process runtime whose `activateLogicPro` is a no-op — keeps the
+    /// coordinate-free path from reaching for the real Logic app under test.
+    private func noopProcessRuntime() -> ProcessUtils.Runtime {
+        ProcessUtils.Runtime(
+            logicProPID: { 4242 },
+            fallbackLogicProPID: { 4242 },
+            logicProRunning: { true },
+            activateLogicPro: { true },
+            logicProBundleURL: { nil }
+        )
+    }
+
+    private func makeChannel(
+        _ fixture: ToggleFixture,
+        keyRuntime: AXMouseHelper.Runtime,
+        performAction: (@Sendable (AXUIElement, String) -> Bool)? = nil
+    ) -> AccessibilityChannel {
+        let logic = fixture.builder.makeLogicRuntime(
+            appElement: fixture.app,
+            setAttributeHandler: nil,
+            performActionHandler: performAction
+        )
+        return AccessibilityChannel(runtime: .axBacked(
+            isTrusted: { true },
+            isLogicProRunning: { true },
+            logicRuntime: logic,
+            trackToggleKeyRuntime: keyRuntime,
+            processRuntime: noopProcessRuntime()
+        ))
+    }
+
+    private func object(_ raw: String) -> [String: Any]? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private func boolValue(_ fixture: ToggleFixture, _ element: AXUIElement) -> Bool? {
+        (fixture.builder.attributeValue(element, kAXValueAttribute as String) as? NSNumber)?.boolValue
+    }
+
+    // MARK: - Solo: AXPress is the (only) actuator
+
+    @Test("solo flips on AXPress → verified State A via press, ZERO mouse/key")
+    func soloAXPressFlipsVerifiedStateA() async throws {
+        let f = makeToggleFixture()
+        let solo = f.solo[0]
+        let key = KeyMouseRecorder()
+        // Real Logic: AXPress on the Solo checkbox flips it directly.
+        let channel = makeChannel(f, keyRuntime: key.runtime()) { element, action in
+            if element == solo, action == kAXPressAction as String {
+                f.builder.setAttribute(solo, kAXValueAttribute as String, 1)
+            }
+            return true
+        }
+
+        let result = await channel.execute(operation: "track.set_solo", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["verified"] as? Bool == true)
+        #expect(obj?["action"] as? String == "press")
+        #expect(obj?["button"] as? String == "Solo")
+        #expect(boolValue(f, solo) == true)
+        // ADR-001: solo needs no keyboard and NO coordinate events.
+        // Mutation-check: a re-added mouse rung would populate mouseEvents.
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("success is judged by the read-back, not the AX return code (#106 sites-6/7)")
+    func soloReadbackBeatsReturnCode() async throws {
+        let f = makeToggleFixture()
+        let solo = f.solo[0]
+        let key = KeyMouseRecorder()
+        // The action REPORTS failure (false) yet the control actually moved —
+        // exactly the live #106 sites-6/7 signature. Only a read-back-driven
+        // ladder reaches State A here; a return-code-gated one would State C.
+        let channel = makeChannel(f, keyRuntime: key.runtime()) { element, action in
+            if element == solo, action == kAXPressAction as String {
+                f.builder.setAttribute(solo, kAXValueAttribute as String, 1)
+                return false
+            }
+            return true
+        }
+
+        let result = await channel.execute(operation: "track.set_solo", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "press")
+        #expect(boolValue(f, solo) == true)
+    }
+
+    // MARK: - Mute: select + key 'm'
+
+    @Test("mute: AXPress no-ops, exclusive-select + key 'm' flips → State A keyboard-mute, ZERO mouse")
+    func muteKeyboardActuatorFlipsStateA() async throws {
+        let f = makeToggleFixture()
+        let mute = f.mute[0]
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(mute, kAXValueAttribute as String, 1)
+            }
+        }
+        // Default performAction (nil): AXPress records + returns true but NEVER
+        // flips a checkbox — modelling Logic's no-op mute press.
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "keyboard-mute")
+        #expect(boolValue(f, mute) == true)
+        // The natural-primary AXPress was still tried first (its return ignored)…
+        #expect(f.builder.actionCalls.contains {
+            $0.elementID == f.builder.elementID(mute) && $0.action == kAXPressAction as String
+        })
+        // …and the rung that LANDED it was the 'm' key command, ZERO mouse.
+        #expect(key.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("mute fails closed (State C) when the keyboard rung does not flip — no coordinate fallback")
+    func muteFailsClosedNoCoordinateFallback() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder() // records the key but never flips the value
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        #expect(boolValue(f, f.mute[0]) == false)
+        // The key WAS attempted (selection was exclusive) but nothing flipped —
+        // and CRUCIALLY no coordinate rung ran to "rescue" it.
+        #expect(key.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    // MARK: - Arm: user-assigned "Toggle Track Record Enable" key command
+
+    @Test("arm: exclusive-select + configurable Ctrl+Shift+E chord flips → State A keyboard-arm, ZERO mouse")
+    func armKeyboardActuatorFlipsStateA() async throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        let armCode = AccessibilityChannel.resolvedArmKeyCode()
+        let armFlags = AccessibilityChannel.resolvedArmModifiers()
+        let key = KeyMouseRecorder()
+        // Correct "Toggle Track Record Enable": flips the track's record-enable,
+        // does NOT touch the transport Record checkbox.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(arm, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "keyboard-arm")
+        #expect(obj?["button"] as? String == "Record")
+        #expect(boolValue(f, arm) == true)
+        // The RESOLVED chord (code + modifier flags) was posted, ZERO mouse, and
+        // no bare-key path was used.
+        #expect(key.flaggedKeyEvents.contains { $0.code == armCode && $0.flags == armFlags })
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+        // Honesty: transport did not start recording.
+        #expect(boolValue(f, f.recordCheckbox) == false)
+    }
+
+    @Test("arm fails closed (State C) with the exact 'Toggle Track Record Enable' key-command hint")
+    func armFailClosedWithKeyCommandHint() async throws {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder() // records the chord but never flips arm
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        // Must say EXACTLY the operator-facing key-command guidance.
+        #expect(obj?["hint"] as? String == "arm requires the Logic key command 'Toggle Track Record "
+            + "Enable' assigned to the configured key (default Ctrl+Shift+E); assign it in Logic ▸ Key "
+            + "Commands, or set LOGIC_PRO_MCP_ARM_KEYCODE/_MODIFIERS to your chosen key.")
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("arm honesty: a key that starts transport RECORDING fails closed, never a false arm")
+    func armFailsClosedWhenKeyStartsRecording() async throws {
+        let f = makeToggleFixture()
+        let armCode = AccessibilityChannel.resolvedArmKeyCode()
+        let key = KeyMouseRecorder()
+        // Mis-assigned key = transport Record: it starts recording (control-bar
+        // Record → 1) and does NOT arm the track.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "ax_write_failed")
+        #expect(obj?["recording_started"] as? Bool == true)
+        let hint = obj?["hint"] as? String ?? ""
+        #expect(hint.contains("transport recording"))
+        #expect(hint.contains("Toggle Track Record Enable"))
+        // The arm checkbox was never (falsely) claimed armed.
+        #expect(boolValue(f, f.arm[0]) == false)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    // MARK: - Toggle-from-read + selection guard
+
+    @Test("toggle-from-read: already at desired → verified no-op with ZERO actuation")
+    func toggleFromReadIsVerifiedNoOp() async throws {
+        let f = makeToggleFixture()
+        f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1) // already muted
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "A")
+        #expect(obj?["action"] as? String == "no-op")
+        // No rung ran: no AXPress on the checkbox, no key, no mouse.
+        // Mutation-check: dropping the toggle-from-read short-circuit would fire
+        // the ladder and populate these.
+        #expect(!f.builder.actionCalls.contains {
+            $0.elementID == f.builder.elementID(f.mute[0]) && $0.action == kAXPressAction as String
+        })
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+    }
+
+    @Test("exclusive-selection guard: ambiguous selection blocks the key (no wrong-track toggle)")
+    func exclusiveSelectionGuardBlocksKey() async throws {
+        // Two tracks, BOTH reporting selected. Keyboard mute would act on the
+        // selected track(s) — so with selection non-exclusive the guard MUST
+        // refuse to post the key, and the op fails closed.
+        let f = makeToggleFixture(trackCount: 2, selected: [0, 1])
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            // If the guard were broken and this fired, it would fabricate a flip.
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        // The load-bearing guard assertion: the key was NEVER posted because
+        // selection could not be proven exclusive, so no track was toggled.
+        #expect(key.keyEvents.isEmpty)
+        #expect(key.mouseEvents.isEmpty)
+        #expect(boolValue(f, f.mute[0]) == false)
+    }
+
+    // MARK: - Configurable arm keycode
+
+    @Test("arm chord: default Ctrl+Shift+E (14); keycode + modifiers env-overridable")
+    func armChordResolution() {
+        // Keycode: default 'e' (14), override parsed, bad value falls back.
+        #expect(AccessibilityChannel.defaultArmKeyCode == 14)
+        #expect(AccessibilityChannel.resolvedArmKeyCode(environment: [:]) == 14)
+        #expect(AccessibilityChannel.resolvedArmKeyCode(
+            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "60"]
+        ) == 60)
+        #expect(AccessibilityChannel.resolvedArmKeyCode(
+            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
+        ) == 14)
+
+        // Modifiers: default control+shift when absent.
+        let def = AccessibilityChannel.resolvedArmModifiers(environment: [:])
+        #expect(def.contains(.maskControl))
+        #expect(def.contains(.maskShift))
+        #expect(!def.contains(.maskCommand))
+        #expect(!def.contains(.maskAlternate))
+        #expect(AccessibilityChannel.defaultArmModifiers == def)
+
+        // Override parses the comma list…
+        let ov = AccessibilityChannel.resolvedArmModifiers(
+            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "command, option"]
+        )
+        #expect(ov.contains(.maskCommand))
+        #expect(ov.contains(.maskAlternate))
+        #expect(!ov.contains(.maskControl))
+        // …and an explicit EMPTY var means no modifiers (a bare key).
+        #expect(AccessibilityChannel.resolvedArmModifiers(
+            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]
+        ).isEmpty)
+    }
+}

--- a/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
+++ b/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
@@ -59,7 +59,11 @@ struct CoordFreeTrackToggleTests {
     /// A Logic-12-shaped fake: an AXList("Track Headers") of AXLayoutItem rows,
     /// each carrying Mute/Solo/Record-Enable AXCheckBoxes (value 0) plus an
     /// AXSelected flag. `selected` seeds which rows report AXSelected == true.
-    private func makeToggleFixture(trackCount: Int = 1, selected: Set<Int> = [0]) -> ToggleFixture {
+    private func makeToggleFixture(
+        trackCount: Int = 1,
+        selected: Set<Int> = [0],
+        nilSelected: Set<Int> = []
+    ) -> ToggleFixture {
         let b = FakeAXRuntimeBuilder()
         let app = b.element(9000)
         let window = b.element(9001)
@@ -71,7 +75,7 @@ struct CoordFreeTrackToggleTests {
         b.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
         b.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
         // Control bar with the transport Record checkbox (value 0 = not
-        // recording) so `isTransportRecording` can read it in arm tests.
+        // recording) so `transportRecordingState` can read it in arm tests.
         b.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
         b.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
         b.setChildren(controlBar, [recordCheckbox])
@@ -91,7 +95,11 @@ struct CoordFreeTrackToggleTests {
             let arm = b.element(base + 3)
             b.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
             b.setAttribute(header, kAXTitleAttribute as String, "Track \(i + 1)")
-            b.setAttribute(header, kAXSelectedAttribute as String, selected.contains(i))
+            // `nilSelected` leaves AXSelected UNSET (nil/unreadable) for those rows,
+            // modelling headers that omit the attribute (#5 fail-closed input).
+            if !nilSelected.contains(i) {
+                b.setAttribute(header, kAXSelectedAttribute as String, selected.contains(i))
+            }
             for (control, desc) in [(mute, "Mute"), (solo, "Solo"), (arm, "Record Enable")] {
                 b.setAttribute(control, kAXRoleAttribute as String, kAXCheckBoxRole as String)
                 b.setAttribute(control, kAXDescriptionAttribute as String, desc)
@@ -259,8 +267,10 @@ struct CoordFreeTrackToggleTests {
     func armKeyboardActuatorFlipsStateA() async throws {
         let f = makeToggleFixture()
         let arm = f.arm[0]
-        let armCode = AccessibilityChannel.resolvedArmKeyCode()
-        let armFlags = AccessibilityChannel.resolvedArmModifiers()
+        guard case let .resolved(armCode, armFlags) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve to a valid code + modifier flags")
+            return
+        }
         let key = KeyMouseRecorder()
         // Correct "Toggle Track Record Enable": flips the track's record-enable,
         // does NOT touch the transport Record checkbox.
@@ -308,7 +318,10 @@ struct CoordFreeTrackToggleTests {
     @Test("arm honesty: a key that starts transport RECORDING fails closed, never a false arm")
     func armFailsClosedWhenKeyStartsRecording() async throws {
         let f = makeToggleFixture()
-        let armCode = AccessibilityChannel.resolvedArmKeyCode()
+        guard case let .resolved(armCode, _) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve")
+            return
+        }
         let key = KeyMouseRecorder()
         // Mis-assigned key = transport Record: it starts recording (control-bar
         // Record → 1) and does NOT arm the track.
@@ -386,36 +399,296 @@ struct CoordFreeTrackToggleTests {
 
     // MARK: - Configurable arm keycode
 
-    @Test("arm chord: default Ctrl+Shift+E (14); keycode + modifiers env-overridable")
-    func armChordResolution() {
-        // Keycode: default 'e' (14), override parsed, bad value falls back.
+    // MARK: - #7 configurable arm chord: config errors fail closed, never fall open
+
+    /// Helper: does `resolveArmChord` return `.resolved` satisfying `check`?
+    private func resolvedChord(
+        _ env: [String: String],
+        _ check: (CGKeyCode, CGEventFlags) -> Bool
+    ) -> Bool {
+        if case let .resolved(code, flags) = AccessibilityChannel.resolveArmChord(environment: env) {
+            return check(code, flags)
+        }
+        return false
+    }
+
+    @Test("#7 arm chord resolution: absent→default; valid→parsed; bad keycode / unknown modifier → config error; empty → bare")
+    func armChordResolutionContract() {
         #expect(AccessibilityChannel.defaultArmKeyCode == 14)
-        #expect(AccessibilityChannel.resolvedArmKeyCode(environment: [:]) == 14)
-        #expect(AccessibilityChannel.resolvedArmKeyCode(
-            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "60"]
-        ) == 60)
-        #expect(AccessibilityChannel.resolvedArmKeyCode(
-            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
-        ) == 14)
 
-        // Modifiers: default control+shift when absent.
-        let def = AccessibilityChannel.resolvedArmModifiers(environment: [:])
-        #expect(def.contains(.maskControl))
-        #expect(def.contains(.maskShift))
-        #expect(!def.contains(.maskCommand))
-        #expect(!def.contains(.maskAlternate))
-        #expect(AccessibilityChannel.defaultArmModifiers == def)
+        // Row: ABSENT → default Ctrl+Shift+E (14). Force-unwrapped via closure so
+        // the assertion is live (never a DEAD `optionalBool == true`).
+        #expect(resolvedChord([:]) { code, flags in
+            code == 14 && flags.contains(.maskControl) && flags.contains(.maskShift)
+                && !flags.contains(.maskCommand) && !flags.contains(.maskAlternate)
+        })
+        #expect(AccessibilityChannel.defaultArmModifiers == [.maskControl, .maskShift])
 
-        // Override parses the comma list…
-        let ov = AccessibilityChannel.resolvedArmModifiers(
-            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "command, option"]
+        // Row: present + valid keycode + valid modifier list → parsed.
+        #expect(resolvedChord([
+            "LOGIC_PRO_MCP_ARM_KEYCODE": "60",
+            "LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "command, option"
+        ]) { code, flags in
+            code == 60 && flags.contains(.maskCommand) && flags.contains(.maskAlternate)
+                && !flags.contains(.maskControl)
+        })
+
+        // Row: `ARM_KEYCODE=not-a-number` → INVALID (no silent fallback to 14).
+        #expect({
+            if case .invalidKeyCode = AccessibilityChannel.resolveArmChord(
+                environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
+            ) { return true }
+            return false
+        }())
+
+        // Row: `ARM_KEY_MODIFIERS=controle,shft` (typos) → INVALID (no dropped tokens).
+        #expect({
+            if case .invalidModifierToken = AccessibilityChannel.resolveArmChord(
+                environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": "controle,shft"]
+            ) { return true }
+            return false
+        }())
+
+        // Row: `ARM_KEY_MODIFIERS=` (present-empty) → resolved as a BARE key (no
+        // flags). The arm PATH then refuses this as unsafe (see behavioral test).
+        #expect(resolvedChord(["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]) { _, flags in
+            flags.isEmpty
+        })
+    }
+
+    @Test("#7 arm path fails closed (arm_key_config_invalid) on an unparseable keycode override — key NOT posted")
+    func armRefusesInvalidKeycodeConfig() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
         )
-        #expect(ov.contains(.maskCommand))
-        #expect(ov.contains(.maskAlternate))
-        #expect(!ov.contains(.maskControl))
-        // …and an explicit EMPTY var means no modifiers (a bare key).
-        #expect(AccessibilityChannel.resolvedArmModifiers(
-            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]
-        ).isEmpty)
+        let result = AccessibilityChannel.defaultSetTrackToggle(
+            params: ["index": "0", "enabled": "true"],
+            button: "Record",
+            runtime: logic,
+            keyRuntime: key.runtime(),
+            processRuntime: noopProcessRuntime(),
+            environment: ["LOGIC_PRO_MCP_ARM_KEYCODE": "not-a-number"]
+        )
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "arm_key_config_invalid")
+        // The chord was never posted — a fail-open default would have posted 14.
+        #expect(key.flaggedKeyEvents.isEmpty)
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    @Test("#7 arm path refuses a BARE (no-modifier) key override as unsafe — key NOT posted")
+    func armRefusesBareKeyConfig() {
+        let f = makeToggleFixture()
+        let key = KeyMouseRecorder()
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let result = AccessibilityChannel.defaultSetTrackToggle(
+            params: ["index": "0", "enabled": "true"],
+            button: "Record",
+            runtime: logic,
+            keyRuntime: key.runtime(),
+            processRuntime: noopProcessRuntime(),
+            environment: ["LOGIC_PRO_MCP_ARM_KEY_MODIFIERS": ""]  // present-empty → bare
+        )
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "arm_key_config_invalid")
+        #expect(key.flaggedKeyEvents.isEmpty)
+        #expect(key.keyEvents.isEmpty)
+    }
+
+    // MARK: - #3 double-toggle halt barrier
+
+    @Test("#3 halt barrier: rung-1 flips but its poll misses ⇒ rung-2 is NOT fired, result State A (no toggle-back)")
+    func haltBarrierStopsSecondRungAfterLatePress() {
+        // Scripted read-back: the barrier BEFORE the press reads 0 (proceed); the
+        // press's poll MISSES (injected false); then — modelling an AXValue that
+        // published only after the press poll window — the barrier BEFORE the
+        // keyboard rung reads 1 (== desired) and HALTS. A ladder without the
+        // barrier would advance and fire (toggle back) the keyboard rung.
+        var pressFired = false
+        var keyboardFired = false
+        let press: AccessibilityChannel.TrackToggleRung = ("press", 250, {
+            pressFired = true
+            return .actuated
+        })
+        let keyboard: AccessibilityChannel.TrackToggleRung = ("keyboard-mute", 600, {
+            keyboardFired = true
+            return .actuated
+        })
+        let reads: [Bool?] = [false, true]  // barrier-before-press, barrier-before-keyboard
+        var idx = 0
+        let outcome = AccessibilityChannel.runTrackToggleLadder(
+            rungs: [press, keyboard],
+            desired: true,
+            readValue: {
+                defer { idx += 1 }
+                return reads[min(idx, reads.count - 1)]
+            },
+            pollMatched: { _ in false }  // press poll MISSES
+        )
+
+        #expect(pressFired)
+        #expect(!keyboardFired)  // ← load-bearing: barrier halted before rung-2
+        #expect({
+            if case .landed(let action) = outcome { return action == "press" }
+            return false
+        }())
+    }
+
+    // MARK: - #5 nil AXSelected is not proof of "unselected"
+
+    @Test("#5 exclusive-select confirm: a non-target header with nil/unreadable AXSelected ⇒ NOT exclusive (fail closed)")
+    func nonTargetNilSelectedIsNotExclusive() {
+        // Target (0) selected; header 1 omits AXSelected entirely (nil). We cannot
+        // PROVE header 1 is unselected, so exclusivity is unproven → refuse.
+        let f = makeToggleFixture(trackCount: 2, selected: [0], nilSelected: [1])
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let exclusive = AccessibilityChannel.confirmExclusiveSelection(
+            index: 0, runtime: logic, processRuntime: noopProcessRuntime()
+        )
+        #expect(!exclusive)
+    }
+
+    // MARK: - #4 select→key TOCTOU
+
+    /// Marks a second header selected on the Nth AXPress of a watched header —
+    /// modelling a concurrent multi-select that appears between the first exclusive
+    /// confirm and the atomic re-confirm right before the key post.
+    private final class HeaderPressFlip: @unchecked Sendable {
+        let builder: FakeAXRuntimeBuilder
+        let watch: AXUIElement
+        let onNthPress: Int
+        let select: AXUIElement
+        var presses = 0
+        init(builder: FakeAXRuntimeBuilder, watch: AXUIElement, onNthPress: Int, select: AXUIElement) {
+            self.builder = builder
+            self.watch = watch
+            self.onNthPress = onNthPress
+            self.select = select
+        }
+        func handler(_ element: AXUIElement, _ action: String) -> Bool {
+            if action == (kAXPressAction as String), element == watch {
+                presses += 1
+                if presses == onNthPress {
+                    builder.setAttribute(select, kAXSelectedAttribute as String, true)
+                }
+            }
+            return true
+        }
+    }
+
+    @Test("#4 select→key TOCTOU: selection lost between confirm and post ⇒ fail closed, key NOT posted")
+    func selectionLostBeforeKeyFailsClosed() async throws {
+        let f = makeToggleFixture(trackCount: 2, selected: [0])  // header 1 starts unselected
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        // The keyboard rung re-confirms exclusivity IMMEDIATELY before the key. The
+        // SECOND confirm's own selectTrackViaAX presses header 0 (press #2 overall),
+        // and at that instant header 1 becomes selected too — so the re-check sees a
+        // non-exclusive selection and must refuse without posting.
+        let flip = HeaderPressFlip(builder: f.builder, watch: f.headers[0], onNthPress: 2, select: f.headers[1])
+        let channel = makeChannel(f, keyRuntime: key.runtime(), performAction: { flip.handler($0, $1) })
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "selection_not_exclusive")
+        // Load-bearing: the TOCTOU re-check caught the change → key NEVER posted.
+        #expect(key.keyEvents.isEmpty)
+        #expect(!boolValue(f, f.mute[0])!)  // live force-unwrap (fixture always sets 0/1)
+    }
+
+    // MARK: - #6 keyboard-focus gate
+
+    @Test("#6 focus gate: a focused editable text field ⇒ mute refuses the synthetic key (unsafe_focus_for_synthetic_key)")
+    func muteRefusesWhenFocusIsEditableText() async throws {
+        let f = makeToggleFixture()
+        // Focus is on a rename/search text field — a synthetic 'm' would type text.
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+        let key = KeyMouseRecorder()
+        key.onKeyEvent = { code in
+            if code == AccessibilityChannel.trackMuteKeyCode {
+                f.builder.setAttribute(f.mute[0], kAXValueAttribute as String, 1)
+            }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_mute", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(key.keyEvents.isEmpty)  // key NEVER posted
+        #expect(!boolValue(f, f.mute[0])!)
+    }
+
+    @Test("#6 focus gate: a focused editable text field ⇒ arm refuses the synthetic chord")
+    func armRefusesWhenFocusIsEditableText() async throws {
+        let f = makeToggleFixture()
+        let textField = f.builder.element(9500)
+        f.builder.setAttribute(textField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        f.builder.setAttribute(f.app, kAXFocusedUIElementAttribute as String, textField)
+        let key = KeyMouseRecorder()
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "unsafe_focus_for_synthetic_key")
+        #expect(key.flaggedKeyEvents.isEmpty)  // chord NEVER posted
+        #expect(!boolValue(f, f.arm[0])!)
+    }
+
+    // MARK: - #2 transport unreadable ⇒ arm fails closed (never State A while maybe recording)
+
+    @Test("#2 arm honesty: transport Record UNREADABLE at post-actuate ⇒ transport_state_unknown, not State A")
+    func armFailsClosedWhenTransportUnreadable() async throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        guard case let .resolved(armCode, _) = AccessibilityChannel.resolveArmChord() else {
+            Issue.record("default arm chord must resolve")
+            return
+        }
+        // Make the control-bar Record checkbox UNREADABLE (a non-numeric AXValue →
+        // readControlBarCheckboxValue returns nil), so transport state is unknown.
+        f.builder.setAttribute(f.recordCheckbox, kAXValueAttribute as String, "unreadable")
+        let key = KeyMouseRecorder()
+        // The arm key genuinely flips the record-enable checkbox — but with the
+        // transport state unreadable we still cannot honestly claim a clean arm.
+        key.onFlaggedKey = { code, _ in
+            if code == armCode { f.builder.setAttribute(arm, kAXValueAttribute as String, 1) }
+        }
+        let channel = makeChannel(f, keyRuntime: key.runtime())
+
+        let result = await channel.execute(operation: "track.set_arm", params: ["index": "0", "enabled": "true"])
+
+        #expect(!result.isSuccess)
+        let obj = object(result.message)
+        #expect(obj?["state"] as? String == "C")
+        #expect(obj?["error"] as? String == "transport_state_unknown")
+        // The checkbox DID flip, yet arm is NOT claimed as State A (success:false
+        // + State C error above prove it was never a verified clean arm).
+        #expect(boolValue(f, arm)!)
+        #expect(key.mouseEvents.isEmpty)
     }
 }

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -36,10 +36,14 @@ struct HCGlobalInvariantTests {
         "logic_project.export_resume",
         "logic_project.launch",
         "logic_project.quit",
+        // Consent-gated one-time Key-Commands GUI drive: without consent it fails
+        // closed to a bare State C (no `verified`), and reaching State A/B needs
+        // consent + real Logic, so it cannot be HC-JSON route-checked headlessly.
+        "logic_system.setup_arm_key",
     ]
 
     // Ratchet: this may only shrink as live-only / legacy non-HC routes become headlessly HC-checkable.
-    private static let hcInvariantAllowlistMaxCount = 6
+    private static let hcInvariantAllowlistMaxCount = 7
 
     private static func makeLogicProjectPath(name: String = UUID().uuidString, create: Bool) throws -> String {
         let path = FileManager.default.temporaryDirectory
@@ -388,6 +392,7 @@ struct HCGlobalInvariantTests {
             "logic_project.export_resume",
             "logic_project.launch",
             "logic_project.quit",
+            "logic_system.setup_arm_key",
         ]))
     }
 

--- a/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
+++ b/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
@@ -779,7 +779,7 @@ struct LPMCPPRD001ProductionReadinessREDTests {
     /// Aggregate production-readiness bar. Two debts remain OPEN and honestly
     /// tracked until reality changes — R-PUB (release assets are owner-replaceable;
     /// no immutable/transparency publication exists — the asset list used to
-    /// self-attest this closed) and R-SEM (semantic coverage is 1/107 until the
+    /// self-attest this closed) and R-SEM (semantic coverage is 1/108 until the
     /// coverage program lands). R-MATRIX is CLOSED: the managed desktop x {en-US,
     /// ko-KR} fixtures now exist as SHA-bound content under `Fixtures/qualification`
     /// (see `managedFixtureManifestSHAsBindActualContent` and

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -142,6 +142,7 @@ struct OperationCatalogTests {
         .systemSagaExecute: ["idempotency_key", "steps"],
         .systemSagaStatus: ["idempotency_key"],
         .systemSagaCancel: ["idempotency_key"],
+        .systemSetupArmKey: ["consent"],
         .pluginsGetInventory: ["track_index"],
         .pluginsSetParamVerified: [
             "insert", "mode", "param", "plugin", "plugin_id", "plugin_name",
@@ -391,7 +392,7 @@ struct OperationCatalogTests {
                     ("get_trace", "system.get_trace", ["trace_id"], .none),
                     ("clear_traces", "system.clear_traces", ["confirmed"], .l2),
                 ]
-                #expect(OperationRegistry.specs.count == 107)
+                #expect(OperationRegistry.specs.count == 108)
                 for (command, operationID, allowedParams, confirmation) in expectedSpecs {
                     let spec = OperationRegistry.spec(tool: "logic_system", command: command)
                     #expect(spec?.id.rawValue == operationID, "\(command) must have one public spec")
@@ -694,7 +695,7 @@ struct OperationCatalogTests {
 
     @Test("strict: every registered operation rejects unknown keys and accepts its pinned keys")
     func strictRegistryWideInvariant() throws {
-        #expect(OperationRegistry.specs.count == 107)
+        #expect(OperationRegistry.specs.count == 108)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
 
         for spec in OperationRegistry.specs {
@@ -861,7 +862,7 @@ struct OperationCatalogTests {
         #expect(sharedToolText(trackRejected).contains("port parameter not supported for record_sequence"))
     }
 
-    @Test("catalog: exact URI reads the generated 107-operation catalog")
+    @Test("catalog: exact URI reads the generated 108-operation catalog")
     func catalogReadsRegistryProjection() async throws {
         let result = try await ResourceHandlers.read(
             uri: Self.uri,
@@ -874,7 +875,7 @@ struct OperationCatalogTests {
         #expect(body["generated_at"] as? String != nil)
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
-        #expect(operations.count == 107)
+        #expect(operations.count == 108)
         #expect(text.contains("\n") == false)
 
         let ids = operations.compactMap { $0["id"] as? String }

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -142,7 +142,7 @@ struct OperationHandlerBindingTests {
         let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
         let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
 
-        #expect(specs.count == 107)
+        #expect(specs.count == 108)
         #expect(bindings.count == specs.count)
         #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
         #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 107)
+        #expect(OperationRegistry.specs.count == 108)
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -85,10 +85,12 @@ struct OperationRegistryCoverageTests {
             .tracksSetInstrument,
         ]
 
-        #expect(mutating.count == 86)
+        #expect(mutating.count == 87)
         #expect(readOnly.count == 21)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
-        #expect(targetless.count == 72)
+        // setup_arm_key is a targetless mutating config utility (assigns a Logic
+        // key command; no track/target to mis-bind) → targetless, not target-bearing.
+        #expect(targetless.count == 73)
         #expect(targetBearingIDs.count + targetless.count == mutating.count)
         #expect(readOnly.allSatisfy { $0.target == .none })
     }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -50,7 +50,7 @@ struct OperationRegistryTests {
         "delete_marker": .requiresKeyBinding,
     ]
 
-    private static let smallToolCount = 16
+    private static let smallToolCount = 17
     private static let expectedRegistryCount =
         commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
             + editCommands.count + projectCommands.count + midiCommands.count + trackCommands.count
@@ -362,6 +362,7 @@ struct OperationRegistryTests {
         ("logic_system", "system.saga_execute", "saga_execute", .mutating, .long, .readbackRequired),
         ("logic_system", "system.saga_status", "saga_status", .readOnly, .short, .none),
         ("logic_system", "system.saga_cancel", "saga_cancel", .mutating, .short, .readbackRequired),
+        ("logic_system", "system.setup_arm_key", "setup_arm_key", .mutating, .long, .readbackRequired),
         ("logic_plugins", "plugins.get_inventory", "get_inventory", .readOnly, .short, .none),
         ("logic_plugins", "plugins.set_param_verified", "set_param_verified", .mutating, .medium, .readbackRequired),
         ("logic_plugins", "plugins.insert_verified", "insert_verified", .mutating, .medium, .readbackRequired),

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -186,8 +186,8 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 107)
-        #expect(mutatingSpecs.count == 86)
+        #expect(OperationRegistry.specs.count == 108)
+        #expect(mutatingSpecs.count == 87)
 
         for spec in mutatingSpecs {
             await OperationTraceStore.shared.clear()
@@ -287,9 +287,9 @@ extension OperationTraceTests {
 
         let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
-        #expect(OperationRegistry.specs.count == 107)
+        #expect(OperationRegistry.specs.count == 108)
         #expect(readOnlySpecs.count == 21)
-        // Mutability is total: the mutating census (86) and this inverse gate
+        // Mutability is total: the mutating census (87) and this inverse gate
         // (21) together account for every registered spec, so a new operation
         // cannot land outside both gates.
         #expect(readOnlySpecs.count + mutatingSpecs.count == OperationRegistry.specs.count)

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -56,12 +56,13 @@ struct QualificationRunnerTests {
         // recorded protocolSmoke ("transport worked, nobody checked meaning").
         // Now every read-only spec has an oracle, so a read that returns its
         // real payload qualifies: passed == 21 (20 oracles + health's bespoke
-        // validator), protocolSmoke == 0. The 86 mutating ops are unchanged —
-        // they still defer to ADR-001-c for live mutation.
-        #expect(operationCases.count == 107)
+        // validator), protocolSmoke == 0. The 87 mutating ops (incl. the new
+        // setup_arm_key config utility) are typed deferrals — they claim NO
+        // semantic coverage and still defer to ADR-001-c for live mutation.
+        #expect(operationCases.count == 108)
         #expect(operationCases.filter { $0.status == .passed }.count == 21)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 86)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
         #expect(operationCases.filter { $0.status == .passed }.allSatisfy {
             $0.verificationKind == .semanticReadback
@@ -212,11 +213,11 @@ struct QualificationRunnerTests {
         #expect(Self.rejectionReasons(try Self.resultObject(decision)).contains("requiredCaseFailed"))
     }
 
-    @Test func zeroOf107QualifiedOperationsRejectsPromotion() async throws {
+    @Test func zeroOf108QualifiedOperationsRejectsPromotion() async throws {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 0)
         #expect(driveResult.operationResults.values.filter { $0.status == .passed }.isEmpty)
-        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 107)
+        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 108)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -233,11 +234,11 @@ struct QualificationRunnerTests {
         ))
     }
 
-    @Test func thirteenLegacyTransportSuccessesAndNinetyFourDeferralsRejectPromotion() async throws {
+    @Test func thirteenLegacyTransportSuccessesAndNinetyFiveDeferralsRejectPromotion() async throws {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 13)
         #expect(driveResult.operationResults.values.filter { $0.isError == false }.count == 13)
-        #expect(driveResult.operationResults.values.filter { $0.isError == true }.count == 94)
+        #expect(driveResult.operationResults.values.filter { $0.isError == true }.count == 95)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -1126,7 +1127,7 @@ struct QualificationRunnerTests {
         ))
 
         #expect(result.handshakeOK)
-        #expect(result.catalog?.operationCount == 107)
+        #expect(result.catalog?.operationCount == 108)
         #expect(result.catalogCountMatch)
         #expect(result.traceOK)
 
@@ -1138,7 +1139,7 @@ struct QualificationRunnerTests {
         let smoke = operationResults.filter { $0.status == .protocolSmoke }
 
         #expect(operationResults.count == OperationRegistry.specs.count)
-        #expect(mutating.count == 86)
+        #expect(mutating.count == 87)
         #expect(readOnly.count == 21)
         #expect(operationResults.allSatisfy { $0.status != .failed })
         #expect(operationResults.allSatisfy { $0.responseData != nil && $0.readback != nil })
@@ -1535,7 +1536,7 @@ struct QualificationRunnerTests {
         // #373 Phase A: the read-only surface now qualifies semantically.
         #expect(operationCases.filter { $0.status == .passed }.count == 21)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 86)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
         // #373 Phase A: 20 oracled read-only ops + system.health's bespoke
         // validator. The aggregate axes contribute no passes here.
         #expect(attestation.passed == 21)

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -523,11 +523,12 @@ enum SemanticOracleFixtures {
             readback: "{}"
         ),
         // AccessibilityChannel+Tracks.defaultSetTrackToggle (Mute): requested==observed bool.
+        // Mute's coordinate-free primary is exclusive-select + key 'm' (#106).
         .tracksMute: SemanticOracleFixture(
             response: """
                 {"success":true,"verified":true,"state":"A","track":1,\
                 "button":"Mute","requested":true,"verification_source":"ax_value",\
-                "observed":true,"action":"press"}
+                "observed":true,"action":"keyboard-mute"}
                 """,
             readback: "{}"
         ),
@@ -539,11 +540,13 @@ enum SemanticOracleFixtures {
                 """,
             readback: "{}"
         ),
+        // Arm's coordinate-free path is exclusive-select + a user-assigned
+        // "Toggle Track Record Enable" key command (#106; 'r' is transport Record).
         .tracksArm: SemanticOracleFixture(
             response: """
                 {"success":true,"verified":true,"state":"A","track":1,\
                 "button":"Record","requested":true,"verification_source":"ax_value",\
-                "observed":true,"action":"mouse-click"}
+                "observed":true,"action":"keyboard-arm"}
                 """,
             readback: "{}"
         ),


### PR DESCRIPTION
## Consent-based server automation of the coordinate-free arm key command (`system.setup_arm_key`)

**Stacked on the actuator PR (#407)** — this is the arm key-command auto-setup only. Review after the actuator merges.

### Why
The track-header Record-Enable AXPress is a live no-op on Logic 12.3, the value isn't settable, and no menu item record-enables a track — so the **only** coordinate-free way to arm is Logic's "Toggle Track Record Enable" key command, which ships unassigned (Logic 12.2+ blocks programmatic key-command import). This op assigns it through the Key Commands GUI entirely coordinate-free, with mandatory consent.

### Flow (all keyboard/AX, zero mouse)
Option+K opens Key Commands → **type** the command name into the search field (typed keystrokes trigger Logic's filter; a bare AXValue write does not, leaving a ~26s outline walk) → select the command row (read back) → drive "Learn by Key Label" **AXCheckBox** to ON (read back) → send the chord → close via **AXPress on the close button** (never a second Option+K, which types into the search field) → re-focus Logic + settle → **self-verify by driving a real record-arm and confirming the observed flip**. Every step judged by a polled observed effect, never an AX return code. Fails closed with a manual-fallback hint at any step.

### Honesty / hardening (adversarial review closed)
- Learn's observed ON state **gates** the chord (never bind to nothing).
- Learn is ensure-ON (read prior, press only if off, restore).
- State B says "steps ran; assignment UNPROVEN", never "assigned".
- Command-row selection, Learn ON, and window-close are all read back.
- Keystroke focus proven (strong activation + observed `logicIsFrontmost`).
- `armSetupVerify` restores the prior track selection + verifies the arm restore.
- **Consent is mandatory** — no action without `consent:"true"` (never modify Logic config silently).

### ADR-001 classification (no regression)
`setup_arm_key` is a mutating CONFIG/SETUP utility = a **typed, explicitly NOT-oracled deferral** (the `export_support_bundle` pattern). It makes **no** semantic-coverage claim (semantic-passed count unchanged at 21); it flows as a `notQualified` live-mutation deferral. ADR-001 contracts/runner untouched — **zero R-SEM regression**; the release stays fail-closed as before.

### Evidence
- Full suite: **3046 tests green** (`swift test --no-parallel`), 0 non-skipped failures.
- Live-verified on Logic 12.3: `consent` missing → State C `consent_required`; `consent:"true"` → **State A, verified=True in 8.0s** ("assigned and confirmed by a live record-arm flip"); Key Commands window closed cleanly; tracks readable; arm restored.
