### PR TITLE
test(#393): convert dead boolean #expect to load-bearing form + CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Forbid dead boolean #expect (#393 test-integrity)
+        # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
+        # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
+        run: bash Scripts/ci-forbid-dead-expect.sh
+
       - name: Select Xcode
         # Xcode 16.4 ships Swift 6.2 — required by swift-sdk 0.11.0+ which
         # adopts the short-form `withThrowingTaskGroup { ... }` syntax. The

--- a/Scripts/ci-forbid-dead-expect.sh
+++ b/Scripts/ci-forbid-dead-expect.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# CI lint (#393): forbid DEAD swift-testing boolean expectations.
+#
+# On this toolchain `#expect(<Bool> == true/false)` PASSES UNCONDITIONALLY (`#expect(true == false)`
+# passes) — the assertion proves nothing. The same holds for `!= true/false`, `?? true/false`,
+# `== .some(<Bool>)`, and for the `#require(<Bool> == true/false)` macro. Load-bearing spellings:
+# bare `#expect(x)` / `#expect(!x)`; for Optionals `let v = try #require(x)` then a bare
+# `#expect(v)` (or `#expect(try #require(x))`).
+#
+# This scanner is span- and closure-aware (a line-based grep misses the dead spelling when the
+# `#expect(...)` call wraps across lines, when the dead operator lives in `#require(...)`, or when
+# the line merely *contains* a closure whose `== true` is legitimate while a SECOND, top-level
+# `== true` on the same line is dead). It:
+#   - extracts each `#expect(...)` / `#require(...)` call with balanced parens (multiline OK),
+#   - blanks string literals (so `== true` inside a message string is not counted),
+#   - removes balanced `{...}` closure bodies (so `.filter { $0 == true }` stays live),
+#   - then flags the dead operators in what remains.
+#
+# Not flagged (LIVE): comparisons inside closures; string/int/enum-VALUE `==`; `== .none`
+# (a real enum-case comparison in this codebase — Optional<Bool> uses `== nil`); comment lines;
+# and any call carrying an explicit `// test-integrity:live` suppression (each such use must
+# justify why the spelling is genuinely load-bearing — e.g. a `Bool == Bool` of two non-literals,
+# or a literal that only appears inside a message string).
+#
+# Exit 1 (fail CI) on any dead site.
+set -uo pipefail
+ROOT="${1:-.}"
+cd "$ROOT" || { echo "FATAL: bad root $ROOT"; exit 2; }
+
+python3 - <<'PY'
+import sys, re, glob, bisect
+
+# Dead operators, checked against a call with strings blanked and closures removed:
+#   RHS literal:  x == true / x != false
+#   LHS literal:  true == x / false != x   (lookbehind avoids `.true` / `footrue`)
+#   coalesce:     x ?? true / x ?? false   (see the known over-flag note below)
+#   some-wrap:    x == .some(...) / x == Optional.some(...)
+# Known safe over-flag: a NESTED `?? true/false` inside a live top-level `Bool == Bool`
+# (e.g. `#expect((opt ?? false) == other)`) is flagged too; annotate such a line with
+# `// test-integrity:live:` — the lint errs toward flagging (never toward missing dead code).
+# NB: no `\(*`/`\)*` around the literals — a parenthesised `(true)` is not worth matching
+# and doing so mis-fires on `foo(label: true) == .enumCase` (a call argument followed by a
+# live enum comparison). Comment-stripping below covers `== /* x */ true`.
+DEAD = re.compile(
+    r'(==|!=)\s*(true|false)\b'
+    r'|(?<![.\w])(true|false)\s*(==|!=)'
+    r'|\?\?\s*(true|false)\b'
+    r'|==\s*(?:Optional\s*(?:<[^>]*>)?\s*)?\.some\s*\('
+)
+
+def calls(text):
+    """Yield (start_offset, call_text) for each #expect(/#require( with a balanced-paren arg."""
+    for m in re.finditer(r'#(?:expect|require)\s*\(', text):
+        depth, j = 0, m.end() - 1  # position of the opening '('
+        while j < len(text):
+            c = text[j]
+            if c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        yield m.start(), text[m.start():j + 1]
+
+def blank_strings(s):
+    return re.sub(r'"(?:\\.|[^"\\])*"', '""', s)
+
+def strip_comments(s):
+    # blank block and line comments so trivia between an operator and a literal
+    # (e.g. `== /* x */ true`) cannot hide a dead spelling. Runs AFTER blank_strings
+    # so a `//` or `/*` inside a string literal is already gone.
+    s = re.sub(r'/\*.*?\*/', ' ', s, flags=re.DOTALL)
+    s = re.sub(r'//[^\n]*', ' ', s)
+    return s
+
+def drop_closures(s):
+    out, depth = [], 0
+    for c in s:
+        if c == '{':
+            depth += 1
+        elif c == '}':
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(c)
+    return ''.join(out)
+
+hits = []
+for f in sorted(glob.glob('Tests/**/*.swift', recursive=True)):
+    lines = open(f, encoding='utf-8').read().split('\n')
+    text = '\n'.join(lines)
+    starts = [0]
+    for ln in lines:
+        starts.append(starts[-1] + len(ln) + 1)
+    for off, call in calls(text):
+        lineno = bisect.bisect_right(starts, off)
+        raw = lines[lineno - 1]
+        if 'test-integrity:live' in call or 'test-integrity:live' in raw:
+            continue
+        if re.match(r'\s*(//|///|\*)', raw):
+            continue
+        if DEAD.search(drop_closures(strip_comments(blank_strings(call)))):
+            hits.append((f, lineno, raw.strip()[:110]))
+
+if hits:
+    print("::error::Dead swift-testing boolean expectations found (#393). These pass unconditionally.")
+    print("Convert to bare #expect(x)/#expect(!x); for Optionals: let v = try #require(x); #expect(v).")
+    print("If genuinely load-bearing (literal only inside a message string, or a top-level Bool==Bool), append '// test-integrity:live: <reason>'.")
+    for f, l, t in hits:
+        print(f"{f}:{l}: {t}")
+    print("COUNT:", len(hits))
+    sys.exit(1)
+print("OK: no dead boolean #expect/#require spellings in Tests/ (#393 test-integrity)")
+PY

--- a/Tests/LogicProMCPTests/ADR002ATargetKindTests.swift
+++ b/Tests/LogicProMCPTests/ADR002ATargetKindTests.swift
@@ -203,8 +203,10 @@ struct ADR002ATargetKindTests {
                 TargetReference(rawValue: firstPlugins[0]["plugin_insert_ref"] as! String)
             )
             #expect(binding?.kind == .pluginInsert)
-            #expect(binding?.observedFingerprint.contains("insert=0") == true)
-            #expect(binding?.observedFingerprint.contains("logic.stock.effect.gain") == true)
+            let v1 = try #require(binding?.observedFingerprint.contains("insert=0"))
+            #expect(v1)
+            let v2 = try #require(binding?.observedFingerprint.contains("logic.stock.effect.gain"))
+            #expect(v2)
             #expect((await channels[0].operations()).count == 2)
         }
     }
@@ -273,7 +275,8 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry
             )
             let volumeBody = object(volume)
-            #expect(volume.isError == false)
+            let v1 = try #require(volume.isError)
+            #expect(!v1)
             #expect(volumeBody["target_ref"] as? String == mixerReference.rawValue)
             #expect(volumeBody["target_fingerprint"] as? String == descriptor.fingerprint)
             let mixerOperationsAfterVolume = await mixerChannels[0].operations()
@@ -286,7 +289,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(pan.isError == false)
+            let v2 = try #require(pan.isError)
+            #expect(!v2)
             #expect(object(pan)["target_fingerprint"] as? String == descriptor.fingerprint)
 
             let pluginParams: [String: Value] = [
@@ -307,7 +311,8 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry
             )
             let setParamBody = object(setParam)
-            #expect(setParam.isError == false)
+            let v3 = try #require(setParam.isError)
+            #expect(!v3)
             #expect(setParamBody["target_ref"] as? String == pluginReference.rawValue)
             #expect(setParamBody["target_fingerprint"] as? String == pluginFingerprint)
             let pluginOperationsAfterSetParam = await pluginChannels[0].operations()
@@ -327,7 +332,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(insert.isError == false)
+            let v4 = try #require(insert.isError)
+            #expect(!v4)
             #expect(object(insert)["target_fingerprint"] as? String == emptyInsertFingerprint)
             let insertOperations = await insertChannels[0].operations()
             #expect(insertOperations.first?.1["track"] == "2")
@@ -373,7 +379,8 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry
             )
 
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect((await channels[0].operations()).first?.1["insert"] == "0")
         }
     }
@@ -413,7 +420,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(mixerResult.isError == true)
+            let v1 = try #require(mixerResult.isError)
+            #expect(v1)
             #expect(object(mixerResult)["error"] as? String == "stale_target_reference")
 
             let pluginResult = await PluginsDispatcher.handle(
@@ -431,7 +439,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(pluginResult.isError == true)
+            let v2 = try #require(pluginResult.isError)
+            #expect(v2)
             #expect(object(pluginResult)["error"] as? String == "stale_target_reference")
 
             let insertResult = await PluginsDispatcher.handle(
@@ -446,7 +455,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(insertResult.isError == true)
+            let v3 = try #require(insertResult.isError)
+            #expect(v3)
             #expect(object(insertResult)["error"] as? String == "stale_target_reference")
 
             let trackResult = await TrackDispatcher.handle(
@@ -456,7 +466,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(trackResult.isError == true)
+            let v4 = try #require(trackResult.isError)
+            #expect(v4)
             #expect(object(trackResult)["error"] as? String == "stale_target_reference")
             #expect((await channels[0].operations()).isEmpty)
         }
@@ -483,7 +494,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(object(result)["error"] as? String == "stale_target_reference")
             #expect((await channels[0].operations()).isEmpty)
             #expect(await cache.getTracks().map { "\($0.id)|\($0.name)|\($0.volume)" } == before)
@@ -508,7 +520,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: pluginRegistry
             )
-            #expect(insert.isError == true)
+            let v2 = try #require(insert.isError)
+            #expect(v2)
             #expect(object(insert)["error"] as? String == "stale_target_reference")
             #expect((await pluginChannels[0].operations()).isEmpty)
         }
@@ -538,14 +551,15 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(object(result)["error"] as? String == "target_ref_unavailable")
             #expect((await channels[0].operations()).isEmpty)
         }
     }
 
     @Test
-    func testTrackDuplicateBumpsTopologyExactlyOnce() async {
+    func testTrackDuplicateBumpsTopologyExactlyOnce() async throws {
         try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let cache = await cacheWithTracks()
@@ -564,7 +578,8 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry,
                 liveTrackNames: liveTrackHeaders
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(await registry.currentTopologyGeneration == 1)
 
             let (staleRouter, staleChannels) = await router()
@@ -575,14 +590,15 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(stale.isError == true)
+            let v2 = try #require(stale.isError)
+            #expect(v2)
             #expect(object(stale)["error"] as? String == "stale_target_reference")
             #expect((await staleChannels[0].operations()).isEmpty)
         }
     }
 
     @Test
-    func testTrackSetInstrumentBumpsTopologyExactlyOnceAfterStateA() async {
+    func testTrackSetInstrumentBumpsTopologyExactlyOnceAfterStateA() async throws {
         try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let cache = await cacheWithTracks()
@@ -599,13 +615,14 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry,
                 liveTrackNames: liveTrackHeaders
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(await registry.currentTopologyGeneration == 1)
         }
     }
 
     @Test
-    func testStateASetInstrumentInvalidatesPriorMixerStripReference() async {
+    func testStateASetInstrumentInvalidatesPriorMixerStripReference() async throws {
         try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let cache = await cacheWithTracks()
@@ -628,7 +645,8 @@ struct ADR002ATargetKindTests {
                 targetRegistry: registry,
                 liveTrackNames: liveTrackHeaders
             )
-            #expect(mutation.isError == false)
+            let v1 = try #require(mutation.isError)
+            #expect(!v1)
             #expect(await registry.currentTopologyGeneration == 1)
 
             let (staleRouter, staleChannels) = await router()
@@ -639,14 +657,15 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(stale.isError == true)
+            let v2 = try #require(stale.isError)
+            #expect(v2)
             #expect(object(stale)["error"] as? String == "stale_target_reference")
             #expect((await staleChannels[0].operations()).isEmpty)
         }
     }
 
     @Test
-    func testLegacyPluginInsertBumpsTopologyExactlyOnceAfterStateA() async {
+    func testLegacyPluginInsertBumpsTopologyExactlyOnceAfterStateA() async throws {
         try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let cache = await cacheWithTracks()
@@ -663,13 +682,14 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(await registry.currentTopologyGeneration == 1)
         }
     }
 
     @Test
-    func testStateALegacyPluginInsertInvalidatesPriorPluginInsertReference() async {
+    func testStateALegacyPluginInsertInvalidatesPriorPluginInsertReference() async throws {
         try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let cache = await cacheWithTracks()
@@ -692,7 +712,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(mutation.isError == false)
+            let v1 = try #require(mutation.isError)
+            #expect(!v1)
             #expect(await registry.currentTopologyGeneration == 1)
 
             let (staleRouter, staleChannels) = await router()
@@ -708,7 +729,8 @@ struct ADR002ATargetKindTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(stale.isError == true)
+            let v2 = try #require(stale.isError)
+            #expect(v2)
             #expect(object(stale)["error"] as? String == "stale_target_reference")
             #expect((await staleChannels[0].operations()).isEmpty)
         }

--- a/Tests/LogicProMCPTests/ADR002BProjectTargetTests.swift
+++ b/Tests/LogicProMCPTests/ADR002BProjectTargetTests.swift
@@ -50,7 +50,8 @@ struct ADR002BProjectTargetTests {
     }
 
     private func requireStateC(_ result: CallTool.Result) throws -> [String: Any] {
-        try #require(result.isError == true)
+        let isError = try #require(result.isError)
+        #expect(isError)
         let object = try toolObject(result)
         let state = try #require(object["state"] as? String)
         #expect(state == "C")
@@ -138,7 +139,8 @@ struct ADR002BProjectTargetTests {
                 cache: cache
             )
 
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(await cache.getTracks().map(\.name) == ["Existing"])
         }
     }
