### PR TITLE
refactor: retire the external click-tool fallback; doctor reports native-only

### DIFF
--- a/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
+++ b/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
@@ -234,13 +234,9 @@ enum LibraryAccessor {
                 usleep(120_000)
                 CGWarpMouseCursorPosition(point)
                 usleep(30_000)
-                // Prefer the native CGEvent double-click (audit #16): spawning
-                // cliclick per click is FD-leak-class. Fall back to cliclick only
-                // if the native post fails.
-                if AXMouseHelper.doubleClick(at: point) {
-                    return true
-                }
-                return LibraryAccessor.postCliclick(command: "dc", at: point)
+                // Native CGEvent only — the external click-tool fallback was
+                // retired (see `productionMouseClick`).
+                return AXMouseHelper.doubleClick(at: point)
             }
         )
     }
@@ -1353,36 +1349,13 @@ enum LibraryAccessor {
         usleep(120_000)
         CGWarpMouseCursorPosition(point)
         usleep(30_000)
-        // Prefer the native CGEvent click (audit #16): spawning cliclick per
-        // click is FD-leak-class. Fall back to cliclick only if the native
-        // post fails.
-        if AXMouseHelper.click(at: point) {
-            return true
-        }
-        return postCliclick(command: "c", at: point)
-    }
-
-    private static func postCliclick(command: String, at point: CGPoint) -> Bool {
-        let candidates = ["/opt/homebrew/bin/cliclick", "/usr/local/bin/cliclick"]
-        guard let executable = candidates.first(where: {
-            FileManager.default.isExecutableFile(atPath: $0)
-        }) else {
-            return false
-        }
-        let x = Int(point.x.rounded())
-        let y = Int(point.y.rounded())
-        debugLibraryClick("cliclick \(command):\(x),\(y) executable=\(executable)")
-        guard case let .completed(output) = BoundedProcessRunner.run(
-            executable: executable,
-            arguments: ["\(command):\(x),\(y)"],
-            timeout: 1.0,
-            outputLimitBytes: 4_096
-        ) else {
-            debugLibraryClick("cliclick \(command):\(x),\(y) result=spawn_or_timeout")
-            return false
-        }
-        debugLibraryClick("cliclick \(command):\(x),\(y) exit=\(output.exitCode)")
-        return output.exitCode == 0
+        // Native CGEvent only. The external click-tool fallback was retired by
+        // the coordinate-free campaign: it was reachable only when the native
+        // post failed (which does not happen for an Accessibility-permitted
+        // process), spawned an external binary per click (audit #16
+        // FD-leak-class), and widened the supply-chain surface. A failed post
+        // surfaces through the caller's existing AX-write/readback logic.
+        return AXMouseHelper.click(at: point)
     }
 
     /// Session-private debug-log file, created inside a `mkdtemp` directory

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -138,23 +138,29 @@ extension SetupDoctor {
 
 
     static func clickFallbackCheck(runtime: Runtime, permissionStatus: PermissionChecker.PermissionStatus) -> Check {
+        // The external click-tool fallback was RETIRED by the coordinate-free
+        // campaign: the server's only synthetic-click path is the native CGEvent
+        // post, which requires PostEvent access. The check id is kept for schema
+        // stability, but a present external tool no longer counts as a server
+        // click path (that would be a false-green about server capability); its
+        // presence is still reported as informational evidence for operators.
         let fallbackTool = "cli" + "click"
         let fallbackToolPresent = ["/opt/homebrew/bin/" + fallbackTool, "/usr/local/bin/" + fallbackTool]
             .contains(where: runtime.isExecutableFile)
         let nativeAvailable = permissionStatus.postEventAccess
-        let warn = !nativeAvailable && !fallbackToolPresent
         return check(
             id: "dependencies.click_fallback",
             domain: "dependencies",
-            status: warn ? .warn : .pass,
-            summary: warn
-                ? "No working click path was found because PostEvent is denied and \(fallbackTool) is absent."
-                : "At least one click path is available or the fallback is not needed.",
+            status: nativeAvailable ? .pass : .warn,
+            summary: nativeAvailable
+                ? "The native synthetic-click path is available (PostEvent granted); no fallback is used."
+                : "No working click path: PostEvent is denied, and the external click-tool fallback "
+                    + "was retired (a present tool is not a server click path).",
             evidence: [
-                fallbackTool: fallbackToolPresent ? "present" : "absent",
+                fallbackTool: (fallbackToolPresent ? "present" : "absent") + " (informational; retired as a server path)",
                 "native_click": nativeAvailable ? "available" : "denied",
             ],
-            remediationType: warn ? .docs : .none
+            remediationType: nativeAvailable ? .none : .docs
         )
     }
 

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -912,3 +912,28 @@ private func registrationFromTemporaryConfig(_ json: String) -> SetupDoctor.Clau
     defer { try? FileManager.default.removeItem(at: dir) }
     return SetupDoctor.readClaudeRegistrationForTesting(configURL: configURL)
 }
