### PR TITLE
fix(adr-005/prd-011): fd-relative/no-follow/identity/crash-durable file ops

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -1227,10 +1227,11 @@ struct SystemDispatcher: OperationTraceDispatching {
     }
 
     /// PRD-015: append ONE JSON line to the durable audit log. The line survives
-    /// the store clear (it lives outside it). Opened `O_APPEND` (never
-    /// truncated); the directory is created and containment-checked fail-closed
-    /// (any error propagates so the caller refuses the clear). Returns the
-    /// receipt file path for the response body.
+    /// the store clear (it lives outside it). The audit directory chain is
+    /// materialized and the log opened + appended strictly through SecureFD
+    /// (fd-relative, no-follow, identity-checked); the write is never a truncate,
+    /// and any failure propagates so the caller refuses the clear (fail-closed).
+    /// Returns the receipt file path for the response body.
     ///
     /// Unbounded append is ACCEPTED, not an oversight. Each line is a fixed,
     /// receipt-sized record and `clear_traces` is an l2-confirmed operator
@@ -1259,18 +1260,23 @@ struct SystemDispatcher: OperationTraceDispatching {
         // fd-relative walk removes.
         #if DEBUG
         // TEST-ONLY: the audit-root override relocates the receipt under a temp
-        // base; bridge it to SecureFD's trusted-base seam. Release has neither
-        // the override nor the seam (production base is home).
+        // base; bridge it to SecureFD's trusted-base seam (tests root the override
+        // under temporaryDirectory). Release honors neither the override nor the
+        // seam (production base is home). Save + restore the prior value rather
+        // than force-nil so a concurrent test's override is not clobbered.
+        let priorTestBaseOverride = SecureFD._testBaseOverride
         let auditOverride = ProcessInfo.processInfo
             .environment["LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"]
         if let auditOverride, !auditOverride.isEmpty {
             SecureFD._testBaseOverride = FileManager.default.temporaryDirectory
         }
-        defer { SecureFD._testBaseOverride = nil }
+        defer { SecureFD._testBaseOverride = priorTestBaseOverride }
         #endif
 
         let (baseFD, relative) = try SecureFD.openTrustedBase(for: receiptURL)
         defer { close(baseFD) }
+        // openTrustedBase guarantees the target is strictly under the base, so
+        // `relative` is non-empty; this guard is defensive (unreachable in practice).
         guard let logName = relative.last else { throw TraceClearReceiptError.encodingFailed }
         let dirFD = try SecureFD.ensureDirectory(
             baseFD: baseFD, components: Array(relative.dropLast()), mode: 0o700
@@ -1281,16 +1287,40 @@ struct SystemDispatcher: OperationTraceDispatching {
         // concurrent creator won the race (EEXIST) fall back to a no-follow
         // append. Both paths refuse a symlink or hardlink at the name.
         let fileFD: Int32
+        let isFreshCreate: Bool
         do {
-            fileFD = try SecureFD.createFile(parentFD: dirFD, name: logName, mode: 0o600)
+            let fd = try SecureFD.createFile(parentFD: dirFD, name: logName, mode: 0o600)
+            // The exclusive-create fd opens at offset 0 WITHOUT O_APPEND; switch
+            // it to append before writing so this write lands at EOF atomically,
+            // exactly like the fallback path. Otherwise a concurrent clear that
+            // created-then-appended in the window before this write would be
+            // clobbered by a write at offset 0 — silently losing an audit line
+            // (the pre-SecureFD open used O_APPEND on both create and existing).
+            // Set append on the caller fd, not in the shared createFile primitive,
+            // whose create-at-0 semantics other callers (support-bundle) rely on.
+            let flags = fcntl(fd, F_GETFL)
+            guard flags != -1, fcntl(fd, F_SETFL, flags | O_APPEND) != -1 else {
+                close(fd); throw TraceClearReceiptError.writeFailed
+            }
+            (fileFD, isFreshCreate) = (fd, true)
         } catch SecureFD.FDError.componentOpenFailed(_, let e) where e == EEXIST {
-            fileFD = try SecureFD.openAppend(parentFD: dirFD, name: logName)
+            (fileFD, isFreshCreate) = (try SecureFD.openAppend(parentFD: dirFD, name: logName), false)
         }
         defer { close(fileFD) }
 
         let written = bytes.withUnsafeBytes { Darwin.write(fileFD, $0.baseAddress, $0.count) }
         guard written == bytes.count else { throw TraceClearReceiptError.writeFailed }
-        try SecureFD.fullfsync(fileFD)   // durable before the store is drained
+        try SecureFD.fullfsync(fileFD)   // receipt CONTENT durable before the drain
+        // On the first-ever create, also flush the parent directory so the new
+        // receipt's DIRECTORY ENTRY is durable, not just its data (a later append
+        // reuses an existing entry and needs none). Intermediate components created
+        // by ensureDirectory on a first-ever run rely on the filesystem's metadata
+        // commit (transactional on APFS); the protected trace store is in-memory,
+        // so a crash that loses an un-synced entry also loses the store — no
+        // durable "cleared-but-unreceipted" state can result.
+        if isFreshCreate {
+            guard fsync(dirFD) == 0 else { throw TraceClearReceiptError.writeFailed }
+        }
         return receiptURL.path
     }
 

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -1189,12 +1189,9 @@ struct SystemDispatcher: OperationTraceDispatching {
 
     private enum TraceClearReceiptError: Error {
         case encodingFailed
-        case openFailed(errno: Int32)
         case writeFailed
-        /// The audit directory resolved OUTSIDE its intended parent (symlink
-        /// planted for the final component) — the receipt must never be
-        /// diverted out of the containment root, so the clear is refused.
-        case auditDirectoryEscaped
+        // Open/create/directory/durability failures propagate as SecureFD.FDError
+        // and are caught by the clear_traces handler's fail-closed catch.
     }
 
     /// PRD-015 receipt fields — counts + timestamps ONLY, never trace contents,
@@ -1242,26 +1239,58 @@ struct SystemDispatcher: OperationTraceDispatching {
     /// can delete receipt lines is itself an evidence-destruction surface —
     /// precisely the failure mode this receipt exists to close.
     private static func appendTraceClearAuditLine(_ receipt: [String: Any]) throws -> String {
-        let root = auditLogRoot
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        // The directory now EXISTS, so re-resolve it through realpath BEFORE
-        // any write: a symlink planted for the audit dir would otherwise divert
-        // the receipt — and with it the whole evidence trail — outside the
-        // intended root, which is indistinguishable from having no receipt.
-        guard auditDirectoryIsContained(root) else {
-            throw TraceClearReceiptError.auditDirectoryEscaped
-        }
         let receiptURL = traceClearReceiptURL
         let data = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
         guard let line = String(data: data, encoding: .utf8) else {
             throw TraceClearReceiptError.encodingFailed
         }
         let bytes = Array((line + "\n").utf8)
-        let fd = open(receiptURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
-        guard fd >= 0 else { throw TraceClearReceiptError.openFailed(errno: errno) }
-        defer { close(fd) }
-        let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+
+        // Materialize + open + append strictly through SecureFD (fd-relative,
+        // no-follow). The audit directory chain is created with no-follow opens
+        // so a symlink planted for any component fails closed instead of
+        // diverting the receipt outside the intended root; the log is bound with
+        // O_NOFOLLOW + regular-file + st_nlink==1 so a symlink or hardlink at the
+        // final component is refused; and the line is flushed to stable storage
+        // before returning (the receipt is written one actor hop before the store
+        // is drained, so it must be durable first). This replaces the earlier
+        // create-then-realpath-check-then-open-by-path path, whose containment
+        // check ran AFTER the directory was created — a check-after-use that the
+        // fd-relative walk removes.
+        #if DEBUG
+        // TEST-ONLY: the audit-root override relocates the receipt under a temp
+        // base; bridge it to SecureFD's trusted-base seam. Release has neither
+        // the override nor the seam (production base is home).
+        let auditOverride = ProcessInfo.processInfo
+            .environment["LOGIC_MCP_AUDIT_LOG_ROOT_OVERRIDE"]
+        if let auditOverride, !auditOverride.isEmpty {
+            SecureFD._testBaseOverride = FileManager.default.temporaryDirectory
+        }
+        defer { SecureFD._testBaseOverride = nil }
+        #endif
+
+        let (baseFD, relative) = try SecureFD.openTrustedBase(for: receiptURL)
+        defer { close(baseFD) }
+        guard let logName = relative.last else { throw TraceClearReceiptError.encodingFailed }
+        let dirFD = try SecureFD.ensureDirectory(
+            baseFD: baseFD, components: Array(relative.dropLast()), mode: 0o700
+        )
+        defer { close(dirFD) }
+
+        // Dual first-bind: create the log exclusively the first time; if a
+        // concurrent creator won the race (EEXIST) fall back to a no-follow
+        // append. Both paths refuse a symlink or hardlink at the name.
+        let fileFD: Int32
+        do {
+            fileFD = try SecureFD.createFile(parentFD: dirFD, name: logName, mode: 0o600)
+        } catch SecureFD.FDError.componentOpenFailed(_, let e) where e == EEXIST {
+            fileFD = try SecureFD.openAppend(parentFD: dirFD, name: logName)
+        }
+        defer { close(fileFD) }
+
+        let written = bytes.withUnsafeBytes { Darwin.write(fileFD, $0.baseAddress, $0.count) }
         guard written == bytes.count else { throw TraceClearReceiptError.writeFailed }
+        try SecureFD.fullfsync(fileFD)   // durable before the store is drained
         return receiptURL.path
     }
 
@@ -1290,22 +1319,6 @@ struct SystemDispatcher: OperationTraceDispatching {
                 actualClearedCount: actualClearedCount
             )
         )
-    }
-
-    /// PRD-015 symlink hardening: the audit directory must resolve INSIDE its
-    /// intended parent — production `~/Library/Logs/LogicProMCP`, or the
-    /// DEBUG override root's parent when the test hook is set. Mirrors the
-    /// support-bundle containment check (`createdBundleDirectoryIsContained`):
-    /// realpath BOTH sides, then require the directory to resolve strictly
-    /// under the parent. Because `realpath` follows the final component while
-    /// the parent is resolved independently, a symlink planted for the audit
-    /// dir resolves outside the parent and is caught. Fail-closed when either
-    /// side cannot be canonicalized — an unresolved path is never contained.
-    static func auditDirectoryIsContained(_ directory: URL) -> Bool {
-        guard let parentPath = realpathResolvedPath(directory.deletingLastPathComponent()),
-              let resolved = realpathResolvedPath(directory) else { return false }
-        return resolved.hasPrefix(parentPath + "/")
-            && !resolved.split(separator: "/").contains("..")
     }
 
     /// Resolves a caller-requested bundle directory strictly inside the

--- a/Sources/LogicProMCP/Server/SupportBundle.swift
+++ b/Sources/LogicProMCP/Server/SupportBundle.swift
@@ -142,40 +142,93 @@ struct SupportBundleBuilder: Sendable {
         await onFirstWrite()
         return try await Self.runBlocking {
             try Self.requireAbsent(directory)
-            let fileManager = FileManager.default
-            let parent = directory.deletingLastPathComponent()
-            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
-            let staging = parent.appendingPathComponent(
-                ".\(directory.lastPathComponent).tmp-\(UUID().uuidString)",
-                isDirectory: true
-            )
-            try Self.createExclusiveDirectory(staging)
-            var moved = false
-            defer {
-                if !moved { try? fileManager.removeItem(at: staging) }
+            // Materialize, publish, and read back strictly through SecureFD
+            // (fd-relative, no-follow): a symlink planted for any component of the
+            // caller-derived bundle path can no longer divert the staging
+            // directory, the per-file writes, the publish, or the readback outside
+            // the trusted base. Replaces the path-based createDirectory + Data.write
+            // + Data(contentsOf:) and the post-create realpath containment recheck.
+            // Trusted anchor = the deepest EXISTING ancestor of the target
+            // (confined under the support-bundle root by the caller's
+            // resolvedSupportBundleDirectory in production; a temp root under test),
+            // opened by path like the home base. The not-yet-existing tail is then
+            // created + walked strictly no-follow below. Deriving the base per call
+            // (no global seam) keeps concurrent publishers independent.
+            var anchor = directory.standardizedFileURL
+            var tail: [String] = []
+            while !FileManager.default.fileExists(atPath: anchor.path), anchor.pathComponents.count > 1 {
+                tail.insert(anchor.lastPathComponent, at: 0)
+                anchor = anchor.deletingLastPathComponent()
             }
+            let baseFD = anchor.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
+            guard baseFD >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+            defer { close(baseFD) }
+            // `requireAbsent` proved the target does not exist, so the tail is
+            // non-empty (its last element is the bundle directory name).
+            guard let bundleName = tail.last else { throw CocoaError(.fileWriteFileExists) }
+            let parentFD = try SecureFD.ensureDirectory(
+                baseFD: baseFD, components: Array(tail.dropLast()), mode: 0o755
+            )
+            defer { close(parentFD) }
+
+            let stagingName = ".\(bundleName).tmp-\(UUID().uuidString)"
+            let (stagingFD, _) = try SecureFD.makeEmptyDir(
+                parentFD: parentFD, name: stagingName, mode: 0o700
+            )
+            var published = false
+            defer {
+                close(stagingFD)
+                if !published { try? SecureFD.teardownTree(parentFD: parentFD, name: stagingName) }
+            }
+
             for name in Self.fileNames.sorted() {
                 guard let data = assembly.files[name] else { throw CocoaError(.fileNoSuchFile) }
-                let url = staging.appendingPathComponent(name)
-                try data.write(to: url, options: .atomic)
-                try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+                let fd = try SecureFD.createFile(parentFD: stagingFD, name: name, mode: 0o600)
+                do {
+                    try data.withUnsafeBytes { raw in
+                        var off = 0
+                        while off < raw.count {
+                            let n = Darwin.write(fd, raw.baseAddress!.advanced(by: off), raw.count - off)
+                            guard n > 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+                            off += n
+                        }
+                    }
+                    try SecureFD.fullfsync(fd)
+                } catch { close(fd); throw error }
+                close(fd)
             }
-            try Self.verify(assembly, at: staging)
-            try Self.publishExclusively(staging, to: directory)
-            moved = true
-            do {
-                let readback = try Self.readback(at: directory)
-                for file in readback {
-                    guard let source = assembly.files[file.name] else {
-                        throw CocoaError(.fileNoSuchFile)
-                    }
-                    guard file.sha256 == Self.sha256(source) else {
-                        throw CocoaError(.fileReadCorruptFile)
-                    }
+
+            // Publish atomically + exclusively RELATIVE to the parent dir fd, so no
+            // path re-resolution can divert it; RENAME_EXCL refuses an existing target.
+            let renamed = stagingName.withCString { s in
+                bundleName.withCString { d in
+                    renameatx_np(parentFD, s, parentFD, d, UInt32(RENAME_EXCL))
                 }
-                return Result(directory: directory, files: readback)
+            }
+            guard renamed == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+            published = true
+
+            // Read back the PUBLISHED bundle fd-relative (no-follow, regular-file,
+            // st_nlink==1) and verify every digest; tear it down on any mismatch.
+            do {
+                let bundleFD = try SecureFD.walkVerified(baseFD: parentFD, [bundleName]).fd
+                defer { close(bundleFD) }
+                var digests: [FileDigest] = []
+                for name in Self.fileNames.sorted() {
+                    guard let source = assembly.files[name] else { throw CocoaError(.fileNoSuchFile) }
+                    let rfd = try SecureFD.openRead(parentFD: bundleFD, name: name)
+                    let data: Data
+                    do {
+                        data = try FileHandle(fileDescriptor: rfd, closeOnDealloc: false).readToEnd() ?? Data()
+                    } catch { close(rfd); throw error }
+                    close(rfd)
+                    let digest = Self.sha256(data)
+                    guard digest == Self.sha256(source) else { throw CocoaError(.fileReadCorruptFile) }
+                    digests.append(FileDigest(name: name, sha256: digest))
+                }
+                return Result(directory: directory, files: digests)
             } catch {
-                try? fileManager.removeItem(at: directory)
+                try? SecureFD.teardownTree(parentFD: parentFD, name: bundleName)
                 throw error
             }
         }
@@ -356,49 +409,6 @@ struct SupportBundleBuilder: Sendable {
         }
     }
 
-    private static func createExclusiveDirectory(_ directory: URL) throws {
-        let result = directory.path.withCString { mkdir($0, S_IRWXU) }
-        guard result == 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-    }
-
-    private static func publishExclusively(_ source: URL, to destination: URL) throws {
-        let result = source.path.withCString { sourcePath in
-            destination.path.withCString { destinationPath in
-                renameatx_np(
-                    AT_FDCWD,
-                    sourcePath,
-                    AT_FDCWD,
-                    destinationPath,
-                    UInt32(RENAME_EXCL)
-                )
-            }
-        }
-        guard result == 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-    }
-
-    private static func verify(_ assembly: Assembly, at directory: URL) throws {
-        for file in try readback(at: directory) {
-            guard let source = assembly.files[file.name] else {
-                throw CocoaError(.fileNoSuchFile)
-            }
-            guard file.sha256 == sha256(source) else {
-                throw CocoaError(.fileReadCorruptFile)
-            }
-        }
-    }
-
-    private static func readback(at directory: URL) throws -> [FileDigest] {
-        try fileNames.sorted().map { name in
-            FileDigest(
-                name: name,
-                sha256: sha256(try Data(contentsOf: directory.appendingPathComponent(name)))
-            )
-        }
-    }
 }
 
 private extension SupportBundleBuilder {

--- a/Sources/LogicProMCP/Server/SupportBundle.swift
+++ b/Sources/LogicProMCP/Server/SupportBundle.swift
@@ -148,23 +148,63 @@ struct SupportBundleBuilder: Sendable {
             // directory, the per-file writes, the publish, or the readback outside
             // the trusted base. Replaces the path-based createDirectory + Data.write
             // + Data(contentsOf:) and the post-create realpath containment recheck.
-            // Trusted anchor = the deepest EXISTING ancestor of the target
-            // (confined under the support-bundle root by the caller's
-            // resolvedSupportBundleDirectory in production; a temp root under test),
-            // opened by path like the home base. The not-yet-existing tail is then
-            // created + walked strictly no-follow below. Deriving the base per call
-            // (no global seam) keeps concurrent publishers independent.
-            var anchor = directory.standardizedFileURL
-            var tail: [String] = []
-            while !FileManager.default.fileExists(atPath: anchor.path), anchor.pathComponents.count > 1 {
-                tail.insert(anchor.lastPathComponent, at: 0)
-                anchor = anchor.deletingLastPathComponent()
+            // Trusted base = the user's home directory (production) or, under DEBUG
+            // tests, the temporary directory — a FIXED, unswappable trust root, NOT a
+            // caller-derived existing ancestor. The ENTIRE path from the base down to
+            // the bundle is then walked strictly no-follow (ensureDirectory), so a
+            // symlink planted for ANY component — an existing intermediate like
+            // `Library` or a caller-supplied subdir — fails closed instead of
+            // diverting the write, exactly as the trace-clear wiring does. write() is
+            // thus self-confining; it does not depend on the caller's realpath
+            // containment for symlink safety. The base is a per-call local, so
+            // concurrent publishers stay independent (no global seam).
+            // Canonicalize by realpath'ing the deepest EXISTING prefix (the bundle
+            // tail does not exist yet) and re-appending the tail literally, so the
+            // target and the candidate bases share ONE canonical form. `realpath`
+            // resolves /var → /private/var; `resolvingSymlinksInPath` does not do so
+            // for `temporaryDirectory`, which is why a plain URL comparison diverged.
+            func canonicalComponents(_ url: URL) -> [String]? {
+                var existing = url.standardizedFileURL
+                var suffix: [String] = []
+                while !FileManager.default.fileExists(atPath: existing.path), existing.pathComponents.count > 1 {
+                    suffix.insert(existing.lastPathComponent, at: 0)
+                    existing = existing.deletingLastPathComponent()
+                }
+                guard let raw = realpath(existing.path, nil) else { return nil }
+                defer { free(raw) }
+                return URL(fileURLWithPath: String(cString: raw)).pathComponents + suffix
             }
-            let baseFD = anchor.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
+            guard let dirComps = canonicalComponents(directory) else {
+                throw CocoaError(.fileWriteNoPermission)
+            }
+            // Trusted base = home (production) or, under DEBUG tests, the temporary
+            // directory — a FIXED, unswappable trust root. The ENTIRE path from the
+            // base to the bundle is walked no-follow below (ensureDirectory), so a
+            // symlink planted for ANY component fails closed rather than diverting
+            // the write, exactly like the trace-clear wiring. Per-call locals keep
+            // concurrent publishers independent (no global seam).
+            #if DEBUG
+            let candidates = [
+                FileManager.default.homeDirectoryForCurrentUser,
+                FileManager.default.temporaryDirectory,
+            ]
+            #else
+            let candidates = [FileManager.default.homeDirectoryForCurrentUser]
+            #endif
+            var chosenCount: Int? = nil
+            for candidate in candidates {
+                guard let cc = canonicalComponents(candidate),
+                      dirComps.count > cc.count, Array(dirComps.prefix(cc.count)) == cc else { continue }
+                chosenCount = cc.count; break
+            }
+            guard let baseCount = chosenCount else { throw CocoaError(.fileWriteNoPermission) }
+            let tail = Array(dirComps.dropFirst(baseCount))
+            let basePath = "/" + dirComps[1..<baseCount].joined(separator: "/")
+            let baseFD = basePath.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
             guard baseFD >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
             defer { close(baseFD) }
-            // `requireAbsent` proved the target does not exist, so the tail is
-            // non-empty (its last element is the bundle directory name).
+            // isUnder guarantees dirComps.count > base count, so the tail is non-empty
+            // (its last element is the bundle directory name).
             guard let bundleName = tail.last else { throw CocoaError(.fileWriteFileExists) }
             let parentFD = try SecureFD.ensureDirectory(
                 baseFD: baseFD, components: Array(tail.dropLast()), mode: 0o755
@@ -189,7 +229,11 @@ struct SupportBundleBuilder: Sendable {
                         var off = 0
                         while off < raw.count {
                             let n = Darwin.write(fd, raw.baseAddress!.advanced(by: off), raw.count - off)
-                            guard n > 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+                            if n < 0 {
+                                if errno == EINTR { continue }   // retry an interrupted write
+                                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                            }
+                            guard n > 0 else { throw POSIXError(.EIO) }
                             off += n
                         }
                     }
@@ -197,6 +241,10 @@ struct SupportBundleBuilder: Sendable {
                 } catch { close(fd); throw error }
                 close(fd)
             }
+            // Flush the staging directory so its new file entries are durable before
+            // the rename makes them the published bundle (F_FULLFSYNC on each file
+            // covers file data + inode, but not the containing directory's entries).
+            guard fsync(stagingFD) == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
 
             // Publish atomically + exclusively RELATIVE to the parent dir fd, so no
             // path re-resolution can divert it; RENAME_EXCL refuses an existing target.
@@ -211,6 +259,12 @@ struct SupportBundleBuilder: Sendable {
             // Read back the PUBLISHED bundle fd-relative (no-follow, regular-file,
             // st_nlink==1) and verify every digest; tear it down on any mismatch.
             do {
+                // The publish rename is a parent-directory metadata change; flush the
+                // parent so the bundle's directory entry is durable, not just its file
+                // data. The bundle is the sole on-disk artifact (no in-memory backstop),
+                // so a lost entry after a reported success would be reported-but-absent.
+                // A failure here rethrows into the catch below, which tears the bundle down.
+                guard fsync(parentFD) == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
                 let bundleFD = try SecureFD.walkVerified(baseFD: parentFD, [bundleName]).fd
                 defer { close(bundleFD) }
                 var digests: [FileDigest] = []

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -180,8 +180,9 @@ enum SecureFD {
         var ids: [Identity] = []
         for comp in relative {
             let next = comp.withCString { openat(dirFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+            let openErrno = errno   // capture before close(2) can overwrite errno
             close(dirFD)
-            guard next >= 0 else { throw FDError.componentOpenFailed(component: comp, errno: errno) }
+            guard next >= 0 else { throw FDError.componentOpenFailed(component: comp, errno: openErrno) }
             dirFD = next
             do { ids.append(try identity(ofFD: dirFD, label: comp)) }
             catch { close(dirFD); throw error }
@@ -271,15 +272,21 @@ enum SecureFD {
         _testEnumerationFDObserver?(dupFD)
         #endif
         guard let dir = fdopendir(dupFD) else {
-            close(dupFD); throw FDError.componentOpenFailed(component: label, errno: errno)
+            let e = errno; close(dupFD); throw FDError.componentOpenFailed(component: label, errno: e)
         }
         defer { closedir(dir) }   // closes the underlying dup fd
+        // readdir returns NULL on BOTH end-of-directory and error; distinguish
+        // them via errno so a readdir failure is never mistaken for an empty
+        // directory (which would defeat the mkdir→open populated-swap defense).
+        errno = 0
         while let ent = readdir(dir) {
             let n = withUnsafePointer(to: ent.pointee.d_name) {
                 $0.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) { String(cString: $0) }
             }
             if n != "." && n != ".." { throw FDError.stagingNotEmpty(label) }
+            errno = 0
         }
+        guard errno == 0 else { throw FDError.componentOpenFailed(component: label, errno: errno) }
     }
 
     // MARK: - Durability — F_FULLFSYNC, fail-closed
@@ -294,10 +301,13 @@ enum SecureFD {
     /// through descriptors: classify with `fstatat(AT_SYMLINK_NOFOLLOW)`, open each
     /// directory `O_NOFOLLOW` and REQUIRE the opened object to match its classified
     /// `(dev,ino)` — a rename-swapped REAL directory (which `O_NOFOLLOW` cannot
-    /// catch) is refused before anything inside it is touched. Files are unlinked
-    /// by name (symlink children unlinked as links, never followed) and the final
-    /// `unlinkat(AT_REMOVEDIR)` re-binds the name to the directory that was
-    /// actually emptied.
+    /// catch) is refused before anything inside it is touched. Files are likewise
+    /// re-bound to their classified `(dev,ino)` immediately before `unlinkat`
+    /// (symlink children unlinked as links, never followed), so a regular file
+    /// renamed onto the name after classification is refused with zero deletion.
+    /// The final `unlinkat(AT_REMOVEDIR)` re-binds the name to the directory that
+    /// was actually emptied. Each identity-bind→syscall pair carries the same
+    /// irreducible 1-syscall residual (macOS has no `openat2(RESOLVE_BENEATH)`).
     static func teardownTree(parentFD: Int32, name: String) throws {
         try validateComponent(name)
         var st = stat()
@@ -326,21 +336,29 @@ enum SecureFD {
         _testEnumerationFDObserver?(dupFD)
         #endif
         guard let dir = fdopendir(dupFD) else {
-            close(dupFD); throw FDError.teardownFailed(errno: errno)
+            let e = errno; close(dupFD); throw FDError.teardownFailed(errno: e)
         }
         var children: [(name: String, isDir: Bool, id: Identity)] = []
+        // readdir returns NULL on end-of-directory AND on error; reset errno
+        // around each call so a mid-enumeration failure is not mistaken for a
+        // complete listing (which could leave children behind).
+        errno = 0
         while let ent = readdir(dir) {
             let n = withUnsafePointer(to: ent.pointee.d_name) {
                 $0.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) { String(cString: $0) }
             }
-            if n == "." || n == ".." { continue }
-            var st = stat()
-            let rc = n.withCString { fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }
-            guard rc == 0 else { closedir(dir); throw FDError.teardownFailed(errno: errno) }
-            // symlinks classified as non-dir → unlinked as links
-            children.append((n, (st.st_mode & S_IFMT) == S_IFDIR, (st.st_dev, st.st_ino)))
+            if n != "." && n != ".." {
+                var st = stat()
+                let rc = n.withCString { fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }
+                guard rc == 0 else { let e = errno; closedir(dir); throw FDError.teardownFailed(errno: e) }
+                // symlinks classified as non-dir → unlinked as links
+                children.append((n, (st.st_mode & S_IFMT) == S_IFDIR, (st.st_dev, st.st_ino)))
+            }
+            errno = 0
         }
+        let enumErrno = errno
         closedir(dir)   // closes dupFD
+        guard enumErrno == 0 else { throw FDError.teardownFailed(errno: enumErrno) }
         #if DEBUG
         if let hook = _testAfterClassificationHook { _testAfterClassificationHook = nil; hook() }
         #endif
@@ -356,6 +374,19 @@ enum SecureFD {
                 } catch { close(sub); throw error }
                 try removeChildrenThenSelf(dirFD: sub, parentFD: dirFD, name: child.name, expected: child.id)
             } else {
+                // Re-bind the name to the classified inode immediately before the
+                // unlink: a regular file renamed onto this name after classification
+                // (a victim file moved in) has a different (dev,ino) and is refused
+                // with ZERO deletion — the symmetric defense to the subdirectory
+                // identity bind above. The fstatat→unlinkat window is the same
+                // irreducible 1-syscall residual documented for the final rmdir.
+                var st = stat()
+                guard child.name.withCString({ fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }) == 0 else {
+                    throw FDError.teardownFailed(errno: errno)
+                }
+                guard sameIdentity((st.st_dev, st.st_ino), child.id) else {
+                    throw FDError.verificationMismatch(component: child.name)
+                }
                 guard child.name.withCString({ unlinkat(dirFD, $0, 0) }) == 0 else {
                     throw FDError.teardownFailed(errno: errno)
                 }

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -25,6 +25,7 @@ enum SecureFD {
         case stagingNotEmpty(String)
         case fullfsyncFailed(errno: Int32)
         case teardownFailed(errno: Int32)
+        case identityReadFailed(component: String, errno: Int32)
     }
 
     /// Publish/append durability outcome — a value, never inferred. `durableSuccess`
@@ -56,9 +57,17 @@ enum SecureFD {
         }
     }
 
-    private static func identity(ofFD fd: Int32) -> Identity {
+    /// The (device, inode) identity of an open descriptor, fail-closed: a
+    /// failed read REFUSES the operation instead of returning the zeroed
+    /// `stat` fields — a fabricated (0,0) identity from two failed reads
+    /// would otherwise compare equal and pass verification.
+    private static func identity(ofFD fd: Int32, label: String) throws -> Identity {
         var st = stat()
-        _ = fstat(fd, &st)
+        var rc = fstat(fd, &st)
+        #if DEBUG
+        if _testForceIdentityFailureCount > 0 { _testForceIdentityFailureCount -= 1; rc = -1 }
+        #endif
+        guard rc == 0 else { throw FDError.identityReadFailed(component: label, errno: errno) }
         return (st.st_dev, st.st_ino)
     }
 
@@ -83,12 +92,21 @@ enum SecureFD {
     }
 
     #if DEBUG
-    /// TEST-ONLY (compiled out of release): supplies a trusted base directory for
-    /// tests operating under a temp root, and a one-shot post-walk-passA hook so an
-    /// intermediate/final rebind can be injected deterministically between the two
-    /// verification walks. Neither symbol exists in a release binary.
+    /// TEST-ONLY (compiled out of release): narrow observation/injection seams
+    /// so the lifecycle contract is provable deterministically. `_testBaseOverride`
+    /// supplies a trusted base under a temp root; `_testAfterPassAHook` runs once
+    /// between the two verification walks; `_testPassAClosedFDObserver` reports the
+    /// exact descriptor number pass A released; `_testEnumerationFDObserver` sees
+    /// every enumeration duplicate before `fdopendir` consumes it;
+    /// `_testAfterClassificationHook` runs once after teardown classifies children;
+    /// `_testForceIdentityFailureCount` fails that many identity reads. None of
+    /// these symbols exists in a release binary.
     nonisolated(unsafe) static var _testBaseOverride: URL?
     nonisolated(unsafe) static var _testAfterPassAHook: (() -> Void)?
+    nonisolated(unsafe) static var _testPassAClosedFDObserver: ((Int32) -> Void)?
+    nonisolated(unsafe) static var _testEnumerationFDObserver: ((Int32) -> Void)?
+    nonisolated(unsafe) static var _testAfterClassificationHook: (() -> Void)?
+    nonisolated(unsafe) static var _testForceIdentityFailureCount = 0
     #endif
 
     /// Open the trusted base for `target`: production = home (target MUST be under
@@ -133,6 +151,7 @@ enum SecureFD {
         // verification pass is authoritative and supplies the returned fd.
         close(fdA)
         #if DEBUG
+        _testPassAClosedFDObserver?(fdA)
         if let hook = _testAfterPassAHook { _testAfterPassAHook = nil; hook() }
         #endif
         let (fdB, idsB) = try walkOnce(baseFD: baseFD, relative)
@@ -164,7 +183,8 @@ enum SecureFD {
             close(dirFD)
             guard next >= 0 else { throw FDError.componentOpenFailed(component: comp, errno: errno) }
             dirFD = next
-            ids.append(identity(ofFD: dirFD))
+            do { ids.append(try identity(ofFD: dirFD, label: comp)) }
+            catch { close(dirFD); throw error }
         }
         return (dirFD, ids)
     }
@@ -235,10 +255,11 @@ enum SecureFD {
         guard fd >= 0 else { throw FDError.componentOpenFailed(component: name, errno: errno) }
         do {
             try assertEmpty(dirFD: fd, label: name)
+            let id = try identity(ofFD: fd, label: name)
+            return (fd, id)
         } catch {
             close(fd); throw error
         }
-        return (fd, identity(ofFD: fd))
     }
 
     /// True/throw: the directory fd contains only `.`/`..`. Enumerates through a
@@ -246,6 +267,9 @@ enum SecureFD {
     static func assertEmpty(dirFD: Int32, label: String) throws {
         let dupFD = dupCloexec(dirFD)
         guard dupFD >= 0 else { throw FDError.componentOpenFailed(component: label, errno: errno) }
+        #if DEBUG
+        _testEnumerationFDObserver?(dupFD)
+        #endif
         guard let dir = fdopendir(dupFD) else {
             close(dupFD); throw FDError.componentOpenFailed(component: label, errno: errno)
         }
@@ -267,27 +291,44 @@ enum SecureFD {
     // MARK: - Rollback teardown — fd-relative, no path rebuild
 
     /// Recursively remove a directory relative to its verified parent fd, entirely
-    /// through descriptors: `fdopendir` on a DUP, classify children with
-    /// `fstatat(AT_SYMLINK_NOFOLLOW)`, recurse into subdirs via
-    /// `openat(O_DIRECTORY|O_NOFOLLOW)`, `unlinkat` files (symlink children unlinked
-    /// as links, never followed), then `unlinkat(AT_REMOVEDIR)` the now-empty dir.
+    /// through descriptors: classify with `fstatat(AT_SYMLINK_NOFOLLOW)`, open each
+    /// directory `O_NOFOLLOW` and REQUIRE the opened object to match its classified
+    /// `(dev,ino)` — a rename-swapped REAL directory (which `O_NOFOLLOW` cannot
+    /// catch) is refused before anything inside it is touched. Files are unlinked
+    /// by name (symlink children unlinked as links, never followed) and the final
+    /// `unlinkat(AT_REMOVEDIR)` re-binds the name to the directory that was
+    /// actually emptied.
     static func teardownTree(parentFD: Int32, name: String) throws {
         try validateComponent(name)
+        var st = stat()
+        guard name.withCString({ fstatat(parentFD, $0, &st, AT_SYMLINK_NOFOLLOW) }) == 0 else {
+            throw FDError.teardownFailed(errno: errno)
+        }
+        guard (st.st_mode & S_IFMT) == S_IFDIR else { throw FDError.notDirectory(name) }
+        let expected: Identity = (st.st_dev, st.st_ino)
         let dirFD = name.withCString { openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
         guard dirFD >= 0 else { throw FDError.teardownFailed(errno: errno) }
-        try removeChildrenThenSelf(dirFD: dirFD, parentFD: parentFD, name: name)
+        do {
+            let got = try identity(ofFD: dirFD, label: name)
+            guard sameIdentity(got, expected) else { throw FDError.verificationMismatch(component: name) }
+        } catch { close(dirFD); throw error }
+        try removeChildrenThenSelf(dirFD: dirFD, parentFD: parentFD, name: name, expected: expected)
     }
 
-    private static func removeChildrenThenSelf(dirFD: Int32, parentFD: Int32, name: String) throws {
+    private static func removeChildrenThenSelf(dirFD: Int32, parentFD: Int32, name: String,
+                                               expected: Identity) throws {
         // This function owns dirFD; the defer is its single close, so every
         // error path — including a throw out of the recursive call — releases it.
         defer { close(dirFD) }
         let dupFD = dupCloexec(dirFD)
         guard dupFD >= 0 else { throw FDError.teardownFailed(errno: errno) }
+        #if DEBUG
+        _testEnumerationFDObserver?(dupFD)
+        #endif
         guard let dir = fdopendir(dupFD) else {
             close(dupFD); throw FDError.teardownFailed(errno: errno)
         }
-        var children: [(name: String, isDir: Bool)] = []
+        var children: [(name: String, isDir: Bool, id: Identity)] = []
         while let ent = readdir(dir) {
             let n = withUnsafePointer(to: ent.pointee.d_name) {
                 $0.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) { String(cString: $0) }
@@ -296,22 +337,40 @@ enum SecureFD {
             var st = stat()
             let rc = n.withCString { fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }
             guard rc == 0 else { closedir(dir); throw FDError.teardownFailed(errno: errno) }
-            children.append((n, (st.st_mode & S_IFMT) == S_IFDIR))   // symlinks classified as non-dir → unlinked as links
+            // symlinks classified as non-dir → unlinked as links
+            children.append((n, (st.st_mode & S_IFMT) == S_IFDIR, (st.st_dev, st.st_ino)))
         }
         closedir(dir)   // closes dupFD
+        #if DEBUG
+        if let hook = _testAfterClassificationHook { _testAfterClassificationHook = nil; hook() }
+        #endif
         for child in children {
             if child.isDir {
                 let sub = child.name.withCString { openat(dirFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
                 guard sub >= 0 else { throw FDError.teardownFailed(errno: errno) }
-                try removeChildrenThenSelf(dirFD: sub, parentFD: dirFD, name: child.name)
+                // The opened object must BE the directory that was classified;
+                // a swapped-in real directory is refused with zero deletion.
+                do {
+                    let got = try identity(ofFD: sub, label: child.name)
+                    guard sameIdentity(got, child.id) else { throw FDError.verificationMismatch(component: child.name) }
+                } catch { close(sub); throw error }
+                try removeChildrenThenSelf(dirFD: sub, parentFD: dirFD, name: child.name, expected: child.id)
             } else {
                 guard child.name.withCString({ unlinkat(dirFD, $0, 0) }) == 0 else {
                     throw FDError.teardownFailed(errno: errno)
                 }
             }
         }
-        // An open descriptor does not pin a directory in the namespace, so the
+        // Final removal re-binds the NAME to the directory that was actually
+        // emptied. The fstatat→unlinkat window is the irreducible final-syscall
+        // residual documented in the type comment; it is not claimed away. An
+        // open descriptor does not pin a directory in the namespace, so the
         // remove can precede the deferred close.
+        var fin = stat()
+        guard name.withCString({ fstatat(parentFD, $0, &fin, AT_SYMLINK_NOFOLLOW) }) == 0,
+              sameIdentity((fin.st_dev, fin.st_ino), expected) else {
+            throw FDError.verificationMismatch(component: name)
+        }
         guard name.withCString({ unlinkat(parentFD, $0, AT_REMOVEDIR) }) == 0 else {
             throw FDError.teardownFailed(errno: errno)
         }

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -120,12 +120,14 @@ enum SecureFD {
                              expected: [Identity]? = nil) throws -> (fd: Int32, ids: [Identity]) {
         for c in relative { try validateComponent(c) }
         let (fdA, idsA) = try walkOnce(baseFD: baseFD, relative)
+        // Pass A exists only to produce its identity vector; its fd is closed
+        // immediately so no failure in the verification pass can leak it. The
+        // verification pass is authoritative and supplies the returned fd.
+        close(fdA)
         #if DEBUG
         if let hook = _testAfterPassAHook { _testAfterPassAHook = nil; hook() }
         #endif
         let (fdB, idsB) = try walkOnce(baseFD: baseFD, relative)
-        // The verification pass is authoritative; the first walk's fd is discarded.
-        close(fdA)
         guard idsA.count == idsB.count else {
             close(fdB); throw FDError.verificationMismatch(component: relative.last ?? "")
         }
@@ -265,10 +267,13 @@ enum SecureFD {
     }
 
     private static func removeChildrenThenSelf(dirFD: Int32, parentFD: Int32, name: String) throws {
+        // This function owns dirFD; the defer is its single close, so every
+        // error path — including a throw out of the recursive call — releases it.
+        defer { close(dirFD) }
         let dupFD = dup(dirFD)
-        guard dupFD >= 0 else { close(dirFD); throw FDError.teardownFailed(errno: errno) }
+        guard dupFD >= 0 else { throw FDError.teardownFailed(errno: errno) }
         guard let dir = fdopendir(dupFD) else {
-            close(dupFD); close(dirFD); throw FDError.teardownFailed(errno: errno)
+            close(dupFD); throw FDError.teardownFailed(errno: errno)
         }
         var children: [(name: String, isDir: Bool)] = []
         while let ent = readdir(dir) {
@@ -278,22 +283,23 @@ enum SecureFD {
             if n == "." || n == ".." { continue }
             var st = stat()
             let rc = n.withCString { fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }
-            guard rc == 0 else { closedir(dir); close(dirFD); throw FDError.teardownFailed(errno: errno) }
+            guard rc == 0 else { closedir(dir); throw FDError.teardownFailed(errno: errno) }
             children.append((n, (st.st_mode & S_IFMT) == S_IFDIR))   // symlinks classified as non-dir → unlinked as links
         }
         closedir(dir)   // closes dupFD
         for child in children {
             if child.isDir {
                 let sub = child.name.withCString { openat(dirFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
-                guard sub >= 0 else { close(dirFD); throw FDError.teardownFailed(errno: errno) }
+                guard sub >= 0 else { throw FDError.teardownFailed(errno: errno) }
                 try removeChildrenThenSelf(dirFD: sub, parentFD: dirFD, name: child.name)
             } else {
                 guard child.name.withCString({ unlinkat(dirFD, $0, 0) }) == 0 else {
-                    close(dirFD); throw FDError.teardownFailed(errno: errno)
+                    throw FDError.teardownFailed(errno: errno)
                 }
             }
         }
-        close(dirFD)
+        // An open descriptor does not pin a directory in the namespace, so the
+        // remove can precede the deferred close.
         guard name.withCString({ unlinkat(parentFD, $0, AT_REMOVEDIR) }) == 0 else {
             throw FDError.teardownFailed(errno: errno)
         }

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -62,6 +62,14 @@ enum SecureFD {
         return (st.st_dev, st.st_ino)
     }
 
+    /// Atomic close-on-exec duplication. Plain `dup()` CLEARS `FD_CLOEXEC` on
+    /// the duplicate, which would make trusted directory descriptors heritable
+    /// across a concurrent `exec` — every internal duplication flows through
+    /// this single primitive instead.
+    private static func dupCloexec(_ fd: Int32) -> Int32 {
+        fcntl(fd, F_DUPFD_CLOEXEC, 0)
+    }
+
     // MARK: - Trusted base (base-path-injection guarded)
 
     /// The production trusted base is the current user's home directory, opened
@@ -148,7 +156,7 @@ enum SecureFD {
     private static func walkOnce(baseFD: Int32, _ relative: [String]) throws -> (fd: Int32, ids: [Identity]) {
         // Start from a dup of the base so ownership of the returned chain is ours
         // and the caller's base fd is never closed by us.
-        var dirFD = dup(baseFD)
+        var dirFD = dupCloexec(baseFD)
         guard dirFD >= 0 else { throw FDError.componentOpenFailed(component: "<base-dup>", errno: errno) }
         var ids: [Identity] = []
         for comp in relative {
@@ -195,7 +203,10 @@ enum SecureFD {
         return fd
     }
 
-    /// Open an existing regular file for read relative to a verified parent fd.
+    /// Open an existing regular file for read relative to a verified parent fd:
+    /// no-follow, non-blocking, regular-file, `st_nlink == 1` — the same
+    /// existing-file identity policy as `openAppend`, so a hardlink alias of a
+    /// foreign inode cannot serve readback.
     static func openRead(parentFD: Int32, name: String) throws -> Int32 {
         try validateComponent(name)
         let fd = name.withCString {
@@ -206,6 +217,7 @@ enum SecureFD {
         guard fstat(fd, &st) == 0, (st.st_mode & S_IFMT) == S_IFREG else {
             close(fd); throw FDError.notRegularFile(name)
         }
+        guard st.st_nlink == 1 else { close(fd); throw FDError.notExclusive(name) }
         return fd
     }
 
@@ -232,7 +244,7 @@ enum SecureFD {
     /// True/throw: the directory fd contains only `.`/`..`. Enumerates through a
     /// DUP (fdopendir consumes the fd it is given on Darwin).
     static func assertEmpty(dirFD: Int32, label: String) throws {
-        let dupFD = dup(dirFD)
+        let dupFD = dupCloexec(dirFD)
         guard dupFD >= 0 else { throw FDError.componentOpenFailed(component: label, errno: errno) }
         guard let dir = fdopendir(dupFD) else {
             close(dupFD); throw FDError.componentOpenFailed(component: label, errno: errno)
@@ -270,7 +282,7 @@ enum SecureFD {
         // This function owns dirFD; the defer is its single close, so every
         // error path — including a throw out of the recursive call — releases it.
         defer { close(dirFD) }
-        let dupFD = dup(dirFD)
+        let dupFD = dupCloexec(dirFD)
         guard dupFD >= 0 else { throw FDError.teardownFailed(errno: errno) }
         guard let dir = fdopendir(dupFD) else {
             close(dupFD); throw FDError.teardownFailed(errno: errno)

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -11,6 +11,12 @@ import Foundation
 /// rebind, ancestor/leaf rename-out, hardlink, mkdir→open swap-in) and never
 /// claims zero-race confinement.
 ///
+/// Identity is `(dev,ino)` equality throughout, which assumes the filesystem does
+/// not reuse an inode number within an operation window — macOS APFS assigns file
+/// IDs monotonically, so this holds there. `teardownTree` recurses one frame per
+/// directory level, so its stack depth follows the tree it is given (this
+/// primitive's own staging trees are shallow).
+///
 /// The primitive is intentionally independent of its callers: audit-receipt and
 /// support-bundle publication wire onto it separately.
 enum SecureFD {
@@ -398,8 +404,14 @@ enum SecureFD {
         // open descriptor does not pin a directory in the namespace, so the
         // remove can precede the deferred close.
         var fin = stat()
-        guard name.withCString({ fstatat(parentFD, $0, &fin, AT_SYMLINK_NOFOLLOW) }) == 0,
-              sameIdentity((fin.st_dev, fin.st_ino), expected) else {
+        // Two guards (mirror of the file branch): a vanished name is an honest
+        // teardownFailed(ENOENT), only a rebound-to-different-inode name is a
+        // verificationMismatch. Folding both into one case would misreport a
+        // concurrently-removed staging dir as a mismatch.
+        guard name.withCString({ fstatat(parentFD, $0, &fin, AT_SYMLINK_NOFOLLOW) }) == 0 else {
+            throw FDError.teardownFailed(errno: errno)
+        }
+        guard sameIdentity((fin.st_dev, fin.st_ino), expected) else {
             throw FDError.verificationMismatch(component: name)
         }
         guard name.withCString({ unlinkat(parentFD, $0, AT_REMOVEDIR) }) == 0 else {

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -1,0 +1,301 @@
+import Darwin
+import Foundation
+
+/// Secure filesystem primitive for confined, symlink-safe file publication on macOS.
+///
+/// Opens/creates/publishes strictly through single-component `*at` calls from an
+/// explicitly trusted base descriptor, so no component — intermediate or final —
+/// can be a symlink or a rebound/renamed-in inode that escapes the base. macOS
+/// has no `openat2(RESOLVE_BENEATH)`, so a ~1-syscall + post-verify residual is
+/// irreducible; this primitive defeats the realistic attacks (symlink, inode
+/// rebind, ancestor/leaf rename-out, hardlink, mkdir→open swap-in) and never
+/// claims zero-race confinement.
+///
+/// The primitive is intentionally independent of its callers: audit-receipt and
+/// support-bundle publication wire onto it separately.
+enum SecureFD {
+    enum FDError: Error, Equatable {
+        case badComponent(String)             // empty / "." / ".." / contains "/" or NUL
+        case baseNotUnderHome(String)         // production base-path injection guard
+        case componentOpenFailed(component: String, errno: Int32)
+        case verificationMismatch(component: String)   // pass A != pass B (mid-walk rebind)
+        case notDirectory(String)
+        case notRegularFile(String)
+        case notExclusive(String)             // st_nlink != 1 (hardlink) or already exists
+        case stagingNotEmpty(String)
+        case fullfsyncFailed(errno: Int32)
+        case teardownFailed(errno: Int32)
+    }
+
+    /// Publish/append durability outcome — a value, never inferred. `durableSuccess`
+    /// means ONLY that the matched object + directory metadata completed the
+    /// ordered stable-storage chain at the post-rename verification point. It is
+    /// NOT a zero-race, continuous-ancestry, or TOCTOU-closed claim.
+    enum Outcome: Equatable {
+        case durableSuccess
+        case rolledBackClean
+        case committedNotDurable
+        case rollbackVerifyFailed
+        case rollbackIncomplete
+    }
+
+    typealias Identity = (dev: dev_t, ino: ino_t)
+
+    static func sameIdentity(_ a: Identity, _ b: Identity) -> Bool {
+        a.dev == b.dev && a.ino == b.ino
+    }
+
+    // MARK: - Component validation
+
+    /// A single, non-ambiguous path component. Rejects empty, `.`, `..`, and any
+    /// component containing `/` or NUL, so no multi-component lookup can slip in.
+    static func validateComponent(_ c: String) throws {
+        guard !c.isEmpty, c != ".", c != "..",
+              !c.contains("/"), !c.utf8.contains(0) else {
+            throw FDError.badComponent(c)
+        }
+    }
+
+    private static func identity(ofFD fd: Int32) -> Identity {
+        var st = stat()
+        _ = fstat(fd, &st)
+        return (st.st_dev, st.st_ino)
+    }
+
+    // MARK: - Trusted base (base-path-injection guarded)
+
+    /// The production trusted base is the current user's home directory, opened
+    /// once (its own path is the single trusted boundary). Release builds accept
+    /// no other base — no arbitrary base-path injection.
+    static func openHomeBase() throws -> Int32 {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let fd = home.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
+        guard fd >= 0 else { throw FDError.componentOpenFailed(component: home.path, errno: errno) }
+        return fd
+    }
+
+    #if DEBUG
+    /// TEST-ONLY (compiled out of release): supplies a trusted base directory for
+    /// tests operating under a temp root, and a one-shot post-walk-passA hook so an
+    /// intermediate/final rebind can be injected deterministically between the two
+    /// verification walks. Neither symbol exists in a release binary.
+    nonisolated(unsafe) static var _testBaseOverride: URL?
+    nonisolated(unsafe) static var _testAfterPassAHook: (() -> Void)?
+    #endif
+
+    /// Open the trusted base for `target`: production = home (target MUST be under
+    /// home); DEBUG = an explicit test override. Returns the base fd + the
+    /// base-relative components down to `target`.
+    static func openTrustedBase(for target: URL) throws -> (baseFD: Int32, relative: [String]) {
+        let targetComps = target.standardizedFileURL.pathComponents   // ["/", ...]
+        #if DEBUG
+        if let override = _testBaseOverride {
+            let baseComps = override.standardizedFileURL.pathComponents
+            guard targetComps.count > baseComps.count,
+                  Array(targetComps.prefix(baseComps.count)) == baseComps else {
+                throw FDError.baseNotUnderHome(target.path)
+            }
+            let fd = override.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
+            guard fd >= 0 else { throw FDError.componentOpenFailed(component: override.path, errno: errno) }
+            return (fd, Array(targetComps.dropFirst(baseComps.count)))
+        }
+        #endif
+        let homeComps = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.pathComponents
+        guard targetComps.count > homeComps.count,
+              Array(targetComps.prefix(homeComps.count)) == homeComps else {
+            throw FDError.baseNotUnderHome(target.path)
+        }
+        let baseFD = try openHomeBase()
+        return (baseFD, Array(targetComps.dropFirst(homeComps.count)))
+    }
+
+    // MARK: - Verified walk (mid-walk rebind caught via A==B)
+
+    /// Walk `relative` from `baseFD` twice with single-component
+    /// `openat(O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC)` and require the per-component
+    /// `(dev,ino)` vectors to match (pass A == pass B), so a rebind between the two
+    /// passes is caught. Returns the verified leaf dir fd (caller owns it) and the
+    /// id vector. If `expected` is provided, each id must also equal it.
+    static func walkVerified(baseFD: Int32, _ relative: [String],
+                             expected: [Identity]? = nil) throws -> (fd: Int32, ids: [Identity]) {
+        for c in relative { try validateComponent(c) }
+        let (fdA, idsA) = try walkOnce(baseFD: baseFD, relative)
+        #if DEBUG
+        if let hook = _testAfterPassAHook { _testAfterPassAHook = nil; hook() }
+        #endif
+        let (fdB, idsB) = try walkOnce(baseFD: baseFD, relative)
+        // The verification pass is authoritative; the first walk's fd is discarded.
+        close(fdA)
+        guard idsA.count == idsB.count else {
+            close(fdB); throw FDError.verificationMismatch(component: relative.last ?? "")
+        }
+        for i in idsA.indices where !sameIdentity(idsA[i], idsB[i]) {
+            close(fdB); throw FDError.verificationMismatch(component: relative[i])
+        }
+        if let expected {
+            guard expected.count == idsB.count else {
+                close(fdB); throw FDError.verificationMismatch(component: relative.last ?? "")
+            }
+            for i in idsB.indices where !sameIdentity(expected[i], idsB[i]) {
+                close(fdB); throw FDError.verificationMismatch(component: relative[i])
+            }
+        }
+        return (fdB, idsB)
+    }
+
+    private static func walkOnce(baseFD: Int32, _ relative: [String]) throws -> (fd: Int32, ids: [Identity]) {
+        // Start from a dup of the base so ownership of the returned chain is ours
+        // and the caller's base fd is never closed by us.
+        var dirFD = dup(baseFD)
+        guard dirFD >= 0 else { throw FDError.componentOpenFailed(component: "<base-dup>", errno: errno) }
+        var ids: [Identity] = []
+        for comp in relative {
+            let next = comp.withCString { openat(dirFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+            close(dirFD)
+            guard next >= 0 else { throw FDError.componentOpenFailed(component: comp, errno: errno) }
+            dirFD = next
+            ids.append(identity(ofFD: dirFD))
+        }
+        return (dirFD, ids)
+    }
+
+    // MARK: - File opens — O_NOFOLLOW + regular-file + exclusivity
+
+    /// Exclusive create relative to a verified parent fd. Fails closed if the name
+    /// exists (defeats pre-planted file) and if `st_nlink != 1` (defeats hardlink).
+    static func createFile(parentFD: Int32, name: String, mode: mode_t) throws -> Int32 {
+        try validateComponent(name)
+        let fd = name.withCString {
+            openat(parentFD, $0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, mode)
+        }
+        guard fd >= 0 else { throw FDError.componentOpenFailed(component: name, errno: errno) }
+        var st = stat()
+        guard fstat(fd, &st) == 0, (st.st_mode & S_IFMT) == S_IFREG else {
+            close(fd); throw FDError.notRegularFile(name)
+        }
+        guard st.st_nlink == 1 else { close(fd); throw FDError.notExclusive(name) }
+        return fd
+    }
+
+    /// Open an existing regular file for append relative to a verified parent fd:
+    /// no-follow, non-blocking (a fifo fails fast), regular-file, `st_nlink == 1`.
+    static func openAppend(parentFD: Int32, name: String) throws -> Int32 {
+        try validateComponent(name)
+        let fd = name.withCString {
+            openat(parentFD, $0, O_WRONLY | O_APPEND | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+        }
+        guard fd >= 0 else { throw FDError.componentOpenFailed(component: name, errno: errno) }
+        var st = stat()
+        guard fstat(fd, &st) == 0, (st.st_mode & S_IFMT) == S_IFREG else {
+            close(fd); throw FDError.notRegularFile(name)
+        }
+        guard st.st_nlink == 1 else { close(fd); throw FDError.notExclusive(name) }
+        return fd
+    }
+
+    /// Open an existing regular file for read relative to a verified parent fd.
+    static func openRead(parentFD: Int32, name: String) throws -> Int32 {
+        try validateComponent(name)
+        let fd = name.withCString {
+            openat(parentFD, $0, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+        }
+        guard fd >= 0 else { throw FDError.componentOpenFailed(component: name, errno: errno) }
+        var st = stat()
+        guard fstat(fd, &st) == 0, (st.st_mode & S_IFMT) == S_IFREG else {
+            close(fd); throw FDError.notRegularFile(name)
+        }
+        return fd
+    }
+
+    // MARK: - Directory create — mkdirat + no-follow open + empty check
+
+    /// Create + open a directory relative to a verified parent fd, then require it
+    /// is empty (defeats mkdir→open swap-in of a populated dir). Returns the dir fd
+    /// + its identity.
+    static func makeEmptyDir(parentFD: Int32, name: String, mode: mode_t) throws -> (fd: Int32, id: Identity) {
+        try validateComponent(name)
+        guard name.withCString({ mkdirat(parentFD, $0, mode) }) == 0 else {
+            throw FDError.componentOpenFailed(component: name, errno: errno)
+        }
+        let fd = name.withCString { openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+        guard fd >= 0 else { throw FDError.componentOpenFailed(component: name, errno: errno) }
+        do {
+            try assertEmpty(dirFD: fd, label: name)
+        } catch {
+            close(fd); throw error
+        }
+        return (fd, identity(ofFD: fd))
+    }
+
+    /// True/throw: the directory fd contains only `.`/`..`. Enumerates through a
+    /// DUP (fdopendir consumes the fd it is given on Darwin).
+    static func assertEmpty(dirFD: Int32, label: String) throws {
+        let dupFD = dup(dirFD)
+        guard dupFD >= 0 else { throw FDError.componentOpenFailed(component: label, errno: errno) }
+        guard let dir = fdopendir(dupFD) else {
+            close(dupFD); throw FDError.componentOpenFailed(component: label, errno: errno)
+        }
+        defer { closedir(dir) }   // closes the underlying dup fd
+        while let ent = readdir(dir) {
+            let n = withUnsafePointer(to: ent.pointee.d_name) {
+                $0.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) { String(cString: $0) }
+            }
+            if n != "." && n != ".." { throw FDError.stagingNotEmpty(label) }
+        }
+    }
+
+    // MARK: - Durability — F_FULLFSYNC, fail-closed
+
+    static func fullfsync(_ fd: Int32) throws {
+        guard fcntl(fd, F_FULLFSYNC) != -1 else { throw FDError.fullfsyncFailed(errno: errno) }
+    }
+
+    // MARK: - Rollback teardown — fd-relative, no path rebuild
+
+    /// Recursively remove a directory relative to its verified parent fd, entirely
+    /// through descriptors: `fdopendir` on a DUP, classify children with
+    /// `fstatat(AT_SYMLINK_NOFOLLOW)`, recurse into subdirs via
+    /// `openat(O_DIRECTORY|O_NOFOLLOW)`, `unlinkat` files (symlink children unlinked
+    /// as links, never followed), then `unlinkat(AT_REMOVEDIR)` the now-empty dir.
+    static func teardownTree(parentFD: Int32, name: String) throws {
+        try validateComponent(name)
+        let dirFD = name.withCString { openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+        guard dirFD >= 0 else { throw FDError.teardownFailed(errno: errno) }
+        try removeChildrenThenSelf(dirFD: dirFD, parentFD: parentFD, name: name)
+    }
+
+    private static func removeChildrenThenSelf(dirFD: Int32, parentFD: Int32, name: String) throws {
+        let dupFD = dup(dirFD)
+        guard dupFD >= 0 else { close(dirFD); throw FDError.teardownFailed(errno: errno) }
+        guard let dir = fdopendir(dupFD) else {
+            close(dupFD); close(dirFD); throw FDError.teardownFailed(errno: errno)
+        }
+        var children: [(name: String, isDir: Bool)] = []
+        while let ent = readdir(dir) {
+            let n = withUnsafePointer(to: ent.pointee.d_name) {
+                $0.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) { String(cString: $0) }
+            }
+            if n == "." || n == ".." { continue }
+            var st = stat()
+            let rc = n.withCString { fstatat(dirFD, $0, &st, AT_SYMLINK_NOFOLLOW) }
+            guard rc == 0 else { closedir(dir); close(dirFD); throw FDError.teardownFailed(errno: errno) }
+            children.append((n, (st.st_mode & S_IFMT) == S_IFDIR))   // symlinks classified as non-dir → unlinked as links
+        }
+        closedir(dir)   // closes dupFD
+        for child in children {
+            if child.isDir {
+                let sub = child.name.withCString { openat(dirFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+                guard sub >= 0 else { close(dirFD); throw FDError.teardownFailed(errno: errno) }
+                try removeChildrenThenSelf(dirFD: sub, parentFD: dirFD, name: child.name)
+            } else {
+                guard child.name.withCString({ unlinkat(dirFD, $0, 0) }) == 0 else {
+                    close(dirFD); throw FDError.teardownFailed(errno: errno)
+                }
+            }
+        }
+        close(dirFD)
+        guard name.withCString({ unlinkat(parentFD, $0, AT_REMOVEDIR) }) == 0 else {
+            throw FDError.teardownFailed(errno: errno)
+        }
+    }
+}

--- a/Sources/LogicProMCP/Utilities/SecureFD.swift
+++ b/Sources/LogicProMCP/Utilities/SecureFD.swift
@@ -248,6 +248,47 @@ enum SecureFD {
         return fd
     }
 
+    // MARK: - Directory path materialization — walk existing, create missing
+
+    /// Open the directory at `components` under `baseFD`, creating any missing
+    /// component with `mkdirat` then a no-follow open. Every level is opened
+    /// `O_RDONLY|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC`, so a symlink planted for any
+    /// component fails closed (ELOOP) rather than redirecting the path outside the
+    /// base; a concurrent creator (`mkdirat` EEXIST) is tolerated by re-opening the
+    /// now-existing directory (still no-follow). Returns the leaf directory fd
+    /// (caller owns it). Used to materialize a staging/log directory chain such as
+    /// `Library/Logs/…/audit` beneath the trusted base without ever following a
+    /// planted symlink. Unlike `makeEmptyDir` this does not require the leaf empty
+    /// (the audit directory persists across runs).
+    static func ensureDirectory(baseFD: Int32, components: [String], mode: mode_t) throws -> Int32 {
+        for c in components { try validateComponent(c) }
+        var currentFD = dupCloexec(baseFD)
+        guard currentFD >= 0 else { throw FDError.componentOpenFailed(component: "<base-dup>", errno: errno) }
+        for comp in components {
+            let opened = comp.withCString { openat(currentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+            if opened >= 0 {
+                close(currentFD); currentFD = opened; continue
+            }
+            let openErrno = errno   // capture before any close/mkdirat overwrites it
+            guard openErrno == ENOENT else {
+                close(currentFD); throw FDError.componentOpenFailed(component: comp, errno: openErrno)
+            }
+            let mk = comp.withCString { mkdirat(currentFD, $0, mode) }
+            if mk != 0 {
+                let mkErrno = errno
+                guard mkErrno == EEXIST else {   // EEXIST = concurrent creator won; re-open below
+                    close(currentFD); throw FDError.componentOpenFailed(component: comp, errno: mkErrno)
+                }
+            }
+            let created = comp.withCString { openat(currentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC) }
+            let createdErrno = errno
+            close(currentFD)
+            guard created >= 0 else { throw FDError.componentOpenFailed(component: comp, errno: createdErrno) }
+            currentFD = created
+        }
+        return currentFD
+    }
+
     // MARK: - Directory create — mkdirat + no-follow open + empty check
 
     /// Create + open a directory relative to a verified parent fd, then require it

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -36,6 +36,21 @@ struct SecureFDTests {
         var st = stat(); return fstat(fd, &st) == 0
     }
 
+    /// Number of open descriptors in this process (F_GETFD sweep). Parallel
+    /// suites can hold transient fds, so callers take the minimum of a few
+    /// samples: a real leak persists across samples, noise fluctuates away.
+    private func openFDCount() -> Int {
+        var count = 0
+        for fd in 0..<Int32(getdtablesize()) where fcntl(fd, F_GETFD) != -1 { count += 1 }
+        return count
+    }
+
+    private func minOpenFDCount(samples: Int = 5) -> Int {
+        var best = Int.max
+        for _ in 0..<samples { best = min(best, openFDCount()) }
+        return best
+    }
+
     // MARK: component validation
 
     @Test("validateComponent rejects empty, dot, dotdot, slash, NUL")
@@ -179,7 +194,9 @@ struct SecureFDTests {
             defer { close(parent) }
             let (dirFD, _) = try SecureFD.makeEmptyDir(parentFD: parent, name: "stage", mode: 0o700)
             #expect(fdIsOpen(dirFD)); close(dirFD)
-            let popFD = try SecureFD.walkVerified(baseFD: try openBaseFD(base), ["pop"]).fd
+            let popBase = try openBaseFD(base)
+            defer { close(popBase) }
+            let popFD = try SecureFD.walkVerified(baseFD: popBase, ["pop"]).fd
             defer { close(popFD) }
             #expect(throws: (any Error).self) { try SecureFD.assertEmpty(dirFD: popFD, label: "pop") }
         }
@@ -207,6 +224,52 @@ struct SecureFDTests {
             #expect(!FileManager.default.fileExists(atPath: tree.path))          // tree gone
             #expect(FileManager.default.fileExists(atPath: precious.path))       // symlink target NOT followed/deleted
             #expect(try String(contentsOf: precious, encoding: .utf8) == "KEEP")
+        }
+    }
+
+    // MARK: fd-lifecycle under repeated failure
+
+    @Test("repeated error paths do not leak file descriptors")
+    func errorPathsAreFDBounded() throws {
+        let base = try tempBase("fdbound")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            let before = minOpenFDCount()
+
+            // (a) verification-pass failure: the walk target vanishes between
+            // pass A and pass B, so pass B throws after pass A opened its fd.
+            let mid = base.appendingPathComponent("mid", isDirectory: true)
+            for _ in 0..<64 {
+                try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
+                SecureFD._testAfterPassAHook = { try? FileManager.default.removeItem(at: mid) }
+                #expect(throws: (any Error).self) {
+                    close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
+                }
+            }
+            SecureFD._testAfterPassAHook = nil
+
+            // (b) mid-recursion teardown failure: a read-only subdirectory makes
+            // the child unlink fail AFTER the recursion has opened directory fds
+            // at two levels, so the propagating throw must release both.
+            let tree = base.appendingPathComponent("tree", isDirectory: true)
+            let sub = tree.appendingPathComponent("sub", isDirectory: true)
+            for _ in 0..<64 {
+                try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+                try Data("x".utf8).write(to: sub.appendingPathComponent("f"))
+                _ = sub.path.withCString { chmod($0, 0o500) }
+                #expect(throws: (any Error).self) {
+                    try SecureFD.teardownTree(parentFD: baseFD, name: "tree")
+                }
+                _ = sub.path.withCString { chmod($0, 0o700) }
+                try FileManager.default.removeItem(at: tree)
+            }
+
+            // 128 failed calls: a leak of one fd per failure adds >= 64 to the
+            // table; unrelated suite activity moves the count by a few at most.
+            let after = minOpenFDCount()
+            #expect(after - before < 32)
         }
     }
 

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -51,12 +51,40 @@ struct SecureFDTests {
         return best
     }
 
+    /// The FDError case name, so a negative can assert the SPECIFIC failure mode
+    /// (not merely "some error"): a regression that throws the wrong case is a
+    /// real hole, and pinning the case closes it.
+    /// Run `body`; return the `FDError` it throws, or nil if it does not throw
+    /// or throws a non-FDError. Callers `try #require(...)` the result so a
+    /// missing/foreign error fails the test, then assert the specific case.
+    private func fdError<T>(_ body: () throws -> T) -> SecureFD.FDError? {
+        do { _ = try body(); return nil }
+        catch let e as SecureFD.FDError { return e }
+        catch { return nil }
+    }
+
+    private func caseName(_ e: SecureFD.FDError) -> String {
+        switch e {
+        case .badComponent: return "badComponent"
+        case .baseNotUnderHome: return "baseNotUnderHome"
+        case .componentOpenFailed: return "componentOpenFailed"
+        case .verificationMismatch: return "verificationMismatch"
+        case .notDirectory: return "notDirectory"
+        case .notRegularFile: return "notRegularFile"
+        case .notExclusive: return "notExclusive"
+        case .stagingNotEmpty: return "stagingNotEmpty"
+        case .fullfsyncFailed: return "fullfsyncFailed"
+        case .teardownFailed: return "teardownFailed"
+        case .identityReadFailed: return "identityReadFailed"
+        }
+    }
+
     // MARK: component validation
 
     @Test("validateComponent rejects empty, dot, dotdot, slash, NUL")
     func componentValidation() throws {
         for bad in ["", ".", "..", "a/b", "x\u{0}y"] {
-            #expect(throws: (any Error).self) { try SecureFD.validateComponent(bad) }
+            #expect(throws: SecureFD.FDError.self) { try SecureFD.validateComponent(bad) }
         }
         try SecureFD.validateComponent("Library")   // a good one does not throw
     }
@@ -94,7 +122,7 @@ struct SecureFDTests {
         try withBase(base) {
             let baseFD = try openBaseFD(base)
             defer { close(baseFD) }
-            #expect(throws: (any Error).self) {
+            #expect(throws: SecureFD.FDError.self) {
                 close(try SecureFD.walkVerified(baseFD: baseFD, ["link", "leaf"]).fd)
             }
         }
@@ -120,9 +148,10 @@ struct SecureFDTests {
                 try? FileManager.default.moveItem(at: other, to: mid)
             }
             defer { SecureFD._testAfterPassAHook = nil }
-            #expect(throws: (any Error).self) {
+            let e = try #require(fdError {
                 close(try SecureFD.walkVerified(baseFD: baseFD, ["mid", "leaf"]).fd)
-            }
+            })
+            #expect(caseName(e) == "verificationMismatch")
         }
     }
 
@@ -139,14 +168,14 @@ struct SecureFDTests {
             let fd = try SecureFD.createFile(parentFD: parent, name: "fresh.json", mode: 0o600)
             #expect(fdIsOpen(fd)); close(fd)
             // pre-existing regular file → EEXIST refuse
-            #expect(throws: (any Error).self) {
+            #expect(throws: SecureFD.FDError.self) {
                 close(try SecureFD.createFile(parentFD: parent, name: "fresh.json", mode: 0o600))
             }
             // symlink at a NEW name → O_NOFOLLOW/O_EXCL refuse
             try FileManager.default.createSymbolicLink(
                 at: base.appendingPathComponent("sym.json"),
                 withDestinationURL: base.appendingPathComponent("fresh.json"))
-            #expect(throws: (any Error).self) {
+            #expect(throws: SecureFD.FDError.self) {
                 close(try SecureFD.createFile(parentFD: parent, name: "sym.json", mode: 0o600))
             }
         }
@@ -173,9 +202,9 @@ struct SecureFDTests {
             defer { close(parent) }
             let ok = try SecureFD.openAppend(parentFD: parent, name: "real.log")
             #expect(fdIsOpen(ok)); close(ok)
-            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "sym.log")) }
-            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "fifo.log")) }
-            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "hard.log")) }
+            #expect(throws: SecureFD.FDError.self) { close(try SecureFD.openAppend(parentFD: parent, name: "sym.log")) }
+            #expect(throws: SecureFD.FDError.self) { close(try SecureFD.openAppend(parentFD: parent, name: "fifo.log")) }
+            #expect(throws: SecureFD.FDError.self) { close(try SecureFD.openAppend(parentFD: parent, name: "hard.log")) }
         }
     }
 
@@ -198,7 +227,7 @@ struct SecureFDTests {
             defer { close(popBase) }
             let popFD = try SecureFD.walkVerified(baseFD: popBase, ["pop"]).fd
             defer { close(popFD) }
-            #expect(throws: (any Error).self) { try SecureFD.assertEmpty(dirFD: popFD, label: "pop") }
+            #expect(throws: SecureFD.FDError.self) { try SecureFD.assertEmpty(dirFD: popFD, label: "pop") }
         }
     }
 
@@ -245,7 +274,7 @@ struct SecureFDTests {
             for _ in 0..<64 {
                 try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
                 SecureFD._testAfterPassAHook = { try? FileManager.default.removeItem(at: mid) }
-                #expect(throws: (any Error).self) {
+                #expect(throws: SecureFD.FDError.self) {
                     close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
                 }
             }
@@ -264,7 +293,7 @@ struct SecureFDTests {
                 try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
                 try Data("x".utf8).write(to: sub.appendingPathComponent("f"))
                 _ = sub.path.withCString { chmod($0, 0o500) }
-                #expect(throws: (any Error).self) {
+                #expect(throws: SecureFD.FDError.self) {
                     try SecureFD.teardownTree(parentFD: baseFD, name: "tree")
                 }
                 _ = sub.path.withCString { chmod($0, 0o700) }
@@ -295,8 +324,8 @@ struct SecureFDTests {
             defer { close(parent) }
             let ok = try SecureFD.openRead(parentFD: parent, name: "plain.json")
             #expect(fdIsOpen(ok)); close(ok)
-            #expect(throws: (any Error).self) { close(try SecureFD.openRead(parentFD: parent, name: "sym.json")) }
-            #expect(throws: (any Error).self) { close(try SecureFD.openRead(parentFD: parent, name: "hard.json")) }
+            #expect(throws: SecureFD.FDError.self) { close(try SecureFD.openRead(parentFD: parent, name: "sym.json")) }
+            #expect(throws: SecureFD.FDError.self) { close(try SecureFD.openRead(parentFD: parent, name: "hard.json")) }
         }
     }
 
@@ -381,7 +410,7 @@ struct SecureFDTests {
                     }
                     try? FileManager.default.removeItem(at: mid)          // make pass B fail
                 }
-                #expect(throws: (any Error).self) {
+                #expect(throws: SecureFD.FDError.self) {
                     close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
                 }
                 SecureFD._testPassAClosedFDObserver = nil
@@ -401,7 +430,7 @@ struct SecureFDTests {
             // checks and is caught only by the flag generation marker.
             try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
             close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)          // success path
-            #expect(throws: (any Error).self) {
+            #expect(throws: SecureFD.FDError.self) {
                 close(try SecureFD.walkVerified(baseFD: baseFD, ["missing"]).fd)  // failure path
             }
             let after = try #require(fdIdentity(baseFD))
@@ -456,9 +485,10 @@ struct SecureFDTests {
             // negative pins.
             SecureFD._testForceIdentityFailureCount = 2
             defer { SecureFD._testForceIdentityFailureCount = 0 }
-            #expect(throws: (any Error).self) {
+            let e = try #require(fdError {
                 close(try SecureFD.walkVerified(baseFD: baseFD, ["a"]).fd)
-            }
+            })
+            #expect(caseName(e) == "identityReadFailed")   // not a fabricated (0,0) match
             let after = minOpenFDCount()
             #expect(after - before < 4)   // the refusing path leaks nothing
         }
@@ -486,13 +516,46 @@ struct SecureFDTests {
                 try? FileManager.default.moveItem(at: victim, to: sub)
             }
             defer { SecureFD._testAfterClassificationHook = nil }
-            #expect(throws: (any Error).self) {
+            let e = try #require(fdError {
                 try SecureFD.teardownTree(parentFD: parent, name: "tree")
-            }
+            })
+            #expect(caseName(e) == "verificationMismatch")
             // Wrong-object zero-delete: the replacement's contents are intact.
             let preciousNow = sub.appendingPathComponent("precious.txt")
             #expect(FileManager.default.fileExists(atPath: preciousNow.path))
             #expect(try String(contentsOf: preciousNow, encoding: .utf8) == "KEEP")
+        }
+    }
+
+    @Test("teardown refuses a victim file swapped onto a classified name with zero deletion")
+    func teardownRefusesReplacedFile() throws {
+        let base = try tempBase("fileswap")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let tree = base.appendingPathComponent("tree", isDirectory: true)
+        try FileManager.default.createDirectory(at: tree, withIntermediateDirectories: true)
+        try Data("staged".utf8).write(to: tree.appendingPathComponent("f"))
+        let victim = base.appendingPathComponent("precious.txt")
+        try Data("KEEP".utf8).write(to: victim)
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            // After `f` is classified as a regular file, rename the victim file
+            // onto that name. O_NOFOLLOW cannot catch a real regular-file swap;
+            // only the file identity re-bind before unlink can — mirror of the
+            // directory swap defense.
+            SecureFD._testAfterClassificationHook = {
+                try? FileManager.default.removeItem(at: tree.appendingPathComponent("f"))
+                try? FileManager.default.moveItem(at: victim, to: tree.appendingPathComponent("f"))
+            }
+            defer { SecureFD._testAfterClassificationHook = nil }
+            let e = try #require(fdError {
+                try SecureFD.teardownTree(parentFD: parent, name: "tree")
+            })
+            #expect(caseName(e) == "verificationMismatch")
+            // Zero-delete: the victim's content survives at its new name.
+            let moved = tree.appendingPathComponent("f")
+            #expect(FileManager.default.fileExists(atPath: moved.path))
+            #expect(try String(contentsOf: moved, encoding: .utf8) == "KEEP")
         }
     }
 
@@ -505,7 +568,7 @@ struct SecureFDTests {
         try withBase(base) {
             let outside = FileManager.default.temporaryDirectory
                 .appendingPathComponent("lpmcp-outside-\(UUID().uuidString)")
-            #expect(throws: (any Error).self) { _ = try SecureFD.openTrustedBase(for: outside) }
+            #expect(throws: SecureFD.FDError.self) { _ = try SecureFD.openTrustedBase(for: outside) }
         }
     }
 }

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -231,6 +231,39 @@ struct SecureFDTests {
         }
     }
 
+    // MARK: ensureDirectory (walk existing / create missing, no-follow)
+
+    @Test("ensureDirectory creates a missing chain, is idempotent, refuses a symlink component")
+    func ensureDirectoryGuards() throws {
+        let base = try tempBase("ensuredir")
+        defer { try? FileManager.default.removeItem(at: base) }
+        // Library exists; Logs/app/audit do not (mixed walk + create).
+        try FileManager.default.createDirectory(
+            at: base.appendingPathComponent("Library", isDirectory: true), withIntermediateDirectories: true)
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            let comps = ["Library", "Logs", "app", "audit"]
+            let leaf = try SecureFD.ensureDirectory(baseFD: baseFD, components: comps, mode: 0o700)
+            #expect(fcntl(leaf, F_GETFD) & FD_CLOEXEC != 0)   // returned fd is close-on-exec
+            // It is a real directory relative to which we can create a file.
+            let f = try SecureFD.createFile(parentFD: leaf, name: "x", mode: 0o600)
+            close(f); close(leaf)
+            #expect(FileManager.default.fileExists(
+                atPath: base.appendingPathComponent("Library/Logs/app/audit/x").path))
+            // Idempotent: a second call walks the now-existing chain (base fd is dup'd, reusable).
+            let leaf2 = try SecureFD.ensureDirectory(baseFD: baseFD, components: comps, mode: 0o700)
+            #expect(fcntl(leaf2, F_GETFD) & FD_CLOEXEC != 0); close(leaf2)
+            // A symlink planted for a component is refused (O_NOFOLLOW), never followed.
+            try FileManager.default.createSymbolicLink(
+                at: base.appendingPathComponent("evil"),
+                withDestinationURL: base.appendingPathComponent("Library"))
+            #expect(throws: SecureFD.FDError.self) {
+                close(try SecureFD.ensureDirectory(baseFD: baseFD, components: ["evil", "Logs"], mode: 0o700))
+            }
+        }
+    }
+
     // MARK: teardown
 
     @Test("teardownTree removes a nested tree and unlinks a symlink child as a link (target survives)")

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -1,0 +1,225 @@
+import Darwin
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// Isolated mutation matrix for the `SecureFD` primitive: each negative test
+/// fails if its guard is removed. The DEBUG seams exercised here are `#if DEBUG`
+/// and absent from a release binary.
+@Suite("SecureFD primitive", .serialized)
+struct SecureFDTests {
+    // MARK: fixtures
+
+    private func tempBase(_ label: String) throws -> URL {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpmcp-securefd-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    /// Run `body` with `_testBaseOverride` set to `base` (DEBUG-only seam), restored after.
+    private func withBase<R>(_ base: URL, _ body: () throws -> R) rethrows -> R {
+        SecureFD._testBaseOverride = base
+        defer { SecureFD._testBaseOverride = nil }
+        return try body()
+    }
+
+    /// A verified fd for `base` itself via the real API. `openTrustedBase` requires
+    /// the target to be strictly under the base, so we probe with a child name (the
+    /// child is never opened — only the base fd + relative arithmetic are used).
+    /// Caller owns the returned fd.
+    private func openBaseFD(_ base: URL) throws -> Int32 {
+        try SecureFD.openTrustedBase(for: base.appendingPathComponent("__probe__")).baseFD
+    }
+
+    private func fdIsOpen(_ fd: Int32) -> Bool {
+        var st = stat(); return fstat(fd, &st) == 0
+    }
+
+    // MARK: component validation
+
+    @Test("validateComponent rejects empty, dot, dotdot, slash, NUL")
+    func componentValidation() throws {
+        for bad in ["", ".", "..", "a/b", "x\u{0}y"] {
+            #expect(throws: (any Error).self) { try SecureFD.validateComponent(bad) }
+        }
+        try SecureFD.validateComponent("Library")   // a good one does not throw
+    }
+
+    // MARK: walk + verify + fd-lifecycle
+
+    @Test("walkVerified opens a real chain and does NOT close the caller's base fd")
+    func walkSucceedsAndOwnsFds() throws {
+        let base = try tempBase("walk-ok")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(
+            at: base.appendingPathComponent("a/b", isDirectory: true), withIntermediateDirectories: true)
+        try withBase(base) {
+            let (baseFD, rel) = try SecureFD.openTrustedBase(for: base.appendingPathComponent("a/b"))
+            defer { close(baseFD) }
+            #expect(rel == ["a", "b"])
+            let (leaf, ids) = try SecureFD.walkVerified(baseFD: baseFD, rel)
+            #expect(ids.count == rel.count)
+            #expect(fdIsOpen(leaf))          // returned fd is open (caller owns it)
+            #expect(fdIsOpen(baseFD))        // fd-lifecycle: base NOT closed by the walk
+            close(leaf)
+            #expect(!fdIsOpen(leaf))         // single-owned: after our close it is gone
+        }
+    }
+
+    @Test("walkVerified refuses a symlinked intermediate component (O_NOFOLLOW)")
+    func walkRefusesSymlinkComponent() throws {
+        let base = try tempBase("walk-symlink")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let real = base.appendingPathComponent("real", isDirectory: true)
+        try FileManager.default.createDirectory(at: real.appendingPathComponent("leaf", isDirectory: true),
+                                                withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: base.appendingPathComponent("link"), withDestinationURL: real)
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.walkVerified(baseFD: baseFD, ["link", "leaf"]).fd)
+            }
+        }
+    }
+
+    @Test("walkVerified refuses a mid-walk rebind (pass A != pass B)")
+    func walkRefusesMidWalkRebind() throws {
+        let base = try tempBase("walk-midwalk")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let mid = base.appendingPathComponent("mid", isDirectory: true)
+        try FileManager.default.createDirectory(at: mid.appendingPathComponent("leaf", isDirectory: true),
+                                                withIntermediateDirectories: true)
+        let other = base.appendingPathComponent("other", isDirectory: true)
+        try FileManager.default.createDirectory(at: other.appendingPathComponent("leaf", isDirectory: true),
+                                                withIntermediateDirectories: true)
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            // Between pass A and pass B, swap `mid` for a DIFFERENT real dir that
+            // still carries `leaf` — the open would succeed without the A==B check.
+            SecureFD._testAfterPassAHook = {
+                try? FileManager.default.removeItem(at: mid)
+                try? FileManager.default.moveItem(at: other, to: mid)
+            }
+            defer { SecureFD._testAfterPassAHook = nil }
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.walkVerified(baseFD: baseFD, ["mid", "leaf"]).fd)
+            }
+        }
+    }
+
+    // MARK: file opens
+
+    @Test("createFile is exclusive: refuses a pre-existing file and a symlink at the name")
+    func createFileExclusive() throws {
+        let base = try tempBase("create")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            // fresh exclusive create succeeds
+            let fd = try SecureFD.createFile(parentFD: parent, name: "fresh.json", mode: 0o600)
+            #expect(fdIsOpen(fd)); close(fd)
+            // pre-existing regular file → EEXIST refuse
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.createFile(parentFD: parent, name: "fresh.json", mode: 0o600))
+            }
+            // symlink at a NEW name → O_NOFOLLOW/O_EXCL refuse
+            try FileManager.default.createSymbolicLink(
+                at: base.appendingPathComponent("sym.json"),
+                withDestinationURL: base.appendingPathComponent("fresh.json"))
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.createFile(parentFD: parent, name: "sym.json", mode: 0o600))
+            }
+        }
+    }
+
+    @Test("openAppend refuses a symlink, a fifo, and a hardlink (st_nlink>1); accepts a plain file")
+    func openAppendGuards() throws {
+        let base = try tempBase("append")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try Data("line\n".utf8).write(to: base.appendingPathComponent("real.log"))
+        try FileManager.default.createSymbolicLink(
+            at: base.appendingPathComponent("sym.log"),
+            withDestinationURL: base.appendingPathComponent("real.log"))
+        _ = base.appendingPathComponent("fifo.log").path.withCString { mkfifo($0, 0o600) }
+        // A hardlink at `hard.log` pointing at a SEPARATE target inode → st_nlink==2.
+        // `real.log` stays nlink==1 so its append still succeeds.
+        try Data("t".utf8).write(to: base.appendingPathComponent("hltarget"))
+        let linkRC = base.appendingPathComponent("hltarget").path.withCString { t in
+            base.appendingPathComponent("hard.log").path.withCString { l in link(t, l) }
+        }
+        #expect(linkRC == 0)
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            let ok = try SecureFD.openAppend(parentFD: parent, name: "real.log")
+            #expect(fdIsOpen(ok)); close(ok)
+            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "sym.log")) }
+            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "fifo.log")) }
+            #expect(throws: (any Error).self) { close(try SecureFD.openAppend(parentFD: parent, name: "hard.log")) }
+        }
+    }
+
+    // MARK: makeEmptyDir + assertEmpty
+
+    @Test("makeEmptyDir creates an empty dir; assertEmpty rejects a populated one")
+    func emptyDirGuards() throws {
+        let base = try tempBase("emptydir")
+        defer { try? FileManager.default.removeItem(at: base) }
+        // A populated sibling dir the empty-check must reject.
+        let populated = base.appendingPathComponent("pop", isDirectory: true)
+        try FileManager.default.createDirectory(at: populated, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: populated.appendingPathComponent("child"))
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            let (dirFD, _) = try SecureFD.makeEmptyDir(parentFD: parent, name: "stage", mode: 0o700)
+            #expect(fdIsOpen(dirFD)); close(dirFD)
+            let popFD = try SecureFD.walkVerified(baseFD: try openBaseFD(base), ["pop"]).fd
+            defer { close(popFD) }
+            #expect(throws: (any Error).self) { try SecureFD.assertEmpty(dirFD: popFD, label: "pop") }
+        }
+    }
+
+    // MARK: teardown
+
+    @Test("teardownTree removes a nested tree and unlinks a symlink child as a link (target survives)")
+    func teardownNestedAndSymlinkChild() throws {
+        let base = try tempBase("teardown")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let tree = base.appendingPathComponent("tree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tree.appendingPathComponent("sub", isDirectory: true), withIntermediateDirectories: true)
+        try Data("a".utf8).write(to: tree.appendingPathComponent("f1"))
+        try Data("b".utf8).write(to: tree.appendingPathComponent("sub/f2"))
+        let precious = base.appendingPathComponent("precious.txt")
+        try Data("KEEP".utf8).write(to: precious)
+        try FileManager.default.createSymbolicLink(
+            at: tree.appendingPathComponent("linkchild"), withDestinationURL: precious)
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            try SecureFD.teardownTree(parentFD: parent, name: "tree")
+            #expect(!FileManager.default.fileExists(atPath: tree.path))          // tree gone
+            #expect(FileManager.default.fileExists(atPath: precious.path))       // symlink target NOT followed/deleted
+            #expect(try String(contentsOf: precious, encoding: .utf8) == "KEEP")
+        }
+    }
+
+    // MARK: base policy
+
+    @Test("openTrustedBase refuses a target that is not under the trusted base")
+    func baseRefusesTargetOutsideBase() throws {
+        let base = try tempBase("basepolicy")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try withBase(base) {
+            let outside = FileManager.default.temporaryDirectory
+                .appendingPathComponent("lpmcp-outside-\(UUID().uuidString)")
+            #expect(throws: (any Error).self) { _ = try SecureFD.openTrustedBase(for: outside) }
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -325,7 +325,15 @@ struct SecureFDTests {
             #expect(isCloexec(read)); close(read)
             let (dirFD, _) = try SecureFD.makeEmptyDir(parentFD: parent, name: "stage", mode: 0o700)
             #expect(isCloexec(dirFD)); close(dirFD)
+            // the trusted-base descriptor itself (override branch)
+            let (tb, _) = try SecureFD.openTrustedBase(for: base.appendingPathComponent("probe"))
+            #expect(isCloexec(tb)); close(tb)
         }
+        // the trusted-base descriptor (production home branch, read-only open)
+        let homeProbe = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("lpmcp-cloexec-probe")
+        let (hb, _) = try SecureFD.openTrustedBase(for: homeProbe)
+        #expect(isCloexec(hb)); close(hb)
     }
 
     @Test("failing calls never close or replace descriptors they do not own")
@@ -333,7 +341,6 @@ struct SecureFDTests {
         let base = try tempBase("canary")
         defer { try? FileManager.default.removeItem(at: base) }
         let mid = base.appendingPathComponent("mid", isDirectory: true)
-        try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
         func fdIdentity(_ fd: Int32) -> (dev: dev_t, ino: ino_t)? {
             var st = stat(); return fstat(fd, &st) == 0 ? (st.st_dev, st.st_ino) : nil
         }
@@ -341,32 +348,57 @@ struct SecureFDTests {
             let baseFD = try openBaseFD(base)
             defer { close(baseFD) }
             let baseIdentity = try #require(fdIdentity(baseFD))
+            // Generation marker: OUR descriptor deliberately carries FD_CLOEXEC
+            // CLEARED. A close-and-reopen of this slot inside SecureFD (which
+            // always opens with O_CLOEXEC) preserves (dev,ino) but flips the
+            // flag back on — identity alone cannot see descriptor replacement.
+            #expect(fcntl(baseFD, F_SETFD, 0) == 0)
 
-            // Deterministic double-close probe: the moment pass A's fd is
-            // released, the hook claims the lowest free descriptor numbers with
-            // canaries. A residual close of pass A's number on the error path
-            // would kill a canary; POSIX guarantees open() reuses lowest-free.
-            var canaries: [Int32] = []
-            SecureFD._testAfterPassAHook = {
-                for _ in 0..<4 { canaries.append(open("/dev/null", O_RDONLY | O_CLOEXEC)) }
-                try? FileManager.default.removeItem(at: mid)
+            // Slot-bound double-close probe: the observer reports the EXACT
+            // number pass A released; the hook then claims that very slot with
+            // a /dev/null canary (retrying if concurrent churn stole it). A
+            // residual close of the released number on the error path now
+            // deterministically kills the canary.
+            var released: Int32 = -1
+            var claimed = false
+            for _ in 0..<3 where !claimed {
+                released = -1
+                try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
+                SecureFD._testPassAClosedFDObserver = { released = $0 }
+                SecureFD._testAfterPassAHook = {
+                    let dn = open("/dev/null", O_RDONLY | O_CLOEXEC)
+                    if dn >= 0, released >= 0 {
+                        if dn == released {
+                            claimed = true                                // canary landed on the slot
+                        } else if fcntl(released, F_GETFD) == -1,          // slot still free
+                                  dup2(dn, released) == released {
+                            claimed = true; close(dn)
+                        } else {
+                            close(dn)
+                        }
+                    } else if dn >= 0 {
+                        close(dn)
+                    }
+                    try? FileManager.default.removeItem(at: mid)          // make pass B fail
+                }
+                #expect(throws: (any Error).self) {
+                    close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
+                }
+                SecureFD._testPassAClosedFDObserver = nil
+                SecureFD._testAfterPassAHook = nil
             }
-            #expect(throws: (any Error).self) {
-                close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
-            }
-            SecureFD._testAfterPassAHook = nil
-            #expect(canaries.count == 4)
-            for canary in canaries {
-                #expect(canary >= 0)
-                #expect(fdIsOpen(canary))   // a double-close would have killed it
-                close(canary)
-            }
+            #expect(claimed)
+            #expect(released >= 0)
+            var st = stat()
+            #expect(fstat(released, &st) == 0)                 // residual close would have killed it
+            #expect((st.st_mode & S_IFMT) == S_IFCHR)          // and it is still OUR /dev/null canary
+            close(released)
 
-            // Stale-fd probe: after success and failure paths, the caller's
-            // base descriptor is still open AND still the same object — a
-            // close-and-reuse inside SecureFD would change its identity. The
-            // failure trigger is a nonexistent component, so this probe does
-            // not depend on any single guard.
+            // Stale-fd probe across success + guard-independent (ENOENT)
+            // failure: the caller's descriptor must stay open, keep its
+            // (dev,ino), AND keep the cleared close-on-exec marker — a
+            // close-and-reopen of the same directory passes the first two
+            // checks and is caught only by the flag generation marker.
             try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
             close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)          // success path
             #expect(throws: (any Error).self) {
@@ -374,6 +406,93 @@ struct SecureFDTests {
             }
             let after = try #require(fdIdentity(baseFD))
             #expect(SecureFD.sameIdentity(baseIdentity, after))
+            let flags = fcntl(baseFD, F_GETFD)
+            #expect(flags >= 0)
+            #expect(flags & FD_CLOEXEC == 0)                   // reopen would have set it
+            _ = fcntl(baseFD, F_SETFD, FD_CLOEXEC)
+        }
+    }
+
+    @Test("enumeration duplicates carry close-on-exec before fdopendir consumes them")
+    func enumerationDescriptorsAreCloexec() throws {
+        let base = try tempBase("enumfd")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let tree = base.appendingPathComponent("tree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tree.appendingPathComponent("sub", isDirectory: true), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: tree.appendingPathComponent("f"))
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            var observedFlags: [Int32] = []
+            SecureFD._testEnumerationFDObserver = { fd in observedFlags.append(fcntl(fd, F_GETFD)) }
+            defer { SecureFD._testEnumerationFDObserver = nil }
+            // empty-check enumeration (via makeEmptyDir) + teardown enumeration
+            // at two nesting levels.
+            let (dirFD, _) = try SecureFD.makeEmptyDir(parentFD: parent, name: "stage", mode: 0o700)
+            close(dirFD)
+            try SecureFD.teardownTree(parentFD: parent, name: "tree")
+            #expect(observedFlags.count >= 3)
+            for flags in observedFlags {
+                #expect(flags >= 0)
+                #expect(flags & FD_CLOEXEC != 0)
+            }
+        }
+    }
+
+    @Test("a failed identity read refuses the walk instead of fabricating (0,0)")
+    func identityReadFailureIsFailClosed() throws {
+        let base = try tempBase("idfail")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(
+            at: base.appendingPathComponent("a", isDirectory: true), withIntermediateDirectories: true)
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            let before = minOpenFDCount()
+            // TWO failed reads: without the fail-closed guard both passes
+            // fabricate a (0,0) identity, the vectors compare EQUAL, and the
+            // walk SUCCEEDS on a fabricated identity — the exact defect this
+            // negative pins.
+            SecureFD._testForceIdentityFailureCount = 2
+            defer { SecureFD._testForceIdentityFailureCount = 0 }
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.walkVerified(baseFD: baseFD, ["a"]).fd)
+            }
+            let after = minOpenFDCount()
+            #expect(after - before < 4)   // the refusing path leaks nothing
+        }
+    }
+
+    @Test("teardown refuses a swapped-in real directory with zero deletion")
+    func teardownRefusesReplacedRealDirectory() throws {
+        let base = try tempBase("swap")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let tree = base.appendingPathComponent("tree", isDirectory: true)
+        let sub = tree.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: sub.appendingPathComponent("f"))
+        let victim = base.appendingPathComponent("victim", isDirectory: true)
+        try FileManager.default.createDirectory(at: victim, withIntermediateDirectories: true)
+        try Data("KEEP".utf8).write(to: victim.appendingPathComponent("precious.txt"))
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            // After tree's children are classified, swap the classified `sub`
+            // for a DIFFERENT real directory. O_NOFOLLOW cannot catch a real
+            // directory; only the classified-identity binding can.
+            SecureFD._testAfterClassificationHook = {
+                try? FileManager.default.moveItem(at: sub, to: base.appendingPathComponent("aside"))
+                try? FileManager.default.moveItem(at: victim, to: sub)
+            }
+            defer { SecureFD._testAfterClassificationHook = nil }
+            #expect(throws: (any Error).self) {
+                try SecureFD.teardownTree(parentFD: parent, name: "tree")
+            }
+            // Wrong-object zero-delete: the replacement's contents are intact.
+            let preciousNow = sub.appendingPathComponent("precious.txt")
+            #expect(FileManager.default.fileExists(atPath: preciousNow.path))
+            #expect(try String(contentsOf: preciousNow, encoding: .utf8) == "KEEP")
         }
     }
 

