### PR TITLE
fix(qualification): credit semantic coverage from live qualification / governed waivers, not validator existence (#409)

### DIFF
--- a/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
+++ b/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
@@ -524,8 +524,13 @@ enum ProductionReadinessContractEvaluator {
                 detail: "governed waiver inventory has \(waiverIssues.count) validation issue(s)"
             ))
         }
+        // #409: a registered semantic-readback validator is inventory, not
+        // coverage. Only live qualification (a case with status .passed and
+        // verificationKind .semanticReadback, per PromotionGate) or a governed
+        // release-visible waiver credits an operation. This static repo-tree
+        // evaluator has no live .passed data (that matrix is #284), so an
+        // operation counts as missing unless a qualifying governed waiver covers it.
         let missingSemantic = registered.filter { operationID in
-            guard !semantic.contains(operationID) else { return false }
             return !governedWaivers.contains { waiver in
                 waiver.governsOperation(
                     caseID: "in-process/\(operationID)",

--- a/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
+++ b/Tests/LogicProMCPTests/LPMCPPRD001ProductionReadinessREDTests.swift
@@ -686,6 +686,65 @@ struct LPMCPPRD001ProductionReadinessREDTests {
         #expect(report.semanticValidatorOperationCount == 1)
     }
 
+    /// #409: a semantic-readback validator merely *existing* is not coverage.
+    /// An operation that HAS a validator but no governed release-visible waiver
+    /// (and no live `.passed` — the static repo-tree reality) must count as
+    /// missing and keep R-SEM open with an honest count. A qualifying governed
+    /// waiver, by contrast, credits the operation and closes the debt. Before the
+    /// fix, validator existence alone suppressed the finding — the false-green seam.
+    @Test func r_sem_validatorExistenceAloneDoesNotCreditCoverage() throws {
+        // Everything else green so R-SEM is the only debt that can open. The one
+        // registered op HAS a semantic validator but no governed waiver.
+        let withoutWaiver = ProductionReadinessContractEvaluator.evaluate(
+            releaseWorkflowYAML: fullGreenWorkflowYAML(),
+            registeredOperationIDs: ["system.health"],
+            semanticValidatorOperationIDs: ["system.health"],
+            requiredMatrixAxisCount: QualificationAxis.requiredCombinations.count,
+            debtBoardMarkdown: "Exact base: \(expectedBaseSHA)",
+            expectedAuthorityBaseSHA: expectedBaseSHA,
+            publishedReleaseEvidencePresent: true,
+            mutationRestoreCompensationEvidencePresent: true,
+            independentProvenanceEnforced: true,
+            managedFixturesPresent: true
+        )
+        // Fails before the fix (validator existence wrongly credited the op, so
+        // openDebts was empty); passes after (op is missing, only R-SEM opens).
+        #expect(withoutWaiver.openDebts == [.semanticCoverageIncomplete])
+        let detail = try #require(
+            withoutWaiver.findings.first { $0.id == .semanticCoverageIncomplete }?.detail
+        )
+        #expect(detail.contains("1/1 operations"))
+        #expect(detail.contains("system.health"))
+
+        // A qualifying governed release-visible waiver DOES credit the operation,
+        // proving the fix did not hardcode "always missing": the waiver path still
+        // closes R-SEM (and, with everything else green, the whole contract).
+        let waiver = QualificationWaiver(
+            caseID: "in-process/system.health",
+            reasonCode: "known-limitation",
+            owningIssue: "#409",
+            userImpact: "static-tree coverage credited via governed waiver",
+            affectedCapability: QualificationWaiver.operationCapability("system.health"),
+            affectsDefaultProfile: true,
+            expiryVersion: "99.0.0",
+            releaseNoteVisible: true
+        )
+        let withWaiver = ProductionReadinessContractEvaluator.evaluate(
+            releaseWorkflowYAML: fullGreenWorkflowYAML(),
+            registeredOperationIDs: ["system.health"],
+            semanticValidatorOperationIDs: ["system.health"],
+            requiredMatrixAxisCount: QualificationAxis.requiredCombinations.count,
+            debtBoardMarkdown: "Exact base: \(expectedBaseSHA)",
+            expectedAuthorityBaseSHA: expectedBaseSHA,
+            publishedReleaseEvidencePresent: true,
+            mutationRestoreCompensationEvidencePresent: true,
+            independentProvenanceEnforced: true,
+            governedWaivers: [waiver],
+            managedFixturesPresent: true
+        )
+        #expect(withWaiver.openDebts.isEmpty)
+    }
+
     @Test func r_matrix_rejectsWhenManagedFixtureMatrixUnbound() {
         let report = ProductionReadinessContractEvaluator.evaluate(
             releaseWorkflowYAML: """
@@ -778,8 +837,9 @@ struct LPMCPPRD001ProductionReadinessREDTests {
 
     /// Aggregate production-readiness bar — the honest debt set on the current tree.
     /// R-PUB (release assets are owner-replaceable; no immutable/transparency
-    /// publication exists) and R-SEM (semantic coverage is 1/108 until the coverage
-    /// program lands) remain open as before. In addition, ADR-001 release-time
+    /// publication exists) and R-SEM (semantic coverage is 0/108 — no operation has
+    /// live qualification or a governed waiver; a registered validator is inventory,
+    /// not coverage, per #409) remain open as before. In addition, ADR-001 release-time
     /// enforcement is DEFERRED behind the `ADR001_QUALIFICATION_ENFORCED` repository
     /// variable (owner decision, 2026-07-21) until the qualification pipeline lands at
     /// #284 / roadmap T5: `release.yml` no longer *unconditionally* runs the


### PR DESCRIPTION
## Root cause (#409)

`ProductionReadinessContractEvaluator.evaluate(...)` computed `missingSemantic` with a validator-existence exemption:

```swift
guard !semantic.contains(operationID) else { return false }
```

`semantic` is `semanticValidatorOperationIDs`, sourced from `operationsWithSemanticValidators()`, which returns non-nil for **every** oracle-table entry — including the mutating oracles added in #404 that the qualification drive never exercises with a live mutation (they have no live `.passed`). That line credited an operation as semantically covered merely because a validator object existed for it. As #404's oracles landed, credited coverage silently grew past the honest `1/108` baseline with no live qualification behind it — a false green in which R-SEM under-counted the missing operations.

The authoritative "qualified" signal is **live** (`PromotionGate`): a required operation is satisfied only through a case with `status == .passed && verificationKind == .semanticReadback`, or a governed release-visible waiver. The static repository-tree evaluator has **no** live `.passed` data (that matrix is #284 / T5, not run here), so the only thing it can honestly credit is a governed release-visible waiver.

## Fix

Drop the validator-existence exemption. An operation now counts as missing **unless** a qualifying governed waiver covers it (`governsOperation` + `affectsDefaultProfile` + `releaseNoteVisible` + valid reason code) — the governed-waiver check is unchanged. A short comment records why validator existence is not coverage.

- `operationsWithSemanticValidators()` and `semanticValidatorOperationCount` reporting are **unchanged** — they honestly report the validator inventory; only the coverage-credit logic (`missingSemantic`) changed.

## Why R-SEM stays open

`.github/qualification/waivers.json` is `[]` (the blanket waivers were removed earlier in this remediation; see `docs/tickets/lpmcp-prd-001/STATUS.md`). With no governed waivers and no live `.passed` data, every registered operation is now honestly missing: the R-SEM detail count rises from the previously-inflated value to `108/108`. R-SEM (`semanticCoverageIncomplete`) was already open and stays open; it closes only when the coverage program (#373) lands real live evidence.

## No other debt flips

The open-debt **set** is unchanged. `productionReadinessContractsAreSatisfiedOnCurrentTree` (which pins the exact set) still passes; only the R-SEM *detail count* becomes honest. The now-stale `1/108` doc note on that test is corrected to `0/108`.

## RED to GREEN evidence

New mutation-proof test `r_sem_validatorExistenceAloneDoesNotCreditCoverage` in suite `LPMCP-PRD-001 production readiness RED`: an op that HAS a validator but NO governed waiver must be missing and keep R-SEM open with an honest `1/1` count; a qualifying governed waiver credits it and closes the whole contract.

Command: `swift test --no-parallel --disable-sandbox --filter LPMCPPRD001ProductionReadinessREDTests`

RED (pre-fix source, new test present):

```
✘ Test r_sem_validatorExistenceAloneDoesNotCreditCoverage() recorded an issue at LPMCPPRD001ProductionReadinessREDTests.swift:712:9: Expectation failed: (withoutWaiver.openDebts → []) == ([.semanticCoverageIncomplete] → [LogicProMCP.LPMCPPRD001DebtID.semanticCoverageIncomplete])
✘ Test r_sem_validatorExistenceAloneDoesNotCreditCoverage() recorded an issue at LPMCPPRD001ProductionReadinessREDTests.swift:713:26: Expectation failed: (withoutWaiver.findings.first { $0.id == .semanticCoverageIncomplete } → nil).detail → nil
✘ Test r_sem_validatorExistenceAloneDoesNotCreditCoverage() failed after 0.005 seconds with 2 issues.
✘ Test run with 21 tests failed after 0.261 seconds with 2 issues.
```

All other 20 tests in the suite passed under RED, including `productionReadinessContractsAreSatisfiedOnCurrentTree` (the open-debt set is unchanged) and `r_sem_rejectsWhenSemanticValidatorsCoverOnlyHealth`.

GREEN (post-fix):

```
✔ Test r_sem_validatorExistenceAloneDoesNotCreditCoverage() passed after 0.009 seconds.
✔ Suite "LPMCP-PRD-001 production readiness RED" passed after 0.224 seconds.
✔ Test run with 21 tests passed after 0.256 seconds.
```

## References

- #409 — the false-green seam fixed here.
- #373 — the coverage program that will close R-SEM with live evidence.
- #404 — the mutating oracles whose validators were being mis-credited.

Do not merge without maintainer / release-gate review.
