### PR TITLE
fix(export): surface input-source precondition and blocking-modal blocker in export readiness (#427 follow-up)

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -35,6 +35,12 @@ struct ProjectDispatcher: OperationTraceDispatching {
         },
         sleep: (UInt64) async -> Void = { try? await Task.sleep(nanoseconds: $0) },
         dialogPresent: @escaping @Sendable () -> Bool = { false },
+        // #427 follow-up: the authoritative blocking-dialog signal the transport
+        // preflight fails closed on (`preflight_blocking_dialog`). Threaded into
+        // the read-only `audit` so a modal present at audit time surfaces as an
+        // export-readiness blocker instead of a false green. Defaults to the same
+        // live source the transport path uses; tests inject a fixture.
+        blockingDialogInfo: @escaping @Sendable () -> AXLogicProElements.BlockingDialogInfo? = { AXLogicProElements.blockingDialogInfo() },
         cleanupAuditFileReader: LogicProjectFileReader.Runtime = .production,
         // #27 Phase 2 — injectable export-execution seams (identity readback,
         // audio analysis, file polling). Defaults to the live wiring; tests
@@ -398,7 +404,10 @@ struct ProjectDispatcher: OperationTraceDispatching {
             return toolTextResult(result)
 
         case "audit":
-            let report = await ProjectSessionAudit.buildAudit(cache: cache)
+            let report = await ProjectSessionAudit.buildAudit(
+                cache: cache,
+                blockingDialogButtons: blockingDialogInfo().map(\.buttonTitles)
+            )
             do {
                 return toolTextResult(try encodeJSONStrict(report, compact: true))
             } catch {

--- a/Sources/LogicProMCP/Projects/ProjectExportPlannerSupport.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportPlannerSupport.swift
@@ -120,6 +120,18 @@ extension ProjectExportPlanner {
                     + "share path, pass the ownership-trust check, and have a python3 interpreter available.",
                 verifyWith: "LogicProMCP doctor"
             ),
+            ProjectExportPrecondition(
+                requirement: "input_source_available",
+                appliesToCommands: ["bounce"],
+                detail: "The export step types the destination filename into Logic's Bounce/save panel with "
+                    + "synthetic keystrokes, so the helper first switches the active keyboard input source to an "
+                    + "ABC or US layout (com.apple.keylayout.ABC or com.apple.keylayout.US); one of those must be "
+                    + "enabled in System Settings > Keyboard > Input Sources. If neither is enabled the helper FAILS "
+                    + "CLOSED with input_source_switch_failed instead of continuing (a Mac with only a French/AZERTY "
+                    + "source enabled hits this once the project has opened). Failing closed is correct because "
+                    + "keystroke automation on a non-ABC/US layout would type the wrong characters into the filename.",
+                verifyWith: "LogicProMCP doctor (bundled logic_input_source.py helper)"
+            ),
         ]
     }
 

--- a/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
+++ b/Sources/LogicProMCP/Workflows/ProjectSessionAudit.swift
@@ -273,12 +273,21 @@ enum ProjectSessionAudit {
         /// `track_readback_gap` when the file says there are more tracks than AX
         /// surfaced — keeping the audit honest against `logic://tracks`.
         let fileTrackCount: Int?
+        /// #427 follow-up: button labels of a blocking modal dialog/sheet owning
+        /// the Logic window at audit time — the same authoritative signal
+        /// (`AXLogicProElements.blockingDialogInfo()`) the transport preflight fails
+        /// closed on (`preflight_blocking_dialog`). `nil` when no blocking dialog is
+        /// present; a non-nil value means a bounce/export cannot run until it is
+        /// dismissed, so the audit surfaces it as an export blocker rather than the
+        /// weaker `ax_occluded` warning. Threaded as a plain value like `axOccluded`.
+        let blockingDialogButtons: [String]?
     }
 
     static func buildAudit(
         cache: StateCache,
         now: Date = Date(),
-        fileReader: LogicProjectFileReader.Runtime = .production
+        fileReader: LogicProjectFileReader.Runtime = .production,
+        blockingDialogButtons: [String]? = nil
     ) async -> AuditReport {
         // Read-only cross-check source: the same MetaData.plist track count the
         // `logic://tracks` resource uses to synthesise placeholder rows. This is
@@ -303,7 +312,8 @@ enum ProjectSessionAudit {
             markersFetchedAt: s.markersFetchedAt,
             channelStrips: s.channelStrips,
             mixerFetchedAt: s.mixerFetchedAt,
-            fileTrackCount: fileTrackCount
+            fileTrackCount: fileTrackCount,
+            blockingDialogButtons: blockingDialogButtons
         )
         return buildAudit(snapshot: snapshot)
     }
@@ -476,6 +486,24 @@ enum ProjectSessionAudit {
                 nil,
                 ["ax_occluded=true"],
                 "cache_stale"
+            ))
+        }
+        // #427 follow-up: a blocking modal dialog/sheet owning the Logic window is
+        // a hard export blocker, not merely occluded readback — a bounce cannot run
+        // while it is up. This mirrors the transport preflight, which fails closed
+        // on the same `blockingDialogInfo()` signal with `preflight_blocking_dialog`;
+        // the audit must not report a false green here.
+        if let buttons = snapshot.blockingDialogButtons {
+            findings.append(finding(
+                "export_blocked_by_modal_dialog",
+                .blocker,
+                "system",
+                "A blocking modal dialog/sheet owns the Logic window; a bounce/export cannot run until it "
+                    + "is dismissed. The transport preflight refuses the same dialog with preflight_blocking_dialog.",
+                "logic://system/health",
+                nil,
+                ["blocking_dialog_present=true", "dialog_buttons=\(buttons.joined(separator: ","))"],
+                "ax_live"
             ))
         }
         if project.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || project.filePath == nil {

--- a/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
+++ b/Tests/LogicProMCPTests/ProjectExportPlannerTests.swift
@@ -77,7 +77,7 @@ struct ProjectExportPlannerTests {
         // The plan must no longer be silent about what the run needs: every
         // precondition names the bounce command it gates.
         #expect(plan.executionPreconditions.map(\.requirement)
-            == ["automation_permission", "post_event_access", "bounce_helper_available"])
+            == ["automation_permission", "post_event_access", "bounce_helper_available", "input_source_available"])
         #expect(plan.executionPreconditions.allSatisfy { $0.appliesToCommands == ["bounce"] })
         #expect(plan.executionPreconditions.allSatisfy { !$0.verifyWith.isEmpty })
 