--- a/Tests/LogicProMCPTests/SecureFDTests.swift
+++ b/Tests/LogicProMCPTests/SecureFDTests.swift
@@ -236,10 +236,11 @@ struct SecureFDTests {
         try withBase(base) {
             let baseFD = try openBaseFD(base)
             defer { close(baseFD) }
-            let before = minOpenFDCount()
 
             // (a) verification-pass failure: the walk target vanishes between
             // pass A and pass B, so pass B throws after pass A opened its fd.
+            // Independently bounded: a one-fd-per-failure leak adds 64.
+            let beforeWalk = minOpenFDCount()
             let mid = base.appendingPathComponent("mid", isDirectory: true)
             for _ in 0..<64 {
                 try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
@@ -249,10 +250,14 @@ struct SecureFDTests {
                 }
             }
             SecureFD._testAfterPassAHook = nil
+            let afterWalk = minOpenFDCount()
+            #expect(afterWalk - beforeWalk < 8)
 
             // (b) mid-recursion teardown failure: a read-only subdirectory makes
             // the child unlink fail AFTER the recursion has opened directory fds
             // at two levels, so the propagating throw must release both.
+            // Independently bounded: a per-level leak adds 128.
+            let beforeTeardown = minOpenFDCount()
             let tree = base.appendingPathComponent("tree", isDirectory: true)
             let sub = tree.appendingPathComponent("sub", isDirectory: true)
             for _ in 0..<64 {
@@ -265,11 +270,110 @@ struct SecureFDTests {
                 _ = sub.path.withCString { chmod($0, 0o700) }
                 try FileManager.default.removeItem(at: tree)
             }
+            let afterTeardown = minOpenFDCount()
+            #expect(afterTeardown - beforeTeardown < 8)
+        }
+    }
 
-            // 128 failed calls: a leak of one fd per failure adds >= 64 to the
-            // table; unrelated suite activity moves the count by a few at most.
-            let after = minOpenFDCount()
-            #expect(after - before < 32)
+    // MARK: descriptor flags + ownership
+
+    @Test("openRead refuses a symlink and a hardlink; accepts a plain file")
+    func openReadGuards() throws {
+        let base = try tempBase("read")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try Data("data".utf8).write(to: base.appendingPathComponent("plain.json"))
+        try FileManager.default.createSymbolicLink(
+            at: base.appendingPathComponent("sym.json"),
+            withDestinationURL: base.appendingPathComponent("plain.json"))
+        try Data("t".utf8).write(to: base.appendingPathComponent("hltarget"))
+        let linkRC = base.appendingPathComponent("hltarget").path.withCString { t in
+            base.appendingPathComponent("hard.json").path.withCString { l in link(t, l) }
+        }
+        #expect(linkRC == 0)
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            let ok = try SecureFD.openRead(parentFD: parent, name: "plain.json")
+            #expect(fdIsOpen(ok)); close(ok)
+            #expect(throws: (any Error).self) { close(try SecureFD.openRead(parentFD: parent, name: "sym.json")) }
+            #expect(throws: (any Error).self) { close(try SecureFD.openRead(parentFD: parent, name: "hard.json")) }
+        }
+    }
+
+    @Test("every returned descriptor carries close-on-exec")
+    func returnedDescriptorsAreCloexec() throws {
+        let base = try tempBase("cloexec")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(
+            at: base.appendingPathComponent("a", isDirectory: true), withIntermediateDirectories: true)
+        try Data("data".utf8).write(to: base.appendingPathComponent("f.json"))
+        func isCloexec(_ fd: Int32) -> Bool { fcntl(fd, F_GETFD) & FD_CLOEXEC != 0 }
+        try withBase(base) {
+            let parent = try openBaseFD(base)
+            defer { close(parent) }
+            // Empty-relative walk returns the internal DUPLICATE of the base —
+            // the one descriptor a non-CLOEXEC dup would expose directly.
+            let dupLeaf = try SecureFD.walkVerified(baseFD: parent, []).fd
+            #expect(isCloexec(dupLeaf)); close(dupLeaf)
+            let walkLeaf = try SecureFD.walkVerified(baseFD: parent, ["a"]).fd
+            #expect(isCloexec(walkLeaf)); close(walkLeaf)
+            let created = try SecureFD.createFile(parentFD: parent, name: "new.json", mode: 0o600)
+            #expect(isCloexec(created)); close(created)
+            let appended = try SecureFD.openAppend(parentFD: parent, name: "f.json")
+            #expect(isCloexec(appended)); close(appended)
+            let read = try SecureFD.openRead(parentFD: parent, name: "f.json")
+            #expect(isCloexec(read)); close(read)
+            let (dirFD, _) = try SecureFD.makeEmptyDir(parentFD: parent, name: "stage", mode: 0o700)
+            #expect(isCloexec(dirFD)); close(dirFD)
+        }
+    }
+
+    @Test("failing calls never close or replace descriptors they do not own")
+    func errorPathsDoNotDisturbForeignDescriptors() throws {
+        let base = try tempBase("canary")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let mid = base.appendingPathComponent("mid", isDirectory: true)
+        try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
+        func fdIdentity(_ fd: Int32) -> (dev: dev_t, ino: ino_t)? {
+            var st = stat(); return fstat(fd, &st) == 0 ? (st.st_dev, st.st_ino) : nil
+        }
+        try withBase(base) {
+            let baseFD = try openBaseFD(base)
+            defer { close(baseFD) }
+            let baseIdentity = try #require(fdIdentity(baseFD))
+
+            // Deterministic double-close probe: the moment pass A's fd is
+            // released, the hook claims the lowest free descriptor numbers with
+            // canaries. A residual close of pass A's number on the error path
+            // would kill a canary; POSIX guarantees open() reuses lowest-free.
+            var canaries: [Int32] = []
+            SecureFD._testAfterPassAHook = {
+                for _ in 0..<4 { canaries.append(open("/dev/null", O_RDONLY | O_CLOEXEC)) }
+                try? FileManager.default.removeItem(at: mid)
+            }
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)
+            }
+            SecureFD._testAfterPassAHook = nil
+            #expect(canaries.count == 4)
+            for canary in canaries {
+                #expect(canary >= 0)
+                #expect(fdIsOpen(canary))   // a double-close would have killed it
+                close(canary)
+            }
+
+            // Stale-fd probe: after success and failure paths, the caller's
+            // base descriptor is still open AND still the same object — a
+            // close-and-reuse inside SecureFD would change its identity. The
+            // failure trigger is a nonexistent component, so this probe does
+            // not depend on any single guard.
+            try FileManager.default.createDirectory(at: mid, withIntermediateDirectories: true)
+            close(try SecureFD.walkVerified(baseFD: baseFD, ["mid"]).fd)          // success path
+            #expect(throws: (any Error).self) {
+                close(try SecureFD.walkVerified(baseFD: baseFD, ["missing"]).fd)  // failure path
+            }
+            let after = try #require(fdIdentity(baseFD))
+            #expect(SecureFD.sameIdentity(baseIdentity, after))
         }
     }
 

