### PR TITLE
qualification: #373 Phase-B2 transport/navigate verified-write oracles

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -97,6 +97,47 @@ enum SemanticOracleTable {
         .pluginsSetParamVerified,
     ]
 
+    /// The mutating operations B2 covers with a verified-write (State A) oracle:
+    /// the transport + navigate safe-mutation surface. Each was derived by READING
+    /// its dispatcher/channel handler and pinning what its `encodeStateA` envelope
+    /// actually emits (cited per oracle below). Like B1 this is an EXPLICIT
+    /// increment, not the whole mutating surface — B3 adds the rest.
+    ///
+    /// COVERAGE CREDIT (#409): defining an oracle here is INVENTORY, not coverage.
+    /// R-SEM (`semanticCoverageIncomplete`) is credited to an operation ONLY when it
+    /// is live-exercised to a `.passed` semanticReadback verdict (the #284 live
+    /// matrix) or covered by a governed release-visible waiver — never by an oracle's
+    /// mere existence. So this B2 increment PINS the State-A contract these
+    /// transport/navigate writes must satisfy in the future live run; it does NOT
+    /// itself reduce the R-SEM static debt.
+    ///
+    /// DELIBERATELY ABSENT (audited, no State-A envelope to verify — see
+    /// `structurallyUnverifiedMutatingOperationIDs`): transport.rewind,
+    /// transport.fast_forward, navigate.zoom_to_fit, navigate.delete_marker,
+    /// navigate.toggle_view. Every one routes ONLY to send-only channels
+    /// (MCU / MIDIKeyCommands / CGEvent) whose handlers emit State B
+    /// `readback_unavailable` with no read-back — there is no State A to pin, so a
+    /// verified-write oracle would have to invent a contract the handler can never
+    /// produce. transport.set_cycle_range is excluded a level earlier: it is
+    /// registry `.unsupported`, so `mutatingSpecIDs` already filters it out (see
+    /// `unsupportedExcludedMutatingOperationIDs`).
+    static let phaseB2MutatingOperationIDs: Set<OperationID> = [
+        // transport (10 of the 12 audited — rewind/fast_forward are send-only)
+        .transportPlay, .transportStop, .transportRecord, .transportPause,
+        .transportToggleCycle, .transportToggleMetronome, .transportToggleCountIn,
+        .transportToggleAutopunch, .transportSetTempo, .transportGotoPosition,
+        // navigate (5 of the 8 audited — zoom_to_fit/delete_marker/toggle_view are send-only)
+        .navigateGotoBar, .navigateGotoMarker, .navigateCreateMarker,
+        .navigateRenameMarker, .navigateSetZoom,
+    ]
+
+    /// Every mutating operation the table covers so far: the B1 verified-write
+    /// increment UNION the B2 transport/navigate increment. Coverage is still
+    /// INCREMENTAL (B3 remains); this is the covered subset the census pins.
+    static var coveredMutatingOperationIDs: Set<OperationID> {
+        phaseB1MutatingOperationIDs.union(phaseB2MutatingOperationIDs)
+    }
+
     /// The mutating surface (non-`.unsupported`), from the registry. Coverage is
     /// INCREMENTAL — unlike `coveredSpecIDs`, the table need not cover all of this
     /// yet; `phaseB1MutatingOperationIDs` is the covered subset.