+
+// MARK: - dependencies.click_fallback — native-only semantics (coordinate-free campaign)
+
+/// The external click-tool fallback was retired: a PRESENT external tool must
+/// no longer mask a PostEvent denial as a passing click path (that was a
+/// false-green about server capability). Warn is driven by PostEvent alone.
+@Test func clickFallbackWarnsOnPostEventDenialEvenWithExternalToolPresent() {
+    let runtime = doctorRuntime(executable: true)   // every path "is executable" → tool present
+    let status = PermissionChecker.PermissionStatus(
+        accessibility: true, automationLogicPro: true, postEventAccess: false
+    )
+    let check = SetupDoctor.clickFallbackCheck(runtime: runtime, permissionStatus: status)
+    #expect(check.status == .warn)
+    #expect(check.evidence["native_click"] == "denied")
+}
+
+@Test func clickFallbackPassesOnPostEventGrantWithoutExternalTool() {
+    let runtime = doctorRuntime(executable: false)  // tool absent everywhere
+    let status = PermissionChecker.PermissionStatus(
+        accessibility: true, automationLogicPro: true, postEventAccess: true
+    )
+    let check = SetupDoctor.clickFallbackCheck(runtime: runtime, permissionStatus: status)
+    #expect(check.status == .pass)
+    #expect(check.evidence["native_click"] == "available")
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -293,7 +293,7 @@ Wire the LogicProMCP MCU port in Logic Pro Control Surfaces if you use MCU-only 
 
 <a id="doctor-dependenciesclick-fallback"></a>
 ### `dependencies.click_fallback`
-Install `cliclick` only if PostEvent is denied and you still need fallback click paths.
+The server's only synthetic-click path is the native CGEvent post, which requires PostEvent access — grant it in System Settings ▸ Privacy & Security ▸ Accessibility. The external `cliclick` fallback was retired (a present tool is no longer used by the server and is reported as informational evidence only).
 
 ## Lifecycle Anchors
 


### PR DESCRIPTION
## Summary
Coordinate-free campaign, step (c): the Library row clicks' external-binary (`cliclick`) fallback is retired, and the doctor's `dependencies.click_fallback` check is aligned to the new reality.

- The fallback fired only when the native CGEvent post returned `false` — which happens only on CGEvent *construction* failure (headless/no WindowServer), where the external tool fails identically (it needs the same WindowServer + Accessibility). Independently reviewed conclusion: **no real environment existed where the retired rung was load-bearing.** It spawned an external process per click (audit #16 FD-leak-class) and widened the supply-chain surface for zero live value.
- The Library row clicks themselves remain under their documented AX-opacity evidence (AX selection reports success without changing the visible column; preset commit requires a double-click) — this step removes only the dead external-tool rung.
- Doctor: the check previously PASSED when PostEvent was denied but the tool was present — after retirement that would be a false-green about server capability. It now warns exactly when PostEvent is denied (the hard fail is already carried by `permissions.post_event_access`); the tool's presence is reported as informational evidence. Check id and count unchanged; the only non-test consumer asserts presence, not pass, so no gate is affected.

## Testing
- Two new pins: denied + tool-present must WARN (fails on the old truth table); granted + tool-absent must pass. Focused doctor/library suites 213/213.
- Full serial suite 3173/3174 — the only failure is the known live-coupled qualification-runner drift documented on the previous PRs (same signature, pre-existing, unrelated).
- `grep cliclick Sources/` now matches only the doctor's informational evidence and a historical comment; setup guidance updated to native-only.