### PR TITLE
qualification: #373 Phase-B4 verified-execution oracles (plugin-insert/export/cleanup) — closes mutating inventory

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -174,15 +174,58 @@ enum SemanticOracleTable {
         .midiImportFile, .midiMMCLocate,
     ]
 
-    /// Every mutating operation the table covers so far: the B1 verified-write
-    /// increment UNION the B2 transport/navigate increment UNION the B3
-    /// project/tracks/system/midi increment. Coverage is still INCREMENTAL (the
-    /// edit surface, mixer/plugin inserts, and export/cleanup executors remain);
-    /// this is the covered subset the census pins.
+    /// The mutating operations B4 covers with a verified-execution oracle: the
+    /// FINAL uncovered mutating surface — the two plugin-insert paths, the export
+    /// executors, the cleanup-apply executor, and the one edit op that reaches a
+    /// genuine State A. Each was DERIVED BY READING its dispatcher/channel handler
+    /// and pinning what the verified path actually emits (cited per oracle below).
+    /// With this increment EVERY supported (non-`.unsupported`) mutating op is
+    /// either covered here or carries an audited structural exclusion — the
+    /// pure-code mutating oracle inventory is CLOSED (asserted by
+    /// `everyMutatingSpecIsCoveredOrAuditedExcluded`).
+    ///
+    /// COVERAGE CREDIT (#409): defining an oracle here is INVENTORY, not coverage.
+    /// R-SEM (`semanticCoverageIncomplete`) is credited to an operation ONLY when it
+    /// is live-exercised to a `.passed` semanticReadback verdict (the #284 live
+    /// matrix) or covered by a governed release-visible waiver — never by an oracle's
+    /// mere existence. So this B4 increment PINS the State-A contract these verified
+    /// executions must satisfy in the future live run; it does NOT itself reduce the
+    /// R-SEM static debt, and it does not change `ProductionReadinessContracts`.
+    ///
+    /// DELIBERATELY ABSENT (audited, no State-A envelope — see
+    /// `structurallyUnverifiedMutatingOperationIDs`): the 13 send-only edit ops
+    /// (undo/redo/cut/copy/paste/delete/select_all/split/join/quantize/
+    /// bounce_in_place/normalize/duplicate). Every one routes ONLY to
+    /// [.midiKeyCommands, .cgEvent] (RoutingTable) — a blind CC key command or a
+    /// CGEvent keystroke — and BOTH channels emit State B (send_only_no_readback /
+    /// readback_unavailable) with no edit read-back, so no State A exists.
+    /// edit.toggle_step_input is the one edit op that DOES reach State A (its
+    /// [.accessibility, …] chain verifies the Step Input Keyboard window open-state
+    /// flipped via an AX window-list read-back), so it is covered, not excluded.
+    static let phaseB4MutatingOperationIDs: Set<OperationID> = [
+        // mixer (1 — the AX slot-popup insert that reads back the slot name)
+        .mixerInsertPlugin,
+        // plugins (1 — the verified apply-back insert, HC v2 State A)
+        .pluginsInsertVerified,
+        // project (3 — the two export executors + the cleanup-apply rename executor)
+        .projectExportRun, .projectExportResume, .projectCleanupApply,
+        // edit (1 — the sole edit op with an AX State-A path; the other 13 are send-only)
+        .editToggleStepInput,
+    ]
+
+    /// Every mutating operation the table covers: the B1 verified-write increment
+    /// UNION the B2 transport/navigate increment UNION the B3
+    /// project/tracks/system/midi increment UNION the B4 plugin-insert / export /
+    /// cleanup / edit increment. B4 is the FINAL increment: with it, the covered set
+    /// plus `structurallyUnverifiedMutatingOperationIDs` account for the ENTIRE
+    /// mutating surface (`everyMutatingSpecIsCoveredOrAuditedExcluded`), so the
+    /// pure-code mutating oracle inventory is closed — no mutating spec is left
+    /// implicitly uncovered.
     static var coveredMutatingOperationIDs: Set<OperationID> {
         phaseB1MutatingOperationIDs
             .union(phaseB2MutatingOperationIDs)
             .union(phaseB3MutatingOperationIDs)
+            .union(phaseB4MutatingOperationIDs)
     }
 
     /// The mutating surface (non-`.unsupported`), from the registry. Coverage is
@@ -308,6 +351,62 @@ enum SemanticOracleTable {
         .midiMMCRecord:
             "send-only VerificationPolicy.none — routes mmc.record_strobe to [.coreMIDI]; the MMC "
             + "record SysEx is echo-less (State B send_only_no_readback), so no State A exists",
+        // B4 audit: the 13 send-only edit ops. Every one routes ONLY to
+        // [.midiKeyCommands, .cgEvent] (RoutingTable) — a blind CC key command
+        // (MIDIKeyCommandsChannel) or a CGEvent keystroke (CGEventChannel) — and
+        // BOTH channels emit State B (send_only_no_readback / readback_unavailable)
+        // with no edit read-back, so no State A exists. Kept explicit so their
+        // absence from the B4 increment is a reviewed decision, not a gap.
+        // (edit.toggle_step_input is NOT here: its [.accessibility, …] chain reaches
+        // a genuine State A — it is B4-covered, not excluded.)
+        .editUndo:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+Z "
+            + "keystroke); both channels emit State B send_only_no_readback with no undo "
+            + "read-back, so there is no State A to verify",
+        .editRedo:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+Shift+Z "
+            + "keystroke); the keystroke is echo-less (State B send_only_no_readback), so no State A",
+        .editCut:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+X "
+            + "keystroke); the clipboard cut has no arrange read-back and emits State B "
+            + "send_only_no_readback, so no State A exists",
+        .editCopy:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+C "
+            + "keystroke); a copy is echo-less (State B send_only_no_readback), so no State A",
+        .editPaste:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+V "
+            + "keystroke); the paste has no arrange read-back and emits State B "
+            + "send_only_no_readback, so no State A exists",
+        .editDelete:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Delete "
+            + "keystroke); the delete has no arrange read-back and emits State B "
+            + "send_only_no_readback, so no State A exists",
+        .editSelectAll:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+A "
+            + "keystroke); the dispatcher maps its unverified State B to isError, and neither "
+            + "channel reads the selection back, so no State A exists",
+        .editSplit:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+T "
+            + "keystroke); the split is echo-less (State B send_only_no_readback), so no State A",
+        .editJoin:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Cmd+J "
+            + "keystroke); the join is echo-less (State B send_only_no_readback), so no State A",
+        .editQuantize:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / Q "
+            + "keystroke); the dispatcher maps its unverified State B to isError, and neither "
+            + "channel reads the quantized grid back, so no State A exists",
+        .editBounceInPlace:
+            "send-only — routes [.midiKeyCommands, .cgEvent] (blind CC key command / CGEvent "
+            + "keystroke); bounce-in-place has no region read-back and emits State B "
+            + "send_only_no_readback, so no State A exists",
+        .editNormalize:
+            "send-only VerificationPolicy.none — routes [.midiKeyCommands, .cgEvent] (blind CC "
+            + "key command / keystroke; availability .requiresKeyBinding is a SETUP axis, not the "
+            + "reason it lacks State A); the normalize is echo-less (State B), so no State A exists",
+        .editDuplicate:
+            "send-only VerificationPolicy.none — routes [.midiKeyCommands, .cgEvent] (blind CC "
+            + "key command / keystroke; availability .requiresKeyBinding is a SETUP axis, not the "
+            + "reason it lacks State A); the duplicate is echo-less (State B), so no State A exists",
     ]
 
     /// Mutating ops that never enter the oracle surface at all because the
