### PR TITLE
fix(#449): raise midi.import_file AppleScript outer timeout

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -126,11 +126,24 @@ extension AccessibilityChannel {
     /// lane the result is DOWNGRADED to State B `imported_as_gm_device` with a
     /// hint, because such lanes route to a General MIDI device and may bounce
     /// silent — a count delta alone must never be claimed audible-verified.
+    ///
+    /// #449: the default `executeScript` uses
+    /// `ServerConfig.midiImportAppleScriptTimeout` (not the global 5.0s
+    /// `appleScriptTimeout`) so BoundedProcessRunner does not SIGTERM the
+    /// osascript child before the script's own poll budgets can finish.
+    /// Note: Logic 12.3 may present a standalone Import browser rather than a
+    /// sheet-attached open panel; that UI mismatch is separate from the outer
+    /// timeout and may still require a helper path when sheet detection fails.
     static func defaultImportMIDIFile(
         systemEventsAuthorized: @Sendable () -> Bool = { PermissionChecker.checkSystemEventsAutomation() },
         path: String,
         runtime: AXLogicProElements.Runtime = .production,
-        executeScript: @escaping @Sendable (String) async -> ChannelResult = { await AppleScriptChannel.executeAppleScript($0) },
+        executeScript: @escaping @Sendable (String) async -> ChannelResult = {
+            await AppleScriptChannel.executeAppleScript(
+                $0,
+                timeout: ServerConfig.midiImportAppleScriptTimeout
+            )
+        },
         trackCount: (@Sendable () -> Int)? = nil,
         trackNames: (@Sendable () -> [String])? = nil,
         regionInfos: (@Sendable () -> MIDIImportRegionReadback)? = nil,

--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -479,12 +479,15 @@ actor AppleScriptChannel: Channel {
         await runtime.runScript(source)
     }
 
-    static func executeAppleScript(_ source: String) async -> ChannelResult {
+    static func executeAppleScript(
+        _ source: String,
+        timeout: TimeInterval = ServerConfig.appleScriptTimeout
+    ) async -> ChannelResult {
         await Task.detached(priority: .userInitiated) {
             let execution = BoundedProcessRunner.run(
                 executable: "/usr/bin/osascript",
                 arguments: appleScriptArguments(for: source),
-                timeout: ServerConfig.appleScriptTimeout,
+                timeout: timeout,
                 outputLimitBytes: 128 * 1024
             )
             let result = channelResult(forAppleScriptExecution: execution)

--- a/Sources/LogicProMCP/Server/ServerConfig.swift
+++ b/Sources/LogicProMCP/Server/ServerConfig.swift
@@ -19,6 +19,14 @@ struct ServerConfig: Sendable {
 
     // MARK: - Timeouts
     static let appleScriptTimeout: TimeInterval = 5.0
+    /// Outer osascript budget for `midi.import_file` / `tracks.record_sequence` SMF import.
+    /// Must exceed the AppleScript's own internal poll budgets in
+    /// `AccessibilityChannel+MIDIImport.defaultImportMIDIFile` (#449): file-open
+    /// sheet (~5s) + go-to-folder field (~3s) + Import-enabled (~4s) + tempo
+    /// dialog (~3s) + fixed delays/self-heal (~2s) ≈ 17s worst case. The default
+    /// 5.0s `appleScriptTimeout` SIGTERMs the child mid-flight and reports a
+    /// false `ax_write_failed` / `timedOut` even when the import later succeeds.
+    static let midiImportAppleScriptTimeout: TimeInterval = 20.0
 
     // MARK: - Logic Pro
     /// Resolved bundle ID for the active Logic Pro variant (desktop or Creator Studio).

--- a/Tests/LogicProMCPTests/ProductionReadinessTests.swift
+++ b/Tests/LogicProMCPTests/ProductionReadinessTests.swift
@@ -260,6 +260,14 @@ import Testing
     #expect(ServerConfig.mmcDeviceID == 0x7F)
 }
 
+/// #449: MIDI import's outer osascript budget must exceed the script's own
+/// internal poll ceilings so BoundedProcessRunner does not false-fail mid-import.
+@Test func testServerConfigMIDIImportAppleScriptTimeoutExceedsDefault() {
+    #expect(ServerConfig.appleScriptTimeout == 5.0)
+    #expect(ServerConfig.midiImportAppleScriptTimeout > ServerConfig.appleScriptTimeout)
+    #expect(ServerConfig.midiImportAppleScriptTimeout >= 17.0)
+}
+
 // MARK: - Architecture: StatePoller Graceful Stop
 
 @Test func testStatePollerStopAwaitsTaskCompletion() async {


### PR DESCRIPTION
## Summary
- Fixes #449: `midi.import_file` / `tracks.record_sequence` was killed by the global 5.0s `appleScriptTimeout` while the import AppleScript's own poll budgets can legitimately take ~17s.
- Adds `ServerConfig.midiImportAppleScriptTimeout = 20.0` and wires `defaultImportMIDIFile`'s default `executeScript` through `AppleScriptChannel.executeAppleScript(_:timeout:)`.
- Leaves the global 5.0s timeout unchanged for other AppleScript ops.

## Notes
- Logic 12.3 may still present a standalone Import browser rather than a sheet-attached open panel; that UI mismatch is separate from this timeout fix. Hosts that already use a helper path (`compose-midi.sh` / Import UI automation) should keep it until a dedicated 12.3 Import-browser fix lands.

## Test plan
- [x] Unit: `testServerConfigMIDIImportAppleScriptTimeoutExceedsDefault` (asserts import budget > default and ≥ 17s)
- [ ] Live: `record_sequence` / `midi.import_file` no longer logs `exceeded 5.0s timeout` on a healthy Logic 12.x session
- [ ] Confirm other AppleScript ops still use 5.0s
