### PR TITLE
fix(#461): derive capability readiness from operation routes, not tagged checks

### DIFF
--- a/Sources/LogicProMCP/Utilities/OperationCapabilityRegistry.swift
+++ b/Sources/LogicProMCP/Utilities/OperationCapabilityRegistry.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+/// #461 — the shared source of truth linking a doctor capability GROUP to the
+/// operations it claims, and each operation to the channels that can actually
+/// run it.
+///
+/// Before this, doctor and the runtime reasoned about readiness through two
+/// unconnected abstractions. Doctor aggregated environment checks tagged with a
+/// group label; the runtime resolved an operation string to an ordered channel
+/// list and executed. Nothing joined them, so `core_transport` could report
+/// `ready` on the strength of "Accessibility permission is granted, Logic is
+/// running" while `transport.goto_position` had no runnable path at all — which
+/// is exactly what a new user hit as their first action.
+///
+/// The fix is not a `goto_position` special case. A capability group is READY
+/// only when every operation it advertises has a runnable route, and both the
+/// group membership and the route candidates are declared here, in one place,
+/// derived from the routing table the router itself executes.
+enum OperationCapabilityRegistry {
+
+    // MARK: - Channel prerequisites
+
+    /// What a channel needs from the environment before it can run anything.
+    ///
+    /// These are the doctor check IDs whose failure makes the channel unusable.
+    /// Keeping the mapping here — rather than inside doctor's rendering — is what
+    /// lets a route plan be computed from a health snapshot without doctor.
+    static let channelPrerequisites: [ChannelID: [String]] = [
+        .accessibility: ["permissions.accessibility", "logic.application_state"],
+        .cgEvent: ["permissions.post_event_access", "logic.application_state"],
+        .appleScript: ["permissions.automation_logic_pro", "logic.application_state"],
+        // Key Commands actuation rides CoreMIDI and needs the staged preset; the
+        // staging check is the one that told users to approve before setup (#457).
+        .midiKeyCommands: ["channels.keycmd_reference"],
+        // MCU and CoreMIDI have no environment check that can PROVE they work —
+        // Logic-side control-surface wiring is not observable from outside. They
+        // are therefore never a basis for a verified-ready claim; see
+        // `verificationStrength`.
+        .mcu: [],
+        .coreMIDI: [],
+        .scripter: [],
+    ]
+
+    /// How strongly a channel's success can be believed.
+    ///
+    /// A send-only channel actuates and cannot read back, so a route whose only
+    /// reachable candidate is send-only must never be published as verified —
+    /// that is the difference between "this will work" and "this will be
+    /// attempted". Doctor downgrades such a route to a live-verify claim.
+    enum VerificationStrength: String, Sendable {
+        /// Writes and independently reads the result back.
+        case verified
+        /// Actuates without readback. Honest Contract State B territory.
+        case sendOnly
+    }
+
+    static func verificationStrength(of channel: ChannelID) -> VerificationStrength {
+        switch channel {
+        case .accessibility, .appleScript:
+            return .verified
+        case .cgEvent, .mcu, .coreMIDI, .midiKeyCommands, .scripter:
+            return .sendOnly
+        }
+    }
+
+    // MARK: - Capability membership
+
+    /// Operations each capability group advertises.
+    ///
+    /// Membership is explicit rather than inferred from the operation-name prefix:
+    /// `transport.get_state` is a read that a broken write path does not make
+    /// unavailable, and grouping by prefix would drag it into the same verdict.
+    /// An operation listed here is one an agent can invoke once the group is
+    /// presented as ready, so listing it is a promise.
+    static let capabilityOperations: [String: [String]] = [
+        "core_transport": [
+            "transport.play",
+            "transport.stop",
+            "transport.record",
+            "transport.goto_position",
+            "transport.get_state",
+            "transport.toggle_cycle",
+            "transport.toggle_metronome",
+            "transport.set_tempo",
+        ],
+        "track_management": [
+            "track.get_tracks",
+            "track.select",
+            "track.create_audio",
+            "track.create_instrument",
+            "track.rename",
+            "track.delete",
+        ],
+        "midi_import": ["midi.import_file"],
+        "project_lifecycle": ["project.save", "project.open"],
+    ]
+
+    /// The channels that can run an operation, in the order the router tries
+    /// them. Read from the router's OWN table so a plan cannot drift from what
+    /// actually executes — a second inventory is precisely the failure this
+    /// registry exists to remove.
+    static func routeCandidates(for operation: String) -> [ChannelID] {
+        ChannelRouter.v2RoutingTable[operation] ?? []
+    }
+
+    // MARK: - Route planning
+
+    /// Why a candidate cannot run. Structural only — no user content.
+    enum CandidateBlock: String, Sendable {
+        case missingPrerequisite = "missing_prerequisite"
+        case prerequisiteUnknown = "prerequisite_unknown"
+        case awaitingManualSetup = "awaiting_manual_setup"
+    }
+
+    struct CandidatePlan: Sendable, Equatable {
+        let channel: ChannelID
+        let block: CandidateBlock?
+        /// The prerequisite check that blocked it, when one did.
+        let blockingCheck: String?
+
+        var isExecutable: Bool { block == nil }
+    }
+
+    /// Operation-level readiness. Distinguishing these is the point: a single
+    /// ready/not-ready bit cannot say "this will run but cannot be verified" or
+    /// "this needs a manual step you have not done", and collapsing them is how
+    /// a group came to be published as ready.
+    enum OperationReadiness: String, Sendable {
+        /// A verified-strength candidate is executable.
+        case readyVerified = "ready_verified"
+        /// Only send-only candidates are executable — it will be attempted, not
+        /// confirmed.
+        case readyDegraded = "ready_degraded"
+        /// Executable, but the only candidates need live confirmation that no
+        /// environment check can supply.
+        case unknownLiveVerifyRequired = "unknown_live_verify_required"
+        /// Every candidate is blocked by a manual step the operator has not done.
+        case manualSetupRequired = "manual_setup_required"
+        /// No candidate can run.
+        case notReady = "not_ready"
+    }
+
+    struct OperationPlan: Sendable, Equatable {
+        let operation: String
+        let readiness: OperationReadiness
+        let candidates: [CandidatePlan]
+
+        var executableChannels: [ChannelID] {
+            candidates.filter(\.isExecutable).map(\.channel)
+        }
+    }
+
+    /// A snapshot of what the environment currently supports, keyed by doctor
+    /// check ID. `nil` for a check that was not run — deliberately distinct from
+    /// `false`, because "we did not look" must not read as "it works".
+    struct HealthSnapshot: Sendable {
+        let satisfied: [String: Bool]
+        /// Checks awaiting an operator action rather than failing outright.
+        let awaitingManual: Set<String>
+
+        init(satisfied: [String: Bool], awaitingManual: Set<String> = []) {
+            self.satisfied = satisfied
+            self.awaitingManual = awaitingManual
+        }
+    }
+
+    /// Plan one operation against a health snapshot. Pure — no AX, no I/O — so
+    /// doctor and any future runtime pre-check can share it and cannot disagree.
+    static func plan(operation: String, health: HealthSnapshot) -> OperationPlan {
+        let candidates = routeCandidates(for: operation).map { channel -> CandidatePlan in
+            let prerequisites = channelPrerequisites[channel] ?? []
+            for check in prerequisites {
+                if health.awaitingManual.contains(check) {
+                    return CandidatePlan(channel: channel, block: .awaitingManualSetup, blockingCheck: check)
+                }
+                guard let satisfied = health.satisfied[check] else {
+                    return CandidatePlan(channel: channel, block: .prerequisiteUnknown, blockingCheck: check)
+                }
+                if !satisfied {
+                    return CandidatePlan(channel: channel, block: .missingPrerequisite, blockingCheck: check)
+                }
+            }
+            return CandidatePlan(channel: channel, block: nil, blockingCheck: nil)
+        }
+
+        return OperationPlan(
+            operation: operation,
+            readiness: readiness(for: candidates),
+            candidates: candidates
+        )
+    }
+
+    private static func readiness(for candidates: [CandidatePlan]) -> OperationReadiness {
+        let executable = candidates.filter(\.isExecutable)
+        guard !executable.isEmpty else {
+            // An operation with NO declared route is not ready either. Reporting
+            // it as ready-by-vacuity is the shape of the original defect.
+            if candidates.contains(where: { $0.block == .awaitingManualSetup }) {
+                return .manualSetupRequired
+            }
+            return .notReady
+        }
+        if executable.contains(where: { verificationStrength(of: $0.channel) == .verified }) {
+            return .readyVerified
+        }
+        // Executable, but nothing that reads back. MCU and CoreMIDI additionally
+        // have no environment check at all, so their "executable" is an absence
+        // of evidence rather than evidence of presence.
+        if executable.allSatisfy({ (channelPrerequisites[$0.channel] ?? []).isEmpty }) {
+            return .unknownLiveVerifyRequired
+        }
+        return .readyDegraded
+    }
+
+    /// Plan every operation a capability group advertises.
+    static func plan(capability: String, health: HealthSnapshot) -> [OperationPlan] {
+        (capabilityOperations[capability] ?? []).map { plan(operation: $0, health: health) }
+    }
+
+    /// The group's verdict, which is the WEAKEST of its operations. A group is
+    /// only as ready as the least-ready thing it lets an agent call — averaging
+    /// or majority would reproduce the original bug on a single broken operation.
+    static func aggregate(_ plans: [OperationPlan]) -> OperationReadiness? {
+        guard !plans.isEmpty else { return nil }
+        let order: [OperationReadiness] = [
+            .notReady, .manualSetupRequired, .unknownLiveVerifyRequired, .readyDegraded, .readyVerified,
+        ]
+        return plans
+            .map(\.readiness)
+            .min { lhs, rhs in
+                (order.firstIndex(of: lhs) ?? 0) < (order.firstIndex(of: rhs) ?? 0)
+            }
+    }
+}

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+V4.swift
@@ -27,15 +27,52 @@ extension SetupDoctor {
         case notInProfile = "not_in_profile"
     }
 
+    /// #461: per-operation readiness inside a capability group. Additive to the
+    /// published schema — the group `status` keeps its existing four values, and
+    /// this row carries the finer taxonomy the group verdict is derived FROM.
+    struct OperationReadinessRow: Codable, Equatable, Sendable {
+        let operation: String
+        let readiness: String
+        /// Channels that could actually run it under the current snapshot.
+        let executableChannels: [String]
+        /// The prerequisite that blocked the first-choice candidate, if any, so
+        /// the output can name the setup action that would enable this operation.
+        let blockedBy: String?
+
+        enum CodingKeys: String, CodingKey {
+            case operation
+            case readiness
+            case executableChannels = "executable_channels"
+            case blockedBy = "blocked_by"
+        }
+    }
+
     struct CapabilityReadiness: Codable, Equatable, Sendable {
         let status: CapabilityStatus
         let checks: [String]
         let liveVerification: String?
+        /// Empty for groups that declare no operations yet; those keep the
+        /// pre-#461 check-only verdict rather than being silently claimed ready
+        /// on the strength of an empty operation list.
+        let operations: [OperationReadinessRow]
+
+        init(
+            status: CapabilityStatus,
+            checks: [String],
+            liveVerification: String?,
+            operations: [OperationReadinessRow] = []
+        ) {
+            self.status = status
+            self.checks = checks
+            self.liveVerification = liveVerification
+            self.operations = operations
+        }
 
         enum CodingKeys: String, CodingKey {
             case status
             case checks
             case liveVerification = "live_verification"
+            case operations
         }
     }
 
@@ -282,25 +319,103 @@ extension SetupDoctor {
             }
             let statuses = required.compactMap { byID[$0]?.status }
             let missingRequired = statuses.count != required.count
-            let status: CapabilityStatus
+            let checkStatus: CapabilityStatus
             if missingRequired || statuses.contains(.fail) || statuses.contains(.warn) {
-                status = .notReady
+                checkStatus = .notReady
             } else if statuses.contains(.manual) || statuses.contains(.skipped) {
-                status = .unknownLiveVerifyRequired
+                checkStatus = .unknownLiveVerifyRequired
             } else if definition.id == "mixer_mcu" {
-                status = .unknownLiveVerifyRequired
+                checkStatus = .unknownLiveVerifyRequired
             } else {
-                status = .ready
+                checkStatus = .ready
             }
+
+            // #461: the environment checks above say the SETUP looks fine. They
+            // do not say every operation the group advertises has a runnable
+            // route, and a group that passes its checks while one member
+            // operation has no executable candidate was still reported ready.
+            // The group verdict is now the weaker of the two, so a route gap can
+            // only lower it — a passing check set can never manufacture
+            // readiness the routes do not support.
+            let plans = OperationCapabilityRegistry.plan(
+                capability: definition.id,
+                health: healthSnapshot(from: checks)
+            )
+            let status = plans.isEmpty
+                ? checkStatus
+                : weaker(checkStatus, capabilityStatus(for: OperationCapabilityRegistry.aggregate(plans)))
+
             return (
                 definition.id,
                 CapabilityReadiness(
                     status: status,
                     checks: required,
-                    liveVerification: definition.liveVerification
+                    liveVerification: definition.liveVerification,
+                    operations: plans.map { plan in
+                        OperationReadinessRow(
+                            operation: plan.operation,
+                            readiness: plan.readiness.rawValue,
+                            executableChannels: plan.executableChannels.map(\.rawValue),
+                            blockedBy: plan.candidates.first(where: { !$0.isExecutable })?.blockingCheck
+                        )
+                    }
                 )
             )
         })
