### PR TITLE
fix(#427): package logic_variants.py + assert Python helper import-closure at release

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -45,6 +45,12 @@ class LogicProMcp < Formula
     pkgshare.install "Scripts/logic_bounce_ui.py" if (buildpath/"Scripts/logic_bounce_ui.py").exist?
     pkgshare.install "Scripts/logic_ui_jxa.py" if (buildpath/"Scripts/logic_ui_jxa.py").exist?
     pkgshare.install "Scripts/logic_input_source.py" if (buildpath/"Scripts/logic_input_source.py").exist?
+    # #427: shared dependency imported by logic_bounce.py / logic_bounce_ui.py /
+    # logic_ui_jxa.py. Omitting it shipped a package that failed at runtime with
+    # ModuleNotFoundError on the bounce/export path. The import-closure gate in
+    # release-verify-formula-install-paths.sh now fails the release if this (or any
+    # other transitively-imported logic_* helper) is not installed.
+    pkgshare.install "Scripts/logic_variants.py" if (buildpath/"Scripts/logic_variants.py").exist?
   end
 
   def caveats

--- a/Scripts/install-common.sh
+++ b/Scripts/install-common.sh
@@ -200,4 +200,6 @@ install_extracted_assets() {
     install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_BOUNCE_UI" "$SHARE_DIR/logic_bounce_ui.py"
     install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_UI_JXA" "$SHARE_DIR/logic_ui_jxa.py"
     install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_INPUT_SOURCE" "$SHARE_DIR/logic_input_source.py"
+    # #427: shared dependency of logic_bounce.py / logic_bounce_ui.py / logic_ui_jxa.py.
+    install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_VARIANTS" "$SHARE_DIR/logic_variants.py"
 }

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -33,7 +33,7 @@ require_command(){ local name="$1" install_hint="$2"; if command -v "$name" >/de
 run_with_optional_sudo(){ local use_sudo="$1"; shift; if [ "$use_sudo" = "1" ]; then sudo "$@"; else "$@"; fi; }
 install_release_asset(){ local use_sudo="$1" mode="$2" source="$3" destination="$4"; run_with_optional_sudo "$use_sudo" install -m "$mode" "$source" "$destination"; }
 install_optional_release_asset(){ local use_sudo="$1" mode="$2" source="$3" destination="$4"; if [ -e "$source" ]; then install_release_asset "$use_sudo" "$mode" "$source" "$destination"; fi; }
-install_extracted_assets(){ local use_sudo="$1"; run_with_optional_sudo "$use_sudo" mkdir -p "$INSTALL_DIR" "$SHARE_DIR"; run_with_optional_sudo "$use_sudo" mv "$EXTRACTED_BINARY" "$INSTALL_DIR/$BINARY"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_SETUP" "$SHARE_DIR/SETUP.md"; install_release_asset "$use_sudo" 0755 "$EXTRACTED_INSTALL_KEYCMDS" "$SHARE_DIR/install-keycmds.sh"; install_release_asset "$use_sudo" 0755 "$EXTRACTED_UNINSTALL_KEYCMDS" "$SHARE_DIR/uninstall-keycmds.sh"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_KEYCMD_PRESET" "$SHARE_DIR/keycmd-preset.plist"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_SCRIPTER" "$SHARE_DIR/LogicProMCP-Scripter.js"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_BOUNCE" "$SHARE_DIR/logic_bounce.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_BOUNCE_UI" "$SHARE_DIR/logic_bounce_ui.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_UI_JXA" "$SHARE_DIR/logic_ui_jxa.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_INPUT_SOURCE" "$SHARE_DIR/logic_input_source.py"; }
+install_extracted_assets(){ local use_sudo="$1"; run_with_optional_sudo "$use_sudo" mkdir -p "$INSTALL_DIR" "$SHARE_DIR"; run_with_optional_sudo "$use_sudo" mv "$EXTRACTED_BINARY" "$INSTALL_DIR/$BINARY"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_SETUP" "$SHARE_DIR/SETUP.md"; install_release_asset "$use_sudo" 0755 "$EXTRACTED_INSTALL_KEYCMDS" "$SHARE_DIR/install-keycmds.sh"; install_release_asset "$use_sudo" 0755 "$EXTRACTED_UNINSTALL_KEYCMDS" "$SHARE_DIR/uninstall-keycmds.sh"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_KEYCMD_PRESET" "$SHARE_DIR/keycmd-preset.plist"; install_release_asset "$use_sudo" 0644 "$EXTRACTED_SCRIPTER" "$SHARE_DIR/LogicProMCP-Scripter.js"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_BOUNCE" "$SHARE_DIR/logic_bounce.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_BOUNCE_UI" "$SHARE_DIR/logic_bounce_ui.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_UI_JXA" "$SHARE_DIR/logic_ui_jxa.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_INPUT_SOURCE" "$SHARE_DIR/logic_input_source.py"; install_optional_release_asset "$use_sudo" 0755 "$EXTRACTED_VARIANTS" "$SHARE_DIR/logic_variants.py"; }
 '
 fi
 
@@ -64,7 +64,7 @@ validate_release_archive_manifest() {
             /*|../*|*/../*|*/..|..)
                 fail_install "release archive contains unsafe path: $path"
                 ;;
-            LogicProMCP|docs|docs/|docs/SETUP.md|Scripts|Scripts/|Scripts/install-keycmds.sh|Scripts/uninstall-keycmds.sh|Scripts/keycmd-preset.plist|Scripts/LogicProMCP-Scripter.js|Scripts/logic_bounce.py|Scripts/logic_bounce_ui.py|Scripts/logic_ui_jxa.py|Scripts/logic_input_source.py)
+            LogicProMCP|docs|docs/|docs/SETUP.md|Scripts|Scripts/|Scripts/install-keycmds.sh|Scripts/uninstall-keycmds.sh|Scripts/keycmd-preset.plist|Scripts/LogicProMCP-Scripter.js|Scripts/logic_bounce.py|Scripts/logic_bounce_ui.py|Scripts/logic_ui_jxa.py|Scripts/logic_input_source.py|Scripts/logic_variants.py)
                 ;;
             *)
                 fail_install "release archive contains unexpected path: $path"
