### PR TITLE
feat(#369): surface the export bounce step's execution preconditions in the plan

### DIFF
--- a/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlanner.swift
@@ -65,6 +65,7 @@ enum ProjectExportPlanner {
                 ),
             ],
             unsupportedOrBlockedSteps: surfacedConstraints,
+            executionPreconditions: executionPreconditions(),
             baselineVerification: [
                 "artifact_exists",
                 "file_size_non_zero",

--- a/Sources/LogicProMCP/Projects/ProjectExportPlannerModels.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlannerModels.swift
@@ -13,6 +13,7 @@ struct ProjectExportPlan: Codable, Sendable, Equatable {
     let projects: [ProjectExportPlanProject]
     let requiredConfirmations: [ProjectExportConfirmation]
     let unsupportedOrBlockedSteps: [ProjectExportBlockedStep]
+    let executionPreconditions: [ProjectExportPrecondition]
     let baselineVerification: [String]
     let enhancementPath: [String]
     let nextSafeAction: String
@@ -30,6 +31,7 @@ struct ProjectExportPlan: Codable, Sendable, Equatable {
         case projects
         case requiredConfirmations = "required_confirmations"
         case unsupportedOrBlockedSteps = "unsupported_or_blocked_steps"
+        case executionPreconditions = "execution_preconditions"
         case baselineVerification = "baseline_verification"
         case enhancementPath = "enhancement_path"
         case nextSafeAction = "next_safe_action"
@@ -135,5 +137,25 @@ struct ProjectExportBlockedStep: Codable, Sendable, Equatable {
         case operation
         case reason
         case safeAlternative = "safe_alternative"
+    }
+}
+
+/// A machine-readable execution dependency of a workflow step, surfaced in the
+/// dry-run plan so a caller can tell from the manifest what the run needs BEFORE
+/// it fails at that step (#369): the plan otherwise validates as `valid` with no
+/// mention of the bounce step's live requirements. These are invariant facts
+/// about what execution needs, not a live probe — verify satisfaction with the
+/// `verify_with` command.
+struct ProjectExportPrecondition: Codable, Sendable, Equatable {
+    let requirement: String
+    let appliesToCommands: [String]
+    let detail: String
+    let verifyWith: String
+
+    enum CodingKeys: String, CodingKey {
+        case requirement
+        case appliesToCommands = "applies_to_commands"
+        case detail
+        case verifyWith = "verify_with"
     }
 }

--- a/Sources/LogicProMCP/Projects/ProjectExportPlannerSupport.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlannerSupport.swift
@@ -85,6 +85,44 @@ extension ProjectExportPlanner {
         ]
     }
 
+    /// #369: the bounce/export step's real execution dependencies, so the manifest
+    /// is honest about what the run needs instead of only reporting
+    /// `validation_status: valid`. The default export path drives Logic's Bounce
+    /// dialog out-of-process (the bundled `logic_bounce.py` helper) — it is NOT
+    /// gated on the MIDIKeyCommands MIDI-Learn binding, which the correction in
+    /// the `automation_permission` detail spells out.
+    static func executionPreconditions() -> [ProjectExportPrecondition] {
+        [
+            ProjectExportPrecondition(
+                requirement: "automation_permission",
+                appliesToCommands: ["bounce"],
+                detail: "The bounce/export step drives Logic Pro's Bounce dialog out-of-process: it issues "
+                    + "Logic's default Bounce command (Cmd+B, or File > Bounce > Project or Section) and confirms "
+                    + "the settings and save panel through System Events, so Automation approval for BOTH System "
+                    + "Events and Logic Pro is required or the run fails at the bounce step. This does NOT require "
+                    + "the MIDIKeyCommands manual MIDI-Learn binding: that channel is only a fallback route for the "
+                    + "standalone project.bounce operation reported by logic_system health (whose primary route is "
+                    + "also System Events), not this dialog-driven export path.",
+                verifyWith: "LogicProMCP --check-permissions"
+            ),
+            ProjectExportPrecondition(
+                requirement: "post_event_access",
+                appliesToCommands: ["bounce"],
+                detail: "The Bounce settings and save panel (filename entry, destination navigation, and the "
+                    + "confirm button) is driven with native CGEvent, which requires trusted PostEvent access "
+                    + "(granted through the launcher app's Accessibility entry).",
+                verifyWith: "LogicProMCP doctor (permissions.post_event_access)"
+            ),
+            ProjectExportPrecondition(
+                requirement: "bounce_helper_available",
+                appliesToCommands: ["bounce"],
+                detail: "The export step runs the bundled logic_bounce.py helper; it must resolve on the install "
+                    + "share path, pass the ownership-trust check, and have a python3 interpreter available.",
+                verifyWith: "LogicProMCP doctor"
+            ),
+        ]
+    }
+
     static func projectPaths(from params: [String: Value]) throws -> [String] {
         if let array = params["projects"]?.arrayValue {
             let paths = array.compactMap { $0.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
@@ -63,6 +63,62 @@ struct ProjectExportPlannerTests {
         #expect(steps.map(\.command) == ["open", "bounce"])
     }
 
+    @Test("#369: surfaces the bounce step's execution preconditions in the manifest")
+    func surfacesBounceExecutionPreconditions() throws {
+        let project = try makeExportPlannerProject(named: "Precondition Song")
+        let outputRoot = try makeExportPlannerDirectory()
+
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("stem")]),
+        ])
+
+        // The plan must no longer be silent about what the run needs: every
+        // precondition names the bounce command it gates.
+        #expect(plan.executionPreconditions.map(\.requirement)
+            == ["automation_permission", "post_event_access", "bounce_helper_available"])
+        #expect(plan.executionPreconditions.allSatisfy { $0.appliesToCommands == ["bounce"] })
+        #expect(plan.executionPreconditions.allSatisfy { !$0.verifyWith.isEmpty })
+
+        // The MIDI-Learn misconception is corrected in-context (the issue's
+        // "Related question"): the dialog-driven export path does NOT need the
+        // MIDIKeyCommands manual binding.
+        let automation = try #require(
+            plan.executionPreconditions.first { $0.requirement == "automation_permission" }
+        )
+        #expect(automation.detail.contains("System Events"))
+        #expect(automation.detail.contains("does NOT require"))
+        #expect(automation.detail.contains("MIDIKeyCommands"))
+    }
+
+    @Test("#369: execution preconditions encode with snake_case keys and survive round-trip")
+    func executionPreconditionsEncodeWithSnakeCaseKeys() throws {
+        let project = try makeExportPlannerProject(named: "Encode Song")
+        let outputRoot = try makeExportPlannerDirectory()
+        let plan = try ProjectExportPlanner.plan(params: [
+            "projects": .array([.string(project.path)]),
+            "output_root": .string(outputRoot.path),
+            "artifacts": .array([.string("bounce")]),
+        ])
+
+        let data = try JSONEncoder().encode(plan)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let preconditions = try #require(object["execution_preconditions"] as? [[String: Any]])
+        #expect(preconditions.count == 3)
+        let first = try #require(preconditions.first)
+        #expect(first["requirement"] as? String == "automation_permission")
+        #expect(first["applies_to_commands"] as? [String] == ["bounce"])
+        let verifyWith = try #require(first["verify_with"] as? String)
+        #expect(!verifyWith.isEmpty)
+
+        // Round-trips back into the model unchanged.
+        let decoded = try JSONDecoder().decode(ProjectExportPlan.self, from: data)
+        #expect(decoded.executionPreconditions == plan.executionPreconditions)
+    }
+
     @Test("reports collision and zero-byte artifact risks without mutating files")
     func collisionAndZeroByteRisks() throws {
         let project = try makeExportPlannerProject(named: "Collision Song")


### PR DESCRIPTION
## Summary
Part 1 of #369 (the "Related question"): `export_plan` validated as `validation_status: valid` with no mention that the bounce/export step has live execution dependencies, so a caller could not tell from the manifest that a run could fail at the bounce step. The plan now carries an explicit `execution_preconditions` array (mirroring the existing `unsupported_or_blocked_steps` / `required_confirmations` surfacing).

Three preconditions on the `bounce` command, grounded in the **actual default export path** (the bundled `logic_bounce.py` dialog driver, not the standalone `project.bounce` operation):
- `automation_permission` — the step issues Logic's default Bounce command (Cmd+B) or clicks File ▸ Bounce ▸ Project or Section through System Events → Automation for System Events **and** Logic Pro.
- `post_event_access` — the settings/save panel is driven with native CGEvent (`CGEventPost`) → trusted PostEvent.
- `bounce_helper_available` — the bundled helper must resolve, pass the ownership-trust check, and have python3.

It corrects the reporter's guess in-context: this dialog-driven export path does **not** require the MIDIKeyCommands manual MIDI-Learn binding (that channel is only a fallback route for the standalone `project.bounce` op, whose primary route is also System Events). Preconditions are invariant execution facts, not a live probe (the planner stays pure); each names the `verify_with` command a caller runs to confirm its host.

Additive field; `logic_pro_mcp_export_manifest.v1` schema name unchanged (field-superset). Two unit tests pin the surfaced preconditions + the snake_case JSON round-trip.

**Part 1 of #369 only** — the issue's main ask (per-track stems / Export All Tracks as Audio Files) is Part 2 and is intentionally NOT closed here; #369 stays open until stems land.

## Testing
Focused planner suite 28/28; full serial suite at exact head (sole failure is the whole-project live-qualification E2E, which is fixture/environment-sensitive and not a regression from this doc/unit change — reproduces identically at the pre-change head; reliable whole-suite live QA is tracked under ADR-001 #284). Public-surface preflight exit 0.

Refs #369