+    }
+
+    /// #461: translate the doctor check set into the pure planner's input.
+    ///
+    /// `manual` and `skipped` become AWAITING rather than false. A held approval
+    /// (#457) or an unstaged preset is not a broken environment — it is a step
+    /// the operator has not taken — and reporting it as a hard failure would tell
+    /// users something is wrong with their machine when nothing is.
+    ///
+    /// A check that did not run is absent from `satisfied` rather than recorded
+    /// as false, so the planner can distinguish "we did not look" from "it does
+    /// not work". Collapsing those is how an unverified claim becomes a verified
+    /// one.
+    static func healthSnapshot(from checks: [Check]) -> OperationCapabilityRegistry.HealthSnapshot {
+        var satisfied: [String: Bool] = [:]
+        var awaiting: Set<String> = []
+        for check in checks {
+            switch check.status {
+            case .pass:
+                satisfied[check.id] = true
+            case .fail, .warn:
+                satisfied[check.id] = false
+            case .manual, .skipped:
+                awaiting.insert(check.id)
+            }
+        }
+        return OperationCapabilityRegistry.HealthSnapshot(satisfied: satisfied, awaitingManual: awaiting)
+    }
+
+    private static func capabilityStatus(
+        for readiness: OperationCapabilityRegistry.OperationReadiness?
+    ) -> CapabilityStatus {
+        switch readiness {
+        case .readyVerified:
+            return .ready
+        // Executable but unconfirmed. Publishing either as `ready` would promote
+        // a send-only route to a verified claim, which is exactly what the
+        // Honest Contract forbids elsewhere.
+        case .readyDegraded, .unknownLiveVerifyRequired:
+            return .unknownLiveVerifyRequired
+        case .manualSetupRequired, .notReady:
+            return .notReady
+        case nil:
+            return .notReady
+        }
+    }
+
+    /// The more pessimistic of two verdicts. `notInProfile` is scoping, not
+    /// readiness, so it is never weakened by a route plan.
+    private static func weaker(_ lhs: CapabilityStatus, _ rhs: CapabilityStatus) -> CapabilityStatus {
+        let rank: [CapabilityStatus: Int] = [
+            .notReady: 0, .unknownLiveVerifyRequired: 1, .ready: 2, .notInProfile: 3,
+        ]
+        return (rank[lhs] ?? 0) <= (rank[rhs] ?? 0) ? lhs : rhs
     }
 
     static func buildEvidence(_ fields: [String: EvidenceValue]) -> [String: String] {

--- a/Tests/LogicProMCPTests/Issue461CapabilityRouteReadinessTests.swift
+++ b/Tests/LogicProMCPTests/Issue461CapabilityRouteReadinessTests.swift
@@ -154,7 +154,7 @@ struct Issue461CapabilityRouteReadinessTests {
     /// agent to try. A check-only verdict cannot see this, which is #461's class
     /// 4: an approval present while its actual prerequisite is not.
     @Test("doctor consults the route plan, not just the tagged check set")
-    func doctorCapabilityFollowsRoutePlan() {
+    func doctorCapabilityFollowsRoutePlan() throws {
         let checks = doctorChecks(accessibilityStatus: .manual)
         let capability = SetupDoctor.capabilities(for: checks, profile: .core)["core_transport"]
 
@@ -169,12 +169,16 @@ struct Issue461CapabilityRouteReadinessTests {
             capability?.status == .notReady,
             "an AX-only operation with no approved AX permission is not ready, however the checks read"
         )
+        // Unwrap once rather than comparing an Optional<Bool> to `true`: that
+        // comparison compiles and passes even when the optional is nil, so it
+        // would assert nothing about a capability the fixture failed to produce.
+        let rows = try #require(capability?.operations, "core_transport must publish operation rows")
         #expect(
-            capability?.operations.contains { $0.operation == "transport.set_tempo" && $0.readiness == "manual_setup_required" } == true,
+            rows.contains { $0.operation == "transport.set_tempo" && $0.readiness == "manual_setup_required" },
             "the blocked operation must be named, not just folded into the group verdict"
         )
         #expect(
-            capability?.operations.contains { $0.blockedBy == "permissions.accessibility" } == true,
+            rows.contains { $0.blockedBy == "permissions.accessibility" },
             "output must name the setup action that would enable the operation"
         )
     }
@@ -182,14 +186,15 @@ struct Issue461CapabilityRouteReadinessTests {
     /// A hard permission failure must still be reported, and must still name the
     /// operation — this is the plainer half of the same contract.
     @Test("doctor reports the blocked operation when a permission has failed")
-    func doctorNamesBlockedOperationOnFailure() {
+    func doctorNamesBlockedOperationOnFailure() throws {
         let capability = SetupDoctor.capabilities(
             for: doctorChecks(accessibilityStatus: .fail),
             profile: .core
         )["core_transport"]
         #expect(capability?.status == .notReady)
-        #expect(capability?.operations.contains { $0.readiness == "not_ready" } == true)
-        #expect(capability?.operations.contains { $0.blockedBy == "permissions.accessibility" } == true)
+        let rows = try #require(capability?.operations, "core_transport must publish operation rows")
+        #expect(rows.contains { $0.readiness == "not_ready" })
+        #expect(rows.contains { $0.blockedBy == "permissions.accessibility" })
     }
 
     // MARK: The release path

--- a/Tests/LogicProMCPTests/Issue461CapabilityRouteReadinessTests.swift
+++ b/Tests/LogicProMCPTests/Issue461CapabilityRouteReadinessTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #461 — a capability group may not outrun its operations
+//
+// `doctor --profile core` reported `core_transport: ready` while
+// `transport.goto_position` had no runnable route, because the group's verdict
+// came from environment checks tagged with its label and nothing joined those
+// checks to the operations the group advertises. A new user's first action then
+// failed against a setup doctor had just called ready.
+//
+// The fix is deliberately NOT a `goto_position` special case — that would leave
+// every other operation exposed to the same drift. A group is ready only when
+// every operation it advertises has a runnable route, and both the membership
+// and the candidates come from one registry that reads the router's own table.
+//
+// These tests lock three things:
+//   1. The registry is structurally sound — no advertised operation without a
+//      route, no route that disagrees with what the router executes.
+//   2. The regression: static checks all pass, AX is unavailable, and the group
+//      must NOT be ready.
+//   3. The release path, and the distinction between "will work", "will be
+//      attempted", and "needs a manual step" — a planner that only ever said
+//      not-ready would be as useless as the one that only ever said ready.
+
+private let allChecksPassing = SetupDoctor.CheckStatus.pass
+
+private func snapshot(
+    accessibility: Bool = true,
+    postEvent: Bool = true,
+    automation: Bool = true,
+    logicRunning: Bool = true,
+    keycmdStaged: Bool? = true
+) -> OperationCapabilityRegistry.HealthSnapshot {
+    var satisfied: [String: Bool] = [
+        "permissions.accessibility": accessibility,
+        "permissions.post_event_access": postEvent,
+        "permissions.automation_logic_pro": automation,
+        "logic.application_state": logicRunning,
+    ]
+    var awaiting: Set<String> = []
+    switch keycmdStaged {
+    case .some(true):
+        satisfied["channels.keycmd_reference"] = true
+    case .some(false):
+        satisfied["channels.keycmd_reference"] = false
+    case nil:
+        awaiting.insert("channels.keycmd_reference")
+    }
+    return OperationCapabilityRegistry.HealthSnapshot(satisfied: satisfied, awaitingManual: awaiting)
+}
+
+@Suite("Issue #461 — capability readiness is derived from operation routes")
+struct Issue461CapabilityRouteReadinessTests {
+
+    // MARK: Structural invariants
+
+    /// Every operation a group advertises must exist in the routing table with at
+    /// least one candidate. An advertised operation with no route is the exact
+    /// shape of the defect: the group promises something nothing can run.
+    @Test("every advertised operation has at least one route candidate")
+    func advertisedOperationsHaveRoutes() {
+        for (capability, operations) in OperationCapabilityRegistry.capabilityOperations {
+            #expect(!operations.isEmpty, "\(capability) declares no operations")
+            for operation in operations {
+                let candidates = OperationCapabilityRegistry.routeCandidates(for: operation)
+                #expect(
+                    !candidates.isEmpty,
+                    "\(capability) advertises \(operation), which has no route destination"
+                )
+            }
+        }
+    }
+
+    /// The planner must read the SAME table the router executes. A second
+    /// inventory that drifts is the failure this registry exists to remove, so
+    /// this compares against the router's own map rather than a copy.
+    @Test("planner candidates match the router's routing table exactly")
+    func plannerAgreesWithRouter() {
+        for operations in OperationCapabilityRegistry.capabilityOperations.values {
+            for operation in operations {
+                #expect(
+                    OperationCapabilityRegistry.routeCandidates(for: operation)
+                        == (ChannelRouter.v2RoutingTable[operation] ?? []),
+                    "\(operation) plan diverges from the executed route"
+                )
+            }
+        }
+    }
+
+    /// Every channel a declared route can reach must have a prerequisite entry,
+    /// even an empty one. A missing entry would silently read as "no
+    /// prerequisites" and mark an unusable channel executable.
+    @Test("every reachable channel declares its prerequisites")
+    func reachableChannelsDeclarePrerequisites() {
+        for operations in OperationCapabilityRegistry.capabilityOperations.values {
+            for channel in operations.flatMap({ OperationCapabilityRegistry.routeCandidates(for: $0) }) {
+                #expect(
+                    OperationCapabilityRegistry.channelPrerequisites[channel] != nil,
+                    "\(channel.rawValue) is reachable but declares no prerequisite entry"
+                )
+            }
+        }
+    }
+
+    // MARK: The regression
+
+    /// The reported defect, at the operation level: AX controls are unavailable,
+    /// so `goto_position` must not be ready even though nothing else changed.
+    @Test("goto_position is not ready when Accessibility is unavailable")
+    func gotoPositionNotReadyWithoutAccessibility() {
+        let plan = OperationCapabilityRegistry.plan(
+            operation: "transport.goto_position",
+            health: snapshot(accessibility: false)
+        )
+
+        #expect(!plan.executableChannels.contains(.accessibility))
+        #expect(plan.readiness != .readyVerified, "no verified path exists without AX readback")
+        let axCandidate = plan.candidates.first { $0.channel == .accessibility }
+        #expect(axCandidate?.blockingCheck == "permissions.accessibility")
+    }
+
+    /// The reported defect, at the group level: every static `core_transport`
+    /// check passes, and the group must still not be reported ready.
+    @Test("core_transport is not ready while a member operation has no verified route")
+    func coreTransportNotReadyWhenAnOperationIsBlocked() {
+        let plans = OperationCapabilityRegistry.plan(
+            capability: "core_transport",
+            health: snapshot(accessibility: false)
+        )
+        #expect(!plans.isEmpty, "core_transport must advertise operations or this proves nothing")
+
+        let aggregate = OperationCapabilityRegistry.aggregate(plans)
+        #expect(aggregate != .readyVerified, "a group may not be verified-ready past a blocked member")
+
+        // `transport.set_tempo` and `get_state` are AX-only, so losing AX leaves
+        // them with no candidate at all — the group verdict must follow the worst.
+        let tempo = plans.first { $0.operation == "transport.set_tempo" }
+        #expect(tempo?.readiness == .notReady)
+        #expect(aggregate == .notReady, "the group is only as ready as its least-ready operation")
+    }
+
+    /// End-to-end through doctor, on the case where the two layers genuinely
+    /// disagree — which is the only case that proves the route plan is consulted
+    /// at all.
+    ///
+    /// With `permissions.accessibility` merely AWAITING approval rather than
+    /// failed, the check layer reaches `unknown_live_verify_required`: nothing is
+    /// broken, something is unconfirmed. The route layer knows more.
+    /// `transport.set_tempo` routes through Accessibility and nothing else, so an
+    /// unapproved AX permission leaves it with no candidate whatsoever — the
+    /// group is NOT ready, and calling it merely "verify live" would invite an
+    /// agent to try. A check-only verdict cannot see this, which is #461's class
+    /// 4: an approval present while its actual prerequisite is not.
+    @Test("doctor consults the route plan, not just the tagged check set")
+    func doctorCapabilityFollowsRoutePlan() {
+        let checks = doctorChecks(accessibilityStatus: .manual)
+        let capability = SetupDoctor.capabilities(for: checks, profile: .core)["core_transport"]
+
+        // The check layer alone would stop here — this pins that the fixture
+        // really does put the two layers in disagreement, so the assertion below
+        // cannot pass for the wrong reason.
+        #expect(
+            SetupDoctor.healthSnapshot(from: checks).satisfied["permissions.accessibility"] == nil,
+            "an awaiting check must not be recorded as satisfied"
+        )
+        #expect(
+            capability?.status == .notReady,
+            "an AX-only operation with no approved AX permission is not ready, however the checks read"
+        )
+        #expect(
+            capability?.operations.contains { $0.operation == "transport.set_tempo" && $0.readiness == "manual_setup_required" } == true,
+            "the blocked operation must be named, not just folded into the group verdict"
+        )
+        #expect(
+            capability?.operations.contains { $0.blockedBy == "permissions.accessibility" } == true,
+            "output must name the setup action that would enable the operation"
+        )
+    }
+
+    /// A hard permission failure must still be reported, and must still name the
+    /// operation — this is the plainer half of the same contract.
+    @Test("doctor reports the blocked operation when a permission has failed")
+    func doctorNamesBlockedOperationOnFailure() {
+        let capability = SetupDoctor.capabilities(
+            for: doctorChecks(accessibilityStatus: .fail),
+            profile: .core
+        )["core_transport"]
+        #expect(capability?.status == .notReady)
+        #expect(capability?.operations.contains { $0.readiness == "not_ready" } == true)
+        #expect(capability?.operations.contains { $0.blockedBy == "permissions.accessibility" } == true)
+    }
+
+    // MARK: The release path
+
+    /// The gate must release, or doctor could never report a healthy machine.
+    @Test("a healthy environment reports core_transport ready")
+    func healthyEnvironmentIsReady() {
+        let plans = OperationCapabilityRegistry.plan(capability: "core_transport", health: snapshot())
+        #expect(OperationCapabilityRegistry.aggregate(plans) == .readyVerified)
+        #expect(plans.allSatisfy { !$0.executableChannels.isEmpty })
+
+        let ready = SetupDoctor.capabilities(for: doctorChecks(accessibilityStatus: .pass), profile: .core)
+        #expect(ready["core_transport"]?.status == .ready)
+    }
+
+    /// A held manual step is not a broken machine. It must read as
+    /// manual-setup-required, so the user is told what to do rather than that
+    /// something is wrong — and it must still not read as ready.
+    @Test("an operation whose only route awaits manual setup is distinguished from a failure")
+    func awaitingManualIsItsOwnStatus() {
+        // capture_recording routes only through Key Commands and CGEvent, so
+        // holding the keycmd staging check plus removing post-event access
+        // leaves nothing executable and nothing broken.
+        let plan = OperationCapabilityRegistry.plan(
+            operation: "transport.capture_recording",
+            health: snapshot(postEvent: false, keycmdStaged: nil)
+        )
+        #expect(plan.readiness == .manualSetupRequired)
+        #expect(plan.readiness != .notReady, "an unfinished setup step is not a failure")
+    }
+
+    /// A send-only route must never be promoted to verified readiness. This is
+    /// the Honest Contract line: CGEvent actuates without reading back.
+    @Test("a send-only-only route is degraded, never verified-ready")
+    func sendOnlyRouteIsNotVerified() {
+        // transport.stop routes CGEvent -> AX -> MCU -> CoreMIDI -> AppleScript.
+        // Removing both readback-capable channels leaves only send-only paths.
+        let plan = OperationCapabilityRegistry.plan(
+            operation: "transport.stop",
+            health: snapshot(accessibility: false, automation: false)
+        )
+        #expect(plan.executableChannels.contains(.cgEvent))
+        #expect(plan.readiness != .readyVerified, "CGEvent cannot read back, so it cannot verify")
+        #expect(plan.readiness == .readyDegraded)
+    }
+
+    /// Verification strength is a property of the channel, and every channel must
+    /// declare one — an unclassified channel would default into whichever branch
+    /// the compiler picked and could silently be treated as verified.
+    @Test("every channel declares a verification strength")
+    func everyChannelHasVerificationStrength() {
+        let verified = ChannelID.allCases.filter {
+            OperationCapabilityRegistry.verificationStrength(of: $0) == .verified
+        }
+        #expect(verified.contains(.accessibility), "AX reads back and must count as verified")
+        #expect(!verified.contains(.cgEvent), "CGEvent is send-only")
+        #expect(!verified.contains(.mcu), "MCU feedback is not an independent readback")
+    }
+}
+
+/// A doctor check set where every `core_transport` check passes except, when
+/// asked, the Accessibility permission — the exact reported configuration.
+private func doctorChecks(accessibilityStatus: SetupDoctor.CheckStatus) -> [SetupDoctor.Check] {
+    let ids = [
+        "binary.path", "binary.executable", "permissions.accessibility",
+        "permissions.post_event_access", "permissions.automation_logic_pro",
+        "logic.installation", "logic.version_support", "logic.application_state",
+        "channels.keycmd_reference",
+    ]
+    return ids.map { id in
+        SetupDoctor.check(
+            id: id,
+            domain: "test",
+            status: id == "permissions.accessibility" ? accessibilityStatus : allChecksPassing,
+            summary: "fixture",
+            evidence: [:],
+            remediationType: .none
+        )
+    }
+}