@@ -126,6 +167,41 @@ enum SemanticOracleTable {
         .mixerSetPluginParam:
             "send-only State B — routes to [.scripter], whose handler emits only "
             + "readback_unavailable / scripter_send_only; there is no State A to verify",
+        // B2 audit: these four transport/navigate ops route ONLY to send-only
+        // channels and their handlers can never reach State A. Kept explicit so
+        // their absence from the B2 increment is a reviewed decision, not a gap.
+        .transportRewind:
+            "send-only — routes to [.mcu, .coreMIDI, .cgEvent]; MCUChannel.sendTransport "
+            + "and the keystroke channels emit only State B readback_unavailable, so a "
+            + "rewind press has no read-back and no State A to verify",
+        .transportFastForward:
+            "send-only — routes to [.mcu, .coreMIDI, .cgEvent] exactly like rewind; the "
+            + "MCU/CoreMIDI/CGEvent transport presses are echo-less, so no State A exists",
+        .navigateZoomToFit:
+            "send-only — routes to [.midiKeyCommands, .cgEvent]; both fire a blind key "
+            + "command (CC 46 / key Z) with no arrange-zoom read-back, so the op is honestly "
+            + "State B and never reaches a verified State A",
+        .navigateDeleteMarker:
+            "send-only — routes to [.midiKeyCommands, .cgEvent] (CC 45 / keystroke); the "
+            + "keycmd channel gives no marker-list read-back, so a delete is State B only. "
+            + "(Availability is .requiresKeyBinding, but that is a SETUP axis — the reason "
+            + "it has no State A is the echo-less channel, not the keybinding requirement.)",
+        .navigateToggleView:
+            "send-only — routes each view to [.midiKeyCommands, .cgEvent] (view.toggle_*); "
+            + "the key command fires blind with no view-state read-back, so no State A exists",
+    ]
+
+    /// Mutating ops that never enter the oracle surface at all because the
+    /// registry marks them `.unsupported` — `mutatingSpecIDs` filters
+    /// `availability != .unsupported`, so they are excluded a level BEFORE the
+    /// structural-exclusion list above (which is for SUPPORTED mutating specs that
+    /// still lack a State-A envelope). Kept explicit + reasoned so the
+    /// `.unsupported` exclusion is documented, not merely implied by the filter.
+    static let unsupportedExcludedMutatingOperationIDs: [OperationID: String] = [
+        .transportSetCycleRange:
+            "registry .unsupported — Logic 12.x exposes no numeric cycle-locator AX fields, "
+            + "so AccessibilityChannel.defaultSetCycleRange fails closed with State C "
+            + "not_implemented and can never verify a write; excluded from mutatingSpecIDs",
     ]
 
     static let all: [OperationOracle] = [
@@ -162,6 +238,22 @@ enum SemanticOracleTable {
         tracksSetAutomation,
         tracksSetInstrument,
         pluginsSetParamVerified,
+        // #373 Phase B2 — transport + navigate safe-mutation oracles (State A).
+        transportPlay,
+        transportStop,
+        transportRecord,
+        transportPause,
+        transportToggleCycle,
+        transportToggleMetronome,
+        transportToggleCountIn,
+        transportToggleAutopunch,
+        transportSetTempo,
+        transportGotoPosition,
+        navigateGotoBar,
+        navigateGotoMarker,
+        navigateCreateMarker,
+        navigateRenameMarker,
+        navigateSetZoom,
     ]
 
     static let byOperationID: [OperationID: OperationOracle] = Dictionary(
@@ -950,6 +1042,306 @@ enum SemanticOracleTable {
             ),
             .typedField(key: "target_identity", type: .object),
             .typedField(key: "param", type: .string),
+        ]
+    )
+
+    // MARK: - #373 Phase B2 — transport safe-mutation oracles
+
+    // Each composes `SafeMutationOracle.verifiedEnvelope` (State A + verified +
+    // success) with the op's own invariant, derived by READING its dispatcher/
+    // channel handler. The envelope is always FIRST, so no oracle asserts what
+    // changed before proving it was verified.
+    //
+    // transport
+
+    /// The control-bar click strategies a transport checkbox toggle records as the
+    /// `action` that landed the write, from
+    /// `AccessibilityChannel+Transport.controlBarClickStrategies`. The ADR-001
+    /// coordinate ban reduced that ladder to AXPress/AXConfirm only — the former
+    /// HID `mouse-click` rung was removed and no handler can emit it — so the domain
+    /// is exactly `axpress`/`axconfirm`. Pinned as a closed set so a toggle claiming
+    /// an unknown strategy (including a regression that re-introduces the banned
+    /// mouse-click) is caught.
+    static let controlBarClickActions = ["axpress", "axconfirm"]
+
+    // TransportDispatcher `handleVerifiedTransportCommand(.play)` → encodeStateA.
+    // BOTH State-A branches (already-playing fast path, and the post-write poll)
+    // emit `operation:"transport.play"`, `verify_source:"transport_state"`, and an
+    // `observed_after` transportStateSummary whose `isPlaying == true` (State A is
+    // reached ONLY when `action.matches(observed)`, i.e. the readback showed
+    // playback). `observed_after.isPlaying == true` is the GENUINE invariant — it
+    // relates the AX transport readback to the operation's target semantics, NOT a
+    // same-source echo. `write_attempted`/`poll_attempts` differ per branch and
+    // are not pinned.
+    static let transportPlay = SafeMutationOracle.oracle(
+        .transportPlay,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("transport.play")),
+            .valueEquals(key: "verify_source", expected: .string("transport_state")),
+            .valueEquals(key: "observed_after.isPlaying", expected: .bool(true)),
+        ]
+    )
+
+    // TransportDispatcher `handleVerifiedTransportCommand(.record)` — same paths as
+    // play, but the State-A gate is `action.matches` = `isPlaying && isRecording`,
+    // so the `observed_after` summary shows BOTH true. Both readback flags are
+    // pinned (the genuine "recording confirmed" invariant); `observed_after` is an
+    // independent AX read, so these are readback semantics, not echoes.
+    static let transportRecord = SafeMutationOracle.oracle(
+        .transportRecord,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("transport.record")),
+            .valueEquals(key: "verify_source", expected: .string("transport_state")),
+            .valueEquals(key: "observed_after.isPlaying", expected: .bool(true)),
+            .valueEquals(key: "observed_after.isRecording", expected: .bool(true)),
+        ]
+    )
+
+    // TransportDispatcher `verifiedStopResult` → encodeStateA. Its TWO State-A
+    // branches diverge in shape: the already-stopped fast path emits
+    // `verify_source:"transport_state"` + a nested `observed_after`/`observed_before`
+    // transportStateSummary, while the post-write path (`stopObservedExtras`) emits
+    // `verify_source:"ax_transport_state"` + FLAT `observed_isPlaying`/… keys. The
+    // only universally-present values are the two hardcoded constants
+    // `operation:"transport.stop"` and `requested_state:"stopped"`, plus
+    // `verify_source` (one of two legal verified-stop provenances — pinned as an
+    // enum so an unknown source is caught). The load-bearing "it actually stopped"
+    // proof is STRUCTURAL: State A is reached only when the readback showed
+    // not-playing/not-recording; the envelope carries that. (Like tracks.select /
+    // tracks.set_automation, only the common keys are declaratively pinnable
+    // because the two branches emit different readback keys.)
+    static let transportStop = SafeMutationOracle.oracle(
+        .transportStop,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("transport.stop")),
+            .valueEquals(key: "requested_state", expected: .string("stopped")),
+            .enumMember(key: "verify_source", allowed: ["transport_state", "ax_transport_state"]),
+        ]
+    )
+
+    // TransportDispatcher `verifiedPauseResult` → encodeStateA. Both State-A
+    // branches (already-paused fast path, post-write path) emit the SAME three
+    // constants: `operation:"transport.pause"`, `requested_state:"paused"`,
+    // `verify_source:"transport_state"` (pause never uses the ax_transport_state
+    // tag stop's write path does). Their readback keys differ (nested
+    // `observed_after` vs flat `observed_isPlaying`), so — as with stop — the
+    // stopped-confirmation is structural (envelope), and only the shared constants
+    // are declaratively pinned.
+    static let transportPause = SafeMutationOracle.oracle(
+        .transportPause,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("transport.pause")),
+            .valueEquals(key: "requested_state", expected: .string("paused")),
+            .valueEquals(key: "verify_source", expected: .string("transport_state")),
+        ]
+    )
+
+    // AccessibilityChannel+Transport `clickControlBarCheckbox` (Cycle) →
+    // encodeStateA. State A is reached ONLY when the AX read-back value flipped
+    // (`waitForControlBarCheckboxValue { $0 != before }`), and the envelope carries
+    // `previous:before` + `observed:after` from TWO independent AX reads — so
+    // `observed == !previous` (`.booleanFlipped`) is the GENUINE "the toggle
+    // changed state" invariant, not a same-source echo. Plus the hardcoded
+    // `button:"Cycle"` / `control:"사이클"` identity and the click-strategy `action`.
+    // Single State-A branch (the dispatcher does a bare `toolTextResult`, no
+    // finalize), so the flip pair is universal here.
+    static let transportToggleCycle = SafeMutationOracle.oracle(
+        .transportToggleCycle,
+        semantics: [
+            .valueEquals(key: "button", expected: .string("Cycle")),
+            .valueEquals(key: "control", expected: .string("사이클")),
+            .booleanFlipped(keyA: "observed", keyB: "previous"),
+            .enumMember(key: "action", allowed: controlBarClickActions),
+        ]
+    )
+
+    // AccessibilityChannel+Transport `clickControlBarCheckbox` (Count In) — same
+    // single-branch flip shape as toggle_cycle; `button:"Count In"`,
+    // `control:"카운트 인"`.
+    static let transportToggleCountIn = SafeMutationOracle.oracle(
+        .transportToggleCountIn,
+        semantics: [
+            .valueEquals(key: "button", expected: .string("Count In")),
+            .valueEquals(key: "control", expected: .string("카운트 인")),
+            .booleanFlipped(keyA: "observed", keyB: "previous"),
+            .enumMember(key: "action", allowed: controlBarClickActions),
+        ]
+    )
+
+    // AccessibilityChannel+Transport `defaultToggleAutopunch` → encodeStateA. Its
+    // single State-A branch fires only when `after == requested == !before`, and
+    // the envelope carries `previous:before` + `observed:after` — so
+    // `observed == !previous` (`.booleanFlipped`) is the genuine flip. Plus the
+    // hardcoded `operation:"transport.toggle_autopunch"`, `button:"Autopunch"`, and
+    // `action:"axpress"` (autopunch uses AXPress exclusively, not the click-strategy
+    // ladder). `control` is a locale LabelSet (`transportAutopunchControl.canonical`)
+    // so it is not pinned.
+    static let transportToggleAutopunch = SafeMutationOracle.oracle(
+        .transportToggleAutopunch,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("transport.toggle_autopunch")),
+            .valueEquals(key: "button", expected: .string("Autopunch")),
+            .valueEquals(key: "action", expected: .string("axpress")),
+            .booleanFlipped(keyA: "observed", keyB: "previous"),
+        ]
+    )
+
+    // toggle_metronome is the one B2 toggle whose verified State A is NOT a single
+    // shape. It routes `[.accessibility, .midiKeyCommands, .cgEvent]` and the
+    // dispatcher RE-VERIFIES a send-only channel via `finalizeToggleMetronomeResult`
+    // (an independent transport-state read). The reachable State-A shapes share NO
+    // non-envelope key:
+    //   * AX-verified (`clickControlBarCheckbox`): flip on `observed`/`previous`,
+    //     plus `button:"Metronome"`/`control:"메트로놈 클릭"`/`action` — and NO
+    //     `operation`/`verification_source`/`*_enabled`.
+    //   * dispatcher-verified (the keycmd/cgEvent State B confirmed by finalize when
+    //     the transport-state metronome flag flipped): flip on
+    //     `observed_enabled`/`previous_enabled` + `verification_source:"transport_state"`
+    //     — and the keycmd/cgEvent State B carries NO `button`/`control`/`action`
+    //     (keycmd emits `operation`/`method`/`cc`; cgEvent emits `operation`/`method`).
+    // So pinning `button`/`control`/`action` (or either flip pair) would FALSE-RED
+    // the other genuine State A — e.g. an AX-control-absent, keycmd-bound setup in
+    // the #284 matrix emits the dispatcher-verified shape, which has none of those
+    // keys. The oracle therefore pins only the channel-independent verified envelope
+    // (State A + verified + success). The "metronome actually toggled" proof is
+    // STRUCTURAL, exactly as for transport.stop / transport.pause: EVERY path
+    // reaches State A only on a CONFIRMED flip — AX via
+    // `waitForControlBarCheckboxValue { $0 != before }`, dispatcher via
+    // `beforeTransport.isMetronomeEnabled != afterTransport.isMetronomeEnabled` — so
+    // a no-op is honest State B (or C) and the envelope rejects it. The dedicated
+    // engine test proves the relaxed oracle accepts BOTH channel shapes yet still
+    // rejects a no-op / failure, so it is not vacuous.
+    static let transportToggleMetronome = SafeMutationOracle.oracle(
+        .transportToggleMetronome,
+        semantics: []
+    )
+
+    // AccessibilityChannel+Transport `defaultSetTempo` → encodeStateA. All three
+    // State-A branches (`via` = slider / slider-increment / slider-value-nudge)
+    // gate on `abs(observed − requested) < 1.0` (the hardcoded 1-BPM convergence
+    // tolerance) and emit `requested` (the input BPM) + `observed` (the slider AX
+    // read). Pinned as `.numericNear(observed, requested, 1.0)` — a genuine
+    // request↔readback bound (the oracle's `<=` is a hair looser than the handler's
+    // strict `<`, which cannot false-pass a realistic verified write). `requested`
+    // is domain-pinned to Logic's 5..990 tempo range (handler guard), and `via` is
+    // the write-path enum (which slider strategy landed).
+    static let transportSetTempo = SafeMutationOracle.oracle(
+        .transportSetTempo,
+        semantics: [
+            .numericNear(keyA: "observed", keyB: "requested", within: .absolute(1.0)),
+            .numericRange(key: "requested", min: 5, max: 990),
+            .enumMember(key: "via", allowed: ["slider", "slider-increment", "slider-value-nudge"]),
+        ]
+    )
+
+    // TransportDispatcher `finalizeGotoPositionResult` → encodeStateA. State A is
+    // reached ONLY when `!requested.contains(":") && observedTransport.position ==
+    // requested`, where `requested` is the requested bar-position string and
+    // `observed` is read from an INDEPENDENT `transport.get_state` AX read — so
+    // `.fieldsEqual(requested, observed)` is a genuine request↔readback pin (the
+    // playhead landed exactly where asked). Plus the hardcoded
+    // `verification_source:"transport_state"` and the shape of the SMPTE echo.
+    static let transportGotoPosition = SafeMutationOracle.oracle(
+        .transportGotoPosition,
+        semantics: [
+            .valueEquals(key: "verification_source", expected: .string("transport_state")),
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "observed_time_position", type: .string),
+        ]
+    )
+
+    // MARK: - #373 Phase B2 — navigate safe-mutation oracles
+
+    // NavigateDispatcher `goto_bar` routes `transport.goto_position` and runs the
+    // SAME `finalizeGotoPositionResult` as transport.goto_position, so its State A
+    // is identical: `requested == observed` playhead position (request↔readback)
+    // plus `verification_source:"transport_state"`.
+    static let navigateGotoBar = SafeMutationOracle.oracle(
+        .navigateGotoBar,
+        semantics: [
+            .valueEquals(key: "verification_source", expected: .string("transport_state")),
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "observed_time_position", type: .string),
+        ]
+    )
+
+    // NavigateDispatcher `goto_marker` resolves the target marker from cache and
+    // routes `transport.goto_position` with its `position`, then runs
+    // `finalizeGotoPositionResult` — so the verified State A is the same
+    // `requested == observed` (the marker's position landed on the playhead) plus
+    // `verification_source:"transport_state"`. A non-canonical marker additionally
+    // carries `marker_position_uncertain`/`marker_position_source` (merged by
+    // `mergeMarkerUncertainty`); those are branch-dependent and NOT pinned so a
+    // canonical-marker State A is not false-failed.
+    static let navigateGotoMarker = SafeMutationOracle.oracle(
+        .navigateGotoMarker,
+        semantics: [
+            .valueEquals(key: "verification_source", expected: .string("transport_state")),
+            .fieldsEqual(keyA: "requested", keyB: "observed"),
+            .typedField(key: "observed_time_position", type: .string),
+        ]
+    )
+
+    // NavigateDispatcher `finalizeCreateMarkerResult` → encodeStateA. State A is
+    // reached only when `afterMarkers.count > beforeMarkers.count` AND (for a named
+    // create) `createdMarker.name == requestedName`. The load-bearing invariant is
+    // `.fieldsEqual(requested_name, observed_marker_name)` — a genuine
+    // request↔readback identity echo: `requested_name` is the input, and
+    // `observed_marker_name` is read back from the INDEPENDENT `logic://markers`
+    // enumeration after the create. Plus the hardcoded
+    // `verification_source:"logic://markers"` (dispatcher) and
+    // `operation:"nav.create_marker"` (channel) constants, and the shape of the
+    // count-delta / new marker id. This models the NAMED create (the qualification
+    // and primary path); an unnamed auto-create is a distinct name-less State-A
+    // shape whose `requested_name` is absent, and the count-delta remains the
+    // structural creation proof carried by the envelope.
+    static let navigateCreateMarker = SafeMutationOracle.oracle(
+        .navigateCreateMarker,
+        semantics: [
+            .valueEquals(key: "verification_source", expected: .string("logic://markers")),
+            .valueEquals(key: "operation", expected: .string("nav.create_marker")),
+            .fieldsEqual(keyA: "requested_name", keyB: "observed_marker_name"),
+            .typedField(key: "observed_marker_id", type: .number),
+            .typedField(key: "marker_count_after", type: .number),
+            .typedField(key: "marker_count_before", type: .number),
+        ]
+    )
+
+    // AccessibilityChannel+Markers `defaultRenameMarker` → encodeStateA. Both
+    // State-A branches (the already-named no-op path and the post-write path) emit
+    // `operation:"nav.rename_marker"`, `requested_name` (input), and `observed_name`
+    // read back from the marker-list enumeration; State A is reached only when
+    // `observed_name == requested_name`, so `.fieldsEqual(requested_name,
+    // observed_name)` is the genuine request↔readback rename proof. `previous_name`
+    // (the pre-rename label) and `index` are shape-pinned. `write_attempted` differs
+    // per branch and is not pinned.
+    static let navigateRenameMarker = SafeMutationOracle.oracle(
+        .navigateRenameMarker,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("nav.rename_marker")),
+            .fieldsEqual(keyA: "requested_name", keyB: "observed_name"),
+            .typedField(key: "index", type: .number),
+            .typedField(key: "previous_name", type: .string),
+        ]
+    )
+
+    // AccessibilityChannel+Transport `defaultSetZoomLevel` (the AX arrange
+    // Horizontal-Zoom slider) → encodeStateA, reached via NavigateDispatcher
+    // `set_zoom` for in/out/numeric levels (fit routes to the send-only
+    // zoom_to_fit). State A gates on `abs(after − target) < 0.02` where `target =
+    // (level−1)/9` and `observed:after` is the slider AX read — pinned as
+    // `.numericNear(observed, requested, 0.02)`, a genuine request↔readback bound
+    // (`requested` carries the computed target). Plus the hardcoded
+    // `operation:"nav.set_zoom"`, `axis:"horizontal"`, `verify_source:"ax_zoom_slider"`
+    // constants and the 1..10 `level` domain.
+    static let navigateSetZoom = SafeMutationOracle.oracle(
+        .navigateSetZoom,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("nav.set_zoom")),
+            .valueEquals(key: "axis", expected: .string("horizontal")),
+            .valueEquals(key: "verify_source", expected: .string("ax_zoom_slider")),
+            .numericNear(keyA: "observed", keyB: "requested", within: .absolute(0.02)),
+            .numericRange(key: "level", min: 1, max: 10),
         ]
     )
 }

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -102,6 +102,18 @@ enum OracleConstraint: Sendable {
     /// e.g. a multi-step op that reaches State A only when its failure/uncertainty
     /// lists are empty. Fails closed on a missing key or a non-array.
     case emptyArray(key: String)
+    /// Two boolean key paths WITHIN THE SAME payload are logical negations:
+    /// `value(keyA) == !value(keyB)`. The load-bearing invariant of a verified
+    /// TOGGLE — a control-bar checkbox flip reaches State A only when the AX
+    /// read-back `observed` is the negation of the `previous` value, so
+    /// `observed == !previous` proves the toggle CHANGED state rather than a no-op
+    /// that still reported success. This is genuinely value-bearing: it relates
+    /// two INDEPENDENTLY-READ observations (the before-read and the after-read),
+    /// not one value to itself, so it is never a same-source echo. BOOLS ONLY,
+    /// with the same CFBoolean discipline as the rest of the model — a numeric
+    /// `0`/`1` must NOT satisfy it (`1` is not the negation of `false`) — and a
+    /// missing key, a non-bool, or two EQUAL bools all fail closed.
+    case booleanFlipped(keyA: String, keyB: String)
 
     /// The primary RESPONSE-side key path — the one the generic mutator drops
     /// and error messages cite. For the relational cases it is the response side
@@ -116,7 +128,8 @@ enum OracleConstraint: Sendable {
              .fieldsEqual(let key, _),
              .crossCheck(let key, _),
              .numericNear(let key, _, _),
-             .emptyArray(let key):
+             .emptyArray(let key),
+             .booleanFlipped(let key, _):
             return key
         }
     }
