### PR TITLE
fix(#453): bind alert acknowledgement to the dialog that was classified

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -110,7 +110,23 @@ enum AXLogicProElements {
         let recoveryAction: String
     }
 
-    static func blockingDialogInfo(runtime: Runtime = .production) -> BlockingDialogInfo? {
+    /// #453: the blocking dialog together with the ELEMENT it was read from and
+    /// its titled button elements.
+    ///
+    /// `BlockingDialogInfo` is `Sendable` and carries only strings, which is what
+    /// makes it safe to publish as diagnostics — but it also means a caller that
+    /// decides something from it has to find the dialog again to act, and "find
+    /// the first AXDialog" evaluated a second time can resolve a DIFFERENT window.
+    /// A caller that must act on precisely the window it classified takes this
+    /// instead and holds the element, so identity is the element itself rather
+    /// than a predicate re-run against whatever is frontmost at click time.
+    struct BlockingDialogTarget {
+        let element: AXUIElement
+        let buttons: [(element: AXUIElement, title: String)]
+        let info: BlockingDialogInfo
+    }
+
+    static func blockingDialogTarget(runtime: Runtime = .production) -> BlockingDialogTarget? {
         guard let app = appRoot(runtime: runtime) else { return nil }
         let windows: [AXUIElement] = AXHelpers.getAttribute(
             app, kAXWindowsAttribute, runtime: runtime.ax
@@ -124,18 +140,42 @@ enum AXLogicProElements {
         let owningWindow = (mainWindow(runtime: runtime).flatMap {
             AXHelpers.getTitle($0, runtime: runtime.ax)
         } ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let buttons = AXHelpers.getChildren(dialog, runtime: runtime.ax)
-            .filter { AXHelpers.getRole($0, runtime: runtime.ax) == (kAXButtonRole as String) }
-            .compactMap { AXHelpers.getTitle($0, runtime: runtime.ax) }
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        return BlockingDialogInfo(
-            title: title,
-            role: role,
-            owningWindow: owningWindow,
-            buttonTitles: buttons,
-            recoveryAction: blockingDialogRecoveryAction(title: title, buttons: buttons)
+        let buttons = titledButtons(of: dialog, runtime: runtime.ax)
+        return BlockingDialogTarget(
+            element: dialog,
+            buttons: buttons,
+            info: BlockingDialogInfo(
+                title: title,
+                role: role,
+                owningWindow: owningWindow,
+                buttonTitles: buttons.map(\.title),
+                recoveryAction: blockingDialogRecoveryAction(title: title, buttons: buttons.map(\.title))
+            )
         )
+    }
+
+    /// The dialog's actionable buttons: direct children with the button role and
+    /// a non-empty trimmed title. Shared by the reader and the #453 re-check so
+    /// "exactly one button" means the same thing at classify time and click time
+    /// — two counts derived differently would let a gate pass on one definition
+    /// and act on another.
+    static func titledButtons(
+        of dialog: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [(element: AXUIElement, title: String)] {
+        AXHelpers.getChildren(dialog, runtime: runtime)
+            .filter { AXHelpers.getRole($0, runtime: runtime) == (kAXButtonRole as String) }
+            .compactMap { button in
+                guard let title = AXHelpers.getTitle(button, runtime: runtime)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                    !title.isEmpty
+                else { return nil }
+                return (element: button, title: title)
+            }
+    }
+
+    static func blockingDialogInfo(runtime: Runtime = .production) -> BlockingDialogInfo? {
+        blockingDialogTarget(runtime: runtime)?.info
     }
 
     /// A safe, non-destructive recovery action for a blocking dialog. Prefers a

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -9,11 +9,48 @@ import Foundation
 /// closed — never blindly dismissed.
 extension AccessibilityChannel {
 
+    /// #453: why an authorized alert acknowledgement was refused at click time.
+    ///
+    /// A refusal is a SAFETY OUTCOME, not an error to be swallowed — the operator
+    /// needs to know the server declined to click and why. Every case is a
+    /// structural fact about the AX tree; none of them carries dialog text,
+    /// button titles or any other UI content, because a refusal reason travels
+    /// into extras and logs where user content must never appear.
+    enum AlertAcknowledgeRefusal: String, Sendable {
+        /// The classifier's dialog element was not carried to the executor.
+        case targetUnavailable = "alert_target_unavailable"
+        /// No blocking dialog is present any more — it closed itself.
+        case targetGone = "alert_target_gone"
+        /// A blocking dialog is present, but not the one that was classified.
+        case targetChanged = "alert_target_changed"
+        /// The re-read button count is not exactly one, so this is a CHOICE.
+        case buttonCountChanged = "alert_button_count_changed"
+        /// The single button was found but the press itself failed.
+        case pressFailed = "alert_press_failed"
+    }
+
     /// Outcome of one reconciliation pass, surfaced as honest extras by callers.
     struct ModalReconcileOutcome: Sendable, Equatable {
         let kind: ModalReconciliation.BlockingModalKind
         let decision: ModalReconciliation.ModalReconcileDecision
         let performed: Bool
+        /// Set only when an authorized action was declined at execution time.
+        /// `performed == false` alone cannot distinguish "the decision was not to
+        /// act" from "the decision was to act and the executor refused", and
+        /// those are very different things to report.
+        let refusal: AlertAcknowledgeRefusal?
+
+        init(
+            kind: ModalReconciliation.BlockingModalKind,
+            decision: ModalReconciliation.ModalReconcileDecision,
+            performed: Bool,
+            refusal: AlertAcknowledgeRefusal? = nil
+        ) {
+            self.kind = kind
+            self.decision = decision
+            self.performed = performed
+            self.refusal = refusal
+        }
 
         static let none = ModalReconcileOutcome(kind: .none, decision: .noAction, performed: false)
     }
@@ -62,7 +99,11 @@ extension AccessibilityChannel {
         clearMandatoryNewTrack: Bool,
         runtime: AXLogicProElements.Runtime
     ) async -> ModalReconcileOutcome {
-        let signals = readModalSignals(runtime: runtime)
+        // #453: the alert ELEMENT is captured with the signals and carried to the
+        // executor. `ModalSignals` is the pure core's input and stays string-only,
+        // so the element travels beside it rather than inside it.
+        let read = readModalSignalsAndAlertTarget(runtime: runtime)
+        let signals = read.signals
         let kind = ModalReconciliation.classify(signals)
         let decision = ModalReconciliation.decide(kind: kind, isDeleteContext: isDeleteContext)
 
@@ -77,8 +118,18 @@ extension AccessibilityChannel {
             return ModalReconcileOutcome(kind: kind, decision: decision, performed: false)
         }
 
-        let performed = await perform(decision, signals: signals, runtime: runtime)
-        return ModalReconcileOutcome(kind: kind, decision: decision, performed: performed)
+        let result = await perform(
+            decision,
+            signals: signals,
+            alertTarget: read.alertTarget,
+            runtime: runtime
+        )
+        return ModalReconcileOutcome(
+            kind: kind,
+            decision: decision,
+            performed: result.performed,
+            refusal: result.refusal
+        )
     }
 
     // MARK: - Signal reader
@@ -88,6 +139,14 @@ extension AccessibilityChannel {
     static func readModalSignals(
         runtime: AXLogicProElements.Runtime = .production
     ) -> ModalReconciliation.ModalSignals {
+        readModalSignalsAndAlertTarget(runtime: runtime).signals
+    }
+
+    /// #453: the same read, keeping the top-level alert's element so the executor
+    /// can act on the element that was classified instead of re-resolving one.
+    static func readModalSignalsAndAlertTarget(
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> (signals: ModalReconciliation.ModalSignals, alertTarget: AXLogicProElements.BlockingDialogTarget?) {
         guard let window = AXLogicProElements.mainWindow(runtime: runtime),
               let sheet = firstSheet(in: window, runtime: runtime.ax) else {
             // No main-window sheet: the remaining blockers are a top-level
@@ -95,7 +154,7 @@ extension AccessibilityChannel {
             // open menu. Alert signals are populated ONLY here, so any sheet
             // above still outranks a top-level alert.
             let alert = topLevelAlertSignals(runtime: runtime)
-            return ModalReconciliation.ModalSignals(
+            return (ModalReconciliation.ModalSignals(
                 sheetPresent: false,
                 sheetDescription: "",
                 createButtonPresent: false,
@@ -109,7 +168,7 @@ extension AccessibilityChannel {
                 createButtonTitle: "",
                 cancelButtonTitle: "",
                 deletePrimaryTitle: ""
-            )
+            ), alert.target)
         }
 
         let description = (AXHelpers.getAttribute(sheet, kAXDescriptionAttribute, runtime: runtime.ax) ?? "")
@@ -139,7 +198,7 @@ extension AccessibilityChannel {
             .flatMap { AXHelpers.getAttribute($0.element, kAXEnabledAttribute, runtime: runtime.ax) as Bool? }
             ?? true
 
-        return ModalReconciliation.ModalSignals(
+        return (ModalReconciliation.ModalSignals(
             sheetPresent: true,
             sheetDescription: description,
             createButtonPresent: createButton != nil,
@@ -153,7 +212,11 @@ extension AccessibilityChannel {
             createButtonTitle: createButton?.label ?? "",
             cancelButtonTitle: cancelButton?.label ?? "",
             deletePrimaryTitle: deleteButton?.label ?? ""
-        )
+        // A sheet outranks a top-level alert, so no alert target is carried here:
+        // the alert branch above is the only one that can reach the acknowledge
+        // executor, and handing back a target on this path would let a future
+        // caller act on a dialog this pass deliberately did not classify.
+        ), nil)
     }
 
     /// Detect a TOP-LEVEL informational `AXDialog` alert (NOT a main-window
@@ -165,12 +228,12 @@ extension AccessibilityChannel {
     /// (an `AXSystemDialog` we could not dismiss is deliberately not claimed).
     private static func topLevelAlertSignals(
         runtime: AXLogicProElements.Runtime
-    ) -> (present: Bool, buttonCount: Int, primaryButton: String) {
-        guard let info = AXLogicProElements.blockingDialogInfo(runtime: runtime),
-              info.role == (kAXDialogSubrole as String) else {
-            return (false, 0, "")
+    ) -> (present: Bool, buttonCount: Int, primaryButton: String, target: AXLogicProElements.BlockingDialogTarget?) {
+        guard let target = AXLogicProElements.blockingDialogTarget(runtime: runtime),
+              target.info.role == (kAXDialogSubrole as String) else {
+            return (false, 0, "", nil)
         }
-        return (true, info.buttonTitles.count, info.buttonTitles.first ?? "")
+        return (true, target.info.buttonTitles.count, target.info.buttonTitles.first ?? "", target)
     }
 
     /// The main window's first attached sheet. Real AX exposes an open sheet via
@@ -214,19 +277,20 @@ extension AccessibilityChannel {
     private static func perform(
         _ decision: ModalReconciliation.ModalReconcileDecision,
         signals: ModalReconciliation.ModalSignals,
+        alertTarget: AXLogicProElements.BlockingDialogTarget?,
         runtime: AXLogicProElements.Runtime
-    ) async -> Bool {
+    ) async -> (performed: Bool, refusal: AlertAcknowledgeRefusal?) {
         switch decision {
         case .noAction, .failClosed:
-            return false
+            return (false, nil)
         case .clickCreate:
-            return await clickNewTrackCreateButton(createTitle: signals.createButtonTitle)
+            return (await clickNewTrackCreateButton(createTitle: signals.createButtonTitle), nil)
         case .confirmDelete:
-            return await confirmDeleteTracksSheet(deleteTitle: signals.deletePrimaryTitle)
+            return (await confirmDeleteTracksSheet(deleteTitle: signals.deletePrimaryTitle), nil)
         case .acknowledgeAlert:
-            return await acknowledgeTopLevelAlert(primaryButton: signals.topLevelAlertPrimaryButton)
+            return acknowledgeTopLevelAlert(target: alertTarget, runtime: runtime)
         case .escapeMenu:
-            return await sendEscapeKey()
+            return (await sendEscapeKey(), nil)
         }
     }
 
@@ -272,26 +336,60 @@ extension AccessibilityChannel {
         return true
     }
 
-    /// Acknowledge a single-button top-level informational alert (the classifier
-    /// has already gated this to EXACTLY ONE button). Clicks the named button on
-    /// the first `AXDialog` window, falling back to that dialog's first button.
-    private static func acknowledgeTopLevelAlert(primaryButton: String) async -> Bool {
-        let target = LogicProTarget.appleScriptTarget()
-        let escapedButton = AppleScriptSafety.escapeForScript(primaryButton)
-        let script = """
-        tell application "System Events"
-            tell \(target.systemEventsProcessTarget)
-                set alertWindow to first window whose subrole is "AXDialog"
-                try
-                    click button "\(escapedButton)" of alertWindow
-                on error
-                    click button 1 of alertWindow
-                end try
-            end tell
-        end tell
-        return "acknowledged"
-        """
-        return await AppleScriptChannel.executeAppleScript(script).isSuccess
+    /// Acknowledge a single-button top-level informational alert.
+    ///
+    /// #453: the classifier gates this to EXACTLY ONE titled button — two or more
+    /// means a choice, and choices are never auto-answered. That decision used to
+    /// be made once and then thrown away: the executor re-resolved `first window
+    /// whose subrole is "AXDialog"` in AppleScript and clicked, so a dialog that
+    /// arrived in between was clicked though it was never classified, and a failed
+    /// title lookup fell through to `click button 1` with no count check at all.
+    /// On that fallback the safety discriminator did not participate.
+    ///
+    /// The gate is now enforced where the click happens, and three things changed
+    /// to make that possible:
+    ///
+    /// - The dialog is the ELEMENT the classifier read, carried here directly. No
+    ///   predicate is evaluated a second time, so there is no window in which a
+    ///   different dialog can be substituted.
+    /// - The button set is re-read from that element immediately before pressing
+    ///   and must still be exactly one. A dialog that gained a button between
+    ///   classification and click is refused.
+    /// - The first-button fallback is gone. There is no path that presses a
+    ///   control the single-button rule did not authorize.
+    ///
+    /// Refusal is the safe direction: an unacknowledged alert leaves the operator
+    /// with a visible dialog, while a wrong click answers a question on their
+    /// behalf and cannot be undone.
+    private static func acknowledgeTopLevelAlert(
+        target: AXLogicProElements.BlockingDialogTarget?,
+        runtime: AXLogicProElements.Runtime
+    ) -> (performed: Bool, refusal: AlertAcknowledgeRefusal?) {
+        guard let target else { return (false, .targetUnavailable) }
+
+        // Re-resolve the app's current blocking dialog and require it to be the
+        // SAME element. This is what makes "the dialog was replaced" and "several
+        // dialogs are present" refusals rather than silent mis-clicks: the reader
+        // returns the first blocking dialog, so a newly-frontmost one yields a
+        // different element and fails the identity check below.
+        guard let current = AXLogicProElements.blockingDialogTarget(runtime: runtime) else {
+            return (false, .targetGone)
+        }
+        guard CFEqual(current.element, target.element) else {
+            return (false, .targetChanged)
+        }
+
+        // Re-read the count from the live element rather than trusting the count
+        // captured at classification time.
+        let buttons = AXLogicProElements.titledButtons(of: current.element, runtime: runtime.ax)
+        guard buttons.count == 1, let only = buttons.first else {
+            return (false, .buttonCountChanged)
+        }
+
+        guard AXHelpers.performAction(only.element, kAXPressAction as String, runtime: runtime.ax) else {
+            return (false, .pressFailed)
+        }
+        return (true, nil)
     }
 
     /// Send Escape (key code 53) to close a stray open menu.
@@ -342,13 +440,20 @@ extension AccessibilityChannel {
         _ extras: inout [String: Any],
         kind: ModalReconciliation.BlockingModalKind,
         action: String,
-        newTrackAutoConfirmed: Bool
+        newTrackAutoConfirmed: Bool,
+        refusal: AlertAcknowledgeRefusal? = nil
     ) {
         guard kind != .none else { return }
         extras["reconciled_modal_kind"] = reconcileKindLabel(kind)
         extras["reconciled_action"] = action
         if newTrackAutoConfirmed {
             extras["new_track_dialog_auto_confirmed"] = true
+        }
+        // #453: an authorized action the executor declined. Reported so a caller
+        // can tell "we chose not to act" from "we tried and refused"; the value is
+        // a fixed structural token, never dialog text or a button title.
+        if let refusal {
+            extras["reconcile_refused"] = refusal.rawValue
         }
     }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -1343,7 +1343,8 @@ extension AccessibilityChannel {
             &extras,
             kind: reconcileOutcome.kind,
             action: reconcileActionLabel(reconcileOutcome.decision),
-            newTrackAutoConfirmed: false
+            newTrackAutoConfirmed: false,
+            refusal: reconcileOutcome.refusal
         )
 
         for attempt in 0..<4 {
@@ -1470,6 +1471,10 @@ extension AccessibilityChannel {
         // fabricated success.
         var reconcileKind = ModalReconciliation.BlockingModalKind.none
         var reconcileAction = "none"
+        // #453: an acknowledgement the executor declined must reach the envelope.
+        // Kept beside kind/action so a refusal on any attempt survives to the
+        // result, rather than being overwritten by a later clean pass.
+        var reconcileRefusal: AlertAcknowledgeRefusal?
         var newTrackAutoConfirmed = false
 
         var lastObservedCount = beforeCount
@@ -1483,6 +1488,7 @@ extension AccessibilityChannel {
                 if outcome.kind != .none {
                     reconcileKind = outcome.kind
                     reconcileAction = reconcileActionLabel(outcome.decision)
+                    if let refusal = outcome.refusal { reconcileRefusal = refusal }
                     if outcome.kind == .mandatoryNewTrack && outcome.performed {
                         newTrackAutoConfirmed = true
                     }
@@ -1498,7 +1504,8 @@ extension AccessibilityChannel {
                     &extras,
                     kind: reconcileKind,
                     action: reconcileAction,
-                    newTrackAutoConfirmed: newTrackAutoConfirmed
+                    newTrackAutoConfirmed: newTrackAutoConfirmed,
+                    refusal: reconcileRefusal
                 )
                 return .success(HonestContract.encodeStateA(extras: extras))
             }
@@ -1513,7 +1520,8 @@ extension AccessibilityChannel {
             &extras,
             kind: reconcileKind,
             action: reconcileAction,
-            newTrackAutoConfirmed: newTrackAutoConfirmed
+            newTrackAutoConfirmed: newTrackAutoConfirmed,
+            refusal: reconcileRefusal
         )
         return .success(HonestContract.encodeStateB(
             reason: .retryExhausted,

--- a/Tests/LogicProMCPTests/Issue453AlertAcknowledgeBindingTests.swift
+++ b/Tests/LogicProMCPTests/Issue453AlertAcknowledgeBindingTests.swift
@@ -1,0 +1,340 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #453 — the classifier's decision must survive to the click
+//
+// `ModalReconciliation.classify` treats a top-level `AXDialog` as safe to
+// acknowledge only when it carries EXACTLY ONE titled button; two or more means
+// a choice, and choices are never auto-answered.
+//
+// That decision used not to reach the click. The executor re-resolved `first
+// window whose subrole is "AXDialog"` in AppleScript, so a dialog that arrived
+// between classification and click was clicked though it was never classified,
+// and a failed title lookup fell through to `click button 1` with no count check
+// at all — on that path the safety discriminator did not participate.
+//
+// The fix binds the click to the classified ELEMENT and re-checks the count from
+// that element immediately before pressing. These tests drive the real
+// `reconcilePreflight` entry point against a fake AX tree, and the AX tree is
+// allowed to CHANGE between the classify read and the click read — which is the
+// only way to exercise the window the old code left open.
+//
+// Both directions are locked. A gate that never acknowledges would be as wrong
+// as one that always does: a genuine single-button alert would then block the
+// server forever, so the success path is asserted too, along with WHICH element
+// was pressed.
+
+/// A value that changes between AX reads, switched at a CALIBRATED boundary.
+///
+/// The point of these tests is the gap between the classify read and the click
+/// read, so the fixture has to flip state exactly once, after classification and
+/// before the executor looks. How many AX reads classification performs is an
+/// implementation detail — `mainWindow`, the dialog filter and the button scan
+/// each read — so hard-coding "switch after the first read" encodes a guess that
+/// silently rots the moment a read is added or removed, and a stale guess makes
+/// the test pass for the wrong reason.
+///
+/// Instead the fixture runs a calibration pass first, counts the reads
+/// classification actually performs, and switches immediately after that count.
+private final class PhasedValue<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var reads = 0
+    private var switchAfter: Int?
+    private let before: T
+    private let after: T
+
+    init(before: T, after: T) {
+        self.before = before
+        self.after = after
+    }
+
+    func next() -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        reads += 1
+        guard let switchAfter else { return before }
+        return reads > switchAfter ? after : before
+    }
+
+    /// Freeze the current read count as the switch boundary and rewind, so the
+    /// measured run starts from zero with the boundary set where classification
+    /// actually ended.
+    func calibrate() {
+        lock.lock()
+        defer { lock.unlock() }
+        switchAfter = reads
+        reads = 0
+    }
+
+    var readCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads
+    }
+
+    var boundary: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return switchAfter ?? 0
+    }
+}
+
+private struct AlertFixture {
+    let builder: FakeAXRuntimeBuilder
+    let runtime: AXLogicProElements.Runtime
+    let buttonIDs: [Int]
+    let windows: PhasedValue<[AXUIElement]>
+    let dialogChildren: PhasedValue<[AXUIElement]>
+
+    var pressedElementIDs: [Int] {
+        builder.actionCalls.filter { $0.action == (kAXPressAction as String) }.map(\.elementID)
+    }
+}
+
+/// Build a Logic app root whose only windows are dialogs, so `mainWindow`
+/// resolves to nil and the reader takes the top-level-alert branch.
+private func makeAlertFixture(
+    initialButtonTitles: [String],
+    laterButtonTitles: [String]? = nil,
+    replaceDialogAfterClassification: Bool = false,
+    removeDialogAfterClassification: Bool = false,
+    pressSucceeds: Bool = true
+) -> AlertFixture {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(1)
+    let dialog = builder.element(2)
+    let otherDialog = builder.element(3)
+
+    builder.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    builder.setAttribute(otherDialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+
+    var buttonIDs: [Int] = []
+    func buttons(_ titles: [String], startingAt base: Int) -> [AXUIElement] {
+        titles.enumerated().map { offset, title in
+            let button = builder.element(base + offset)
+            builder.setAttribute(button, kAXRoleAttribute as String, kAXButtonRole as String)
+            builder.setAttribute(button, kAXTitleAttribute as String, title)
+            buttonIDs.append(builder.elementID(button))
+            return button
+        }
+    }
+
+    let initialButtons = buttons(initialButtonTitles, startingAt: 100)
+    builder.setChildren(dialog, initialButtons)
+    // The substitute dialog is itself a legitimate single-button alert. If only
+    // the button count were re-checked it would be acknowledged happily, so this
+    // is what forces the identity check to carry the test.
+    builder.setChildren(otherDialog, buttons(["OK"], startingAt: 200))
+
+    let laterWindows: [AXUIElement]
+    if removeDialogAfterClassification {
+        laterWindows = []
+    } else if replaceDialogAfterClassification {
+        laterWindows = [otherDialog]
+    } else {
+        laterWindows = [dialog]
+    }
+    let windows = PhasedValue(before: [dialog], after: laterWindows)
+    let dialogChildren = PhasedValue(
+        before: initialButtons,
+        after: laterButtonTitles.map { buttons($0, startingAt: 300) } ?? initialButtons
+    )
+
+    // `nil` means "not handled, fall through to the builder"; `.some(x)` means
+    // "handled, here is x" — the double optional is load-bearing.
+    let windowsHandler: (@Sendable (AXUIElement, String) -> AnyObject??) = { element, attribute in
+        guard attribute == (kAXWindowsAttribute as String), CFEqual(element, app) else { return nil }
+        let list: [AXUIElement] = windows.next()
+        return AnyObject??.some(list as AnyObject)
+    }
+    let refusingPress: @Sendable (AXUIElement, String) -> Bool = { _, _ in false }
+    let pressHandler: (@Sendable (AXUIElement, String) -> Bool)? =
+        pressSucceeds ? nil : refusingPress
+
+    let base = builder.makeLogicRuntime(
+        appElement: app,
+        attributeValueHandler: windowsHandler,
+        setAttributeHandler: nil,
+        performActionHandler: pressHandler
+    )
+    let runtime = AXLogicProElements.Runtime(
+        logicProPID: { 4242 },
+        ax: AXHelpers.Runtime(
+            axApp: base.ax.axApp,
+            attributeValue: base.ax.attributeValue,
+            setAttributeValue: base.ax.setAttributeValue,
+            children: { element in
+                CFEqual(element, dialog) ? dialogChildren.next() : base.ax.children(element)
+            },
+            performAction: base.ax.performAction,
+            childCount: base.ax.childCount
+        ),
+        executeAppleScript: base.executeAppleScript
+    )
+
+    // Calibration pass: read-only, presses nothing, and establishes exactly where
+    // classification stops so the flip lands in the gap the executor must survive.
+    _ = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+    windows.calibrate()
+    dialogChildren.calibrate()
+
+    return AlertFixture(
+        builder: builder,
+        runtime: runtime,
+        buttonIDs: buttonIDs,
+        windows: windows,
+        dialogChildren: dialogChildren
+    )
+}
+
+@Suite("Issue #453 — alert acknowledgement binds to the classified dialog")
+struct Issue453AlertAcknowledgeBindingTests {
+    /// The gate must release, or a real single-button alert blocks the server.
+    @Test("a stable single-button alert is acknowledged by pressing that button")
+    func stableSingleButtonAlertIsAcknowledged() async {
+        let fixture = makeAlertFixture(initialButtonTitles: ["OK"])
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(outcome.kind == .informationalAlert)
+        #expect(outcome.decision == .acknowledgeAlert)
+        #expect(outcome.performed)
+        #expect(outcome.refusal == nil)
+
+        #expect(fixture.pressedElementIDs.count == 1, "exactly one control may be actuated")
+        #expect(
+            fixture.pressedElementIDs.first == fixture.buttonIDs.first,
+            "the press must land on the classified dialog's own button"
+        )
+    }
+
+    /// The regression: a different dialog came forward between classify and click.
+    /// The substitute here is itself a valid single-button alert, so only an
+    /// identity check can reject it — a count check alone would wave it through.
+    @Test("a dialog swapped in after classification is not clicked")
+    func replacedDialogIsRefused() async {
+        let fixture = makeAlertFixture(
+            initialButtonTitles: ["OK"],
+            replaceDialogAfterClassification: true
+        )
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(outcome.decision == .acknowledgeAlert, "the classifier still authorized the action")
+        #expect(!outcome.performed)
+        #expect(outcome.refusal == .targetChanged)
+        #expect(
+            fixture.pressedElementIDs.isEmpty,
+            "no control may be actuated on a dialog that was never classified"
+        )
+        #expect(
+            fixture.windows.readCount > fixture.windows.boundary,
+            "the executor must re-read past the calibrated classification boundary, or the swap never reached it"
+        )
+    }
+
+    /// A dialog that closed itself between the two reads must not be chased.
+    @Test("an alert that disappears after classification is not clicked")
+    func vanishedDialogIsRefused() async {
+        let fixture = makeAlertFixture(
+            initialButtonTitles: ["OK"],
+            removeDialogAfterClassification: true
+        )
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(!outcome.performed)
+        #expect(outcome.refusal == .targetGone)
+        #expect(fixture.pressedElementIDs.isEmpty)
+    }
+
+    /// The sharpest case: the SAME dialog grows a second button after being
+    /// classified as single-button. It is now a choice, and the old executor
+    /// would have clicked it anyway through the `click button 1` fallback.
+    @Test("a dialog that gains a second button after classification is not clicked")
+    func buttonCountGrowthIsRefused() async {
+        let fixture = makeAlertFixture(
+            initialButtonTitles: ["OK"],
+            laterButtonTitles: ["Save", "Don't Save"]
+        )
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(outcome.decision == .acknowledgeAlert)
+        #expect(!outcome.performed)
+        #expect(outcome.refusal == .buttonCountChanged)
+        #expect(
+            fixture.pressedElementIDs.isEmpty,
+            "a two-button dialog is a choice and must never be answered automatically"
+        )
+    }
+
+    /// A dialog whose buttons all vanished is equally unactionable — zero is not
+    /// one, and "press whatever is left" is the failure mode being removed.
+    @Test("a dialog left with no titled button is not clicked")
+    func zeroButtonsIsRefused() async {
+        let fixture = makeAlertFixture(
+            initialButtonTitles: ["OK"],
+            laterButtonTitles: []
+        )
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(!outcome.performed)
+        #expect(outcome.refusal == .buttonCountChanged)
+        #expect(fixture.pressedElementIDs.isEmpty)
+    }
+
+    /// A press that the AX layer rejects is reported as a refusal, not silently
+    /// counted as success — the alert is still on screen either way.
+    @Test("a failed press is reported rather than claimed")
+    func failedPressIsReported() async {
+        let fixture = makeAlertFixture(initialButtonTitles: ["OK"], pressSucceeds: false)
+
+        let outcome = await AccessibilityChannel.reconcilePreflight(runtime: fixture.runtime)
+
+        #expect(!outcome.performed)
+        #expect(outcome.refusal == .pressFailed)
+    }
+
+    /// Refusal reasons travel into operation extras and logs, so they must be
+    /// fixed structural tokens. A reason carrying dialog text or a button title
+    /// would publish UI content the server is not allowed to emit.
+    @Test("refusal reasons carry no dialog or button content")
+    func refusalReasonsAreStructuralOnly() {
+        let reasons: [AccessibilityChannel.AlertAcknowledgeRefusal] = [
+            .targetUnavailable, .targetGone, .targetChanged, .buttonCountChanged, .pressFailed,
+        ]
+        #expect(Set(reasons.map(\.rawValue)).count == reasons.count, "reasons must be distinguishable")
+        for reason in reasons {
+            #expect(reason.rawValue.hasPrefix("alert_"))
+            #expect(reason.rawValue.allSatisfy { $0.isLowercase || $0 == "_" })
+        }
+    }
+
+    /// The refusal has to reach the envelope; a value recorded but never merged
+    /// would leave the caller unable to tell a declined click from no click.
+    @Test("a refusal is merged into operation extras")
+    func refusalReachesExtras() {
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .informationalAlert,
+            action: AccessibilityChannel.reconcileActionLabel(.acknowledgeAlert),
+            newTrackAutoConfirmed: false,
+            refusal: .targetChanged
+        )
+        #expect(extras["reconcile_refused"] as? String == "alert_target_changed")
+
+        var clean: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &clean,
+            kind: .informationalAlert,
+            action: AccessibilityChannel.reconcileActionLabel(.acknowledgeAlert),
+            newTrackAutoConfirmed: false
+        )
+        #expect(clean["reconcile_refused"] == nil, "a clean acknowledgement must not report a refusal")
+    }
+}


### PR DESCRIPTION
`ModalReconciliation.classify` treats a top-level `AXDialog` as safe to acknowledge only when it carries **exactly one** titled button — two or more is a choice, and choices are never auto-answered.

That decision did not reach the click.

### The three gaps

`acknowledgeTopLevelAlert` re-resolved the dialog in AppleScript and clicked:

```applescript
set alertWindow to first window whose subrole is "AXDialog"
try
    click button "<title>" of alertWindow
on error
    click button 1 of alertWindow
end try
```

1. **The clicked window was not proven to be the classified window.** The predicate was evaluated at click time, so a dialog that came forward in between was clicked though it had never been classified.
2. **The button count was never re-checked** — verified once, before the click.
3. **A failed title lookup fell through to `click button 1`** with no count check and no identity check. On that path the safety discriminator did not participate at all. This is the sharpest of the three: it needs no timing to occur.

### The fix

The executor is now native AX and acts on the **element** the classifier read:

- `blockingDialogTarget` returns the dialog element and its titled buttons; `blockingDialogInfo` is derived from it, so there is one inventory rather than two that can disagree.
- The current blocking dialog is re-resolved and must be `CFEqual` to the classified one — a replacement or a second dialog fails identity instead of being clicked.
- The button set is re-read from that element immediately before pressing and must still be exactly one.
- The first-button fallback is **gone**. No path presses a control the single-button rule did not authorize.
- Refusals are typed and reported through extras as `reconcile_refused`. The values are fixed structural tokens and never carry dialog text or button titles, because they travel into extras and logs.

Refusal is the safe direction: an unacknowledged alert leaves the operator with a visible dialog, while a wrong click answers a question on their behalf and cannot be undone.

### Testing

The tests drive the real `reconcilePreflight` entry point against a fake AX tree that **changes between the classify read and the click read** — without that, both reads see identical state and the test could not fail no matter what the executor did.

How many AX reads classification performs is an implementation detail (`mainWindow`, the dialog filter and the button scan each read). Hard-coding "switch after the first read" would encode a guess that rots the moment a read is added, and a stale guess makes the test pass for the wrong reason. So the fixture **calibrates**: a read-only pass counts the reads classification actually performs, and the flip is placed immediately after that boundary.

Verified by mutation, in both directions:

| Mutation | Result |
|---|---|
| Remove the identity check | The swap test presses the **substitute** dialog's button — gap 1 reproduced |
| Restore "press whatever button is first" | The growth test presses **"Save"** on a two-button dialog — gap 3 reproduced |

The release path is asserted too, and names *which* element was pressed: a gate that only ever refuses would block the server on every genuine alert.

Full suite `--no-parallel`: 3346 tests. The single failure — the library-inventory panel snapshot — reproduces identically on the unmodified tree and is unrelated to this branch.

### Not yet covered

**Live Logic QA.** The timing window in gaps 1 and 2 has not been observed on a running Logic; this change is derived from the static path, which is also where gap 3 lives. Required scope item 9 is outstanding.

Closes #453
