### PR TITLE
feat(#425): coordinate-free plugin-insert leaf selection (Option B)

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1935,6 +1935,23 @@ extension AccessibilityChannel {
         // flag is on — the discriminator can never be falsely pinned to the flag.
         trace["leaf_select_coord_free"] = leafSelectCoordFree(for: pluginClick)
 
+        #if DEBUG
+        // QA/test-only seam (#425): after a winning leaf select, deterministically
+        // take the postCommitTimeout branch — set via the env var
+        // LOGIC_MCP_FORCE_POSTCOMMIT_TIMEOUT=1 (live server over stdio) or the
+        // @TaskLocal (unit tests). It short-circuits the mount readback so a
+        // controlled coord-free/coordinate win exercises the honest
+        // `commit_strategy` end to end. It ONLY forces the fail-closed State-C
+        // timeout envelope — it NEVER fabricates a State-A success. Stripped in
+        // release (`#if DEBUG`).
+        if forcePostCommitTimeoutForTestsActive {
+            return (
+                .postCommitTimeout(strategy: postCommitTimeoutStrategy(coordFree: pluginClick.coordFree)),
+                trace
+            )
+        }
+        #endif
+
         let poll = await pollStripInventoryUntil(
             track: track, runtime: runtime, timeoutMs: 2_000
         ) { inv in
@@ -1979,15 +1996,46 @@ extension AccessibilityChannel {
             // #425: report the actuation that ACTUALLY selected the leaf, derived
             // from the winning strategy — a coord-free (AXPress) win must not
             // misreport a physical/coordinate menu commit.
-            let commitStrategy = pluginClick.coordFree
-                ? "slot_popup_axpress_menu_select"
-                : "slot_popup_physical_menu_click"
-            return (.postCommitTimeout(strategy: commitStrategy), trace)
+            return (
+                .postCommitTimeout(strategy: postCommitTimeoutStrategy(coordFree: pluginClick.coordFree)),
+                trace
+            )
         }
         return (.mountMismatch(observedName: postInventory[insert]?.name), trace)
     }
 
     // MARK: - insert_verified live driver helpers
+
+    /// The honest commit-strategy label for a post-commit timeout, derived from
+    /// the winning actuation (coord-free AXPress vs the legacy coordinate menu
+    /// click). Single source of truth so the live timeout path and the DEBUG
+    /// force-timeout QA seam can never report different strategies.
+    static func postCommitTimeoutStrategy(coordFree: Bool) -> String {
+        coordFree ? "slot_popup_axpress_menu_select" : "slot_popup_physical_menu_click"
+    }
+
+    #if DEBUG
+    /// QA/test seam (#425): when set, `liveExactSlotPopupInsert` short-circuits to
+    /// the postCommitTimeout branch after a winning leaf select, so a controlled
+    /// insert deterministically exercises the honest `commit_strategy` without a
+    /// real mount. It only forces the fail-closed State-C timeout envelope — it
+    /// never fabricates a State-A success. Read from the @TaskLocal (unit tests)
+    /// or the LOGIC_MCP_FORCE_POSTCOMMIT_TIMEOUT env var (live server driven over
+    /// stdio). Stripped entirely in release.
+    @TaskLocal static var forcePostCommitTimeoutForTests: Bool?
+
+    static var forcePostCommitTimeoutForTestsActive: Bool {
+        if let forcePostCommitTimeoutForTests { return forcePostCommitTimeoutForTests }
+        return ProcessInfo.processInfo.environment["LOGIC_MCP_FORCE_POSTCOMMIT_TIMEOUT"] == "1"
+    }
+
+    static func withForcePostCommitTimeoutForTests<Result>(
+        _ value: Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $forcePostCommitTimeoutForTests.withValue(value, operation: operation)
+    }
+    #endif
 
     /// Raise the window that contains the visible mixer (the R12 key step — the
     /// Mix menu item is disabled until the mixer window is frontmost). Falls back

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1976,7 +1976,13 @@ extension AccessibilityChannel {
         }
 
         if poll.satisfied == nil {
-            return (.postCommitTimeout(strategy: "slot_popup_physical_menu_click"), trace)
+            // #425: report the actuation that ACTUALLY selected the leaf, derived
+            // from the winning strategy — a coord-free (AXPress) win must not
+            // misreport a physical/coordinate menu commit.
+            let commitStrategy = pluginClick.coordFree
+                ? "slot_popup_axpress_menu_select"
+                : "slot_popup_physical_menu_click"
+            return (.postCommitTimeout(strategy: commitStrategy), trace)
         }
         return (.mountMismatch(observedName: postInventory[insert]?.name), trace)
     }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1889,6 +1889,11 @@ extension AccessibilityChannel {
         }
         trace["target_slot_found"] = true
 
+        // #425 note: the empty-slot picker is opened by a coordinate click. Coord-free
+        // alternatives were live-probed and rejected: AXPress on the slot element is a
+        // no-op (picker never opens), and AXShowMenu opens the picker into an NSMenu
+        // tracking loop that WEDGES Logic (AX blocks). The slot-open therefore stays a
+        // coordinate click (governed waiver); only the leaf SELECTION is coord-free.
         guard clickElementCenter(targetSlot.element, runtime: runtime.ax) else {
             return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
         }
@@ -1923,6 +1928,9 @@ extension AccessibilityChannel {
         trace["winning_strategy"] = pluginClick.strategy
         trace["winning_menu_path"] = pluginClick.path.joined(separator: " > ")
         trace["plugin_selection_id"] = pluginID
+        // #425: record which leaf-selection path executed so the receipt self-attests
+        // coordinate-free (AXPress) vs the legacy coordinate click.
+        trace["leaf_select_coord_free"] = FeatureFlags.insertCoordFree
 
         let poll = await pollStripInventoryUntil(
             track: track, runtime: runtime, timeoutMs: 2_000
@@ -2404,6 +2412,9 @@ extension AccessibilityChannel {
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
     ) async -> Bool {
+        if FeatureFlags.insertCoordFree {
+            return await pressPopupPluginLeaf(item, runtime: runtime)
+        }
         guard moveElementCenter(item, runtime: runtime) else { return false }
         try? await Task.sleep(for: .milliseconds(120))
         if let submenu = visibleSubmenu(of: item, runtime: runtime),
@@ -2411,6 +2422,53 @@ extension AccessibilityChannel {
             return clickElementCenter(leaf, runtime: runtime)
         }
         return clickElementCenter(item, runtime: runtime)
+    }
+
+    /// #425: coordinate-free leaf selection. Reads the plugin's format submenu (if
+    /// any) as an AX child — populated without a hover, per `popupExactLeafPaths` —
+    /// and AXPresses the preferred-format leaf; otherwise AXPresses the item itself.
+    /// If a format submenu exists but AXPress on its leaf did not take, fall through
+    /// to pressing the item (which on many builds opens the submenu / selects the
+    /// default format). Fail-closed: no coordinate fallback.
+    private static func pressPopupPluginLeaf(
+        _ item: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) async -> Bool {
+        if let submenu = axChildMenu(of: item, runtime: runtime),
+           let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime),
+           pressElement(leaf, runtime: runtime) {
+            return true
+        }
+        return pressElement(item, runtime: runtime)
+    }
+
+    /// A submenu exposed as an AX child of `item`, regardless of visual visibility.
+    private static func axChildMenu(
+        of item: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        AXHelpers.getChildren(item, runtime: runtime).first {
+            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuRole as String)
+        }
+    }
+
+    /// `preferredFormatLeaf` without the on-screen-position requirement, so it works
+    /// on a submenu that has not been visually revealed (AX children only).
+    private static func preferredFormatLeafByLabel(
+        in submenu: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        let items = AXHelpers.getChildren(submenu, runtime: runtime).filter {
+            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
+        }
+        for labels in AXLocalePolicy.pluginFormatLeafPriority {
+            if let match = items.first(where: {
+                AXLocalePolicy.elementMatches($0, labels, runtime: runtime)
+            }) {
+                return match
+            }
+        }
+        return items.first
     }
 
     private static func popupExactLeafPaths(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1928,9 +1928,12 @@ extension AccessibilityChannel {
         trace["winning_strategy"] = pluginClick.strategy
         trace["winning_menu_path"] = pluginClick.path.joined(separator: " > ")
         trace["plugin_selection_id"] = pluginID
-        // #425: record which leaf-selection path executed so the receipt self-attests
-        // coordinate-free (AXPress) vs the legacy coordinate click.
-        trace["leaf_select_coord_free"] = FeatureFlags.insertCoordFree
+        // #425: record which leaf-selection path ACTUALLY executed so the receipt
+        // self-attests coordinate-free (AXPress) vs the legacy coordinate click.
+        // Sourced from the winning strategy (`pluginClick.coordFree`), not the raw
+        // flag, so a recursive (coordinate-only) win reports false even when the
+        // flag is on — the discriminator can never be falsely pinned to the flag.
+        trace["leaf_select_coord_free"] = pluginClick.coordFree
 
         let poll = await pollStripInventoryUntil(
             track: track, runtime: runtime, timeoutMs: 2_000
@@ -2285,28 +2288,43 @@ extension AccessibilityChannel {
         return popupExactLeafPaths(displayName: displayName, rootMenu: rootMenu, runtime: runtime).first
     }
 
-    private struct SlotPopupPluginClick: Sendable {
+    /// `internal` (was `private`) so the coord-free discriminator is unit-testable
+    /// without driving the CGEvent-bound live insert flow.
+    struct SlotPopupPluginClick: Sendable {
         let strategy: String
         let path: [String]
         let strategies: [String]
+        /// The coord-free value the WINNING strategy actually used. Direct/search
+        /// carry `FeatureFlags.insertCoordFree`; the recursive category-hover
+        /// fallback is coordinate-only and always carries `false`. The caller
+        /// records THIS (not the raw flag) as `trace["leaf_select_coord_free"]`, so
+        /// a recursive win truthfully reports `false` even when the flag is on.
+        let coordFree: Bool
     }
 
-    private static func clickPluginInAnchoredSlotPopup(
+    /// `internal` (was `private`) so the coord-free discriminator is unit-testable
+    /// without driving the CGEvent-bound live insert flow.
+    static func clickPluginInAnchoredSlotPopup(
         pluginID: String,
         displayName: String,
         rootMenu: AXUIElement,
         runtime: AXHelpers.Runtime
     ) async -> SlotPopupPluginClick? {
         var strategies: [String] = []
+        // Direct/search honor the #425 flag; the recursive fallback below is
+        // coordinate-only. Captured once so the value passed to the leaf click and
+        // the value recorded on the winning result cannot diverge.
+        let coordFree = FeatureFlags.insertCoordFree
 
         strategies.append("slot_popup_direct_exact_leaf")
         if let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
            let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime) {
+           await clickPopupPluginLeaf(item, runtime: runtime, coordFree: coordFree) {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_direct_exact_leaf",
                 path: [label],
-                strategies: strategies
+                strategies: strategies,
+                coordFree: coordFree
             )
         }
 
@@ -2314,11 +2332,12 @@ extension AccessibilityChannel {
         if await filterSlotPopupSearchField(displayName: displayName, rootMenu: rootMenu, runtime: runtime),
            let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
            let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime) {
+           await clickPopupPluginLeaf(item, runtime: runtime, coordFree: coordFree) {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_search_exact_leaf",
                 path: [label],
-                strategies: strategies
+                strategies: strategies,
+                coordFree: coordFree
             )
         }
 
@@ -2333,7 +2352,8 @@ extension AccessibilityChannel {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_recursive_exact_leaf",
                 path: result,
-                strategies: strategies
+                strategies: strategies,
+                coordFree: false
             )
         }
 
@@ -2379,7 +2399,7 @@ extension AccessibilityChannel {
 
         if let direct = directExactPopupMenuItem(displayName: displayName, in: menu, runtime: runtime),
            let label = popupMenuItemLabel(direct, runtime: runtime),
-           await clickPopupPluginLeaf(direct, runtime: runtime) {
+           await clickPopupPluginLeaf(direct, runtime: runtime, coordFree: false) {
             return path + [label]
         }
 
@@ -2408,11 +2428,21 @@ extension AccessibilityChannel {
         return nil
     }
 
-    private static func clickPopupPluginLeaf(
+    /// Select the matched plugin leaf. `coordFree == true` (the #425 default) uses
+    /// AXPress over the AX-children format submenu (`pressPopupPluginLeaf`, no
+    /// coordinates); `coordFree == false` uses the legacy coordinate path
+    /// (moveElementCenter/clickElementCenter). The mode is a PARAMETER rather than a
+    /// direct `FeatureFlags.insertCoordFree` read so the recursive category-hover
+    /// fallback can force the coordinate path (it always passes `coordFree: false`),
+    /// while direct/search honor the flag. `internal` (was `private`) so the
+    /// coord-free-vs-coordinate contract is unit-testable without the CGEvent-bound
+    /// live insert flow.
+    static func clickPopupPluginLeaf(
         _ item: AXUIElement,
-        runtime: AXHelpers.Runtime
+        runtime: AXHelpers.Runtime,
+        coordFree: Bool
     ) async -> Bool {
-        if FeatureFlags.insertCoordFree {
+        if coordFree {
             return await pressPopupPluginLeaf(item, runtime: runtime)
         }
         guard moveElementCenter(item, runtime: runtime) else { return false }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1930,10 +1930,10 @@ extension AccessibilityChannel {
         trace["plugin_selection_id"] = pluginID
         // #425: record which leaf-selection path ACTUALLY executed so the receipt
         // self-attests coordinate-free (AXPress) vs the legacy coordinate click.
-        // Sourced from the winning strategy (`pluginClick.coordFree`), not the raw
-        // flag, so a recursive (coordinate-only) win reports false even when the
+        // Sourced from the winning strategy via `leafSelectCoordFree(for:)`, not the
+        // raw flag, so a recursive (coordinate-only) win reports false even when the
         // flag is on — the discriminator can never be falsely pinned to the flag.
-        trace["leaf_select_coord_free"] = pluginClick.coordFree
+        trace["leaf_select_coord_free"] = leafSelectCoordFree(for: pluginClick)
 
         let poll = await pollStripInventoryUntil(
             track: track, runtime: runtime, timeoutMs: 2_000
@@ -2302,6 +2302,17 @@ extension AccessibilityChannel {
         let coordFree: Bool
     }
 
+    /// The single source of truth for the `leaf_select_coord_free` discriminator:
+    /// the coord-free value the WINNING strategy actually used, read off the result
+    /// — NOT the raw `FeatureFlags.insertCoordFree` flag. A recursive
+    /// (coordinate-only) win carries `false` here even when the flag is on, so the
+    /// receipt can never be falsely pinned to the flag. Extracted (and `internal`)
+    /// so the flag-vs-path divergence is unit-testable without the CGEvent-bound
+    /// live insert flow.
+    static func leafSelectCoordFree(for click: SlotPopupPluginClick) -> Bool {
+        click.coordFree
+    }
+
     /// `internal` (was `private`) so the coord-free discriminator is unit-testable
     /// without driving the CGEvent-bound live insert flow.
     static func clickPluginInAnchoredSlotPopup(
@@ -2611,8 +2622,28 @@ extension AccessibilityChannel {
         return items.first
     }
 
+    #if DEBUG
+    /// Test seam (coord-free #425 durability): when set, the coordinate hover/click
+    /// primitives below return this value INSTEAD of computing an element centre and
+    /// posting a real CGEvent. It lets a hermetic test drive the coordinate-only
+    /// recursive-win path — proving the discriminator reports `coordFree == false`
+    /// even with the flag on — without moving the physical mouse. Never compiled
+    /// into release; production always posts the real CGEvent.
+    @TaskLocal static var forceCoordinateActuationForTests: Bool?
+
+    static func withForceCoordinateActuationForTests<Result>(
+        _ value: Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $forceCoordinateActuationForTests.withValue(value, operation: operation)
+    }
+    #endif
+
     @discardableResult
     private static func moveElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
+        #if DEBUG
+        if let forceCoordinateActuationForTests { return forceCoordinateActuationForTests }
+        #endif
         guard let center = elementCenter(element, runtime: runtime) else { return false }
         let source = CGEventSource(stateID: .combinedSessionState)
         guard let move = CGEvent(
@@ -2627,6 +2658,9 @@ extension AccessibilityChannel {
 
     @discardableResult
     private static func clickElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
+        #if DEBUG
+        if let forceCoordinateActuationForTests { return forceCoordinateActuationForTests }
+        #endif
         guard let center = elementCenter(element, runtime: runtime) else { return false }
         let source = CGEventSource(stateID: .combinedSessionState)
         if let down = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -6,6 +6,7 @@ enum FeatureFlags: Sendable {
     @TaskLocal static var adr003StrictParamsOverride: Bool?
     @TaskLocal static var adr004MutationSagaOverride: Bool?
     @TaskLocal static var adr005OperationTraceOverride: Bool?
+    @TaskLocal static var insertCoordFreeOverride: Bool?
     #endif
 
     /// PRD-007 Part 2 (ADR-002 #285): promoted from opt-in to DEFAULT ON, so the
@@ -87,13 +88,30 @@ enum FeatureFlags: Sendable {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR006_VERSIONED_CACHE"] == "1"
     }
 
-    /// #425 experiment: coordinate-free plugin-insert leaf selection (AXPress +
-    /// AX-children submenu traversal) in place of moveElementCenter/clickElementCenter.
-    /// Opt-in during the live spike so the shipped coordinate path stays the default;
-    /// promoted to the default (coordinates removed) once live-verified.
+    /// #425 (Option B): coordinate-free plugin-insert LEAF selection (AXPress over an
+    /// AX-children format submenu) in place of moveElementCenter/clickElementCenter.
+    /// Live-verified during the spike, so promoted from opt-in to DEFAULT ON: the
+    /// variable is now a kill-switch — read with `!= "0"` because an absent variable
+    /// must mean ON. Only the exact string "0" rolls back to the legacy coordinate
+    /// leaf click. Slot-open and the recursive category-hover fallback stay
+    /// coordinate (governed waiver): AXPress on the empty slot is a no-op and
+    /// AXShowMenu wedges Logic, and the recursive path is unreachable for the
+    /// Release-1 plugins — see `clickPopupPluginLeaf` / `pressPopupPluginLeaf`.
     static var insertCoordFree: Bool {
-        ProcessInfo.processInfo.environment["LOGIC_MCP_INSERT_COORD_FREE"] == "1"
+        #if DEBUG
+        if let insertCoordFreeOverride { return insertCoordFreeOverride }
+        #endif
+        return ProcessInfo.processInfo.environment["LOGIC_MCP_INSERT_COORD_FREE"] != "0"
     }
+
+    #if DEBUG
+    static func withInsertCoordFree<Result>(
+        _ value: Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $insertCoordFreeOverride.withValue(value, operation: operation)
+    }
+    #endif
 
     static var adr007SelectorAtlas: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR007_SELECTOR_ATLAS"] == "1"

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -95,8 +95,10 @@ enum FeatureFlags: Sendable {
     /// must mean ON. Only the exact string "0" rolls back to the legacy coordinate
     /// leaf click. Slot-open and the recursive category-hover fallback stay
     /// coordinate (governed waiver): AXPress on the empty slot is a no-op and
-    /// AXShowMenu wedges Logic, and the recursive path is unreachable for the
-    /// Release-1 plugins — see `clickPopupPluginLeaf` / `pressPopupPluginLeaf`.
+    /// AXShowMenu wedges Logic; the recursive path is a REACHABLE coordinate-only
+    /// fallback (tried after direct+search) that is unreachable IN PRACTICE for the
+    /// Release-1 plugins (Gain/Channel EQ/Compressor, always reached by
+    /// direct/search) — see `clickPopupPluginLeaf` / `pressPopupPluginLeaf`.
     static var insertCoordFree: Bool {
         #if DEBUG
         if let insertCoordFreeOverride { return insertCoordFreeOverride }

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -87,6 +87,14 @@ enum FeatureFlags: Sendable {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR006_VERSIONED_CACHE"] == "1"
     }
 
+    /// #425 experiment: coordinate-free plugin-insert leaf selection (AXPress +
+    /// AX-children submenu traversal) in place of moveElementCenter/clickElementCenter.
+    /// Opt-in during the live spike so the shipped coordinate path stays the default;
+    /// promoted to the default (coordinates removed) once live-verified.
+    static var insertCoordFree: Bool {
+        ProcessInfo.processInfo.environment["LOGIC_MCP_INSERT_COORD_FREE"] == "1"
+    }
+
     static var adr007SelectorAtlas: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR007_SELECTOR_ATLAS"] == "1"
     }

--- a/Tests/LogicProMCPTests/FeatureFlagsTests.swift
+++ b/Tests/LogicProMCPTests/FeatureFlagsTests.swift
@@ -124,4 +124,42 @@ struct FeatureFlagEnvironmentTests {
             }
         }
     }
+
+    // #425 (Option B): `LOGIC_MCP_INSERT_COORD_FREE` is DEFAULT ON — coordinate-free
+    // plugin-insert LEAF selection is the shipped default, the variable now a
+    // kill-switch read with `!= "0"`. Same kill-switch shape as ADR-002/005 above;
+    // bare / negated `#expect` only (`== true/false` is DEAD under this toolchain
+    // and would pass against the pre-promotion `== "1"` source these guard against).
+    @Test("(a) #425 no env and no override reads as ON — the shipped default")
+    func insertCoordFreeDefaultsToOn() {
+        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", nil) {
+            #expect(FeatureFlags.insertCoordFree)
+        }
+    }
+
+    @Test("(b) #425 the =0 kill-switch restores the legacy coordinate leaf click")
+    func insertCoordFreeKillSwitchZeroDisables() {
+        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", "0") {
+            #expect(!FeatureFlags.insertCoordFree)
+        }
+    }
+
+    @Test("(c) #425 the pre-promotion =1 opt-in spelling still reads as ON")
+    func insertCoordFreeExplicitOneStaysOn() {
+        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", "1") {
+            #expect(FeatureFlags.insertCoordFree)
+        }
+    }
+
+    @Test("#425 kill-switch matches \"0\" exactly — =false does NOT disable")
+    func insertCoordFreeKillSwitchMatchesZeroExactly() {
+        for notDisabled in ["false", "off", "no", "", " 0", "00"] {
+            Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", notDisabled) {
+                #expect(
+                    FeatureFlags.insertCoordFree,
+                    "LOGIC_MCP_INSERT_COORD_FREE=\(notDisabled) must NOT read as disabled — only \"0\" is the kill-switch"
+                )
+            }
+        }
+    }
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -678,3 +678,136 @@ private func insertParams(
     let hint = (obj["hint"] as? String) ?? ""
     #expect(hint.contains("no enumerable insert slots"))
 }
+
+// MARK: - #425 (Option B): coordinate-free leaf selection contract
+//
+// The four assertions below pin the contract for promoting the leaf SELECTION
+// to coordinate-free-by-default (kill-switch: insertCoordFree).
+// They exercise the real leaf-select seam (`clickPopupPluginLeaf` /
+// `clickPluginInAnchoredSlotPopup`) directly rather than through
+// `defaultInsertVerified`, because the insert-entry tests above inject a fake
+// driver that REPLACES the entire live path (so they never reach leaf-select),
+// and the full `liveExactSlotPopupInsert` flow is CGEvent-bound (the slot-open
+// at ~L1897 requires a real coordinate click). The coordinate leaf primitives
+// (moveElementCenter/clickElementCenter) short-circuit to `false` when an
+// element has no on-screen geometry, BEFORE posting any CGEvent, so these
+// hermetic tests never move the physical mouse. `clickPopupPluginLeaf` /
+// `clickPluginInAnchoredSlotPopup` / `SlotPopupPluginClick` were relaxed from
+// `private` to `internal` solely so this contract is unit-testable.
+
+/// Records which elements received a `kAXPress` when the default action-
+/// recording is bypassed by an injected `performActionHandler` (contract C).
+/// Invoked sequentially within one test (awaited), so plain mutation is
+/// race-free here; `@unchecked Sendable` documents that.
+private final class AXPressRecorder: @unchecked Sendable {
+    private(set) var pressedElementIDs: [Int] = []
+    func record(_ id: Int) { pressedElementIDs.append(id) }
+}
+
+/// A plugin menu item whose format submenu is exposed as an AX child (as Logic
+/// exposes it without a hover) with a single preferred-format leaf ("Stereo").
+private func addPluginItemWithFormatLeaf(
+    _ b: FakeAXRuntimeBuilder,
+    itemID: Int,
+    title: String,
+    formatLeafTitle: String = "Stereo"
+) -> (item: AXUIElement, formatLeaf: AXUIElement) {
+    let formatLeaf = addMenuItem(b, itemID * 10 + 1, title: formatLeafTitle)
+    let submenu = addMenu(b, itemID * 10 + 2, children: [formatLeaf])
+    let item = addMenuItem(b, itemID, title: title, children: [submenu])
+    return (item, formatLeaf)
+}
+
+// Contract A (mechanism): coordFree:true selects the matched leaf via kAXPress.
+@Test func test425ContractA_coordFreeTruePressesMatchedLeafViaAXPress() async {
+    let b = FakeAXRuntimeBuilder()
+    let (gain, formatLeaf) = addPluginItemWithFormatLeaf(b, itemID: 8210, title: "Gain")
+
+    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
+        gain, runtime: b.makeAXRuntime(), coordFree: true
+    )
+
+    #expect(ok)
+    let pressAction = kAXPressAction as String
+    let leafID = b.elementID(formatLeaf)
+    // The preferred-format leaf was AXPressed …
+    #expect(b.actionCalls.contains { $0.elementID == leafID && $0.action == pressAction })
+    // … and NOTHING else happened via a non-AXPress action (no coordinate path).
+    #expect(b.actionCalls.allSatisfy { $0.action == pressAction })
+}
+
+// Contract A (discriminator): a coord-free DIRECT win reports coordFree == true.
+// `SlotPopupPluginClick.coordFree` is the exact value the production flow assigns
+// to `select_trace["leaf_select_coord_free"]` (liveExactSlotPopupInsert ~L1933),
+// so asserting it here asserts the discriminator's truth value for a coord-free
+// win — and it is sourced from the winning strategy, not the raw flag.
+@Test func test425ContractA_discriminatorTrueForCoordFreeDirectWin() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let (gain, formatLeaf) = addPluginItemWithFormatLeaf(b, itemID: 8220, title: "Gain")
+    let root = addMenu(b, 8229, children: [gain])
+    let runtime = b.makeAXRuntime()
+
+    let click = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+            pluginID: "logic.stock.effect.gain",
+            displayName: "Gain",
+            rootMenu: root,
+            runtime: runtime
+        )
+    }
+
+    let winner = try #require(click)
+    #expect(winner.strategy == "slot_popup_direct_exact_leaf")
+    #expect(winner.coordFree)
+    let pressAction = kAXPressAction as String
+    let leafID = b.elementID(formatLeaf)
+    #expect(b.actionCalls.contains { $0.elementID == leafID && $0.action == pressAction })
+}
+
+// Contracts B & D: coordFree:false takes the COORDINATE path — never AXPress.
+// This is the exact mode the recursive category-hover fallback forces (it always
+// passes coordFree:false), so it also covers the "recursive is coordinate-only"
+// half of contract D. Coverage gap (noted honestly): a WINNING recursive path
+// cannot be produced hermetically — the recursive win requires the coordinate
+// leaf click to succeed, which needs real on-screen geometry and would post a
+// CGEvent (physical mouse move). So the recursive-win trace value (coordFree ==
+// false while the flag is ON) is verified structurally (recursive call site +
+// SlotPopupPluginClick(coordFree: false)) rather than behaviorally.
+@Test func test425ContractBD_coordFreeFalseUsesCoordinateNeverAXPress() async {
+    let b = FakeAXRuntimeBuilder()
+    // Deliberately NO kAXPosition/kAXSize: the coordinate primitives return false
+    // before posting a CGEvent, so the load-bearing assertion is the ABSENCE of
+    // AXPress, proving coordFree:false does not use the coord-free press path.
+    let (gain, _) = addPluginItemWithFormatLeaf(b, itemID: 8240, title: "Gain")
+
+    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
+        gain, runtime: b.makeAXRuntime(), coordFree: false
+    )
+
+    #expect(!ok)
+    let pressAction = kAXPressAction as String
+    #expect(!b.actionCalls.contains { $0.action == pressAction })
+}
+
+// Contract C: if AXPress is neutralized, coord-free leaf select FAILS CLOSED —
+// it must not silently "succeed", and it must genuinely have attempted AXPress.
+@Test func test425ContractC_failsClosedWhenAXPressNeutralized() async {
+    let b = FakeAXRuntimeBuilder()
+    let (gain, _) = addPluginItemWithFormatLeaf(b, itemID: 8250, title: "Gain")
+    let recorder = AXPressRecorder()
+    let pressAction = kAXPressAction as String
+    let runtime = b.makeAXRuntime(
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if action == pressAction { recorder.record(b.elementID(element)) }
+            return false // AXPress refused everywhere
+        }
+    )
+
+    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
+        gain, runtime: runtime, coordFree: true
+    )
+
+    #expect(!ok)
+    #expect(!recorder.pressedElementIDs.isEmpty)
+}

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -684,16 +684,17 @@ private func insertParams(
 // The four assertions below pin the contract for promoting the leaf SELECTION
 // to coordinate-free-by-default (kill-switch: insertCoordFree).
 // They exercise the real leaf-select seam (`clickPopupPluginLeaf` /
-// `clickPluginInAnchoredSlotPopup`) directly rather than through
-// `defaultInsertVerified`, because the insert-entry tests above inject a fake
-// driver that REPLACES the entire live path (so they never reach leaf-select),
-// and the full `liveExactSlotPopupInsert` flow is CGEvent-bound (the slot-open
-// at ~L1897 requires a real coordinate click). The coordinate leaf primitives
-// (moveElementCenter/clickElementCenter) short-circuit to `false` when an
-// element has no on-screen geometry, BEFORE posting any CGEvent, so these
-// hermetic tests never move the physical mouse. `clickPopupPluginLeaf` /
-// `clickPluginInAnchoredSlotPopup` / `SlotPopupPluginClick` were relaxed from
-// `private` to `internal` solely so this contract is unit-testable.
+// `clickPluginInAnchoredSlotPopup`) directly — a focused unit — because the
+// insert-entry tests above inject a fake driver that REPLACES the entire live
+// path (so they never reach leaf-select). The full `liveExactSlotPopupInsert`
+// flow (including its governed slot-open coordinate click) is driven end to end
+// by the RESPONSE-LEVEL tests further below via the DEBUG
+// `forceCoordinateActuationForTests` seam, so no CGEvent / physical mouse is
+// issued there either. In these focused tests the coordinate leaf primitives
+// (moveElementCenter/clickElementCenter) simply short-circuit to `false` when an
+// element has no on-screen geometry, before posting any CGEvent.
+// `clickPopupPluginLeaf` / `clickPluginInAnchoredSlotPopup` / `SlotPopupPluginClick`
+// were relaxed from `private` to `internal` solely so this contract is testable.
 
 /// Records which elements received a `kAXPress` when the default action-
 /// recording is bypassed by an injected `performActionHandler` (contract C).
@@ -767,12 +768,11 @@ private func addPluginItemWithFormatLeaf(
 // Contracts B & D: coordFree:false takes the COORDINATE path — never AXPress.
 // This is the exact mode the recursive category-hover fallback forces (it always
 // passes coordFree:false), so it also covers the "recursive is coordinate-only"
-// half of contract D. Coverage gap (noted honestly): a WINNING recursive path
-// cannot be produced hermetically — the recursive win requires the coordinate
-// leaf click to succeed, which needs real on-screen geometry and would post a
-// CGEvent (physical mouse move). So the recursive-win trace value (coordFree ==
-// false while the flag is ON) is verified structurally (recursive call site +
-// SlotPopupPluginClick(coordFree: false)) rather than behaviorally.
+// half of contract D at the helper level. A WINNING recursive path is exercised
+// end to end by the response-level
+// `test425ResponseTraceCoordFreeFalseOnRecursiveWinUnderFlagOn` (via the DEBUG
+// coordinate-actuation seam), which asserts the assembled response reports
+// coordFree == false even with the flag ON.
 @Test func test425ContractBD_coordFreeFalseUsesCoordinateNeverAXPress() async {
     let b = FakeAXRuntimeBuilder()
     // Deliberately NO kAXPosition/kAXSize: the coordinate primitives return false
@@ -882,7 +882,10 @@ private struct SlotPopupInsertFixture {
 /// menu holding the exact "Gain" leaf. `refuseLeafAXPress` makes AXPress on the
 /// leaf fail (forcing direct/search to fall through to the recursive coordinate
 /// path); track-header AXPress stays allowed so track selection still verifies.
-private func makeSlotPopupInsertFixture(refuseLeafAXPress: Bool) -> SlotPopupInsertFixture {
+private func makeSlotPopupInsertFixture(
+    refuseLeafAXPress: Bool,
+    mountGainOnLeafAXPress: Bool = false
+) -> SlotPopupInsertFixture {
     let b = FakeAXRuntimeBuilder()
     let app = b.element(9000)
     let window = b.element(9001)
@@ -948,7 +951,26 @@ private func makeSlotPopupInsertFixture(refuseLeafAXPress: Bool) -> SlotPopupIns
         performActionHandler: { element, action in
             if action == pressAction {
                 presses.record(b.elementID(element))
-                if refuseLeafAXPress && b.elementID(element) == leafKey { return false }
+                if b.elementID(element) == leafKey {
+                    if refuseLeafAXPress { return false }
+                    if mountGainOnLeafAXPress {
+                        // Model Logic mounting the plugin at the empty slot on the
+                        // leaf AXPress: swap the empty-button slot to an occupied
+                        // "Gain" group so a NON-seamed run reads back State A. This
+                        // lets the force-timeout seam be mutation-proved (seam OFF →
+                        // State A, seam ON → forced State-C timeout).
+                        b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+                        b.setAttribute(slot, kAXDescriptionAttribute as String, "Gain")
+                        let bypass = b.element(9010)
+                        let open = b.element(9011)
+                        b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                        b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
+                        b.setAttribute(bypass, kAXValueAttribute as String, 0)
+                        b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
+                        b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
+                        b.setChildren(slot, [bypass, open])
+                    }
+                }
             }
             return true
         }
@@ -1035,4 +1057,46 @@ private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
     #expect(coordFree)
+}
+
+// The DEBUG force-postcommit-timeout QA seam (LOGIC_MCP_FORCE_POSTCOMMIT_TIMEOUT
+// / @TaskLocal) deterministically routes a WINNING insert to the honest
+// postCommitTimeout envelope, reporting the commit_strategy of the actual
+// actuation. Fail-closed: State-C timeout, NEVER a false State-A verified mount —
+// proved by mounting Gain on the leaf press (so WITHOUT the seam this fixture
+// would read back State A; disabling the seam turns the State-C assertion RED).
+@Test func test425ForcePostCommitTimeoutSeamIsHonestAndFailsClosed() async throws {
+    // Coord-free (AXPress) win under flag ON; the fixture MOUNTS Gain on the leaf
+    // press, so a non-seamed run would reach State A. The seam forces the honest
+    // AXPress-commit timeout instead.
+    let axFixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
+    let axObj = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await AccessibilityChannel.withForcePostCommitTimeoutForTests(true) {
+                await runRealInsert(runtime: axFixture.runtime)
+            }
+        }
+    }
+    let axState = try #require(axObj["state"] as? String)
+    #expect(axState == "C")
+    let axError = try #require(axObj["error"] as? String)
+    #expect(axError == "operation_timeout")
+    let axVerified = try #require(axObj["verified"] as? Bool)
+    #expect(!axVerified)
+    let axCommit = try #require(axObj["commit_strategy"] as? String)
+    #expect(axCommit == "slot_popup_axpress_menu_select")
+
+    // Coordinate win under flag OFF + seam → the physical commit strategy.
+    let coordFixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
+    let coordObj = await FeatureFlags.withInsertCoordFree(false) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await AccessibilityChannel.withForcePostCommitTimeoutForTests(true) {
+                await runRealInsert(runtime: coordFixture.runtime)
+            }
+        }
+    }
+    let coordState = try #require(coordObj["state"] as? String)
+    #expect(coordState == "C")
+    let coordCommit = try #require(coordObj["commit_strategy"] as? String)
+    #expect(coordCommit == "slot_popup_physical_menu_click")
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -811,3 +811,47 @@ private func addPluginItemWithFormatLeaf(
     #expect(!ok)
     #expect(!recorder.pressedElementIDs.isEmpty)
 }
+
+// Contract #3 (discriminator honesty) — the DIVERGENCE case. A recursive
+// (coordinate-only) win under the flag ON must report `coordFree == false`, NOT
+// the flag. This is the ONLY case where the honest value diverges from the raw
+// flag, so it is what makes the discriminator sourcing mutation-provable. The 4
+// tests above all use a direct win with the flag on, where pluginClick.coordFree
+// and FeatureFlags.insertCoordFree are BOTH true — they cannot catch a re-pin to
+// the flag. This one can, driven hermetically via the DEBUG coordinate-actuation
+// seam (no CGEvent / physical mouse): direct+search fail because AXPress is
+// refused, so the recursive strategy wins ONLY via the coordinate path. It kills:
+//   (i)   trace repinned to the flag        → leafSelectCoordFree(for:) returns false, not the flag
+//   (ii)  recursive SlotPopupPluginClick(coordFree:) flipped to the flag → winner.coordFree
+//   (iii) recursive clickPopupPluginLeaf(coordFree:) flipped to the flag → it would AXPress
+//         (refused) → no recursive win → #require fails
+@Test func test425Contract3_recursiveWinReportsCoordFreeFalseUnderFlagOn() async throws {
+    let b = FakeAXRuntimeBuilder()
+    // Exact-match leaf at the ROOT, no format submenu / text field / geometry.
+    let gain = addMenuItem(b, 8260, title: "Gain")
+    let root = addMenu(b, 8269, children: [gain])
+    let pressAction = kAXPressAction as String
+    let runtime = b.makeAXRuntime(
+        setAttributeHandler: nil,
+        // Refuse AXPress everywhere so the ONLY route to a win is the coordinate
+        // path — a win therefore PROVES the recursive coordinate route executed.
+        performActionHandler: { _, action in action == pressAction ? false : true }
+    )
+
+    let click = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+                pluginID: "logic.stock.effect.gain",
+                displayName: "Gain",
+                rootMenu: root,
+                runtime: runtime
+            )
+        }
+    }
+
+    let winner = try #require(click)
+    #expect(winner.strategy == "slot_popup_recursive_exact_leaf")
+    // The divergence: flag override is true, honest path is coordinate → false.
+    #expect(!winner.coordFree)
+    #expect(!AccessibilityChannel.leafSelectCoordFree(for: winner))
+}

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -855,3 +855,184 @@ private func addPluginItemWithFormatLeaf(
     #expect(!winner.coordFree)
     #expect(!AccessibilityChannel.leafSelectCoordFree(for: winner))
 }
+
+// MARK: - #425 (Option B) RESPONSE-LEVEL coverage (real defaultInsertVerified flow)
+//
+// These drive the REAL `liveExactSlotPopupInsert` driver end to end (no injected
+// fake driver), so they traverse the ACTUAL trace assignment at
+// VerifiedPlugins ~L1936 (`trace["leaf_select_coord_free"] = leafSelectCoordFree(
+// for: pluginClick)`) AND the response serialization — which the helper-level
+// tests above cannot. The DEBUG `forceCoordinateActuationForTests` seam makes
+// every coordinate primitive (the governed slot-OPEN click AND the coordinate
+// leaf path) succeed WITHOUT posting a CGEvent, so no physical mouse moves. The
+// fake's post-inventory never changes, so a win settles on `postCommitTimeout`
+// (State C operation_timeout) carrying the populated select_trace + commit_strategy.
+
+private let coordFreeExpectedPath = "/Users/me/Music/CoordFree425 copy.logicx"
+
+private struct SlotPopupInsertFixture {
+    let runtime: AXLogicProElements.Runtime
+    let leafItemID: Int
+    let presses: AXPressRecorder
+}
+
+/// The full AX tree the real slot-popup insert flow walks: a track header
+/// (AXSelected, so selection verifies) → mixer → strip → ONE empty target slot
+/// (with geometry for the anchor check) → an app-reachable, slot-anchored popup
+/// menu holding the exact "Gain" leaf. `refuseLeafAXPress` makes AXPress on the
+/// leaf fail (forcing direct/search to fall through to the recursive coordinate
+/// path); track-header AXPress stays allowed so track selection still verifies.
+private func makeSlotPopupInsertFixture(refuseLeafAXPress: Bool) -> SlotPopupInsertFixture {
+    let b = FakeAXRuntimeBuilder()
+    let app = b.element(9000)
+    let window = b.element(9001)
+    let headersGroup = b.element(9002)
+    let headerRow = b.element(9003)
+    let mixer = b.element(9004)
+    let strip = b.element(9005)
+    let slot = b.element(9006)
+    let popupMenu = b.element(9007)
+    let gainItem = b.element(9008)
+    let searchField = b.element(9009)
+
+    // Track header rail (getTrackHeaders matches the "트랙 헤더" group), one
+    // selected row so verifiedTrackSelected reads AXSelected == true.
+    b.setAttribute(headersGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    b.setAttribute(headersGroup, kAXDescriptionAttribute as String, "트랙 헤더")
+    b.setChildren(headersGroup, [headerRow])
+    b.setAttribute(headerRow, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setAttribute(headerRow, kAXDescriptionAttribute as String, "1개의 ‘Track 1’ 트랙")
+    b.setAttribute(headerRow, kAXSelectedAttribute as String, true)
+
+    // Mixer → strip → one empty insert slot (with geometry for the anchor check).
+    b.setAttribute(slot, kAXRoleAttribute as String, kAXButtonRole as String)
+    b.setAttribute(slot, kAXDescriptionAttribute as String, "오디오 플러그인")
+    b.setAttribute(slot, kAXHelpAttribute as String, "오디오 이펙트 슬롯. 오디오 이펙트를 삽입합니다.")
+    b.setAttribute(slot, kAXPositionAttribute as String, axPoint(400, 300))
+    b.setAttribute(slot, kAXSizeAttribute as String, axSize(70, 18))
+    b.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setChildren(strip, [slot])
+    b.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
+    b.setAttribute(mixer, kAXDescriptionAttribute as String, "Mixer")
+    b.setChildren(mixer, [strip])
+
+    b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    b.setAttribute(window, kAXTitleAttribute as String, "CoordFree425 — Tracks")
+    b.setChildren(window, [headersGroup, mixer])
+
+    // Slot popup: visible (geometry) + anchored to the slot + holds the exact leaf.
+    // slotPopupMenu recognizes a slot popup by a search text field AND a menu item,
+    // so the fixture carries both (as the live Logic popup does). Refusing the leaf
+    // AXPress still fails the direct+search strategies at the CLICK step, forcing
+    // the recursive coordinate fallback.
+    b.setAttribute(gainItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+    b.setAttribute(gainItem, kAXTitleAttribute as String, "Gain")
+    b.setAttribute(searchField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    b.setAttribute(popupMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+    b.setAttribute(popupMenu, kAXPositionAttribute as String, axPoint(410, 320))
+    b.setAttribute(popupMenu, kAXSizeAttribute as String, axSize(240, 420))
+    b.setChildren(popupMenu, [searchField, gainItem])
+
+    // App: AXWindows for mainWindow; children so slotPopupMenu's app-descent finds
+    // the (top-level) popup menu.
+    b.setAttribute(app, kAXWindowsAttribute as String, [window])
+    b.setAttribute(app, kAXMainWindowAttribute as String, window)
+    b.setChildren(app, [window, popupMenu])
+
+    let leafKey = b.elementID(gainItem)
+    let presses = AXPressRecorder()
+    let pressAction = kAXPressAction as String
+    let runtime = b.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            if action == pressAction {
+                presses.record(b.elementID(element))
+                if refuseLeafAXPress && b.elementID(element) == leafKey { return false }
+            }
+            return true
+        }
+    )
+    return SlotPopupInsertFixture(runtime: runtime, leafItemID: leafKey, presses: presses)
+}
+
+private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String: Any] {
+    let result = await AccessibilityChannel.defaultInsertVerified(
+        params: [
+            "track": "0", "insert": "0", "plugin": "Gain",
+            "mode": "duplicate_applyback", "project_expected_path": coordFreeExpectedPath,
+        ],
+        runtime: runtime,
+        frontDocumentPath: { coordFreeExpectedPath }
+    )
+    return try! JSONSerialization.jsonObject(with: result.message.data(using: .utf8)!) as! [String: Any]
+}
+
+// The ASSEMBLED RESPONSE's select_trace["leaf_select_coord_free"] is false for a
+// recursive (coordinate-only) win under the flag ON — this traverses the real
+// trace assignment, so re-pinning it to the raw flag turns this RED.
+@Test func test425ResponseTraceCoordFreeFalseOnRecursiveWinUnderFlagOn() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: true)
+    let obj = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let strategy = try #require(trace["winning_strategy"] as? String)
+    #expect(strategy == "slot_popup_recursive_exact_leaf")
+    // Divergence: flag ON, but the actual winning actuation is coordinate → false.
+    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
+    #expect(!coordFree)
+    // Coordinate win → physical commit strategy (pins the coordFree:false branch).
+    let commit = try #require(obj["commit_strategy"] as? String)
+    #expect(commit == "slot_popup_physical_menu_click")
+}
+
+// Flag ON (default): the kill-switch routes a direct/search win through the
+// AXPress path — leaf selected via kAXPress, response reports coordFree true.
+@Test func test425ResponseFlagOnSelectsLeafViaAXPress() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
+    let obj = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
+    #expect(coordFree)
+    #expect(fixture.presses.pressedElementIDs.contains(fixture.leafItemID))
+}
+
+// Flag OFF: LOGIC_MCP_INSERT_COORD_FREE=0 routes the SAME direct win through the
+// COORDINATE path — no kAXPress on the leaf, response reports false.
+@Test func test425ResponseFlagOffUsesCoordinateNotAXPress() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
+    let obj = await FeatureFlags.withInsertCoordFree(false) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
+    #expect(!coordFree)
+    #expect(!fixture.presses.pressedElementIDs.contains(fixture.leafItemID))
+}
+
+// A coord-free (AXPress) win that times out post-commit must report an AXPress
+// commit strategy, NOT the physical/coordinate one (commit_strategy honesty).
+@Test func test425ResponseAXPressWinReportsAXPressCommitStrategy() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
+    let obj = await FeatureFlags.withInsertCoordFree(true) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+    let error = try #require(obj["error"] as? String)
+    #expect(error == "operation_timeout")
+    let commit = try #require(obj["commit_strategy"] as? String)
+    #expect(commit == "slot_popup_axpress_menu_select")
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
+    #expect(coordFree)
+}

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -1,0 +1,50 @@
+# #425 — Coordinate-free plugin-insert (Option B)
+
+Status: leaf selection coordinate-free by DEFAULT; slot-open and the recursive
+category-hover fallback remain coordinate by **governed waiver**.
+
+## Decision (CEO-ratified Option B)
+
+The plugin-insert leaf SELECTION is coordinate-free by default: it reads the
+plugin's format submenu as an AX child and `AXPress`es the preferred-format leaf
+(`pressPopupPluginLeaf`), with no `moveElementCenter`/`clickElementCenter`. The
+`FeatureFlags.insertCoordFree` flag is retained as a **kill-switch** —
+`LOGIC_MCP_INSERT_COORD_FREE=0` rolls back to the legacy coordinate leaf click.
+
+`clickPopupPluginLeaf` takes an explicit `coordFree` argument (not a direct flag
+read) so the two supported paths (direct / search) honor the flag while the
+recursive fallback can force the coordinate path.
+
+## Governed coordinate waivers (live-probed, documented)
+
+1. **Slot-open stays a coordinate click.** Opening a slot's empty picker is a
+   coordinate click on the slot element (`liveExactSlotPopupInsert`). Coord-free
+   alternatives were live-probed and rejected:
+   - `AXPress` on the empty-slot element is a **no-op** — the picker never opens.
+   - `AXShowMenu` opens the picker into an **NSMenu tracking loop that wedges
+     Logic** (AX calls block).
+
+2. **Recursive category-hover fallback stays coordinate.** The recursive
+   discovery path (`clickPopupExactLeafRecursively`) hovers categories with
+   `moveElementCenter` and always selects the matched leaf with `coordFree:
+   false`. It is **unreachable for the Release-1 supported plugins** — Gain,
+   Channel EQ, and Compressor (`insertableAllowlist`) are always found by the
+   direct or search strategy, so the recursive branch is a documented
+   coordinate-fallback only.
+
+## Discriminator honesty
+
+`select_trace["leaf_select_coord_free"]` is sourced from the WINNING strategy
+(`SlotPopupPluginClick.coordFree`), not the raw flag. A recursive
+(coordinate-only) win therefore reports `false` even when the flag is on, so the
+receipt can never be falsely pinned to the flag value.
+
+## Tests
+
+`Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` (`#425 (Option B)`
+section) covers the four contract points: leaf press via `kAXPress`, the
+discriminator's true value on a coord-free direct win, `coordFree:false` taking
+the coordinate path (never `AXPress`), and fail-closed behavior when `AXPress`
+is neutralized. A winning recursive path cannot be exercised hermetically (it
+would require real on-screen geometry and post a CGEvent); that case is noted in
+the test file and verified structurally.

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -27,24 +27,37 @@ recursive fallback can force the coordinate path.
 2. **Recursive category-hover fallback stays coordinate.** The recursive
    discovery path (`clickPopupExactLeafRecursively`) hovers categories with
    `moveElementCenter` and always selects the matched leaf with `coordFree:
-   false`. It is **unreachable for the Release-1 supported plugins** — Gain,
-   Channel EQ, and Compressor (`insertableAllowlist`) are always found by the
-   direct or search strategy, so the recursive branch is a documented
-   coordinate-fallback only.
+   false`. It is a **reachable** coordinate-only failure fallback — tried after
+   the direct and search strategies — but is **unreachable in practice for the
+   Release-1 supported plugins**: Gain, Channel EQ, and Compressor
+   (`insertableAllowlist`) are always found by the direct or search strategy, so
+   the recursive branch is a coordinate-only safety net the supported set never
+   exercises.
 
 ## Discriminator honesty
 
 `select_trace["leaf_select_coord_free"]` is sourced from the WINNING strategy
-(`SlotPopupPluginClick.coordFree`), not the raw flag. A recursive
-(coordinate-only) win therefore reports `false` even when the flag is on, so the
-receipt can never be falsely pinned to the flag value.
+(`SlotPopupPluginClick.coordFree`) via `leafSelectCoordFree(for:)`, not the raw
+flag. A recursive (coordinate-only) win therefore reports `false` even when the
+flag is on, so the receipt can never be falsely pinned to the flag value.
 
 ## Tests
 
-`Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` (`#425 (Option B)`
-section) covers the four contract points: leaf press via `kAXPress`, the
-discriminator's true value on a coord-free direct win, `coordFree:false` taking
-the coordinate path (never `AXPress`), and fail-closed behavior when `AXPress`
-is neutralized. A winning recursive path cannot be exercised hermetically (it
-would require real on-screen geometry and post a CGEvent); that case is noted in
-the test file and verified structurally.
+`Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` covers, at the helper
+level, leaf press via `kAXPress`, the discriminator's value on a coord-free
+direct win, `coordFree:false` taking the coordinate path (never `AXPress`), and
+fail-closed behavior when `AXPress` is neutralized.
+
+Response-level tests drive the real `defaultInsertVerified` flow (fake AX runtime
+plus a DEBUG-only coordinate-actuation seam, `forceCoordinateActuationForTests`,
+so no CGEvent / physical mouse is issued) and assert the assembled response's
+`select_trace["leaf_select_coord_free"]`:
+
+- a recursive (coordinate-only) win under the flag ON reports `false` — the
+  flag-vs-path divergence is exercised hermetically end to end, not merely
+  structurally;
+- a direct win selects the leaf via `kAXPress` under the flag ON
+  (`leaf_select_coord_free == true`) and via the coordinate primitives under the
+  flag OFF (`false`, with no `kAXPress` on the leaf);
+- an AXPress win that times out post-commit reports an AXPress commit strategy
+  (`commit_strategy`), never a physical/coordinate one.


