### PR TITLE
fix(#440): post zero CGEvents when Logic does not own the keyboard

### DIFF
--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -12,6 +12,35 @@ actor CGEventChannel: Channel {
         let logicProPID: @Sendable () -> pid_t?
         let postKeyEvent: @Sendable (CGKeyCode, CGEventFlags, pid_t) -> Bool
         let sleepMicros: @Sendable (useconds_t) -> Void
+        /// #440 D: whether Logic currently owns the keyboard.
+        let isLogicFrontmost: @Sendable () -> Bool
+        /// #440 D: bring Logic forward. Must NOT activate in-process — an
+        /// in-process activation poisons this process's own `postToPid`, so the
+        /// production path goes through AppleScript.
+        let activateLogic: @Sendable () -> Bool
+
+        /// The two #440 fields default to an already-frontmost Logic so existing
+        /// callers that construct a Runtime for an unrelated reason keep
+        /// compiling. The default is deliberately the PERMISSIVE one: a test
+        /// that wants to exercise the gate must say so, and a test that does not
+        /// mention frontmost is testing something else and should not be
+        /// silently blocked by it. Production never takes these defaults — it
+        /// uses `.production`, which wires the real probes.
+        init(
+            isLogicProRunning: @escaping @Sendable () -> Bool,
+            logicProPID: @escaping @Sendable () -> pid_t?,
+            postKeyEvent: @escaping @Sendable (CGKeyCode, CGEventFlags, pid_t) -> Bool,
+            sleepMicros: @escaping @Sendable (useconds_t) -> Void,
+            isLogicFrontmost: @escaping @Sendable () -> Bool = { true },
+            activateLogic: @escaping @Sendable () -> Bool = { true }
+        ) {
+            self.isLogicProRunning = isLogicProRunning
+            self.logicProPID = logicProPID
+            self.postKeyEvent = postKeyEvent
+            self.sleepMicros = sleepMicros
+            self.isLogicFrontmost = isLogicFrontmost
+            self.activateLogic = activateLogic
+        }
 
         static let production = Runtime(
             isLogicProRunning: { ProcessUtils.isLogicProRunning },
@@ -19,9 +48,38 @@ actor CGEventChannel: Channel {
             postKeyEvent: { keyCode, flags, pid in
                 performKeyEvent(keyCode: keyCode, flags: flags, pid: pid)
             },
-            sleepMicros: { usleep($0) }
+            sleepMicros: { usleep($0) },
+            isLogicFrontmost: ProcessUtils.Runtime.production.logicIsFrontmost,
+            activateLogic: ProcessUtils.Runtime.production.activateLogicPro
         )
     }
+
+    /// #440 D: why no event was posted. A CGEvent keystroke delivered while
+    /// Logic is in the background is swallowed by the window server, and the
+    /// caller previously saw a sent-but-unverified success for a keystroke Logic
+    /// never received. Preparation now runs first and posts nothing when it
+    /// fails, so the failure is visible instead of silent.
+    enum FrontmostPreparation: String, Sendable {
+        /// Logic already owned the keyboard; nothing was activated.
+        case alreadyFrontmost = "already_frontmost"
+        /// Logic was background and came forward within the bound.
+        case activated = "activated"
+        /// Logic did not become frontmost within the bound. Zero events posted.
+        case activationTimedOut = "activation_timed_out"
+        /// The activation call itself refused. Zero events posted.
+        case activationRefused = "activation_refused"
+
+        var isReady: Bool { self == .alreadyFrontmost || self == .activated }
+    }
+
+    /// Consecutive frontmost observations required before posting. One reading
+    /// can catch the window server mid-switch, which is exactly the race that
+    /// makes a keystroke land nowhere.
+    static let requiredFrontmostObservations = 2
+    /// Bound on how long activation is given, as a count of polls.
+    static let maximumActivationPolls = 20
+    /// Settle between polls, and between activation and the first observation.
+    static let activationPollMicros: useconds_t = 50_000
 
     private let runtime: Runtime
 
@@ -140,6 +198,13 @@ actor CGEventChannel: Channel {
             guard let sequence = Self.gotoPositionSequence(for: position) else {
                 return .error("Unsupported position format for CGEvent fallback: \(position)")
             }
+            // #440 D: prepare BEFORE the sequence, not per keystroke. A sequence
+            // that lost the keyboard halfway would leave the Go To Position
+            // dialog open with a partial value typed into it.
+            let preparation = prepareFrontmost()
+            guard preparation.isReady else {
+                return Self.frontmostRefusal(operation: operation, preparation: preparation)
+            }
             let sent = postShortcutSequence(sequence, pid: pid)
             if sent {
                 // v3.1.1 (P2-2) — State B envelope. CGEvent sends keystrokes
@@ -151,6 +216,7 @@ actor CGEventChannel: Channel {
                         "operation": operation,
                         "method": "cgevent",
                         "position": position,
+                        "frontmost_preparation": preparation.rawValue,
                         "sent": true
                     ]
                 ))
@@ -163,6 +229,14 @@ actor CGEventChannel: Channel {
             return .error("No keyboard shortcut mapped for: \(operation)")
         }
 
+        // #440 D: same gate as the sequence path. A mapped chord posted while
+        // Logic is in the background is swallowed, and the State B envelope
+        // below would then report a keystroke Logic never received.
+        let preparation = prepareFrontmost()
+        guard preparation.isReady else {
+            return Self.frontmostRefusal(operation: operation, preparation: preparation)
+        }
+
         let sent = runtime.postKeyEvent(shortcut.keyCode, shortcut.flags, pid)
         if sent {
             // v3.1.1 (P2-2) — same rationale as above. Single key chord
@@ -172,6 +246,7 @@ actor CGEventChannel: Channel {
                 extras: [
                     "operation": operation,
                     "method": "cgevent",
+                    "frontmost_preparation": preparation.rawValue,
                     "sent": true
                 ]
             ))
@@ -241,6 +316,59 @@ actor CGEventChannel: Channel {
 
         Log.debug("Posted key \(keyCode) flags \(flags.rawValue) to PID \(pid)", subsystem: "cgEvent")
         return true
+    }
+
+    /// #440 D: bring Logic forward and prove it owns the keyboard, before any
+    /// event is created. Returns without posting anything when it cannot.
+    ///
+    /// Two consecutive frontmost observations are required rather than one. A
+    /// single reading can be taken while the window server is mid-switch, and a
+    /// keystroke posted in that window reaches nothing — which is the failure
+    /// this gate exists to remove, so a gate that could itself be fooled by it
+    /// would be pointless.
+    func prepareFrontmost() -> FrontmostPreparation {
+        if consecutiveFrontmostObservations() >= Self.requiredFrontmostObservations {
+            return .alreadyFrontmost
+        }
+        guard runtime.activateLogic() else { return .activationRefused }
+        for _ in 0..<Self.maximumActivationPolls {
+            runtime.sleepMicros(Self.activationPollMicros)
+            if consecutiveFrontmostObservations() >= Self.requiredFrontmostObservations {
+                return .activated
+            }
+        }
+        return .activationTimedOut
+    }
+
+    private func consecutiveFrontmostObservations() -> Int {
+        var seen = 0
+        for _ in 0..<Self.requiredFrontmostObservations {
+            guard runtime.isLogicFrontmost() else { return 0 }
+            seen += 1
+            if seen < Self.requiredFrontmostObservations {
+                runtime.sleepMicros(Self.activationPollMicros)
+            }
+        }
+        return seen
+    }
+
+    /// State C for a refused preparation. `write_attempted` is false and
+    /// `events_posted` is zero because nothing was created: the caller can
+    /// retry without wondering whether a partial keystroke landed.
+    static func frontmostRefusal(operation: String, preparation: FrontmostPreparation) -> ChannelResult {
+        .error(HonestContract.encodeStateC(
+            error: .axWriteFailed,
+            hint: "CGEvent keystrokes are delivered to the frontmost application; Logic Pro did not own the "
+                + "keyboard, so no event was posted. Bring Logic Pro to the front and retry.",
+            extras: [
+                "operation": operation,
+                "method": "cgevent",
+                "frontmost_preparation": preparation.rawValue,
+                "events_posted": 0,
+                "write_attempted": false,
+                "safe_to_retry": true,
+            ]
+        ))
     }
 
     private func postShortcutSequence(_ sequence: [Shortcut], pid: pid_t) -> Bool {

--- a/Tests/LogicProMCPTests/Issue440FrontmostGateTests.swift
+++ b/Tests/LogicProMCPTests/Issue440FrontmostGateTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - Issue #440 D — CGEvent must post nothing when Logic is not frontmost
+//
+// `CGEvent.postToPid` does not guarantee delivery: a keystroke posted while
+// Logic is in the background is swallowed by the window server. The channel used
+// to post regardless and return a State B "sent" envelope, so a caller was told
+// a keystroke had been delivered to an application that never received it.
+//
+// The fix prepares first and posts nothing when preparation fails. These tests
+// assert the property that actually matters — the EVENT COUNT — rather than the
+// returned envelope, because an envelope can be made to look right while events
+// still leak out. Every case counts real calls into the posting seam.
+//
+// Both directions are covered. A gate that never posts would be as wrong as one
+// that always posts, so the already-frontmost and activated paths are asserted
+// to post exactly the events the operation requires.
+
+/// Records every post so a test can assert on the count, and drives frontmost
+/// state as a scripted sequence so the mid-switch race can be reproduced.
+private final class PostRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var posts: [(CGKeyCode, CGEventFlags)] = []
+    private var frontmostReadings: [Bool]
+    private var activationsRequested = 0
+    private let activationSucceeds: Bool
+    private let frontmostAfterActivation: Bool
+
+    init(frontmostReadings: [Bool], activationSucceeds: Bool = true, frontmostAfterActivation: Bool = true) {
+        self.frontmostReadings = frontmostReadings
+        self.activationSucceeds = activationSucceeds
+        self.frontmostAfterActivation = frontmostAfterActivation
+    }
+
+    var postCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return posts.count
+    }
+
+    var activationCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return activationsRequested
+    }
+
+    func runtime() -> CGEventChannel.Runtime {
+        CGEventChannel.Runtime(
+            isLogicProRunning: { true },
+            logicProPID: { 4242 },
+            postKeyEvent: { [self] code, flags, _ in
+                lock.lock(); defer { lock.unlock() }
+                posts.append((code, flags))
+                return true
+            },
+            sleepMicros: { _ in },
+            isLogicFrontmost: { [self] in
+                lock.lock(); defer { lock.unlock() }
+                if !frontmostReadings.isEmpty { return frontmostReadings.removeFirst() }
+                return frontmostAfterActivation
+            },
+            activateLogic: { [self] in
+                lock.lock(); defer { lock.unlock() }
+                activationsRequested += 1
+                return activationSucceeds
+            }
+        )
+    }
+}
+
+private func refusalReason(_ result: ChannelResult) -> String? {
+    guard case let .error(payload) = result,
+          let object = sharedJSONObject(payload) else { return nil }
+    return object["frontmost_preparation"] as? String
+}
+
+@Suite("Issue #440 D — CGEvent frontmost gate")
+struct Issue440FrontmostGateTests {
+    /// The regression: Logic is in the background and stays there. Nothing may
+    /// be posted, and the caller must be told, not handed a "sent" envelope.
+    @Test("a mapped shortcut posts zero events when Logic never becomes frontmost")
+    func mappedShortcutPostsNothingWhenBackground() async {
+        let recorder = PostRecorder(frontmostReadings: [false], frontmostAfterActivation: false)
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(operation: "transport.play", params: [:])
+
+        #expect(recorder.postCount == 0, "no event may be created when Logic does not own the keyboard")
+        #expect(!result.isSuccess)
+        #expect(refusalReason(result) == "activation_timed_out")
+    }
+
+    /// The same property on the multi-keystroke path. A sequence that lost the
+    /// keyboard halfway would leave a dialog open with a partial value typed in,
+    /// so this one matters more than the single chord.
+    @Test("a goto_position sequence posts zero events when Logic never becomes frontmost")
+    func sequencePostsNothingWhenBackground() async {
+        let recorder = PostRecorder(frontmostReadings: [false], frontmostAfterActivation: false)
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(
+            operation: "transport.goto_position",
+            params: ["position": "5.1.1.1"]
+        )
+
+        #expect(recorder.postCount == 0, "a partial sequence is worse than none; zero events required")
+        #expect(!result.isSuccess)
+        #expect(refusalReason(result) == "activation_timed_out")
+    }
+
+    /// Activation itself refusing is a distinct outcome and must also post
+    /// nothing, rather than falling through to a hopeful post.
+    @Test("a refused activation posts zero events and is reported distinctly")
+    func refusedActivationPostsNothing() async {
+        let recorder = PostRecorder(
+            frontmostReadings: [false],
+            activationSucceeds: false,
+            frontmostAfterActivation: false
+        )
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(operation: "transport.play", params: [:])
+
+        #expect(recorder.postCount == 0)
+        #expect(refusalReason(result) == "activation_refused")
+        #expect(recorder.activationCount == 1, "activation is attempted exactly once, not retried blindly")
+    }
+
+    /// The gate must release when Logic already owns the keyboard, and must not
+    /// activate anything in that case — an unnecessary activation is a visible
+    /// window flash for the user.
+    @Test("an already-frontmost Logic is not activated and receives the keystroke")
+    func alreadyFrontmostPostsWithoutActivating() async {
+        let recorder = PostRecorder(frontmostReadings: [true, true])
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(operation: "transport.play", params: [:])
+
+        #expect(recorder.postCount == 1, "the mapped chord must actually be delivered")
+        #expect(recorder.activationCount == 0, "no activation when Logic already owns the keyboard")
+        #expect(result.isSuccess)
+    }
+
+    /// Background at first, forward after activation: the whole point of
+    /// activating. The sequence must then be delivered in full.
+    @Test("a background Logic is activated and then receives the full sequence")
+    func activatedThenPostsFullSequence() async {
+        let recorder = PostRecorder(frontmostReadings: [false], frontmostAfterActivation: true)
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(
+            operation: "transport.goto_position",
+            params: ["position": "5.1.1.1"]
+        )
+
+        #expect(recorder.activationCount == 1)
+        let expected = CGEventChannel.gotoPositionSequence(for: "5.1.1.1")?.count
+        #expect(recorder.postCount == expected, "every keystroke of the sequence must be delivered")
+        #expect(result.isSuccess)
+    }
+
+    /// The mid-switch race the two-observation rule exists for: one reading says
+    /// frontmost, the next says not. A single-observation gate would post here.
+    @Test("a single frontmost reading is not enough to post")
+    func oneFrontmostReadingDoesNotRelease() async {
+        let recorder = PostRecorder(
+            frontmostReadings: [true, false, false],
+            activationSucceeds: false,
+            frontmostAfterActivation: false
+        )
+        let channel = CGEventChannel(runtime: recorder.runtime())
+
+        let result = await channel.execute(operation: "transport.play", params: [:])
+
+        #expect(recorder.postCount == 0, "an unstable frontmost observation must not authorise a post")
+        #expect(!result.isSuccess)
+    }
+
+    /// The gate's own constants must be sane: a single required observation
+    /// would reintroduce the race the previous test covers.
+    @Test("the gate requires more than one frontmost observation")
+    func gateRequiresStableObservation() {
+        #expect(CGEventChannel.requiredFrontmostObservations >= 2)
+        #expect(CGEventChannel.maximumActivationPolls > 0)
+    }
+}


