### PR TITLE
ci(release): defer ADR-001 qualification gate behind ADR001_QUALIFICATION_ENFORCED flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,17 +166,32 @@ jobs:
       # The independently produced bundle must cover Desktop/Creator × en-US/ko-KR,
       # every registered operation by semantic readback or a governed default-profile
       # waiver, and mutation/readback/restore/compensation. Missing evidence fails closed.
+      #
+      # ADR-001 terminal qualification is roadmap T5 / issue #284 and is not yet
+      # deliverable: the full same-artifact live matrix plus per-operation semantic
+      # coverage (#373) that would produce a passing signed evidence bundle does not
+      # exist yet (Scripts/live-qualification-runner.py can only emit a not_qualified
+      # skeleton). Until #284 lands, these enforcement steps are gated OFF by owner
+      # decision (2026-07-21) so stable releases ship exactly as they did through
+      # v3.11.0. To turn the gate back on: set repository variable
+      # ADR001_QUALIFICATION_ENFORCED=true AND provision the QUALIFICATION_EVIDENCE_URL,
+      # QUALIFICATION_EVIDENCE_SHA256, and TRUSTED_QUALIFICATION_PUBLIC_KEY secrets.
+      # When the variable is 'true' the gate enforces fail-closed exactly as before;
+      # the enforcement logic below is unchanged.
       - name: Checkout pinned trusted verifier
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: 67fec5fccf817f9978022f0ca262b80a789e2dce
           path: trusted-verifier-src
 
       - name: Build pinned trusted verifier
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         working-directory: trusted-verifier-src
         run: swift build -c release --product trusted-verifier
 
       - name: Enforce independent exact-artifact qualification
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         env:
           QUALIFICATION_EVIDENCE_URL: ${{ secrets.QUALIFICATION_EVIDENCE_URL }}
           QUALIFICATION_EVIDENCE_SHA256: ${{ secrets.QUALIFICATION_EVIDENCE_SHA256 }}
@@ -200,6 +215,7 @@ jobs:
               --expected-commit "$GITHUB_SHA"
 
       - name: trusted-provenance-verify
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         env:
           TRUSTED_QUALIFICATION_PUBLIC_KEY: ${{ secrets.TRUSTED_QUALIFICATION_PUBLIC_KEY }}
         run: |
@@ -208,18 +224,26 @@ jobs:
 
       - name: Create release artifact SHA256 manifest
         run: |
-          shasum -a 256 \
-            LogicProMCP \
-            LogicProMCP-macOS-universal.tar.gz \
-            LogicProMCP-macOS-arm64.tar.gz \
-            RELEASE-METADATA.json \
-            SHA256SUMS.txt \
-            qualification-evidence/release-qualification-attestation.json \
-            qualification-evidence/evidence-manifest.json \
-            qualification-evidence/case-manifest.json \
-            qualification-evidence/public-transcript.json \
-            qualification-evidence/mutation-restore-compensation.json \
-            > release-artifacts.sha256
+          files=(
+            LogicProMCP
+            LogicProMCP-macOS-universal.tar.gz
+            LogicProMCP-macOS-arm64.tar.gz
+            RELEASE-METADATA.json
+            SHA256SUMS.txt
+          )
+          # qualification-evidence/* exists only when the ADR-001 gate is enforced
+          # (repository variable ADR001_QUALIFICATION_ENFORCED == 'true'). Include it
+          # in the manifest only when present so a deferred-gate release still succeeds.
+          if [ -d qualification-evidence ]; then
+            files+=(
+              qualification-evidence/release-qualification-attestation.json
+              qualification-evidence/evidence-manifest.json
+              qualification-evidence/case-manifest.json
+              qualification-evidence/public-transcript.json
+              qualification-evidence/mutation-restore-compensation.json
+            )
+          fi
+          shasum -a 256 "${files[@]}" > release-artifacts.sha256
 
       - name: Upload verified release artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
@@ -251,16 +275,19 @@ jobs:
           name: verified-release-artifacts
 
       - name: Checkout pinned trusted verifier for publish
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: 67fec5fccf817f9978022f0ca262b80a789e2dce
           path: trusted-verifier-src
 
       - name: Build pinned trusted verifier for publish
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         working-directory: trusted-verifier-src
         run: swift build -c release --product trusted-verifier
 
       - name: Reverify downloaded release artifact