@@ -90,6 +90,20 @@ struct ProjectExportPlannerTests {
         #expect(automation.detail.contains("System Events"))
         #expect(automation.detail.contains("does NOT require"))
         #expect(automation.detail.contains("MIDIKeyCommands"))
+
+        // #427 follow-up: the keyboard-driven bounce/save panel needs an ABC or
+        // US input source. The bundled helper fails closed with
+        // `input_source_switch_failed` on a non-ABC/US layout (a real French/AZERTY
+        // user report), so the manifest must surface it as a bounce precondition.
+        let inputSource = try #require(
+            plan.executionPreconditions.first { $0.requirement == "input_source_available" }
+        )
+        #expect(inputSource.appliesToCommands == ["bounce"])
+        #expect(inputSource.detail.contains("com.apple.keylayout.ABC"))
+        #expect(inputSource.detail.contains("com.apple.keylayout.US"))
+        #expect(inputSource.detail.contains("input_source_switch_failed"))
+        #expect(inputSource.detail.contains("Input Sources"))
+        #expect(!inputSource.verifyWith.isEmpty)
     }
 
     @Test("#369: execution preconditions encode with snake_case keys and survive round-trip")
@@ -107,7 +121,7 @@ struct ProjectExportPlannerTests {
             try JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
         let preconditions = try #require(object["execution_preconditions"] as? [[String: Any]])
-        #expect(preconditions.count == 3)
+        #expect(preconditions.count == 4)
         let first = try #require(preconditions.first)
         #expect(first["requirement"] as? String == "automation_permission")
         #expect(first["applies_to_commands"] as? [String] == ["bounce"])

--- a/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
+++ b/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
@@ -17,7 +17,8 @@ private func makeAuditSnapshot(
     regionsComplete: Bool = true,
     markers: [MarkerState] = [],
     channelStrips: [ChannelStripState] = [],
-    fileTrackCount: Int? = nil
+    fileTrackCount: Int? = nil,
+    blockingDialogButtons: [String]? = nil
 ) -> ProjectSessionAudit.Snapshot {
     var proj = project ?? ProjectInfo()
     if project == nil {
@@ -47,7 +48,8 @@ private func makeAuditSnapshot(
         markersFetchedAt: now,
         channelStrips: channelStrips,
         mixerFetchedAt: now,
-        fileTrackCount: fileTrackCount
+        fileTrackCount: fileTrackCount,
+        blockingDialogButtons: blockingDialogButtons
     )
 }
 
@@ -353,6 +355,80 @@ private func messySnapshot(
         $0.id == "software_instrument_regions_without_audible_plugin"
     })
     #expect(!report.evidence.exportReadiness.blockers.contains("software_instrument_regions_without_audible_plugin"))
+}
+
+@Test func testProjectAuditSurfacesBlockingModalAsExportBlocker() throws {
+    // #427 follow-up: a blocking modal dialog owning the Logic window at audit
+    // time must flow into export_readiness.blockers (a bounce cannot run while
+    // it is up), matching the transport preflight's `preflight_blocking_dialog`
+    // refusal — NOT be silently downgraded to the `ax_occluded` warning.
+    let snap = makeAuditSnapshot(
+        tracks: [TrackState(id: 0, name: "Lead", type: .audio)],
+        blockingDialogButtons: ["Show Conflicts", "Ignore"]
+    )
+    let report = ProjectSessionAudit.buildAudit(snapshot: snap)
+
+    let blocker = try #require(report.findings.first { $0.id == "export_blocked_by_modal_dialog" })
+    #expect(blocker.severity == .blocker)
+    #expect(blocker.category == "system")
+    #expect(blocker.evidence.resource == "logic://system/health")
+    #expect(blocker.evidence.values.contains("dialog_buttons=Show Conflicts,Ignore"))
+    #expect(report.status == .failed)
+    #expect(report.evidence.exportReadiness.status == "blocked")
+    #expect(report.evidence.exportReadiness.blockers.contains("export_blocked_by_modal_dialog"))
+}
+
+@Test func testProjectAuditWithoutBlockingModalOmitsExportBlocker() throws {
+    // Control: no blocking dialog ⇒ the modal blocker is absent and export
+    // readiness is not blocked on account of it.
+    let snap = makeAuditSnapshot(
+        tracks: [TrackState(id: 0, name: "Lead", type: .audio)],
+        blockingDialogButtons: nil
+    )
+    let report = ProjectSessionAudit.buildAudit(snapshot: snap)
+
+    #expect(!report.findings.contains { $0.id == "export_blocked_by_modal_dialog" })
+    #expect(!report.evidence.exportReadiness.blockers.contains("export_blocked_by_modal_dialog"))
+}
+
+@Test func testProjectAuditDispatcherSurfacesBlockingModalBlocker() async throws {
+    // Mirrors the live repro: `logic_project audit` while a blocking modal
+    // (AXDialog owned by the project window, buttons "Show Conflicts"/"Ignore")
+    // is present must report the modal blocker in export_readiness instead of a
+    // false green, using the SAME blockingDialogInfo() signal the transport
+    // preflight fails closed on. A fixture is injected so the path is headless.
+    let cache = StateCache()
+    var project = ProjectInfo()
+    project.name = "Modal Repro"
+    project.filePath = "/tmp/Modal Repro.logicx"
+    project.source = "ax_live"
+    await cache.updateProject(project)
+    await cache.updateTracks([TrackState(id: 0, name: "Lead", type: .audio)])
+
+    let result = await ProjectDispatcher.handle(
+        command: "audit",
+        params: [:],
+        router: ChannelRouter(),
+        cache: cache,
+        blockingDialogInfo: {
+            AXLogicProElements.BlockingDialogInfo(
+                title: "",
+                role: "AXDialog",
+                owningWindow: "Modal Repro",
+                buttonTitles: ["Show Conflicts", "Ignore"],
+                recoveryAction: "Dismiss the blocking dialog (press Escape), then retry."
+            )
+        }
+    )
+
+    #expect(!result.isError!)
+    let json = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(json["status"] as? String == "failed")
+    let evidence = try #require(json["evidence"] as? [String: Any])
+    let exportReadiness = try #require(evidence["export_readiness"] as? [String: Any])
+    #expect(exportReadiness["status"] as? String == "blocked")
+    let blockers = try #require(exportReadiness["blockers"] as? [String])
+    #expect(blockers.contains("export_blocked_by_modal_dialog"))
 }
 
 @Test func testProjectAuditAndCleanupPlanResourcesAndCommandsReturnJSON() async throws {


### PR DESCRIPTION
Two reviewer-confirmed export-path honesty fixes. Both make the export/bounce path declare or surface a precondition it previously left implicit, so a run can no longer look "ready" while a known blocker is present. Follow-up to #427; the first fix extends the execution-precondition work added in #426.

## Fix 1 — surface the input-source precondition (declarative)

**Root cause.** `executionPreconditions()` in `ProjectExportPlannerSupport.swift` advertised only three preconditions (`automation_permission`, `post_event_access`, `bounce_helper_available`). The keyboard-driven bounce/save panel automation (`Scripts/logic_bounce.py`) first switches the active keyboard input source to an ABC or US layout (`com.apple.keylayout.ABC` / `com.apple.keylayout.US`, via `Scripts/logic_input_source.py`) and **fails closed with `input_source_switch_failed`** when neither is enabled — a real user report on a Mac with only French/AZERTY active hit this after the project opened. The plan manifest was silent about this, so a plan could validate as ready and still fail at bounce time.

**Change.** Add a fourth `ProjectExportPrecondition` — `input_source_available` (`appliesToCommands: ["bounce"]`) — whose `detail` explains the ABC/US requirement, cites the exact layout identifiers and the `input_source_switch_failed` fail-closed behavior, points the user at System Settings > Keyboard > Input Sources, and states why failing closed is correct (keystrokes on a non-ABC/US layout would type the wrong filename). `verifyWith` matches the tone of the existing three entries.

**RED → GREEN** (`ProjectExportPlannerTests`, the existing test pinned the count at 3):

RED (before the code change):
```
✘ "#369: surfaces the bounce step's execution preconditions in the manifest"
  :79  (…map(\.requirement) → ["automation_permission","post_event_access","bounce_helper_available"])
       == [ … , "input_source_available"]   (± removed ["input_source_available"])
  :98  plan.executionPreconditions.first { $0.requirement == "input_source_available" } → nil
✘ "#369: execution preconditions encode with snake_case keys and survive round-trip"
  :124 (preconditions.count → 3) == 4
```
GREEN (after): `Test run with 7 tests passed`.

## Fix 2 — surface a blocking modal as a BLOCKER in export_readiness (false-green bug)

**Root cause.** `ProjectSessionAudit.exportReadiness(from:)` computes `blockers` as `findings.filter { $0.severity == .blocker }`. A blocking modal dialog present at audit time produced only the `ax_occluded` finding (severity `.warn`, keyed off `snapshot.axOccluded` — a weaker, different signal) and never a blocker. So `logic_project audit` reported `export_readiness: { blockers: [], status: "review_required" }` while the transport preflight correctly failed closed on the **same** dialog with `preflight_blocking_dialog`. A bounce cannot succeed while a modal owns the window — a false green.

**Change.** Reuse the authoritative detection — `AXLogicProElements.blockingDialogInfo()`, the same source the transport preflight consumes in `DispatcherSupport.blockingLogicDialogResult`:

- Add a plain-value field `blockingDialogButtons: [String]?` to the pure audit `Snapshot` (threaded like `axOccluded`; `nil` = no dialog).
- Emit a new `.blocker` finding `export_blocked_by_modal_dialog` (category `system`, resource `logic://system/health`) when it is non-nil, including the dialog button labels in the evidence values so it matches the transport path's honesty. It flows into `export_readiness.blockers` and drives report `status` to `failed`.
- Populate the field in `ProjectDispatcher`'s read-only `audit` case from `blockingDialogInfo()` (a new injectable seam defaulting to the same live source the transport path uses; tests inject a fixture).

The `ax_occluded` warning is unchanged; the modal blocker is a separate, stronger signal.

**RED → GREEN** (`ProjectSessionAuditTests`; the plumbing was added first so the tests compile, then the finding emission was added — that emission is the RED→GREEN evidence):

RED (plumbing present, finding not yet emitted):
```
✘ testProjectAuditSurfacesBlockingModalAsExportBlocker
  :371 report.findings.first { $0.id == "export_blocked_by_modal_dialog" } → nil
✘ testProjectAuditDispatcherSurfacesBlockingModalBlocker
  :426 (json["status"] as? String → "degraded") == "failed"
  :429 (exportReadiness["status"] as? String → "review_ready") == "blocked"
  :431 (blockers → []).contains("export_blocked_by_modal_dialog")
```
(control `testProjectAuditWithoutBlockingModalOmitsExportBlocker` passed in both states.)

GREEN (after emission added): all three pass; `Test run with 42 tests passed` for the audit filter.

The dispatcher test drives `ProjectDispatcher.handle(command: "audit", …)` with an injected blocking-dialog fixture and asserts the emitted audit JSON — it reproduces the live repro headlessly (no live Logic required).

## Test matrix

| Suite / test | Fix | RED | GREEN |
|---|---|---|---|
| `ProjectExportPlannerTests` "surfaces … execution preconditions" | 1 | list ≠ 4-entry, entry nil | pass |
| `ProjectExportPlannerTests` "encode with snake_case keys" | 1 | count 3 ≠ 4 | pass |
| `ProjectExportPlannerTests` (7 total) | 1 | 3 failing | 7/7 pass |
| `testProjectAuditSurfacesBlockingModalAsExportBlocker` (pure) | 2 | finding nil | pass |
| `testProjectAuditWithoutBlockingModalOmitsExportBlocker` (control) | 2 | pass | pass |
| `testProjectAuditDispatcherSurfacesBlockingModalBlocker` (dispatcher JSON) | 2 | status degraded / blockers [] | pass |
| Combined `ProjectExportPlanner|Audit|Dispatcher` | 1+2 | — | 320/320 pass |

Run: `swift test --no-parallel --disable-sandbox --filter …`. The dead-`#expect` CI lint (`scripts/ci-forbid-dead-expect.sh`) passes; every new assertion is load-bearing.

## Notes

- The dispatcher-level JSON test lives in `ProjectSessionAuditTests` (which already exercises `handle(command: "audit")` and parses the audit JSON) rather than in `ProjectAuditPhaseTests` (which is scoped to `[AUDIT]` log-phase capture, not JSON). Both `ProjectAuditPhaseTests` and `DispatcherTests` were run and stay green.
- `cleanup_plan` / `cleanup_apply` are intentionally out of scope: the bounce preflight and `cleanup_apply` already fail closed on a present dialog via the existing `dialogPresent()` gate; this change targets the read-only `audit` false-green specifically. The new `buildAudit` parameter defaults to `nil`, so those paths are unchanged.
- No live Logic was required to verify either fix; both are covered headlessly (pure `Snapshot → findings` for the audit, injected fixtures for the dispatcher).

Follow-up to #427. Relates to #426.