### PR DESCRIPTION
Addresses **finding D** of #440. Finding E is deliberately untouched — see the end.

### The defect

`CGEvent.postToPid` does not guarantee delivery. A keystroke posted while Logic is in the background is swallowed by the window server. The channel posted anyway and returned a State B *"sent"* envelope, so a caller was told a keystroke had been delivered to an application that **never received it**.

### The fix

Preparation runs before any event is created, and creates none when it fails.

Two details carry the correctness:

- **Two consecutive frontmost observations, not one.** A single reading can be taken while the window server is mid-switch, and a keystroke posted in that window reaches nothing. That is the exact race this gate exists to close — a gate that could itself be fooled by it would be pointless.
- **Activation goes through AppleScript.** Activating in-process poisons this process's own `postToPid`, so the obvious call is the wrong one here.

Both paths are gated. The multi-keystroke `goto_position` sequence matters more than the single chord: losing the keyboard halfway would leave the Go To Position dialog open with a **partial value typed into it**, so preparation happens once before the sequence rather than per keystroke.

A refused preparation is State C carrying `write_attempted:false`, `events_posted:0`, `safe_to_retry:true`, with the cause distinguished as `activation_timed_out` or `activation_refused`. Nothing partial can have landed, so the retry is genuinely safe. Successful envelopes now also record which preparation path ran.

### On the new `Runtime` defaults

The two added fields default to an already-frontmost Logic so existing callers keep compiling. That default is the **permissive** one deliberately: a test that does not mention frontmost is testing something else and must not be silently blocked by this gate. Production never takes the defaults — it uses `.production`, which wires the real probes.

### Testing

Tests assert the **event count**, not the returned envelope — an envelope can be made to look right while events still leak out.

Verified by mutation:

| Mutation | Result |
|---|---|
| Remove the gate from the mapped-shortcut path | background case posts an event and emits a `sent:true` envelope |
| Relax stability to one observation | the mid-switch race test passes |

Both directions are covered: already-frontmost posts without activating (an unnecessary activation is a visible window flash), and background→frontmost delivers the full sequence.

Full suite `--no-parallel`: 3369 tests. The single failure — the library-inventory panel snapshot — reproduces identically on the unmodified tree.

### Not addressed: finding E

The Bounce helper on a French/AZERTY-primary environment. #440 requires a reproduction **or** an exact-artifact validation receipt from that class of environment before an E fix may be claimed, and neither is available here. Claiming E without one is exactly what the issue forbids.

Refs #440