@@ -128,7 +141,8 @@ enum OracleConstraint: Sendable {
     /// oracle carrying one is never a checkbox oracle.
     var isValueConstraint: Bool {
         switch self {
-        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck, .numericNear:
+        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck, .numericNear,
+             .booleanFlipped:
             return true
         case .nonEmptyArray, .typedField, .emptyArray:
             return false
@@ -190,6 +204,16 @@ enum OracleConstraint: Sendable {
         case .emptyArray(let key):
             guard let array = JSONPath.resolve(root, keyPath: key) as? [Any] else { return false }
             return array.isEmpty
+        case .booleanFlipped(let keyA, let keyB):
+            // BOOLS ONLY: both sides must be genuine CFBooleans — a numeric 0/1
+            // fails closed (`isBoolean` gates it) — and they must be logical
+            // negations. A missing key, a non-bool, or two EQUAL bools all fail.
+            guard let aValue = JSONPath.resolve(root, keyPath: keyA),
+                  let bValue = JSONPath.resolve(root, keyPath: keyB),
+                  JSONInspector.isBoolean(aValue), JSONInspector.isBoolean(bValue),
+                  let a = (aValue as? NSNumber)?.boolValue,
+                  let b = (bValue as? NSNumber)?.boolValue else { return false }
+            return a != b
         }
     }
 }

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -599,5 +599,171 @@ enum SemanticOracleFixtures {
                 """,
             readback: "{}"
         ),
+
+        // ── #373 Phase B2 — transport + navigate verified State-A fixtures ────
+        // Each is a faithful State-A payload from the op's dispatcher/channel
+        // `encodeStateA` path. Readback is unused (no B2 oracle cross-checks), so
+        // it is a bare `{}`.
+
+        // TransportDispatcher.handleVerifiedTransportCommand(.play) write path:
+        // observed_after summary shows isPlaying:true (the State-A gate).
+        .transportPlay: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"transport.play","verify_source":"transport_state",\
+                "write_attempted":true,"poll_attempts":1,\
+                "observed_before":{"isPlaying":false,"isRecording":false,\
+                "position":"1.1.1.1","tempo":120},\
+                "observed_after":{"isPlaying":true,"isRecording":false,\
+                "position":"1.3.1.1","tempo":120},"write_result":{"state":"B"}}
+                """,
+            readback: "{}"
+        ),
+        // .record gate: observed_after shows isPlaying && isRecording.
+        .transportRecord: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"transport.record","verify_source":"transport_state",\
+                "write_attempted":true,"poll_attempts":1,\
+                "observed_before":{"isPlaying":false,"isRecording":false,\
+                "position":"1.1.1.1","tempo":120},\
+                "observed_after":{"isPlaying":true,"isRecording":true,\
+                "position":"1.2.1.1","tempo":120},"write_result":{"state":"B"}}
+                """,
+            readback: "{}"
+        ),
+        // verifiedStopResult post-write path (stopObservedExtras): FLAT observed_*
+        // keys, verify_source ax_transport_state.
+        .transportStop: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"transport.stop","requested_state":"stopped",\
+                "verify_source":"ax_transport_state","write_attempted":true,\
+                "poll_attempts":2,"observed_isPlaying":false,"observed_isRecording":false,\
+                "observed_position":"5.1.1.1","observed_time_position":"00:00:08:12",\
+                "write_result":{"state":"B"}}
+                """,
+            readback: "{}"
+        ),
+        // verifiedPauseResult post-write path: verify_source transport_state.
+        .transportPause: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"transport.pause","requested_state":"paused",\
+                "verify_source":"transport_state","write_attempted":true,\
+                "poll_attempts":1,"observed_isPlaying":false,"observed_isRecording":false,\
+                "observed_position":"5.1.1.1","observed_time_position":"00:00:08:12",\
+                "write_result":{"state":"B"}}
+                """,
+            readback: "{}"
+        ),
+        // clickControlBarCheckbox(Cycle): observed:true == !previous:false.
+        .transportToggleCycle: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","button":"Cycle",\
+                "control":"사이클","observed":true,"previous":false,\
+                "action":"axpress","attempts":["axpress"]}
+                """,
+            readback: "{}"
+        ),
+        // clickControlBarCheckbox(Count In).
+        .transportToggleCountIn: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","button":"Count In",\
+                "control":"카운트 인","observed":true,"previous":false,\
+                "action":"axpress","attempts":["axpress"]}
+                """,
+            readback: "{}"
+        ),
+        // defaultToggleAutopunch: observed:true == !previous:false, action axpress.
+        .transportToggleAutopunch: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","button":"Autopunch",\
+                "control":"Autopunch","operation":"transport.toggle_autopunch",\
+                "action":"axpress","previous":false,"observed":true,"requested":true}
+                """,
+            readback: "{}"
+        ),
+        // toggle_metronome — AX-verified shape (clickControlBarCheckbox). The
+        // oracle pins only the channel-independent envelope (the two channel shapes
+        // share no non-envelope key); the dispatcher-verified keycmd shape and the
+        // no-op/failure rejection are covered by a dedicated engine test.
+        .transportToggleMetronome: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","button":"Metronome",\
+                "control":"메트로놈 클릭","observed":true,"previous":false,\
+                "action":"axpress","attempts":["axpress"]}
+                """,
+            readback: "{}"
+        ),
+        // defaultSetTempo (via slider): observed 119.7 within 1.0 BPM of requested 120.
+        .transportSetTempo: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "requested":120.0,"observed":119.7,"via":"slider"}
+                """,
+            readback: "{}"
+        ),
+        // finalizeGotoPositionResult: observed position == requested (exact landing).
+        .transportGotoPosition: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "verification_source":"transport_state","requested":"5.1.1.1",\
+                "observed":"5.1.1.1","observed_time_position":"00:00:08:12","via":"dialog"}
+                """,
+            readback: "{}"
+        ),
+        // navigate.goto_bar → same finalizeGotoPositionResult shape.
+        .navigateGotoBar: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "verification_source":"transport_state","requested":"9.1.1.1",\
+                "observed":"9.1.1.1","observed_time_position":"00:00:14:03","via":"dialog"}
+                """,
+            readback: "{}"
+        ),
+        // navigate.goto_marker → canonical marker, same finalize shape.
+        .navigateGotoMarker: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "verification_source":"transport_state","requested":"12.1.1.1",\
+                "observed":"12.1.1.1","observed_time_position":"00:00:22:00","via":"dialog"}
+                """,
+            readback: "{}"
+        ),
+        // finalizeCreateMarkerResult (named create): observed_marker_name == requested_name,
+        // count delta +1.
+        .navigateCreateMarker: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"nav.create_marker","method":"accessibility_menu",\
+                "menu_path":"Navigate > Create Marker","sent":true,\
+                "marker_count_before_channel":2,"marker_count_after_channel":3,\
+                "verification_source":"logic://markers","marker_count_before":2,\
+                "marker_count_after":3,"requested_name":"Chorus",\
+                "observed_marker_id":2,"observed_marker_name":"Chorus",\
+                "observed_marker_position":"12.1.1.1","observed_marker_position_source":"parser"}
+                """,
+            readback: "{}"
+        ),
+        // defaultRenameMarker post-write path: observed_name == requested_name.
+        .navigateRenameMarker: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"nav.rename_marker","index":1,"previous_name":"Verse",\
+                "requested_name":"Bridge","observed_name":"Bridge","write_attempted":true}
+                """,
+            readback: "{}"
+        ),
+        // defaultSetZoomLevel (level 8 → target 7/9 ≈ 0.7778): observed within 0.02.
+        .navigateSetZoom: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","operation":"nav.set_zoom",\
+                "axis":"horizontal","level":8,"requested":0.7777777777777778,\
+                "observed_before":0.3333333333333333,"observed":0.7777777777777778,\
+                "observed_after":0.7777777777777778,"verify_source":"ax_zoom_slider"}
+                """,
+            readback: "{}"
+        ),
     ]
 }

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -189,6 +189,72 @@ struct SemanticOracleEngineTests {
         #expect(!OracleConstraint.emptyArray(key: "a").isValueConstraint)
     }
 
