### PR TITLE
refactor: remove region.select_last coordinate-click fallback (fail closed)

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -248,12 +248,11 @@ enum AXHelpers {
     /// value (e.g. from `AXUIElementCopyAttributeValue`). Verifies BOTH that it
     /// is an AXValue AND that the `.cgPoint` extraction succeeds, returning nil
     /// (fail-closed) on a non-AXValue or a wrong-subtype AXValue (e.g. a
-    /// `.cgRect` AXValue). Hoists the `AXValueGetValue` Bool check out of four
-    /// coord-click call sites (`AccessibilityChannel.postMouseClickAt` /
-    /// `.trackViewport`, `AXLogicProElements` track-header click,
-    /// `LibraryAccessor` header click) that previously ignored it and would
-    /// fall back to a (0,0) misclick / bogus viewport on drift or a malformed
-    /// test double.
+    /// `.cgRect` AXValue). Originally hoisted the `AXValueGetValue` Bool check
+    /// out of coordinate-click call sites that ignored it and would fall back
+    /// to a (0,0) misclick on drift; those callers have since been removed by
+    /// the coordinate-free campaign, and the remaining consumers use this for
+    /// fail-closed position READS.
     static func point(fromRawAttribute raw: AnyObject?) -> CGPoint? {
         guard let raw, CFGetTypeID(raw) == AXValueGetTypeID() else { return nil }
         // swiftlint:disable:next force_cast — guarded by CFGetTypeID above.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -439,18 +439,15 @@ extension AccessibilityChannel {
                 if target is missing value then
                     return "NO_REGION"
                 end if
-                -- Use AXPress / AXShowMenu may open contextual menu; instead set AXSelected
+                -- Use AXPress / AXShowMenu may open contextual menu; instead set AXSelected.
+                -- No coordinate fallback: a failed AXSelected write returns a typed
+                -- marker and the handler fails closed (coordinate-free policy — the
+                -- former `click at {center}` fallback was removed with the campaign).
                 try
                     set selected of target to true
                     return "SELECTED"
                 on error
-                    -- Fallback: click at center
-                    set p to position of target
-                    set s to size of target
-                    set cx to (item 1 of p) + ((item 1 of s) / 2)
-                    set cy to (item 2 of p) + ((item 2 of s) / 2)
-                    click at {cx, cy}
-                    return "CLICKED"
+                    return "SELECT_FAILED"
                 end try
             end tell
         end tell
@@ -462,6 +459,15 @@ extension AccessibilityChannel {
                 return .error(HonestContract.encodeStateC(
                     error: .elementNotFound,
                     hint: "region.select_last: no region found in arrange area"
+                ))
+            }
+            if output.contains("SELECT_FAILED") {
+                // The target region was found but its AXSelected write failed.
+                // Fail closed — no coordinate fallback is attempted.
+                return .error(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: "region.select_last: the target region's AXSelected attribute could not be "
+                        + "written; no fallback was attempted"
                 ))
             }
             // Settle window so Logic's AX tree reflects the new selection

--- a/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
@@ -298,6 +298,37 @@ private func makeRegionFixture(
     #expect(obj["selected_start_bar"] as? Int == 5)
 }
 
+@Test func testSelectLastFailsClosedWhenAXSelectedWriteFails() async {
+    // Order-7 coordinate-free campaign: the former `click at {center}` fallback
+    // after a failed AXSelected write was REMOVED. A SELECT_FAILED marker from
+    // the script must fail closed (State C ax_write_failed) with no fallback —
+    // never a fabricated success.
+    let regionAHelp = "리전은 1 마디 에서 시작하여 3 마디 에서 끝납니다., MIDI 리전."
+
+    let fixture = makeRegionFixture(
+        headers: [(axPoint(0, 100), axSize(200, 40))],
+        regions: [
+            (name: "RegionA", help: regionAHelp,
+             pos: axPoint(100, 108), size: axSize(160, 24), selected: false)
+        ],
+        playheadPosition: "1.1.1.1"
+    )
+
+    let result = await AccessibilityChannel.defaultSelectLastRegion(
+        runtime: fixture.runtime,
+        executeScript: { _ in .success("SELECT_FAILED") },
+        settle: { }
+    )
+
+    #expect(!result.isSuccess)
+    let obj = decodeJSON(result.message)
+    let success = (obj["success"] as? Bool)!
+    #expect(!success)
+    #expect(obj["error"] as? String == "ax_write_failed")
+    let hint = obj["hint"] as? String ?? ""
+    #expect(hint.contains("no fallback"))
+}
+
 @Test func testSelectLastReturnsStateBOnMismatch() async {
     // AppleScript flips selection on the WRONG region (RegionA / bar 1)
     // even though "last" is RegionB / bar 5 → State B readback_mismatch.


### PR DESCRIPTION
## Summary
Coordinate-free campaign, step (a) of the residual-census closure: removes the last AppleScript `click at {x, y}` in the production tree — the `region.select_last` fallback that clicked a heuristic-located region's center when the `AXSelected` write threw. A failed write now returns a typed `SELECT_FAILED` marker and the handler fails closed (State C `ax_write_failed`, "no fallback was attempted"); the success path and its independent read-back verification (selected-vs-last identity, State A/B) are unchanged.

Why this is safe (independently reviewed):
- The operation is orphaned in production: it has no OperationRegistry spec and no dispatcher routes it (registry-gated dispatch means no tool surface reaches it) — removal costs no live capability.
- The click was positional actuation on an AX-addressable target — exactly the class the campaign bans — and the readback (not the click marker) was always the authority, so a click that failed to select already surfaced as State B.
- `ax_write_failed` is the right taxonomy: the write threw (attempted-and-failed), not readback ambiguity; consistent with the op's existing error mapping.

Also aligns the `point(fromRawAttribute:)` doc comment (its cited coordinate-click callers were removed by earlier campaign steps; the remaining consumer is a fail-closed position read).

## Testing
- New regression test pins SELECT_FAILED → fail-closed; mutation-proven (disabling the handler branch fails it, falling through to a State B envelope).
- Focused select_last suite 6/6; full serial suite 3171/3172 — the only failure is the known live-coupled `realReleaseBinaryExecutesEveryOperationWithIndependentReadback` drift documented on the previous PR (same signature, pre-existing, unrelated: this op is not registry-probed by that runner).
- `grep 'click at' Sources/` now matches only prose describing the removal.