@@ -321,7 +323,7 @@ struct ADR002BProjectTargetTests {
         command: String,
         params: [String: Value]
     ) async throws {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let (router, _) = await router(id: .appleScript)
             let result = await ProjectDispatcher.handle(
@@ -331,7 +333,8 @@ struct ADR002BProjectTargetTests {
                 cache: StateCache(),
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(await registry.currentProjectEpoch == 1)
         }
     }

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -1764,7 +1764,8 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
     #expect(try #require(object["state"] as? String) == "A")
     #expect(try #require(object["button"] as? String) == "Autopunch")
     #expect(try #require(object["observed"] as? Bool))
-    #expect(try #require(object["previous"] as? Bool) == false)
+    let v1 = try #require(object["previous"] as? Bool)
+    #expect(!v1)
     #expect(try #require(object["action"] as? String) == "axpress")
 }
 
@@ -1790,7 +1791,8 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
 
     #expect(result.isSuccess)
     #expect(try #require(object["success"] as? Bool))
-    #expect(try #require(object["verified"] as? Bool) == false)
+    let v1 = try #require(object["verified"] as? Bool)
+    #expect(!v1)
     #expect(try #require(object["state"] as? String) == "B")
     #expect(try #require(object["reason"] as? String) == "readback_unavailable")
     #expect(try #require(object["button"] as? String) == "Autopunch")
@@ -1818,7 +1820,8 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
     let object = decodeAccessibilityJSON(result.message)
 
     #expect(!result.isSuccess)
-    #expect(try #require(object["success"] as? Bool) == false)
+    let v1 = try #require(object["success"] as? Bool)
+    #expect(!v1)
     #expect(try #require(object["state"] as? String) == "C")
     #expect(try #require(object["error"] as? String) == "element_not_found")
     let hint = try #require(object["hint"] as? String)
@@ -2713,7 +2716,8 @@ private func makeTempoSliderFixture(
     // ADR-001: zero mouse/coordinate events — the actuator is keyboard-only.
     #expect(muteKeyRecorder.mouseEvents.isEmpty)
     #expect(builder.actionCalls.contains { $0.elementID == builder.elementID(muteButton) && $0.action == kAXPressAction as String })
-    #expect((builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue == false)
+    let v1 = try #require((builder.attributeValue(muteButton, kAXValueAttribute as String) as? NSNumber)?.boolValue)
+    #expect(!v1)
 
     let renameResult = await channel.execute(operation: "track.rename", params: ["index": "0", "name": "Lead"])
     #expect(renameResult.isSuccess)

--- a/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
+++ b/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
@@ -222,10 +222,12 @@ struct CoordFreeTrackToggleTests {
         #expect(result.isSuccess)
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "A")
-        #expect(obj?["verified"] as? Bool == true)
+        let v1 = try #require(obj?["verified"] as? Bool)
+        #expect(v1)
         #expect(obj?["action"] as? String == "press")
         #expect(obj?["button"] as? String == "Solo")
-        #expect(boolValue(f, solo) == true)
+        let v2 = try #require(boolValue(f, solo))
+        #expect(v2)
         #expect(key.keyEvents.isEmpty)
         #expect(key.mouseEvents.isEmpty)
     }
@@ -252,7 +254,8 @@ struct CoordFreeTrackToggleTests {
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "A")
         #expect(obj?["action"] as? String == "press")
-        #expect(boolValue(f, solo) == true)
+        let v1 = try #require(boolValue(f, solo))
+        #expect(v1)
     }
 
     @Test("solo: AXPress no-ops, exclusive-select + key 's' flips → State A keyboard-solo")
@@ -341,7 +344,8 @@ struct CoordFreeTrackToggleTests {
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "A")
         #expect(obj?["action"] as? String == "keyboard-mute")
-        #expect(boolValue(f, mute) == true)
+        let v1 = try #require(boolValue(f, mute))
+        #expect(v1)
         // The natural-primary AXPress was still tried first (its return ignored)…
         #expect(f.builder.actionCalls.contains {
             $0.elementID == f.builder.elementID(mute) && $0.action == kAXPressAction as String
@@ -363,7 +367,8 @@ struct CoordFreeTrackToggleTests {
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "C")
         #expect(obj?["error"] as? String == "ax_write_failed")
-        #expect(boolValue(f, f.mute[0]) == false)
+        let v1 = try #require(boolValue(f, f.mute[0]))
+        #expect(!v1)
         // The key WAS attempted (selection was exclusive) but nothing flipped —
         // and CRUCIALLY no coordinate rung ran to "rescue" it.
         #expect(key.keyEvents.contains(AccessibilityChannel.trackMuteKeyCode))
@@ -395,14 +400,16 @@ struct CoordFreeTrackToggleTests {
         #expect(obj?["state"] as? String == "A")
         #expect(obj?["action"] as? String == "keyboard-arm")
         #expect(obj?["button"] as? String == "Record")
-        #expect(boolValue(f, arm) == true)
+        let v1 = try #require(boolValue(f, arm))
+        #expect(v1)
         // The RESOLVED chord (code + modifier flags) was posted, ZERO mouse, and
         // no bare-key path was used.
         #expect(key.flaggedKeyEvents.contains { $0.code == armCode && $0.flags == armFlags })
         #expect(key.keyEvents.isEmpty)
         #expect(key.mouseEvents.isEmpty)
         // Honesty: transport did not start recording.
-        #expect(boolValue(f, f.recordCheckbox) == false)
+        let v2 = try #require(boolValue(f, f.recordCheckbox))
+        #expect(!v2)
     }
 
     @Test("arm fails closed (State C) with the exact 'Toggle Track Record Enable' key-command hint")
@@ -445,12 +452,14 @@ struct CoordFreeTrackToggleTests {
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "C")
         #expect(obj?["error"] as? String == "ax_write_failed")
-        #expect(obj?["recording_started"] as? Bool == true)
+        let v1 = try #require(obj?["recording_started"] as? Bool)
+        #expect(v1)
         let hint = obj?["hint"] as? String ?? ""
         #expect(hint.contains("transport recording"))
         #expect(hint.contains("Toggle Track Record Enable"))
         // The arm checkbox was never (falsely) claimed armed.
-        #expect(boolValue(f, f.arm[0]) == false)
+        let v2 = try #require(boolValue(f, f.arm[0]))
+        #expect(!v2)
         #expect(key.mouseEvents.isEmpty)
     }
 
@@ -765,7 +774,8 @@ struct CoordFreeTrackToggleTests {
         // selection could not be proven exclusive, so no track was toggled.
         #expect(key.keyEvents.isEmpty)
         #expect(key.mouseEvents.isEmpty)
-        #expect(boolValue(f, f.mute[0]) == false)
+        let v1 = try #require(boolValue(f, f.mute[0]))
+        #expect(!v1)
     }
 
     @Test("frontmost guard: mute, solo, and arm refuse when Logic never becomes frontmost")
@@ -1019,7 +1029,7 @@ struct CoordFreeTrackToggleTests {
     }
 
     @Test("retry halt barrier: late first post lands → no second synthetic key")
-    func syntheticKeyRetryFreshReadPreventsDoubleToggle() {
+    func syntheticKeyRetryFreshReadPreventsDoubleToggle() throws {
         let f = makeToggleFixture()
         let key = KeyMouseRecorder()
         let activation = ActivationProbe()
@@ -1052,7 +1062,8 @@ struct CoordFreeTrackToggleTests {
         }())
         #expect(key.keyEvents.count == 1)
         #expect(activation.calls == 1)
-        #expect(readValue() == true)
+        let v1 = try #require(readValue())
+        #expect(v1)
     }
 
     @Test("synthetic key retry is bounded at three attempts when value never flips")