@@ -264,11 +264,13 @@ if curl -fsSL "$DOWNLOAD_URL" -o "$TMP_ARCHIVE" 2>/dev/null; then
     EXTRACTED_BOUNCE_UI="$TMP_DIR/Scripts/logic_bounce_ui.py"
     EXTRACTED_UI_JXA="$TMP_DIR/Scripts/logic_ui_jxa.py"
     EXTRACTED_INPUT_SOURCE="$TMP_DIR/Scripts/logic_input_source.py"
+    EXTRACTED_VARIANTS="$TMP_DIR/Scripts/logic_variants.py"
     for required in "$EXTRACTED_BINARY" "$EXTRACTED_SETUP" "$EXTRACTED_INSTALL_KEYCMDS" "$EXTRACTED_UNINSTALL_KEYCMDS" "$EXTRACTED_KEYCMD_PRESET" "$EXTRACTED_SCRIPTER"; do validate_extracted_asset_file "$required"; done
     validate_optional_extracted_asset_file "$EXTRACTED_BOUNCE"
     validate_optional_extracted_asset_file "$EXTRACTED_BOUNCE_UI"
     validate_optional_extracted_asset_file "$EXTRACTED_UI_JXA"
     validate_optional_extracted_asset_file "$EXTRACTED_INPUT_SOURCE"
+    validate_optional_extracted_asset_file "$EXTRACTED_VARIANTS"
 
     verify_signature "$EXTRACTED_BINARY"
     verify_gatekeeper "$EXTRACTED_BINARY"

--- a/Scripts/release-package.sh
+++ b/Scripts/release-package.sh
@@ -87,7 +87,8 @@ tar czf LogicProMCP-macOS-universal.tar.gz \
   Scripts/logic_bounce.py \
   Scripts/logic_bounce_ui.py \
   Scripts/logic_ui_jxa.py \
-  Scripts/logic_input_source.py
+  Scripts/logic_input_source.py \
+  Scripts/logic_variants.py
 
 cp LogicProMCP-macOS-universal.tar.gz LogicProMCP-macOS-arm64.tar.gz
 shasum -a 256 LogicProMCP-macOS-universal.tar.gz > SHA256SUMS.txt

--- a/Scripts/release-verify-formula-install-paths.sh
+++ b/Scripts/release-verify-formula-install-paths.sh
@@ -50,11 +50,16 @@ while IFS= read -r mod; do
     closure_fail=1
     continue
   fi
-  # local logic_* modules this helper imports (both `import X` and `from X import`).
+  # local logic_* modules this helper imports. `grep -oE` captures only
+  # `<keyword> <module>` (the regex stops after the module token, so a
+  # `from logic_x import some_symbol` line yields logic_x, never the symbol);
+  # `[[:space:]]*`/`[[:space:]]+` also matches indented/lazy imports inside
+  # functions or try-blocks. (Known limitation: the rare `import a, b` multi-module
+  # form captures only the first — no shipped helper uses it; all use `from X import`.)
   # `|| true`: a helper with no logic_* imports makes grep exit 1, which would
   # trip `set -euo pipefail` and abort the gate before it finished checking.