+    // MARK: - booleanFlipped (Phase B2 — verified toggles)
+
+    /// The verified-toggle invariant: `observed == !previous`. A genuine flip
+    /// (true/false or false/true) passes; two equal bools fail; a missing side
+    /// fails closed. This is what proves a toggle CHANGED state, not a no-op that
+    /// still reported success.
+    @Test func booleanFlippedHoldsForNegationAndFailsForEqualOrMissing() {
+        let flip = OracleConstraint.booleanFlipped(keyA: "observed", keyB: "previous")
+        #expect(flip.isSatisfied(by: root(#"{"observed":true,"previous":false}"#)))
+        #expect(flip.isSatisfied(by: root(#"{"observed":false,"previous":true}"#)))
+        // Two equal bools are not a flip — a no-op reporting success is caught.
+        #expect(!flip.isSatisfied(by: root(#"{"observed":true,"previous":true}"#)))
+        #expect(!flip.isSatisfied(by: root(#"{"observed":false,"previous":false}"#)))
+        // A missing side can never be a negation — corrupt inputs fail closed.
+        #expect(!flip.isSatisfied(by: root(#"{"observed":true}"#)))
+        #expect(!flip.isSatisfied(by: root(#"{"previous":false}"#)))
+    }
+
+    /// Same CFBoolean discipline as the rest of the model: a numeric `0`/`1` is
+    /// NOT the negation of a bool, so `observed:1` never satisfies the flip even
+    /// though NSNumber bridges `1` and `true`. Otherwise every toggle's
+    /// "it changed" proof would be forgeable with an integer.
+    @Test func booleanFlippedRejectsNumericOneAsABoolean() {
+        let flip = OracleConstraint.booleanFlipped(keyA: "observed", keyB: "previous")
+        #expect(!flip.isSatisfied(by: root(#"{"observed":1,"previous":false}"#)))
+        #expect(!flip.isSatisfied(by: root(#"{"observed":true,"previous":0}"#)))
+        #expect(!flip.isSatisfied(by: root(#"{"observed":1,"previous":0}"#)))
+    }
+
+    /// booleanFlipped is VALUE-bearing (it asserts a concrete cross-field
+    /// relation between two observed bools), so an oracle carrying only a
+    /// booleanFlipped survives the anti-checkbox strength gate.
+    @Test func booleanFlippedIsValueBearing() {
+        #expect(OracleConstraint.booleanFlipped(keyA: "a", keyB: "b").isValueConstraint)
+        let flipOnly = OperationOracle(
+            .transportPlay,
+            strength: .shapeAndDomain,
+            constraints: [.booleanFlipped(keyA: "observed", keyB: "previous")]
+        )
+        #expect(flipOnly.isSemanticallyLoadBearing)
+    }
+
+    /// Every mutant the generic harness derives for a booleanFlipped (flip-same
+    /// on either side, numeric-1 in place of a bool, and the generic key drop)
+    /// MUST sink the oracle — the same proof the table-driven B2 toggle oracles
+    /// rely on.
+    @Test func booleanFlippedMutantsAreAllRejected() throws {
+        let response = #"{"observed":true,"previous":false}"#
+        let rootValue = try #require(JSONInspector.parse(Data(response.utf8)))
+        let constraint = OracleConstraint.booleanFlipped(keyA: "observed", keyB: "previous")
+        let oracle = OperationOracle(.transportPlay, strength: .shapeAndDomain, constraints: [constraint])
+
+        let baseline = try #require(oracle.evaluate(
+            responseData: Data(response.utf8), readbackData: Data("{}".utf8)))
+        #expect(baseline)
+
+        let mutants = JSONMutator.mutants(for: constraint, in: rootValue)
+        #expect(mutants.count >= 3, "expected drop + flip-same + non-bool mutants, got \(mutants.count)")
+        for mutant in mutants {
+            let data = try #require(JSONMutator.encode(mutant.json))
+            let survived: Bool = oracle.evaluate(
+                responseData: data, readbackData: Data("{}".utf8)) == true
+            #expect(!survived, "booleanFlipped survived mutant [\(mutant.label)]")
+        }
+    }
+
     @Test func crossCheckAgreesAcrossPayloadsAndFailsOnDivergenceOrMissingReadback() {
         let response = root(#"{"value":-6.0,"name":"Bass"}"#)
         let constraint = OracleConstraint.crossCheck(responseKey: "value", readbackKey: "observed_value")
@@ -326,25 +392,33 @@ struct SemanticOracleCensusTests {
 
     // MARK: - #373 Phase B1 — mutating-surface increment (dual census)
 
-    /// The mutating oracles present are EXACTLY the declared Phase-B1 increment —
-    /// no accidental add or drop. Pinning the set (not just a count) is what makes
-    /// the increment a deliberate, reviewable diff.
-    @Test func mutatingOraclesAreExactlyThePhaseB1Increment() {
+    /// The mutating oracles present are EXACTLY the declared increment (B1 UNION
+    /// B2) — no accidental add or drop. Pinning the set (not just a count) is what
+    /// makes the increment a deliberate, reviewable diff. B1 and B2 are each
+    /// pinned by count so a premature or miscounted oracle in either fails here.
+    @Test func mutatingOraclesAreExactlyTheDeclaredIncrement() {
         let mutatingOracles = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.mutatingSpecIDs)
-        #expect(mutatingOracles == SemanticOracleTable.phaseB1MutatingOperationIDs)
+        #expect(mutatingOracles == SemanticOracleTable.coveredMutatingOperationIDs)
         #expect(SemanticOracleTable.phaseB1MutatingOperationIDs.count == 12)
-    }
-
-    /// Soundness of the increment: every id it names is a REAL `.mutating`,
-    /// non-`.unsupported` registry spec — a read-only id or a typo cannot
-    /// masquerade as mutating coverage.
-    @Test func everyPhaseB1IDIsARealMutatingSpec() {
+        #expect(SemanticOracleTable.phaseB2MutatingOperationIDs.count == 15)
+        // B1 and B2 are DISJOINT increments — no op is claimed by both phases.
         #expect(
             SemanticOracleTable.phaseB1MutatingOperationIDs
+                .isDisjoint(with: SemanticOracleTable.phaseB2MutatingOperationIDs)
+        )
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 27)
+    }
+
+    /// Soundness of the increment: every id in B1 AND B2 is a REAL `.mutating`,
+    /// non-`.unsupported` registry spec — a read-only id or a typo cannot
+    /// masquerade as mutating coverage.
+    @Test func everyCoveredMutatingIDIsARealMutatingSpec() {
+        #expect(
+            SemanticOracleTable.coveredMutatingOperationIDs
                 .isSubset(of: SemanticOracleTable.mutatingSpecIDs)
         )
-        for id in SemanticOracleTable.phaseB1MutatingOperationIDs {
+        for id in SemanticOracleTable.coveredMutatingOperationIDs {
             let spec = OperationRegistry.specs.first { $0.id == id }
             #expect(spec?.mutability == .mutating, "\(id.rawValue) is not mutating")
             #expect(spec?.availability != .unsupported, "\(id.rawValue) is unsupported")
@@ -366,18 +440,45 @@ struct SemanticOracleCensusTests {
     }
 
     /// FIX 5 — the structural-exclusion allowlist is EXPLICIT: every entry is a
-    /// real mutating spec, is DISJOINT from the covered increment, and carries a
-    /// reason, so the uncovered surface is a reviewed decision, not implicit.
+    /// real mutating spec, is DISJOINT from the covered increment (B1 ∪ B2), and
+    /// carries a reason, so the uncovered surface is a reviewed decision, not
+    /// implicit. B2 adds the send-only transport/navigate ops with no State A.
     @Test func structuralExclusionsAreExplicitDisjointAndReasoned() {
         let exclusions = SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs
         #expect(!exclusions.isEmpty)
         #expect(exclusions[.mixerSetPluginParam] != nil)
+        // The five B2 send-only ops that structurally cannot reach State A.
+        for id in [
+            OperationID.transportRewind, .transportFastForward,
+            .navigateZoomToFit, .navigateDeleteMarker, .navigateToggleView,
+        ] {
+            #expect(exclusions[id] != nil, "\(id.rawValue) missing its send-only exclusion reason")
+        }
         for (id, reason) in exclusions {
             #expect(SemanticOracleTable.mutatingSpecIDs.contains(id), "\(id.rawValue) is not a mutating spec")
             #expect(
-                !SemanticOracleTable.phaseB1MutatingOperationIDs.contains(id),
+                !SemanticOracleTable.coveredMutatingOperationIDs.contains(id),
                 "\(id.rawValue) is both covered and excluded"
             )
+            #expect(reason.count > 20, "\(id.rawValue) exclusion reason is too thin")
+        }
+    }
+
+    /// set_cycle_range is excluded a level EARLIER than the structural list: it is
+    /// registry `.unsupported`, so `mutatingSpecIDs` (which filters `.unsupported`)
+    /// never surfaces it, and it can carry no oracle. Its exclusion is documented
+    /// explicitly + reasoned, NOT left implicit in the availability filter.
+    @Test func unsupportedExclusionsAreDocumentedAndFilteredOut() {
+        let unsupported = SemanticOracleTable.unsupportedExcludedMutatingOperationIDs
+        #expect(unsupported[.transportSetCycleRange] != nil)
+        for (id, reason) in unsupported {
+            let spec = OperationRegistry.specs.first { $0.id == id }
+            // Registered mutating, but `.unsupported` — so filtered from the surface.
+            #expect(spec?.mutability == .mutating, "\(id.rawValue) is not a mutating spec")
+            #expect(spec?.availability == .unsupported, "\(id.rawValue) is not .unsupported")
+            #expect(!SemanticOracleTable.mutatingSpecIDs.contains(id), "\(id.rawValue) leaked into the surface")
+            #expect(!SemanticOracleTable.supportedOracleSurface.contains(id))
+            #expect(SemanticOracleTable.byOperationID[id] == nil, "\(id.rawValue) must carry no oracle")
             #expect(reason.count > 20, "\(id.rawValue) exclusion reason is too thin")
         }
     }
@@ -490,6 +591,48 @@ struct SemanticOracleMutationTests {
             responseData: fixture.responseData,
             readbackData: fixture.readbackData
         )!)
+    }
+
+    /// #373 B2 — toggle_metronome is uniquely channel-INDEPENDENT: its verified
+    /// State A arrives in two shapes with DISJOINT keys — AX-verified (flip on
+    /// observed/previous, plus button/control/action) and dispatcher-verified via
+    /// the keycmd/cgEvent fallback (flip on observed_enabled/previous_enabled +
+    /// verification_source, and NO button/control/action). The relaxed oracle must
+    /// accept BOTH — pinning button/control/action would FALSE-RED the keycmd-bound,
+    /// AX-control-absent setup in the #284 matrix — while still rejecting a no-op
+    /// (honest State B) and a failure (State C). This is what keeps the relaxed
+    /// oracle non-vacuous: the toggle-changed proof is structural (neither shape
+    /// reaches State A without a confirmed flip), and the envelope rejects every
+    /// non-State-A result.
+    @Test func metronomeOracleAcceptsBothChannelShapesYetRejectsNoOpOrFailure() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.transportToggleMetronome])
+
+        // AX-verified State A: control-bar checkbox flipped (observed != previous).
+        let axVerified = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","button":"Metronome","control":"메트로놈 클릭","observed":true,"previous":false,"action":"axpress","attempts":["axpress"]}"#.utf8),
+            readbackData: Data("{}".utf8)))
+        #expect(axVerified, "metronome oracle rejected the AX-verified State A shape")
+
+        // Dispatcher-verified State A via the keycmd fallback (AX control absent):
+        // NO button/control/action; the flip is on observed_enabled/previous_enabled.
+        // This is the shape the former button/control/action pins false-RED'd.
+        let keycmdVerified = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"transport.toggle_metronome","method":"midi_key_command","cc":98,"channel":16,"verification_source":"transport_state","previous_enabled":false,"requested_enabled":true,"observed_enabled":true}"#.utf8),
+            readbackData: Data("{}".utf8)))
+        #expect(keycmdVerified, "metronome oracle false-RED the dispatcher-verified keycmd State A")
+
+        // No-op: finalize could not confirm a flip (observed_enabled == previous_enabled),
+        // so it is honest State B — the envelope must reject it.
+        let noOp: Bool = oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":false,"state":"B","reason":"readback_mismatch","operation":"transport.toggle_metronome","verification_source":"transport_state","previous_enabled":true,"requested_enabled":false,"observed_enabled":true}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!noOp, "metronome oracle accepted a no-op State B result")
+
+        // Failure: State C must never launder into a semantic pass.
+        let failure: Bool = oracle.evaluate(
+            responseData: Data(#"{"success":false,"verified":false,"state":"C","error":"element_not_found"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!failure, "metronome oracle accepted a State C failure")
     }
 
     /// The anti-checkbox tool. For every constraint of every declarative oracle,
@@ -607,9 +750,13 @@ struct SemanticOracleMutationTests {
     }
 
     @Test func validatorStillReturnsNilForOperationsWithNoOracle() {
-        // A mutating op has no oracle; it must stay honestly unvalidated here.
+        // A mutating op with no oracle stays honestly unvalidated here.
+        // transport.rewind is the canonical B2 case: send-only (no State A), so it
+        // is structurally excluded and carries no oracle — the validator must
+        // return nil, not a verdict, so the runner records it as protocolSmoke.
+        #expect(SemanticOracleTable.byOperationID[.transportRewind] == nil)
         let mutating: Bool = QualificationSemanticReadbackValidator.validate(
-            operationID: OperationID.transportPlay.rawValue,
+            operationID: OperationID.transportRewind.rawValue,
             responseData: Data("{}".utf8),
             readbackData: Data("{}".utf8)
         ) == nil
@@ -772,18 +919,20 @@ struct SemanticOracleRelationalMutationTests {
 @Suite("#373 read-only census non-regression")
 struct SemanticOracleB0CensusTests {
     /// The read-only census is a STANDING invariant across phases. B0 added
-    /// framework only; B1 adds the mutating increment WITHOUT perturbing the
+    /// framework only; B1/B2 add mutating increments WITHOUT perturbing the
     /// fully-covered read-only surface. So the read-only census stays exactly 20,
-    /// and the table's total is the read-only 20 plus the pinned B1 increment — a
-    /// premature or miscounted mutating oracle fails here.
-    @Test func readOnlyCensusStaysTwentyAndB1AddsTheMutatingIncrement() {
+    /// and the table's total is the read-only 20 plus the pinned B1 + B2 increments
+    /// — a premature or miscounted mutating oracle fails here.
+    @Test func readOnlyCensusStaysTwentyAndMutatingIncrementsAreAdditive() {
         #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
         let readOnlyOracles = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.coveredSpecIDs)
         #expect(readOnlyOracles.count == 20)
         #expect(
             SemanticOracleTable.all.count
-                == 20 + SemanticOracleTable.phaseB1MutatingOperationIDs.count
+                == 20
+                + SemanticOracleTable.phaseB1MutatingOperationIDs.count
+                + SemanticOracleTable.phaseB2MutatingOperationIDs.count
         )
     }
 }
@@ -864,6 +1013,22 @@ enum JSONMutator {
             }
         case .emptyArray(let key):
             mutants.append(contentsOf: replacements(root, key, [("non-empty", [1] as [Any])]))
+        case .booleanFlipped(let keyA, let keyB):
+            // Break the negation three ways, each of which MUST sink the oracle:
+            //   * same-value on EITHER side ⇒ not a flip (`a == b`);
+            //   * a numeric 1 in place of a bool ⇒ CFBoolean discipline rejects it.
+            // (`drop keyA` is already added generically via `key`.)
+            if let aValue = JSONPath.resolve(root, keyPath: keyA),
+               JSONInspector.isBoolean(aValue),
+               let a = (aValue as? NSNumber)?.boolValue {
+                mutants.append(contentsOf: replacements(root, keyB, [("flip-same", a)]))
+                mutants.append(contentsOf: replacements(root, keyA, [("non-bool", 1)]))
+            }
+            if let bValue = JSONPath.resolve(root, keyPath: keyB),
+               JSONInspector.isBoolean(bValue),
+               let b = (bValue as? NSNumber)?.boolValue {
+                mutants.append(contentsOf: replacements(root, keyA, [("flip-same", b)]))
+            }
         }
         return mutants
     }