### PR DESCRIPTION
Implements the ratified **Option B** for #425.

## What changed

The plugin **leaf selection** in `logic_plugins.insert_verified`'s slot popup is now coordinate-free: the matched plugin leaf is chosen with **AXPress** over the AX-children format submenu instead of a coordinate mouse-move + click. It is the default; `LOGIC_MCP_INSERT_COORD_FREE=0` is a kill-switch that restores the legacy coordinate click.

The insert `select_trace` gains `leaf_select_coord_free`, sourced from the **winning strategy** (`leafSelectCoordFree(for:)`), not the raw flag — so a coordinate win reports `false` even when the flag is on. The receipt cannot be falsely pinned to the flag.

## Scope — this is PARTIAL coordinate removal (honest)

The leaf **hover + click** are removed. Two coordinate uses remain under a governed waiver (`docs/tickets/issue-425-coord-free-insert.md`), both backed by live probes:

- **Slot-open** (single-click the empty insert slot to open the picker) stays a coordinate click. Coordinate-free alternatives were live-probed and rejected: AXPress on the empty slot is a no-op (the picker never opens), and AXShowMenu opens the picker into an NSMenu tracking loop that **wedges** Logic (AX blocks).
- The **recursive category-hover** fallback stays coordinate. It is unreachable for the Release-1 insert allowlist (Gain / Channel EQ / Compressor), which are always reached by the direct/search strategies; it is forced to the coordinate path (`coordFree: false`) so it can never silently become an unverified coord-free route.

## Verification

- `swift build -c release` green; unit tests: coord-free leaf select via AXPress, the flag default/kill-switch, and the discriminator **divergence** case (a recursive coordinate win reports `leaf_select_coord_free == false` under the flag) — the last is mutation-proof (re-pinning the discriminator to the flag, or flipping the recursive path's `coordFree` to the flag, turns it RED).
- Live-verified on Logic Pro 12.3 against a fresh release build: default → the plugin mounts via AXPress with a State-A inventory readback; kill-switch → mounts via the coordinate path (no regression).

## Not in scope

Full coordinate-free insert (slot-open) is deferred — the slot-open wall (AXShowMenu wedge) needs a separate approach. Tracked via the waiver.