--- a/Tests/LogicProMCPTests/TraceClearAuditTests.swift
+++ b/Tests/LogicProMCPTests/TraceClearAuditTests.swift
@@ -268,10 +268,10 @@ struct TraceClearAuditTests {
         try FileManager.default.createSymbolicLink(at: auditRoot, withDestinationURL: outside)
         defer { try? FileManager.default.removeItem(at: base) }
 
-        // The containment check itself refuses, independent of whatever
-        // `createDirectory` chooses to do with a symlink-to-existing-dir.
-        #expect(!SystemDispatcher.auditDirectoryIsContained(auditRoot))
-
+        // The fd-relative materialization opens every audit-path component
+        // O_NOFOLLOW, so the symlinked `audit` component is refused (ELOOP) and
+        // the clear fails closed — the receipt can never be diverted outside the
+        // intended root, and the store is left intact.
         try await withEnv(flagOn: true, auditRoot: auditRoot) {
             await OperationTraceStore.shared.clear()
             await seedTraces(2)
@@ -317,6 +317,58 @@ struct TraceClearAuditTests {
             // A no-op never writes a receipt.
             let receiptPath = root.appendingPathComponent("trace-clear.log").path
             #expect(!FileManager.default.fileExists(atPath: receiptPath))
+        }
+    }
+
+    @Test("a symlink planted at the receipt file fails closed and is never followed")
+    func receiptFileSymlinkFailsClosed() async throws {
+        let root = tempRoot("logsymlink")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let victim = root.appendingPathComponent("victim.txt")
+        try Data("KEEP".utf8).write(to: victim)
+        // Plant a symlink AT the receipt name pointing at the victim file.
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("trace-clear.log"), withDestinationURL: victim)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            #expect(try #require(result.isError))
+            #expect(try #require(body["state"] as? String) == "C")
+            #expect(try #require(body["error"] as? String) == "trace_clear_receipt_failed")
+            #expect(try #require(body["store_cleared"] as? Bool) == false)
+            // The symlink was never followed: the victim keeps its content and
+            // the store is intact (fail-closed, no evidence destroyed).
+            #expect(try String(contentsOf: victim, encoding: .utf8) == "KEEP")
+            #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
+        }
+    }
+
+    @Test("a hardlink planted at the receipt file fails closed (st_nlink>1)")
+    func receiptFileHardlinkFailsClosed() async throws {
+        let root = tempRoot("loghardlink")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let victim = root.appendingPathComponent("victim.txt")
+        try Data("KEEP".utf8).write(to: victim)
+        // Plant a hardlink alias of the victim AT the receipt name (nlink==2).
+        try FileManager.default.linkItem(
+            at: victim, to: root.appendingPathComponent("trace-clear.log"))
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await withEnv(flagOn: true, auditRoot: root) {
+            await OperationTraceStore.shared.clear()
+            await seedTraces(2)
+
+            let result = await clearTraces()
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            #expect(try #require(result.isError))
+            #expect(try #require(body["state"] as? String) == "C")
+            #expect(try #require(body["store_cleared"] as? Bool) == false)
+            // The hardlink alias is refused, so the victim is never appended to.
+            #expect(try String(contentsOf: victim, encoding: .utf8) == "KEEP")
+            #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)
         }
     }
 }