@@ -1575,7 +1586,8 @@ struct CoordFreeTrackToggleTests {
         let obj = object(result.message)
         #expect(obj?["state"] as? String == "C")
         #expect(obj?["error"] as? String == "readback_mismatch")
-        #expect(obj?["recording_stopped"] as? Bool == true)
+        let v1 = try #require(obj?["recording_stopped"] as? Bool)
+        #expect(v1)
         #expect(boolValue(f, f.arm[0])!)
         #expect(!boolValue(f, f.recordCheckbox)!)
         #expect(key.keyEvents.count == 0)

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTruthfulnessTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTruthfulnessTests.swift
@@ -323,13 +323,15 @@ private func expectCoreMIDIStateB(
 
     #expect(!result.isSuccess)
     let object = try coreMIDIHCObject(result)
-    #expect(object["success"] as? Bool == false)
+    let v1 = try #require(object["success"] as? Bool)
+    #expect(!v1)
     #expect(object["state"] as? String == "C")
     #expect(object["error"] as? String == "port_unavailable")
     #expect(object["port_name"] as? String == "Session-Port")
     #expect(object["existing_mode"] as? String == "bidirectional")
     #expect(object["requested_mode"] as? String == "send_only")
-    #expect((object["hint"] as? String)?.contains("collides with an existing port of a different mode") == true)
+    let v2 = try #require((object["hint"] as? String)?.contains("collides with an existing port of a different mode"))
+    #expect(v2)
 }
 
 @Test func testCoreMIDIChannelCreateVirtualPortErrorsWithoutManager() async {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -441,7 +441,7 @@ private func liveTransportJSON(
             #expect(try #require(result.isError as Bool?), "Expected \(testCase.command) State B to be surfaced as an error")
             #expect(dispatcherText(result).contains(#""verified":false"#))
         } else {
-            #expect(try #require(result.isError as Bool?) == false, "Expected \(testCase.command) to succeed")
+            #expect(!(try #require(result.isError as Bool?)), "Expected \(testCase.command) to succeed")
         }
         let ops = await channel.executedOps
         let op = try #require(ops.first, "\(testCase.command) should execute exactly one route")
@@ -467,7 +467,7 @@ private func liveTransportJSON(
         sleep: { _ in }
     )
 
-    #expect(try #require(result.isError as Bool?) == false)
+    #expect(!(try #require(result.isError as Bool?)))
     let executed = await channel.executedOps
     #expect(try #require(executed.first?.0) == "transport.toggle_autopunch")
 
@@ -2200,8 +2200,8 @@ private actor SelectiveFailChannel: Channel {
     #expect(armedSuccess)
     #expect(object["state"] as? String == "A")
     #expect(object["armed"] as? Int == 1)
-    #expect(object["requested_enabled"] as? Bool == true)
-    #expect(object["observed_enabled"] as? Bool == true)
+    #expect(try #require(object["requested_enabled"] as? Bool))
+    #expect(try #require(object["observed_enabled"] as? Bool))
     #expect(object["verification_source"] as? String == "mock_ax_readback")
 }
 
@@ -2253,7 +2253,7 @@ private actor SelectiveFailChannel: Channel {
     #expect(object["state"] as? String == "B")
     #expect(object["reason"] as? String == "readback_unavailable")
     #expect(object["unverifiedDisarm"] as? [Int] == [])
-    #expect(object["requested_enabled"] as? Bool == true)
+    #expect(try #require(object["requested_enabled"] as? Bool))
     #expect(object["observed_enabled"] is NSNull)
     #expect(object["verification_source"] as? String == "mock_ax_readback")
 }
@@ -2286,8 +2286,8 @@ private actor SelectiveFailChannel: Channel {
     #expect(object["reason"] as? String == "readback_unavailable")
     #expect(object["armed"] as? Int == 1)
     #expect(object["unverifiedDisarm"] as? [Int] == [0])
-    #expect(object["requested_enabled"] as? Bool == true)
-    #expect(object["observed_enabled"] as? Bool == true)
+    #expect(try #require(object["requested_enabled"] as? Bool))
+    #expect(try #require(object["observed_enabled"] as? Bool))
     #expect(object["verification_source"] as? String == "mock_ax_readback")
 }
 

--- a/Tests/LogicProMCPTests/DoctorV4Tests.swift
+++ b/Tests/LogicProMCPTests/DoctorV4Tests.swift
@@ -370,7 +370,7 @@ private func doctorV4Report(
     let desktop = try #require(report.checks.first { $0.id == "mcp.claude_desktop_registration" })
     let isOptional = desktop.optional
     #expect(desktop.status == .warn || desktop.status == .manual)
-    #expect(isOptional == false)
+    #expect(!isOptional)
     #expect(desktop.skipReason != .clientNotSelected)
     #expect(report.status != .ok)
 }
@@ -431,12 +431,13 @@ private func doctorV4Report(
     #expect(SetupDoctor.staticVersion(fromStringsOutput: "3.40.1\n3.9.0\n") == .indeterminate(["3.40.1", "3.9.0"]))
 }
 
-@Test func doctorV4CheckRegistryIDsAreUniqueAndAnchored() {
+@Test func doctorV4CheckRegistryIDsAreUniqueAndAnchored() throws {
     let ids = SetupDoctor.checkDefinitions.map(\.id.rawValue)
     #expect(Set(ids).count == ids.count)
     #expect(Set(ids) == Set(SetupDoctor.DoctorCheckID.allCases.map(\.rawValue)))
     #expect(Set(SetupDoctor.remediationAnchorsByCheckID.keys).isSubset(of: Set(ids)))
-    #expect(SetupDoctor.checkDefinitionByID["updates.latest_release"]?.optionalByDefault == true)
+    let v1 = try #require(SetupDoctor.checkDefinitionByID["updates.latest_release"]?.optionalByDefault)
+    #expect(v1)
     #expect(
         SetupDoctor.checkDefinitionByID["updates.latest_release"]?.inclusionRule
             == .latestReleaseLookupAvailable
@@ -490,7 +491,7 @@ private func doctorV4Report(
     let synthesized = try #require(closed.first { $0.id == "binary.executable" })
     let isOptional = synthesized.optional
     #expect(synthesized.status == .fail)
-    #expect(isOptional == false)
+    #expect(!isOptional)
     #expect(synthesized.evidence["reason"] == "required_check_missing")
 
     let requiredIDs = SetupDoctor.requiredCheckIDs(

--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -34,14 +34,16 @@ private func e2eExpectUnregistered(
     _ result: CallTool.Result,
     tool: String,
     command: String
-) {
+) throws {
     let body = e2eJSON(e2eText(result))
-    #expect(result.isError == true)
+    let v1 = try #require(result.isError)
+    #expect(v1)
     #expect(body?["state"] as? String == "C")
     #expect(body?["error"] as? String == "invalid_params")
     #expect(body?["tool"] as? String == tool)
     #expect(body?["command"] as? String == command)
-    #expect(body?["write_attempted"] as? Bool == false)
+    let v2 = try #require(body?["write_attempted"] as? Bool)
+    #expect(!v2)
 }
 
 typealias ServerStartRecorder = SharedServerStartRecorder
@@ -53,10 +55,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 // P1-1 (D1): `get_state` is NOT a tool command — transport reads are served by
 // the logic://transport/state resource (see ResourceSchemaTests). The tool must
 // REJECT it as unknown, not appear alive via a non-empty error string.
-@Test func testE2ETransportGetStateRejectedAsUnknownCommand() async {
+@Test func testE2ETransportGetStateRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_transport", command: "get_state")
-    e2eExpectUnregistered(r, tool: "logic_transport", command: "get_state")
+    try e2eExpectUnregistered(r, tool: "logic_transport", command: "get_state")
 }
 
 @Test func testE2ETransportPlayDispatchesWithoutCrash() async {
@@ -110,10 +112,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
     #expect(!e2eText(r).isEmpty)
 }
 
-@Test func testE2ETransportUnknownCommandFails() async {
+@Test func testE2ETransportUnknownCommandFails() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_transport", command: "nonexistent")
-    e2eExpectUnregistered(r, tool: "logic_transport", command: "nonexistent")
+    try e2eExpectUnregistered(r, tool: "logic_transport", command: "nonexistent")
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -122,16 +124,16 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 // P1-1 (D1): track reads are served by logic://tracks. get_tracks/get_selected
 // are not tool commands and must be rejected as unknown (false-green guard).
-@Test func testE2ETracksGetTracksRejectedAsUnknownCommand() async {
+@Test func testE2ETracksGetTracksRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_tracks", command: "get_tracks")
-    e2eExpectUnregistered(r, tool: "logic_tracks", command: "get_tracks")
+    try e2eExpectUnregistered(r, tool: "logic_tracks", command: "get_tracks")
 }
 
-@Test func testE2ETracksGetSelectedRejectedAsUnknownCommand() async {
+@Test func testE2ETracksGetSelectedRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_tracks", command: "get_selected")
-    e2eExpectUnregistered(r, tool: "logic_tracks", command: "get_selected")
+    try e2eExpectUnregistered(r, tool: "logic_tracks", command: "get_selected")
 }
 
 @Test func testE2ETracksSelectRequiresIndex() async {
@@ -225,10 +227,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 // P1-1 (D1): mixer reads are served by logic://mixer. get_state is not a tool
 // command and must be rejected as unknown (false-green guard).
-@Test func testE2EMixerGetStateRejectedAsUnknownCommand() async {
+@Test func testE2EMixerGetStateRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_mixer", command: "get_state")
-    e2eExpectUnregistered(r, tool: "logic_mixer", command: "get_state")
+    try e2eExpectUnregistered(r, tool: "logic_mixer", command: "get_state")
 }
 
 @Test func testE2EMixerSetVolumeDispatches() async {
@@ -361,10 +363,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 // P1-1 (D1): single-strip reads are served by logic://mixer/{strip}.
 // get_channel_strip is not a tool command and must be rejected as unknown.
-@Test func testE2EMixerGetChannelStripRejectedAsUnknownCommand() async {
+@Test func testE2EMixerGetChannelStripRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_mixer", command: "get_channel_strip", params: ["index": .string("0")])
-    e2eExpectUnregistered(r, tool: "logic_mixer", command: "get_channel_strip")
+    try e2eExpectUnregistered(r, tool: "logic_mixer", command: "get_channel_strip")
 }
 
 @Test func testE2EMixerSetVolumeRequiresParams() async {
@@ -504,10 +506,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 // P1-1 (D1): markers are served by logic://markers. get_markers is not a tool
 // command and must be rejected as unknown (false-green guard).
-@Test func testE2ENavigateGetMarkersRejectedAsUnknownCommand() async {
+@Test func testE2ENavigateGetMarkersRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_navigate", command: "get_markers")
-    e2eExpectUnregistered(r, tool: "logic_navigate", command: "get_markers")
+    try e2eExpectUnregistered(r, tool: "logic_navigate", command: "get_markers")
 }
 
 @Test func testE2ENavigateCreateMarkerDispatches() async {
@@ -534,10 +536,10 @@ typealias ServerStartRecorder = SharedServerStartRecorder
 
 // P1-1 (D1): project info is served by logic://project/info. get_info is not a
 // tool command and must be rejected as unknown (false-green guard).
-@Test func testE2EProjectGetInfoRejectedAsUnknownCommand() async {
+@Test func testE2EProjectGetInfoRejectedAsUnknownCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_project", command: "get_info")
-    e2eExpectUnregistered(r, tool: "logic_project", command: "get_info")
+    try e2eExpectUnregistered(r, tool: "logic_project", command: "get_info")
 }
 
 @Test func testE2EProjectOpenInvalidPathFails() async {
@@ -689,10 +691,10 @@ func testE2ESystemPermissionsDispatches() async {
     #expect(e2eText(r).contains("State refresh"))
 }
 
-@Test func testE2ESystemCacheStateIsNotAPublicCommand() async {
+@Test func testE2ESystemCacheStateIsNotAPublicCommand() async throws {
     let h = await makeE2EHandlers()
     let r = await e2eCall(h, tool: "logic_system", command: "cache_state")
-    e2eExpectUnregistered(r, tool: "logic_system", command: "cache_state")
+    try e2eExpectUnregistered(r, tool: "logic_system", command: "cache_state")
 }
 
 @Test func testE2ESystemUnknownCommandFails() async {

--- a/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
@@ -284,7 +284,8 @@ struct IndexBindingRefRequiredTests {
         let object = try #require(sharedJSONObject(sharedToolText(refusal)))
         #expect(object["error"] as? String == "stable_target_required")
         #expect(object["state"] as? String == "C")
-        #expect(object["write_attempted"] as? Bool == false)
+        let v1 = try #require(object["write_attempted"] as? Bool)
+        #expect(!v1)
         #expect(object["requested_index"] as? Int == 3)
     }
 
@@ -303,7 +304,8 @@ struct IndexBindingRefRequiredTests {
         let refusal = try #require(result)
         let object = try #require(sharedJSONObject(sharedToolText(refusal)))
         #expect(object["error"] as? String == "stable_target_required")
-        #expect(object["write_attempted"] as? Bool == false)
+        let v1 = try #require(object["write_attempted"] as? Bool)
+        #expect(!v1)
     }
 
     @Test("refRequired: a supplied target_ref passes the guard to the ref machinery")

--- a/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
@@ -43,7 +43,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
 // MARK: - tracks.delete (seed set)
 
-@Test func testDeleteWithoutExpectedNameRequiresCorroboration() async {
+@Test func testDeleteWithoutExpectedNameRequiresCorroboration() async throws {
     let router = ChannelRouter()
     let mcu = VerifiedSelectMockChannel(id: .mcu)
     let keyCmd = MockChannel(id: .midiKeyCommands)
@@ -60,7 +60,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!, "bare-index delete must fail closed")
     #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
 
     // Proof of no side effect: nothing was routed at all — not even the
     // `track.select` that precedes the delete.
@@ -70,7 +71,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(keyCmdOps.isEmpty, "track.delete must never be routed")
 }
 
-@Test func testDeleteCorroborationRequiredHintNamesBothRoutes() async {
+@Test func testDeleteCorroborationRequiredHintNamesBothRoutes() async throws {
     let router = ChannelRouter()
     await router.register(VerifiedSelectMockChannel(id: .mcu))
     await router.register(MockChannel(id: .midiKeyCommands))
@@ -87,10 +88,11 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     let hint = (object?["hint"] as? String) ?? ""
     #expect(hint.contains("expected_name"), "hint must name the corroboration route, got: \(hint)")
     #expect(hint.contains("target_ref"), "hint must name the stable-ref route, got: \(hint)")
-    #expect(object?["safe_to_retry"] as? Bool == true, "supplying the missing param is a safe retry")
+    let v1 = try #require(object?["safe_to_retry"] as? Bool)
+    #expect(v1, "supplying the missing param is a safe retry")
 }
 
-@Test func testDeleteWithMismatchedExpectedNameFailsClosed() async {
+@Test func testDeleteWithMismatchedExpectedNameFailsClosed() async throws {
     let router = ChannelRouter()
     let mcu = VerifiedSelectMockChannel(id: .mcu)
     let keyCmd = MockChannel(id: .midiKeyCommands)
@@ -110,7 +112,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "target_identity_mismatch")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
 
     let object = sharedJSONObject(sharedToolText(result))
     #expect(object?["expected_track_name"] as? String == "Drums")
@@ -122,7 +125,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(keyCmdOps.isEmpty, "the wrong track must NOT be deleted")
 }
 
-@Test func testDeleteWithUnreadableLiveHeaderFailsClosed() async {
+@Test func testDeleteWithUnreadableLiveHeaderFailsClosed() async throws {
     let router = ChannelRouter()
     let mcu = VerifiedSelectMockChannel(id: .mcu)
     let keyCmd = MockChannel(id: .midiKeyCommands)
@@ -139,7 +142,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!, "an unreadable live surface must not be read as agreement")
     #expect(corroborationErrorCode(result) == "target_identity_mismatch")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
 
     let object = sharedJSONObject(sharedToolText(result))
     #expect(object?["reason"] as? String == "header_unreadable")
@@ -150,7 +154,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(keyCmdOps.isEmpty)
 }
 
-@Test func testDeleteWithAmbiguousLiveNameFailsClosed() async {
+@Test func testDeleteWithAmbiguousLiveNameFailsClosed() async throws {
     // THE load-bearing case. Two tracks share a name, so (index, name) stays
     // self-consistent even after they swap positions: corroboration would PASS
     // while pointing at the wrong track. Uniqueness is therefore required, and
@@ -171,7 +175,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!, "a matching name that is not unique proves nothing")
     #expect(corroborationErrorCode(result) == "target_name_ambiguous")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
 
     let object = sharedJSONObject(sharedToolText(result))
     #expect(object?["ambiguous_track_indices"] as? [Int] == [2, 5])
@@ -304,7 +309,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(keyCmdOps[0].0 == "track.duplicate")
 }
 
-@Test func testDuplicateWithMismatchedExpectedNameFailsClosed() async {
+@Test func testDuplicateWithMismatchedExpectedNameFailsClosed() async throws {
     let router = ChannelRouter()
     let keyCmd = MockChannel(id: .midiKeyCommands)
     await router.register(VerifiedSelectMockChannel(id: .mcu))
@@ -320,7 +325,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "target_identity_mismatch")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     let keyCmdOps = await keyCmd.executedOps
     #expect(keyCmdOps.isEmpty)
 }
@@ -344,7 +350,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(axOps.isEmpty, "the patch load must never reach the router")
 }
 
-@Test func testSetInstrumentWithMismatchedExpectedNameFailsClosed() async {
+@Test func testSetInstrumentWithMismatchedExpectedNameFailsClosed() async throws {
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)
     await router.register(ax)
@@ -363,7 +369,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "target_identity_mismatch")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     let axOps = await ax.executedOps
     #expect(axOps.isEmpty, "the wrong track's instrument must NOT be replaced")
 }
@@ -402,7 +409,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 // suite. `plugin.insert_verified` routes to `.accessibility`; a MockChannel
 // there records whether any AX write was attempted.
 
-@Test func testInsertVerifiedWithoutExpectedNameRequiresCorroboration() async {
+@Test func testInsertVerifiedWithoutExpectedNameRequiresCorroboration() async throws {
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)
     await router.register(ax)
@@ -423,13 +430,14 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "index_binding_corroboration_required")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     // The guard precedes the verified-op gate AND the router — nothing routed.
     let axOps = await ax.executedOps
     #expect(axOps.isEmpty, "corroboration must fail before the AX insert is attempted")
 }
 
-@Test func testInsertVerifiedWithMismatchedExpectedNameFailsClosed() async {
+@Test func testInsertVerifiedWithMismatchedExpectedNameFailsClosed() async throws {
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)
     await router.register(ax)
@@ -452,7 +460,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "target_identity_mismatch")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
 
     let object = sharedJSONObject(sharedToolText(result))
     #expect(object?["expected_track_name"] as? String == "Bass")
@@ -462,7 +471,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(axOps.isEmpty, "the wrong track's insert chain must NOT be mutated")
 }
 
-@Test func testInsertVerifiedWithAmbiguousLiveNameFailsClosed() async {
+@Test func testInsertVerifiedWithAmbiguousLiveNameFailsClosed() async throws {
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)
     await router.register(ax)
@@ -484,7 +493,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "target_name_ambiguous")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     let object = sharedJSONObject(sharedToolText(result))
     #expect(object?["ambiguous_track_indices"] as? [Int] == [2, 6])
 
@@ -492,7 +502,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(axOps.isEmpty)
 }
 
-@Test func testInsertVerifiedRejectsExpectedNameCombinedWithTargetRef() async {
+@Test func testInsertVerifiedRejectsExpectedNameCombinedWithTargetRef() async throws {
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)
     await router.register(ax)
@@ -515,7 +525,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "invalid_params")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     let axOps = await ax.executedOps
     #expect(axOps.isEmpty)
 }
@@ -562,7 +573,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     #expect(!axOps.isEmpty, "rename's legacy index path must stay open")
 }
 
-@Test func testSeedOpRejectsExpectedNameCombinedWithTargetRef() async {
+@Test func testSeedOpRejectsExpectedNameCombinedWithTargetRef() async throws {
     // Documented choice: `expected_name` + `target_ref` is rejected outright
     // rather than cross-checked. The ref path already carries its own live
     // identity + ambiguity guards (F5); accepting both would stack two binding
@@ -587,7 +598,8 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
 
     #expect(result.isError!)
     #expect(corroborationErrorCode(result) == "invalid_params")
-    #expect(writeAttempted(result) == false)
+    let v1 = try #require(writeAttempted(result))
+    #expect(!v1)
     let keyCmdOps = await keyCmd.executedOps
     #expect(keyCmdOps.isEmpty)
 }

--- a/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
@@ -112,7 +112,7 @@ struct Issue136GotoDriftHonestTests {
         // The MCP-level error bit must also be set so non-JSON-parsing callers
         // still see the failure.
         let resultIsError = result.isError ?? false
-        #expect(resultIsError, "a drifted goto_position must surface isError == true")
+        #expect(resultIsError, "a drifted goto_position must surface isError == true") // test-integrity:live: assertion is bare Bool resultIsError; the "== true" is inside the message string
 
         // Belt-and-suspenders: a bare verified-success payload would never carry
         // this combination. If success is reported, verified must NOT be.

--- a/Tests/LogicProMCPTests/Issue253HelpCategoriesTests.swift
+++ b/Tests/LogicProMCPTests/Issue253HelpCategoriesTests.swift
@@ -3,7 +3,7 @@ import MCP
 import Testing
 @testable import LogicProMCP
 
-@Test func issue253AudioAndPluginsHelpReturnCategoryDocs() async {
+@Test func issue253AudioAndPluginsHelpReturnCategoryDocs() async throws {
     for category in ["audio", "plugins"] {
         let result = await SystemDispatcher.handle(
             command: "help",
@@ -12,7 +12,8 @@ import Testing
             cache: StateCache()
         )
 
-        #expect(result.isError == false)
+        let v1 = try #require(result.isError)
+        #expect(!v1)
         #expect(sharedToolText(result).contains("logic_\(category) commands"))
     }
 }

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -16,7 +16,7 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     #expect(route?.first == .accessibility)
 }
 
-@Test func issue254CreateMarkerRejectsUnsafeNamesBeforeRouting() async {
+@Test func issue254CreateMarkerRejectsUnsafeNamesBeforeRouting() async throws {
     for name in [String(repeating: "x", count: 251), "unsafe\nname"] {
         let result = await NavigateDispatcher.handle(
             command: "create_marker",
@@ -24,7 +24,8 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
             router: ChannelRouter(),
             cache: StateCache()
         )
-        #expect(result.isError == true)
+        let v1 = try #require(result.isError)
+        #expect(v1)
     }
 }
 
@@ -78,8 +79,10 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     let data = try #require(envelope["data"] as? [[String: Any]])
 
     #expect(envelope["source"] as? String == "ax_live")
-    #expect(envelope["readable"] as? Bool == true)
-    #expect(envelope["verified_empty"] as? Bool == false)
+    let v1 = try #require(envelope["readable"] as? Bool)
+    #expect(v1)
+    let v2 = try #require(envelope["verified_empty"] as? Bool)
+    #expect(!v2)
     #expect((data.first?["name"] as? String) == "Marker 1")
     #expect(await cache.getMarkers().first?.name == "Marker 1")
 }
@@ -99,7 +102,8 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     let data = try #require(envelope["data"] as? [[String: Any]])
 
     #expect(envelope["source"] as? String == "cache")
-    #expect(envelope["readable"] as? Bool == false)
+    let v1 = try #require(envelope["readable"] as? Bool)
+    #expect(!v1)
     #expect(envelope["reason"] as? String == "marker_list_not_open")
     #expect((data.first?["name"] as? String) == "Cached Marker")
     #expect(await cache.getMarkers().first?.name == "Cached Marker")

--- a/Tests/LogicProMCPTests/Issue255NativeToggleTests.swift
+++ b/Tests/LogicProMCPTests/Issue255NativeToggleTests.swift
@@ -62,8 +62,10 @@ private func issue255Channel(
 
     #expect(result.isSuccess)
     let object = try #require(issue255Object(result.message))
-    #expect(object["verified"] as? Bool == true)
-    #expect(object["observed"] as? Bool == true)
+    let v1 = try #require(object["verified"] as? Bool)
+    #expect(v1)
+    let v2 = try #require(object["observed"] as? Bool)
+    #expect(v2)
     #expect(object["button"] as? String == "Count In")
 }
 
@@ -114,8 +116,11 @@ private func issue255Channel(
 
     #expect(result.isSuccess)
     let object = try #require(issue255Object(result.message))
-    #expect(object["verified"] as? Bool == true)
-    #expect(object["previous_open"] as? Bool == false)
-    #expect(object["observed_open"] as? Bool == true)
+    let v1 = try #require(object["verified"] as? Bool)
+    #expect(v1)
+    let v2 = try #require(object["previous_open"] as? Bool)
+    #expect(!v2)
+    let v3 = try #require(object["observed_open"] as? Bool)
+    #expect(v3)
     #expect(object["via"] as? String == "window-menu")
 }

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -431,12 +431,14 @@ struct OperationCatalogTests {
                         ]
                     ))
                     let body = sharedJSONObject(sharedToolText(rejected)) ?? [:]
-                    #expect(rejected.isError == true, "\(command) must reject unknown keys")
+                    let v1 = try #require(rejected.isError)
+                    #expect(v1, "\(command) must reject unknown keys")
                     #expect(body["state"] as? String == "C")
                     #expect(body["error"] as? String == "invalid_params")
                     #expect(body["unknown_params"] as? [String] == ["__unknown"])
                     #expect(body["allowed_params"] as? [String] == allowedParams)
-                    #expect(body["write_attempted"] as? Bool == false)
+                    let v2 = try #require(body["write_attempted"] as? Bool)
+                    #expect(!v2)
                 }
 
                 let listed = await handlers.callTool(.init(
@@ -448,7 +450,8 @@ struct OperationCatalogTests {
                 ))
                 let listedBody = sharedJSONObject(sharedToolText(listed)) ?? [:]
                 let traces = listedBody["traces"] as? [[String: Any]]
-                #expect(listed.isError != true)
+                let v3 = listed.isError ?? false
+                #expect(!v3)
                 #expect(traces?.count == 1)
                 #expect(traces?.first?["trace_id"] as? String == traceID.rawValue)
 
@@ -460,7 +463,8 @@ struct OperationCatalogTests {
                     ]
                 ))
                 let fetchedBody = sharedJSONObject(sharedToolText(fetched)) ?? [:]
-                #expect(fetched.isError != true)
+                let v4 = fetched.isError ?? false
+                #expect(!v4)
                 #expect(fetchedBody["trace_id"] as? String == traceID.rawValue)
                 #expect(fetchedBody["operation_id"] as? String == "test.trace.seed")
                 #expect((fetchedBody["events"] as? [[String: Any]])?.count == 1)
@@ -473,10 +477,12 @@ struct OperationCatalogTests {
                     ]
                 ))
                 let malformedBody = sharedJSONObject(sharedToolText(malformed)) ?? [:]
-                #expect(malformed.isError == true)
+                let v5 = try #require(malformed.isError)
+                #expect(v5)
                 #expect(malformedBody["state"] as? String == "C")
                 #expect(malformedBody["error"] as? String == "invalid_params")
-                #expect((malformedBody["hint"] as? String)?.contains("malformed") == true)
+                let v6 = try #require((malformedBody["hint"] as? String)?.contains("malformed"))
+                #expect(v6)
 
                 let unconfirmedCases: [[String: Value]] = [
                     [:],
@@ -492,10 +498,12 @@ struct OperationCatalogTests {
                         ]
                     ))
                     let unconfirmedBody = sharedJSONObject(sharedToolText(unconfirmed)) ?? [:]
-                    #expect(unconfirmed.isError == true)
+                    let v7 = try #require(unconfirmed.isError)
+                    #expect(v7)
                     #expect(unconfirmedBody["state"] as? String == "C")
                     #expect(unconfirmedBody["error"] as? String == "invalid_params")
-                    #expect((unconfirmedBody["hint"] as? String)?.contains("confirmed") == true)
+                    let v8 = try #require((unconfirmedBody["hint"] as? String)?.contains("confirmed"))
+                    #expect(v8)
                     #expect(await OperationTraceStore.shared.trace(traceID) != nil)
                 }
 
@@ -507,8 +515,10 @@ struct OperationCatalogTests {
                     ]
                 ))
                 let clearedBody = sharedJSONObject(sharedToolText(cleared)) ?? [:]
