### PR TITLE
fix(#381,#405): locale-neutral plugin-editor + Drummer Smart Controls modal classifier

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -559,32 +559,18 @@ enum AXLocalePolicy {
         rationale: "Locates a plugin-slot open/list control by label; read-only locator (structural fallback exists)."
     )
 
-    /// #234: the "Compare" checkbox in a Logic plugin-EDITOR window. Combined
-    /// with `pluginBypassControl` and the window's `kAXCloseButtonAttribute`, it
-    /// forms the conjunctive chrome signature that classifies a plugin editor as
-    /// NON-blocking (so unrelated ops proceed while it is open). English
-    /// canonical only: the Korean/localized "Compare" label is UNVERIFIED
-    /// (OQ-1 — English UI is the only live-confirmed locale), so `variants` stays
-    /// empty and unverified locales conservatively remain BLOCKING (fail-closed)
-    /// rather than risk excluding a real modal.
-    static let pluginWindowCompareControl = LabelSet(
-        canonical: "compare",
+    /// #405: the "Smart Controls" toggle in a Drummer track's docked Smart Controls
+    /// pane. Combined with an AXDialog subrole and an empty window title it forms
+    /// the `isSmartControlsWindow` signature that classifies that pane as
+    /// NON-blocking (it is tagged AXDialog but, unlike a plugin editor, carries no
+    /// close-button attribute, so the plugin-editor signature never matched it).
+    /// English canonical only: the localized "Smart Controls" label is UNVERIFIED
+    /// (OQ-1), so `variants` stays empty and non-EN panes conservatively remain
+    /// BLOCKING (fail-closed) rather than risk excluding a real modal.
+    static let pluginWindowSmartControlsControl = LabelSet(
+        canonical: "smart controls",
         variants: [],
-        rationale: "Locates a plugin-editor window's Compare checkbox for the non-blocking chrome signature; English canonical only (OQ-1: Korean/localized unverified → unverified locales stay blocking, fail-closed). Read-only classifier."
-    )
-
-    /// #234: the channel-strip "Link" checkbox in a Logic plugin-EDITOR window.
-    /// Present from the moment the editor first opens — UNLIKE the Compare
-    /// checkbox, which only appears once the plugin has preset/edit state to
-    /// compare (live 12.3 Gain evidence 2026-07-05, `axwhy234.out`). Combined with
-    /// the bypass checkbox + close-button attribute it forms the alternative
-    /// chrome branch (compare OR link) that recognizes a freshly-inserted editor.
-    /// English canonical only; Korean/localized UNVERIFIED (OQ-1) → unverified
-    /// locales conservatively stay BLOCKING (fail-closed).
-    static let pluginWindowLinkControl = LabelSet(
-        canonical: "link",
-        variants: [],
-        rationale: "Locates a plugin-editor window's channel-strip Link checkbox for the non-blocking chrome signature (present from first open, unlike Compare); English canonical only (OQ-1 fail-closed). Read-only classifier."
+        rationale: "Locates the Smart Controls toggle in a Drummer track's docked Smart Controls pane for the non-blocking classifier; English canonical only (OQ-1: localized label unverified → non-EN panes stay blocking, fail-closed). Read-only classifier."
     )
 
     /// Automation-mode labels that must NOT be read as a plugin display name.

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -176,6 +176,7 @@ enum AXLogicProElements {
         guard isDialogWindow(window, runtime: runtime) else { return false }
         return !isKeyboardLayoutOverlayWindow(window, runtime: runtime)
             && !isPluginEditorWindow(window, runtime: runtime)
+            && !isSmartControlsWindow(window, runtime: runtime)
     }
 
     /// #234: Logic 12.3 tags plugin-EDITOR windows with subrole `AXDialog` and a
@@ -193,19 +194,32 @@ enum AXLogicProElements {
     ///      handle the live 2026-07-04 probe closed the editor through; true
     ///      modal sheets do not carry one. This is the ATTRIBUTE, never the
     ///      child button's localized `desc='close'` text (PRD D4);
-    ///   3. a bypass-labeled toggle among the DIRECT children;
-    ///   4. a compare-labeled OR link-labeled toggle among the DIRECT children.
+    ///   3. a bypass-labeled toggle among the DIRECT children.
     /// A "toggle" is an `AXCheckBox` OR an `AXButton` (any subrole): the editor's
     /// toggle chrome ROLE-FLAPS with window focus on 12.3 — checkbox when the
     /// editor is key, button when it is not (live evidence `axwhy234b.out`,
     /// 2026-07-05: same 'Audio 1' window dumped minutes apart; Logic exposes the
-    /// same toggle species as AXButton elsewhere, e.g. strip mute/solo). Compare
-    /// chrome is preset-state-dependent — absent on a freshly-inserted plugin —
-    /// while the channel-strip Link toggle is present from first open
-    /// (`axwhy234.out`); either satisfies conjunct 4, and a true modal carries
-    /// none of bypass/compare/link nor a close-button attribute. Follows the
-    /// `isKeyboardLayoutOverlayWindow` exclusion precedent; compare/link labels
-    /// are English-only (OQ-1) so non-EN locales stay blocking.
+    /// same toggle species as AXButton elsewhere, e.g. strip mute/solo).
+    ///
+    /// #381: a former conjunct 4 additionally required a compare- OR link-labeled
+    /// toggle whose labels were English-only (empty locale `variants`, OQ-1), so a
+    /// ko-KR (or any localized) plugin editor — which DOES carry a localized
+    /// bypass toggle (`바이패스`) and a close-button
+    /// attribute — failed conjunct 4 and was misclassified as BLOCKING, refusing
+    /// unrelated ops while the editor was open. Conjunct 4 is dropped; conjunct 3
+    /// is simultaneously TIGHTENED from substring to EXACT-field matching, because
+    /// a substring bypass match is NOT modal-exclusive: Logic's own Bounce-in-Place
+    /// dialog (reachable via `edit.bounce_in_place`) carries a "Bypass Effect
+    /// Plug-ins" checkbox whose text CONTAINS "bypass" (adversarial review, #381
+    /// B1). The editor's bypass toggle is labeled exactly `bypass`/`바이패스`
+    /// (live `axwhy234.out`/`axwhy234b.out`), while the bounce checkbox is a
+    /// longer phrase in every locale, so exact matching separates them without
+    /// relying on conjunct 2. Honesty note: the premise that genuine modals carry
+    /// no `kAXCloseButtonAttribute` is live-verified only for the #234 editor
+    /// dumps, NOT for every modal class — conjunct 2 is treated as a narrowing
+    /// guard, and the exact bypass label carries the discrimination. Unverified
+    /// locales still fail conjunct 3 → stay blocking (fail-closed). Follows the
+    /// `isKeyboardLayoutOverlayWindow` exclusion precedent.
     static func isPluginEditorWindow(
         _ window: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -219,22 +233,85 @@ enum AXLogicProElements {
         guard closeButton != nil else { return false }
 
         // Scan AXCheckBox AND AXButton toggles — the labeled chrome role-flaps
-        // with window focus (see doc comment). The close-button attribute conjunct
-        // already gates out true modal sheets (they carry no close button), so
-        // widening the toggle role cannot promote a real modal to an editor.
+        // with window focus (see doc comment).
         let directToggles = AXHelpers.getChildren(window, runtime: runtime).filter {
             let role = AXHelpers.getRole($0, runtime: runtime) ?? ""
             return role == (kAXCheckBoxRole as String) || role == (kAXButtonRole as String)
         }
-        let hasBypass = directToggles.contains { child in
-            AXLocalePolicy.pluginBypassControl.containsAny(in: elementSearchText(child, runtime: runtime))
+        return directToggles.contains { child in
+            hasExactLabel(child, matching: AXLocalePolicy.pluginBypassControl, runtime: runtime)
         }
-        let hasCompareOrLink = directToggles.contains { child in
-            let text = elementSearchText(child, runtime: runtime)
-            return AXLocalePolicy.pluginWindowCompareControl.containsAny(in: text)
-                || AXLocalePolicy.pluginWindowLinkControl.containsAny(in: text)
+    }
+
+    /// True when ANY single label field (identifier, description, title, help) of
+    /// `element` EXACTLY equals one of `labelSet`'s labels (trimmed,
+    /// case-insensitive). Deliberately NOT a substring test over the joined
+    /// `elementSearchText` aggregate: the non-blocking classifiers use this to
+    /// tell chrome toggles labeled exactly `bypass`/`Smart Controls` apart from
+    /// modal options that merely CONTAIN those words (e.g. the Bounce-in-Place
+    /// dialog's "Bypass Effect Plug-ins" checkbox — #381 adversarial review B1).
+    private static func hasExactLabel(
+        _ element: AXUIElement,
+        matching labelSet: AXLocalePolicy.LabelSet,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        [
+            AXHelpers.getIdentifier(element, runtime: runtime),
+            AXHelpers.getDescription(element, runtime: runtime),
+            AXHelpers.getTitle(element, runtime: runtime),
+            AXHelpers.getHelp(element, runtime: runtime)
+        ]
+        .contains { labelSet.matches($0, mode: .exact) }
+    }
+
+    /// #405: Logic 12 tags a Drummer track's "Smart Controls" pane with subrole
+    /// `AXDialog` but — UNLIKE a plugin editor — WITHOUT a `kAXCloseButtonAttribute`
+    /// (it is docked, not a floating editor), so `isPluginEditorWindow` (which
+    /// requires the close-button, conjunct 2) never recognized it and it fell
+    /// through to BLOCKING, refusing unrelated ops while the pane was open
+    /// (live en-US evidence 2026-07: title `""`, subrole `AXDialog`, direct
+    /// children include `Pad Controls`/`Kit Controls` buttons and a `Smart
+    /// Controls` toggle, no close button).
+    ///
+    /// Recognized CONJUNCTIVELY, fail-closed on any missing conjunct:
+    ///   1. subrole `AXDialog`;
+    ///   2. an EMPTY window title — a NARROWING guard only, NOT the modal
+    ///      discriminator: NSAlert-style confirmation dialogs (unsaved-changes,
+    ///      delete, overwrite) commonly have an empty `AXTitle` too (their
+    ///      headline is an `AXStaticText` child), so an empty title does NOT
+    ///      separate a real alert from this pane. It only keeps TITLED windows
+    ///      out of this branch;
+    ///   3. a toggle among the DIRECT children (checkbox OR button, matching the
+    ///      editor role-flap precedent) whose SINGLE label field EXACTLY equals
+    ///      `Smart Controls` — this is the SOLE discriminator. Exact-field
+    ///      matching (never substring over the joined search text) keeps a
+    ///      button that merely mentions the phrase in a longer label or tooltip
+    ///      from matching.
+    /// The label is English-only (`pluginWindowSmartControlsControl` has empty
+    /// `variants`, OQ-1 — the localized string is unverified), so a non-EN DMD
+    /// pane fails conjunct 3 and conservatively STAYS blocking (fail-closed),
+    /// mirroring the bypass-label OQ-1 posture. No known modal carries a control
+    /// labeled exactly `Smart Controls`, and a titled one is excluded by
+    /// conjunct 2 regardless.
+    static func isSmartControlsWindow(
+        _ window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let subrole: String? = AXHelpers.getAttribute(window, kAXSubroleAttribute, runtime: runtime)
+        guard subrole == (kAXDialogSubrole as String) else { return false }
+
+        let title: String = AXHelpers.getAttribute(window, kAXTitleAttribute, runtime: runtime) ?? ""
+        guard title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+
+        let directToggles = AXHelpers.getChildren(window, runtime: runtime).filter {
+            let role = AXHelpers.getRole($0, runtime: runtime) ?? ""
+            return role == (kAXCheckBoxRole as String) || role == (kAXButtonRole as String)
         }
-        return hasBypass && hasCompareOrLink
+        return directToggles.contains { child in
+            hasExactLabel(
+                child, matching: AXLocalePolicy.pluginWindowSmartControlsControl, runtime: runtime
+            )
+        }
     }
 
     private static func isKeyboardLayoutOverlayWindow(

--- a/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
@@ -230,14 +230,25 @@ import Testing
 /// track name), which tripped the v3.7.2 modal guard on unrelated ops. A plugin
 /// editor is distinguished from a true modal by Logic's own chrome — the window
 /// exposes `kAXCloseButtonAttribute` plus, among its direct children, a
-/// bypass-labeled `AXCheckBox` AND a compare-OR-link-labeled `AXCheckBox`. This
-/// "Deluxe" shape (bypass + compare) transcribes the live 12.3 dump
+/// bypass-labeled toggle (`AXCheckBox` OR `AXButton`).
+///
+/// #381 narrowed the signature: a former conjunct additionally required a
+/// compare- OR link-labeled toggle, but those labels were English-only, so a
+/// localized (ko-KR) editor — bypass + close-button present — was misclassified
+/// as blocking. The compare/link conjunct was dropped and the bypass conjunct
+/// simultaneously TIGHTENED from substring to exact-field matching, because a
+/// substring match is NOT modal-exclusive: the Bounce-in-Place dialog carries a
+/// "Bypass Effect Plug-ins" checkbox whose text contains "bypass" (adversarial
+/// review B1; pinned below by the bounce-dialog tests). These builders still
+/// BUILD compare/link children (now ignored by the classifier) to keep
+/// transcribing the live 12.3 dumps.
+///
+/// `buildPluginEditorWindow` transcribes the "Deluxe" live 12.3 dump
 /// (`axdialog234.out` / PRD Appendix A); `buildFreshGainEditorWindow` models the
-/// freshly-inserted shape (bypass + link, no compare — `axwhy234.out`). The
-/// `include*` / `chromeRole` knobs let the fail-closed partial-chrome cases strip
-/// one conjunct at a time. The close-button is set as the ATTRIBUTE (locale-
-/// neutral, the exact handle the live probe closed the editor through), never as
-/// a `desc='close'` child.
+/// freshly-inserted shape (`axwhy234.out`). The `include*` / `chromeRole` knobs
+/// let the fail-closed partial-chrome cases strip one conjunct at a time. The
+/// close-button is set as the ATTRIBUTE (locale-neutral, the exact handle the
+/// live probe closed the editor through), never as a `desc='close'` child.
 private func buildPluginEditorWindow(
     _ builder: FakeAXRuntimeBuilder,
     base: Int,
@@ -419,16 +430,6 @@ struct PartialChromeVariant: Sendable {
 }
 
 @Test(arguments: [
-    // bypass present (checkbox) but NEITHER compare NOR link → chrome branch unmet.
-    PartialChromeVariant(
-        includeBypass: true, includeCompare: false, includeLink: false, includeClose: true,
-        chromeRole: kAXCheckBoxRole as String, name: "bypass checkbox without companion"
-    ),
-    // same, bypass as a BUTTON — the pin must hold in either toggle role form.
-    PartialChromeVariant(
-        includeBypass: true, includeCompare: false, includeLink: false, includeClose: true,
-        chromeRole: kAXButtonRole as String, name: "bypass button without companion"
-    ),
     // link (button) but no bypass → bypass conjunct unmet.
     PartialChromeVariant(
         includeBypass: false, includeCompare: false, includeLink: true, includeClose: true,
@@ -546,4 +547,261 @@ func testPartialChromeStaysBlocking(_ variant: PartialChromeVariant) {
     #expect(resolved.title == "Save")
     #expect(resolved.buttonTitles.contains("Cancel"))
     #expect(resolved.buttonTitles.contains("Save"))
+}
+
+// MARK: - #381 localized plugin editor (compare/link conjunct dropped)
+
+/// #381: a ko-KR plugin editor carries a localized bypass toggle (`바이패스`) and a
+/// close-button attribute but NO English compare/link toggle. Pre-fix the
+/// compare-OR-link conjunct was unmet → the editor was misclassified as a
+/// blocking modal and unrelated ops (project.save, track.select) were refused
+/// while it was open. Post-fix the bypass + close-button signature recognizes it
+/// as an editor → non-blocking on BOTH public surfaces. FAILS pre-fix.
+@Test func testKoLocalizedPluginEditorIsNonBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let window = builder.element(100)
+    let closeButton = builder.element(101)
+    let bypass = builder.element(102)
+    let bodySlider = builder.element(103)
+
+    builder.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "오디오 1")
+    builder.setAttribute(closeButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(window, kAXCloseButtonAttribute as String, closeButton)
+    // Localized bypass toggle — the only chrome label present in a ko editor.
+    builder.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(bypass, kAXTitleAttribute as String, "바이패스")
+    builder.setAttribute(bodySlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setChildren(window, [bypass, bodySlider])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(!AXLogicProElements.dialogPresent(runtime: runtime))
+    #expect(AXLogicProElements.blockingDialogInfo(runtime: runtime) == nil)
+}
+
+/// #381 safety: an AXDialog exposing a close-button attribute but NO bypass toggle
+/// (a real sheet that happens to carry a close box) still fails the editor
+/// signature → stays blocking. The bypass toggle, not the close-button alone,
+/// carries the editor identity. Passes pre- and post-fix.
+@Test func testCloseButtonWithoutBypassStaysBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let window = builder.element(100)
+    let closeButton = builder.element(101)
+    let okButton = builder.element(102)
+
+    builder.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "Confirm")
+    builder.setAttribute(closeButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(window, kAXCloseButtonAttribute as String, closeButton)
+    builder.setAttribute(okButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(okButton, kAXTitleAttribute as String, "OK")
+    builder.setChildren(window, [okButton])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
+}
+
+/// #381 adversarial-review B1 pin: Logic's Bounce-in-Place dialog (reachable via
+/// `edit.bounce_in_place`) is a GENUINE mutating modal that carries a "Bypass
+/// Effect Plug-ins" checkbox — its text CONTAINS "bypass", so a SUBSTRING bypass
+/// conjunct would classify it as a plugin editor whenever it also exposes a
+/// close-button attribute (modeled here as the adversarial worst case; the
+/// attribute's absence on real modals is live-unverified). The exact-field
+/// matcher rejects the longer phrase → the dialog stays BLOCKING. FAILS on a
+/// substring implementation.
+@Test func testBounceInPlaceDialogWithBypassOptionStaysBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let dialog = builder.element(100)
+    let closeButton = builder.element(101)
+    let bypassOption = builder.element(102)
+    let okButton = builder.element(103)
+    let cancelButton = builder.element(104)
+
+    builder.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(dialog, kAXTitleAttribute as String, "Bounce Regions in Place")
+    builder.setAttribute(closeButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(dialog, kAXCloseButtonAttribute as String, closeButton)
+    builder.setAttribute(bypassOption, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(bypassOption, kAXTitleAttribute as String, "Bypass Effect Plug-ins")
+    builder.setAttribute(okButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(okButton, kAXTitleAttribute as String, "OK")
+    builder.setAttribute(cancelButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(cancelButton, kAXTitleAttribute as String, "Cancel")
+    builder.setChildren(dialog, [bypassOption, okButton, cancelButton])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [dialog, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
+}
+
+/// #381 B1 pin, ko locale: the localized bounce dialog's checkbox is a longer
+/// phrase CONTAINING `바이패스` — a substring match on the ko variant would
+/// misclassify it exactly like the EN case. Exact-field matching keeps it
+/// BLOCKING. FAILS on a substring implementation.
+@Test func testKoBounceInPlaceDialogStaysBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let dialog = builder.element(100)
+    let closeButton = builder.element(101)
+    let bypassOption = builder.element(102)
+    let confirmButton = builder.element(103)
+
+    builder.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(dialog, kAXTitleAttribute as String, "리전을 제자리에 바운스")
+    builder.setAttribute(closeButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(dialog, kAXCloseButtonAttribute as String, closeButton)
+    builder.setAttribute(bypassOption, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(bypassOption, kAXTitleAttribute as String, "이펙트 플러그인 바이패스")
+    builder.setAttribute(confirmButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(confirmButton, kAXTitleAttribute as String, "바운스")
+    builder.setChildren(dialog, [bypassOption, confirmButton])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [dialog, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
+}
+
+// MARK: - #381 T5 verified-parameter-write gate (pluginWindowMatch)
+
+/// #381 M2: `pluginWindowMatch` (the T5 verified param-write gate) is the second
+/// consumer of `isPluginEditorWindow`. The narrowed signature must let a
+/// localized bypass-only editor through that gate too — a ko editor with the
+/// right track-name title and a unique slider must resolve `.unique`, so the
+/// localized verified-write path works. FAILS pre-fix (the editor fails the old
+/// compare/link conjunct → never considered).
+@Test func testPluginWindowMatchRecognizesLocalizedBypassOnlyEditor() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let editor = builder.element(100)
+    let closeButton = builder.element(101)
+    let bypass = builder.element(102)
+    let gainSlider = builder.element(103)
+
+    builder.setAttribute(editor, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(editor, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(editor, kAXTitleAttribute as String, "오디오 1")
+    builder.setAttribute(closeButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(editor, kAXCloseButtonAttribute as String, closeButton)
+    builder.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(bypass, kAXTitleAttribute as String, "바이패스")
+    builder.setAttribute(gainSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(gainSlider, kAXDescriptionAttribute as String, "Gain")
+    builder.setChildren(editor, [bypass, gainSlider])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [editor, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    let match = AXLogicProElements.pluginWindowMatch(
+        forTrackName: "오디오 1",
+        matchingSliderDescription: "Gain",
+        runtime: runtime
+    )
+    guard case .unique(let window) = match else {
+        Issue.record("expected .unique, got \(match)")
+        return
+    }
+    #expect(window == editor)
+}
+
+// MARK: - #405 Drummer Smart Controls docked pane
+
+/// #405: a Drummer track's docked Smart Controls pane is tagged `AXDialog` with an
+/// EMPTY title and NO close-button attribute (it is docked, not a floating
+/// editor), so `isPluginEditorWindow` never recognized it and it fell through to
+/// BLOCKING — refusing unrelated ops while the pane was open. The dedicated
+/// Smart-Controls signature (AXDialog + empty title + a `Smart Controls` toggle)
+/// classifies it as non-blocking on BOTH public surfaces. FAILS pre-fix.
+private func buildSmartControlsPane(_ builder: FakeAXRuntimeBuilder, base: Int) -> AXUIElement {
+    let window = builder.element(base)
+    let padControls = builder.element(base + 1)
+    let kitControls = builder.element(base + 2)
+    let smartControls = builder.element(base + 3)
+    let bodyGroup = builder.element(base + 4)
+
+    builder.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "")
+    builder.setAttribute(padControls, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(padControls, kAXTitleAttribute as String, "Pad Controls")
+    builder.setAttribute(kitControls, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(kitControls, kAXTitleAttribute as String, "Kit Controls")
+    builder.setAttribute(smartControls, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(smartControls, kAXTitleAttribute as String, "Smart Controls")
+    builder.setAttribute(bodyGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setChildren(window, [padControls, kitControls, smartControls, bodyGroup])
+    return window
+}
+
+@Test func testDmdSmartControlsPaneIsNonBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let pane = buildSmartControlsPane(builder, base: 100)
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [pane, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(!AXLogicProElements.dialogPresent(runtime: runtime))
+    #expect(AXLogicProElements.blockingDialogInfo(runtime: runtime) == nil)
+}
+
+/// #405 safety: the Smart-Controls exclusion requires an EMPTY title. A titled
+/// AXDialog that happens to contain a `Smart Controls`-labeled toggle (a
+/// hypothetical modal) still fails the empty-title conjunct → stays blocking, so
+/// the recognizer cannot be tricked into excluding a titled modal.
+@Test func testTitledDialogWithSmartControlsLabelStaysBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let window = builder.element(100)
+    let smartControls = builder.element(101)
+
+    builder.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "Delete Track?")
+    builder.setAttribute(smartControls, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(smartControls, kAXTitleAttribute as String, "Smart Controls")
+    builder.setChildren(window, [smartControls])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
+}
+
+/// #405 safety: an empty-title AXDialog WITHOUT a Smart-Controls toggle (a
+/// title-less alert) is not a Smart Controls pane → stays blocking. The
+/// Smart-Controls label, not the empty title alone, carries the exclusion.
+@Test func testTitlelessDialogWithoutSmartControlsStaysBlocking() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let arrange = builder.element(2)
+    let window = builder.element(100)
+    let okButton = builder.element(101)
+    let cancelButton = builder.element(102)
+
+    builder.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, "")
+    builder.setAttribute(okButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(okButton, kAXTitleAttribute as String, "OK")
+    builder.setAttribute(cancelButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(cancelButton, kAXTitleAttribute as String, "Cancel")
+    builder.setChildren(window, [okButton, cancelButton])
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window, arrange])
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.dialogPresent(runtime: runtime))
 }

--- a/docs/tickets/issue-234/T3-plugin-editor-dialog-classification.md
+++ b/docs/tickets/issue-234/T3-plugin-editor-dialog-classification.md
@@ -1,5 +1,10 @@
 # T3: Plugin-Editor Window ≠ Blocking Modal (Distinct Classification)
 
+> **Historical (superseded by #381):** the compare/link conjunct described below
+> was English-only and misclassified localized editors as blocking; #381 dropped
+> it and tightened the bypass conjunct to exact-field matching. See
+> `isPluginEditorWindow` in `AXLogicProElements.swift` for the current signature.
+
 **PRD Ref**: PRD-issue-234-mixer-strip-selection-12-3 > US-4 (AC-4.1~4.5), D4/D7
 **Priority**: P1 (High)
 **Size**: M (2-4h)


### PR DESCRIPTION
## Summary
- **#381** — a localized (ko-KR) plugin editor was misclassified as a blocking modal (unrelated ops refused while it was open). Root cause: the editor signature's 4th conjunct required an English-only compare/link-labeled toggle. That conjunct is dropped, and the bypass conjunct is simultaneously **tightened from substring to single-field exact matching**: adversarial review showed a substring match is not modal-exclusive (the Bounce-in-Place dialog's "Bypass Effect Plug-ins" checkbox contains "bypass"). The editor's toggle is labeled exactly `bypass`/`바이패스` in the live #234 dumps, so exact matching separates editor from modal structurally instead of relying on the unverified premise that modals never expose `kAXCloseButtonAttribute`. Two now-unused LabelSets removed.
- **#405** — a Drummer track's docked Smart Controls pane (AXDialog, empty title, **no** close-button attribute) fell through to BLOCKING. A dedicated `isSmartControlsWindow` recognizer (AXDialog + empty title as a narrowing guard + a toggle labeled exactly `Smart Controls` as the sole discriminator, English-only fail-closed) excludes it.
- Both fixes route through `dialogPresent`/`isBlockingDialogWindow`, so all consumers (dispatcher modal guards, StatePoller cache lifecycle, ProjectExportExecutor) see them consistently; the second `isPluginEditorWindow` consumer (`pluginWindowMatch`, the verified-parameter-write gate) now recognizes a localized bypass-only editor and has a dedicated test.

## Safety invariant (genuine modals stay blocking)
- Bounce-in-Place pins in EN **and** ko, modeled with the close-button attribute **present** (adversarial worst case) — mutation-proven: reverting the matcher to substring makes exactly those two tests fail.
- `Save` sheet, `AXSystemDialog`, close-button-without-bypass, titled-dialog-with-Smart-Controls-label, and empty-title-alert-without-the-label all pinned blocking.
- Partial-chrome fail-closed variants retained for every remaining conjunct.

## Testing
- Focused classifier suite 16/16 green; full serial suite **3169/3169** green; release build clean.
- Live re-verification (ko editor / real Drummer pane / live bounce dialog) could not be performed on this host — only the arrange window was open with an unsaved project, so driving the live UI was declined; recorded honestly rather than claimed. A read-only AX probe confirmed a standard window also exposes the close-button attribute, reinforcing that the attribute is a narrowing guard, never the discriminator.

Closes #381
Closes #405