### PR TITLE
fix: default-install path — import timeout, keycmd remediation path, approval ordering, goto_position fallback

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -130,7 +130,9 @@ extension AccessibilityChannel {
         systemEventsAuthorized: @Sendable () -> Bool = { PermissionChecker.checkSystemEventsAutomation() },
         path: String,
         runtime: AXLogicProElements.Runtime = .production,
-        executeScript: @escaping @Sendable (String) async -> ChannelResult = { await AppleScriptChannel.executeAppleScript($0) },
+        executeScript: @escaping @Sendable (String) async -> ChannelResult = {
+            await AppleScriptChannel.executeAppleScript($0, timeout: ServerConfig.midiImportAppleScriptTimeout)
+        },
         trackCount: (@Sendable () -> Int)? = nil,
         trackNames: (@Sendable () -> [String])? = nil,
         regionInfos: (@Sendable () -> MIDIImportRegionReadback)? = nil,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -392,7 +392,18 @@ extension AccessibilityChannel {
         end importMIDI
         return importMIDI()
         """
+        // #452: the only measurement of the segment the osascript bound governs.
+        // The clock brackets the call rather than the executor, so it observes
+        // whatever actually ran — wrapping the injected closure instead would
+        // measure the wrapper and prove nothing about production. Recorded on
+        // every outcome, including timeout, because a segment that hit its bound
+        // is exactly the one an operator needs the number for.
+        let segmentStart = ContinuousClock.now
         let result = await executeScript(script)
+        await OperationTraceContext.record(
+            .scriptSegmentCompleted,
+            attributes: ["applescript_duration_ms": elapsedMilliseconds(since: segmentStart)]
+        )
         switch result {
         case .success(let output):
             let scriptOutput = normalizedAppleScriptPayload(output)

--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -479,12 +479,15 @@ actor AppleScriptChannel: Channel {
         await runtime.runScript(source)
     }
 
-    static func executeAppleScript(_ source: String) async -> ChannelResult {
+    static func executeAppleScript(
+        _ source: String,
+        timeout: TimeInterval = ServerConfig.appleScriptTimeout
+    ) async -> ChannelResult {
         await Task.detached(priority: .userInitiated) {
             let execution = BoundedProcessRunner.run(
                 executable: "/usr/bin/osascript",
                 arguments: appleScriptArguments(for: source),
-                timeout: ServerConfig.appleScriptTimeout,
+                timeout: timeout,
                 outputLimitBytes: 128 * 1024
             )
             let result = channelResult(forAppleScriptExecution: execution)

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -22,13 +22,33 @@ actor ChannelRouter {
 
     private var channels: [ChannelID: any Channel] = [:]
 
-    private static let transportToggleOpsAllowingAXElementFallback: Set<String> = [
+    // Operations for which an Accessibility `element_not_found` is provably a
+    // PRE-WRITE miss, so a later channel may still run. Three conditions must all
+    // hold before an op belongs here, and #460 is why they are written down rather
+    // than left implicit:
+    //
+    //  1. `element_not_found` means the AX control was never located, so no
+    //     actuation reached Logic and no partial write can be stranded.
+    //  2. The failure is Accessibility-specific — a missing control-bar button or
+    //     ruler element — not a rejection of the request itself.
+    //  3. Every later candidate expresses the same semantics, so falling through
+    //     cannot silently change what the caller asked for.
+    //
+    // `transport.goto_position` satisfies all three exactly as the toggles do: a
+    // missing ruler element moves nothing, and MCU/CoreMIDI/CGEvent all position
+    // the playhead. Omitting it stranded a real default-install workflow whose
+    // first action was `goto_position` (Discussion #455).
+    //
+    // An op that can leave a partial write, or whose later candidates differ in
+    // meaning, must NOT be added here; it needs per-op recovery instead.
+    private static let opsAllowingAXElementNotFoundFallback: Set<String> = [
         "transport.play",
         "transport.stop",
         "transport.record",
         "transport.toggle_cycle",
         "transport.toggle_metronome",
         "transport.toggle_count_in",
+        "transport.goto_position",
     ]
 
     /// Active routing table (v2). `internal` so test-targets can introspect
@@ -258,7 +278,7 @@ actor ChannelRouter {
         message: String
     ) -> Bool {
         channelID == .accessibility &&
-            transportToggleOpsAllowingAXElementFallback.contains(operation) &&
+            opsAllowingAXElementNotFoundFallback.contains(operation) &&
             HonestContract.stateCErrorCode(message) == HonestContract.FailureError.elementNotFound.rawValue
     }
 

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -130,6 +130,21 @@ final class OperationTraceContext: @unchecked Sendable {
     }
 }
 
+/// #452: render a monotonic interval as integer milliseconds for a trace
+/// attribute. `ContinuousClock` is used rather than a `Date` difference because
+/// wall-clock can step backwards across an NTP correction, which would report a
+/// segment as negative or absurdly long — and a timing number that a clock
+/// adjustment can invent is not evidence.
+///
+/// Clamped at zero: the clock is non-decreasing, so a negative reading means the
+/// measurement is unusable, not that the work was fast, and emitting it as a
+/// duration would let a consumer average it into nonsense.
+func elapsedMilliseconds(since start: ContinuousClock.Instant) -> String {
+    let components = (ContinuousClock.now - start).components
+    let milliseconds = components.seconds * 1000 + components.attoseconds / 1_000_000_000_000_000
+    return String(max(0, milliseconds))
+}
+
 struct TraceID: RawRepresentable, Codable, Sendable, Hashable, CustomStringConvertible {
     let rawValue: String
 
@@ -171,6 +186,13 @@ enum TracePhase: String, Codable, Sendable, CaseIterable {
     /// phase's contract is "a channel began executing this write", not "this
     /// exact channel wrote".
     case writeBoundaryCrossed = "write_boundary.crossed"
+    /// #452 — a bounded AppleScript execution finished inside a channel, carrying
+    /// how long it actually took. `channel.started`/`channel.completed` bracket
+    /// the whole channel call, so the segment governed by the osascript timeout
+    /// was not separable from the surrounding Swift AX work; #449 could be
+    /// argued about but not measured. This phase is diagnostic and additive:
+    /// nothing gates on it, and it never replaces the channel bracket.
+    case scriptSegmentCompleted = "script_segment.completed"
     case channelCompleted = "channel.completed"
     case verificationPoll = "verification.poll"
     case verificationCompleted = "verification.completed"
@@ -223,6 +245,12 @@ actor OperationTraceStore {
         "outcome": .publicDiagnostic,
         "parent_trace_id": .publicDiagnostic,
         "gate_mode": .publicDiagnostic,
+        // #452 — measured elapsed time of a bounded AppleScript segment.
+        // Undeclared keys are DROPPED by `filteredAttributes`, so an emission
+        // without this row would record nothing and expose nothing. The bound it
+        // ran under is deliberately NOT emitted here: the executor is injected,
+        // so the call site cannot attest to a timeout it does not own.
+        "applescript_duration_ms": .publicDiagnostic,
     ]
 
     let maximumTraceCount: Int

--- a/Sources/LogicProMCP/Server/ServerConfig.swift
+++ b/Sources/LogicProMCP/Server/ServerConfig.swift
@@ -20,6 +20,15 @@ struct ServerConfig: Sendable {
     // MARK: - Timeouts
     static let appleScriptTimeout: TimeInterval = 5.0
 
+    // midi.import_file drives a File > Import > MIDI File sheet, a path-entry
+    // dialog, an import button and a tempo prompt, each polled inside the
+    // script itself. Summing one delay per iteration across those loops gives a
+    // floor of 17.2 s, so the shared 5.0 s bound killed osascript while Logic
+    // was still importing — the region landed but the caller saw a timeout
+    // (#449). This bound must stay above that floor; the polling loops in
+    // AccessibilityChannel+MIDIImport are the thing it has to outlast.
+    static let midiImportAppleScriptTimeout: TimeInterval = 30.0
+
     // MARK: - Logic Pro
     /// Resolved bundle ID for the active Logic Pro variant (desktop or Creator Studio).
     static var logicProBundleID: String { LogicProTarget.current.bundleID }

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -89,8 +89,23 @@ extension SetupDoctor {
                 : "Key Commands preset is not staged; ignore this if MIDIKeyCommands-only ops are unused.",
             evidence: ["preset_staged": String(staged)],
             remediationType: staged ? .none : .command,
-            remediationValueOverride: staged ? nil : "install-keycmds.sh"
+            remediationValueOverride: staged ? nil : keyCommandsRemediation(runtime: runtime)
         )
+    }
+
+    // #456: Homebrew installs install-keycmds.sh into the formula pkgshare, not on
+    // PATH, so printing the bare script name hands the user a command they cannot
+    // run — and fetching the script alone fails on its sibling keycmd-preset.plist.
+    // The share dir is already resolved for the install checks, so the remediation
+    // is derived from that same probe and stays runnable wherever the package put
+    // it. Only an unresolved share dir falls back to the bare name, and it says so.
+    static func keyCommandsRemediation(runtime: Runtime) -> String {
+        switch runtime.shareDirProbe() {
+        case let .complete(path, _), let .missing(path, _, _), let .invalid(path, _):
+            return "\(path)/install-keycmds.sh"
+        case .unresolved:
+            return "install-keycmds.sh (share dir unresolved; set LOGIC_PRO_MCP_SHARE_DIR or reinstall)"
+        }
     }
 
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+ChannelDependencyChecks.swift
@@ -4,7 +4,8 @@ extension SetupDoctor {
     static func manualValidationCheck(
         approvals: [ManualValidationChannel: ManualValidationApproval],
         profile: DoctorProfile,
-        storeHealth: ManualValidationStoreHealth
+        storeHealth: ManualValidationStoreHealth,
+        checks: [Check] = []
     ) -> Check {
         if case let .corrupt(reason) = storeHealth {
             return check(
@@ -28,6 +29,22 @@ extension SetupDoctor {
                 remediationType: .none,
                 optional: true,
                 skipReason: .profileNotRequired
+            )
+        }
+
+        // #457: hold the approval prompt until the setup it attests exists. The fix
+        // plan drops blocked checks, so a user is never told to assert readiness for
+        // a channel whose staging has not happened — the approval would be a durable
+        // false attestation that no later file check can repair.
+        if let cause = blockingCause(for: "channels.manual_validation", checks: checks) {
+            return check(
+                id: "channels.manual_validation",
+                domain: "channels",
+                status: .skipped,
+                summary: "Operator approval is held until Key Commands staging completes; approving first would attest setup that has not happened.",
+                evidence: ["blocked_by": cause],
+                remediationType: .docs,
+                blockedBy: cause
             )
         }
 

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRegistry.swift
@@ -114,8 +114,16 @@ extension SetupDoctor {
         .init(.logicVersionSupport, dependencies: [.logicInstallation], capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-logicversion-support"),
         .init(.logicApplicationState, capabilityGroups: allCapabilityGroups, remediationAnchor: "docs/SETUP.md#doctor-logicapplication-state"),
         .init(.logicBlockingDialog, dependencies: [.logicApplicationState, .permissionsAccessibility], capabilityGroups: ["track_management", "mixer_ax", "verified_plugin_applyback"], remediationAnchor: "docs/SETUP.md#doctor-logicblocking-dialog"),
-        .init(.channelsManualValidation, capabilityGroups: ["keycmd_only_ops", "legacy_scripter"], remediationAnchor: "docs/SETUP.md#doctor-channelsmanual-validation", profileRule: "keycmd|legacy-scripter|full"),
         .init(.channelsKeycmdReference, capabilityGroups: ["keycmd_only_ops"], remediationAnchor: "docs/SETUP.md#doctor-channelskeycmd-reference", profileRule: "keycmd|full"),
+        // #457: --approve-channel records an OPERATOR ASSERTION that manual setup was
+        // done; it neither configures nor verifies Logic. Ordering it before the
+        // staging step it attests let a new user approve both channels first and only
+        // then discover Key Commands had never been staged — a durable false
+        // attestation the helper cannot repair, because Logic 12.2+ still requires
+        // manual MIDI Learn that no file presence can prove. Declaring the dependency
+        // makes the fix plan put staging first instead of relying on declaration
+        // order among equal-severity manual checks.
+        .init(.channelsManualValidation, dependencies: [.channelsKeycmdReference], capabilityGroups: ["keycmd_only_ops", "legacy_scripter"], remediationAnchor: "docs/SETUP.md#doctor-channelsmanual-validation", profileRule: "keycmd|legacy-scripter|full"),
         .init(.channelsMCUWiringHint, capabilityGroups: ["mixer_mcu"], remediationAnchor: "docs/SETUP.md#doctor-channelsmcu-wiring-hint", profileRule: "full"),
         .init(.dependenciesClickFallback, remediationAnchor: "docs/SETUP.md#doctor-dependenciesclick-fallback"),
         .init(

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRunner.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+CheckRunner.swift
@@ -113,7 +113,8 @@ extension SetupDoctor {
             return manualValidationCheck(
                 approvals: context.approvals,
                 profile: context.doctorProfile,
-                storeHealth: context.manualStoreHealth
+                storeHealth: context.manualStoreHealth,
+                checks: checks
             )
         case .channelsKeycmdReference:
             return keycmdReferenceCheck(runtime: context.runtime, profile: context.doctorProfile)

--- a/Tests/LogicProMCPTests/Issue449ImportTimeoutBudgetTests.swift
+++ b/Tests/LogicProMCPTests/Issue449ImportTimeoutBudgetTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #449 — the import bound must outlast the import script's own polling
+//
+// `midi.import_file` returned `ax_write_failed` / `timedOut` while the region
+// was actually landing in Logic. Cause: the script drives four polled stages —
+// the File > Import > MIDI File sheet, the path-entry dialog, the import button
+// and the tempo prompt — and the shared 5.0 s `appleScriptTimeout` killed
+// osascript mid-import. Summing one `delay` per iteration across those loops
+// gives a 17.2 s floor, so the outer bound fired first and the caller saw a
+// timeout for work that had in fact succeeded.
+//
+// These tests lock the invariant that actually matters: the bound the import
+// path runs under must exceed the budget the import script can spend. A test
+// that only asserted `midiImportAppleScriptTimeout == 30.0` would pass while
+// someone widened a polling loop past it, so the budget is DERIVED from the
+// generated script rather than hard-coded.
+
+/// Worst-case seconds a `repeat N times { ... delay D ... }` block can spend,
+/// counting one delay per iteration. Nested loops are deliberately not summed:
+/// this is a floor, and a floor is enough to prove the bound is too small.
+private func pollingBudgetSeconds(of script: String) -> Double {
+    let lines = script.components(separatedBy: "\n")
+    var total = 0.0
+    for (index, line) in lines.enumerated() {
+        guard let iterations = firstInteger(in: line, after: "repeat ", before: " times") else { continue }
+        // First delay inside this loop body, before its `end repeat`.
+        for probe in lines.dropFirst(index + 1) {
+            if probe.contains("end repeat") { break }
+            if let delay = firstDouble(in: probe, after: "delay ") {
+                total += Double(iterations) * delay
+                break
+            }
+        }
+    }
+    return total
+}
+
+private func firstInteger(in line: String, after prefix: String, before suffix: String) -> Int? {
+    guard let start = line.range(of: prefix), let end = line.range(of: suffix, range: start.upperBound..<line.endIndex)
+    else { return nil }
+    return Int(line[start.upperBound..<end.lowerBound].trimmingCharacters(in: .whitespaces))
+}
+
+private func firstDouble(in line: String, after prefix: String) -> Double? {
+    guard let start = line.range(of: prefix) else { return nil }
+    let tail = line[start.upperBound...]
+    let digits = tail.prefix { $0.isNumber || $0 == "." }
+    return Double(digits)
+}
+
+@Suite("Issue #449 — midi.import_file timeout budget")
+struct Issue449ImportTimeoutBudgetTests {
+    /// The regression itself: the import path must not run under the shared bound.
+    @Test("import path uses a bound distinct from the shared AppleScript bound")
+    func importBoundIsSeparate() {
+        #expect(ServerConfig.midiImportAppleScriptTimeout > ServerConfig.appleScriptTimeout)
+    }
+
+    /// The invariant that would have caught #449 before it shipped: whatever the
+    /// import script can spend polling, the bound it runs under must exceed it.
+    @Test("import bound exceeds the script's own derived polling floor")
+    func importBoundExceedsScriptBudget() async throws {
+        let box = ScriptBox()
+        _ = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
+            path: try requireTemporaryMIDIFile(),
+            executeScript: { script in
+                box.store(script)
+                return .error("stop after capture")
+            }
+        )
+
+        let script = try #require(box.value, "import path must build a script to bound")
+        let floor = pollingBudgetSeconds(of: script)
+
+        // Guard the guard: if the parser stops seeing loops the test would pass
+        // vacuously, so require the script to actually contain polling.
+        #expect(floor > 0, "derived polling floor must be non-zero or this test proves nothing")
+        #expect(
+            ServerConfig.midiImportAppleScriptTimeout > floor,
+            "import bound \(ServerConfig.midiImportAppleScriptTimeout)s must exceed derived polling floor \(floor)s"
+        )
+    }
+
+    /// The parser is the instrument; prove it can fail before trusting it.
+    @Test("polling-budget parser detects a loop it is aimed at")
+    func parserDetectsKnownLoop() {
+        let sample = """
+        repeat 20 times
+            delay 0.25
+        end repeat
+        """
+        #expect(pollingBudgetSeconds(of: sample) == 5.0)
+        #expect(pollingBudgetSeconds(of: "no loops here") == 0.0)
+    }
+}
+
+/// The import path calls `executeScript` from a `@Sendable` context, so the
+/// captured script has to cross a concurrency boundary rather than mutate a var.
+private final class ScriptBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: String?
+
+    func store(_ script: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if stored == nil { stored = script }
+    }
+
+    var value: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}
+
+private func requireTemporaryMIDIFile() throws -> String {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("issue449-\(UUID().uuidString).mid")
+    try Data([0x4D, 0x54, 0x68, 0x64]).write(to: url)
+    return url.path
+}

--- a/Tests/LogicProMCPTests/Issue452ScriptSegmentDurationTests.swift
+++ b/Tests/LogicProMCPTests/Issue452ScriptSegmentDurationTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #452 — the AppleScript segment must be externally measurable
+//
+// `midi.import_file` spans three time budgets, and only the outermost one — the
+// operation deadline — crossed the process boundary. The middle budget, the one
+// `midiImportAppleScriptTimeout` governs and the one #449 is about, could be
+// argued from summed `delay` statements but never measured: those sums exclude
+// every AX query and file operation between the delays, so they cannot establish
+// real headroom.
+//
+// The fix records a monotonic interval around the script call and emits it as a
+// `script_segment.completed` trace attribute. Two properties make it evidence
+// rather than decoration:
+//
+//  1. It is measured with `ContinuousClock`, so an NTP step cannot invent it.
+//  2. It survives the trace store's attribute filter. Undeclared keys are
+//     silently dropped, so an emission whose key is missing from
+//     `attributePrivacyClasses` records nothing and exposes nothing while the
+//     source still reads as though it emits. Asserting only "the code calls
+//     record" would pass in exactly that broken state.
+//
+// This file covers the declaration and the clock in isolation. The end-to-end
+// assertion — a real import run producing a readable duration on a stored trace
+// — is in `OperationTraceTests`, which is serialized against the shared store
+// that test has to drive.
+
+@Suite("Issue #452 — AppleScript segment duration")
+struct Issue452ScriptSegmentDurationTests {
+    /// The key must be declared, or the emission is dropped before storage.
+    @Test("the duration attribute is declared and publicly classified")
+    func durationKeyIsDeclared() {
+        #expect(OperationTraceStore.attributePrivacyClasses["applescript_duration_ms"] == .publicDiagnostic)
+    }
+
+    /// The formatter is the instrument; prove it can distinguish intervals and
+    /// clamps rather than emitting a negative duration.
+    @Test("elapsed milliseconds are non-negative and grow with real elapsed time")
+    func elapsedMillisecondsIsMonotonicAndClamped() async throws {
+        let start = ContinuousClock.now
+        let immediate = try #require(Int(elapsedMilliseconds(since: start)))
+        #expect(immediate >= 0)
+
+        try await Task.sleep(nanoseconds: 40_000_000)
+        let later = try #require(Int(elapsedMilliseconds(since: start)))
+        #expect(later >= immediate)
+        #expect(later >= 30, "a 40ms sleep must be visible, or the reading is not measuring anything")
+
+        // A future instant clamps to zero instead of reporting a negative span.
+        #expect(elapsedMilliseconds(since: ContinuousClock.now.advanced(by: .seconds(5))) == "0")
+    }
+}

--- a/Tests/LogicProMCPTests/Issue457ApprovalOrderingTests.swift
+++ b/Tests/LogicProMCPTests/Issue457ApprovalOrderingTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #457 — approval must not be offered before the setup it attests
+//
+// `--approve-channel` records an OPERATOR ASSERTION that manual setup happened.
+// It neither configures nor verifies Logic. The fix plan listed it before
+// `channels.keycmd_reference`, so a new user approved both channels first and
+// only afterwards discovered Key Commands had never been staged — a durable
+// false attestation the helper cannot repair, because Logic 12.2+ still needs a
+// manual MIDI Learn that no file-presence check can prove.
+//
+// The fix declares the dependency and holds the approval check until staging
+// passes. `computeFixPlan` drops blocked checks, so the prompt disappears from
+// the plan rather than merely sorting later.
+//
+// These tests lock both directions. A gate that only ever blocks would be as
+// wrong as one that never blocks, so the release path is asserted too.
+
+private func manualCheck(staged: Bool, profile: SetupDoctor.DoctorProfile = .keycmd) -> SetupDoctor.Check {
+    let keycmd = SetupDoctor.check(
+        id: "channels.keycmd_reference",
+        domain: "channels",
+        status: staged ? .pass : .manual,
+        summary: staged ? "staged" : "not staged",
+        evidence: ["preset_staged": String(staged)],
+        remediationType: staged ? .none : .command
+    )
+    return SetupDoctor.manualValidationCheck(
+        approvals: [:],
+        profile: profile,
+        storeHealth: .ok,
+        checks: [keycmd]
+    )
+}
+
+@Suite("Issue #457 — approval ordering")
+struct Issue457ApprovalOrderingTests {
+    /// The regression: approving before staging is a false attestation.
+    @Test("approval is held while Key Commands staging is incomplete")
+    func approvalHeldUntilStagingCompletes() {
+        let manual = manualCheck(staged: false)
+        #expect(manual.blockedBy == "channels.keycmd_reference")
+        #expect(manual.status == .skipped)
+    }
+
+    /// A held check must actually leave the fix plan, not just sort later —
+    /// sorting alone still shows the user the premature command.
+    @Test("a held approval does not appear in the fix plan")
+    func heldApprovalIsAbsentFromFixPlan() {
+        let keycmd = SetupDoctor.check(
+            id: "channels.keycmd_reference",
+            domain: "channels",
+            status: .manual,
+            summary: "not staged",
+            evidence: [:],
+            remediationType: .command
+        )
+        let plan = SetupDoctor.computeFixPlan([keycmd, manualCheck(staged: false)])
+        #expect(plan.contains("channels.keycmd_reference"), "staging must still be offered")
+        #expect(
+            !plan.contains("channels.manual_validation"),
+            "approval must not be offered before the setup it attests"
+        )
+    }
+
+    /// The gate must release, or the user could never approve at all.
+    @Test("approval is offered once staging passes")
+    func approvalReleasedAfterStaging() {
+        let manual = manualCheck(staged: true)
+        #expect(manual.blockedBy == nil, "staging complete must release the approval prompt")
+        #expect(manual.status == .manual, "approval is still required, just no longer premature")
+    }
+
+    /// Profile scoping outranks the dependency: a profile that never needs these
+    /// channels must report `profile_not_required`, not "waiting on staging".
+    @Test("a profile that does not require manual channels is unaffected")
+    func profileScopingWinsOverBlocking() {
+        let manual = manualCheck(staged: false, profile: .core)
+        #expect(manual.skipReason == .profileNotRequired)
+        #expect(manual.blockedBy == nil)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue460GotoPositionFallbackTests.swift
+++ b/Tests/LogicProMCPTests/Issue460GotoPositionFallbackTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #460 — goto_position must fall through after an AX element miss
+//
+// `transport.goto_position` declares four routing candidates
+// (Accessibility -> MCU -> CoreMIDI -> CGEvent), but an Accessibility
+// `element_not_found` stopped the chain before any later candidate ran. A real
+// default-install workflow whose first action was `goto_position` therefore
+// failed while three usable channels sat behind the miss (Discussion #455).
+//
+// `element_not_found` is a PRE-WRITE miss: the AX control was never located, so
+// nothing was actuated and no partial write can be stranded. The later channels
+// all position the playhead, so falling through cannot change what the caller
+// asked for. Those are the same conditions that already admitted the transport
+// toggles, which is why the fallback set is keyed on that predicate rather than
+// on "is a toggle".
+//
+// These tests lock both directions: the op falls through, and the fallthrough is
+// still gated — an unrelated error code must NOT resume the chain, or the set
+// would silently become "retry everything".
+
+@Suite("Issue #460 — goto_position AX fallback")
+struct Issue460GotoPositionFallbackTests {
+    /// The regression: a ruler-element miss must not strand three usable channels.
+    @Test("goto_position falls through to a later channel after AX element_not_found")
+    func gotoPositionFallsThroughOnElementNotFound() async {
+        let router = ChannelRouter()
+        let ax = TerminalStateCChannel(
+            id: .accessibility,
+            envelope: HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "playhead position field not located in the visible Logic ruler",
+                extras: ["element": "playhead_position"]
+            )
+        )
+        let mcu = MockChannel(id: .mcu)
+        await router.register(ax)
+        await router.register(mcu)
+
+        let result = await router.route(operation: "transport.goto_position")
+
+        #expect(result.isSuccess, "goto_position should fall through when the AX ruler lookup misses")
+        let executed = await mcu.executedOps
+        #expect(executed.count == 1)
+        #expect(executed[0].0 == "transport.goto_position")
+    }
+
+    /// The gate must stay closed for anything that is not a pre-write miss,
+    /// otherwise the allowlist degrades into blanket retry.
+    @Test("a non-element_not_found terminal State C still stops the chain")
+    func unrelatedTerminalErrorDoesNotResumeChain() async {
+        let router = ChannelRouter()
+        let ax = TerminalStateCChannel(
+            id: .accessibility,
+            envelope: HonestContract.encodeStateC(
+                error: .invalidParams,
+                hint: "position out of range",
+                extras: [:]
+            )
+        )
+        let mcu = MockChannel(id: .mcu)
+        await router.register(ax)
+        await router.register(mcu)
+
+        let result = await router.route(operation: "transport.goto_position")
+
+        #expect(!result.isSuccess, "a rejected request must not be retried on another channel")
+        let executed = await mcu.executedOps
+        #expect(executed.isEmpty, "no later channel may run after a non-pre-write failure")
+    }
+
+    /// The toggles that already relied on this branch must keep working, so the
+    /// rename from a toggle-shaped set to a predicate-shaped one is behaviour-safe.
+    /// Each op is paired with a channel its own routing table actually lists —
+    /// `transport.play` reaches AppleScript, the toggles reach Key Commands — so a
+    /// failure here means the fallback broke, not that the candidate was wrong.
+    @Test("existing transport ops still fall through after an AX element miss")
+    func togglesStillFallThrough() async {
+        let cases: [(operation: String, fallback: ChannelID)] = [
+            ("transport.play", .appleScript),
+            ("transport.toggle_metronome", .midiKeyCommands),
+            ("transport.toggle_cycle", .midiKeyCommands),
+        ]
+        for testCase in cases {
+            let router = ChannelRouter()
+            let ax = TerminalStateCChannel(
+                id: .accessibility,
+                envelope: HonestContract.encodeStateC(
+                    error: .elementNotFound,
+                    hint: "control not located",
+                    extras: [:]
+                )
+            )
+            let fallback = MockChannel(id: testCase.fallback)
+            await router.register(ax)
+            await router.register(fallback)
+
+            let result = await router.route(operation: testCase.operation)
+            #expect(result.isSuccess, "\(testCase.operation) must still fall through")
+            let executed = await fallback.executedOps
+            #expect(executed.count == 1, "\(testCase.operation) must reach its fallback exactly once")
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/OperationTraceTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceTests.swift
@@ -1067,4 +1067,53 @@ extension OperationTraceTests {
         }
         await OperationTraceStore.shared.clear()
     }
+
+    /// #452: the AppleScript segment of `midi.import_file` must be measurable
+    /// from outside the process. It lives in THIS suite rather than beside the
+    /// other #452 tests because it drives `OperationTraceStore.shared`; run in a
+    /// parallel suite it races the clears here and reads back a nil trace.
+    ///
+    /// The load-bearing assertion is that the value survives the store's
+    /// attribute filter. Undeclared keys are dropped silently, so a test that
+    /// only checked "record was called" would pass while the trace exposed
+    /// nothing — the exact failure this observability work exists to prevent.
+    @Test func OperationTraceMIDIImportRecordsScriptSegmentDuration() async throws {
+        await OperationTraceStore.shared.clear()
+        let traceID = await OperationTraceStore.shared.start(operationID: "midi.import_file")
+        let context = OperationTraceContext()
+        context.register(traceID)
+
+        let midiFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue452-\(UUID().uuidString).mid")
+        try Data([0x4D, 0x54, 0x68, 0x64]).write(to: midiFile)
+        defer { try? FileManager.default.removeItem(at: midiFile) }
+
+        await OperationTraceContext.$current.withValue(context) {
+            _ = await AccessibilityChannel.defaultImportMIDIFile(
+                systemEventsAuthorized: { true },
+                path: midiFile.path,
+                executeScript: { _ in
+                    // A deterministic, measurable segment: the recorded value has
+                    // to reflect this rather than the surrounding Swift AX work.
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    return .error("stop after the measured segment")
+                }
+            )
+        }
+
+        let trace = try #require(await OperationTraceStore.shared.trace(traceID))
+        let segment = try #require(
+            trace.events.first { $0.phase == .scriptSegmentCompleted },
+            "the import path must emit a script_segment.completed event"
+        )
+        let raw = try #require(
+            segment.attributes["applescript_duration_ms"],
+            "the duration must survive the attribute filter, not merely be passed to record"
+        )
+        let milliseconds = try #require(Int(raw), "the duration must be an integer count of milliseconds")
+        #expect(milliseconds >= 40, "the recorded segment must cover the 50ms executor, got \(milliseconds)ms")
+        #expect(milliseconds < 30_000, "a segment longer than the bound itself means the clock is wrong")
+        #expect(segment.privacyClasses["applescript_duration_ms"] == .publicDiagnostic)
+        await OperationTraceStore.shared.clear()
+    }
 }

--- a/Tests/LogicProMCPTests/SetupDoctorTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorTests.swift
@@ -124,8 +124,12 @@ private func issue26RepositoryRootURL() -> URL {
         "logic.version_support",
         "logic.application_state",
         "logic.blocking_dialog",
-        "channels.manual_validation",
+        // #457: keycmd_reference now precedes manual_validation because the approval
+        // check declares it as a dependency, and a dependency has to have run before
+        // blockingCause can see its status. The order is part of the JSON contract, so
+        // this move is deliberate and recorded rather than absorbed silently.
         "channels.keycmd_reference",
+        "channels.manual_validation",
         "channels.mcu_wiring_hint",
         "dependencies.click_fallback",
     ])

--- a/docs/API.md
+++ b/docs/API.md
@@ -256,6 +256,14 @@ Operation tracing is on by default (set `LOGIC_MCP_ADR005_OPERATION_TRACE=0` to 
 `get_trace` returns one stored trace by required `trace_id`.
 `clear_traces` clears only the in-process trace store and requires `confirmed:true` because it destroys in-session diagnostic evidence.
 
+#### Measuring the AppleScript segment (v3.13+)
+
+`midi.import_file` runs under three nested time budgets: the operation deadline, the bound on its `osascript` call, and the Swift-side AX polling around it. Only the outermost one used to cross the process boundary, so the middle budget — the one that produced the `midi.import_file` timeout reported in #449 — could be reasoned about but not measured. Summing the script's own `delay` statements is not a substitute: those sums omit every AX query and file operation between the delays, so they cannot establish real headroom.
+
+Traces for that operation now carry a `script_segment.completed` event with an `applescript_duration_ms` attribute: the measured elapsed time of the `osascript` call, taken with a monotonic clock so an NTP correction cannot invent or erase it. Compare it against the bound in `ServerConfig.midiImportAppleScriptTimeout` to read actual headroom on a given machine and project.
+
+The attribute is diagnostic only. Nothing gates on it, it is never a verification signal, and it carries no user content — only an elapsed count of milliseconds.
+
 `saga_preflight` and `saga_execute` accept `{ steps: [step], idempotency_key: String }`; each step contains `operation_id`, optional `target_ref`, `params`, and `expected_inverse`. Preflight performs no Logic writes and reports per-step before-state availability. Execute reports verified per-step evidence; a failed request remains State C even when every applied step is compensated, while partial or unknown compensation is State B.
 
 The bounded journal belongs only to the current server session and is cleared on session end or process restart. A completed duplicate key returns its stored outcome with `duplicate:true`; `saga_status` reads that record. `saga_cancel` returns a typed refusal for active work because the current engine has no safe cancellation seam. Ordered work with compensation does not promise all-or-nothing completion or durable recovery.


### PR DESCRIPTION
Four defects reported against the default-install path, three of which a new user hits before doing anything else. Each fix is a separate commit with its own reasoning, and each is verified by mutation — reverting the fix fails the new test.

### #449 — `midi.import_file` timed out on imports that succeeded

The import script drives four polled stages (the import sheet, the path dialog, the import button, the tempo prompt). Summing one delay per iteration gives a **17.2 s floor**, but the shared `appleScriptTimeout` is 5.0 s, so `osascript` was killed mid-import and the caller saw `ax_write_failed` / `timedOut` for a region that had actually landed.

Adds a dedicated `midiImportAppleScriptTimeout` (30.0 s) and an optional `timeout` parameter on `executeAppleScript` that defaults to the existing bound — the other fifteen call sites are untouched, so short lifecycle paths keep failing fast.

The test **derives** the polling floor from the generated script rather than asserting `== 30.0`; a hard-coded assertion would pass while someone widened a loop past the bound. It also guards against a vacuous pass (`floor > 0`) and tests the parser itself.

### #456 — doctor recommended a command that does not exist

Remediation printed a bare `install-keycmds.sh`, but Homebrew installs it only under `pkgshare`. Now derived from the resolved share dir, with an explicit message when the share dir is unresolved instead of a path that cannot be run.

### #457 — doctor asked users to approve setup that had not happened

`--approve-channel` records an *operator assertion*; it neither configures nor verifies Logic. The fix plan offered it **before** `channels.keycmd_reference`, so users approved first and only afterwards found Key Commands were never staged — a durable false attestation the helper cannot repair, since Logic 12.2+ still needs a manual MIDI Learn no file-presence check can prove.

`channels.manual_validation` now declares the dependency and reports `skipped` / `blocked_by` while staging is incomplete. `computeFixPlan` drops blocked checks, so the premature command leaves the plan rather than merely sorting later.

Two ordering details this rests on:
- `keycmd_reference` now precedes `manual_validation` in the check definitions — a dependency must have run before its status can be read, and the old order was the root cause. Check-ID order is part of the JSON contract, so the contract test is updated with the reason rather than silently absorbing the move.
- The block is evaluated **after** the profile guard; evaluating it first made `--profile core` report "waiting on staging" for channels that profile never requires.

### #460 — `goto_position` stopped the chain on a recoverable miss

`transport.goto_position` declares four candidate channels, but an Accessibility `element_not_found` ended the chain before any later candidate ran — so a workflow whose first action was `goto_position` failed with three usable channels behind the miss.

The fallback set was keyed on *"is a transport toggle"*, which is not the property that makes a fallthrough safe. It is renamed and the actual admission test is written down: `element_not_found` is a **pre-write** miss (the control was never located, so nothing was actuated and no partial write can be stranded), the failure is Accessibility-specific rather than a rejection of the request, and every later candidate expresses the same semantics. Recording the predicate matters more than adding the one op — it states which operations may **not** be added.

### #452 — the AppleScript segment was unmeasurable

`midi.import_file` runs under three nested time budgets, and only the outermost — the operation deadline — crossed the process boundary. The middle one is exactly the budget #449 is about, so its remedy could be *argued* from summed `delay` statements but never **measured**: those sums omit every AX query and file operation between the delays.

Adds a `script_segment.completed` trace phase carrying `applescript_duration_ms`. Three things make it evidence rather than decoration:

- Measured with `ContinuousClock`, not a `Date` difference — a timing number an NTP correction can invent is not proof.
- The clock brackets the **call site**, not the executor. Wrapping the injected closure would measure the wrapper and say nothing about production.
- The key is declared in `attributePrivacyClasses`. Undeclared keys are dropped silently, so an emission without that row would record nothing and expose nothing while the source still read as though it emitted.

The bound the segment ran under is deliberately *not* emitted beside it: the executor is injected, so the call site cannot attest to a timeout it does not own.

### Testing

Full suite `--no-parallel`: 3338 tests. The one failure — the library-inventory panel snapshot — reproduces identically on the unmodified tree and is unrelated to this branch.

Every new suite locks **both** directions. A gate that only ever blocks is as wrong as one that never blocks, and a fallback set that only grows degrades into blanket retry — so the release path and the still-refused path are asserted alongside the fix.

Reported in #455.

Closes #449
Closes #452
Closes #456
Closes #457
Closes #460