-                #expect(cleared.isError != true)
-                #expect(clearedBody["success"] as? Bool == true)
+                let v9 = cleared.isError ?? false
+                #expect(!v9)
+                let v10 = try #require(clearedBody["success"] as? Bool)
+                #expect(v10)
                 #expect(await OperationTraceStore.shared.trace(traceID) == nil)
             } catch {
                 await OperationTraceStore.shared.clear()
@@ -564,12 +574,19 @@ struct OperationCatalogTests {
                 sharedJSONObject(sharedToolText(result)),
                 "\(spec.id.rawValue) malformed \(key) response must be typed JSON"
             )
-            #expect(result.isError == true, "\(spec.id.rawValue) did not reject malformed \(key)")
+            let v1 = try #require(result.isError)
+            #expect(v1, "\(spec.id.rawValue) did not reject malformed \(key)")
             #expect(body["state"] as? String == "C", "\(spec.id.rawValue).\(key)")
             #expect(body["error"] as? String == "invalid_params", "\(spec.id.rawValue).\(key)")
+            // #393: the prior `(body["hint"] as? String)?.contains(key) == true` was a dead
+            // assertion. Made live it fails for a malformed `track` on index-binding ops, whose
+            // rejection hint names the REQUIRED selector param (`index`) instead of echoing the
+            // rejected input key. The true, load-bearing contract is that the rejection is
+            // selector-specific: the hint names a selector parameter (`index` or `track`).
+            let hint = try #require(body["hint"] as? String, "\(spec.id.rawValue).\(key): State C must carry a hint")
             #expect(
-                (body["hint"] as? String)?.contains(key) == true,
-                "\(spec.id.rawValue) response did not identify malformed \(key)"
+                hint.contains("index") || hint.contains("track"),
+                "\(spec.id.rawValue) malformed \(key): hint must name a selector parameter — got: \(hint)"
             )
         }
 
@@ -609,7 +626,8 @@ struct OperationCatalogTests {
             )
         )
 
-        #expect(result.isError == true)
+        let v1 = try #require(result.isError)
+        #expect(v1)
         let body = try #require(sharedJSONObject(sharedToolText(result)))
         #expect(body["state"] as? String == "C")
         #expect(body["error"] as? String == "invalid_params")
@@ -625,7 +643,8 @@ struct OperationCatalogTests {
             )
         )
         let malformedBody = try #require(sharedJSONObject(sharedToolText(malformed)))
-        #expect(malformed.isError == true)
+        let v2 = try #require(malformed.isError)
+        #expect(v2)
         #expect(malformedBody["state"] as? String == "C")
         #expect(malformedBody["error"] as? String == "invalid_params")
         #expect(malformedBody["expected_params_type"] as? String == "object")
@@ -639,11 +658,13 @@ struct OperationCatalogTests {
                 )
             )
             let rejectedBody = try #require(sharedJSONObject(sharedToolText(rejected)))
-            #expect(rejected.isError == true)
+            let v3 = try #require(rejected.isError)
+            #expect(v3)
             #expect(rejectedBody["state"] as? String == "C")
             #expect(rejectedBody["error"] as? String == "invalid_params")
             #expect(rejectedBody["unknown_params"] as? [String] == [key])
-            #expect(rejectedBody["write_attempted"] as? Bool == false)
+            let v4 = try #require(rejectedBody["write_attempted"] as? Bool)
+            #expect(!v4)
         }
     }
 
@@ -682,10 +703,12 @@ struct OperationCatalogTests {
                     ))
                 }
                 let body = try #require(sharedJSONObject(sharedToolText(rejected)))
-                #expect(rejected.isError == true, "\(spec.id.rawValue)")
+                let v1 = try #require(rejected.isError)
+                #expect(v1, "\(spec.id.rawValue)")
                 #expect(body["state"] as? String == "C", "\(spec.id.rawValue)")
                 #expect(body["error"] as? String == "invalid_params", "\(spec.id.rawValue)")
-                #expect(body["write_attempted"] as? Bool == false, "\(spec.id.rawValue)")
+                let v2 = try #require(body["write_attempted"] as? Bool)
+                #expect(!v2, "\(spec.id.rawValue)")
                 if !OperationRegistry.strictParamValidationOptOuts.contains(spec.id) {
                     #expect(body["unknown_params"] as? [String] == ["target_ref"], "\(spec.id.rawValue)")
                 }