### PR DESCRIPTION
## Summary

Extends the #373 dual semantic-oracle census with verified-write (State A) oracles for the transport + navigate mutating surface — the B2 increment on top of B0 (#403 constraint model) and B1 (#404, 12 verified-write oracles). Each oracle was derived by reading the operation's dispatcher/channel handler and pinning what its `encodeStateA` envelope actually emits.

## Review fixes (adversarial review WARN)

**FIX 1 — stale banned `mouse-click` strategy removed.** The ADR-001 coordinate ban removed the HID mouse-click rung from `controlBarClickStrategies` (now `axpress`/`axconfirm` only; no handler emits `mouse-click`). The oracle domain `controlBarClickActions` still listed `"mouse-click"`, which would silently accept the banned strategy if a regression re-introduced it. Removed it (domain is now `["axpress", "axconfirm"]`) and updated the `toggle_cycle` / `toggle_count_in` / `toggle_metronome` fixtures to the real emitted values (`action:"axpress"`, `attempts:["axpress"]`).

**FIX 2 — `transport.toggle_metronome` oracle no longer false-REDs the keycmd fallback.** Metronome uniquely routes `[.accessibility, .midiKeyCommands, .cgEvent]` with dispatcher re-verification (`finalizeToggleMetronomeResult`). Its verified State A arrives in two shapes with disjoint keys: AX-verified (`observed`/`previous` flip + `button`/`control`/`action`) and dispatcher-verified (keycmd/cgEvent State B confirmed via a transport-state read: `observed_enabled`/`previous_enabled` flip + `verification_source`, and NO `button`/`control`/`action`). The old oracle pinned `button`/`control`/`action` (fail-closed on missing), so it rejected the genuine dispatcher-verified State A — a false-RED that would fire in the #284 matrix on an AX-control-absent, keycmd-bound setup. Relaxed the oracle to pin only the channel-independent verified envelope; the toggle-changed proof is structural (State A is unreachable in any path without a confirmed flip), exactly as `transport.stop` / `transport.pause`. A dedicated test proves the relaxed oracle accepts BOTH channel shapes yet rejects a no-op (State B) and a failure (State C).