+        if: ${{ vars.ADR001_QUALIFICATION_ENFORCED == 'true' }}
         env:
           TRUSTED_QUALIFICATION_PUBLIC_KEY: ${{ secrets.TRUSTED_QUALIFICATION_PUBLIC_KEY }}
         run: |

--- a/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
+++ b/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
@@ -776,16 +776,25 @@ struct LPMCPPRD001ProductionReadinessREDTests {
         }
     }
 
-    /// Aggregate production-readiness bar. Two debts remain OPEN and honestly
-    /// tracked until reality changes — R-PUB (release assets are owner-replaceable;
-    /// no immutable/transparency publication exists — the asset list used to
-    /// self-attest this closed) and R-SEM (semantic coverage is 1/108 until the
-    /// coverage program lands). R-MATRIX is CLOSED: the managed desktop x {en-US,
-    /// ko-KR} fixtures now exist as SHA-bound content under `Fixtures/qualification`
-    /// (see `managedFixtureManifestSHAsBindActualContent` and
-    /// `managedFixtureMatrixCoversRequiredShipAxes`). Every other contract must
-    /// stay closed. This assertion fails if any other debt opens (regression) and
-    /// when either remaining debt closes (forcing the honest flip).
+    /// Aggregate production-readiness bar — the honest debt set on the current tree.
+    /// R-PUB (release assets are owner-replaceable; no immutable/transparency
+    /// publication exists) and R-SEM (semantic coverage is 1/108 until the coverage
+    /// program lands) remain open as before. In addition, ADR-001 release-time
+    /// enforcement is DEFERRED behind the `ADR001_QUALIFICATION_ENFORCED` repository
+    /// variable (owner decision, 2026-07-21) until the qualification pipeline lands at
+    /// #284 / roadmap T5: `release.yml` no longer *unconditionally* runs the
+    /// pinned-verifier qualification/provenance steps, so the release-enforced
+    /// contracts R-REL, R-MATRIX, R-MUT, and R-PROV are honestly open too. The
+    /// fixtures themselves still exist as SHA-bound content on disk —
+    /// `managedFixtureManifestSHAsBindActualContent` stays green; what is deferred is
+    /// their *enforcement at release*, not their presence. Flipping the variable to
+    /// `true` makes the gate run again at release time, but does NOT re-close these
+    /// static contracts on its own: the evaluator matches the workflow text and the
+    /// deferral `if:` conditions remain, so `blockingStep` still treats the steps as
+    /// conditional. Re-closing all four happens at #284 / T5, which removes the
+    /// deferral (restoring the unconditional pinned-verifier gate) and provisions the
+    /// QUALIFICATION_* evidence/secrets. This assertion is the tripwire: it fails if
+    /// the debt set drifts from this honestly-tracked state in either direction.
     @Test func productionReadinessContractsAreSatisfiedOnCurrentTree() throws {
         let report = try ProductionReadinessContractEvaluator.evaluateRepositoryRoot(
             repositoryRoot,
@@ -793,18 +802,26 @@ struct LPMCPPRD001ProductionReadinessREDTests {
         )
         #expect(
             report.openDebts == [
+                .managedFixtureMatrixUnbound,
+                .mutationRestoreCompensationMissing,
+                .independentProvenanceNotEnforced,
                 .publishedImmutableEvidenceMissing,
+                .releaseWorkflowMissingIndependentQualification,
                 .semanticCoverageIncomplete,
             ],
             "LPMCP-PRD-001 open debts: \(report.openDebts.map(\.rawValue).joined(separator: ",")) — \(report.findings.map(\.detail).joined(separator: " | "))"
         )
     }
 
-    // MARK: - R-MATRIX managed fixtures (closed on the current tree)
+    // MARK: - R-MATRIX managed fixtures (present on disk; release enforcement deferred)
 
-    /// The managed-fixture manifest is recognized by the contract, so R-MATRIX
-    /// is closed on the current tree. Removing the manifest or fixtures reopens it.
-    @Test func managedFixturesAreBoundAndRMatrixIsClosedOnCurrentTree() throws {
+    /// The managed-fixture manifest and fixture bodies exist as SHA-bound content on
+    /// disk — the substance of R-MATRIX — and `managedFixturesPresent` still recognizes
+    /// them. While ADR-001 release enforcement is deferred behind
+    /// `ADR001_QUALIFICATION_ENFORCED` (until #284 / T5), `release.yml` does not wire
+    /// that matrix into publication, so R-MATRIX is an honestly-open, release-enforced
+    /// debt even though the fixtures are present. Re-enabling the gate re-closes it.
+    @Test func managedFixturesPresentOnDiskWhileRMatrixReleaseEnforcementDeferred() throws {
         #expect(ProductionReadinessContractEvaluator.managedFixturesPresent(
             atRepositoryRoot: repositoryRoot
         ))
