### PR TITLE
release: sync Formula sha256 to v3.13.0 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz release artifact.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "702705253b99ba1ed2111afc1294074b23d4cff9e14af5e3d27ecaf602654f1c"
+    sha256 "83d3f3ffc1651917da077da24fa43c8490c9e32a0c6d29aa8663a0085007c2b9"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
Syncs Formula sha256 to the published v3.13.0 LogicProMCP-macOS-universal.tar.gz asset (83d3f3ffc165…), matching the release SHA256SUMS.txt (independently recomputed via download+shasum). Without this, brew install of v3.13.0 fails the checksum. One-line change; version/url already bumped in the v3.13.0 prep (#442).