RED to GREEN evidence for FIX 2:
- With the former `button`/`control`/`action` pins, the dispatcher-verified keycmd State A is REJECTED: `Expectation failed: keycmdVerified` — "metronome oracle false-RED the dispatcher-verified keycmd State A". After relaxation the same shape is accepted (GREEN).
- The no-op rejection is load-bearing: forging the no-op payload to a verified State-A envelope makes the oracle accept it (`Expectation failed: !(noOp ...)` — "accepted a no-op State B result"); the real no-op (honest State B, `verified:false`) is rejected. The envelope constraints are formally mutation-proofed by `everyConstraintRejectsItsMutants(.transportToggleMetronome)`.

## What B2 covers (15 oracles)

- transport: `play`, `stop`, `record`, `pause`, `toggle_cycle`, `toggle_metronome`, `toggle_count_in`, `toggle_autopunch`, `set_tempo`, `goto_position`
- navigate: `goto_bar`, `goto_marker`, `create_marker`, `rename_marker`, `set_zoom`

New relational constraint `booleanFlipped(keyA:keyB:)` expresses the verified-toggle invariant `observed == !previous` — a control-bar checkbox reaches State A only when the AX read-back is the negation of the pre-read, so this proves the toggle CHANGED state rather than a no-op that still reported success. It uses the same CFBoolean discipline as the rest of the model (a numeric `0`/`1` never satisfies it), is value-bearing (a toggle oracle survives the anti-checkbox strength gate), and carries a case in the generic mutation harness.