@@ -389,6 +488,13 @@ enum SemanticOracleTable {
         systemExportSupportBundle,
         midiImportFile,
         midiMMCLocate,
+        // #373 Phase B4 — plugin-insert / export / cleanup / edit verified-execution oracles.
+        mixerInsertPlugin,
+        pluginsInsertVerified,
+        projectExportRun,
+        projectExportResume,
+        projectCleanupApply,
+        editToggleStepInput,
     ]
 
     static let byOperationID: [OperationID: OperationOracle] = Dictionary(
@@ -1788,6 +1894,179 @@ enum SemanticOracleTable {
             .valueEquals(key: "verification_source", expected: .string("transport_state")),
             .fieldsEqual(keyA: "requested", keyB: "observed"),
             .typedField(key: "observed_time_position", type: .string),
+        ]
+    )
+
+    // MARK: - #373 Phase B4 — plugin-insert / edit safe-mutation oracles
+
+    // Each composes `SafeMutationOracle.verifiedEnvelope` (State A + verified +
+    // success) with the op's own invariant, derived by READING its dispatcher/
+    // channel handler. The envelope is always FIRST, so no oracle asserts what
+    // changed before proving it was verified. (The export executors are the
+    // exception — they emit a run RECORD, not an HC State-A envelope — see
+    // projectExportRun.)
+    //
+    // mixer
+
+    // AccessibilityChannel+Plugins `defaultInsertPlugin` → encodeStateA (chain
+    // [.accessibility] for plugin.insert; MixerDispatcher.insert_plugin routes it
+    // after a confirmation gate). State A is reached ONLY when the polled slot name
+    // is non-nil AND `spec.matches(observed)` (the read-back plugin name normalizes
+    // to the requested canonical name), so the "the plugin landed" proof is
+    // STRUCTURAL — the envelope carries it. The pinnable content is the hardcoded
+    // `verify_source:"ax_plugin_slot"` (the readback provenance), the requested
+    // `plugin_name` domain (the allowlisted stock inserts — a claim of any other
+    // plugin is caught), and the shape of the readback (`observed_plugin_name` is a
+    // string on every State A, `track`/`slot` the addressed target). NOT
+    // `.fieldsEqual(plugin_name, observed_plugin_name)`: `spec.matches` is a
+    // case/whitespace-normalized compare, so a legitimate State A may carry a
+    // differently-cased `observed_plugin_name` that an exact equality would
+    // false-reject — the match itself is the structural State-A gate.
+    static let mixerInsertPlugin = SafeMutationOracle.oracle(
+        .mixerInsertPlugin,
+        semantics: [
+            .valueEquals(key: "verify_source", expected: .string("ax_plugin_slot")),
+            .enumMember(key: "plugin_name", allowed: ["Gain", "Compressor", "Channel EQ"]),
+            .typedField(key: "observed_plugin_name", type: .string),
+            .typedField(key: "track", type: .number),
+            .typedField(key: "slot", type: .number),
+        ]
+    )
+
+    // plugins
+
+    // AccessibilityChannel+VerifiedPlugins `defaultInsertVerified` →
+    // encodeV2StateA (HC v2, chain [.accessibility]). The verified-insert path:
+    // State A is reachable ONLY through the post-insert `get_inventory` readback
+    // diff, and the handler gates it on `observedID == pluginID` (the requested
+    // canonical id) AND `observedSlot == insert` (the requested slot) — every other
+    // outcome (mismatch, landed-at-different-slot, readback-unavailable) fails closed
+    // to State C/B. The envelope's `target_identity` carries the REQUESTED
+    // {track_index, insert, plugin_id}, while `observed_plugin_id`/`observed_slot`
+    // are the INDEPENDENT post-insert readback — so
+    // `.fieldsEqual(target_identity.plugin_id, observed_plugin_id)` and
+    // `.fieldsEqual(target_identity.insert, observed_slot)` are GENUINE
+    // request↔readback pins (the RIGHT plugin landed in the RIGHT slot), not
+    // same-source echoes. Plus `hc_schema:2`, the `operation` identity, and the
+    // hardcoded `verify_source:"ax_plugin_inventory"` (the sole State-A provenance).
+    // `write_source` is driver-supplied (trace-derived, defaulting to
+    // ax_exact_slot_popup), so it is shape-typed, not value-pinned.
+    static let pluginsInsertVerified = SafeMutationOracle.oracle(
+        .pluginsInsertVerified,
+        semantics: [
+            .valueEquals(key: "hc_schema", expected: .number(2)),
+            .valueEquals(key: "operation", expected: .string("logic_plugins.insert_verified")),
+            .valueEquals(key: "verify_source", expected: .string("ax_plugin_inventory")),
+            .fieldsEqual(keyA: "target_identity.plugin_id", keyB: "observed_plugin_id"),
+            .fieldsEqual(keyA: "target_identity.insert", keyB: "observed_slot"),
+            .typedField(key: "write_source", type: .string),
+        ]
+    )
+
+    // project
+
+    // ProjectExportExecutor.aggregate → `logic_pro_mcp_export_run.v1` RunResult
+    // (ProjectDispatcher `export_run`). NOTE — this op is DELIBERATELY NOT built
+    // through `SafeMutationOracle.oracle`: the executor emits a run RECORD keyed on
+    // `status`, NOT an `HonestContract.encodeStateA` envelope (there is no
+    // state/verified/success field). Pinning `state:"A"` would encode a shape the
+    // handler never emits. The verified-execution proof is `status:"completed"`,
+    // which the aggregator emits ONLY when `artifacts_failed == 0 &&
+    // artifacts_uncertain == 0` — so `.valueEquals(artifacts_uncertain, 0)` +
+    // `.valueEquals(artifacts_failed, 0)` are pinned ALONGSIDE the status as
+    // independent guards (a handler that mislabels a partial run "completed" is
+    // caught, mirroring the State-A triple-guard). `confirmed:true` (a completed run
+    // is always a confirmed execution), the `run` mode (per-op discriminator — the
+    // executor emits `mode: resume ? "resume" : "run"`), and the schema tag are the
+    // hardcoded provenance. `artifacts_total >= 1` + a non-empty `projects` array are
+    // the anti-vacuity gate (a "completed" export that produced nothing is not a
+    // verified execution). Per-artifact HC state is not pinned at
+    // `projects.0.artifacts.0` because the first project need not carry the first
+    // artifact — the aggregate `artifacts_failed/uncertain == 0` captures the
+    // per-artifact "every artifact reached State A" invariant.
+    static let projectExportRun = OperationOracle(
+        .projectExportRun,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schema", expected: .string("logic_pro_mcp_export_run.v1")),
+            .valueEquals(key: "mode", expected: .string("run")),
+            .valueEquals(key: "confirmed", expected: .bool(true)),
+            .valueEquals(key: "status", expected: .string("completed")),
+            .valueEquals(key: "artifacts_uncertain", expected: .number(0)),
+            .valueEquals(key: "artifacts_failed", expected: .number(0)),
+            .numericRange(key: "artifacts_total", min: 1, max: 100_000),
+            .nonEmptyArray(key: "projects"),
+            .typedField(key: "projects.0.artifacts", type: .array),
+        ]
+    )
+
+    // ProjectExportExecutor.aggregate → same `logic_pro_mcp_export_run.v1` RunResult
+    // as export_run, reached through ProjectDispatcher `export_resume` (idempotent
+    // resume). The ONLY wire difference is `mode:"resume"` (the per-op discriminator),
+    // so this oracle is export_run's twin with the mode flipped. A completed resume
+    // may legitimately be all-SKIPPED (`artifacts_verified:0`, `artifacts_skipped:N`
+    // — already-present-and-verified artifacts), so `artifacts_verified` is NOT
+    // pinned to a minimum; the "nothing went wrong" gate (uncertain/failed == 0) plus
+    // the non-vacuity gate (artifacts_total >= 1) are the shared verified-run pins.
+    static let projectExportResume = OperationOracle(
+        .projectExportResume,
+        strength: .shapeAndDomain,
+        constraints: [
+            .valueEquals(key: "schema", expected: .string("logic_pro_mcp_export_run.v1")),
+            .valueEquals(key: "mode", expected: .string("resume")),
+            .valueEquals(key: "confirmed", expected: .bool(true)),
+            .valueEquals(key: "status", expected: .string("completed")),
+            .valueEquals(key: "artifacts_uncertain", expected: .number(0)),
+            .valueEquals(key: "artifacts_failed", expected: .number(0)),
+            .numericRange(key: "artifacts_total", min: 1, max: 100_000),
+            .nonEmptyArray(key: "projects"),
+            .typedField(key: "projects.0.artifacts", type: .array),
+        ]
+    )
+
+    // ProjectDispatcher `handleCleanupApply` → encodeStateA. cleanup_apply executes
+    // ONE cleanup-plan rename step by delegating each target to the existing
+    // TrackDispatcher.rename path, and reaches State A ONLY after EVERY target's
+    // nested rename returned a verified State A (the loop fails closed to State C the
+    // moment any target comes back isError/unverified) — so the "every rename
+    // landed" proof is STRUCTURAL, carried by the envelope. The pinnable content is
+    // the hardcoded provenance: `op:"project.cleanup_apply"` (NOTE the key is `op`,
+    // not `operation`), the fixed `tool:"logic_tracks"` + `command:"rename"` (only
+    // rename_* steps are executable), and `verify_source:"track.rename ax_readback"`
+    // (the inherited readback provenance). `target_track_indices` + `applied` are
+    // pinned NON-EMPTY (at least one track was actually renamed — an empty batch is
+    // not a verified apply), and `step_id` is the applied plan step.
+    static let projectCleanupApply = SafeMutationOracle.oracle(
+        .projectCleanupApply,
+        semantics: [
+            .valueEquals(key: "op", expected: .string("project.cleanup_apply")),
+            .valueEquals(key: "tool", expected: .string("logic_tracks")),
+            .valueEquals(key: "command", expected: .string("rename")),
+            .valueEquals(key: "verify_source", expected: .string("track.rename ax_readback")),
+            .nonEmptyArray(key: "target_track_indices"),
+            .nonEmptyArray(key: "applied"),
+            .typedField(key: "step_id", type: .string),
+        ]
+    )
+
+    // edit
+
+    // AccessibilityChannel+Editing `defaultToggleStepInputKeyboard` → encodeStateA
+    // (EditDispatcher routes edit.toggle_step_input [.accessibility, …]; the
+    // midiKeyCommands/cgEvent fallbacks are send-only State B, so the AX path is the
+    // ONLY State-A shape). State A is reached ONLY when the Step Input Keyboard
+    // window open-state CHANGED after the menu press (`observedOpen != previousOpen`,
+    // polled from the live AX window list), and the envelope carries both reads
+    // (`previous_open`/`observed_open`) — so `observed_open == !previous_open`
+    // (`.booleanFlipped`) is the GENUINE "the window toggled" invariant, relating two
+    // independent AX reads, not a same-source echo. Plus the hardcoded
+    // `operation:"edit.toggle_step_input"` and `via:"window-menu"` provenance.
+    static let editToggleStepInput = SafeMutationOracle.oracle(
+        .editToggleStepInput,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("edit.toggle_step_input")),
+            .valueEquals(key: "via", expected: .string("window-menu")),
+            .booleanFlipped(keyA: "observed_open", keyB: "previous_open"),
         ]
     )
 }

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -944,5 +944,110 @@ enum SemanticOracleFixtures {
                 """,
             readback: "{}"
         ),
+
+        // ── #373 Phase B4 — plugin-insert / export / cleanup / edit fixtures ──
+        // Each is a faithful payload from the op's verified path (traced to the
+        // dispatcher/channel handler). Readback is unused (no B4 oracle
+        // cross-checks a separate readback payload), so it is a bare `{}`.
+
+        // AccessibilityChannel+Plugins.defaultInsertPlugin State A: observed slot
+        // name matched the requested spec (spec.matches), so verify_source
+        // ax_plugin_slot + the readback name are present.
+        .mixerInsertPlugin: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","track":0,"slot":1,\
+                "plugin_name":"Gain","observed_plugin_name":"Gain",\
+                "verify_source":"ax_plugin_slot"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+VerifiedPlugins.defaultInsertVerified HC v2 State A:
+        // target_identity carries the REQUESTED {track_index,insert,plugin_id};
+        // observed_plugin_id/observed_slot are the post-insert readback, gated equal
+        // to the request (the RIGHT plugin at the RIGHT slot). plugin_id is the
+        // canonical VerifiedPluginCatalog id (logic.stock.effect.gain).
+        .pluginsInsertVerified: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","hc_schema":2,\
+                "operation":"logic_plugins.insert_verified",\
+                "target_identity":{"track_index":0,"insert":1,"plugin_id":"logic.stock.effect.gain"},\
+                "observed_plugin_id":"logic.stock.effect.gain","observed_plugin_name":"Gain",\
+                "observed_slot":1,"select_trace":{"write_source":"ax_exact_slot_popup"},\
+                "write_source":"ax_exact_slot_popup","verify_source":"ax_plugin_inventory"}
+                """,
+            readback: "{}"
+        ),
+        // ProjectExportExecutor.aggregate → logic_pro_mcp_export_run.v1, completed
+        // fresh run: one project, one bounced+verified artifact (state A,
+        // bounce_fired true, on-disk logic_audio evidence). uncertain/failed 0.
+        .projectExportRun: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_export_run.v1","run_id":"run-1","mode":"run",\
+                "confirmed":true,"status":"completed",\
+                "output_root":"/Users/qualification/exports","collision_policy":"fail_if_exists",\
+                "project_count":1,"artifacts_total":1,"artifacts_verified":1,\
+                "artifacts_skipped":0,"artifacts_uncertain":0,"artifacts_failed":0,\
+                "projects":[{"index":0,"project_path":"/Users/qualification/a.logicx",\
+                "display_name":"a","observed_project_path":"/Users/qualification/a.logicx",\
+                "identity_verified":true,"opened":true,\
+                "artifacts":[{"kind":"bounce","path":"/Users/qualification/exports/a.wav",\
+                "state":"A","verified":true,"bounce_fired":true,"error":null,"reason":null,\
+                "evidence":{"exists":true,"file_size_bytes":2400044,"duration_seconds":12.5,\
+                "sample_rate":48000,"channel_count":2,"silence_ratio":0.02,"peak_dbfs":-1.0,\
+                "verification_status":"pass","verification_reasons":[],"source":"logic_audio"}}]}],\
+                "next_safe_action":"verify_artifacts_with_logic_audio"}
+                """,
+            readback: "{}"
+        ),
+        // ProjectExportExecutor.aggregate via export_resume → same schema, mode
+        // "resume". A completed resume where the artifact was already present and
+        // verified: state A, bounce_fired FALSE (skipped, not re-bounced),
+        // artifacts_skipped 1 / artifacts_verified 0 — a legitimate completed run
+        // with zero verified (the resume idempotency path).
+        .projectExportResume: SemanticOracleFixture(
+            response: """
+                {"schema":"logic_pro_mcp_export_run.v1","run_id":"run-2","mode":"resume",\
+                "confirmed":true,"status":"completed",\
+                "output_root":"/Users/qualification/exports","collision_policy":"skip_existing",\
+                "project_count":1,"artifacts_total":1,"artifacts_verified":0,\
+                "artifacts_skipped":1,"artifacts_uncertain":0,"artifacts_failed":0,\
+                "projects":[{"index":0,"project_path":"/Users/qualification/a.logicx",\
+                "display_name":"a","observed_project_path":"/Users/qualification/a.logicx",\
+                "identity_verified":true,"opened":true,\
+                "artifacts":[{"kind":"bounce","path":"/Users/qualification/exports/a.wav",\
+                "state":"A","verified":true,"bounce_fired":false,"error":null,\
+                "reason":"already_present_verified",\
+                "evidence":{"exists":true,"file_size_bytes":2400044,"duration_seconds":12.5,\
+                "sample_rate":48000,"channel_count":2,"silence_ratio":0.02,"peak_dbfs":-1.0,\
+                "verification_status":"pass","verification_reasons":[],"source":"logic_audio"}}]}],\
+                "next_safe_action":"verify_artifacts_with_logic_audio"}
+                """,
+            readback: "{}"
+        ),
+        // ProjectDispatcher.handleCleanupApply State A: one rename target reached
+        // verified State A through the delegated track.rename path (key is `op`, not
+        // `operation`). applied/target_track_indices are non-empty.
+        .projectCleanupApply: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A","op":"project.cleanup_apply",\
+                "step_id":"rename_track_0","tool":"logic_tracks","command":"rename",\
+                "target_track_indices":[0],\
+                "applied":[{"track_index":0,"new_name":"Lead Synth",\
+                "result":"{\\"success\\":true,\\"verified\\":true,\\"state\\":\\"A\\"}"}],\
+                "verify_source":"track.rename ax_readback"}
+                """,
+            readback: "{}"
+        ),
+        // AccessibilityChannel+Editing.defaultToggleStepInputKeyboard State A: the
+        // Step Input Keyboard window open-state flipped (observed_open:true ==
+        // !previous_open:false), verified via the live AX window list.
+        .editToggleStepInput: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"edit.toggle_step_input","previous_open":false,\
+                "observed_open":true,"via":"window-menu"}
+                """,
+            readback: "{}"
+        ),
     ]
 }

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -393,9 +393,10 @@ struct SemanticOracleCensusTests {
     // MARK: - #373 Phase B1 — mutating-surface increment (dual census)
 
     /// The mutating oracles present are EXACTLY the declared increment (B1 UNION
-    /// B2 UNION B3) — no accidental add or drop. Pinning the set (not just a count)
-    /// is what makes the increment a deliberate, reviewable diff. B1, B2 and B3 are
-    /// each pinned by count so a premature or miscounted oracle in any fails here.
+    /// B2 UNION B3 UNION B4) — no accidental add or drop. Pinning the set (not just
+    /// a count) is what makes the increment a deliberate, reviewable diff. B1, B2,
+    /// B3 and B4 are each pinned by count so a premature or miscounted oracle in any
+    /// fails here.
     @Test func mutatingOraclesAreExactlyTheDeclaredIncrement() {
         let mutatingOracles = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.mutatingSpecIDs)
@@ -403,23 +404,47 @@ struct SemanticOracleCensusTests {
         #expect(SemanticOracleTable.phaseB1MutatingOperationIDs.count == 12)
         #expect(SemanticOracleTable.phaseB2MutatingOperationIDs.count == 15)
         #expect(SemanticOracleTable.phaseB3MutatingOperationIDs.count == 15)
-        // B1, B2 and B3 are PAIRWISE-DISJOINT increments — no op is claimed twice.
-        #expect(
-            SemanticOracleTable.phaseB1MutatingOperationIDs
-                .isDisjoint(with: SemanticOracleTable.phaseB2MutatingOperationIDs)
-        )
-        #expect(
-            SemanticOracleTable.phaseB1MutatingOperationIDs
-                .isDisjoint(with: SemanticOracleTable.phaseB3MutatingOperationIDs)
-        )
-        #expect(
-            SemanticOracleTable.phaseB2MutatingOperationIDs
-                .isDisjoint(with: SemanticOracleTable.phaseB3MutatingOperationIDs)
-        )
-        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 42)
+        #expect(SemanticOracleTable.phaseB4MutatingOperationIDs.count == 6)
+        // B1, B2, B3 and B4 are PAIRWISE-DISJOINT increments — no op claimed twice.
+        let increments = [
+            SemanticOracleTable.phaseB1MutatingOperationIDs,
+            SemanticOracleTable.phaseB2MutatingOperationIDs,
+            SemanticOracleTable.phaseB3MutatingOperationIDs,
+            SemanticOracleTable.phaseB4MutatingOperationIDs,
+        ]
+        for i in increments.indices {
+            for j in increments.indices where j > i {
+                #expect(
+                    increments[i].isDisjoint(with: increments[j]),
+                    "increments \(i + 1) and \(j + 1) overlap"
+                )
+            }
+        }
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 48)
     }
 
-    /// Soundness of the increment: every id in B1 AND B2 is a REAL `.mutating`,
+    /// #373 B4 — the mutating oracle inventory is CLOSED. Every supported
+    /// (non-`.unsupported`) mutating spec is EITHER covered by an oracle OR carries
+    /// an audited structural exclusion — the two partition the entire mutating
+    /// surface, with no implicit residual. This is the ticket's terminal invariant:
+    /// after B4 there is no mutating op left silently uncovered. (The two sets are
+    /// proven disjoint here too, so an op can never be both covered and excluded.)
+    @Test func everyMutatingSpecIsCoveredOrAuditedExcluded() {
+        let covered = SemanticOracleTable.coveredMutatingOperationIDs
+        let excluded = Set(SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs.keys)
+        #expect(covered.isDisjoint(with: excluded))
+        #expect(covered.union(excluded) == SemanticOracleTable.mutatingSpecIDs)
+        // The complement is empty: nothing supported-mutating is unaccounted for.
+        let unaccounted = SemanticOracleTable.mutatingSpecIDs
+            .subtracting(covered)
+            .subtracting(excluded)
+        #expect(
+            unaccounted.isEmpty,
+            "mutating specs neither covered nor excluded: \(unaccounted.map(\.rawValue).sorted())"
+        )
+    }
+
+    /// Soundness of the increment: every id in B1..B4 is a REAL `.mutating`,
     /// non-`.unsupported` registry spec — a read-only id or a typo cannot
     /// masquerade as mutating coverage.
     @Test func everyCoveredMutatingIDIsARealMutatingSpec() {
@@ -434,24 +459,31 @@ struct SemanticOracleCensusTests {
         }
     }
 
-    /// The census DELIBERATELY does not yet require full mutating coverage: B1 is
-    /// an increment, and B2/B3 add the rest. If this ever reaches parity, the
-    /// mutating census contract must flip from "incremental" to "complete".
+    /// The COVERED set stays below parity with the mutating surface — and after B4
+    /// that gap is PERMANENT, not future work: the complement is entirely audited
+    /// structural exclusions (send-only / no-State-A ops), NOT ops awaiting an
+    /// oracle. `everyMutatingSpecIsCoveredOrAuditedExcluded` proves covered ∪
+    /// excluded == the whole surface, so this "covered < total" is the honest
+    /// statement that some mutating ops are structurally unverifiable, never a TODO.
+    /// If a currently-excluded op ever gains a State-A path (so covered could grow),
+    /// that is a deliberate move of an id from the exclusion map into an increment.
     @Test func mutatingCoverageIsIncrementalNotYetComplete() {
         let covered = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.mutatingSpecIDs)
         #expect(covered.count < SemanticOracleTable.mutatingSpecIDs.count)
-        // mixer.set_plugin_param is the canonical NOT-yet-covered case: it is a
-        // send-only State-B write (Scripter), so it has no State A to verify and
-        // deliberately carries no B1 verified-write oracle.
+        // mixer.set_plugin_param is the canonical structurally-excluded case: it is
+        // a send-only State-B write (Scripter), so it has no State A to verify and
+        // deliberately carries no verified-write oracle.
         #expect(!covered.contains(.mixerSetPluginParam))
         #expect(SemanticOracleTable.mutatingSpecIDs.contains(.mixerSetPluginParam))
+        // And it is honestly accounted for in the exclusion map, not left implicit.
+        #expect(SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs[.mixerSetPluginParam] != nil)
     }
 
     /// FIX 5 — the structural-exclusion allowlist is EXPLICIT: every entry is a
-    /// real mutating spec, is DISJOINT from the covered increment (B1 ∪ B2), and
-    /// carries a reason, so the uncovered surface is a reviewed decision, not
-    /// implicit. B2 adds the send-only transport/navigate ops with no State A.
+    /// real mutating spec, is DISJOINT from the covered increment (B1 ∪ B2 ∪ B3 ∪
+    /// B4), and carries a reason, so the uncovered surface is a reviewed decision,
+    /// not implicit. B4 adds the 13 send-only edit ops with no State A.
     @Test func structuralExclusionsAreExplicitDisjointAndReasoned() {
         let exclusions = SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs
         #expect(!exclusions.isEmpty)
@@ -466,7 +498,7 @@ struct SemanticOracleCensusTests {
         // The B3 audited exclusions: project lifecycle ops with no State A
         // (new/open/close State-B ceiling, launch/quit prose), the send-only
         // tracks.duplicate, and the send-only midi surface (a representative
-        // subset — the generic loop below validates all 25 entries).
+        // subset — the generic loop below validates all 38 entries).
         for id in [
             OperationID.projectNew, .projectOpen, .projectClose,
             .projectLaunch, .projectQuit, .tracksDuplicate,
@@ -477,6 +509,19 @@ struct SemanticOracleCensusTests {
         ] {
             #expect(exclusions[id] != nil, "\(id.rawValue) missing its B3 exclusion reason")
         }
+        // The 13 B4 send-only edit exclusions. edit.toggle_step_input is COVERED
+        // (its AX chain reaches State A), so it must NOT appear in the exclusion map.
+        for id in [
+            OperationID.editUndo, .editRedo, .editCut, .editCopy, .editPaste,
+            .editDelete, .editSelectAll, .editSplit, .editJoin, .editQuantize,
+            .editBounceInPlace, .editNormalize, .editDuplicate,
+        ] {
+            #expect(exclusions[id] != nil, "\(id.rawValue) missing its B4 edit exclusion reason")
+        }
+        #expect(
+            exclusions[.editToggleStepInput] == nil,
+            "edit.toggle_step_input is covered, not excluded"
+        )
         for (id, reason) in exclusions {
             #expect(SemanticOracleTable.mutatingSpecIDs.contains(id), "\(id.rawValue) is not a mutating spec")
             #expect(
@@ -747,6 +792,72 @@ struct SemanticOracleMutationTests {
             responseData: Data(#"{"success":true,"verified":true,"state":"A","bundle_path":"/x/b","files":[]}"#.utf8),
             readbackData: Data("{}".utf8)) == true
         #expect(!emptyManifest, "export_support_bundle accepted an empty file manifest")
+    }
+
+    /// #373 B4 — RED evidence for representative oracles: each REJECTS the
+    /// semantically-wrong result it exists to catch. The good-leg (each fixture
+    /// passes) is the parameterized `oraclePassesItsRealisticFixture`; the two
+    /// explicit good-legs below make the RED→GREEN contrast self-contained for the
+    /// value-bearing (insert_verified) and bespoke (export_run) representatives.
+    @Test func phaseB4RepresentativeOraclesRejectSemanticMutations() throws {
+        // VALUE-BEARING representative: plugins.insert_verified pins the
+        // request↔readback identity. First the GREEN leg (its own fixture passes),
+        // then the RED legs — the insert landed the WRONG plugin, and the WRONG slot.
+        let insert = try #require(SemanticOracleTable.byOperationID[.pluginsInsertVerified])
+        let insertFixture = try #require(SemanticOracleFixtures.byOperationID[.pluginsInsertVerified])
+        let insertGreen = try #require(insert.evaluate(
+            responseData: insertFixture.responseData, readbackData: insertFixture.readbackData))
+        #expect(insertGreen, "insert_verified rejected its own verified fixture")
+        // Requested Gain, but the readback observed Compressor at the slot — a false
+        // verified insert. target_identity.plugin_id != observed_plugin_id.
+        let wrongPlugin: Bool = insert.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","hc_schema":2,"operation":"logic_plugins.insert_verified","target_identity":{"track_index":0,"insert":1,"plugin_id":"logic.stock.effect.gain"},"observed_plugin_id":"logic.stock.effect.compressor","observed_plugin_name":"Compressor","observed_slot":1,"select_trace":{},"write_source":"ax_exact_slot_popup","verify_source":"ax_plugin_inventory"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!wrongPlugin, "insert_verified accepted a plugin that differs from the requested one")
+        // Requested slot 1, but the readback saw the plugin at slot 2.
+        let wrongSlot: Bool = insert.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","hc_schema":2,"operation":"logic_plugins.insert_verified","target_identity":{"track_index":0,"insert":1,"plugin_id":"logic.stock.effect.gain"},"observed_plugin_id":"logic.stock.effect.gain","observed_plugin_name":"Gain","observed_slot":2,"select_trace":{},"write_source":"ax_exact_slot_popup","verify_source":"ax_plugin_inventory"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!wrongSlot, "insert_verified accepted a slot that differs from the requested one")
+
+        // BESPOKE representative: project.export_run pins the completed-run contract
+        // (no HC state:"A" envelope — a run RECORD keyed on `status`). GREEN leg
+        // first, then RED — a partial run (some artifact failed) is not a verified
+        // execution, and a run that mislabels itself completed while carrying a
+        // failed artifact is caught by the independent artifacts_failed guard.
+        let run = try #require(SemanticOracleTable.byOperationID[.projectExportRun])
+        let runFixture = try #require(SemanticOracleFixtures.byOperationID[.projectExportRun])
+        let runGreen = try #require(run.evaluate(
+            responseData: runFixture.responseData, readbackData: runFixture.readbackData))
+        #expect(runGreen, "export_run rejected its own completed-run fixture")
+        // status:"partial" — an honest partial run must not read as a verified pass.
+        let partialRun: Bool = run.evaluate(
+            responseData: Data(#"{"schema":"logic_pro_mcp_export_run.v1","run_id":"r","mode":"run","confirmed":true,"status":"partial","output_root":"/x","collision_policy":"fail_if_exists","project_count":1,"artifacts_total":2,"artifacts_verified":1,"artifacts_skipped":0,"artifacts_uncertain":0,"artifacts_failed":1,"projects":[{"index":0,"project_path":"/x/a.logicx","display_name":"a","observed_project_path":"/x/a.logicx","identity_verified":true,"opened":true,"artifacts":[]}],"next_safe_action":"review_then_export_resume"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!partialRun, "export_run accepted a partial run")
+        // status forged "completed" while a failed artifact remains — the
+        // artifacts_failed:0 guard is independent of status, so this is caught.
+        let mislabelledCompleted: Bool = run.evaluate(
+            responseData: Data(#"{"schema":"logic_pro_mcp_export_run.v1","run_id":"r","mode":"run","confirmed":true,"status":"completed","output_root":"/x","collision_policy":"fail_if_exists","project_count":1,"artifacts_total":2,"artifacts_verified":1,"artifacts_skipped":0,"artifacts_uncertain":0,"artifacts_failed":1,"projects":[{"index":0,"project_path":"/x/a.logicx","display_name":"a","observed_project_path":"/x/a.logicx","identity_verified":true,"opened":true,"artifacts":[]}],"next_safe_action":"verify_artifacts_with_logic_audio"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!mislabelledCompleted, "export_run accepted a completed status with a failed artifact")
+
+        // TOGGLE representative: edit.toggle_step_input rejects a no-op — the window
+        // open-state did not change (observed_open == previous_open), so it is not a
+        // verified toggle even though the envelope claims State A.
+        let toggle = try #require(SemanticOracleTable.byOperationID[.editToggleStepInput])
+        let noOpToggle: Bool = toggle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"edit.toggle_step_input","previous_open":true,"observed_open":true,"via":"window-menu"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!noOpToggle, "edit.toggle_step_input accepted a no-op (window state unchanged)")
+
+        // DOMAIN representative: mixer.insert_plugin rejects a plugin outside the
+        // insertable stock allowlist.
+        let mixerInsert = try #require(SemanticOracleTable.byOperationID[.mixerInsertPlugin])
+        let unknownPlugin: Bool = mixerInsert.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","track":0,"slot":1,"plugin_name":"Space Designer","observed_plugin_name":"Space Designer","verify_source":"ax_plugin_slot"}"#.utf8),
+            readbackData: Data("{}".utf8)) == true
+        #expect(!unknownPlugin, "mixer.insert_plugin accepted a plugin outside the stock allowlist")
     }
 
     /// The anti-checkbox tool. For every constraint of every declarative oracle,
@@ -1033,9 +1144,9 @@ struct SemanticOracleRelationalMutationTests {
 @Suite("#373 read-only census non-regression")
 struct SemanticOracleB0CensusTests {
     /// The read-only census is a STANDING invariant across phases. B0 added
-    /// framework only; B1/B2/B3 add mutating increments WITHOUT perturbing the
+    /// framework only; B1/B2/B3/B4 add mutating increments WITHOUT perturbing the
     /// fully-covered read-only surface. So the read-only census stays exactly 20,
-    /// and the table's total is the read-only 20 plus the pinned B1 + B2 + B3
+    /// and the table's total is the read-only 20 plus the pinned B1 + B2 + B3 + B4
     /// increments — a premature or miscounted mutating oracle fails here.
     @Test func readOnlyCensusStaysTwentyAndMutatingIncrementsAreAdditive() {
         #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
@@ -1048,6 +1159,7 @@ struct SemanticOracleB0CensusTests {
                 + SemanticOracleTable.phaseB1MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB2MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB3MutatingOperationIDs.count
+                + SemanticOracleTable.phaseB4MutatingOperationIDs.count
         )
     }
 }


### PR DESCRIPTION
## Summary

The FINAL #373 mutating-oracle increment after B1(12)+B2(15)+B3(15)=42. B4 adds
**6** oracles and **13** audited structural exclusions, which **closes the
pure-code (non-live) mutating oracle inventory**: every supported
(non-`.unsupported`) mutating spec is now either covered by an oracle or carries a
reasoned exclusion — no mutating op is left implicitly uncovered.

Each oracle was derived by **reading the handler** and pinning EXACTLY what its
State-A path emits — the real semantic invariant, never invented/over-loose — and
each rejects the semantically-wrong result it exists to catch.

## B4 covered (6)

| op | State-A source | pinned invariant |
|----|----------------|------------------|
| `plugins.insert_verified` | `defaultInsertVerified` → `encodeV2StateA` | `hc_schema:2` + `operation` + `verify_source:"ax_plugin_inventory"` + **request↔readback** `fieldsEqual(target_identity.plugin_id, observed_plugin_id)` and `fieldsEqual(target_identity.insert, observed_slot)` (RIGHT plugin in the RIGHT slot) |
| `mixer.insert_plugin` | `defaultInsertPlugin` → `encodeStateA` (gated on `spec.matches(observed)`) | `verify_source:"ax_plugin_slot"` + `plugin_name` stock allowlist {Gain, Compressor, Channel EQ} + observed/track/slot shape |
| `project.export_run` | `ProjectExportExecutor.aggregate` run RECORD (**bespoke** — no `state:"A"` envelope) | `schema:"logic_pro_mcp_export_run.v1"` + `mode:"run"` + `confirmed:true` + `status:"completed"` + `artifacts_failed:0` + `artifacts_uncertain:0` (independent guards) + non-vacuity (`artifacts_total>=1`, non-empty projects) |
| `project.export_resume` | same record, `export_resume` | export_run's twin with `mode:"resume"` (a completed resume may legitimately be all-skipped, so `artifacts_verified` is not floored) |
| `project.cleanup_apply` | `handleCleanupApply` → `encodeStateA` (inherits the `track.rename` readback) | `op:"project.cleanup_apply"` (key is `op`, not `operation`) + `tool:"logic_tracks"` + `command:"rename"` + `verify_source:"track.rename ax_readback"` + non-empty `applied`/`target_track_indices` |
| `edit.toggle_step_input` | `defaultToggleStepInputKeyboard` → `encodeStateA` | `operation` + `via:"window-menu"` + `booleanFlipped(observed_open, previous_open)` (the window open-state actually flipped) |

**Task-list correction (honest trace):** the B3 PR listed `edit.*(14)` as remaining.
Tracing each: `edit.toggle_step_input` routes `[.accessibility, …]` and reaches a
**genuine State A** (AX window-list read-back confirms the flip), so it is **covered**,
not excluded. The other 13 edit ops are send-only.

## B4 excluded (13, audited)

The send-only edit ops — `edit.undo / redo / cut / copy / paste / delete /
select_all / split / join / quantize / bounce_in_place / normalize / duplicate`.
Each routes ONLY to `[.midiKeyCommands, .cgEvent]` (a blind CC key command /
CGEvent keystroke); both channels emit State B `send_only_no_readback` /
`readback_unavailable` with no edit read-back, so **no State A exists**. Each is
added to `structurallyUnverifiedMutatingOperationIDs` with a per-op reason citing
the handler. (`edit.toggle_step_input` is deliberately NOT in the exclusion map.)

`.unsupported` specs (e.g. `transport.set_cycle_range`) need no exclusion entry —
`mutatingSpecIDs` already filters them out.

## Ambiguity / latent-false-green watch

- `mixer.insert_plugin`: `spec.matches(observed)` is a case/whitespace-normalized
  compare, so `observed_plugin_name` may not be **byte-equal** to `plugin_name` on a
  legitimate State A → deliberately **NOT** a `fieldsEqual` (would risk false-RED);
  the match itself is the structural State-A gate. Pinned the `plugin_name`
  allowlist + `verify_source` instead.
- `project.export_run/resume`: pinned `status:"completed"` (rejects `partial` /
  `failed` / `confirmation_required`) rather than accepting `partial`. A partial run
  is an honest partial, not a verified execution. `artifacts_failed:0` +
  `artifacts_uncertain:0` are pinned as **independent** guards so a run that
  mislabels itself `completed` while carrying a failed artifact is still caught.
- `plugins.insert_verified`: `observed_plugin_id`/`observed_slot` are the
  post-insert readback; `target_identity.*` is the request — different sources, so
  the two `fieldsEqual` are genuine request↔readback pins, not same-source echoes.

## RED → GREEN evidence

`phaseB4RepresentativeOraclesRejectSemanticMutations` (bad-legs) + the parameterized
good-leg/bad-leg harnesses (`oraclePassesItsRealisticFixture`,
`everyConstraintRejectsItsMutants`) cover every B4 oracle. Explicit RED was captured
by temporarily removing the load-bearing pins and rebuilding:

- **value-bearing** (`plugins.insert_verified`): with the `fieldsEqual` pins removed,
  the oracle ACCEPTED a State A whose `observed_plugin_id` (Compressor) differed from
  the requested `plugin_id` (Gain), and one at the wrong slot → test RED. Restored → GREEN.
- **bespoke** (`project.export_run`): with `status`/`artifacts_failed` removed, the
  oracle ACCEPTED a `partial` run and a run mislabelled `completed` with a failed
  artifact → test RED. Restored → GREEN.

No dead `#expect` (`Scripts/ci-forbid-dead-expect.sh` → OK).

## Census / suite counts

- `phaseB4MutatingOperationIDs` (6); pairwise-disjoint from B1/B2/B3; covered
  mutating total **42 → 48**; read-only 20 untouched; table total = 20 + 12 + 15 +
  15 + 6.
- New **`everyMutatingSpecIsCoveredOrAuditedExcluded`**: covered (48) ∪ audited
  exclusions (38) == the entire mutating surface (86 non-`.unsupported`), complement
  empty — the inventory is closed.
- `COVERAGE CREDIT (#409)` note on the B4 set: inventory pinning the State-A
  contracts for the #284 live run; does **not** reduce R-SEM static debt, does not
  change `ProductionReadinessContracts`.
- B3-review NIT fixed: `everyCoveredMutatingIDIsARealMutatingSpec` doc-comment now
  says B1..B4.

Suites (foreground, `--no-parallel --disable-sandbox`): `SemanticOracle` **62
passed**; `LPMCPPRD001ProductionReadinessREDTests` **21 passed** (R-SEM debt stays
open, unchanged); `QualificationRunner` **80 passed** (2 skipped — require a release
binary; unrelated to this change).

## What mutating ops remain uncovered, and why

Nothing is left **implicitly** uncovered. The 38 structurally-excluded mutating ops
are permanently unverifiable by construction, each with an audited reason:
- **send-only MIDI** (send_note/chord/cc/program_change/pitch_bend/aftertouch/sysex,
  play_sequence, step_input, create_virtual_port, mmc_play/stop/record) → CoreMIDI State B;
- **send-only transport/navigate** (rewind, fast_forward, zoom_to_fit, delete_marker,
  toggle_view) → MCU/keycmd State B;
- **project lifecycle** (new/open/close State-B ceiling; launch/quit prose);
- **send-only** `tracks.duplicate`, `mixer.set_plugin_param` (Scripter);
- **the 13 send-only edit ops** (this PR).

`transport.set_cycle_range` is `.unsupported` (filtered a level earlier). Promoting
any excluded op would be a deliberate move from the exclusion map into an increment
once/if it gains a State-A path.

Refs #373, #438. **Do not merge** — inventory review only.