### PR TITLE
docs(#401): record ADR-002 .legacyIndexAllowed residual as issue-linked waiver

### DIFF
--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -430,13 +430,19 @@ enum OperationRegistry {
     /// Excluded: reversible param writes and state toggles (mixer.set_volume /
     /// set_pan, plugins.set_param_verified, tracks.select / rename / mute / solo
     /// / arm / arm_only / set_automation) — a wrong-target write there is
-    /// recoverable, so the ratchet's cost is not yet earned.
+    /// recoverable, so the ratchet's cost is not yet earned. This deliberate
+    /// `.legacyIndexAllowed` residual is the ADR-002 done-bar's recorded,
+    /// issue-linked waiver: it is tracked by #401 (not a silent gap), and each
+    /// member fails closed on a stale ref and echoes fingerprints. Promoting these
+    /// reversible ops to `.corroborated` would contradict this earned-cost rule;
+    /// the waiver, not promotion, is the honest classification.
     ///
     /// KNOWN RESIDUAL (next batch): `mixer.insert_plugin` is an index-keyed
     /// plugin insert that this tier CANNOT cover, because its `TargetPolicy` is
     /// `.none` — it accepts no `target_ref`, so `.corroborated`'s "or supply a
     /// target_ref" escape hatch would be unofferable. Ratcheting it requires
-    /// first making it target-bearing.
+    /// first making it target-bearing. Tracked as the recorded, issue-linked
+    /// waiver in #401 (ADR-002 done-bar) so the residual is a visible fact.
     static let corroboratedOperationIDs: Set<OperationID> = [
         .tracksDelete, .tracksDuplicate, .tracksSetInstrument, .pluginsInsertVerified,
     ]

--- a/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
@@ -90,7 +90,9 @@ struct IndexBindingCensusTests {
         // DEPRECATED TIER. Every member still writes to a bare, unproven
         // ordinal. Shrinking this list is the ratchet turning; it must never
         // grow. Each entry earns its place only by being reversible — a
-        // wrong-target write here is recoverable by the user.
+        // wrong-target write here is recoverable by the user. This pinned set is
+        // the ADR-002 done-bar's recorded, issue-linked waiver (#401): the
+        // residual is visible and enforced here, not a silent gap.
         let expectedLegacy: Set<OperationID> = [
             .mixerSetVolume,           // reversible level write
             .mixerSetPan,              // reversible pan write
@@ -111,8 +113,9 @@ struct IndexBindingCensusTests {
         // — it accepts no target_ref, so `.corroborated`'s "or supply target_ref"
         // escape hatch would be unofferable. Ratcheting it requires first making
         // it target-bearing. Asserted here so the gap is a tracked fact, not an
-        // oversight that reads as coverage. The FULL hazard class (this op plus
-        // its reversible sibling) is pinned by `unratchetedTrackKeyedHazardsArePinned`.
+        // oversight that reads as coverage — the recorded, issue-linked waiver is
+        // #401. The FULL hazard class (this op plus its reversible sibling) is
+        // pinned by `unratchetedTrackKeyedHazardsArePinned`.
         let insertPlugin = try #require(
             OperationRegistry.specs.first { $0.id == .mixerInsertPlugin }
         )


### PR DESCRIPTION
Follow-up to #285/#401 (ADR-002 done-bar bookkeeping — no production defect).

The PRD-007 index-binding ratchet deliberately leaves the reversible ops (mixer set_volume/set_pan, plugins.set_param_verified, tracks select/rename/mute/solo/arm/arm_only/set_automation) and the not-yet-target-bearing `mixer.insert_plugin` as `.legacyIndexAllowed`: a wrong-target write on a reversible op is recoverable, and `mixer.insert_plugin` accepts no `target_ref` so `.corroborated`'s escape hatch is unofferable. Promoting the reversible ops would contradict that earned-cost rule.

The ADR-002 done-bar requires this residual to be an **explicit issue-linked waiver** rather than a silent gap. This links the existing in-code rationale (`OperationRegistry`) and the `IndexBindingCensusTests` pin to #401.

**No behavior change** — doc-only. The ops already fail closed on a stale ref and echo fingerprints; the pinned `.legacyIndexAllowed` set is unchanged (`IndexBindingCensusTests` 14/14).

Closes #401

https://claude.ai/code/session_01721hJgvKNTYscDZPHu82bq