## Audited send-only exclusions

Send-only operations are excluded explicitly with a reason, not silently dropped:

- `transport.rewind`, `transport.fast_forward`, `navigate.zoom_to_fit`, `navigate.delete_marker`, `navigate.toggle_view` route only to send-only channels (MCU / MIDIKeyCommands / CGEvent) whose handlers emit State B `readback_unavailable` with no read-back. There is no State A to pin, so each is recorded in `structurallyUnverifiedMutatingOperationIDs` with its reason (census-asserted: real mutating spec, disjoint from covered, reason length checked).
- `transport.set_cycle_range` is registry `.unsupported`, so `mutatingSpecIDs` filters it a level earlier; documented + reasoned in `unsupportedExcludedMutatingOperationIDs`.

## Census soundness

- Read-only surface stays fully covered (20).
- Mutating increment pinned exactly: B1 (12) + B2 (15) = 27, and the two increments are disjoint.
- Every covered id is proven a real `.mutating`, non-`.unsupported` registry spec.
- `everyOracleHasAFixture`, `everyOracleMapsToASupportedSpec`, and the read-only non-regression invariant all hold.

## Dead-assertion audit (preflight C2 / test-integrity CI lint)

No dead boolean `#expect`/`#require` was present in the preserved checkpoint. Every added assertion uses a load-bearing form — `let v = try #require(oracle.evaluate(...)); #expect(v)` and `let survived: Bool = oracle.evaluate(...) == true; #expect(!survived)` (the `== true` collapses `Bool?` on its own line, not inside `#expect`). Both gates pass on this head:

