### PR TITLE
release: sync Formula sha256 to v3.12.0 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz release artifact.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "268bffbf17ece58a373e1a1ddca0155d7c04691b7801bb2274327ce44a8ed4b9"
+    sha256 "702705253b99ba1ed2111afc1294074b23d4cff9e14af5e3d27ecaf602654f1c"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
Sync the Homebrew Formula `sha256` to the published `v3.12.0` `LogicProMCP-macOS-universal.tar.gz`.

- Published (from the v3.12.0 release `SHA256SUMS.txt`): `702705253b99ba1ed2111afc1294074b23d4cff9e14af5e3d27ecaf602654f1c`
- Previous placeholder in Formula: `268bffbf17ece58a373e1a1ddca0155d7c04691b7801bb2274327ce44a8ed4b9`

Post-publish release step so `brew install logic-pro-mcp` resolves the v3.12.0 tarball (which carries the #427 `logic_variants.py` packaging fix). The release workflow published successfully (build/publish/validate-install on macos-14 and macos-15 all green).