-  deps=$(grep -hoE '^(from|import) logic_[a-z0-9_]+' "$src" 2>/dev/null \
-    | sed -E 's/^(from|import) //' | sort -u || true)
+  deps=$(grep -hoE '^[[:space:]]*(from|import)[[:space:]]+logic_[a-z0-9_]+' "$src" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*(from|import)[[:space:]]+//' | sort -u || true)
   while IFS= read -r dep; do
     [ -z "$dep" ] && continue
     if printf '%s\n' "$installed_pys" | grep -Fxq "$dep"; then

--- a/Scripts/release-verify-formula-install-paths.sh
+++ b/Scripts/release-verify-formula-install-paths.sh
@@ -26,3 +26,48 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "Formula install paths verified against the built tarball."
+
+# #427: import-closure completeness. The check above is one-directional (every
+# installed path exists in the tarball); it CANNOT catch a *missing* install
+# line, which is exactly how v3.11.0 shipped logic_bounce.py without its shared
+# dependency logic_variants.py -> ModuleNotFoundError at runtime. This asserts
+# that for every Python helper the Formula installs, every `logic_*` module it
+# imports is ALSO installed by the Formula. Imports are read from the EXTRACTED
+# tarball (the actual shipped bytes), not the repo, so the gate verifies what
+# ships and runs identically in CI and in the hermetic contract test. A future
+# split/rename that adds a new intra-helper dependency fails the release at tag
+# time instead of silently dropping a module from the package.
+installed_pys=$(printf '%s\n' "$paths" | sed -nE 's#^Scripts/(logic_[a-z0-9_]+)\.py$#\1#p' | sort -u)
+closure_extract=$(mktemp -d)
+trap 'rm -rf "$closure_extract"' EXIT
+tar -xzf LogicProMCP-macOS-universal.tar.gz -C "$closure_extract"
+closure_fail=0
+while IFS= read -r mod; do
+  [ -z "$mod" ] && continue
+  src="$closure_extract/Scripts/${mod}.py"
+  if [ ! -f "$src" ]; then
+    echo "::error::Formula installs Scripts/${mod}.py but it is absent from the built tarball"
+    closure_fail=1
+    continue
+  fi
+  # local logic_* modules this helper imports (both `import X` and `from X import`).
+  # `|| true`: a helper with no logic_* imports makes grep exit 1, which would
+  # trip `set -euo pipefail` and abort the gate before it finished checking.
+  deps=$(grep -hoE '^(from|import) logic_[a-z0-9_]+' "$src" 2>/dev/null \
+    | sed -E 's/^(from|import) //' | sort -u || true)
+  while IFS= read -r dep; do
+    [ -z "$dep" ] && continue
+    if printf '%s\n' "$installed_pys" | grep -Fxq "$dep"; then
+      echo "OK closure: $mod -> $dep"
+    else
+      echo "::error::Formula installs Scripts/${mod}.py which imports '${dep}', but Scripts/${dep}.py is NOT in the Formula install list (incomplete package -> runtime ModuleNotFoundError). Add it to Formula/logic-pro-mcp.rb and Scripts/release-package.sh."
+      closure_fail=1
+    fi
+  done <<< "$deps"
+done <<< "$installed_pys"
+
+if [ "$closure_fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Python helper import-closure verified: every imported logic_* module is packaged."

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ShareDirSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ShareDirSupport.swift
@@ -11,6 +11,10 @@ extension SetupDoctor {
         "logic_bounce_ui.py",
         "logic_ui_jxa.py",
         "logic_input_source.py",
+        // #427: shared dependency of the bounce/export helpers. Listed here so the
+        // runtime share-dir completeness probe DETECTS an install that dropped it
+        // (the exact v3.11.0 regression) instead of reporting `.complete`.
+        "logic_variants.py",
     ]
 
 

--- a/Tests/LogicProMCPTests/InstallScriptContractTestSupport.swift
+++ b/Tests/LogicProMCPTests/InstallScriptContractTestSupport.swift
@@ -141,12 +141,17 @@ func makeInstallerFixture(
     try writeFile(scripts.appendingPathComponent("keycmd-preset.plist"), contents: "plist")
     try writeFile(scripts.appendingPathComponent("LogicProMCP-Scripter.js"), contents: "// scripter\n")
     if includeProjectHelperScripts {
-        try writeExecutable(scripts.appendingPathComponent("logic_bounce.py"), contents: "#!/usr/bin/env python3\nprint('{}')\n")
+        // #427: logic_bounce imports the shared logic_variants module; the fixture
+        // must mirror the real package (which now ships logic_variants.py) so the
+        // Formula-path check AND the import-closure check in
+        // release-verify-formula-install-paths.sh are exercised truthfully.
+        try writeExecutable(scripts.appendingPathComponent("logic_bounce.py"), contents: "#!/usr/bin/env python3\nfrom logic_variants import logic_process_osa\nprint('{}')\n")
         try writeExecutable(scripts.appendingPathComponent("logic_bounce_ui.py"), contents: "#!/usr/bin/env python3\n")
         if includeSharedJXAHelper {
             try writeExecutable(scripts.appendingPathComponent("logic_ui_jxa.py"), contents: "#!/usr/bin/env python3\n")
         }
         try writeExecutable(scripts.appendingPathComponent("logic_input_source.py"), contents: "#!/usr/bin/env python3\n")
+        try writeExecutable(scripts.appendingPathComponent("logic_variants.py"), contents: "#!/usr/bin/env python3\ndef logic_process_osa():\n    pass\n")
         if symlinkedBounceHelper {
             let target = sandbox.appendingPathComponent("outside-bounce-helper.py")
             try writeFile(target, contents: "# outside\n")

--- a/Tests/LogicProMCPTests/VersionConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/VersionConsistencyTests.swift
@@ -210,8 +210,8 @@ private func latestChangelogReleaseHeading() throws -> ChangelogReleaseHeading? 
     let pkgsharePaths = installPaths("pkgshare")
     let binPaths = installPaths("bin")
     #expect(
-        pkgsharePaths.count == 9,
-        "expected the 9 helper assets in Formula pkgshare.install; parser or Formula drifted: \(pkgsharePaths)"
+        pkgsharePaths.count == 10,
+        "expected the 10 helper assets in Formula pkgshare.install; parser or Formula drifted: \(pkgsharePaths)"
     )
     #expect(binPaths == ["LogicProMCP"], "Formula bin.install drifted: \(binPaths)")
     #expect(
@@ -229,6 +229,13 @@ private func latestChangelogReleaseHeading() throws -> ChangelogReleaseHeading? 
     #expect(
         formula.contains("pkgshare.install \"Scripts/logic_input_source.py\" if (buildpath/\"Scripts/logic_input_source.py\").exist?"),
         "Formula must keep logic_input_source.py optional so brew install stays compatible with published tarballs that predate project-helper scripts"
+    )
+    // #427: logic_variants.py is the shared dependency of the bounce/export helpers;
+    // it must be packaged (its omission shipped a ModuleNotFoundError in v3.11.0) and
+    // kept optional for compatibility with pre-existing tarballs.
+    #expect(
+        formula.contains("pkgshare.install \"Scripts/logic_variants.py\" if (buildpath/\"Scripts/logic_variants.py\").exist?"),
+        "Formula must package logic_variants.py (shared bounce/export dependency, #427) and keep it optional"
     )
 
     let root = repositoryRootURL()


### PR DESCRIPTION
## Summary
Fixes the packaging bug @thomas-doesburg reported in #427: the v3.11.0 Homebrew release (and the pinned shell installer) ship `logic_bounce.py` / `logic_bounce_ui.py` / `logic_ui_jxa.py` **without their shared dependency `logic_variants.py`**, so the bounce/export path fails at runtime with `ModuleNotFoundError` once a project is opened.

**Not a version issue** — v3.11.0 is the latest release and `main` carried the identical omission (verified). Root cause is one layer below the Formula: `Scripts/logic_variants.py` was never added to the release tarball (`release-package.sh`), so neither the Formula nor the shell installer could install it, and the existing `#22` tarball-listing gate is one-directional (checks installed-paths ⊆ tarball) so it structurally cannot catch a *missing* install line / dropped dependency.

## Changes
- **Package + install the module:** `release-package.sh` (tarball), `Formula/logic-pro-mcp.rb`, `install.sh` (allowlist + extract + validate + install), `install-common.sh`.
- **Systemic guard (issue's suggestion 1):** `release-verify-formula-install-paths.sh` now asserts the **import closure** — for every `logic_*.py` the Formula installs, every `logic_*` module it imports (read from the *extracted tarball*, i.e. the shipped bytes) must also be installed. A future split/rename that adds an intra-helper dependency now fails the release at tag time instead of silently dropping a module.
- **Contract fixture** mirrors the real package (adds `logic_variants.py` + a real import) so `testReleaseTarballFixtureMatchesFormulaInstallPaths` exercises both the path check and the closure check truthfully.

## Testing
- Install-script contract suite 33/33 green (incl. the previously-red tarball-fixture test).
- Import-closure gate **mutation-proven**: with the fix, closure verifies clean; removing `logic_variants` from the Formula fails the gate naming all three importers (`logic_bounce`, `logic_bounce_ui`, `logic_ui_jxa`). Testing also caught and fixed a `set -euo pipefail` abort in the gate when a helper has no `logic_*` imports.
- `bash -n` clean on all touched scripts; `py_compile` clean on `logic_variants.py`.

Delivering this to Homebrew requires a patch release (v3.11.1) with a refreshed Formula `sha256`. The issue stays open until that ships.

Refs #427