@@ -812,7 +829,7 @@ struct LPMCPPRD001ProductionReadinessREDTests {
             repositoryRoot,
             expectedAuthorityBaseSHA: expectedBaseSHA
         )
-        #expect(!report.openDebts.contains(.managedFixtureMatrixUnbound))
+        #expect(report.openDebts.contains(.managedFixtureMatrixUnbound))
     }
 
     /// Every manifest SHA-256 binds the actual fixture bytes on disk. Tampering

--- a/docs/tickets/lpmcp-prd-001/STATUS.md
+++ b/docs/tickets/lpmcp-prd-001/STATUS.md
@@ -121,3 +121,24 @@ No merge or successor work is allowed until the committed exact-head gate is com
 - NOT claimed: a live/consumed matrix load. These files are canonical, reproducible fixture **descriptors** (a consumer that drives them through a live Logic Pro session does not exist yet). Driving them end-to-end belongs to the ADR-001 live-matrix program, not to this repository-content debt; nothing here implies it is done.
 - Aggregate contract bar now pins **two** open debts exactly: `R-PUB`, `R-SEM`. `productionReadinessContractsAreSatisfiedOnCurrentTree` flips accordingly; closing either remaining debt forces the next honest flip.
 - Base SHA pin unchanged: cc5922e5c5c2786c401713fd80b1bd40d1e15f14.
+
+---
+
+## ADR-001 release enforcement deferred to #284 (2026-07-21)
+
+Owner-approved decision (roadmap T0a). The `release.yml` independent-qualification
+gate was wired in ahead of the qualification pipeline that satisfies it (the
+same-artifact live matrix + per-operation semantic coverage, #373), so every
+release tag failed closed at the gate with no producible evidence. To ship v3.12.0
+(carrying the #427 packaging fix), the pinned-verifier qualification and provenance
+steps in both the build and publish jobs are now gated behind the repository
+variable `ADR001_QUALIFICATION_ENFORCED` (default off). While off, the release
+publishes as it did through v3.11.0 and the release-enforced contracts R-REL,
+R-MATRIX, R-MUT, and R-PROV are honestly OPEN (tracked here and by
+`productionReadinessContractsAreSatisfiedOnCurrentTree`). The managed fixtures
+remain present and SHA-bound on disk — only their enforcement at release is
+deferred. Flipping the variable to `true` makes the gate run again at release time,
+but the static production-readiness contract still reads the `if:` deferral in the
+workflow text, so re-closing all four happens at #284 / T5 — which removes the
+deferral conditions (restoring the unconditional gate) and provisions the
+QUALIFICATION_* evidence/secrets.


### PR DESCRIPTION
## Problem

The independent exact-artifact qualification gate in `.github/workflows/release.yml` was wired in ahead of the pipeline that satisfies it. The full same-artifact live matrix plus per-operation semantic coverage (#373) that would produce a passing signed evidence bundle is roadmap T5 / #284 and does not exist yet — `Scripts/live-qualification-runner.py` can only emit a `not_qualified` skeleton. As shipped, every release tag fails closed at the gate because no qualifying evidence can be produced. v3.12.0 is the first tag to hit it (the gate postdates v3.11.0), which is why its release run failed at "Enforce independent exact-artifact qualification".

## Change

Gate the qualification/verifier steps in both the `build` and `publish` jobs behind the repository variable `ADR001_QUALIFICATION_ENFORCED`:

- Unset/false (current): the gate is skipped and releases ship exactly as they did through v3.11.0.
- `'true'` (when #284 lands, with `QUALIFICATION_EVIDENCE_URL`, `QUALIFICATION_EVIDENCE_SHA256`, and `TRUSTED_QUALIFICATION_PUBLIC_KEY` provisioned): the enforcement runs fail-closed exactly as before.

The enforcement logic itself is unchanged. The SHA256 manifest step lists the `qualification-evidence/*` files only when present, so a deferred-gate release still produces a complete manifest of the shipped artifacts.

## Effect

Unblocks the v3.12.0 stable release, which carries the #427 `logic_variants.py` packaging fix. #284 re-enables the gate with the real qualification pipeline.