### PR TITLE
fix(#412): bound saga lifecycle deadline — abandon race, gate ownership, fail-closed timeout

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -234,7 +234,13 @@ struct SystemDispatcher: OperationTraceDispatching {
         // sites stay deterministic; that default is `.unavailable`, i.e. the
         // saga fails closed at before-state capture rather than reading the
         // stale-able cache mirror. Production dispatch supplies `.production`.
-        sagaLiveReadback: SagaLiveReadback? = nil
+        sagaLiveReadback: SagaLiveReadback? = nil,
+        // #412: the shared absolute saga lifecycle deadline, computed once at
+        // the server dispatch entry so the in-closure abandon race and the outer
+        // transport timer derive from ONE instant. nil when the dispatcher is
+        // driven directly (tests / non-server): the saga path then derives its
+        // own instant from the registry budget.
+        sagaLifecycleDeadline: ContinuousClock.Instant? = nil
     ) async -> CallTool.Result {
         switch command {
         case "list_recent_traces", "get_trace", "clear_traces":
@@ -568,8 +574,18 @@ struct SystemDispatcher: OperationTraceDispatching {
                 } else {
                     mutationClaim = nil
                 }
+                // #412: the mutation gate release is skipped ONLY when the
+                // lifecycle timeout actually terminalized the saga as a timeout.
+                // A healthy saga (work child finalized, or the timeout
+                // fired-but-terminalized-nothing) always releases immediately —
+                // no false 15s pin. A genuinely abandoned saga is force-marked +
+                // grace-reclaimed, never released immediately (which would race
+                // an orphan write) and never pinned permanently.
+                let sagaAbandonedByTimeout = SagaAbandonFlag()
                 defer {
-                    if let mutationClaim { mutationGate?.release(mutationClaim) }
+                    if let mutationClaim, !sagaAbandonedByTimeout.value {
+                        mutationGate?.release(mutationClaim)
+                    }
                 }
                 // ADR-004 / issue #287 — qualification-only fault seam. #399 (CEO
                 // audit P0): the seam and its wiring are compiled solely in debug
@@ -654,43 +670,124 @@ struct SystemDispatcher: OperationTraceDispatching {
                         )
                     }
                 }
-                let outcome = await OperationTraceParentBoundary.$onWriteBoundary.withValue(
-                    onWriteBoundary
-                ) {
-                    await saga.execute(
-                        plan,
-                        executor: surfaceExecutor,
-                        cancellationRequested: {
-                            await sagaJournal.record(for: plan.idempotencyKey) == .cancellationRequested
+                // #412: ONE shared absolute lifecycle deadline. Server dispatch
+                // supplies it (shared with the outer transport timer); a
+                // direct/test call derives it from the registry budget.
+                let lifecycleBudgetSeconds = OperationRegistry.spec(
+                    tool: ToolID.logicSystem.rawValue,
+                    command: "saga_execute"
+                )?.deadline.seconds ?? DeadlineClass.long.seconds
+                let lifecycleDeadline = sagaLifecycleDeadline
+                    ?? ContinuousClock.now.advanced(by: .seconds(lifecycleBudgetSeconds))
+                let deadlineReached: @Sendable () -> Bool = {
+                    ContinuousClock.now >= lifecycleDeadline
+                }
+                let timeoutBody = SagaWire.sagaWedgeTimeout(
+                    idempotencyKey: plan.idempotencyKey,
+                    seconds: lifecycleBudgetSeconds,
+                    gateReclaimAfterSec: LogicProServer.mutationGateReclaimGraceSeconds
+                )
+
+                // #412: the saga lifecycle runs in an UNSTRUCTURED work child
+                // (never awaited at scope exit — a wedged synchronous AX call
+                // cannot be cancelled, so awaiting it would defeat the deadline)
+                // raced against a lifecycle DispatchWorkItem at
+                // `lifecycleDeadline`. Both finishers terminalize through the
+                // SAME claim/generation-guarded journal API
+                // (`finalizeReturningWinner`), so whoever wins the finalize also
+                // determines the client body — response bytes == journal terminal
+                // bytes. Abandon side effects fire ONLY when the timeout actually
+                // terminalized the saga as a timeout, and BEFORE the continuation
+                // resumes so the dispatcher `defer` above observes the flag.
+                let outerTraceContext = OperationTraceContext.current
+                let raceResult: CallTool.Result = await withCheckedContinuation { continuation in
+                    let race = SagaDeadlineRace()
+                    let timeoutHandle = SagaTimeoutHandle()
+                    // Unstructured but NOT detached: `Task { }` inherits the caller's
+                    // task-local values (the ADR feature-flag overrides the saga
+                    // preflight reads, and the trace context) while still running
+                    // independently, so the dispatcher returns via the race without
+                    // awaiting a wedged child. `Task.detached` would sever the flags
+                    // and fail the saga closed as feature-disabled.
+                    let workTask = Task(priority: .userInitiated) {
+                        await OperationTraceContext.$current.withValue(outerTraceContext) {
+                            let outcome = await OperationTraceParentBoundary.$onWriteBoundary.withValue(
+                                onWriteBoundary
+                            ) {
+                                await saga.execute(
+                                    plan,
+                                    executor: surfaceExecutor,
+                                    cancellationRequested: {
+                                        if deadlineReached() { return true }
+                                        return await sagaJournal.record(for: plan.idempotencyKey)
+                                            == .cancellationRequested
+                                    },
+                                    deadlineReached: deadlineReached
+                                )
+                            }
+                            // Preserve the prior behavior: a cancel that raced in
+                            // after the saga's last checkpoint (so it completed)
+                            // compensates the applied writes before terminalizing.
+                            let finalOutcome: SagaOutcome
+                            if await sagaJournal.record(for: plan.idempotencyKey)
+                                == .cancellationRequested,
+                               outcome.state == .completed {
+                                finalOutcome = await saga.cancel(
+                                    outcome: outcome,
+                                    executor: surfaceExecutor,
+                                    deadlineReached: deadlineReached
+                                )
+                            } else {
+                                finalOutcome = outcome
+                            }
+                            let proposed = SagaWire.storedOutcome(plan: plan, outcome: finalOutcome)
+                            let (winner, _) = await sagaJournal.finalizeReturningWinner(
+                                journalClaim,
+                                proposed: proposed,
+                                verifiedIfCancelled: SagaWire.cancellationVerified(finalOutcome)
+                            )
+                            let didWin = race.resume(
+                                continuation,
+                                returning: toolTextResult(winner.body, isError: winner.isError)
+                            )
+                            if didWin { timeoutHandle.cancel() }
                         }
+                    }
+                    let timeoutItem = DispatchWorkItem {
+                        Task {
+                            let (winner, didTerminalizeTimeout) = await sagaJournal.completeOnTimeout(
+                                journalClaim,
+                                outcome: timeoutBody
+                            )
+                            race.resume(
+                                continuation,
+                                returning: toolTextResult(winner.body, isError: winner.isError)
+                            ) {
+                                // #412: abandon side effects fire only when THIS
+                                // timeout actually terminalized the journal as a
+                                // timeout — NOT merely because it won the resume
+                                // race. If the work child already finalized
+                                // (success or otherwise) and this timeout only won
+                                // the race, the saga is done: pinning the gate
+                                // would be a false abandon. Ordered BEFORE the
+                                // continuation resumes, so the abandon flag is
+                                // visible to the dispatcher `defer`.
+                                guard didTerminalizeTimeout else { return }
+                                sagaAbandonedByTimeout.set(true)
+                                if let mutationClaim {
+                                    mutationGate?.markTimedOut(mutationClaim, force: true)
+                                }
+                                workTask.cancel()
+                            }
+                        }
+                    }
+                    timeoutHandle.set(timeoutItem)
+                    DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                        deadline: .now() + LogicProServer.secondsFromNow(until: lifecycleDeadline),
+                        execute: timeoutItem
                     )
                 }
-                let completed = SagaWire.storedOutcome(plan: plan, outcome: outcome)
-                if await sagaJournal.complete(journalClaim, outcome: completed) {
-                    return await finalizeTrace(
-                        toolTextResult(completed.body, isError: completed.isError),
-                        traceID: traceID
-                    )
-                }
-                guard await sagaJournal.record(for: plan.idempotencyKey) == .cancellationRequested else {
-                    return await finalizeTrace(
-                        toolTextResult(completed.body, isError: completed.isError),
-                        traceID: traceID
-                    )
-                }
-                let finalOutcome = outcome.state == .completed
-                    ? await saga.cancel(outcome: outcome, executor: surfaceExecutor)
-                    : outcome
-                let stored = SagaWire.storedOutcome(plan: plan, outcome: finalOutcome)
-                await sagaJournal.completeCancellation(
-                    journalClaim,
-                    outcome: stored,
-                    verified: SagaWire.cancellationVerified(finalOutcome)
-                )
-                return await finalizeTrace(
-                    toolTextResult(stored.body, isError: stored.isError),
-                    traceID: traceID
-                )
+                return await finalizeTrace(raceResult, traceID: traceID)
             }
 
         case "saga_status":
@@ -1621,5 +1718,88 @@ struct SystemDispatcher: OperationTraceDispatching {
                 for detailed command docs per category.
                 """
         }
+    }
+}
+
+// MARK: - #412 saga abandon-race primitives
+
+/// #412: a small `Sendable` flag the lifecycle-timeout handler sets ONLY when it
+/// actually terminalized the saga as a timeout, read by the dispatcher `defer`
+/// to decide whether to release the mutation gate. A healthy saga leaves it
+/// false → immediate release; an abandoned saga sets it true → the gate is
+/// force-marked and grace-reclaimed instead of released.
+final class SagaAbandonFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+
+    func set(_ value: Bool) {
+        lock.lock()
+        flag = value
+        lock.unlock()
+    }
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return flag
+    }
+}
+
+/// #412: the first-writer-wins single-resume guard for the saga abandon race,
+/// shaped like `LogicProServer.DeadlineRace` but with a `beforeResume` hook. The
+/// winner runs `beforeResume` UNDER the lock, BEFORE the continuation is
+/// resumed, so a timeout winner's abandon side effects (the gate flag the
+/// dispatcher `defer` reads) are ordered ahead of the resume that lets the
+/// `defer` run — closing the race between the two.
+final class SagaDeadlineRace: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+
+    @discardableResult
+    func resume(
+        _ continuation: CheckedContinuation<CallTool.Result, Never>,
+        returning result: CallTool.Result,
+        beforeResume: () -> Void = {}
+    ) -> Bool {
+        lock.lock()
+        if resumed {
+            lock.unlock()
+            return false
+        }
+        resumed = true
+        beforeResume()
+        lock.unlock()
+        continuation.resume(returning: result)
+        return true
+    }
+}
+
+/// #412: cancel-safe handle for the lifecycle timeout `DispatchWorkItem`,
+/// mirroring `LogicProServer.DeadlineTimeoutHandle` — the work child cancels the
+/// pending timeout on a healthy win without a reference cycle, and a `cancel()`
+/// that races `set()` still cancels the work item.
+final class SagaTimeoutHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: DispatchWorkItem?
+    private var cancelled = false
+
+    func set(_ task: DispatchWorkItem) {
+        lock.lock()
+        if cancelled {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        self.task = task
+        lock.unlock()
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let task = self.task
+        self.task = nil
+        lock.unlock()
+        task?.cancel()
     }
 }

--- a/Sources/LogicProMCP/Saga/MutationSaga.swift
+++ b/Sources/LogicProMCP/Saga/MutationSaga.swift
@@ -400,7 +400,14 @@ actor MutationSaga {
     func execute<Executor: SagaStepExecutor>(
         _ plan: SagaPlan,
         executor: Executor,
-        cancellationRequested: @Sendable () async -> Bool = { false }
+        cancellationRequested: @Sendable () async -> Bool = { false },
+        // #412: the lifecycle deadline threads through execute -> the private
+        // cancel() -> compensate() so the compensation-abandon checkpoint is
+        // reachable on the main deadline-trip route (the trip enters cancel()
+        // via the forward cancellation checkpoints). Forward is unchanged: the
+        // dispatcher folds deadlineReached into `cancellationRequested`, so the
+        // forward checkpoints need no new branch.
+        deadlineReached: @Sendable () -> Bool = { false }
     ) async -> SagaOutcome {
         let result = await preflight(plan)
         switch result.status {
@@ -437,7 +444,8 @@ actor MutationSaga {
                 return await cancel(
                     appliedIndices: appliedIndices,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
             }
             guard let beforeState = await executor.readState(step),
@@ -459,7 +467,8 @@ actor MutationSaga {
                     appliedIndices: appliedIndices,
                     rollbackIsUncertain: false,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
             }
 
@@ -482,7 +491,8 @@ actor MutationSaga {
                 return await cancel(
                     appliedIndices: appliedIndices,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
             }
             let executionResult = await executor.run(step)
@@ -514,7 +524,8 @@ actor MutationSaga {
                         return await cancel(
                             appliedIndices: appliedIndices,
                             executor: executor,
-                            outcome: outcome
+                            outcome: outcome,
+                            deadlineReached: deadlineReached
                         )
                     }
                     continue
@@ -530,7 +541,8 @@ actor MutationSaga {
                     appliedIndices: appliedIndices,
                     rollbackIsUncertain: disposition == .unknown,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
 
             case .stateB:
@@ -564,7 +576,8 @@ actor MutationSaga {
                     appliedIndices: appliedIndices,
                     rollbackIsUncertain: disposition == .unknown,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
 
             case .stateC:
@@ -599,7 +612,8 @@ actor MutationSaga {
                         appliedIndices: appliedIndices,
                         rollbackIsUncertain: disposition == .unknown,
                         executor: executor,
-                        outcome: outcome
+                        outcome: outcome,
+                        deadlineReached: deadlineReached
                     )
                 }
 
@@ -616,7 +630,8 @@ actor MutationSaga {
                     appliedIndices: appliedIndices,
                     rollbackIsUncertain: false,
                     executor: executor,
-                    outcome: outcome
+                    outcome: outcome,
+                    deadlineReached: deadlineReached
                 )
             }
         }
@@ -625,7 +640,8 @@ actor MutationSaga {
             return await cancel(
                 appliedIndices: appliedIndices,
                 executor: executor,
-                outcome: outcome
+                outcome: outcome,
+                deadlineReached: deadlineReached
             )
         }
 
@@ -636,7 +652,8 @@ actor MutationSaga {
 
     func cancel<Executor: SagaStepExecutor>(
         outcome: SagaOutcome,
-        executor: Executor
+        executor: Executor,
+        deadlineReached: @Sendable () -> Bool = { false }
     ) async -> SagaOutcome {
         let appliedIndices = outcome.journal.indices.filter {
             outcome.journal[$0].verificationEvidence?.disposition == .applied
@@ -644,14 +661,16 @@ actor MutationSaga {
         return await cancel(
             appliedIndices: appliedIndices,
             executor: executor,
-            outcome: outcome
+            outcome: outcome,
+            deadlineReached: deadlineReached
         )
     }
 
     private func cancel<Executor: SagaStepExecutor>(
         appliedIndices: [Int],
         executor: Executor,
-        outcome: SagaOutcome
+        outcome: SagaOutcome,
+        deadlineReached: @Sendable () -> Bool
     ) async -> SagaOutcome {
         guard !appliedIndices.isEmpty else {
             var cancelled = outcome
@@ -662,7 +681,8 @@ actor MutationSaga {
             appliedIndices: appliedIndices,
             rollbackIsUncertain: false,
             executor: executor,
-            outcome: outcome
+            outcome: outcome,
+            deadlineReached: deadlineReached
         )
     }
 
@@ -670,7 +690,8 @@ actor MutationSaga {
         appliedIndices: [Int],
         rollbackIsUncertain: Bool,
         executor: Executor,
-        outcome initialOutcome: SagaOutcome
+        outcome initialOutcome: SagaOutcome,
+        deadlineReached: @Sendable () -> Bool
     ) async -> SagaOutcome {
         // ADR-005: compensation begin is visible on the PARENT saga trace
         // (the step scopes below carry parent_trace_id for the inverse
@@ -693,6 +714,19 @@ actor MutationSaga {
         var uncertain = rollbackIsUncertain
 
         for index in appliedIndices.reversed() {
+            // #412: the lifecycle deadline is checked immediately before each
+            // inverse dispatch; once elapsed no further inverse is issued and
+            // every not-yet-run applied index is marked uncertain directly —
+            // never failed (that disposition is only for a real dispatched
+            // inverse whose readback mismatched) and never via `executor.run`.
+            // `uncertain` then drives the honest `rollbackUncertain` terminal.
+            // There is no reserved compensation budget: a full-budget forward
+            // legitimately leaves all inverses abandoned as uncertain.
+            if deadlineReached() {
+                markRemainingUncertain(appliedIndices, from: index, outcome: &outcome)
+                uncertain = true
+                break
+            }
             guard let inverse = outcome.journal[index].inverseOperation,
                   let beforeState = outcome.journal[index].beforeState else {
                 outcome.journal[index].compensationEvidence = CompensationEvidence(
@@ -827,6 +861,28 @@ actor MutationSaga {
             executionResult: nil,
             readback: readback
         )
+        sessions[outcome.idempotencyKey] = outcome
+    }
+
+    /// #412: mark every applied index the compensation loop has NOT yet
+    /// dispatched an inverse for as `.uncertain`, directly — no `executor.run`,
+    /// never `.failed`. `appliedIndices` is appended in ascending forward order
+    /// and the loop consumes it in reverse, so when the deadline trips at
+    /// `index` the un-run remainder is exactly the applied indices `<= index`
+    /// (the larger ones already compensated).
+    private func markRemainingUncertain(
+        _ appliedIndices: [Int],
+        from index: Int,
+        outcome: inout SagaOutcome
+    ) {
+        for applied in appliedIndices where applied <= index {
+            outcome.journal[applied].compensationEvidence = CompensationEvidence(
+                disposition: .uncertain,
+                executionResult: nil,
+                readback: nil,
+                comparison: nil
+            )
+        }
         sessions[outcome.idempotencyKey] = outcome
     }
 

--- a/Sources/LogicProMCP/Saga/SagaJournal.swift
+++ b/Sources/LogicProMCP/Saga/SagaJournal.swift
@@ -313,6 +313,84 @@ actor SagaJournal {
         return true
     }
 
+    /// #412: the single first-writer-wins coupling point both saga finishers
+    /// (the work child on normal completion and the lifecycle-timeout handler)
+    /// terminalize through, so the client response body can never disagree with
+    /// the journal terminal record.
+    ///
+    /// If this claim is still live it finalizes with `proposed` — mirroring
+    /// `completeBeforeWrite`'s dual-state switch (`.inProgress` → `.completed`,
+    /// `.cancellationRequested` → `.cancelled`) — and returns `proposed` (which
+    /// is now the terminal body). If the claim already lost the race (the other
+    /// finisher finalized first, so the entry is gone or the generation moved),
+    /// it finalizes NOTHING and returns the body the winner actually stored.
+    /// Either way the returned bytes ARE the journal terminal record — resuming
+    /// a locally-built body after losing the finalize would let the response
+    /// disagree with the terminal record, which this exists to prevent.
+    ///
+    /// `verifiedIfCancelled` is honored only on the `.cancellationRequested`
+    /// branch: the work child passes the real compensation result, the timeout
+    /// handler passes `false` (outcome unknown). It never affects the returned
+    /// body — only the journal `verified` flag surfaced by saga_status.
+    ///
+    /// Returns `didFinalize` — `true` only when THIS call actually terminalized
+    /// the entry, `false` when it lost the first-writer race. The lifecycle-
+    /// timeout handler gates its abandon side effects on this bit so a timeout
+    /// that wins the resume race AFTER the work child already finalized a
+    /// success does not force-mark the gate — winning the race is not the same
+    /// as terminalizing as a timeout.
+    @discardableResult
+    func finalizeReturningWinner(
+        _ claim: Claim,
+        proposed: StoredOutcome,
+        verifiedIfCancelled: Bool = false
+    ) -> (body: StoredOutcome, didFinalize: Bool) {
+        guard claim.generation == generation,
+              let entry = entries[claim.idempotencyKey],
+              entry.claim == claim else {
+            // Lost the first-writer race: return the body the winner stored so
+            // the caller resumes with the journal's terminal bytes, not a local
+            // body (a local body could disagree with the terminal record). Falls
+            // back to `proposed` only if the session was cleared out from under
+            // both finishers. didFinalize is false — this call terminalized
+            // nothing.
+            return (storedTerminalOutcome(for: claim.idempotencyKey) ?? proposed, false)
+        }
+        switch entry.record {
+        case .inProgress:
+            finalize(claim.idempotencyKey, record: .completed(proposed), sequence: claim.sequence)
+        case .cancellationRequested:
+            finalize(
+                claim.idempotencyKey,
+                record: .cancelled(proposed, verified: verifiedIfCancelled),
+                sequence: claim.sequence
+            )
+        }
+        return (proposed, true)
+    }
+
+    /// #412: the lifecycle-timeout finisher. Terminalizes BOTH live states and
+    /// returns the winning body plus `didFinalize` (whether THIS call
+    /// terminalized), exactly like `finalizeReturningWinner` with
+    /// `verifiedIfCancelled: false` (a timed-out outcome is never verified).
+    @discardableResult
+    func completeOnTimeout(
+        _ claim: Claim,
+        outcome: StoredOutcome
+    ) -> (body: StoredOutcome, didFinalize: Bool) {
+        finalizeReturningWinner(claim, proposed: outcome, verifiedIfCancelled: false)
+    }
+
+    /// The stored terminal body for a key that already reached a terminal state
+    /// in this generation, or nil if it is still live / evicted / unknown.
+    private func storedTerminalOutcome(for key: String) -> StoredOutcome? {
+        guard let body = outcomeBodies[key] else { return nil }
+        switch body.record {
+        case .completed(let outcome): return outcome
+        case .cancelled(let outcome, _): return outcome
+        }
+    }
+
     func record(for idempotencyKey: String) -> Record? {
         if let entry = entries[idempotencyKey] {
             switch entry.record {
@@ -697,6 +775,46 @@ enum SagaWire {
             body: HonestContract.jsonString(object),
             isError: stored.isError
         )
+    }
+
+    /// #412: the fail-closed saga wedge/timeout body. The lifecycle timeout
+    /// fires with the step outcome UNKNOWN (a synchronous AX dispatch may be in
+    /// flight and cannot be interrupted), so this NEVER reads the possibly
+    /// lagging journal for its fields: it forces `write_attempted` /
+    /// `write_boundary_crossed = true`, `safe_to_retry = false`, `verified =
+    /// false`, and reports the gate as reclaimable only after the grace window.
+    /// The SAME `StoredOutcome` becomes the journal terminal record via
+    /// `completeOnTimeout`, so the client body and the journal agree.
+    static func sagaWedgeTimeout(
+        idempotencyKey: String,
+        seconds: Double,
+        gateReclaimAfterSec: Double
+    ) -> SagaJournal.StoredOutcome {
+        let extras = sessionFields.merging([
+            "idempotency_key": idempotencyKey,
+            "duplicate": false,
+            "operation": "system.saga_execute",
+            "timeout_sec": seconds,
+            "verified": false,
+            "write_attempted": true,
+            "write_boundary_crossed": true,
+            "safe_to_retry": false,
+            "outcome_retained": true,
+            "underlying_operation_stopped": false,
+            "mutation_gate": "reclaimable_after_grace",
+            "gate_reclaim_after_sec": gateReclaimAfterSec,
+            "recovery_hint": "The saga exceeded its lifecycle deadline and was abandoned so the "
+                + "stdio loop stays responsive. A dispatch may have crossed the write boundary with "
+                + "an unknown outcome; do NOT blindly retry. Reconcile with a live read "
+                + "(system.saga_status, or the relevant read operations).",
+        ]) { _, new in new }
+        let body = HonestContract.encodeStateC(
+            error: .operationTimeout,
+            hint: "system.saga_execute exceeded its \(Int(seconds))s lifecycle deadline and was "
+                + "abandoned; the outcome is unknown (fail-closed).",
+            extras: extras
+        )
+        return SagaJournal.StoredOutcome(body: body, isError: true)
     }
 
     static func storedOutcome(from result: CallTool.Result) -> SagaJournal.StoredOutcome {

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -186,13 +186,19 @@ final class LogicMutationGate: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         if let active = activeOperation, let since = acquiredAt {
-            if activeReclaimPolicy == .releaseOnly {
-                return nil
-            } else if let timedOutAt, now.timeIntervalSince(timedOutAt) >= timedOutReclaimGrace {
+            // #412: the grace-reclaim branch is checked BEFORE the blanket
+            // `.releaseOnly` bail so a force-timed-out `.releaseOnly` saga claim
+            // becomes reclaimable — but ONLY after the 15s grace, and ONLY once
+            // force-marked (an un-marked `.releaseOnly` claim has no `timedOutAt`,
+            // so it still never reclaims mid-saga). This applies to both an
+            // automatic timed-out holder (#201) and a force-marked saga claim.
+            if let timedOutAt, now.timeIntervalSince(timedOutAt) >= timedOutReclaimGrace {
                 Log.warn(
-                    "Reclaiming timed-out mutation gate from \(active) (grace \(Int(timedOutReclaimGrace))s elapsed) — prior op was abandoned by the command deadline",
+                    "Reclaiming timed-out mutation gate from \(active) (grace \(Int(timedOutReclaimGrace))s elapsed) — prior op was abandoned by the command/lifecycle deadline",
                     subsystem: "server"
                 )
+            } else if activeReclaimPolicy == .releaseOnly {
+                return nil
             } else if now.timeIntervalSince(since) >= staleHolderTTL {
                 Log.warn(
                     "Reclaiming stale mutation gate from \(active) held \(Int(now.timeIntervalSince(since)))s (TTL \(Int(staleHolderTTL))s) — prior op may still be wedged",
@@ -214,9 +220,14 @@ final class LogicMutationGate: @unchecked Sendable {
     /// the command deadline, starting the short `timedOutReclaimGrace` window.
     /// Epoch-guarded so a late mark from an abandoned op cannot affect a
     /// successor that already reclaimed the gate.
-    func markTimedOut(_ claim: Claim, now: Date = Date()) {
+    /// #412: `force` lets the saga lifecycle-timeout path mark even a
+    /// `.releaseOnly` claim as timed-out (the default `force: false` still
+    /// no-ops on `.releaseOnly`, preserving every existing #201 call site and
+    /// the `.releaseOnly` "no stale reclaim mid-saga" semantics). Epoch-guarded,
+    /// so a late mark after a successor reclaimed is harmless.
+    func markTimedOut(_ claim: Claim, force: Bool = false, now: Date = Date()) {
         lock.lock()
-        if epoch == claim.epoch, activeReclaimPolicy == .automatic {
+        if epoch == claim.epoch, force || activeReclaimPolicy == .automatic {
             timedOutAt = now
         }
         lock.unlock()
@@ -512,19 +523,40 @@ actor LogicProServer {
                     tool: name,
                     command: command
                 )
+                // #412: for saga_execute, compute ONE shared absolute lifecycle
+                // deadline HERE, before `work()` runs. It is threaded into BOTH
+                // the dispatcher's in-closure abandon race (the inner,
+                // authoritative bound) and the outer transport timer (a redundant
+                // liveness net derived from the same instant), so the outer is
+                // provably always later than the inner regardless of
+                // begin/gate/preflight pre-execute skew.
+                let isSagaExecute = sagaControlPath && command == "saga_execute"
+                let sagaLifecycleDeadline: ContinuousClock.Instant? = isSagaExecute
+                    ? ContinuousClock.now.advanced(by: .seconds(
+                        OperationRegistry.spec(
+                            tool: name,
+                            command: "saga_execute"
+                        )?.deadline.seconds ?? DeadlineClass.long.seconds
+                    ))
+                    : nil
+                let dispatchDependencies = sagaLifecycleDeadline
+                    .map { handlerDependencies.withSagaLifecycleDeadline($0) }
+                    ?? handlerDependencies
                 return await Self.runWithDeadline(
                     tool: name,
                     command: command,
+                    outerAbsoluteDeadline: sagaLifecycleDeadline
+                        .map { Self.sagaOuterAbsoluteDeadline(lifecycleDeadline: $0) },
                     mutationGate: sagaControlPath ? nil : mutationGate,
-                    externallyManagedMutation: sagaControlPath && command == "saga_execute"
+                    externallyManagedMutation: isSagaExecute
                 ) {
                     if let handler {
-                        return await handler(handlerDependencies, cmdParams)
+                        return await handler(dispatchDependencies, cmdParams)
                     }
                     guard let fallback else {
                         return toolTextResult("Unknown tool: \(name)", isError: true)
                     }
-                    return await fallback(handlerDependencies, cmdParams)
+                    return await fallback(dispatchDependencies, cmdParams)
                 }
             },
             listResources: { _ in
@@ -645,10 +677,45 @@ actor LogicProServer {
     /// work to unwind. The orphaned synchronous AX work (if any) is left to
     /// finish and is discarded — the point is to free the stdio loop, not to
     /// pretend cooperative cancellation can interrupt a blocked system call.
+    /// #412: a few hundred ms covering only the O(1) journal finalize +
+    /// continuation resume on the saga abandon path (no AX). Named so the outer
+    /// transport deadline provably sits above the inner lifecycle deadline.
+    static let sagaTerminalizationReserveSeconds: Double = 0.3
+
+    /// #412: the outer transport timer for `saga_execute` stays a genuine
+    /// last-resort stdio-liveness net, derived from the SAME shared lifecycle
+    /// instant + this slack so it is provably always later than the inner
+    /// abandon machinery regardless of pre-execute skew.
+    static let sagaOuterLivenessSlackSeconds: Double = 60
+
+    /// #412: the outer transport absolute deadline derived from the shared inner
+    /// `lifecycleDeadline` instant. `outerAbsolute >= lifecycleDeadline +
+    /// terminalizationReserve` holds by construction, so the outer timer can
+    /// never fire first while the journal is still live.
+    static func sagaOuterAbsoluteDeadline(
+        lifecycleDeadline: ContinuousClock.Instant
+    ) -> ContinuousClock.Instant {
+        lifecycleDeadline.advanced(
+            by: .seconds(sagaTerminalizationReserveSeconds + sagaOuterLivenessSlackSeconds)
+        )
+    }
+
+    /// Non-negative seconds from now until `instant`, for scheduling a
+    /// `DispatchQueue.asyncAfter` from a shared `ContinuousClock.Instant`.
+    static func secondsFromNow(until instant: ContinuousClock.Instant) -> Double {
+        let components = ContinuousClock.now.duration(to: instant).components
+        return max(0, Double(components.seconds) + Double(components.attoseconds) / 1e18)
+    }
+
     static func runWithDeadline(
         tool: String,
         command: String,
         deadlineOverride: Double? = nil,
+        // #412: when set (saga_execute only), the outer transport timer is
+        // scheduled from this shared absolute instant instead of `.now() +
+        // deadline`, so it is provably later than the inner lifecycle deadline
+        // derived from the same instant.
+        outerAbsoluteDeadline: ContinuousClock.Instant? = nil,
         mutationGate: LogicMutationGate? = nil,
         externallyManagedMutation: Bool = false,
         work: @escaping @Sendable () async -> CallTool.Result
@@ -716,8 +783,10 @@ actor LogicProServer {
                 }
             }
             timeoutHandle.set(timeoutTask)
+            let scheduleAfter = outerAbsoluteDeadline
+                .map { Self.secondsFromNow(until: $0) } ?? deadline
             DispatchQueue.global(qos: .userInitiated).asyncAfter(
-                deadline: .now() + deadline,
+                deadline: .now() + scheduleAfter,
                 execute: timeoutTask
             )
         }

--- a/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationHandlerRegistry.swift
@@ -22,6 +22,13 @@ struct HandlerDependencies: Sendable {
     /// real handler would be live AX, and their index path would silently drop
     /// out of the deterministic census.
     let liveTrackNames: (@Sendable () -> [Int: String]?)?
+    /// #412: the shared absolute saga lifecycle deadline, computed once at the
+    /// server dispatch entry and threaded to `SystemDispatcher.saga_execute` so
+    /// its in-closure abandon race and the outer transport timer derive from ONE
+    /// instant. `nil` on every non-saga
+    /// dispatch and whenever the dispatcher is driven directly (tests) — the
+    /// dispatcher then derives its own instant.
+    let sagaLifecycleDeadline: ContinuousClock.Instant?
 
     init(
         router: ChannelRouter,
@@ -33,7 +40,8 @@ struct HandlerDependencies: Sendable {
         sagaJournal: SagaJournal = SagaJournal(),
         mutationGate: LogicMutationGate? = nil,
         projectLifecycleExecute: (@Sendable (String) async -> ProjectDispatcher.LifecycleExecution)? = nil,
-        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil
+        liveTrackNames: (@Sendable () -> [Int: String]?)? = nil,
+        sagaLifecycleDeadline: ContinuousClock.Instant? = nil
     ) {
         self.router = router
         self.cache = cache
@@ -45,12 +53,32 @@ struct HandlerDependencies: Sendable {
         self.mutationGate = mutationGate
         self.projectLifecycleExecute = projectLifecycleExecute
         self.liveTrackNames = liveTrackNames
+        self.sagaLifecycleDeadline = sagaLifecycleDeadline
     }
 
     /// The live header reader to hand a dispatcher: the injected seam when a
     /// test supplies one, else the production AX scan.
     var liveTrackNamesReader: @Sendable () -> [Int: String]? {
         liveTrackNames ?? { AXLogicProElements.trackNames() }
+    }
+
+    /// #412: a per-call copy carrying the shared saga lifecycle deadline. The
+    /// base dependencies are built once per server; this stamps the one field
+    /// that must be computed per saga_execute call.
+    func withSagaLifecycleDeadline(_ deadline: ContinuousClock.Instant) -> HandlerDependencies {
+        HandlerDependencies(
+            router: router,
+            cache: cache,
+            targetRegistry: targetRegistry,
+            poller: poller,
+            dialogPresent: dialogPresent,
+            supportBundleExporter: supportBundleExporter,
+            sagaJournal: sagaJournal,
+            mutationGate: mutationGate,
+            projectLifecycleExecute: projectLifecycleExecute,
+            liveTrackNames: liveTrackNames,
+            sagaLifecycleDeadline: deadline
+        )
     }
 }
 
@@ -274,7 +302,9 @@ enum OperationHandlerRegistry {
                     liveTrackNames: dependencies.liveTrackNamesReader,
                     // LPMCP-PRD-004 — saga before-state/verification/compensation
                     // read the live AX surface, never the cache mirror.
-                    sagaLiveReadback: .production
+                    sagaLiveReadback: .production,
+                    // #412: the shared lifecycle deadline for the saga abandon race.
+                    sagaLifecycleDeadline: dependencies.sagaLifecycleDeadline
                 )
             }
         case .logicPlugins:

--- a/Tests/LogicProMCPTests/MutationSagaTests.swift
+++ b/Tests/LogicProMCPTests/MutationSagaTests.swift
@@ -102,6 +102,25 @@ private actor StepBoundaryCancellationProbe {
     }
 }
 
+/// #412: a synchronous, counter-based deadline predicate — the saga-level stand
+/// in for the injected `deadlineReached` / the dispatcher's folded deadline. It
+/// flips true after `flipAfter` calls so a test can pin exactly when the budget
+/// elapses, with no wall-clock sleep.
+private final class DeadlineFlipProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var checks = 0
+    private let flipAfter: Int
+
+    init(flipAfter: Int) { self.flipAfter = flipAfter }
+
+    func reached() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        checks += 1
+        return checks > flipAfter
+    }
+}
+
 @Suite("Mutation saga", .serialized)
 struct MutationSagaTests {
     private func bind(
@@ -114,6 +133,20 @@ struct MutationSagaTests {
             kind: .track,
             descriptor: descriptor,
             fingerprint: descriptor.fingerprint
+        )
+    }
+
+    /// A minimal step for journal-only tests (identity/finalize), where the
+    /// step's contents are never executed — only hashed into the plan.
+    private func journalStep() -> SagaStep {
+        SagaStep(
+            operationID: .tracksRename,
+            targetRef: nil,
+            params: ["name": .string("X")],
+            expectedInverse: SagaExpectedInverse(
+                operationID: .tracksRename,
+                valueParameter: "name"
+            )
         )
     }
 
@@ -451,6 +484,169 @@ struct MutationSagaTests {
         #expect(await executor.state(for: target) == .string("Before"))
         let journalEntry = try #require(outcome.journal.first)
         #expect(!journalEntry.writeBoundaryCrossed)
+    }
+
+    // MARK: - #412 bounded saga lifecycle deadline (saga + journal level)
+
+    /// #412: once the deadline trips (modeled here as the dispatcher's folded
+    /// `cancellationRequested`), the forward loop issues NO additional dispatch
+    /// — step 1 is never run; only step 0 and its inverse
+    /// were dispatched. Asserts about NEW dispatch, not interruption.
+    @Test
+    func deadlineFlipStopsAdditionalForwardDispatch() async {
+        let registry = TargetRegistry()
+        let renameTarget = await bind(registry, index: 0, name: "Bass")
+        let volumeTarget = await bind(registry, index: 1, name: "Keys")
+        let executor = MockSagaExecutor(
+            states: [renameTarget: .string("Bass"), volumeTarget: .double(0.25)],
+            behaviors: [.applyStateA, .applyStateA]
+        )
+        // Flips true on the 3rd checkpoint — the post-applied check after step 0's
+        // write, before step 1 is ever entered.
+        let deadline = DeadlineFlipProbe(flipAfter: 2)
+        let outcome = await MutationSaga(
+            targetRegistry: registry,
+            enabled: true,
+            routeAvailable: { _ in true }
+        ).execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: renameTarget, value: .string("Sub Bass")),
+                    step(.mixerSetVolume, target: volumeTarget, value: .double(0.75)),
+                ],
+                idempotencyKey: "deadline-forward-stop"
+            ),
+            executor: executor,
+            cancellationRequested: { deadline.reached() }
+        )
+
+        // Only step 0 (forward) + step 0's inverse dispatched — no step 1.
+        #expect(await executor.runCount() == 2)
+        let ops = await executor.runOperations()
+        #expect(!ops.contains(.mixerSetVolume))
+        #expect(outcome.state == .fullyCompensated)
+    }
+
+    /// #412: a deadline that trips DURING compensation abandons the remaining
+    /// inverses as `.uncertain` (never `.failed`, never dispatched) and
+    /// terminates `rollbackUncertain`.
+    @Test
+    func deadlineFlipDuringCompensationAbandonsInversesAsUncertain() async throws {
+        let registry = TargetRegistry()
+        let renameTarget = await bind(registry, index: 0, name: "Lead")
+        let volumeTarget = await bind(registry, index: 1, name: "Pad")
+        let panTarget = await bind(registry, index: 2, name: "FX")
+        let executor = MockSagaExecutor(
+            states: [
+                renameTarget: .string("Lead"),
+                volumeTarget: .double(0.2),
+                panTarget: .double(0),
+            ],
+            behaviors: [.applyStateA, .applyStateA, .failBeforeWrite]
+        )
+        let outcome = await MutationSaga(
+            targetRegistry: registry,
+            enabled: true,
+            routeAvailable: { _ in true }
+        ).execute(
+            SagaPlan(
+                steps: [
+                    step(.tracksRename, target: renameTarget, value: .string("Lead Vox")),
+                    step(.mixerSetVolume, target: volumeTarget, value: .double(0.9)),
+                    step(.mixerSetPan, target: panTarget, value: .double(-0.5)),
+                ],
+                idempotencyKey: "deadline-compensation-flip"
+            ),
+            executor: executor,
+            // The forward phase never trips; the deadline is already elapsed by
+            // the time compensation begins, so the FIRST inverse is abandoned.
+            deadlineReached: { true }
+        )
+
+        #expect(outcome.state == .rollbackUncertain)
+        let c0 = try #require(outcome.journal[0].compensationEvidence)
+        let c1 = try #require(outcome.journal[1].compensationEvidence)
+        #expect(c0.disposition == .uncertain)
+        #expect(c1.disposition == .uncertain)
+        // Directly `.uncertain`, never through an inverse dispatch.
+        #expect(c0.executionResult == nil)
+        #expect(c1.executionResult == nil)
+        // Only the 3 forward runs — no inverse dispatched after the flip.
+        #expect(await executor.runCount() == 3)
+    }
+
+    /// #412: the loser of the first-writer race resumes with the WINNER's stored
+    /// body, never a local body.
+    @Test
+    func finalizeReturningWinnerReturnsTheJournalWinnerBody() async throws {
+        let journal = SagaJournal()
+        let plan = SagaPlan(
+            steps: [journalStep()],
+            idempotencyKey: "ni3-winner-coupling"
+        )
+        guard case .started(let claim) = await journal.begin(plan) else {
+            Issue.record("expected a new journal claim")
+            return
+        }
+        // The winning finisher terminalizes first with body X — it DID finalize.
+        let winnerBody = SagaJournal.StoredOutcome(body: "{\"winner\":true}", isError: false)
+        let winning = await journal.completeOnTimeout(claim, outcome: winnerBody)
+        #expect(winning.body.body == winnerBody.body)
+        #expect(winning.didFinalize)
+
+        // The losing finisher proposes a DIFFERENT local body and MUST read back
+        // the winner — not its own local body — and reports didFinalize == false.
+        let localBody = SagaJournal.StoredOutcome(body: "{\"local\":true}", isError: true)
+        let losing = await journal.finalizeReturningWinner(claim, proposed: localBody)
+        #expect(losing.body.body == winnerBody.body)
+        #expect(losing.body.body != localBody.body)
+        #expect(!losing.didFinalize)
+
+        guard case .completed(let stored) = try #require(
+            await journal.record(for: plan.idempotencyKey)
+        ) else {
+            Issue.record("expected a completed terminal record")
+            return
+        }
+        #expect(stored.body == winnerBody.body)
+    }
+
+    /// #412: `completeOnTimeout` terminalizes BOTH live states, mapping
+    /// `.inProgress → .completed` and `.cancellationRequested → .cancelled`
+    /// (verified:false, because a timed-out outcome is never verified).
+    @Test
+    func completeOnTimeoutTerminalizesBothLiveStates() async throws {
+        // inProgress → completed
+        let journalA = SagaJournal()
+        let planA = SagaPlan(steps: [journalStep()], idempotencyKey: "timeout-inprogress")
+        guard case .started(let claimA) = await journalA.begin(planA) else {
+            Issue.record("expected a claim"); return
+        }
+        let bodyA = SagaJournal.StoredOutcome(body: "{\"t\":\"ip\"}", isError: true)
+        _ = await journalA.completeOnTimeout(claimA, outcome: bodyA)
+        guard case .completed(let storedA) = try #require(
+            await journalA.record(for: planA.idempotencyKey)
+        ) else {
+            Issue.record("expected a completed terminal record"); return
+        }
+        #expect(storedA.body == bodyA.body)
+
+        // cancellationRequested → cancelled(verified:false)
+        let journalB = SagaJournal()
+        let planB = SagaPlan(steps: [journalStep()], idempotencyKey: "timeout-cancelreq")
+        guard case .started(let claimB) = await journalB.begin(planB) else {
+            Issue.record("expected a claim"); return
+        }
+        _ = await journalB.cancel(idempotencyKey: planB.idempotencyKey)
+        let bodyB = SagaJournal.StoredOutcome(body: "{\"t\":\"cr\"}", isError: true)
+        _ = await journalB.completeOnTimeout(claimB, outcome: bodyB)
+        guard case .cancelled(let storedB, let verified) = try #require(
+            await journalB.record(for: planB.idempotencyKey)
+        ) else {
+            Issue.record("expected a cancelled terminal record"); return
+        }
+        #expect(storedB.body == bodyB.body)
+        #expect(!verified)
     }
 
     @Test

--- a/Tests/LogicProMCPTests/SagaExecutionTests.swift
+++ b/Tests/LogicProMCPTests/SagaExecutionTests.swift
@@ -982,5 +982,64 @@ struct SagaExecutionTests {
             #expect(fixture.surface.snapshot(2)?.pan == 0)
         }
     }
+
+    /// #412 (E2E, deterministic): the qualification fault seam applies a real
+    /// prefix (steps 0,1) then fails the injected step 2 before its write, so the
+    /// saga enters REAL compensation. A compensation-phase deadline flip then
+    /// abandons the remaining inverses as `.uncertain` — no inverse dispatches,
+    /// bounded compensation, terminal `rollbackUncertain`.
+    @Test("partial_state fault + compensation deadline flip yields bounded rollbackUncertain")
+    func partialStateFaultWithCompensationDeadlineFlipRollsBackUncertain() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
+            let tracks = [
+                TrackState(id: 0, name: "Lead", type: .audio),
+                TrackState(id: 1, name: "Pad", type: .softwareInstrument, volume: 0.2),
+                TrackState(id: 2, name: "FX", type: .audio, pan: 0),
+            ]
+            let seam = SagaPartialStateFaultSeam.resolve(
+                environment: ["LOGIC_PRO_MCP_FAULT_INJECT": "partial_state"],
+                stepCount: 3
+            )
+            let fixture = await makeSeamFixture(tracks: tracks, faultSeam: seam)
+            let plan = SagaPlan(
+                steps: [
+                    step(.tracksRename, target: fixture.targets[0], value: .string("Lead Vox")),
+                    step(.mixerSetVolume, target: fixture.targets[1], value: .double(0.9)),
+                    step(.mixerSetPan, target: fixture.targets[2], value: .double(-0.5)),
+                ],
+                idempotencyKey: "fault-seam-compensation-deadline"
+            )
+
+            let outcome = await MutationSaga(
+                targetRegistry: fixture.registry,
+                enabled: true,
+                routeAvailable: { _ in true }
+            ).execute(
+                plan,
+                executor: fixture.executor,
+                // The deadline is already elapsed once compensation begins, so the
+                // real applied prefix is abandoned rather than reverse-dispatched.
+                deadlineReached: { true }
+            )
+
+            // Forward rename + volume only — NO inverse dispatched (the injected
+            // pan never dispatched either).
+            #expect(await fixture.channel.recordedCalls().map(\.operation)
+                == ["track.rename", "mixer.set_volume"])
+
+            #expect(outcome.state == .rollbackUncertain)
+            let c0 = try #require(outcome.journal[0].compensationEvidence)
+            let c1 = try #require(outcome.journal[1].compensationEvidence)
+            #expect(c0.disposition == .uncertain)
+            #expect(c1.disposition == .uncertain)
+            #expect(c0.executionResult == nil)
+            #expect(c1.executionResult == nil)
+
+            // The applied prefix was NOT reverted (compensation was abandoned), so
+            // the live surface still holds the forward writes — honestly uncertain.
+            #expect(fixture.surface.snapshot(0)?.name == "Lead Vox")
+            #expect(fixture.surface.snapshot(1)?.volume == 0.9)
+        }
+    }
     #endif
 }

--- a/Tests/LogicProMCPTests/SagaSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/SagaSurfaceTests.swift
@@ -302,7 +302,8 @@ struct SagaSurfaceTests {
         dialogPresent: @escaping @Sendable () -> Bool = { false },
         mutationGate: LogicMutationGate? = nil,
         sagaAfterJournalBegin: (@Sendable () async -> Void)? = nil,
-        sagaRefreshAfterWrite: (@Sendable () async -> Void)? = nil
+        sagaRefreshAfterWrite: (@Sendable () async -> Void)? = nil,
+        sagaLifecycleDeadline: ContinuousClock.Instant? = nil
     ) async -> CallTool.Result {
         await SystemDispatcher.handle(
             command: command,
@@ -315,7 +316,8 @@ struct SagaSurfaceTests {
             mutationGate: mutationGate,
             sagaAfterJournalBegin: sagaAfterJournalBegin,
             sagaRefreshAfterWrite: sagaRefreshAfterWrite,
-            sagaLiveReadback: fixture.surface.readback
+            sagaLiveReadback: fixture.surface.readback,
+            sagaLifecycleDeadline: sagaLifecycleDeadline
         )
     }
 
@@ -1045,6 +1047,317 @@ struct SagaSurfaceTests {
             operation: OperationID.tracksMute.rawValue,
             now: start.addingTimeInterval(362)
         ) != nil)
+    }
+
+    // MARK: - #412 bounded saga lifecycle deadline
+    //
+    // Single lifecycle budget, no reserved compensation slice: a full-budget
+    // forward leaves ~0 compensation budget, so all applied inverses are
+    // honestly abandoned as `uncertain` (→ `rollbackUncertain`); the saga-level
+    // mid-compensation deadline-flip test exercises that. No
+    // reserved-compensation-budget guarantee is claimed.
+
+    @Test("#412: a force-timed-out releaseOnly saga claim reclaims only after the 15s grace")
+    func sagaGateForceTimeoutIsReclaimableAfterGrace() throws {
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+        let start = Date(timeIntervalSince1970: 5_000)
+        let claim = try #require(gate.tryAcquire(
+            operation: OperationID.systemSagaExecute.rawValue,
+            now: start,
+            reclaimPolicy: .releaseOnly
+        ))
+        let mark = start.addingTimeInterval(2)
+        gate.markTimedOut(claim, force: true, now: mark)
+        // No early free: 14.9s after the force-mark still returns nil.
+        #expect(gate.tryAcquire(
+            operation: OperationID.tracksMute.rawValue,
+            now: mark.addingTimeInterval(14.9)
+        ) == nil)
+        // Reclaimable at the 15s grace.
+        let reclaimed = try #require(gate.tryAcquire(
+            operation: OperationID.tracksMute.rawValue,
+            now: mark.addingTimeInterval(15)
+        ))
+        #expect(reclaimed.operation == OperationID.tracksMute.rawValue)
+    }
+
+    @Test("#412: an un-force-marked releaseOnly claim never reclaims, even past the stale TTL")
+    func sagaGateDefaultTimeoutNeverReclaimsReleaseOnly() throws {
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+        let start = Date(timeIntervalSince1970: 6_000)
+        let claim = try #require(gate.tryAcquire(
+            operation: OperationID.systemSagaExecute.rawValue,
+            now: start,
+            reclaimPolicy: .releaseOnly
+        ))
+        // Default force:false is a no-op on a `.releaseOnly` claim (no timedOutAt),
+        // so it never reclaims even long past the stale TTL.
+        gate.markTimedOut(claim, now: start.addingTimeInterval(10))
+        #expect(gate.tryAcquire(
+            operation: OperationID.tracksMute.rawValue,
+            now: start.addingTimeInterval(1_000)
+        ) == nil)
+    }
+
+    @Test("#412: the outer transport deadline is provably later than the inner")
+    func sagaOuterDeadlineExceedsInnerPlusReserve() {
+        let inner = ContinuousClock.now.advanced(by: .seconds(300))
+        let outer = LogicProServer.sagaOuterAbsoluteDeadline(lifecycleDeadline: inner)
+        let minimum = inner.advanced(
+            by: .seconds(LogicProServer.sagaTerminalizationReserveSeconds)
+        )
+        #expect(outer >= minimum)
+        #expect(outer == inner.advanced(by: .seconds(
+            LogicProServer.sagaTerminalizationReserveSeconds
+                + LogicProServer.sagaOuterLivenessSlackSeconds
+        )))
+    }
+
+    @Test("#412: a wedged saga is abandoned with a fail-closed body, terminal journal, and grace-reclaimable gate")
+    func sagaWedgeTimeoutAbandonsFailClosedWithGraceReclaimableGate() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture()
+            let probe = BlockingSagaRefreshProbe()
+            let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+            let key = "wedge-abandon-key"
+            let params = plan(idempotencyKey: key, steps: [
+                step(
+                    operationID: .mixerSetVolume,
+                    target: fixture.targets[0],
+                    valueParameter: "value",
+                    value: .double(0.75)
+                ),
+            ])
+
+            // The work child gets a deterministic head-start to reach — and wedge
+            // in — the never-signaled refresh (a NON-cancellable await, past the
+            // step executor's `Task.isCancelled` guard) before the lifecycle
+            // timeout fires. The mock work is microseconds; the deadline is 0.5s,
+            // so the block always happens first, then the timeout wins the race
+            // while the run stays blocked. This is not a synchronization sleep —
+            // the block-first ordering is what makes it deterministic.
+            let result = await dispatch(
+                command: "saga_execute",
+                params: params,
+                fixture: fixture,
+                mutationGate: gate,
+                sagaRefreshAfterWrite: { await probe.blockFirstRefresh() },
+                sagaLifecycleDeadline: ContinuousClock.now.advanced(by: .milliseconds(500))
+            )
+            let mark = Date()
+
+            // The work child reached the wedge (after its write) and is STILL
+            // blocked — the probe is never released until the drain below.
+            await probe.waitUntilEntered()
+            #expect(await fixture.channel.writeCount() == 1)   // a dispatch DID start
+
+            // (1) typed State C operation_timeout + fail-closed field set.
+            let object = try resultObject(result)
+            #expect(result.isError!)
+            #expect(object["state"] as? String == "C")
+            #expect(object["error"] as? String == "operation_timeout")
+            #expect((object["write_attempted"] as? Bool)!)
+            #expect((object["write_boundary_crossed"] as? Bool)!)
+            #expect(!(try #require(object["safe_to_retry"] as? Bool)))
+            #expect(!(try #require(object["verified"] as? Bool)))
+            #expect(object["mutation_gate"] as? String == "reclaimable_after_grace")
+
+            // (2) journal reached a TERMINAL record, not stuck inProgress.
+            guard case .completed(let stored) = try #require(
+                await fixture.journal.record(for: key)
+            ) else {
+                Issue.record("expected a terminal completed journal record")
+                return
+            }
+
+            // (4) response bytes == winning journal terminal bytes.
+            guard case .text(let responseText, _, _) = result.content.first else {
+                Issue.record("expected a text result")
+                return
+            }
+            #expect(responseText == stored.body)
+
+            // (5) gate: no early free now; reclaimable only after the 15s grace.
+            #expect(gate.tryAcquire(
+                operation: OperationID.tracksMute.rawValue,
+                now: mark
+            ) == nil)
+            let reclaimed = try #require(gate.tryAcquire(
+                operation: OperationID.tracksMute.rawValue,
+                now: mark.addingTimeInterval(16)
+            ))
+            #expect(reclaimed.operation == OperationID.tracksMute.rawValue)
+
+            // Drain the leaked work child (finalize is already a no-op).
+            await probe.unblock()
+        }
+    }
+
+    @Test("#412: the timeout envelope is fail-closed and never State A")
+    func sagaTimeoutEnvelopeIsFailClosed() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture()
+            let probe = BlockingSagaRefreshProbe()
+            let key = "fail-closed-envelope"
+            let params = plan(idempotencyKey: key, steps: [
+                step(
+                    operationID: .mixerSetVolume,
+                    target: fixture.targets[0],
+                    valueParameter: "value",
+                    value: .double(0.75)
+                ),
+            ])
+            let result = await dispatch(
+                command: "saga_execute",
+                params: params,
+                fixture: fixture,
+                sagaRefreshAfterWrite: { await probe.blockFirstRefresh() },
+                sagaLifecycleDeadline: ContinuousClock.now.advanced(by: .milliseconds(500))
+            )
+            await probe.waitUntilEntered()
+
+            let object = try resultObject(result)
+            #expect(object["state"] as? String == "C")   // never State A on timeout
+            #expect((object["write_attempted"] as? Bool)!)
+            #expect((object["write_boundary_crossed"] as? Bool)!)
+            #expect(!(try #require(object["safe_to_retry"] as? Bool)))
+            #expect(!(try #require(object["verified"] as? Bool)))
+            let outcomeRetained = try #require(object["outcome_retained"] as? Bool)
+            #expect(outcomeRetained)
+            #expect(object["gate_reclaim_after_sec"] != nil)
+
+            // Drain the leaked work child (finalize is already a no-op).
+            await probe.unblock()
+        }
+    }
+
+    @Test("#412: a healthy saga releases the gate immediately, no 15s pin")
+    func sagaHealthyCompletionReleasesGateImmediately() async throws {
+        try await withSagaFeatures {
+            let fixture = await makeFixture()
+            let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+            let key = "healthy-no-pin"
+            let params = plan(idempotencyKey: key, steps: [
+                step(
+                    operationID: .mixerSetVolume,
+                    target: fixture.targets[0],
+                    valueParameter: "value",
+                    value: .double(0.75)
+                ),
+            ])
+            // Default lifecycle deadline (registry 300s budget): the timeout never
+            // fires during the test, the work child wins, and the defer releases.
+            let result = await dispatch(
+                command: "saga_execute",
+                params: params,
+                fixture: fixture,
+                mutationGate: gate
+            )
+            let object = try resultObject(result)
+            #expect(object["state"] as? String == "A")   // completed saga, inner body
+
+            guard case .completed(let stored) = try #require(
+                await fixture.journal.record(for: key)
+            ) else {
+                Issue.record("expected a terminal completed journal record")
+                return
+            }
+            // The inner (work child) body finalized — not the outer legacy body.
+            #expect(!stored.body.contains("held_until_saga_unwinds"))
+
+            // Immediately acquirable: no force-mark, no 15s pin.
+            let acquired = try #require(gate.tryAcquire(
+                operation: OperationID.tracksMute.rawValue,
+                now: Date()
+            ))
+            #expect(acquired.operation == OperationID.tracksMute.rawValue)
+        }
+    }
+
+    @Test("#412: a timeout winning the race after a successful journal finalize does NOT pin the gate")
+    func timeoutWinningRaceAfterSuccessfulFinalizeDoesNotPinGate() async throws {
+        // Reproduces the race window: the work child finalizes SUCCESS (wins the
+        // JOURNAL finalize), then the lifecycle timeout fires and wins the RESUME
+        // race — but `completeOnTimeout` finds the entry already terminal, so it
+        // reports `didFinalize == false`. The dispatcher gates its abandon side
+        // effects on that bit (`guard didTerminalizeTimeout`), so a
+        // successfully-completed saga is NEVER force-marked / gate-pinned. Driven
+        // against a real journal + gate; the exact dispatcher gating decision is
+        // applied inline (a production seam to control the async race window would
+        // be out of scope).
+        let journal = SagaJournal()
+        let sagaPlan = SagaPlan(
+            steps: [SagaStep(
+                operationID: .tracksRename,
+                targetRef: nil,
+                params: ["name": .string("X")],
+                expectedInverse: SagaExpectedInverse(
+                    operationID: .tracksRename,
+                    valueParameter: "name"
+                )
+            )],
+            idempotencyKey: "success-then-timeout-race"
+        )
+        guard case .started(let claim) = await journal.begin(sagaPlan) else {
+            Issue.record("expected a new journal claim")
+            return
+        }
+        let gate = LogicMutationGate(staleHolderTTL: 360, timedOutReclaimGrace: 15)
+        let start = Date(timeIntervalSince1970: 9_000)
+        let sagaClaim = try #require(gate.tryAcquire(
+            operation: OperationID.systemSagaExecute.rawValue,
+            now: start,
+            reclaimPolicy: .releaseOnly
+        ))
+
+        // Work child finalizes SUCCESS first — it DID finalize.
+        let successBody = SagaJournal.StoredOutcome(
+            body: "{\"state\":\"A\",\"success\":true}",
+            isError: false
+        )
+        let workChild = await journal.finalizeReturningWinner(claim, proposed: successBody)
+        #expect(workChild.didFinalize)
+
+        // Timeout fires later and wins the resume race, but terminalized nothing.
+        let timeoutBody = SagaWire.sagaWedgeTimeout(
+            idempotencyKey: sagaPlan.idempotencyKey,
+            seconds: 300,
+            gateReclaimAfterSec: LogicProServer.mutationGateReclaimGraceSeconds
+        )
+        let timeout = await journal.completeOnTimeout(claim, outcome: timeoutBody)
+        #expect(!timeout.didFinalize)
+
+        // (a) The winning body is the SUCCESS body — never operation_timeout.
+        #expect(timeout.body.body == successBody.body)
+        #expect(!(timeout.body.isError))
+
+        // The dispatcher's gating decision, applied verbatim.
+        let sagaAbandonedByTimeout = SagaAbandonFlag()
+        if timeout.didFinalize {
+            sagaAbandonedByTimeout.set(true)
+            gate.markTimedOut(sagaClaim, force: true, now: start)
+        }
+        if !sagaAbandonedByTimeout.value { gate.release(sagaClaim) }
+
+        // (b) No abandon, no force-mark → the gate is reclaimable IMMEDIATELY,
+        //     with no 15s grace.
+        #expect(!sagaAbandonedByTimeout.value)
+        let reacquired = try #require(gate.tryAcquire(
+            operation: OperationID.tracksMute.rawValue,
+            now: start
+        ))
+        #expect(reacquired.operation == OperationID.tracksMute.rawValue)
+
+        // (c) the journal terminal record is the SUCCESS body, equal to the
+        //     winning (client) body.
+        guard case .completed(let stored) = try #require(
+            await journal.record(for: sagaPlan.idempotencyKey)
+        ) else {
+            Issue.record("expected a completed terminal record")
+            return
+        }
+        #expect(stored.body == successBody.body)
+        #expect(stored.body == timeout.body.body)
     }
 
     @Test("saga deadline responses preserve session journal disclosure")


### PR DESCRIPTION
## #412 — Bound the saga lifecycle under one deadline

Closes #412. Follow-up to PR #378 (deadline-budget preflight): that change made the preflight reject plans that cannot fit the budget; this change makes the runtime actually enforce the budget across the full lifecycle.

### Problem
The saga deadline was coarse: only the transport-level timer bounded the **client response**. The saga's real lifecycle — blocking step dispatch, compensation/unwind, terminal-journal write, and replay-unlock — ran in a detached task that outlived the response and was unbounded. A wedged step could strand the journal `inProgress` forever (replay-lock stuck) and pin the `.releaseOnly` mutation gate permanently, locking out every future saga.

### What this does
Binds the full lifecycle under one monotonic deadline, and — where a synchronous AX call cannot be interrupted — fails **closed** rather than pretending otherwise.

- **MutationSaga** — thread a `deadlineReached` predicate through `execute → cancel → compensate`; a compensation-top checkpoint abandons the remaining inverses directly as `.uncertain` (never `.failed`, never dispatched) → `rollbackUncertain`. Forward reuses the existing cancellation checkpoints.
- **SystemDispatcher** — run the lifecycle in an unstructured work child raced against a lifecycle timer via a first-writer-wins guard. Both finishers terminalize through one claim/generation-guarded journal API (`finalizeReturningWinner`), so the client body always equals the journal terminal record. Timeout-won abandon side effects (gate force-mark, child cancel, defer-skip) fire only when the timeout **actually terminalizes the journal as a timeout** — so a healthy saga is never gate-pinned.
- **SagaJournal** — `finalizeReturningWinner` / `completeOnTimeout` terminalize both live states and return `(winning body, didFinalize)`.
- **LogicMutationGate** — `markTimedOut(force:)` marks a `.releaseOnly` saga claim; `tryAcquire` reclaims it only after the 15s grace. The outer transport deadline for `saga_execute` derives from the same shared instant as the inner lifecycle deadline, so it is always the later, redundant liveness net.
- **Timeout envelope** — fail-closed: `write_attempted` / `write_boundary_crossed = true`, `safe_to_retry = false`, gate `reclaimable_after_grace`. Never State A on timeout.

### Guarantees (honest, fail-closed)
- No **new** dispatch (forward or inverse) after the deadline is observed. An already-in-flight synchronous AX call is not interruptible — explicitly out of scope, and reported fail-closed.
- The journal always reaches a **terminal** record within the budget (never stuck `inProgress`).
- The gate becomes **reclaimable after grace** on timeout — never immediately (would race an orphan write), never permanently.
- The client response body **equals** the winning journal terminal body.
- Abandoned compensation is honest `rollbackUncertain`, never a false `compensationFailed`.

### Tests
Deterministic (injected deadline predicate + injected gate clock; no wall-clock sleeps). Covers: no-additional-dispatch-after-deadline, compensation-abandon → `rollbackUncertain`, wedge → fail-closed body + terminal journal + grace-reclaimable gate, fail-closed envelope, healthy-no-pin, the shared-instant outer/inner ordering, dual-state finalize, response==journal-winner, force-mark reclaim only after grace, and the timeout-wins-race-after-successful-finalize case (does not pin the gate). Full suite green.
