### PR TITLE
refactor: convert menu-ITEM activation from coordinate click to AXPress

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2045,7 +2045,14 @@ extension AccessibilityChannel {
                     continue
                 }
 
-                if clickElementCenter(item, runtime: runtime.ax) {
+                // ADR-001 coordinate ban: activate the menu ITEM via AXPress, like
+                // the menu-bar OPEN above — the former element-derived
+                // clickElementCenter rung is removed. AXPress reports success
+                // synchronously; on failure the Escape + retry hygiene below still
+                // runs, the mixer-reveal consumer falls back to the non-coordinate
+                // cgevent key-7 channel, and the hide-plugin-windows consumer is
+                // explicitly best-effort — so no feature is degraded.
+                if AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) {
                     return (true, true, attempt)
                 }
                 AXMouseHelper.pressEscape()
@@ -2122,7 +2129,10 @@ extension AccessibilityChannel {
                 AXMouseHelper.pressEscape()
                 return .disabled
             }
-            if clickElementCenter(item, runtime: runtime.ax) {
+            // ADR-001 coordinate ban: AXPress the Undo menu item (same conversion
+            // as the menu-bar open above); the coordinate-free Cmd+Z fallback in
+            // the caller still covers an AXPress failure, so no feature is degraded.
+            if AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) {
                 return .ok
             }
             AXMouseHelper.pressEscape()


### PR DESCRIPTION
## Summary
Coordinate-free campaign, step (b): the two remaining app-menu ITEM coordinate clicks — the top-level menu-item activation used by mixer reveal (View ▸ Show Mixer) and hide-plugin-windows (Window ▸ Hide Plug-in Windows), and the Edit ▸ Undo rollback item — are converted to `AXPress`, completing the conversion the menu-bar OPEN in the same file already shipped under the same rationale.

Independently reviewed (adversarial): AXPress is strictly safer than the coordinate click (no coordinate → the stale-frame misclick class is structurally eliminated; activation is by AX reference); the failure path is byte-equivalent (Escape hygiene + retry unchanged); every consumer's non-coordinate fallback chain was traced end-to-end — mixer reveal falls back to the cgevent key-7 channel gated by structural visibility readback, Undo falls back to Cmd+Z exactly when the menu path misses (and deliberately NOT when the item is disabled, preserving the no-blind-undo safety property), and hide-plugin-windows is explicitly best-effort with nothing gating on it.

## Live evidence
Reversible probe on the running Logic instance: AXPress on the View menu's mixer ITEM activated it (title toggled and the mixer visibly hid — observed effect), a second AXPress restored the original state, confirmed by a third menu open. The exact primitive this diff introduces is live-proven on the exact surface it targets.

## Testing
- Focused plugin-insert/locale/E2E suites 169/169 green; full serial suite 3171/3172 — the only failure is the known live-coupled qualification-runner drift documented on the previous PRs (same signature, pre-existing, unrelated).
- Remaining coordinate actuation (plugin-insert slot/popup, Library rows) is tracked by the campaign census for the next steps; the popup-leaf surface depends on hover-to-reveal semantics AXPress does not replicate and is deliberately out of this step's scope.