- `Scripts/ci-forbid-dead-expect.sh` (span/closure-aware, scans all of `Tests/`): `OK: no dead boolean #expect/#require spellings`.
- public-surface preflight C2 (and C1/C3): `PREFLIGHT PASS`.

The four `#expect(dict[id] == nil)` / `!= nil` sites are `Optional<OperationOracle>` / `Optional<String>` presence checks — genuinely load-bearing, and not the flagged bool-literal form.

## RED to GREEN evidence (mutation-proof)

The B2 oracles are mutation-proofed by the parameterized harnesses (`oraclePassesItsRealisticFixture` = good-fixture leg; `everyConstraintRejectsItsMutants` = per-constraint wrong-value leg), which now iterate all 15 B2 oracles and pass. RED-before / GREEN-after was additionally confirmed empirically on two representative oracles:

1. `transport.set_tempo` — temporarily tightened the oracle's request/readback bound from `numericNear(..., .absolute(1.0))` to `0.01`. Its fixture (`observed 119.7`, `requested 120.0`, delta 0.3) then FAILED: `oraclePassesItsRealisticFixture(.transportSetTempo)` recorded "rejected its own realistic fixture", and `validatorRoutesEachOracleOperationToItsOracle(.transportSetTempo)` recorded "is not routed". Reverted to GREEN.
2. `transport.toggle_cycle` — temporarily corrupted the fixture to a no-op (`previous:true` so `observed == previous`, still reporting `success/verified/state:A`). The unchanged oracle REJECTED it via `booleanFlipped` (the exact "no-op reported success" hazard the constraint exists to catch): the same two tests went RED. Reverted to GREEN.

Both RED signals surfaced through live `#expect` (the `try #require`-unwrapped verdict and the `!survived` bool), confirming the assertions are load-bearing.

## Coverage-credit honesty (#409)

Per #409 (already on main), a mutating oracle definition is inventory, not coverage: R-SEM (`semanticCoverageIncomplete`) is credited only by live qualification `.passed` (the #284 live matrix) or a governed release-visible waiver — never by an oracle's existence. A comment on `phaseB2MutatingOperationIDs` records this: these B2 oracles pin the State-A contract for the future live run and do NOT themselves reduce the R-SEM static debt. The `ProductionReadinessContracts` coverage-credit logic is unchanged.

## Verification

- `swift test --no-parallel --disable-sandbox --filter SemanticOracle` -> 57 passed (adds the dedicated metronome channel-shape test)
- `--filter LPMCPPRD001ProductionReadinessREDTests` -> 21 passed
- `--filter QualificationRunner` -> 80 passed
- Rebased cleanly onto `origin/main` (no conflicts).

Refs #373, #404.