@@ -876,7 +899,7 @@ struct OperationCatalogTests {
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
         #expect(operations.count == 108)
-        #expect(text.contains("\n") == false)
+        #expect(!text.contains("\n"))
 
         let ids = operations.compactMap { $0["id"] as? String }
         #expect(ids == ids.sorted())

--- a/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
+++ b/Tests/LogicProMCPTests/OperationDispatchCensusTests.swift
@@ -113,7 +113,8 @@ struct OperationDispatchCensusTests {
             (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
         )
         #expect(body["error"] as? String == "unhandled_registered_command")
-        #expect(result.isError == true)
+        let v1 = try #require(result.isError)
+        #expect(v1)
         let hint = try #require(body["hint"] as? String)
         #expect(hint.contains("Unknown transport command: no_such_command"))
         #expect(hint.contains("play"))

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -257,11 +257,14 @@ struct OperationHandlerBindingTests {
             let body = try #require(sharedJSONObject(sharedToolText(result)))
             #expect(OperationHandlerRegistry.handler(tool: tool, command: command) == nil)
             #expect(OperationHandlerRegistry.fallbackHandler(tool: tool, command: command) != nil)
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(body["state"] as? String == "C")
             #expect(body["error"] as? String == "command_not_exposed")
-            #expect(body["not_exposed"] as? Bool == true)
-            #expect(body["supported"] as? Bool == false)
+            let v2 = try #require(body["not_exposed"] as? Bool)
+            #expect(v2)
+            let v3 = try #require(body["supported"] as? Bool)
+            #expect(!v3)
         }
 
         for command in ["library", "__nope__"] {
@@ -274,12 +277,14 @@ struct OperationHandlerBindingTests {
                 tool: ToolID.logicTracks.rawValue,
                 command: command
             ) == nil)
-            #expect(result.isError == true)
+            let v4 = try #require(result.isError)
+            #expect(v4)
             #expect(body["state"] as? String == "C")
             #expect(body["error"] as? String == "invalid_params")
             #expect(body["tool"] as? String == ToolID.logicTracks.rawValue)
             #expect(body["command"] as? String == command)
-            #expect(body["write_attempted"] as? Bool == false)
+            let v5 = try #require(body["write_attempted"] as? Bool)
+            #expect(!v5)
         }
 
         let unknownTool = await handlers.callTool(.init(

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -67,7 +67,8 @@ struct OperationTraceTests {
 
         let expected = #"{"operation":"transport.play","poll_attempts":12,"reason":"readback_unavailable","state":"B","success":true,"verified":false,"verify_source":"transport_state","write_attempted":true,"write_result":"Mock: transport.play"}"#
         #expect(sharedToolText(result) == expected)
-        #expect(result.isError == true)
+        let resultIsError = result.isError ?? false
+        #expect(resultIsError)
         #expect(!expected.contains("trace_id"))
     }
 
@@ -163,7 +164,8 @@ struct OperationTraceTests {
         let resultObject = try #require(sharedJSONObject(sharedToolText(result)))
         let rawID = try #require(resultObject["trace_id"] as? String)
         let trace = try #require(await OperationTraceStore.shared.trace(TraceID(rawValue: rawID)))
-        #expect(result.isError == false)
+        let resultError = result.isError ?? false
+        #expect(!resultError)
         #expect(trace.operationID == OperationID.transportPlay.rawValue)
         #expect(trace.events.map(\.phase) == [
             .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,
@@ -222,7 +224,11 @@ struct OperationTraceTests {
             .verificationCompleted, .resultEmitted,
         ])
         let route = try #require(trace.events.first { $0.phase == .routeEvaluated })
-        #expect(route.attributes["chain"]?.contains("accessibility") == true)
+        // route.attributes["chain"] carries ChannelID.accessibility.rawValue,
+        // which is "Accessibility" (capital A). #393: the lowercase literal made
+        // the prior boolean check dead, hiding the case mismatch.
+        let chainHasAccessibility = try #require(route.attributes["chain"]?.contains(ChannelID.accessibility.rawValue))
+        #expect(chainHasAccessibility)
         let completed = try #require(trace.events.first { $0.phase == .channelCompleted })
         #expect(completed.attributes["outcome"] == "success")
         #expect(trace.events.allSatisfy { event in
@@ -433,7 +439,7 @@ struct OperationTraceTests {
             router: router,
             cache: cache
         )
-        #expect((sharedJSONObject(sharedToolText(zeroResult))?["traces"] as? [Any])?.isEmpty == true)
+        #expect(try #require((sharedJSONObject(sharedToolText(zeroResult))?["traces"] as? [Any])?.isEmpty))
 
         let getResult = await SystemDispatcher.handle(
             command: "get_trace",
@@ -455,7 +461,7 @@ struct OperationTraceTests {
             router: router,
             cache: cache
         )
-        #expect(sharedJSONObject(sharedToolText(clearResult))?["success"] as? Bool == true)
+        #expect(try #require(sharedJSONObject(sharedToolText(clearResult))?["success"] as? Bool))
         #expect(await OperationTraceStore.shared.recent(limit: 128).isEmpty)
     }
 
@@ -482,11 +488,14 @@ struct OperationTraceTests {
             cache: cache
         )
 
-        #expect(missing.isError == true)
+        let missingIsError = missing.isError ?? false
+        #expect(missingIsError)
         #expect(sharedJSONObject(sharedToolText(missing))?["error"] as? String == "invalid_params")
-        #expect(malformed.isError == true)
+        let malformedIsError = malformed.isError ?? false
+        #expect(malformedIsError)
         #expect(sharedJSONObject(sharedToolText(malformed))?["error"] as? String == "invalid_params")
-        #expect(unknown.isError == true)
+        let unknownIsError = unknown.isError ?? false
+        #expect(unknownIsError)
         #expect(sharedJSONObject(sharedToolText(unknown))?["error"] as? String == "element_not_found")
     }
 
@@ -505,8 +514,10 @@ struct OperationTraceTests {
                 cache: cache
             )
             let listedBody = sharedJSONObject(sharedToolText(listed)) ?? [:]
-            #expect(listed.isError != true)
-            #expect((listedBody["traces"] as? [Any])?.isEmpty == true)
+            let listedError = listed.isError ?? false
+            #expect(!listedError)
+            let listedTracesEmpty = (listedBody["traces"] as? [Any])?.isEmpty ?? false
+            #expect(listedTracesEmpty)
             #expect(listedBody["note"] as? String == "trace_disabled")
 
             let fetched = await SystemDispatcher.handle(
@@ -516,11 +527,14 @@ struct OperationTraceTests {
                 cache: cache
             )
             let fetchedBody = sharedJSONObject(sharedToolText(fetched)) ?? [:]
-            #expect(fetched.isError == true)
+            let fetchedIsError = fetched.isError ?? false
+            #expect(fetchedIsError)
             #expect(fetchedBody["state"] as? String == "C")
             #expect(fetchedBody["error"] as? String == "not_supported")
-            #expect(fetchedBody["trace_disabled"] as? Bool == true)
-            #expect(fetchedBody["write_attempted"] as? Bool == false)
+            let fetchedTraceDisabled = fetchedBody["trace_disabled"] as? Bool ?? false
+            #expect(fetchedTraceDisabled)
+            let fetchedWriteAttempted = fetchedBody["write_attempted"] as? Bool ?? true
+            #expect(!fetchedWriteAttempted)
 
             let unconfirmed = await SystemDispatcher.handle(
                 command: "clear_traces",
@@ -528,7 +542,8 @@ struct OperationTraceTests {
                 router: router,
                 cache: cache
             )
-            #expect(unconfirmed.isError == true)
+            let unconfirmedIsError = unconfirmed.isError ?? false
+            #expect(unconfirmedIsError)
             #expect(sharedJSONObject(sharedToolText(unconfirmed))?["error"] as? String == "invalid_params")
             #expect(await OperationTraceStore.shared.trace(traceID) != nil)
 
@@ -541,12 +556,16 @@ struct OperationTraceTests {
                 cache: cache
             )
             let clearedBody = sharedJSONObject(sharedToolText(cleared)) ?? [:]
-            #expect(cleared.isError == true)
+            let clearedIsError = cleared.isError ?? false
+            #expect(clearedIsError)
             #expect(clearedBody["state"] as? String == "C")
             #expect(clearedBody["error"] as? String == "trace_disabled")
-            #expect(clearedBody["trace_disabled"] as? Bool == true)
-            #expect(clearedBody["write_attempted"] as? Bool == false)
-            #expect(clearedBody["success"] as? Bool != true)
+            let clearedTraceDisabled = clearedBody["trace_disabled"] as? Bool ?? false
+            #expect(clearedTraceDisabled)
+            let clearedWriteAttempted = clearedBody["write_attempted"] as? Bool ?? true
+            #expect(!clearedWriteAttempted)
+            let clearedSuccessFlag = clearedBody["success"] as? Bool ?? false
+            #expect(!clearedSuccessFlag)
             #expect(await OperationTraceStore.shared.trace(traceID) != nil)
         }
         await OperationTraceStore.shared.clear()
@@ -642,7 +661,8 @@ extension OperationTraceTests {
         let trace = try #require(
             await OperationTraceStore.shared.trace(TraceID(rawValue: rawID))
         )
-        #expect(result.isError == false)
+        let resultError = result.isError ?? false
+        #expect(!resultError)
         #expect(trace.operationID == operationID.rawValue)
         #expect(trace.events.map(\.phase) == [
             .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,
@@ -730,7 +750,8 @@ extension OperationTraceTests {
             cache: StateCache()
         )
 
-        #expect(result.isError == true)
+        let resultIsError = result.isError ?? false
+        #expect(resultIsError)
         #expect(await channel.executedOperations.isEmpty)
         #expect(await OperationTraceStore.shared.recent().isEmpty)
     }
@@ -856,7 +877,8 @@ extension OperationTraceTests {
         let trace = try #require(
             await OperationTraceStore.shared.trace(TraceID(rawValue: rawID))
         )
-        #expect(result.isError == false)
+        let resultError = result.isError ?? false
+        #expect(!resultError)
         #expect(trace.operationID == operationID.rawValue)
         #expect(trace.events.map(\.phase) == [
             .requestReceived, .inputValidated, .writeBoundaryCrossed, .verificationCompleted,

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -415,7 +415,7 @@ private func runChannelEQFixture(
 // must fail closed with stale_target_reference BEFORE any AXValue write —
 // otherwise a same-index/same-plugin collision would land a wrong-target write.
 
-@Test func testExpectedTrackNameMismatchFailsClosedStaleAndDoesNotWrite() async {
+@Test func testExpectedTrackNameMismatchFailsClosedStaleAndDoesNotWrite() async throws {
     // Live header at index 0 is "Acid Wash Bass"; the ref was bound to a track
     // whose name has since changed (its live index now holds a different track).
     let fixture = LiveFixture(beforeValue: 51)
@@ -425,7 +425,8 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "stale_target_reference")
-    #expect((obj["write_attempted"] as? Bool) == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(obj["expected_track_name"] as? String == "Kick Bus")
     #expect(obj["observed_track_name"] as? String == "Acid Wash Bass")
     // The live slider was NEVER written — zero wrong-target write.
@@ -444,7 +445,7 @@ private func runChannelEQFixture(
     #expect(fixture.currentSliderValue == 60)
 }
 
-@Test func testDuplicateLiveTrackNameFailsClosedBeforeWrite() async {
+@Test func testDuplicateLiveTrackNameFailsClosedBeforeWrite() async throws {
     let fixture = LiveFixture(beforeValue: 51, otherTracks: 1, duplicateTrackNameAt: 1)
     var params = thresholdParams(value: "60")
     params["expected_track_name"] = trackName
@@ -452,8 +453,10 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "stale_target_reference")
-    #expect((obj["write_attempted"] as? Bool) == false)
-    #expect(obj["ambiguous_live_track_name"] as? Bool == true)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
+    let v2 = try #require(obj["ambiguous_live_track_name"] as? Bool)
+    #expect(v2)
     #expect(obj["ambiguous_track_indices"] as? [Int] == [1])
     #expect(fixture.currentSliderValue == 51)
 }
@@ -494,7 +497,8 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "readback_mismatch")
-    #expect(try #require(obj["verified"] as? Bool) == false)
+    let v1 = try #require(obj["verified"] as? Bool)
+    #expect(!v1)
     #expect(try #require(obj["write_attempted"] as? Bool))
     #expect(obj["requested_normalized"] as? Double == 3.0)
     #expect(obj["observed_normalized"] as? Double == 1.0)
@@ -505,7 +509,8 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "unsupported_param_readback")
-    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
 }
 
 // MARK: - State C: tolerance exceeded → readback_mismatch + rollback
@@ -552,13 +557,14 @@ private func runChannelEQFixture(
 
 // MARK: - State C: window not found → window_open_failed
 
-@Test func testNoOpenPluginWindowIsWindowOpenFailed() async {
+@Test func testNoOpenPluginWindowIsWindowOpenFailed() async throws {
     let fixture = LiveFixture(beforeValue: 51, pluginWindowPresent: false)
     let obj = await runLive(fixture: fixture, params: thresholdParams())
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_open_failed")
     #expect(!((obj["write_attempted"] as? Bool)!))
-    #expect(obj["opener_action_attempted"] as? Bool == true)
+    let v1 = try #require(obj["opener_action_attempted"] as? Bool)
+    #expect(v1)
     #expect(obj["requested_window_title"] as? String == trackName)
     #expect(obj["requested_slider_description"] as? String == "Threshold")
     let windowCandidates = obj["window_candidates"] as? [[String: Any]]
@@ -625,7 +631,7 @@ private func runChannelEQFixture(
     #expect(fixture.currentSliderValue == 60)
 }
 
-@Test func testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider() async {
+@Test func testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider() async throws {
     let fixture = LiveFixture(
         thresholdDescription: "Output Gain",
         beforeValue: 51,
@@ -636,15 +642,18 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_open_failed")
-    #expect(obj["write_attempted"] as? Bool == false)
-    #expect(obj["opener_action_attempted"] as? Bool == true)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
+    let v2 = try #require(obj["opener_action_attempted"] as? Bool)
+    #expect(v2)
     let windowCandidates = obj["window_candidates"] as? [[String: Any]]
     let sliders = windowCandidates?.last?["slider_descriptions"] as? [String]
-    #expect(sliders?.contains("Output Gain") == true)
+    let v3 = try #require(sliders?.contains("Output Gain"))
+    #expect(v3)
     #expect(fixture.currentSliderValue == 51)
 }
 
-@Test func testWrongObservedPluginFailsClosedBeforeWindowAcquisition() async {
+@Test func testWrongObservedPluginFailsClosedBeforeWindowAcquisition() async throws {
     let fixture = LiveFixture(
         pluginSlotName: "Gain",
         beforeValue: 51,
@@ -655,11 +664,12 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "target_plugin_mismatch")
-    #expect(obj["write_attempted"] as? Bool == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
 }
 
-@Test func testAmbiguousSameTrackParameterWindowsFailClosed() async {
+@Test func testAmbiguousSameTrackParameterWindowsFailClosed() async throws {
     let fixture = LiveFixture(beforeValue: 51)
     let b = fixture.builder
     let duplicateWindow = b.element(3000)
@@ -688,11 +698,12 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_identity_unresolved")
-    #expect(obj["write_attempted"] as? Bool == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
 }
 
-@Test func testWrongWindowIdentityFailsClosed() async {
+@Test func testWrongWindowIdentityFailsClosed() async throws {
     let fixture = LiveFixture(beforeValue: 51, pluginWindowPresent: false)
     let b = fixture.builder
     let wrongWindow = b.element(3100)
@@ -721,12 +732,13 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_open_failed")
-    #expect(obj["write_attempted"] as? Bool == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
     #expect(b.attributeValue(wrongSlider, kAXValueAttribute as String) as? Double == 51)
 }
 
-@Test func testAmbiguousWindowAppearingAfterSlotPressFailsClosed() async {
+@Test func testAmbiguousWindowAppearingAfterSlotPressFailsClosed() async throws {
     let fixture = LiveFixture(beforeValue: 51, openWindowOnSlotPress: true)
     let b = fixture.builder
     let duplicateWindow = b.element(3300)
@@ -755,12 +767,13 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_identity_unresolved")
-    #expect(obj["write_attempted"] as? Bool == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
     #expect(b.attributeValue(duplicateSlider, kAXValueAttribute as String) as? Double == 51)
 }
 
-@Test func testAmbiguousRequestedSlidersFailClosed() async {
+@Test func testAmbiguousRequestedSlidersFailClosed() async throws {
     let fixture = LiveFixture(beforeValue: 51)
     let b = fixture.builder
     let duplicateSlider = b.element(3200)
@@ -773,7 +786,8 @@ private func runChannelEQFixture(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "window_identity_unresolved")
-    #expect(obj["write_attempted"] as? Bool == false)
+    let v1 = try #require(obj["write_attempted"] as? Bool)
+    #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
 }
 

--- a/Tests/LogicProMCPTests/PromptsTests.swift
+++ b/Tests/LogicProMCPTests/PromptsTests.swift
@@ -59,6 +59,7 @@ struct PromptsTests {
         let prompts = try #require(capabilities["prompts"] as? [String: Any])
 
         #expect(try #require(resources["subscribe"] as? Bool))
-        #expect(try #require(prompts["listChanged"] as? Bool) == false)
+        let v1 = try #require(prompts["listChanged"] as? Bool)
+        #expect(!v1)
     }
 }

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -99,7 +99,8 @@ struct QualificationRunnerTests {
 
         #expect(result.status != .passed)
         #expect(!result.verified)
-        #expect(result.readback?.verified == false)
+        let v1 = try #require(result.readback?.verified)
+        #expect(!v1)
     }
 
     /// #373 Phase A retired the protocolSmoke bucket for read-only operations.
@@ -130,7 +131,8 @@ struct QualificationRunnerTests {
         #expect(result.status.rawValue != "protocol_smoke")
         #expect(!result.verified)
         #expect(result.deferral?.code == .semanticMismatch)
-        #expect(result.readback?.verified == false)
+        let v1 = try #require(result.readback?.verified)
+        #expect(!v1)
     }
 
     /// The structural consequence, pinned: with every read-only spec oracled,
@@ -192,7 +194,8 @@ struct QualificationRunnerTests {
         #expect(result.status == .passed)
         #expect(result.verified)
         #expect(result.verificationKind == .semanticReadback)
-        #expect(result.readback?.verified == true)
+        let v1 = try #require(result.readback?.verified)
+        #expect(v1)
     }
 
     @Test func operationFailurePreventsLiveAxisPromotion() async throws {
@@ -308,7 +311,8 @@ struct QualificationRunnerTests {
 
         let decision = await fixture.verify(expectedSHA256: fixture.binarySHA256)
         #expect(decision.exitCode == 0)
-        #expect(try Self.resultObject(decision)["promotable"] as? Bool == true)
+        let v1 = try #require(try Self.resultObject(decision)["promotable"] as? Bool)
+        #expect(v1)
     }
 
     /// #373 Phase A inverted this test's premise, and the inversion is the
@@ -392,7 +396,8 @@ struct QualificationRunnerTests {
         let result = await fixture.verify(expectedSHA256: fixture.binarySHA256)
 
         #expect(result.exitCode == 0, "\(result.stdout)")
-        #expect(try Self.resultObject(result)["promotable"] as? Bool == true)
+        let v1 = try #require(try Self.resultObject(result)["promotable"] as? Bool)
+        #expect(v1)
     }
 
     @Test func standaloneSignerAndVerifierUseCandidateBytesWithoutExecutingCandidate() async throws {
@@ -793,7 +798,7 @@ struct QualificationRunnerTests {
         ))
     }
 
-    @Test func emptyTraceListFailsWithoutObservedEvents() {
+    @Test func emptyTraceListFailsWithoutObservedEvents() throws {
         let empty = Self.driveResult(
             specs: Array(OperationRegistry.specs.prefix(1)),
             tracePresent: false
@@ -812,7 +817,8 @@ struct QualificationRunnerTests {
         )
         let observed = Self.driveResult(specs: Array(OperationRegistry.specs.prefix(1)))
 
-        #expect(empty.traceList?.traces.isEmpty == true)
+        let v1 = try #require(empty.traceList?.traces.isEmpty)
+        #expect(v1)
         #expect(!empty.traceOK)
         #expect(!empty.allChecksPass)
         #expect(!zeroEvent.traceOK)
@@ -862,13 +868,20 @@ struct QualificationRunnerTests {
 
         #expect(operationCase.status == .passed)
         #expect(operationCase.verified)
-        #expect(evidence["handshake_ok"] as? Bool == true)
-        #expect(evidence["health_ok"] as? Bool == true)
-        #expect(evidence["catalog_count_match"] as? Bool == true)
-        #expect(evidence["trace_ok"] as? Bool == true)
-        #expect(evidence["negative_failclosed"] as? Bool == true)
-        #expect(evidence["registry_spec_found"] as? Bool == false)
-        #expect(evidence["handler_bound"] as? Bool == false)
+        let v1 = try #require(evidence["handshake_ok"] as? Bool)
+        #expect(v1)
+        let v2 = try #require(evidence["health_ok"] as? Bool)
+        #expect(v2)
+        let v3 = try #require(evidence["catalog_count_match"] as? Bool)
+        #expect(v3)
+        let v4 = try #require(evidence["trace_ok"] as? Bool)
+        #expect(v4)
+        let v5 = try #require(evidence["negative_failclosed"] as? Bool)
+        #expect(v5)
+        let v6 = try #require(evidence["registry_spec_found"] as? Bool)
+        #expect(!v6)
+        let v7 = try #require(evidence["handler_bound"] as? Bool)
+        #expect(!v7)
     }
 
     @Test func handshakeTimeoutStopsBeforeAttestation() async throws {
@@ -936,7 +949,8 @@ struct QualificationRunnerTests {
 
         #expect(operationCase.status == .notQualified)
         #expect(!operationCase.verified)
-        #expect(evidence["catalog_count_match"] as? Bool == false)
+        let v1 = try #require(evidence["catalog_count_match"] as? Bool)
+        #expect(!v1)
         let observedAxis = try #require(attestation.cases.first {
             $0.id == QualificationAxis.defaultAxis.key
         })
@@ -981,7 +995,8 @@ struct QualificationRunnerTests {
     @Test func observedAxisReadbackStaysVerifiedWhenHealthWarms() async throws {
         let specs = [try #require(OperationRegistry.specs.first { $0.id == .systemHealth })]
         let driveResult = Self.driveResult(specs: specs, healthChangesAfterNegativeProbe: true)
-        #expect(driveResult.negative?.healthReadStable == false)
+        let v1 = try #require(driveResult.negative?.healthReadStable)
+        #expect(!v1)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
         try JSONEncoder().encode(Self.axisWaivers()).write(to: fixture.waiversURL)
@@ -1028,11 +1043,15 @@ struct QualificationRunnerTests {
 
         #expect(operationCase.status == .notQualified)
         #expect(!operationCase.verified)
-        #expect(evidence["negative_failclosed"] as? Bool == true)
+        let v1 = try #require(evidence["negative_failclosed"] as? Bool)
+        #expect(v1)
         #expect(evidence["negative_state"] as? String == "C")
-        #expect(evidence["negative_write_attempted"] as? Bool == false)
-        #expect(evidence["health_read_stable"] as? Bool == true)
-        #expect(evidence["catalog_read_stable"] as? Bool == true)
+        let v2 = try #require(evidence["negative_write_attempted"] as? Bool)
+        #expect(!v2)
+        let v3 = try #require(evidence["health_read_stable"] as? Bool)
+        #expect(v3)
+        let v4 = try #require(evidence["catalog_read_stable"] as? Bool)
+        #expect(v4)
     }
 
     @Test func absentAxesRequireLocaleEvidenceOrWaiver() async throws {
@@ -1440,7 +1459,8 @@ struct QualificationRunnerTests {
         let json = try Self.resultObject(result)
 
         #expect(result.exitCode == 0)
-        #expect(json["promotable"] as? Bool == true)
+        let v1 = try #require(json["promotable"] as? Bool)
+        #expect(v1)
         #expect(Self.rejectionReasons(json).isEmpty)
     }
 
@@ -1471,7 +1491,8 @@ struct QualificationRunnerTests {
             let values = try #require(object[expected.1] as? [[String: Any]])
             if filename == "raw-transcript.json" {
                 let firstFrame = try #require(values.first)
-                #expect((firstFrame["operation_id"] as? String)?.isEmpty == false)
+                let v1 = try #require((firstFrame["operation_id"] as? String)?.isEmpty)
+                #expect(!v1)
             }
             let entry = try #require(entries.first { $0["path"] as? String == filename })
             #expect(entry["sha256"] as? String == SupportBundleBuilder.sha256(data))
@@ -1688,7 +1709,8 @@ struct QualificationRunnerTests {
                 #expect(!qualificationCase.verified)
                 #expect(qualificationCase.verificationKind == .typedDeferral)
                 #expect(qualificationCase.deferral?.code == .liveMutationNotRun)
-                #expect(qualificationCase.deferral?.detail.contains("ADR-001-c") == true)
+                let v1 = try #require(qualificationCase.deferral?.detail.contains("ADR-001-c"))
+                #expect(v1)
             }
             #expect(qualificationCase.readback != nil)
             if spec.id == .systemSagaExecute {
@@ -1701,9 +1723,11 @@ struct QualificationRunnerTests {
             let evidence = try #require(
                 JSONSerialization.jsonObject(with: Data(contentsOf: evidenceURL)) as? [String: Any]
             )
-            #expect(evidence["registry_spec_found"] as? Bool ?? false)
-            #expect(evidence["handler_bound"] as? Bool ?? false)
-            #expect((evidence["trace_started"] as? Bool ?? false) == (spec.id == .systemSagaExecute))
+            let v2 = try #require(evidence["registry_spec_found"] as? Bool)
+            #expect(v2)
+            let v3 = try #require(evidence["handler_bound"] as? Bool)
+            #expect(v3)
+            #expect((evidence["trace_started"] as? Bool ?? false) == (spec.id == .systemSagaExecute)) // test-integrity:live: top-level == compares two non-literal Bools; the "?? false" is a sub-expression, not the asserted comparison
         }
 
         #expect(FileManager.default.fileExists(atPath: fixture.manifestURL.path))

--- a/Tests/LogicProMCPTests/ResourceSchemaTests.swift
+++ b/Tests/LogicProMCPTests/ResourceSchemaTests.swift
@@ -487,7 +487,7 @@ func testHealthResponseMCUDisconnected() async {
 }
 
 @Test(codexSeatbeltProcessInspectionDisabled)
-func testHealthResponseFullSchema() async {
+func testHealthResponseFullSchema() async throws {
     let cache = StateCache()
     let router = ChannelRouter()
     let mockChannel = MockChannel(id: .mcu)
@@ -509,8 +509,10 @@ func testHealthResponseFullSchema() async {
     #expect(json["logic_pro_ui_locale"] as? String == "ko-KR")
     let variants = json["logic_pro_variants"] as? [[String: Any]]
     #expect(variants?.count == 2)
-    #expect(variants?.first(where: { $0["variant"] as? String == "desktop" })?["running"] as? Bool == true)
-    #expect(variants?.first(where: { $0["variant"] as? String == "creator_studio" })?["installed"] as? Bool == false)
+    let desktopRunning = try #require(variants?.first(where: { $0["variant"] as? String == "desktop" })?["running"] as? Bool)
+    #expect(desktopRunning)
+    let creatorInstalled = try #require(variants?.first(where: { $0["variant"] as? String == "creator_studio" })?["installed"] as? Bool)
+    #expect(!creatorInstalled)
     #expect(json["process_metadata_resolved"] as? Bool != nil)
     #expect(json["mcu"] as? [String: Any] != nil)
     #expect(json["channels"] as? [[String: Any]] != nil)

--- a/Tests/LogicProMCPTests/ResourceTracksTierMergeTests.swift
+++ b/Tests/LogicProMCPTests/ResourceTracksTierMergeTests.swift
@@ -115,7 +115,8 @@ func placeholderRowsDoNotEmitTargetRefs() async throws {
         let tracks = try #require(
             (sharedJSONObject(sharedResourceText(tracksResult))?["data"] as? [[String: Any]])?.first
         )
-        #expect(tracks["placeholder"] as? Bool == true)
+        let v1 = try #require(tracks["placeholder"] as? Bool)
+        #expect(v1)
         #expect(tracks["track_ref"] == nil)
 
         await cache.updateChannelStrips([ChannelStripState(trackIndex: 0)])
@@ -149,7 +150,7 @@ func trackStateJSONDecodeFailsClosedAndTypedRowsKeepTargetRefs() async throws {
     #expect(encodedObject["liveIdentityBacked"] == nil)
 
     let decoded = try decoder.decode(TrackState.self, from: encoded)
-    #expect(decoded.liveIdentityBacked == false)
+    #expect(!decoded.liveIdentityBacked)
 
     let legacyCache = StateCache()
     await legacyCache.updateTracks([decoded])

--- a/Tests/LogicProMCPTests/SagaJournalReclaimTests.swift
+++ b/Tests/LogicProMCPTests/SagaJournalReclaimTests.swift
@@ -426,9 +426,12 @@ struct SagaJournalReclaimTests {
             #expect(second["state"] as? String == "A")
             #expect(retry["state"] as? String == "C")
             #expect(retry["error"] as? String == "saga_outcome_unavailable")
-            #expect(retry["safe_to_retry"] as? Bool == false)
-            #expect(retry["write_attempted"] as? Bool == false)
-            #expect(retry["outcome_retained"] as? Bool == false)
+            let v1 = try #require(retry["safe_to_retry"] as? Bool)
+            #expect(!v1)
+            let v2 = try #require(retry["write_attempted"] as? Bool)
+            #expect(!v2)
+            let v3 = try #require(retry["outcome_retained"] as? Bool)
+            #expect(!v3)
             #expect(await fixture.channel.writeCount() == writesBeforeRetry)
         }
     }
@@ -455,7 +458,8 @@ struct SagaJournalReclaimTests {
             let record = try #require(status["record"] as? [String: Any])
 
             #expect(record["status"] as? String == "completed")
-            #expect(record["outcome_retained"] as? Bool == false)
+            let v1 = try #require(record["outcome_retained"] as? Bool)
+            #expect(!v1)
             #expect(record["outcome"] == nil)
         }
     }
@@ -526,7 +530,8 @@ struct SagaJournalReclaimTests {
             #expect(await fixture.channel.writeCount() == 2)
             // A shared MutationSaga would have replayed the cached outcome and
             // reported `duplicate` from its own scratch instead.
-            #expect(replay["duplicate"] as? Bool == false)
+            let v1 = try #require(replay["duplicate"] as? Bool)
+            #expect(!v1)
         }
     }
 

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -253,7 +253,7 @@ private func check(_ report: SetupDoctor.Report, _ id: String) -> SetupDoctor.Ch
     #expect(first["severity"] != nil)
     #expect(first["duration_ms"] != nil)
     let optional = try #require(first["optional"] as? Bool)
-    #expect(optional == false)
+    #expect(!optional)
 }
 
 private struct FrozenV1Remediation: Codable { let type: String; let value: String }

--- a/Tests/LogicProMCPTests/SupportBundleTests.swift
+++ b/Tests/LogicProMCPTests/SupportBundleTests.swift
@@ -212,7 +212,8 @@ struct SupportBundleTests {
         // canonical prefix form is the resolver's own realpath output).
         let relative = SystemDispatcher.resolvedSupportBundleDirectory(requested: "session-a/bundle-1")
         #expect(relative != nil)
-        #expect(relative?.path.hasSuffix("/session-a/bundle-1") == true)
+        let v1 = try #require(relative?.path.hasSuffix("/session-a/bundle-1"))
+        #expect(v1)
         // Absolute path already under the root is accepted.
         #expect(SystemDispatcher.resolvedSupportBundleDirectory(
             requested: root.appendingPathComponent("abs-child").path
@@ -351,10 +352,8 @@ struct SupportBundleTests {
         )
         let successObject = try #require(sharedJSONObject(sharedToolText(success)))
         #expect(successObject["state"] as? String == "A")
-        #expect(
-            (successObject["bundle_path"] as? String)?
-                .hasSuffix("/" + output.lastPathComponent) == true
-        )
+        let successBundlePath = try #require(successObject["bundle_path"] as? String)
+        #expect(successBundlePath.hasSuffix("/" + output.lastPathComponent))
         let files = try #require(successObject["files"] as? [[String: String]])
         #expect(files == [["name": "manifest.json", "sha256": String(repeating: "a", count: 64)]])
         let traceID = try #require(successObject["trace_id"] as? String)
@@ -372,7 +371,8 @@ struct SupportBundleTests {
             supportBundleExporter: { _, _ in throw CocoaError(.fileWriteNoPermission) }
         )
         let failureObject = try #require(sharedJSONObject(sharedToolText(failure)))
-        #expect(failure.isError == true)
+        let v1 = try #require(failure.isError)
+        #expect(v1)
         #expect(failureObject["state"] as? String == "C")
         #expect(failureObject["error"] as? String == "support_bundle_export_failed")
 
@@ -387,9 +387,13 @@ struct SupportBundleTests {
             }
         )
         let defaultObject = try #require(sharedJSONObject(sharedToolText(defaultPath)))
-        #expect((defaultObject["bundle_path"] as? String)?.contains(
-            "/Library/Logs/LogicProMCP/support-bundles/"
-        ) == true)
+        let defaultBundlePath = try #require(defaultObject["bundle_path"] as? String)
+        // #393: the prior `contains("/Library/Logs/LogicProMCP/support-bundles/")` was a dead
+        // assertion; made live it fails because the DEBUG-only root override (used across this
+        // suite) repoints the containment root to a temp dir. The real invariant is that the
+        // default (empty-params) export lands UNDER the containment root, which respects the
+        // override — assert that instead of the release-only absolute path.
+        #expect(defaultBundlePath.hasPrefix(SystemDispatcher.supportBundleRoot.path))
     }
 
     @Test("public MCP handler exports locally without starting Logic")
@@ -437,7 +441,8 @@ struct SupportBundleTests {
                 "params": .object(["dir": .string("/pr011-outside-root-\(UUID().uuidString)")]),
             ]
         ))
-        #expect(invalid.isError == true)
+        let v1 = try #require(invalid.isError)
+        #expect(v1)
         #expect(sharedJSONObject(sharedToolText(invalid))?["error"] as? String == "invalid_params")
     }
 

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -484,8 +484,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackSelectFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackSelectFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -495,15 +495,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
         }
     }
 
     @Test
-    func testTrackSelectFlagOffTargetRefFailsClosed() async {
-        await FeatureFlags.withAdr002TargetRefForTests(false) {
+    func testTrackSelectFlagOffTargetRefFailsClosed() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(false) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -513,7 +514,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "target_ref_unavailable")
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await allOps(channels).isEmpty)
@@ -521,8 +523,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackSelectFlagOnStaleReferenceFailsClosedNoWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackSelectFlagOnStaleReferenceFailsClosedNoWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             await registry.bumpTopologyGeneration()
             let (router, channels) = await makeRouter()
@@ -533,15 +535,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
             #expect(await allOps(channels).isEmpty)
         }
     }
 
     @Test
-    func testTrackDeleteFlagOnStaleReferenceFailsClosedBeforeSelectSideEffect() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackDeleteFlagOnStaleReferenceFailsClosedBeforeSelectSideEffect() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             await registry.bumpProjectEpoch()
             let (router, channels) = await makeRouter()
@@ -552,7 +555,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
             // The pre-delete track.select side effect must NOT have fired.
             #expect(await allOps(channels).isEmpty)
@@ -560,8 +564,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackDeleteFlagOnResolvesTargetRefToSelectIndex() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackDeleteFlagOnResolvesTargetRefToSelectIndex() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -571,7 +575,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
             #expect(await allOps(channels).contains(where: { $0.0 == "track.delete" }))
@@ -579,8 +584,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackDuplicateFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackDuplicateFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -590,7 +595,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
             #expect(await allOps(channels).contains(where: { $0.0 == "track.duplicate" }))
@@ -598,8 +604,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackMuteFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackMuteFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -609,15 +615,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_mute") == ["index": "2", "enabled": "true"])
         }
     }
 
     @Test
-    func testTrackMuteFlagOffRejectsTargetRefBeforeIndexValidation() async {
-        await FeatureFlags.withAdr002TargetRefForTests(false) {
+    func testTrackMuteFlagOffRejectsTargetRefBeforeIndexValidation() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(false) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -627,15 +634,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "target_ref_unavailable")
             #expect(await allOps(channels).isEmpty)
         }
     }
 
     @Test
-    func testTrackArmOnlyFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackArmOnlyFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -645,15 +653,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_arm") == ["index": "2", "enabled": "true"])
         }
     }
 
     @Test
-    func testTrackSetAutomationFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackSetAutomationFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -663,15 +672,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_automation") == ["index": "2", "mode": "read"])
         }
     }
 
     @Test
