### PR TITLE
feat(ax): add typed AX status internal API, uncalled

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -11,6 +11,29 @@ enum AXHelpers {
         let children: @Sendable (AXUIElement) -> [AXUIElement]
         let performAction: @Sendable (AXUIElement, String) -> Bool
         let childCount: @Sendable (AXUIElement) -> Int?
+        /// Injectable typed-children seam. `nil` means "use the production read".
+        let childrenResult: (@Sendable (AXUIElement) -> Result<[AXUIElement], AXStatusError>)?
+
+        /// Explicit memberwise initializer, replacing the compiler-synthesized one so
+        /// `childrenResult` can default to `nil`. Every existing construction that omits
+        /// it continues to compile unchanged.
+        init(
+            axApp: @escaping @Sendable (pid_t) -> AXUIElement,
+            attributeValue: @escaping @Sendable (AXUIElement, String) -> AnyObject?,
+            setAttributeValue: @escaping @Sendable (AXUIElement, String, CFTypeRef) -> Bool,
+            children: @escaping @Sendable (AXUIElement) -> [AXUIElement],
+            performAction: @escaping @Sendable (AXUIElement, String) -> Bool,
+            childCount: @escaping @Sendable (AXUIElement) -> Int?,
+            childrenResult: (@Sendable (AXUIElement) -> Result<[AXUIElement], AXStatusError>)? = nil
+        ) {
+            self.axApp = axApp
+            self.attributeValue = attributeValue
+            self.setAttributeValue = setAttributeValue
+            self.children = children
+            self.performAction = performAction
+            self.childCount = childCount
+            self.childrenResult = childrenResult
+        }
 
         static let production = Runtime(
             axApp: { pid in
@@ -77,6 +100,47 @@ enum AXHelpers {
     /// Get the children of an AX element.
     static func getChildren(_ element: AXUIElement, runtime: Runtime = .production) -> [AXUIElement] {
         runtime.children(element)
+    }
+
+    /// Typed AX status error carrying the raw `AXError` rawValue.
+    struct AXStatusError: Error, Sendable, Equatable {
+        let raw: Int32
+
+        init(raw: Int32) {
+            self.raw = raw
+        }
+    }
+
+    /// Pure projection of an AX read outcome into a typed result.
+    ///
+    /// Nothing is fabricated in either direction: a non-success status keeps its own raw
+    /// value rather than collapsing to a single code, and a successful read never invents
+    /// a status. Absent children (`nil`) and a malformed non-`CFArray` value are both an
+    /// empty success, because neither is an AX error — the earlier defect here was a
+    /// synthesised `noValue` for the absent case.
+    static func projectChildrenStatus(
+        _ status: AXError,
+        _ value: AnyObject?
+    ) -> Result<[AXUIElement], AXStatusError> {
+        guard status == .success else {
+            return .failure(AXStatusError(raw: status.rawValue))
+        }
+        guard let value else { return .success([]) }
+        return .success(decodeChildrenArray(value))
+    }
+
+    /// Read an element's children, preserving a non-success AX status as a typed error
+    /// instead of flattening it to an empty array the way `getChildren` does.
+    static func childrenResult(
+        _ element: AXUIElement,
+        runtime: Runtime = .production
+    ) -> Result<[AXUIElement], AXStatusError> {
+        if let injected = runtime.childrenResult {
+            return injected(element)
+        }
+        var value: AnyObject?
+        let status = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value)
+        return projectChildrenStatus(status, value)
     }
 
     /// Decode a raw `kAXChildrenAttribute` value into `[AXUIElement]`, guarding

--- a/Tests/LogicProMCPTests/AXStatusProjectionTests.swift
+++ b/Tests/LogicProMCPTests/AXStatusProjectionTests.swift
@@ -1,0 +1,74 @@
+@preconcurrency import ApplicationServices
+import Testing
+@testable import LogicProMCP
+
+// Focused coverage for the typed AX status projection shipped as an internal,
+// caller-free API. References no K0 surface-resolver symbol by construction.
+//
+// Each test prints its expected and actual values with an EVIDENCE prefix so the
+// receipt can carry observed values rather than a claim that they matched.
+@Suite("AXStatusProjectionTests")
+struct AXStatusProjectionTests {
+
+    static let pinnedRaws: [Int32] = [-25200, -25201, -25202, -25204, -25205, -25208, -25211]
+
+    @Test func rawValuePreservedForEveryPinnedStatus() {
+        var recovered: [Int32] = []
+        for raw in Self.pinnedRaws {
+            guard let status = AXError(rawValue: raw) else { continue }
+            switch AXHelpers.projectChildrenStatus(status, nil) {
+            case .failure(let error):
+                recovered.append(error.raw)
+            case .success:
+                recovered.append(0)
+            }
+        }
+        print("EVIDENCE AC-1 expected=\(Self.pinnedRaws) actual=\(recovered) count=\(Self.pinnedRaws.count)")
+        let sevenRawsPinned: Bool = (Self.pinnedRaws.count == 7)
+        #expect(sevenRawsPinned)
+        let everyRawPreserved: Bool = (recovered == Self.pinnedRaws)
+        #expect(everyRawPreserved)
+    }
+
+    @Test func absentValueIsEmptySuccess() {
+        var emptySuccess = false
+        var observed = "failure"
+        if case .success(let elements) = AXHelpers.projectChildrenStatus(.success, nil) {
+            emptySuccess = elements.isEmpty
+            observed = "success(count: \(elements.count))"
+        }
+        print("EVIDENCE AC-2 expected=success(count: 0) actual=\(observed)")
+        let absentIsEmptySuccess: Bool = emptySuccess
+        #expect(absentIsEmptySuccess)
+    }
+
+    @Test func malformedNonArrayIsEmptySuccess() {
+        var emptySuccess = false
+        var observed = "failure"
+        if case .success(let elements) = AXHelpers.projectChildrenStatus(.success, "10,20" as NSString) {
+            emptySuccess = elements.isEmpty
+            observed = "success(count: \(elements.count))"
+        }
+        print("EVIDENCE AC-3 expected=success(count: 0) actual=\(observed)")
+        let malformedIsEmptySuccess: Bool = emptySuccess
+        #expect(malformedIsEmptySuccess)
+    }
+
+    @Test func wellFormedChildrenProjectToExpectedElements() {
+        let expected = [AXUIElementCreateSystemWide()]
+        var actual: [AXUIElement] = []
+        if case .success(let elements) = AXHelpers.projectChildrenStatus(.success, expected as CFArray) {
+            actual = elements
+        }
+        print("EVIDENCE AC-4 expected=\(expected) actual=\(actual)")
+        let projectsExpectedElements: Bool = (actual == expected)
+        #expect(projectsExpectedElements)
+    }
+
+    @Test func productionRuntimeSeamIsAbsent() {
+        let seam = AXHelpers.Runtime.production.childrenResult
+        print("EVIDENCE AC-7 expected=nil actual=\(seam == nil ? "nil" : "non-nil")")
+        let seamIsAbsent: Bool = (seam == nil)
+        #expect(seamIsAbsent)
+    }
+}


### PR DESCRIPTION
Adds a typed accessibility status API to `AXHelpers` as an internal, **caller-free** addition.

## What this adds

Four new internal symbols, none of which is invoked anywhere in `Sources`:

- `AXStatusError` — a typed error carrying the raw `AXError` value
- `projectChildrenStatus(_:_:)` — a pure projection from an AX read outcome to a typed result
- `childrenResult(_:runtime:)` — a children read that preserves a non-success status instead of flattening it
- `Runtime.childrenResult` — an injection seam, with an explicit memberwise initializer defaulting it to `nil`

The pre-existing `getChildren` is unchanged and every existing call site continues to use it. The tool
surface, the response envelope and the error taxonomy are unchanged.

## Scope

Exactly two files: `Sources/LogicProMCP/Accessibility/AXHelpers.swift` (additive, 64 inserted / 0 deleted)
and `Tests/LogicProMCPTests/AXStatusProjectionTests.swift` (new, 74 lines).

## Verification at this exact head

| lane | result |
|---|---|
| focused suite | 5 tests passed |
| full suite `swift test --no-parallel` | **3330 passed / 0 failed** |
| baseline at the merge base | **3325 passed / 0 failed** |
| debug build / release build | both succeed |
| test-target compile | succeeds |
| release artifacts | `LogicProMCP` and `trusted-verifier` both built and hashed |
| `Package.resolved` | unchanged; verified before and after every build and test lane |

The full suite differs from the baseline by exactly the five new tests: no regression, no test removed.

## Mutation testing

Each new assertion was verified to be live by mutating the implementation and confirming that the
assertion — and only that assertion — fails:

| mutation | assertion that failed |
|---|---|
| collapse every non-success status onto one raw value | `rawValuePreservedForEveryPinnedStatus` |
| map an absent value to an error | `absentValueIsEmptySuccess` |
| map a malformed non-array value to an error | `malformedNonArrayIsEmptySuccess` |
| return an empty collection for a well-formed value | `wellFormedChildrenProjectToExpectedElements` |
| give the runtime seam a non-`nil` default | `productionRuntimeSeamIsAbsent` |

Every mutation produced exactly one failing test, and the tree was restored and re-verified after each.

## Behaviour notes

Fail-closed in both directions: a non-success status is surfaced with its own raw value, a successful
read never invents an error, and an absent value is an empty success rather than an error. Seven
distinct `AXError` raw values round-trip distinctly.

**Known limitation:** an absent children value and a malformed non-array value both project to an empty
success, so a caller cannot distinguish the two from the result alone. Neither is an accessibility
error, so this is the intended contract, but it is recorded here for any future caller that needs to
tell them apart.

No logging, file or network calls are added. No deadline, retry or blocking wait is introduced. The
addition is read-only and pure, so no operation can be left half-applied.

## Manual/live QA: LIVE_NA

No live verification is claimed. The shipment is caller-free and adds no user-reachable behaviour, so a
live session could not distinguish this build from its base — a live PASS here would be unfalsifiable.
LIVE_NA records that live evidence is **inapplicable**, not that it was obtained.

## This is not a completion

This change ships capability only. It does not close its parent work item, grants no completion credit,
and does not authorise the deferred live verification lane that work still owes.
