### PR TITLE
fix(#415): pin arm-verify two-transition causality; align VerifyResult docs

### DIFF
--- a/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
+++ b/Sources/LogicProMCP/Accessibility/ArmKeyCommandSetup.swift
@@ -176,9 +176,10 @@ enum ArmKeyCommandSetup {
 
     /// Typed outcome of the functional arm-flip verification, so a partially
     /// mutated host is never treated the same as a cleanly unmapped one. From
-    /// verify-first, only `.unmapped` and `.environmentUnavailable` fall through to
-    /// the GUI assignment; `.partialRestore` and `.couldNotPost` fail closed (never
-    /// pile GUI mutations onto a dirty/undrivable host).
+    /// verify-first, only a clean `.unmapped` falls through to the GUI
+    /// assignment; `.partialRestore`, `.couldNotPost`, AND `.environmentUnavailable`
+    /// all fail closed (never pile GUI mutations onto a dirty/undrivable host, and
+    /// never run a GUI assignment that could not be functionally verified). (#415)
     enum VerifyResult: Equatable {
         /// The chord flipped record-enable AND every mutation was restored.
         case verified
@@ -192,8 +193,10 @@ enum ArmKeyCommandSetup {
         /// The verification chord could not be posted at all (e.g. focus/selection
         /// gates never let a key land) — distinct from "posted, no flip".
         case couldNotPost
-        /// The environment could not be captured/tested (e.g. no selectable track);
-        /// nothing was mutated, so verify-first may still try the GUI assignment.
+        /// The environment could not be captured/tested (e.g. no selectable track).
+        /// Nothing was mutated, but a GUI assignment could not be functionally
+        /// verified either — verify-first fails closed WITHOUT opening the Key
+        /// Commands GUI (`verify_environment_unavailable`). (#415)
         case environmentUnavailable
     }
 
@@ -322,9 +325,10 @@ enum ArmKeyCommandSetup {
 
         // Verify-first idempotent fast path: before touching the Key Commands GUI,
         // drive a real arm with the captured chord. Only a clean `.verified` short-
-        // circuits to State A; `.unmapped`/`.environmentUnavailable` fall through to
-        // the GUI path; a partial restore or a post failure fails closed (never
-        // pile GUI mutations onto a host we already left dirty or could not drive).
+        // circuits to State A and only a clean `.unmapped` falls through to the GUI
+        // path; every other outcome — `.environmentUnavailable` included — fails
+        // closed (never pile GUI mutations onto a host we already left dirty,
+        // could not drive, or could not functionally verify against). (#415)
         evidence.verificationMutationAttempted = true
         switch runtime.verifyArmFlip(keyCode, modifiers) {
         case .verified:

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -463,6 +463,24 @@ extension AccessibilityChannel {
     /// from a PARTIAL restore (a flip or restore failed, host left dirty — must
     /// fail closed), a POST failure, and an unavailable environment, so a partially
     /// mutated host never receives further mutations.
+    /// Functional arm-chord verification: flip record-enable with ONLY the chord,
+    /// then restore it with the SAME chord, observing both transitions by AX
+    /// read-back.
+    ///
+    /// #415 verify-causality: `.verified` requires TWO opposite chord-correlated
+    /// transitions — the flip leg AND the restore leg — each gated by an
+    /// arm-not-yet-at-target read immediately before a SUCCESSFUL post (see
+    /// `postArmChordAndObserveFlip`). The restore leg IS the "second confirming
+    /// flip" #415 asked to consider: a SINGLE external record-enable change
+    /// landing inside one observation window (or a settle gap) can at most
+    /// satisfy one leg, so with an unmapped chord it degrades to
+    /// `.partialRestore` (fail-closed — never GUI assignment, never a false
+    /// `.verified`); before any post it is never credited at all. The residual
+    /// is DOUBLE external interference — two opposite flips, each landing inside
+    /// its own ≤3×600ms window, mimicking both legs — which is observationally
+    /// indistinguishable from the chord by AX read-back and is accepted as
+    /// irreducible for this surface (a stricter single-attempt window would not
+    /// remove it and costs live reliability against slow CGEvent delivery).
     static func armSetupVerify(
         keyCode: CGKeyCode,
         modifiers: CGEventFlags,

--- a/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
+++ b/Tests/LogicProMCPTests/CoordFreeTrackToggleTests.swift
@@ -609,6 +609,85 @@ struct CoordFreeTrackToggleTests {
         #expect(result == .couldNotPost)
     }
 
+    /// #415 verify-causality: an external record-enable change landing INSIDE the
+    /// post-observation window of a genuine (successful) post can be credited as
+    /// the chord's late flip by the FLIP leg alone — but end-to-end `.verified`
+    /// additionally requires the RESTORE leg to observe a second, opposite,
+    /// chord-correlated transition. With an unmapped chord the restore leg posts
+    /// and observes nothing, so a SINGLE external interference degrades to
+    /// `.partialRestore` (fail-closed; never proceeds to GUI assignment), never a
+    /// false `.verified`. This pins the two-transition requirement: it FAILS if
+    /// `.verified` is ever weakened to credit the flip leg alone.
+    @Test("#415 arm-setup verify: external flip inside the observe window of an unmapped chord → .partialRestore, never .verified")
+    func armSetupVerifySingleExternalFlipInObserveWindowIsNeverVerified() throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        let key = KeyMouseRecorder()
+        // The chord is UNMAPPED. An external agent flips arm to the target right
+        // after the FIRST successful post (indistinguishable, to observation, from
+        // a late chord flip). It never flips back, so the restore leg — the second
+        // confirming transition — cannot be satisfied by the unmapped chord.
+        final class OneShot: @unchecked Sendable { var fired = false }
+        let external = OneShot()
+        key.onFlaggedKey = { code, _ in
+            guard code == 14, !external.fired else { return }
+            external.fired = true
+            f.builder.setAttribute(arm, kAXValueAttribute as String, 1)
+        }
+        let (logic, keyRuntime, proc) = armVerifyRuntimes(f, key: key)
+        let result = AccessibilityChannel.armSetupVerify(
+            keyCode: 14, modifiers: [.maskControl, .maskShift],
+            runtime: logic, keyRuntime: keyRuntime, processRuntime: proc
+        )
+        #expect(result != .verified)
+        guard case .partialRestore = result else {
+            Issue.record("expected .partialRestore, got \(result)")
+            return
+        }
+    }
+
+    /// #415 verify-causality: the settle-gap variant. The first successful post of
+    /// an unmapped chord observes no flip; the external change lands in the SETTLE
+    /// gap between attempts, so the next attempt's late-publish (double-toggle)
+    /// guard credits the flip leg. The restore leg still observes no chord-caused
+    /// transition → `.partialRestore`, never `.verified`.
+    @Test("#415 arm-setup verify: external flip in the settle gap (late-publish credit) → .partialRestore, never .verified")
+    func armSetupVerifySettleGapExternalFlipIsNeverVerified() throws {
+        let f = makeToggleFixture()
+        let arm = f.arm[0]
+        let key = KeyMouseRecorder()   // unmapped: posts succeed, chord moves nothing
+        // Fire the external flip on the SETTLE sleep (200_000µs) — after the first
+        // observation window expired, before the next attempt's loop-top guard.
+        final class OneShot: @unchecked Sendable { var fired = false }
+        let external = OneShot()
+        let keyRuntime = AXMouseHelper.Runtime(
+            postMouseEvent: { _, _, _ in true },
+            postKeyEvent: { _ in true },
+            postUnicodeScalar: { _ in false },
+            sleepMicros: { us in
+                guard us == AccessibilityChannel.syntheticKeyRetrySettleMicros, !external.fired else { return }
+                external.fired = true
+                f.builder.setAttribute(arm, kAXValueAttribute as String, 1)
+            },
+            postFlaggedKeyEvent: { code, _ in
+                key.flaggedKeyEvents.append((code, [.maskControl, .maskShift]))
+                return true
+            }
+        )
+        let logic = f.builder.makeLogicRuntime(
+            appElement: f.app, setAttributeHandler: nil, performActionHandler: nil
+        )
+        let result = AccessibilityChannel.armSetupVerify(
+            keyCode: 14, modifiers: [.maskControl, .maskShift],
+            runtime: logic, keyRuntime: keyRuntime, processRuntime: noopProcessRuntime()
+        )
+        #expect(result != .verified)
+        guard case .partialRestore = result else {
+            Issue.record("expected .partialRestore, got \(result)")
+            return
+        }
+    }
+
     /// Deadline safety (#413): if the flip post happened and the command deadline
     /// then fires, the restore chord is NOT posted (no new key after the deadline);
     /// the verifier reports honestly (partial restore), never a clean State A.


### PR DESCRIPTION
## Summary
Closes the #413 follow-up #415 (both items).

**Item 1 — verify-causality:** analysis shows the correlation #415 asked to consider ("a second confirming flip") is already the shipped design: `.verified` requires the flip leg AND the restore leg — two opposite chord-correlated transitions, each gated by an arm-not-yet-at-target read immediately before a successful post. A single external record-enable change (inside one observation window or a settle gap) satisfies at most one leg, so with an unmapped chord it degrades to `.partialRestore` (fail-closed, never GUI assignment), and before any post it is never credited. That invariant was undocumented and unpinned: this adds the causality doc to `armSetupVerify` (including the honestly accepted irreducible residual — double opposite external interference, one inside each leg's window, is observationally indistinguishable by AX read-back) and two regression tests covering exactly the scenarios the issue raised (observe-window flip; settle-gap flip via the late-publish credit). Mutation-proven: weakening `.verified` to flip-leg-only makes exactly those two tests fail. A stricter single-attempt window was considered and rejected (does not remove the double-interference residual; costs live reliability against slow synthetic-key delivery).

**Item 2 — doc alignment (3 sub-items):** two were already aligned (definitive `AXFocused == true` header wording; `restored`/`verify_restored` split). The third had drifted opposite to the issue's snapshot: the code now fails closed on `.environmentUnavailable` (`verify_environment_unavailable`, no Key Commands GUI), but three doc sites still claimed it falls through to GUI assignment. Those three are aligned to the code (behavior unchanged; an existing regression test already pins the fail-closed path).

Production-code changes are doc comments only; the behavioral surface of this PR is the two new tests.

## Testing
- Focused arm-verify suite 10/10 green; mutation run: flip-leg-only weakening fails exactly the 2 new pins.
- Full serial suite: 3168/3171 with the ONLY failure being the live-coupled `realReleaseBinaryExecutesEveryOperationWithIndependentReadback` (release-binary × live Logic qualification QA). That test executed and PASSED twice earlier today against a binary built from tree content identical to main; it now fails repeatably with the same binary, tracking live Logic session drift, not this diff (the Sources diff is comment-only, mechanically verified). CI does not run live-coupled tests.