### PR TITLE
fix(qualification): correct R-SEM missing-coverage detail wording

### DIFF
--- a/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
+++ b/Sources/LogicProMCP/Qualification/ProductionReadinessContracts.swift
@@ -544,7 +544,7 @@ enum ProductionReadinessContractEvaluator {
         if !missingSemantic.isEmpty {
             findings.append(.init(
                 id: .semanticCoverageIncomplete,
-                detail: "semantic validators or release-gated governed waivers missing for \(missingSemantic.count)/\(registered.count) operations (e.g. \(missingSemantic.prefix(5).joined(separator: ", ")))"
+                detail: "semantic coverage missing (no live qualification .passed and no governed release-visible waiver) for \(missingSemantic.count)/\(registered.count) operations (e.g. \(missingSemantic.prefix(5).joined(separator: ", ")))"
             ))
         }
 


### PR DESCRIPTION
Post-#409, a registered semantic-readback validator no longer credits semantic coverage — only live qualification (a case with status `.passed`) or a governed release-visible waiver does. The R-SEM finding detail still read "semantic validators or release-gated governed waivers missing for N/M operations", which could mislead a reader into thinking adding a validator closes the gap.

Reword the prefix to "semantic coverage missing (no live qualification .passed and no governed release-visible waiver) for N/M operations". Purely a human-readable detail string; no behavioral change. The "N/M operations (e.g. …)" shape is unchanged, so the existing test assertions (`1/1 operations`, `system.health`) still hold — LPMCPPRD001 suite stays green (21 tests). Closes the guardian follow-up NIT from #433.

Refs #409, #433.