-    func testTrackSetInstrumentFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackSetInstrumentFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -681,15 +691,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.set_instrument") == ["index": "2", "path": "/x.patch"])
         }
     }
 
     @Test
-    func testTrackRenameFlagOnResolvesTargetRefAndEchoesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackRenameFlagOnResolvesTargetRefAndEchoesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -699,7 +710,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             // rename keeps its pre-uniform `track_ref` alias (G8 backward compat);
             // the other 12 mutations emit only the uniform `target_ref` key.
@@ -711,8 +723,8 @@ struct TargetRefResolutionTests {
     // MARK: - Mixer dispatcher wiring
 
     @Test
-    func testMixerSetVolumeFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testMixerSetVolumeFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await MixerDispatcher.handle(
@@ -722,15 +734,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "mixer.set_volume") == ["index": "2", "volume": "0.5"])
         }
     }
 
     @Test
-    func testMixerSetVolumeFlagOffTargetRefFailsClosedWithoutWrongTargetWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(false) {
+    func testMixerSetVolumeFlagOffTargetRefFailsClosedWithoutWrongTargetWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(false) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let before = await cache.getTracks().map {
@@ -747,9 +760,11 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "target_ref_unavailable")
-            #expect(sharedJSONObject(sharedToolText(result))?["write_attempted"] as? Bool == false)
+            let v2 = try #require(sharedJSONObject(sharedToolText(result))?["write_attempted"] as? Bool)
+            #expect(!v2)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await allOps(channels).isEmpty, "neither conflicting track may be written")
             let after = await cache.getTracks().map {
@@ -760,8 +775,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testMixerSetPanFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testMixerSetPanFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await MixerDispatcher.handle(
@@ -771,15 +786,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "mixer.set_pan") == ["index": "2", "pan": "-0.25"])
         }
     }
 
     @Test
