### PR TITLE
fix(qualification): #399 — exclude fault-injection seam from release binaries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,18 @@ let package = Package(
                 "LogicProMCP",
                 .product(name: "Testing", package: "swift-testing"),
             ],
-            path: "Tests/LogicProMCPTests"
+            path: "Tests/LogicProMCPTests",
+            swiftSettings: [
+                // #399 (CEO audit P0) — mirror the LogicProMCP target's
+                // configuration-scoped define on the test target. `#if
+                // QUALIFICATION_FAULT_SEAM` test code then aligns with the module
+                // under test: the seam tests compile and run in the debug build
+                // (where the module HAS the seam symbols) and are compiled out of a
+                // `-c release` test build (where the module has NONE), so the
+                // release-config test target references no excluded symbols and
+                // builds clean.
+                .define("QUALIFICATION_FAULT_SEAM", .when(configuration: .debug)),
+            ]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,14 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk"),
             ],
             path: "Sources/LogicProMCP",
+            swiftSettings: [
+                // #399 (CEO audit P0) — the qualification fault-injection seam is
+                // a TEST affordance, never a shipped feature. Compiling it only in
+                // debug guarantees a release binary contains no
+                // `LOGIC_PRO_MCP_FAULT_INJECT` string and no code path that acts on
+                // it, so its ordinary process environment cannot activate a fault.
+                .define("QUALIFICATION_FAULT_SEAM", .when(configuration: .debug)),
+            ],
             linkerSettings: [
                 .linkedFramework("CoreMIDI"),
                 .linkedFramework("ApplicationServices"),

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -571,6 +571,12 @@ struct SystemDispatcher: OperationTraceDispatching {
                 defer {
                     if let mutationClaim { mutationGate?.release(mutationClaim) }
                 }
+                // ADR-004 / issue #287 — qualification-only fault seam. #399 (CEO
+                // audit P0): the seam and its wiring are compiled solely in debug
+                // via `QUALIFICATION_FAULT_SEAM`. The release executor is
+                // constructed with no seam, so `LOGIC_PRO_MCP_FAULT_INJECT` in the
+                // process environment cannot engage any fault here.
+                #if QUALIFICATION_FAULT_SEAM
                 let executor = ProductionSagaStepExecutor(
                     router: router,
                     cache: cache,
@@ -579,15 +585,22 @@ struct SystemDispatcher: OperationTraceDispatching {
                     liveReadback: sagaLiveReadback ?? .unavailable,
                     liveTrackName: liveTrackName,
                     liveTrackNames: liveTrackNames,
-                    // ADR-004 / issue #287 — qualification-only fault seam. nil
-                    // in normal operation; engages only when the operator sets
-                    // LOGIC_PRO_MCP_FAULT_INJECT=partial_state to qualify real
-                    // reverse-order compensation. Never a product code path.
                     faultSeam: SagaPartialStateFaultSeam.resolve(
                         environment: ProcessInfo.processInfo.environment,
                         stepCount: plan.steps.count
                     )
                 )
+                #else
+                let executor = ProductionSagaStepExecutor(
+                    router: router,
+                    cache: cache,
+                    targetRegistry: targetRegistry,
+                    dialogPresent: dialogPresent,
+                    liveReadback: sagaLiveReadback ?? .unavailable,
+                    liveTrackName: liveTrackName,
+                    liveTrackNames: liveTrackNames
+                )
+                #endif
                 let saga = MutationSaga(
                     targetRegistry: targetRegistry,
                     routeAvailable: Self.sagaRouteProbe(router: router)

--- a/Sources/LogicProMCP/Qualification/QualificationFaultInjection.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationFaultInjection.swift
@@ -1,3 +1,8 @@
+// #399 (CEO audit P0) — QUALIFICATION-ONLY. Compiled solely in debug via the
+// `QUALIFICATION_FAULT_SEAM` define (see Package.swift). A release binary
+// therefore holds no `LOGIC_PRO_MCP_FAULT_INJECT` string and no code that parses
+// it, so the ordinary process environment can never activate a fault.
+#if QUALIFICATION_FAULT_SEAM
 struct QualificationFaultInjection: Equatable, Sendable {
     static let environmentKey = "LOGIC_PRO_MCP_FAULT_INJECT"
 
@@ -16,3 +21,4 @@ struct QualificationFaultInjection: Equatable, Sendable {
         self.mode = mode
     }
 }
+#endif

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -496,7 +496,15 @@ struct QualificationTransport: Sendable {
     }
 
     func drive(_ request: QualificationDriveRequest) throws -> QualificationDriveResult {
-        let faultInjection = QualificationFaultInjection(environment: request.environment)
+        // #399 (CEO audit P0) — the fault-injection probe timeout only applies in
+        // debug, where the seam exists. A release build has no
+        // `QualificationFaultInjection`, so `faultActive` is a constant false and
+        // the probe uses its normal request timeout.
+        #if QUALIFICATION_FAULT_SEAM
+        let faultActive = QualificationFaultInjection(environment: request.environment) != nil
+        #else
+        let faultActive = false
+        #endif
         let session = QualificationSubprocessSession(
             request: request,
             requestTimeout: requestTimeout,
@@ -551,12 +559,15 @@ struct QualificationTransport: Sendable {
                         let responseID = nextID
                         nextID += 1
                         responseRequestID = String(responseID)
+                        let probeTimeout: TimeInterval? = faultActive && spec.id == .transportPlay
+                            ? spec.deadline.seconds + 5
+                            : nil
                         response = try operation(
                             session,
                             id: responseID,
                             spec: spec,
                             traceID: traceSummary.traceID,
-                            faultInjection: faultInjection
+                            timeout: probeTimeout
                         )
                     }
                 } catch {
@@ -818,7 +829,7 @@ struct QualificationTransport: Sendable {
         id: Int,
         spec: OperationSpec,
         traceID: String,
-        faultInjection: QualificationFaultInjection?
+        timeout: TimeInterval? = nil
     ) throws -> (text: String, isError: Bool) {
         let result: ToolCallResult = try session.request(
             id: id,
@@ -831,9 +842,7 @@ struct QualificationTransport: Sendable {
                 ],
             ],
             phase: "operation_probe.\(spec.id.rawValue)",
-            timeout: faultInjection != nil && spec.id == .transportPlay
-                ? spec.deadline.seconds + 5
-                : nil
+            timeout: timeout
         )
         return (
             try result.text(phase: "operation_probe.\(spec.id.rawValue)"),

--- a/Sources/LogicProMCP/Saga/SagaExecution.swift
+++ b/Sources/LogicProMCP/Saga/SagaExecution.swift
@@ -97,6 +97,11 @@ extension SagaLiveReadback {
 /// Mirrors `QualificationFaultInjection(environment:)`'s nil-unless-set contract
 /// exactly: same env key, same `partial_state` mode. Only that mode engages the
 /// saga — `.timeout` belongs to the transport probe and leaves the saga inert.
+///
+/// #399 (CEO audit P0) — compiled solely in debug via `QUALIFICATION_FAULT_SEAM`
+/// (see Package.swift), so the release binary carries neither this seam nor its
+/// env-key strings.
+#if QUALIFICATION_FAULT_SEAM
 final class SagaPartialStateFaultSeam: @unchecked Sendable {
     /// Optional operator override pinning WHICH forward step fails. Zero-based;
     /// an absent, unparseable, or out-of-range value falls back to the LAST
@@ -154,6 +159,7 @@ final class SagaPartialStateFaultSeam: @unchecked Sendable {
         )
     }
 }
+#endif
 
 struct ProductionSagaStepExecutor: SagaStepExecutor {
     private static let allowlist: Set<OperationID> = [
@@ -191,6 +197,11 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
     /// operation (env unset); non-nil ONLY when the operator explicitly set
     /// `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` to qualify compensation. A
     /// test affordance, never a product code path — see SagaPartialStateFaultSeam.
+    ///
+    /// #399 (CEO audit P0) — the seam property, its init parameter, and the
+    /// branch that consults it are compiled solely in debug via
+    /// `QUALIFICATION_FAULT_SEAM`. The release executor has no seam at all.
+    #if QUALIFICATION_FAULT_SEAM
     private let faultSeam: SagaPartialStateFaultSeam?
 
     init(
@@ -214,6 +225,27 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
         self.now = now
         self.faultSeam = faultSeam
     }
+    #else
+    init(
+        router: ChannelRouter,
+        cache: StateCache,
+        targetRegistry: TargetRegistry,
+        dialogPresent: @escaping @Sendable () -> Bool,
+        liveReadback: SagaLiveReadback,
+        liveTrackName: (@Sendable (Int) -> String?)? = nil,
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.router = router
+        self.cache = cache
+        self.targetRegistry = targetRegistry
+        self.dialogPresent = dialogPresent
+        self.liveReadback = liveReadback
+        self.liveTrackName = liveTrackName
+        self.liveTrackNames = liveTrackNames
+        self.now = now
+    }
+    #endif
 
     func run(_ step: SagaStep) async -> StepResult {
         // ADR-004 / issue #287 — QUALIFICATION-ONLY fault seam. Completely dead
@@ -223,9 +255,11 @@ struct ProductionSagaStepExecutor: SagaStepExecutor {
         // engaged for the injected step it returns State C BEFORE any dispatch —
         // no trace scope, no write, no mutation — so earlier steps' real
         // compensation can be exercised. Never a product code path.
+        #if QUALIFICATION_FAULT_SEAM
         if let faultSeam, let injected = faultSeam.injectionResult(for: step) {
             return injected
         }
+        #endif
         // ADR-005: each saga step dispatch gets a NESTED trace context
         // carrying the parent saga trace ID — without it a child's trace
         // start would clobber the parent's registration in the shared box,

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -434,6 +434,13 @@ actor LogicProServer {
                     return invalidParams
                 }
                 let cmdParams: [String: Value] = rawCmdParams?.objectValue ?? [:]
+                // #399 (CEO audit P0) — the transport fault-injection probe is a
+                // qualification-only affordance compiled solely in debug via
+                // `QUALIFICATION_FAULT_SEAM`. In a release binary this block does
+                // not exist: `__adr001b_no_write_probe` on transport.play falls
+                // straight through to normal strict-param handling, so
+                // `LOGIC_PRO_MCP_FAULT_INJECT` in the environment engages nothing.
+                #if QUALIFICATION_FAULT_SEAM
                 if cmdParams["__adr001b_no_write_probe"]?.boolValue == true,
                    OperationRegistry.spec(tool: name, command: command)?.id == .transportPlay,
                    let injection = QualificationFaultInjection(
@@ -453,6 +460,7 @@ actor LogicProServer {
                         )
                     }
                 }
+                #endif
                 if let invalidParams = Self.strictParamValidationResult(
                     tool: name,
                     command: command,

--- a/Tests/LogicProMCPTests/QualificationFaultInjectionTests.swift
+++ b/Tests/LogicProMCPTests/QualificationFaultInjectionTests.swift
@@ -2,44 +2,105 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
-@Suite("Qualification M4 fault injection")
+/// #399 (CEO audit P0) — the qualification fault-injection seam is a debug-only
+/// TEST affordance, never a shipped feature. A release binary must contain
+/// neither the `LOGIC_PRO_MCP_FAULT_INJECT` string nor any code path that acts on
+/// it, so its ordinary process environment cannot activate a fault. These tests
+/// pin both the debug seam contract and the release exclusion.
+///
+/// The `swift test` build compiles the LogicProMCP module in debug (with
+/// `QUALIFICATION_FAULT_SEAM`), so `QualificationFaultInjection` is present here;
+/// the release-binary probes drive the separately built `-c release` executable,
+/// which has it compiled out.
+@Suite("Qualification fault seam — release exclusion (#399)")
 struct QualificationFaultInjectionTests {
-    @Test func injectionIsOffUnlessDocumentedModeIsExplicit() {
+    /// TEST (C) — debug seam contract. `QualificationFaultInjection` returns
+    /// non-nil ONLY for the exact documented modes; every other value is nil.
+    @Test func injectionResolvesOnlyDocumentedModes() throws {
         #expect(QualificationFaultInjection(environment: [:]) == nil)
         #expect(QualificationFaultInjection(environment: [
             QualificationFaultInjection.environmentKey: "unknown",
         ]) == nil)
-        #expect(QualificationFaultInjection(environment: [
+        let timeout = try #require(QualificationFaultInjection(environment: [
             QualificationFaultInjection.environmentKey: "timeout",
-        ])?.mode == .timeout)
-        #expect(QualificationFaultInjection(environment: [
+        ]))
+        #expect(timeout.mode == .timeout)
+        let partial = try #require(QualificationFaultInjection(environment: [
             QualificationFaultInjection.environmentKey: "partial_state",
-        ])?.mode == .partialState)
+        ]))
+        #expect(partial.mode == .partialState)
     }
 
