### PR TITLE
fix(audit): surface blocking-modal blocker on the logic://project/audit resource via cached signal (#432)

### DIFF
--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -574,7 +574,16 @@ extension ResourceHandlers {
     }
 
     static func readProjectAudit(cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        let report = await ProjectSessionAudit.buildAudit(cache: cache)
+        // #432: source the blocking-dialog signal from the cache (populated every
+        // poll by StatePoller from AXLogicProElements.blockingDialogInfo()) rather
+        // than making a live AX call here — resources are cache-only projections.
+        // This is the SAME authoritative signal the #431 tool audit passes live, so
+        // the resource now surfaces `export_blocked_by_modal_dialog` instead of a
+        // false green and agrees with the tool for the same blocking-modal state.
+        let report = await ProjectSessionAudit.buildAudit(
+            cache: cache,
+            blockingDialogButtons: await cache.getBlockingDialogButtons()
+        )
         // Honest Contract: never emit a success-shaped body that is missing the
         // schema/read_only contract fields. On encode failure, fail loud.
         do {

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -29,6 +29,19 @@ actor StateCache {
     /// than silently returning prior values.
     private(set) var axOccluded: Bool = false
 
+    /// #432 — button titles of a blocking modal dialog/sheet that owns the Logic
+    /// window at the last poll, sampled from the SAME authoritative signal the
+    /// transport preflight and the #431 tool audit fail closed on
+    /// (`AXLogicProElements.blockingDialogInfo()`; post-classifier, so plugin
+    /// editors / Smart Controls / keyboard-layout overlays are excluded). `nil`
+    /// when no blocking dialog is present. Written every poll by
+    /// `StatePoller.pollOnce`, exactly like `axOccluded`. The `logic://project/audit`
+    /// resource — a cache-only projection that must not make live AX calls at read
+    /// time — reads this via `getBlockingDialogButtons()` so it surfaces the
+    /// `export_blocked_by_modal_dialog` blocker instead of a false green, matching
+    /// the live tool path (#431).
+    private(set) var blockingDialogButtons: [String]? = nil
+
     /// Timestamp of last tool call — drives adaptive poll intervals.
     private(set) var lastToolAccess: Date = .distantPast
 
@@ -105,6 +118,11 @@ actor StateCache {
     /// poll or when the document is genuinely closed.
     func getAXOccluded() -> Bool { axOccluded }
 
+    /// #432 — current blocking-dialog button titles (`nil` when none). See the
+    /// field comment for provenance; written every poll by `StatePoller.pollOnce`
+    /// via `updateBlockingDialogButtons`, mirroring `getAXOccluded`/`updateAXOccluded`.
+    func getBlockingDialogButtons() -> [String]? { blockingDialogButtons }
+
     /// Atomic, single-hop read of every field the project audit consumes.
     /// `buildAudit` previously assembled its snapshot from ~13 separate `await`
     /// calls; each was individually actor-serialized but the sequence was not a
@@ -159,6 +177,14 @@ actor StateCache {
     /// poll cycle by `StatePoller.pollOnce`.
     func updateAXOccluded(_ occluded: Bool) {
         axOccluded = occluded
+    }
+
+    /// #432 — set the cached blocking-dialog signal (button titles, or `nil`
+    /// when no blocking dialog owns the Logic window). Idempotent; called every
+    /// poll cycle by `StatePoller.pollOnce` from
+    /// `AXLogicProElements.blockingDialogInfo()`, mirroring `updateAXOccluded`.
+    func updateBlockingDialogButtons(_ buttons: [String]?) {
+        blockingDialogButtons = buttons
     }
 
     func clearProjectState() {

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -23,6 +23,16 @@ actor StatePoller {
         /// the arrange-window AX subtree can return empty, so `pollOnce`
         /// also flags the corresponding cache state via `axOccluded`.
         let dialogPresent: @Sendable () -> Bool
+        /// #432 — authoritative blocking-dialog signal: the post-classifier
+        /// `AXLogicProElements.blockingDialogInfo()` (excludes plugin-editor /
+        /// Smart-Controls / keyboard-layout overlay windows) that the transport
+        /// preflight and the #431 tool audit fail closed on. Sampled once per
+        /// visible-window poll and written to `StateCache.blockingDialogButtons`
+        /// so the cache-only `logic://project/audit` resource surfaces the export
+        /// blocker (`export_blocked_by_modal_dialog`) from the same source the
+        /// tool uses — instead of a false green. Distinct from `dialogPresent`,
+        /// which drives the coarser occlusion (`axOccluded`) lifecycle.
+        let blockingDialogInfo: @Sendable () -> AXLogicProElements.BlockingDialogInfo?
         /// Inter-poll sleep. Injectable so tests can drive the loop at
         /// microsecond cadence instead of waiting out the production 3s
         /// interval — the original reason both lifecycle tests took
@@ -34,21 +44,27 @@ actor StatePoller {
         /// only override `hasVisibleWindow`) keep compiling without change.
         /// `dialogPresent` defaults to `{ false }` so existing tests behave
         /// identically to pre-v3.1.4 — they exercise the non-occluded path.
+        /// `blockingDialogInfo` defaults to `{ nil }` so existing tests (which
+        /// only override `hasVisibleWindow` / `dialogPresent`) behave exactly as
+        /// before — they exercise the no-blocking-dialog path.
         init(
             hasVisibleWindow: @Sendable @escaping () -> Bool,
             dialogPresent: @Sendable @escaping () -> Bool = { false },
             sleep: @Sendable @escaping (UInt64) async throws -> Void = { ns in
                 try await Task.sleep(nanoseconds: ns)
-            }
+            },
+            blockingDialogInfo: @Sendable @escaping () -> AXLogicProElements.BlockingDialogInfo? = { nil }
         ) {
             self.hasVisibleWindow = hasVisibleWindow
             self.dialogPresent = dialogPresent
             self.sleep = sleep
+            self.blockingDialogInfo = blockingDialogInfo
         }
 
         static let production = Runtime(
             hasVisibleWindow: { ProcessUtils.hasVisibleWindow() },
-            dialogPresent: { AXLogicProElements.dialogPresent() }
+            dialogPresent: { AXLogicProElements.dialogPresent() },
+            blockingDialogInfo: { AXLogicProElements.blockingDialogInfo() }
         )
 
         /// Test-friendly runtime for lifecycle-only coverage. Short-circuits
@@ -155,12 +171,23 @@ actor StatePoller {
             if consecutiveWindowMisses >= Self.failureThreshold {
                 await cache.updateDocumentState(false)
                 await cache.updateAXOccluded(false)
+                // #432: no Logic window ⇒ no blocking dialog can own it. This
+                // branch returns before the per-cycle sample above runs, so clear
+                // explicitly to avoid a stale positive after the window vanishes.
+                await cache.updateBlockingDialogButtons(nil)
                 cacheKeys.append(.document)
             }
             if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
             return
         }
         consecutiveWindowMisses = 0
+        // #432: sample the authoritative blocking-dialog signal once per
+        // visible-window cycle and cache it, so the cache-only audit resource can
+        // surface `export_blocked_by_modal_dialog`. A blocking modal is exactly
+        // what makes the project/track polls below fail (they occlude the arrange
+        // subtree), so we capture it here — before those polls — regardless of
+        // their outcome. `nil` when no blocking dialog owns the Logic window.
+        await cache.updateBlockingDialogButtons(runtime.blockingDialogInfo()?.buttonTitles)
 
         let projectReady = await poll(
             operation: "project.get_info", label: "ProjectInfo",
@@ -210,6 +237,8 @@ actor StatePoller {
             if consecutivePollMisses >= Self.failureThreshold {
                 await cache.updateDocumentState(false)
                 await cache.updateAXOccluded(false)
+                // #432: document confirmed closed ⇒ no blocking dialog owns it.
+                await cache.updateBlockingDialogButtons(nil)
                 cacheKeys.append(.document)
             }
         }

--- a/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
+++ b/Tests/LogicProMCPTests/ProjectSessionAuditTests.swift
@@ -431,6 +431,107 @@ private func messySnapshot(
     #expect(blockers.contains("export_blocked_by_modal_dialog"))
 }
 
+@Test func testProjectAuditResourceSurfacesBlockingModalBlockerFromCache() async throws {
+    // #432 (load-bearing): the `logic://project/audit` RESOURCE is a cache-only
+    // projection (it must not make live AX calls at read time). Before the fix it
+    // built the audit without the blocking-dialog signal, so it reported
+    // export_readiness.blockers:[] even while a blocking modal owned the Logic
+    // window — the exact false-green class #431 removed on the tool path, still
+    // live on the resource. With the poller-cached signal read at the resource
+    // boundary, the resource must now surface the SAME
+    // `export_blocked_by_modal_dialog` blocker the tool does.
+    let cache = StateCache()
+    var project = ProjectInfo()
+    project.name = "Modal Repro"
+    project.filePath = "/tmp/Modal Repro.logicx"
+    project.source = "ax_live"
+    await cache.updateProject(project)
+    await cache.updateTracks([TrackState(id: 0, name: "Lead", type: .audio)])
+    // Stands in for the poller having observed a blocking modal via
+    // AXLogicProElements.blockingDialogInfo() and cached its button titles.
+    await cache.updateBlockingDialogButtons(["Show Conflicts", "Ignore"])
+
+    let router = ChannelRouter()
+    let auditResource = try await ResourceHandlers.read(uri: "logic://project/audit", cache: cache, router: router)
+    let json = try #require(sharedJSONObject(sharedResourceText(auditResource)))
+
+    #expect(json["status"] as? String == "failed")
+    let evidence = try #require(json["evidence"] as? [String: Any])
+    let exportReadiness = try #require(evidence["export_readiness"] as? [String: Any])
+    #expect(exportReadiness["status"] as? String == "blocked")
+    let blockers = try #require(exportReadiness["blockers"] as? [String])
+    #expect(blockers.contains("export_blocked_by_modal_dialog"))
+}
+
+@Test func testProjectAuditResourceOmitsBlockingModalBlockerWhenCacheClear() async throws {
+    // #432 control: with no blocking dialog cached (the poller writes nil when
+    // AXLogicProElements.blockingDialogInfo() returns nil), the resource must NOT
+    // report the modal blocker — proving the finding is driven by the cached
+    // signal, not emitted unconditionally.
+    let cache = StateCache()
+    var project = ProjectInfo()
+    project.name = "Clean Session"
+    project.filePath = "/tmp/Clean Session.logicx"
+    project.source = "ax_live"
+    await cache.updateProject(project)
+    await cache.updateTracks([TrackState(id: 0, name: "Lead", type: .audio)])
+
+    let router = ChannelRouter()
+    let auditResource = try await ResourceHandlers.read(uri: "logic://project/audit", cache: cache, router: router)
+    let json = try #require(sharedJSONObject(sharedResourceText(auditResource)))
+    let evidence = try #require(json["evidence"] as? [String: Any])
+    let exportReadiness = try #require(evidence["export_readiness"] as? [String: Any])
+    let blockers = try #require(exportReadiness["blockers"] as? [String])
+    #expect(!blockers.contains("export_blocked_by_modal_dialog"))
+}
+
+@Test func testProjectAuditToolAndResourceAgreeOnCachedBlockingModal() async throws {
+    // #432 core assertion: the tool (live signal) and the resource (cached
+    // signal) must agree for the same blocking-modal state. Here the modal is
+    // present through BOTH the poller-cached signal (drives the resource) and the
+    // dispatcher's live blockingDialogInfo() seam (drives the tool); both read
+    // surfaces must report the export blocker.
+    let cache = StateCache()
+    var project = ProjectInfo()
+    project.name = "Agreement"
+    project.filePath = "/tmp/Agreement.logicx"
+    project.source = "ax_live"
+    await cache.updateProject(project)
+    await cache.updateTracks([TrackState(id: 0, name: "Lead", type: .audio)])
+    await cache.updateBlockingDialogButtons(["Show Conflicts", "Ignore"])
+
+    let router = ChannelRouter()
+
+    let resource = try await ResourceHandlers.read(uri: "logic://project/audit", cache: cache, router: router)
+    let resourceJSON = try #require(sharedJSONObject(sharedResourceText(resource)))
+    let resourceEvidence = try #require(resourceJSON["evidence"] as? [String: Any])
+    let resourceReadiness = try #require(resourceEvidence["export_readiness"] as? [String: Any])
+    let resourceBlockers = try #require(resourceReadiness["blockers"] as? [String])
+
+    let tool = await ProjectDispatcher.handle(
+        command: "audit",
+        params: [:],
+        router: router,
+        cache: cache,
+        blockingDialogInfo: {
+            AXLogicProElements.BlockingDialogInfo(
+                title: "",
+                role: "AXDialog",
+                owningWindow: "Agreement",
+                buttonTitles: ["Show Conflicts", "Ignore"],
+                recoveryAction: "Dismiss the blocking dialog (press Escape), then retry."
+            )
+        }
+    )
+    let toolJSON = try #require(sharedJSONObject(sharedToolText(tool)))
+    let toolEvidence = try #require(toolJSON["evidence"] as? [String: Any])
+    let toolReadiness = try #require(toolEvidence["export_readiness"] as? [String: Any])
+    let toolBlockers = try #require(toolReadiness["blockers"] as? [String])
+
+    #expect(resourceBlockers.contains("export_blocked_by_modal_dialog"))
+    #expect(toolBlockers.contains("export_blocked_by_modal_dialog"))
+}
+
 @Test func testProjectAuditAndCleanupPlanResourcesAndCommandsReturnJSON() async throws {
     let cache = StateCache()
     var project = ProjectInfo()

--- a/Tests/LogicProMCPTests/StateCacheTests.swift
+++ b/Tests/LogicProMCPTests/StateCacheTests.swift
@@ -138,3 +138,19 @@ import Testing
     #expect(!(tracks[2].isSelected))
     #expect(await cache.getSelectedTrack()?.id == 1)
 }
+
+@Test func testStateCacheBlockingDialogButtonsRoundTrip() async throws {
+    // #432 — the blocking-dialog signal the poller caches must round-trip
+    // through the actor-isolated accessors so both the resource audit read and
+    // the poller pin can rely on it. Defaults to nil (no dialog).
+    let cache = StateCache()
+    #expect(await cache.getBlockingDialogButtons() == nil)
+
+    await cache.updateBlockingDialogButtons(["Show Conflicts", "Ignore"])
+    let stored = try #require(await cache.getBlockingDialogButtons())
+    #expect(stored == ["Show Conflicts", "Ignore"])
+
+    // Dismissal clears it back to nil (poller writes nil when no dialog is present).
+    await cache.updateBlockingDialogButtons(nil)
+    #expect(await cache.getBlockingDialogButtons() == nil)
+}

--- a/Tests/LogicProMCPTests/StatePollerTests.swift
+++ b/Tests/LogicProMCPTests/StatePollerTests.swift
@@ -132,6 +132,64 @@ private func makeStatePollerAccessibilityRuntime(
     #expect(!(await poller.isRunning))
 }
 
+@Test func testStatePollerCachesBlockingDialogSignalFromRuntime() async throws {
+    // #432 — every visible-window poll the poller samples the authoritative
+    // AXLogicProElements.blockingDialogInfo() signal and caches its button titles,
+    // so the cache-only logic://project/audit resource can surface the
+    // export_blocked_by_modal_dialog blocker from the same source the tool uses.
+    let cache = StateCache()
+    let channel = AccessibilityChannel(
+        runtime: makeStatePollerAccessibilityRuntime(
+            projectInfoResult: .success(#"{"name":"Modal","sampleRate":48000,"bitDepth":24,"tempo":120,"timeSignature":"4/4","trackCount":1,"filePath":null,"lastUpdated":"2026-07-16T00:00:00Z"}"#)
+        )
+    )
+    let poller = StatePoller(
+        axChannel: channel,
+        cache: cache,
+        runtime: .init(
+            hasVisibleWindow: { true },
+            blockingDialogInfo: {
+                AXLogicProElements.BlockingDialogInfo(
+                    title: "Alert",
+                    role: "AXDialog",
+                    owningWindow: "Modal",
+                    buttonTitles: ["Show Conflicts", "Ignore"],
+                    recoveryAction: "Dismiss the blocking dialog (press Escape), then retry."
+                )
+            }
+        )
+    )
+
+    await poller.refreshNow()
+
+    let cached = try #require(await cache.getBlockingDialogButtons())
+    #expect(cached == ["Show Conflicts", "Ignore"])
+}
+
+@Test func testStatePollerClearsCachedBlockingDialogSignalWhenAbsent() async {
+    // #432 — when blockingDialogInfo() returns nil (no blocking modal) the poller
+    // actively clears any prior cached signal, so the resource never reports a
+    // phantom blocker after a dialog is dismissed.
+    let cache = StateCache()
+    // Seed a stale positive to prove the poll clears it rather than merely
+    // leaving it untouched.
+    await cache.updateBlockingDialogButtons(["Stale"])
+    let channel = AccessibilityChannel(
+        runtime: makeStatePollerAccessibilityRuntime(
+            projectInfoResult: .success(#"{"name":"Clean","sampleRate":48000,"bitDepth":24,"tempo":120,"timeSignature":"4/4","trackCount":1,"filePath":null,"lastUpdated":"2026-07-16T00:00:00Z"}"#)
+        )
+    )
+    let poller = StatePoller(
+        axChannel: channel,
+        cache: cache,
+        runtime: .init(hasVisibleWindow: { true }, blockingDialogInfo: { nil })
+    )
+
+    await poller.refreshNow()
+
+    #expect(await cache.getBlockingDialogButtons() == nil)
+}
+
 @Test func testStatePollerIgnoresInvalidProjectPayloadsAndChannelErrors() async throws {
     let invalidCache = StateCache()
     let invalidChannel = AccessibilityChannel(


### PR DESCRIPTION
## Root cause

Follow-up to #427 / #431. The `logic_project audit` **tool** surfaces a blocking
modal as an `export_blocked_by_modal_dialog` blocker in `export_readiness` (#431,
via the live `AXLogicProElements.blockingDialogInfo()` signal — the same one the
transport preflight fails closed on). The sibling **resource**
`logic://project/audit` renders the identical `AuditReport` via the shared
`buildAudit(cache:)` builder, but it was called **without** that signal, so it kept
reporting `export_readiness: { blockers: [] }` while a blocking modal owned the
Logic window.

Result: the tool and the resource **disagreed** for the same live state — the
resource retained the exact false-green class #431 eliminated on the tool. Not a
safety hole (write paths such as `bounce` still fail closed on the live
`dialogPresent()` gate), but a read-surface honesty/consistency gap.

## Fix — cache-fed signal (resources stay cache-only projections)

A live AX call inside a resource read would break the cache-only-projection
boundary. Instead, capture the authoritative blocking-dialog signal in the cache
when the state poller runs, and read it at the resource boundary:

- **`StateCache`**: add `blockingDialogButtons: [String]?` plus actor-isolated
  `getBlockingDialogButtons()` / `updateBlockingDialogButtons(_:)`, mirroring how
  `axOccluded` / `getAXOccluded` / `updateAXOccluded` are already stored and
  retrieved.
- **`StatePoller`**: add a `blockingDialogInfo` runtime seam. Production wires it
  to `AXLogicProElements.blockingDialogInfo()` (post-classifier — plugin-editor,
  Smart-Controls, and keyboard-layout overlay windows are excluded), the **same**
  signal the transport preflight and the #431 tool audit use. It is sampled once
  per visible-window poll and cached as button titles (or `nil`); cleared when the
  window/document goes away. No new detection was invented.
- **`readProjectAudit`**: sources the existing `buildAudit` `blockingDialogButtons`
  parameter from `cache.getBlockingDialogButtons()`.

The tool audit (live seam) and the bounce preflight are **unchanged**, so neither
regresses. Both the tool and the resource now surface the blocker for the same
blocking-modal state; `nil` ⇒ no finding, non-`nil` ⇒ the `.blocker` flows into
`export_readiness.blockers` and status → `failed`, for both surfaces. The finding
id/severity and `export_readiness` flow are reused as-is from #431.

## RED → GREEN (load-bearing resource test)

`testProjectAuditResourceSurfacesBlockingModalBlockerFromCache` reads
`logic://project/audit` with a blocking dialog cached.

- **Before the fix (RED):** `export_readiness.blockers → []`, `status → review_ready`
  / report `degraded` — the false green.
- **After the fix (GREEN):** `export_readiness.blockers` contains
  `export_blocked_by_modal_dialog`, `status → blocked`, report `failed`.

### Tests added
- Resource-path: cache carrying a blocking dialog ⇒ resource surfaces the blocker;
  control proves absence when the cache is clear.
- Tool + resource agreement for the same cached/live blocking-modal state.
- `StateCache` round-trip pin for the cached signal.
- `StatePoller` pins: caches the signal from the runtime seam; clears it when
  absent.

All assertions use `try #require` + concrete comparisons or force-unwrap (no dead
`#expect` bool-optional forms).

## Verification
- `swift test --no-parallel --disable-sandbox` filtered to the audit, resource /
  state-reader, `StateCache`, `StatePoller`, and dispatcher suites: **433 tests
  passed**. The 8 blocking-modal / cache / poller tests pass; the load-bearing
  resource test fails before the fix and passes after.
- Public-surface preflight: **PASS**.

Closes #432. Refs #431, #427.