### PR DESCRIPTION
`doctor --profile core` reported `core_transport: ready` while `transport.goto_position` had no runnable path. The group's verdict came from environment checks tagged with its label, and **nothing joined those checks to the operations the group advertises** — so a new user's first action failed against a setup doctor had just called ready.

Adding a `goto_position` check to `core_transport` would leave every other operation and every future route exposed to the same drift. The join is made once instead.

### The shared registry

`OperationCapabilityRegistry` is now the single source of truth:

- **`capabilityOperations`** — which operations each group advertises. Membership is explicit rather than inferred from the name prefix, because `transport.get_state` is a read that a broken *write* path does not make unavailable.
- **`routeCandidates`** — reads the **router's own table**. A second inventory that can drift is the failure this registry exists to remove.
- **`channelPrerequisites`** — the checks a channel needs before it can run anything.
- **`verificationStrength`** — separates channels that read back from channels that only actuate, so a send-only route can never be published as verified.

`plan(operation:health:)` is pure and returns per-candidate executable/blocked with a structural reason, plus an operation readiness of `ready_verified` / `ready_degraded` / `unknown_live_verify_required` / `manual_setup_required` / `not_ready`.

The group verdict is the **weakest** of its operations — a group is only as ready as the least-ready thing it lets an agent call, and averaging would reproduce the original bug on a single broken operation.