+    /// TEST (A) — dead-string scan. The release binary must not contain the fault
+    /// env-key bytes anywhere. RED before #399 (the string was present); GREEN
+    /// after the compile-time exclusion. No shelling to `strings`.
     @Test(.enabled(
         if: FileManager.default.isExecutableFile(atPath: Self.releaseExecutableURL.path),
-        "Requires `swift build -c release` before running the real-server fault probe."
+        "Requires `swift build -c release` before scanning the release binary."
     ))
-    func timeoutIsObservedFromRealServerResponse() throws {
-        try assertRealServerFault(mode: .timeout, expectedError: "operation_timeout")
+    func releaseBinaryContainsNoFaultInjectionEnvString() throws {
+        let data = try Data(contentsOf: Self.releaseExecutableURL, options: .mappedIfSafe)
+        let needle = Data("LOGIC_PRO_MCP_FAULT_INJECT".utf8)
+        #expect(data.range(of: needle) == nil)
     }
 
+    /// TEST (B) — release behavior. Launching the release binary with the fault
+    /// env set must yield behavior identical to the unset-env run: the
+    /// transport.play no-write probe is the normal typed zero-write refusal, never
+    /// the injected fault. RED before #399 (`partial_state` → readback_unavailable);
+    /// GREEN after.
     @Test(.enabled(
         if: FileManager.default.isExecutableFile(atPath: Self.releaseExecutableURL.path),
-        "Requires `swift build -c release` before running the real-server fault probe."
+        "Requires `swift build -c release` before the release fault-exclusion probe."
     ))
-    func partialStateIsObservedFromRealServerResponse() throws {
-        try assertRealServerFault(mode: .partialState, expectedError: "readback_unavailable")
+    func releaseBinaryIgnoresPartialStateFaultEnv() throws {
+        let baseline = try driveTransportPlayProbe(faultEnv: [:])
+        let withFault = try driveTransportPlayProbe(faultEnv: [
+            "LOGIC_PRO_MCP_FAULT_INJECT": "partial_state",
+            "LOGIC_PRO_MCP_FAULT_INJECT_STEP": "0",
+        ])
+        #expect(withFault.error != "readback_unavailable")
+        try assertNormalZeroWriteRefusal(baseline)
+        try assertNormalZeroWriteRefusal(withFault)
     }
 
-    private func assertRealServerFault(
-        mode: QualificationFaultInjection.Mode,
-        expectedError: String
+    /// TEST (B), timeout mode. The `timeout` fault (a 60s sleep in debug) must be
+    /// absent from release: the probe returns the normal refusal promptly, never
+    /// `operation_timeout`. RED before #399; GREEN after.
+    @Test(.enabled(
+        if: FileManager.default.isExecutableFile(atPath: Self.releaseExecutableURL.path),
+        "Requires `swift build -c release` before the release fault-exclusion probe."
+    ))
+    func releaseBinaryIgnoresTimeoutFaultEnv() throws {
+        let baseline = try driveTransportPlayProbe(faultEnv: [:])
+        let withFault = try driveTransportPlayProbe(faultEnv: [
+            "LOGIC_PRO_MCP_FAULT_INJECT": "timeout",
+        ])
+        #expect(withFault.error != "operation_timeout")
+        try assertNormalZeroWriteRefusal(baseline)
+        try assertNormalZeroWriteRefusal(withFault)
+    }
+
+    /// The shipped behavior for a mutating no-write probe: a typed State-C
+    /// zero-write refusal (`invalid_params`, `write_attempted=false`).
+    private func assertNormalZeroWriteRefusal(
+        _ probe: QualificationOperationResult
     ) throws {
+        #expect(probe.state == "C")
+        let error = try #require(probe.error)
+        #expect(error == "invalid_params")
+        let isError = try #require(probe.isError)
+        #expect(isError)
+        let writeAttempted = try #require(probe.writeAttempted)
+        #expect(!writeAttempted)
+    }
+
+    private func driveTransportPlayProbe(
+        faultEnv: [String: String]
+    ) throws -> QualificationOperationResult {
         let spec = try #require(OperationRegistry.specs.first { $0.id == .transportPlay })
         var childEnvironment = ProcessInfo.processInfo.environment
-        childEnvironment[QualificationFaultInjection.environmentKey] = mode.rawValue
+        for (key, value) in faultEnv { childEnvironment[key] = value }
         let result = try QualificationTransport(
             requestTimeout: 30,
             shutdownGrace: 1
@@ -49,17 +110,7 @@ struct QualificationFaultInjectionTests {
             expectedOperationCount: OperationRegistry.specs.count,
             operations: [spec]
         ))
-        let operation = try #require(result.operationResults[spec.id.rawValue])
-        let frames = result.wireFrames.filter {
-            $0.operationID == "operation_probe.\(spec.id.rawValue)"
-        }
-
-        #expect(frames.map(\.direction) == [.request, .response])
-        #expect(operation.isError == true)
-        #expect(operation.state == "C")
-        #expect(operation.error == expectedError)
-        #expect(operation.status == .failed)
-        #expect(operation.responseData?.contains(Data("fault_injection".utf8)) == false)
+        return try #require(result.operationResults[spec.id.rawValue])
     }
 
     private static let releaseExecutableURL = ProcessInfo.processInfo.environment[

--- a/Tests/LogicProMCPTests/QualificationFaultInjectionTests.swift
+++ b/Tests/LogicProMCPTests/QualificationFaultInjectionTests.swift
@@ -14,6 +14,14 @@ import Testing
 /// which has it compiled out.
 @Suite("Qualification fault seam — release exclusion (#399)")
 struct QualificationFaultInjectionTests {
+    // #399 (CEO audit P0) — DEBUG-ONLY seam coverage. `QualificationFaultInjection`
+    // and the transport fault modes are compiled solely under
+    // `QUALIFICATION_FAULT_SEAM` (see Package.swift). This block references those
+    // excluded symbols and/or drives the DEBUG executable (which HAS the seam), so
+    // it compiles/runs only in the debug test build and is absent from a
+    // `-c release` test build. It proves the qualification fault modes STILL WORK
+    // in debug — the coverage the release-exclusion inversion would otherwise drop.
+    #if QUALIFICATION_FAULT_SEAM
     /// TEST (C) — debug seam contract. `QualificationFaultInjection` returns
     /// non-nil ONLY for the exact documented modes; every other value is nil.
     @Test func injectionResolvesOnlyDocumentedModes() throws {
@@ -30,6 +38,77 @@ struct QualificationFaultInjectionTests {
         ]))
         #expect(partial.mode == .partialState)
     }
+
+    /// FINDING 1 (#399) — debug transport-fault E2E, restored. The retired
+    /// `timeoutIsObservedFromRealServerResponse` proved the transport `timeout`
+    /// fault is observable end-to-end from a real server response. The seam is now
+    /// compiled out of release, but it MUST still work in debug — that IS the
+    /// qualification affordance. Driving the DEBUG executable (which has the seam)
+    /// with `LOGIC_PRO_MCP_FAULT_INJECT=timeout` still yields `operation_timeout`,
+    /// State C, and the FAILED classification, over a real request/response frame
+    /// pair — matching what the old test proved.
+    @Test(.enabled(
+        if: FileManager.default.isExecutableFile(atPath: Self.debugExecutableURL.path),
+        "Requires `swift build` (debug) before driving the debug fault seam."
+    ))
+    func debugSeamTimeoutIsObservedFromRealServerResponse() throws {
+        try assertDebugServerFault(mode: .timeout, expectedError: "operation_timeout")
+    }
+
+    /// FINDING 1 (#399) — debug transport-fault E2E, restored. Mirrors the retired
+    /// `partialStateIsObservedFromRealServerResponse`: the DEBUG executable with
+    /// `LOGIC_PRO_MCP_FAULT_INJECT=partial_state` still yields
+    /// `readback_unavailable`, State C, and the FAILED classification.
+    @Test(.enabled(
+        if: FileManager.default.isExecutableFile(atPath: Self.debugExecutableURL.path),
+        "Requires `swift build` (debug) before driving the debug fault seam."
+    ))
+    func debugSeamPartialStateIsObservedFromRealServerResponse() throws {
+        try assertDebugServerFault(mode: .partialState, expectedError: "readback_unavailable")
+    }
+
+    /// Drives the transport.play `__adr001b_no_write_probe` against the DEBUG
+    /// server with the fault mode armed and asserts the fault is observed from the
+    /// real wire response — the exact contract of the retired real-server tests.
+    private func assertDebugServerFault(
+        mode: QualificationFaultInjection.Mode,
+        expectedError: String
+    ) throws {
+        let spec = try #require(OperationRegistry.specs.first { $0.id == .transportPlay })
+        var childEnvironment = ProcessInfo.processInfo.environment
+        childEnvironment[QualificationFaultInjection.environmentKey] = mode.rawValue
+        let result = try QualificationTransport(
+            requestTimeout: 30,
+            shutdownGrace: 1
+        ).drive(.init(
+            executableURL: Self.debugExecutableURL,
+            environment: childEnvironment,
+            expectedOperationCount: OperationRegistry.specs.count,
+            operations: [spec]
+        ))
+        let operation = try #require(result.operationResults[spec.id.rawValue])
+        let frames = result.wireFrames.filter {
+            $0.operationID == "operation_probe.\(spec.id.rawValue)"
+        }
+        #expect(frames.map(\.direction) == [.request, .response])
+        let isError = try #require(operation.isError)
+        #expect(isError)
+        let state = try #require(operation.state)
+        #expect(state == "C")
+        let error = try #require(operation.error)
+        #expect(error == expectedError)
+        #expect(operation.status == .failed)
+        let responseData = try #require(operation.responseData)
+        #expect(!responseData.contains(Data("fault_injection".utf8)))
+    }
+
+    private static let debugExecutableURL = ProcessInfo.processInfo.environment[
+        "LPMCP_TEST_DEBUG_SERVER_EXECUTABLE"
+    ].map { URL(fileURLWithPath: $0) } ?? URL(
+        fileURLWithPath: FileManager.default.currentDirectoryPath,
+        isDirectory: true
+    ).appendingPathComponent(".build/debug/LogicProMCP")
+    #endif
 
     /// TEST (A) — dead-string scan. The release binary must not contain the fault
     /// env-key bytes anywhere. RED before #399 (the string was present); GREEN

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -1162,19 +1162,26 @@ struct QualificationRunnerTests {
         )
     }
 
+    /// #399 (CEO audit P0) — INVERTED. This test used to prove the runner CAUGHT
+    /// a real env-induced `partial_state` fault; that capability was the
+    /// vulnerability. With the fault seam compiled out of release, driving the
+    /// real release binary through the full runner with the fault env set must now
+    /// yield the normal typed zero-write refusal — no `readback_unavailable`, no
+    /// failed case. (The generic "a failed required case is not promotable"
+    /// rejection stays covered by `verificationEmitsEveryApplicableRejection`.)
     @Test(.enabled(
         if: FileManager.default.isExecutableFile(atPath: Self.releaseExecutableURL.path),
-        "Requires `swift build -c release` before running the Runner fault probe."
+        "Requires `swift build -c release` before the Runner fault-exclusion probe."
     ))
-    func runnerRejectsPartialStateObservedFromRealServer() async throws {
+    func runnerIgnoresPartialStateFaultEnvOnRealServer() async throws {
         let spec = try #require(OperationRegistry.specs.first { $0.id == .transportPlay })
         let executableData = try Data(contentsOf: Self.releaseExecutableURL)
         let fixture = try Fixture(
             specs: [spec],
             executableData: executableData,
             environmentAdditions: [
-                QualificationFaultInjection.environmentKey:
-                    QualificationFaultInjection.Mode.partialState.rawValue,
+                "LOGIC_PRO_MCP_FAULT_INJECT": "partial_state",
+                "LOGIC_PRO_MCP_FAULT_INJECT_STEP": "0",
             ],
             drive: { request in
                 let observed = try QualificationTransport(
@@ -1222,14 +1229,15 @@ struct QualificationRunnerTests {
                 && $0["direction"] as? String == "response"
         })
         let responsePayload = try #require(response["payload"] as? String)
-        let promotion = await fixture.verify(expectedSHA256: fixture.binarySHA256)
-        let promotionJSON = try Self.resultObject(promotion)
 
         #expect(qualification.exitCode == 0)
-        #expect(responsePayload.contains(#"\"error\":\"readback_unavailable\""#))
-        #expect(operationCase.status == .failed)
-        #expect(promotion.exitCode == 1)
-        #expect(promotionJSON["promotable"] as? Bool == false)
+        // The fault env engaged nothing: the release binary emitted the normal
+        // typed zero-write refusal, never the injected readback_unavailable fault.
+        #expect(!responsePayload.contains("readback_unavailable"))
+        #expect(responsePayload.contains(#"\"error\":\"invalid_params\""#))
+        // transport.play is mutating → the shipped `not_qualified` deferral, not a
+        // fault-induced failure.
+        #expect(operationCase.status == .notQualified)
     }
 
     @Test func handshakeStillFailsClosedBeyondStartupBudget() throws {

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -1240,6 +1240,88 @@ struct QualificationRunnerTests {
         #expect(operationCase.status == .notQualified)
     }
 
+    /// FINDING 3 (#399) — debug-gated restoration of the runner-rejection
+    /// contract. The inverted `runnerIgnoresPartialStateFaultEnvOnRealServer`
+    /// proves the RELEASE binary ignores the fault env, but it can no longer prove
+    /// the runner REJECTS a real fault-induced failure, because release has no
+    /// seam. This drives the DEBUG binary (which HAS the seam) so `partial_state`
+    /// really induces `readback_unavailable`, then re-asserts the original exact
+    /// contract: the transport.play case is present and FAILED, and verification
+    /// refuses to promote it (exit 1, promotable=false). Compiled solely under
+    /// `QUALIFICATION_FAULT_SEAM` (see Package.swift) — references excluded symbols.
+    #if QUALIFICATION_FAULT_SEAM
+    @Test(.enabled(
+        if: FileManager.default.isExecutableFile(atPath: Self.debugExecutableURL.path),
+        "Requires `swift build` (debug) before the Runner fault-seam probe."
+    ))
+    func runnerRejectsPartialStateObservedFromRealServer() async throws {
+        let spec = try #require(OperationRegistry.specs.first { $0.id == .transportPlay })
+        let executableData = try Data(contentsOf: Self.debugExecutableURL)
+        let fixture = try Fixture(
+            specs: [spec],
+            executableData: executableData,
+            environmentAdditions: [
+                QualificationFaultInjection.environmentKey:
+                    QualificationFaultInjection.Mode.partialState.rawValue,
+            ],
+            drive: { request in
+                let observed = try QualificationTransport(
+                    requestTimeout: 30,
+                    shutdownGrace: 1
+                ).drive(request)
+                let baseline = Self.driveResult(specs: [spec])
+                return QualificationDriveResult(
+                    handshake: baseline.handshake,
+                    health: baseline.health,
+                    catalog: baseline.catalog,
+                    expectedOperationCount: baseline.expectedOperationCount,
+                    traceList: baseline.traceList,
+                    traceDetail: baseline.traceDetail,
+                    negative: baseline.negative,
+                    observedLocale: baseline.observedLocale,
+                    operationResults: observed.operationResults,
+                    wireFrames: observed.wireFrames,
+                    mutationRestoreRecords: observed.mutationRestoreRecords,
+                    failureReason: observed.failureReason
+                )
+            }
+        )
+        defer { fixture.remove() }
+
+        let qualification = await fixture.runQualification()
+        let attestationData = try #require(
+            try? Data(contentsOf: fixture.attestationURL),
+            "qualification failed: \(qualification.stderr)"
+        )
+        let attestation = try JSONDecoder().decode(
+            ReleaseQualificationAttestation.self,
+            from: attestationData
+        )
+        let operationCase = try #require(
+            attestation.cases.first { $0.id == "in-process/transport.play" }
+        )
+        let transcript = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fixture.directory
+                .appendingPathComponent("raw-transcript.json"))) as? [String: Any]
+        )
+        let frames = try #require(transcript["frames"] as? [[String: Any]])
+        let response = try #require(frames.first {
+            $0["operation_id"] as? String == "operation_probe.transport.play"
+                && $0["direction"] as? String == "response"
+        })
+        let responsePayload = try #require(response["payload"] as? String)
+        let promotion = await fixture.verify(expectedSHA256: fixture.binarySHA256)
+        let promotionJSON = try Self.resultObject(promotion)
+
+        #expect(qualification.exitCode == 0)
+        #expect(responsePayload.contains(#"\"error\":\"readback_unavailable\""#))
+        #expect(operationCase.status == .failed)
+        #expect(promotion.exitCode == 1)
+        let promotable = try #require(promotionJSON["promotable"] as? Bool)
+        #expect(!promotable)
+    }
+    #endif
+
     @Test func handshakeStillFailsClosedBeyondStartupBudget() throws {
         let fixture = try SlowHandshakeFixture()
         defer { fixture.remove() }
@@ -2634,6 +2716,16 @@ struct QualificationRunnerTests {
         fileURLWithPath: FileManager.default.currentDirectoryPath,
         isDirectory: true
     ).appendingPathComponent(".build/release/LogicProMCP")
+
+    // #399 (CEO audit P0) — the DEBUG executable HAS the fault seam compiled in,
+    // so it is what the debug-gated runner-rejection test drives. Only referenced
+    // under `QUALIFICATION_FAULT_SEAM`.
+    #if QUALIFICATION_FAULT_SEAM
+    private static let debugExecutableURL = URL(
+        fileURLWithPath: FileManager.default.currentDirectoryPath,
+        isDirectory: true
+    ).appendingPathComponent(".build/debug/LogicProMCP")
+    #endif
 
     private enum PublicTranscriptMutation: String, CaseIterable, CustomStringConvertible {
         case digestMismatch

--- a/Tests/LogicProMCPTests/SagaExecutionTests.swift
+++ b/Tests/LogicProMCPTests/SagaExecutionTests.swift
@@ -701,6 +701,14 @@ struct SagaExecutionTests {
     }
 
     // MARK: - ADR-004 / issue #287 qualification-only partial-state fault seam
+    //
+    // #399 (CEO audit P0) — the partial-state fault seam is a debug-only test
+    // affordance compiled solely under `QUALIFICATION_FAULT_SEAM` (see
+    // Package.swift). Everything below references the excluded
+    // `SagaPartialStateFaultSeam` and/or the `faultSeam:` executor initializer, so
+    // it compiles/runs only in the debug test build and is absent from a
+    // `-c release` test build.
+    #if QUALIFICATION_FAULT_SEAM
 
     private struct SeamFixture: Sendable {
         let executor: ProductionSagaStepExecutor
@@ -974,4 +982,5 @@ struct SagaExecutionTests {
             #expect(fixture.surface.snapshot(2)?.pan == 0)
         }
     }
+    #endif
 }


### PR DESCRIPTION
## #399 — exclude the fault-injection seam from release binaries (CEO audit P0)

**Finding:** a shipping `-c release` binary could activate saga and transport fault-injection through the ordinary environment variable `LOGIC_PRO_MCP_FAULT_INJECT` — so qualification authority was not provable (a shipped binary carried an env-activated fault path).

**Fix — compile-time exclusion.** `Package.swift` defines `QUALIFICATION_FAULT_SEAM` only for debug builds; both acting paths and the owning struct are wrapped in `#if QUALIFICATION_FAULT_SEAM`:
- `QualificationFaultInjection` struct (owns the env-key string)
- saga `SagaPartialStateFaultSeam` + the executor `faultSeam` property/init parameter
- the `SystemDispatcher` saga wiring
- the `LogicProServer` `transportPlay` `__adr001b_no_write_probe` block
- the `QualificationTransport` fault usage (refactored to `timeout: TimeInterval?`)

**Proof (release binary):**
- Dead-string scan: the release binary contains **zero** occurrences of `LOGIC_PRO_MCP_FAULT_INJECT` (independently confirmed via both `grep` and `strings`).
- Release-behavior tests: the release binary launched with the fault env **set** behaves identically to **unset** (normal typed `invalid_params` / zero-write refusal). The three tests that previously asserted the release binary faults are inverted to assert it ignores the env.
- Debug-flag builds keep the seam, so reverse-order compensation / runner-rejection stay covered by the debug seam suite; the documented-modes contract test pins that resolve() accepts only `timeout`/`partial_state`.
- Full suite: **3061 passed / 0 non-skipped failures**. `Package.resolved` unchanged.

Fault injection is a debug-only test affordance, never a shipped feature.

**Accepted residual (follow-up, non-blocking to this P0 close):**
- Release-exclusion tests soft-skip if no release binary is present — the exact-head gate builds `-c release`, so they run there; a CI hard-require is a follow-up.
- ADR-004/#287 narrative note that induced compensation/timeout qualification is intentionally debug-only (same-source coverage retained; the shipped artifact is never env-faultable).
- Dual `#if/#else` executor init is minor maintainability debt.