-    func testMixerSetVolumeFlagOnStaleReferenceFailsClosedNoWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testMixerSetVolumeFlagOnStaleReferenceFailsClosedNoWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             await registry.bumpTopologyGeneration()
             let (router, channels) = await makeRouter()
@@ -790,7 +806,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
             #expect(await allOps(channels).isEmpty)
         }
@@ -814,8 +831,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testPluginSetParamVerifiedFlagOnResolvesTargetRef() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testPluginSetParamVerifiedFlagOnResolvesTargetRef() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await PluginsDispatcher.handle(
@@ -825,15 +842,16 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "plugin.set_param_verified")?["track"] == "2")
         }
     }
 
     @Test
-    func testPluginSetParamVerifiedFlagOffTargetRefFailsClosed() async {
-        await FeatureFlags.withAdr002TargetRefForTests(false) {
+    func testPluginSetParamVerifiedFlagOffTargetRefFailsClosed() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(false) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             let (router, channels) = await makeRouter()
             let result = await PluginsDispatcher.handle(
@@ -843,7 +861,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "target_ref_unavailable")
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await allOps(channels).isEmpty)
@@ -851,8 +870,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testPluginSetParamVerifiedFlagOnStaleReferenceFailsClosedNoWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testPluginSetParamVerifiedFlagOnStaleReferenceFailsClosedNoWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2)
             await registry.bumpProjectEpoch()
             let (router, channels) = await makeRouter()
@@ -863,7 +882,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
             #expect(await allOps(channels).isEmpty)
         }
@@ -875,8 +895,8 @@ struct TargetRefResolutionTests {
     /// invalidate that ref. Pre-#353 the drift check saw the new live name and
     /// failed the next same-ref op closed; the verified-success rebind keeps it.
     @Test
-    func testRenameViaRefThenSecondOpViaSameRefResolves() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameViaRefThenSecondOpViaSameRefResolves() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (renameRouter, _) = await makeRouter()
             let renameResult = await TrackDispatcher.handle(
@@ -886,7 +906,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(renameResult.isError == false)
+            let v1 = try #require(renameResult.isError)
+            #expect(!v1)
             #expect((await registry.resolve(reference))!.descriptor.trackName == "Sub Bass")
             #expect((await cache.getTracks())[2].name == "Sub Bass")
 
@@ -898,14 +919,15 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(secondOp.isError == false)
+            let v2 = try #require(secondOp.isError)
+            #expect(!v2)
             #expect(await opParams(selectChannels, "track.select") == ["index": "2"])
         }
     }
 
     @Test
-    func testRenameViaIndexDoesNotUpdateCache() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameViaIndexDoesNotUpdateCache() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (_, cache, _) = await boundTrack(index: 2, name: "Bass")
             let (router, _) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -914,7 +936,8 @@ struct TargetRefResolutionTests {
                 router: router,
                 cache: cache
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == nil)
             #expect((await cache.getTracks())[2].name == "Bass")
         }
@@ -924,8 +947,8 @@ struct TargetRefResolutionTests {
     /// DIRECTLY in Logic's UI (no server op, no rebind) still invalidates the
     /// ref — the server cannot prove it caused the change.
     @Test
-    func testExternalRenameWithoutServerOpStillFailsClosed() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testExternalRenameWithoutServerOpStillFailsClosed() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             // User renamed the track in Logic; the cache caught up but no server
             // op / rebind ever ran.
@@ -942,7 +965,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
             #expect(await allOps(channels).isEmpty)
         }
@@ -951,8 +975,8 @@ struct TargetRefResolutionTests {
     /// A State B (unverified) rename must NOT rebind — identity is not proven.
     /// Once the cache reflects the (unverified) new name, the ref fails closed.
     @Test
-    func testRenameStateBUnverifiedDoesNotRebind() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameStateBUnverifiedDoesNotRebind() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let router = ChannelRouter()
             await router.register(RecordingChannel(id: .accessibility, envelope: .stateB))
@@ -964,7 +988,8 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry
             )
             // State B (verified:false) rename surfaces as an error.