Two distinctions carry the correctness:

- A check that **did not run** is absent from the snapshot rather than recorded as `false`, so the planner can tell *"we did not look"* from *"it does not work"*.
- `manual` and `skipped` become **awaiting** rather than false. A held approval (#457) or an unstaged preset is a step the operator has not taken, not a broken machine.

Doctor takes the weaker of its check verdict and the route verdict, so a route gap can only *lower* readiness and a passing check set can never manufacture readiness the routes do not support. Per-operation rows are published alongside the group status, naming the blocked operation and the prerequisite that would enable it. The group `status` keeps its existing four values, so the schema change is additive.

### The load-bearing case

An earlier revision of the doctor test **could not tell the fix from the old behaviour** — a failed-permission fixture reaches `not_ready` through the check path alone, so the mutation survived. That test was replaced with the case where the two layers genuinely disagree:

> With `permissions.accessibility` merely **awaiting** approval, the check layer reaches `unknown_live_verify_required` — nothing is broken, something is unconfirmed. But `transport.set_tempo` routes through Accessibility and **nothing else**, so it has no candidate at all and the group is **not ready**. Calling it "verify live" would invite an agent to try.

That is #461's class 4: an approval present while its actual prerequisite is not.

### Mutations

| Mutation | Killed by |
|---|---|
| Ignore the route plan in doctor | the disagreement case above |
| Aggregate to the strongest member instead of the weakest | same |
| Treat an awaiting check as satisfied | same |

Structural invariants are pinned too: every advertised operation has ≥1 route candidate, planner candidates equal the router's table exactly, and every reachable channel declares a prerequisite entry — a missing entry would read as "no prerequisites" and mark an unusable channel executable.

Full suite `--no-parallel`: one pre-existing failure (the library-inventory panel snapshot) that reproduces identically on the unmodified tree.

### Deliberately not in scope

Parameter-domain validation, runtime re-planning between doctor time and call time, and per-tool-command census coupling. Each needs its own design; the issue tracks them. This PR closes the readiness-vs-route gap that produced the report.

Closes #461