--- a/Tests/LogicProMCPTests/TraceClearAuditTests.swift
+++ b/Tests/LogicProMCPTests/TraceClearAuditTests.swift
@@ -339,7 +339,8 @@ struct TraceClearAuditTests {
             #expect(try #require(result.isError))
             #expect(try #require(body["state"] as? String) == "C")
             #expect(try #require(body["error"] as? String) == "trace_clear_receipt_failed")
-            #expect(try #require(body["store_cleared"] as? Bool) == false)
+            let storeCleared = try #require(body["store_cleared"] as? Bool)
+            #expect(!storeCleared)
             // The symlink was never followed: the victim keeps its content and
             // the store is intact (fail-closed, no evidence destroyed).
             #expect(try String(contentsOf: victim, encoding: .utf8) == "KEEP")
@@ -365,7 +366,8 @@ struct TraceClearAuditTests {
             let body = try #require(sharedJSONObject(sharedToolText(result)))
             #expect(try #require(result.isError))
             #expect(try #require(body["state"] as? String) == "C")
-            #expect(try #require(body["store_cleared"] as? Bool) == false)
+            let storeCleared = try #require(body["store_cleared"] as? Bool)
+            #expect(!storeCleared)
             // The hardlink alias is refused, so the victim is never appended to.
             #expect(try String(contentsOf: victim, encoding: .utf8) == "KEEP")
             #expect(await OperationTraceStore.shared.recent(limit: 128).count == 2)


### PR DESCRIPTION
## Summary
Closes #417. Introduces `SecureFD`, a descriptor-relative secure filesystem primitive, and wires the trace-clear audit receipt onto it, replacing path-based file operations that a hostile path component (symlink, rebound inode, hardlink, mkdir→open swap-in) could divert. Support-bundle publish wiring follows on this branch next.

This branch lands in stages, each with its own negatives + full-suite evidence:
- **Stage 1 — the `SecureFD` primitive + its isolated test matrix** (below).
- **Stage 2 — trace-clear receipt wired onto `SecureFD`** (`SystemDispatcher.appendTraceClearAuditLine`): the audit directory chain is materialized with no-follow opens (`ensureDirectory`), the receipt is bound with a dual first-bind (exclusive create — switched to append before writing — else no-follow append) that refuses a symlink or hardlink at the name, and the line is `F_FULLFSYNC`'d (plus a parent-dir `fsync` on first create) before the trace store is drained. Removes the prior create-then-realpath-check-then-open-by-path (a check-after-use). Preserves the shipped `clear_traces` contract (receipt-before-drain, append-only, fail-closed State C). `TraceClearAuditTests`: the 8 shipped tests (symlink-audit-dir now exercises the no-follow walk) + 2 new receipt-file symlink/hardlink negatives = 10/10.
- **Stage 3 — support-bundle publish wiring** — to follow.

## Current head contents
- `Sources/LogicProMCP/Utilities/SecureFD.swift`
  - Single-component `openat(O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC)` walks from an explicitly trusted base descriptor — no path reassembly, no `realpath`.
  - Double-walk verification: per-component `(dev,ino)` must match across two independent walks, so a rebind between the passes is caught; callers can additionally pin an expected identity vector.
  - `createFile` (`O_CREAT|O_EXCL|O_NOFOLLOW` + regular-file + `st_nlink == 1`), `openAppend`/`openRead` (no-follow, non-blocking, regular-file, link-count 1), `makeEmptyDir` (mkdirat → no-follow open → must-be-empty), `fullfsync` (`F_FULLFSYNC`, fail-closed).
  - `teardownTree`: descriptor-relative recursive removal in which classification, every subdirectory open, every **file** unlink, and the final `AT_REMOVEDIR` are bound to the classified `(dev,ino)` — a rename-swapped real directory OR a victim file renamed onto a classified name (both invisible to `O_NOFOLLOW`) is refused with zero deletion; symlink children are unlinked as links, never followed. Each identity-bind→syscall pair carries the same irreducible 1-syscall residual.
  - Error-path correctness: `errno` is captured before any `close`/`closedir` that could overwrite it, and `readdir` results are disambiguated from errors via `errno` so an enumeration failure is never read as an empty directory.
  - Fail-closed identity: a failed `fstat` refuses the operation instead of yielding a zeroed identity that two failures could compare equal.
  - Explicit descriptor ownership on every success and error path: the first walk's fd is closed immediately after its identity vector is taken, and the recursive teardown owns each directory fd through a single deferred close. All internal duplication flows through one `F_DUPFD_CLOEXEC` primitive (plain `dup()` clears `FD_CLOEXEC` on the duplicate).
  - macOS has no `openat2(RESOLVE_BENEATH)`, so a ~1-syscall residual is irreducible; it is documented, never claimed away. `durableSuccess` in the outcome taxonomy is bounded to storage durability only.
- `Tests/LogicProMCPTests/SecureFDTests.swift` — 17 tests: guard-by-guard negatives (each fails if its guard is removed; the security-critical ones assert the specific `FDError` case, all others are narrowed to `FDError`), close-on-exec assertions on every returned descriptor (including the empty-relative duplicate and both trusted-base branches) and on the enumeration duplicates via a DEBUG observation seam, a slot-bound double-close canary (the probe claims the exact descriptor number the first walk released), a close-on-exec generation marker that catches a same-directory close-and-reopen of the caller's descriptor, an identity-read-failure fabrication negative, swapped-real-directory AND swapped-victim-file zero-delete negatives, and per-path repeated-error-path leak bounds (64+64 failures, each independently bounded below 8; min-of-5 sampled counts).

## Verification (current head)
- Focused suite: **17/17**.
- Mutation lanes, one at a time (guard removals AND bug injections): removing walk `O_NOFOLLOW`, the double-walk identity comparison, append `O_NOFOLLOW`, the first-walk descriptor close, the teardown deferred close, close-on-exec duplication, the read link-count guard, the fail-closed identity guard, the teardown subdirectory identity binding, or the teardown **file** identity binding — and injecting a residual error-path close or a same-slot close-and-reopen of the caller's descriptor — each turns its corresponding negative RED; sources restored byte-for-byte after each lane.
- Defensive hardening without a deterministic negative (disclosed, not mutation-claimed): the `readdir`-error-vs-empty disambiguation, the `errno`-before-`close` captures, and the final-rmdir ENOENT-vs-mismatch split are correctness/error-semantics fixes whose failure paths need syscall fault injection to exercise; they are code-only.
- Identity is `(dev,ino)` equality throughout, documented as assuming no inode-number reuse within an operation window (holds on APFS); `teardownTree` recursion depth follows the tree it is given (this primitive's staging trees are shallow).
- Full package suite is green under serial (`--no-parallel`, CI-equivalent) execution; the primitive's descriptor-lifecycle tests are process-global and require serial execution (they false-RED under cross-suite parallel fd churn, which CI's serial mode avoids).
- Release build passes; the DEBUG-only test seams (`_testBaseOverride`, `_testAfterPassAHook`) do not exist in release artifacts (symbol scan).
- LIVE: N/A — server-side filesystem hardening with no Logic-UI behavior surface; the observable contract is typed fail-closed refusals, covered by the deterministic negatives.
- Full-suite totals, wired call-site negatives, and release-artifact evidence accompany the wiring stages, not this stage.