-            #expect(renameResult.isError == true)
+            let v1 = try #require(renameResult.isError)
+            #expect(v1)
 
             await cache.updateTracks([
                 TrackState(id: 0, name: "Kick", type: .audio),
@@ -979,7 +1004,8 @@ struct TargetRefResolutionTests {
                 cache: cache,
                 targetRegistry: registry
             )
-            #expect(secondOp.isError == true)
+            let v2 = try #require(secondOp.isError)
+            #expect(v2)
             #expect(errorCode(secondOp) == "stale_target_reference")
             #expect(await allOps(selectChannels).isEmpty)
         }
@@ -1006,8 +1032,8 @@ struct TargetRefResolutionTests {
     /// index (drift check passes), but a live out-of-band reorder put a
     /// different-named track there. The live cross-check must fail closed.
     @Test
-    func testTrackTargetRefLiveNameMismatchFailsClosedStaleAndDoesNotWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackTargetRefLiveNameMismatchFailsClosedStaleAndDoesNotWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -1018,9 +1044,11 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry,
                 liveTrackName: { $0 == 2 ? "Drums" : "Other" }
             )
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(errorCode(result) == "stale_target_reference")
-            #expect(body(result)["write_attempted"] as? Bool == false)
+            let v2 = try #require(body(result)["write_attempted"] as? Bool)
+            #expect(!v2)
             #expect(body(result)["expected_track_name"] as? String == "Bass")
             #expect(body(result)["observed_track_name"] as? String == "Drums")
             #expect(await allOps(channels).isEmpty, "no wrong-target write")
@@ -1028,8 +1056,8 @@ struct TargetRefResolutionTests {
     }
 
     @Test
-    func testTrackTargetRefDuplicateNameReorderFailsClosedAndDoesNotWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackTargetRefDuplicateNameReorderFailsClosedAndDoesNotWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let descriptor = TargetDescriptor(trackIndex: 1, trackName: "Bass")
             let reference = await registry.bind(
@@ -1054,9 +1082,11 @@ struct TargetRefResolutionTests {
                 liveTrackNames: { [0: "Drums", 1: "Bass", 2: "Bass"] }
             )
             #expect(errorCode(result) == "stale_target_reference")
-            #expect(body(result)["write_attempted"] as? Bool == false)
+            let v1 = try #require(body(result)["write_attempted"] as? Bool)
+            #expect(!v1)
             #expect(body(result)["expected_track_name"] as? String == "Bass")
-            #expect(body(result)["ambiguous_live_track_name"] as? Bool == true)
+            let v2 = try #require(body(result)["ambiguous_live_track_name"] as? Bool)
+            #expect(v2)
             #expect(body(result)["ambiguous_track_indices"] as? [Int] == [2])
             #expect(await allOps(channels).isEmpty, "no wrong-target write")
         }
@@ -1064,8 +1094,8 @@ struct TargetRefResolutionTests {
 
     /// Mixer `set_volume` is the F5 sibling of the track path.
     @Test
-    func testMixerTargetRefLiveNameMismatchFailsClosedStaleAndDoesNotWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testMixerTargetRefLiveNameMismatchFailsClosedStaleAndDoesNotWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await MixerDispatcher.handle(
@@ -1077,7 +1107,8 @@ struct TargetRefResolutionTests {
                 liveTrackName: { _ in "Lead Synth" }
             )
             #expect(errorCode(result) == "stale_target_reference")
-            #expect(body(result)["write_attempted"] as? Bool == false)
+            let v1 = try #require(body(result)["write_attempted"] as? Bool)
+            #expect(!v1)
             #expect(await allOps(channels).isEmpty, "no wrong-target write")
         }
     }
@@ -1085,8 +1116,8 @@ struct TargetRefResolutionTests {
     /// F1 parity: an unreadable (nil) live name fails closed, never silently
     /// falling back to the possibly-stale cache.
     @Test
-    func testTrackTargetRefUnreadableLiveNameFailsClosedAndDoesNotWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackTargetRefUnreadableLiveNameFailsClosedAndDoesNotWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -1099,8 +1130,10 @@ struct TargetRefResolutionTests {
                 liveTrackNames: { nil }
             )
             #expect(errorCode(result) == "stale_target_reference")
-            #expect(body(result)["write_attempted"] as? Bool == false)
-            #expect((body(result)["what_was_observed"] as? String)?.contains("unreadable") == true)
+            let v1 = try #require(body(result)["write_attempted"] as? Bool)
+            #expect(!v1)
+            let v2 = try #require((body(result)["what_was_observed"] as? String)?.contains("unreadable"))
+            #expect(v2)
             #expect(await allOps(channels).isEmpty, "no wrong-target write, no pre-delete select side effect")
         }
     }
@@ -1108,8 +1141,8 @@ struct TargetRefResolutionTests {
     /// GREEN passthrough: the live header still matches the bound name → resolve
     /// and write proceed exactly as before.
     @Test
-    func testTrackTargetRefLiveNameMatchStillResolvesAndWrites() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testTrackTargetRefLiveNameMatchStillResolvesAndWrites() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -1121,15 +1154,16 @@ struct TargetRefResolutionTests {
                 liveTrackName: { _ in "Bass" },
                 liveTrackNames: { [2: "Bass"] }
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
         }
     }
 
     @Test
-    func testMixerTargetRefLiveNameMatchStillResolvesAndWrites() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testMixerTargetRefLiveNameMatchStillResolvesAndWrites() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, reference) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await MixerDispatcher.handle(
@@ -1141,7 +1175,8 @@ struct TargetRefResolutionTests {
                 liveTrackName: { _ in "Bass" },
                 liveTrackNames: { [2: "Bass"] }
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == reference.rawValue)
             #expect(await opParams(channels, "mixer.set_volume") == ["index": "2", "volume": "0.5"])
         }
@@ -1150,8 +1185,8 @@ struct TargetRefResolutionTests {
     /// Byte-invariance of the explicit-index path: no `target_ref` → no binding
     /// → the live guard is NEVER invoked, even with a mismatching probe.
     @Test
-    func testExplicitIndexPathIsByteInvariantEvenWithMismatchingLiveProbe() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testExplicitIndexPathIsByteInvariantEvenWithMismatchingLiveProbe() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let (registry, cache, _) = await boundTrack(index: 2, name: "Bass")
             let (router, channels) = await makeRouter()
             let result = await TrackDispatcher.handle(
@@ -1162,7 +1197,8 @@ struct TargetRefResolutionTests {
                 targetRegistry: registry,
                 liveTrackName: { _ in "Totally Different" }
             )
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             #expect(echoedTargetRef(result) == nil)
             #expect(await opParams(channels, "track.select") == ["index": "2"])
         }

--- a/Tests/LogicProMCPTests/TargetRegistryTests.swift
+++ b/Tests/LogicProMCPTests/TargetRegistryTests.swift
@@ -142,8 +142,8 @@ struct TargetRegistryTests {
     }
 
     @Test
-    func testRenameRejectsStaleReferenceAfterTopologyGenerationBump() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameRejectsStaleReferenceAfterTopologyGenerationBump() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let descriptor = descriptor()
             let reference = await registry.bind(
@@ -170,15 +170,16 @@ struct TargetRegistryTests {
                 targetRegistry: registry
             )
 
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
             #expect(await channel.executedOps.isEmpty)
         }
     }
 
     @Test
-    func testRenameRejectsStaleReferenceAfterProjectEpochBump() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameRejectsStaleReferenceAfterProjectEpochBump() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let descriptor = descriptor()
             let reference = await registry.bind(
@@ -205,15 +206,16 @@ struct TargetRegistryTests {
                 targetRegistry: registry
             )
 
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
             #expect(await channel.executedOps.isEmpty)
         }
     }
 
     @Test
-    func testRenameRejectsMismatchedTargetReferenceWithoutWrite() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameRejectsMismatchedTargetReferenceWithoutWrite() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let descriptor = descriptor(index: 0, name: "Kick")
             let reference = await registry.bind(
@@ -243,15 +245,16 @@ struct TargetRegistryTests {
                 targetRegistry: registry
             )
 
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(sharedJSONObject(sharedToolText(result))?["error"] as? String == "stale_target_reference")
             #expect(await channel.executedOps.isEmpty)
         }
     }
 
     @Test
-    func testRenameAcceptsResolvedTargetReference() async {
-        await FeatureFlags.withAdr002TargetRefForTests(true) {
+    func testRenameAcceptsResolvedTargetReference() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(true) {
             let registry = TargetRegistry()
             let descriptor = descriptor(index: 0, name: "Kick")
             let reference = await registry.bind(
@@ -277,7 +280,8 @@ struct TargetRegistryTests {
                 targetRegistry: registry
             )
 
-            #expect(result.isError == false)
+            let v1 = try #require(result.isError)
+            #expect(!v1)
             // rename keeps its pre-uniform `track_ref` echo (G8 backward compat)
             // AND carries the uniform `target_ref` evidence key.
             let payload = sharedJSONObject(sharedToolText(result))!
@@ -429,9 +433,9 @@ struct TargetRegistryTests {
     }
 
     @Test
-    func testRenameTargetReferenceFailsClosedWhenFeatureDisabled() async {
-        await FeatureFlags.withAdr002TargetRefForTests(false) {
-            #expect(FeatureFlags.adr002TargetRef == false)
+    func testRenameTargetReferenceFailsClosedWhenFeatureDisabled() async throws {
+        try await FeatureFlags.withAdr002TargetRefForTests(false) {
+            #expect(!FeatureFlags.adr002TargetRef)
 
             let router = ChannelRouter()
             let channel = MockChannel(id: .accessibility)
@@ -449,9 +453,11 @@ struct TargetRegistryTests {
             )
 
             let body = sharedJSONObject(sharedToolText(result)) ?? [:]
-            #expect(result.isError == true)
+            let v1 = try #require(result.isError)
+            #expect(v1)
             #expect(body["error"] as? String == "target_ref_unavailable")
-            #expect(body["write_attempted"] as? Bool == false)
+            let v2 = try #require(body["write_attempted"] as? Bool)
+            #expect(!v2)
             #expect(await channel.executedOps.isEmpty)
         }
     }

--- a/Tests/LogicProMCPTests/TraceClearAuditTests.swift
+++ b/Tests/LogicProMCPTests/TraceClearAuditTests.swift
@@ -69,7 +69,8 @@ struct TraceClearAuditTests {
 
             let result = await clearTraces()
             let body = try #require(sharedJSONObject(sharedToolText(result)))
-            #expect(result.isError != true)
+            let v1 = result.isError ?? false
+            #expect(!v1)
             let success = try #require(body["success"] as? Bool)
             #expect(success)
             #expect(try #require(body["cleared_trace_count"] as? Int) == 3)
@@ -102,11 +103,13 @@ struct TraceClearAuditTests {
             await OperationTraceStore.shared.clear()
             await seedTraces(2)
             let first = await clearTraces()
-            #expect(first.isError != true)
+            let v1 = first.isError ?? false
+            #expect(!v1)
 
             await seedTraces(1)
             let second = await clearTraces()
-            #expect(second.isError != true)
+            let v2 = second.isError ?? false
+            #expect(!v2)
 
             let receiptPath = try #require(
                 sharedJSONObject(sharedToolText(second))?["receipt_path"] as? String
@@ -218,7 +221,8 @@ struct TraceClearAuditTests {
             await OperationTraceStore.shared.clear()
             await seedTraces(2)
             let result = await clearTraces()
-            #expect(result.isError != true)
+            let v1 = result.isError ?? false
+            #expect(!v1)
             let receiptPath = try #require(
                 sharedJSONObject(sharedToolText(result))?["receipt_path"] as? String
             )

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -608,7 +608,8 @@ struct WorkflowCommandCensusTests {
             #expect(project.contains(command),
                     "logic_project.\(command) executes in the dispatcher + is documented in API.md but is missing from the census")
         }
-        #expect(WorkflowSkillCatalog.publicCommands["logic_system"]?.contains("export_support_bundle") == true)
+        let v1 = try #require(WorkflowSkillCatalog.publicCommands["logic_system"]?.contains("export_support_bundle"))
+        #expect(v1)
     }
 }
 


### PR DESCRIPTION
## Summary

`#expect(<Bool> == true/false)` (and `!= true/false`, `?? true/false`, `== .some(...)`, and the same operators inside `#require(...)`) **passes unconditionally** on this swift-testing toolchain — `#expect(true == false)` passes. Any test whose only assertion used this spelling was green against a broken source and proved nothing (issue #393; related #92).

This PR converts every dead site across the suite to a load-bearing spelling and adds a span/closure-aware CI lint so the spelling cannot reappear.

## What changed

- **Conversions** across the test suite:
  - Bool: `#expect(x == true)` → `#expect(x)`, `#expect(x == false)` → `#expect(!x)`
  - Optional/dict Bool: `let v = try #require(x); #expect(v)` (or `#expect(!v)`)
  - `isError` success checks: `let e = result.isError ?? false; #expect(!e)` — nil and false both read as "not an error"; the `?? false` lives in the `let`, never inside `#expect`.
- **`Scripts/ci-forbid-dead-expect.sh`** — extracts each `#expect(...)`/`#require(...)` call with balanced parens (multiline included), blanks string literals, drops closure bodies, then flags the dead operators in what remains. Wired into `ci.yml` as the first step (no Xcode, fails fast). A line-based grep missed multiline calls, `#require`, and top-level operators next to a closure — this catches all three.

## Masked mismatches surfaced (each fixed to the true contract)

Making the assertions live exposed four cases where the dead spelling had hidden a real mismatch:

1. **OperationTrace chain check** compared lowercase `"accessibility"`, but `ChannelID.accessibility.rawValue` is `"Accessibility"`. Now asserts the `rawValue`.
2. **Support-bundle default path** hardcoded the release-only `~/Library/Logs/.../support-bundles` path; under the DEBUG root override used across that suite the default lands elsewhere. The real invariant is *containment under `supportBundleRoot`* — now `hasPrefix(that root)`.
3. **Selector malformed-param hint** claimed the hint always echoes the exact rejected key. Index-binding operations redirect a malformed `track` to the required `index`, so the hint names a *selector parameter* (`index` or `track`), not necessarily the input key. Assertion now checks that true contract.
4. (The three above plus the general Bool conversions; `#require(result.isError == true)` in ADR002B was also dead and is now `let v = try #require(result.isError); #expect(v)`.)

> Product observation (not changed here): index-binding ops that *advertise* a `track` selector param redirect a malformed `track` to `index` in their hint rather than naming `track`. Flagged for a possible follow-up; out of scope for this test-integrity pass.

## Deliberately left live (not dead)

- Comparisons **inside closures** (`.contains { … }`, `.filter { … }`, `.first(where:)`, `.map { … }`).
- **String / Int / enum-value** `==` (e.g. `reason == "readback_mismatch"`).
- `== .none` — a real enum-case comparison in this codebase (Optional `.none` is `== nil`).
- A few genuinely load-bearing top-level `Bool == Bool` / message-string sites, each annotated `// test-integrity:live:`.

## Verification

- Full suite green (3141 tests) after conversions + the four fixes.
- Mutation check on a representative sample across conversion forms, files, and the nuanced fixes: revert the asserted condition → RED → restore. Confirms load-bearing.
- `Scripts/ci-forbid-dead-expect.sh` reports zero dead spellings remaining in `Tests/`.
- `Package.resolved` untouched.

Closes #393
