### PR TITLE
test(library): give the category check an oracle that can fail

### DIFF
--- a/Sources/LogicProMCP/Accessibility/LibraryDiskScanner.swift
+++ b/Sources/LogicProMCP/Accessibility/LibraryDiskScanner.swift
@@ -69,7 +69,11 @@ enum LibraryDiskScanner {
     /// 1-segment Panel path `Acoustic Drums/...` before the fallback
     /// `Drums & Percussion` → (no-match) check runs.
     ///
-    /// Verified against `Resources/library-inventory.json` (AX panel snapshot).
+    /// The combined range of this table and `identityCategories` is pinned
+    /// against the v3.0.4 Panel inventory by `LibraryDiskScannerTests`. It is
+    /// not verified against `Resources/library-inventory.json`: that path is
+    /// matched by `.gitignore`, so it is absent on CI and is a stale local AX
+    /// probe artifact anywhere else.
     /// Panel categories: Bass, Acoustic Drums, Electronic Drums, Percussion,
     /// Guitar, Acoustic Piano, Clavinet, Electric Piano, Mellotron, Organ,
     /// Mallet, Studio Horns, Studio Strings, Synthesizer, Orchestral, World.

--- a/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
+++ b/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
@@ -233,14 +233,9 @@ struct LibraryDiskScannerTests {
     /// on the machine. Verifies that a full scan returns a clinically
     /// implausible-low count (e.g. under 1000 leaves) does NOT ship — the
     /// whole point of v3.0.5 is to fix the 345-leaf undercount.
-    @Test("local-machine integration: factory Library reports at least 1000 leaves when present")
+    @Test("local-machine integration: factory Library reports at least 1000 leaves when present",
+          .enabled(if: installedLogicLibraryExists))
     func scanLocalFactoryLibraryReportsFullCoverage() throws {
-        let home = URL(fileURLWithPath: NSHomeDirectory())
-        let bundleURL = home.appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath)
-        guard FileManager.default.fileExists(atPath: bundleURL.path) else {
-            // Expected in CI; skip silently.
-            return
-        }
         let root = try LibraryDiskScanner.scan()
         #expect(
             root.leafCount >= 1000,

--- a/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
+++ b/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
@@ -2,6 +2,14 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
+/// Whether this machine has the Logic factory Library installed. Used as an
+/// `.enabled(if:)` trait so an absent Library is reported as a skipped test
+/// rather than as a body that returns early and counts as a pass.
+private let installedLogicLibraryExists: Bool = FileManager.default.fileExists(
+    atPath: URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath).path
+)
+
 /// v3.0.5 — filesystem-backed library scan tests. Uses a real temp dir
 /// populated with fixture `.patch` bundles (empty directories suffixed with
 /// `.patch`) so the production code path under `FileManager.default` is
@@ -540,53 +548,78 @@ struct LibraryDiskScannerTests {
         #expect(kit.path == "Acoustic Drums/Multi-Channel Kits/8-Bit+")
     }
 
-    /// v3.0.6 contract assertion: every emitted top-level category must exist
-    /// in the v3.0.4 AX Panel snapshot's `categories` array. This is the
-    /// "mapping bug detector" — if a new disk taxonomy slips through without
-    /// a `diskToPanel` entry, this test starts failing.
-    @Test("scan result: every emitted category exists in Resources/library-inventory.json Panel snapshot")
-    func everyEmittedCategoryExistsInPanelInventory() throws {
-        let home = URL(fileURLWithPath: NSHomeDirectory())
-        let bundleURL = home.appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath)
-        guard FileManager.default.fileExists(atPath: bundleURL.path) else {
-            // Expected in CI; skip silently.
-            return
-        }
+    /// The v3.0.4 AX Panel inventory, as the sixteen category names the Panel
+    /// exposes. This lives here, in a committed file, because the machine-local
+    /// `Resources/library-inventory.json` it used to be read from is matched by
+    /// `.gitignore` and therefore can never be a shared oracle: on CI it is
+    /// absent, and on a developer machine it is whatever the last AX probe left
+    /// behind, which is not a Panel snapshot at all.
+    private static let panelCategoriesV304: Set<String> = [
+        "Bass", "Acoustic Drums", "Electronic Drums", "Percussion",
+        "Guitar", "Acoustic Piano", "Clavinet", "Electric Piano",
+        "Mellotron", "Organ", "Mallet", "Studio Horns",
+        "Studio Strings", "Synthesizer", "Orchestral", "World",
+    ]
 
-        // Load Panel snapshot from committed resource. Scan-result
-        // categories must be a subset.
-        let panelCategories = try loadPanelCategoriesFromResource()
-        guard !panelCategories.isEmpty else {
-            // Fixture missing — skip rather than misreport.
-            return
-        }
-
-        let root = try LibraryDiskScanner.scan()
-        for cat in root.categories {
-            #expect(
-                panelCategories.contains(cat),
-                "Disk scan emitted `\(cat)` which is not in the v3.0.4 AX Panel snapshot (\(panelCategories.sorted()))"
-            )
-        }
+    /// The mapping tables are the only two ways a category can be emitted, so
+    /// their combined range **is** the set of categories the scanner can
+    /// produce. Pinning that range against the Panel inventory catches a table
+    /// edit that invents a category `selectPath` could never navigate to —
+    /// which is the failure the old subset check was named for but could not
+    /// detect, because a path with no table entry is dropped rather than
+    /// emitted under its raw disk name.
+    @Test("the mapping tables can only ever emit v3.0.4 Panel categories")
+    func mappingTableRangeEqualsPanelInventory() {
+        let emittable = Set(LibraryDiskScanner.diskToPanel.values)
+            .union(LibraryDiskScanner.identityCategories)
+        #expect(
+            emittable == Self.panelCategoriesV304,
+            """
+            emittable-but-not-Panel: \(emittable.subtracting(Self.panelCategoriesV304).sorted()); \
+            Panel-but-unreachable: \(Self.panelCategoriesV304.subtracting(emittable).sorted())
+            """
+        )
     }
 
-    private func loadPanelCategoriesFromResource() throws -> Set<String> {
-        // Tests run from the package root by default; try a couple of
-        // candidate paths so either a raw `swift test` invocation or one
-        // launched from a subdirectory still resolves the resource.
-        let fm = FileManager.default
-        let candidates = [
-            fm.currentDirectoryPath + "/Resources/library-inventory.json",
-            fm.currentDirectoryPath + "/../Resources/library-inventory.json",
-        ]
-        for path in candidates where fm.fileExists(atPath: path) {
-            let data = try Data(contentsOf: URL(fileURLWithPath: path))
-            if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let cats = obj["categories"] as? [String] {
-                return Set(cats)
-            }
-        }
-        return []
+    /// The real mapping-drift detector, and the one the old test could not be:
+    /// when Logic ships a new sub-taxonomy under a category the table already
+    /// knows, the scanner drops it. A silent drop costs the user library
+    /// content with no signal, so the drop must be counted and reported.
+    ///
+    /// This runs everywhere, including CI, because it drives a fixture rather
+    /// than the installed Library.
+    @Test("a new sub-taxonomy under a known parent is dropped, counted, and reported")
+    func newSubTaxonomyIsReportedNotSilentlyDropped() throws {
+        let (bundle, tmp) = try makeFixture(tree: [
+            "Keyboard/Acoustic Piano/Grand.patch",
+            "Keyboard/Harpsichord/Flemish.patch",
+        ])
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let root = try LibraryDiskScanner.scan(bundleURL: bundle)
+
+        #expect(root.categories == ["Acoustic Piano"])
+        #expect(!root.categories.contains("Harpsichord"))
+        #expect(root.candidatePatchCount == 2)
+        #expect(root.nonApplicablePatchCount == 1)
+        #expect(root.scanWarnings.contains { warning in
+            warning.contains("unmapped_patch")
+                && warning.contains("Keyboard/Harpsichord/Flemish")
+                && warning.contains("no_panel_taxonomy_route")
+        })
+    }
+
+    /// The subset property on the installed Library. It is environment-bound,
+    /// so the condition is a trait: where no Library exists the framework
+    /// reports the test as skipped instead of running a body that returns
+    /// early. An early return reads as a pass, which is how the previous
+    /// version of this test asserted nothing on CI for its whole life.
+    @Test("installed Library emits no category outside the Panel inventory",
+          .enabled(if: installedLogicLibraryExists))
+    func installedLibraryEmitsOnlyPanelCategories() throws {
+        let root = try LibraryDiskScanner.scan()
+        let unexpected = Set(root.categories).subtracting(Self.panelCategoriesV304)
+        #expect(unexpected.isEmpty, "emitted outside the Panel inventory: \(unexpected.sorted())")
     }
 
     @Test("scan handles symlink cycles via visited-set guard (no runaway recursion)")

--- a/Tests/LogicProMCPTests/ProcessUtilsStdioParityTests.swift
+++ b/Tests/LogicProMCPTests/ProcessUtilsStdioParityTests.swift
@@ -19,17 +19,16 @@ import Testing
 // Logic Pro), so this guard is most useful on developer machines and
 // any future macOS runner with Logic available.
 
-private func logicProInstalled() -> Bool {
-    return FileManager.default.fileExists(atPath: "/Applications/Logic Pro.app")
-}
+/// Evaluated once, and used as an `.enabled(if:)` trait rather than as a guard
+/// inside each body. A body that returns early on a missing Logic install is
+/// reported as a passing test, so on a host without Logic these two would have
+/// claimed to pin the post-fix behaviour while asserting nothing at all.
+private let logicProInstalled: Bool = FileManager.default.fileExists(
+    atPath: "/Applications/Logic Pro.app"
+)
 
-@Test(codexSeatbeltProcessInspectionDisabled)
+@Test(codexSeatbeltProcessInspectionDisabled, .enabled(if: logicProInstalled))
 func testProcessUtilsBundleURLResolvesWithoutAppKitRunloop() async {
-    guard logicProInstalled() else {
-        // CI without Logic Pro — the assertion below would fail on
-        // missing bundle, not on the bug under test. Skip cleanly.
-        return
-    }
 
     // Run the lookup on a detached cooperative-pool task — no main
     // runloop, no AppKit context. Pre-fix this returned nil because
@@ -44,10 +43,8 @@ func testProcessUtilsBundleURLResolvesWithoutAppKitRunloop() async {
     #expect(url?.lastPathComponent == "Logic Pro.app")
 }
 
-@Test(codexSeatbeltProcessInspectionDisabled)
+@Test(codexSeatbeltProcessInspectionDisabled, .enabled(if: logicProInstalled))
 func testProcessUtilsLogicProVersionResolvesOffMain() async {
-    guard logicProInstalled() else { return }
-
     let version: String? = await Task.detached(priority: .userInitiated) {
         ProcessUtils.logicProVersion(runtime: .production)
     }.value


### PR DESCRIPTION
## The defect

`LibraryDiskScannerTests` had a check named *"every emitted category exists in Resources/library-inventory.json Panel snapshot"*. It read its oracle from `Resources/library-inventory.json` — a path matched by `.gitignore:29`, so it can never be the committed snapshot the test's own comment described.

That produced two failures at once:

- **On CI the file is absent**, the body returned early, and the test asserted nothing for its entire life.
- **Locally it resolved to whatever the last AX probe left behind.** On this machine that was a seven-node, two-category artifact (`source: ax`, generated 2026-08-07), so the full suite was **red** against the real Library with 15 issues — all from this one test.

The check could not have caught what it was named for in any case. `mapDiskPathToPanel` returns `nil` for an unmapped path and the caller drops it, so no raw disk name is ever emitted. The subset property it asserted holds **vacuously**.

## The replacement

Three checks, and the mapping range is now pinned in a file that can actually be committed.

| check | what it catches | runs on CI |
|---|---|---|
| `mappingTableRangeEqualsPanelInventory` | a table edit inventing a category `selectPath` could never navigate to, or a Panel category becoming unreachable | yes |
| `newSubTaxonomyIsReportedNotSilentlyDropped` | the real drift case — Logic ships a new sub-taxonomy under a known parent and it is dropped; asserts the drop is counted and reported, not silent | yes |
| `installedLibraryEmitsOnlyPanelCategories` | the subset property on a real Library | skipped via `.enabled(if:)` |

The environment condition moved from an early `return` to an `.enabled(if:)` trait, so an absent Library is reported by the framework as a **skip** rather than as a body that returns early and reads as a pass.

The source comment claiming the table is *"Verified against `Resources/library-inventory.json`"* is corrected — it names the test that actually pins it, and says why that path cannot be the source.

## Mutation evidence

All four assertions were mutated and observed to fail, so none of them is green by construction:

| mutation | result |
|---|---|
| add `"Woodwind/Flutes": "Flutes"` to `diskToPanel` | `mappingTableRangeEqualsPanelInventory` **FAIL** |
| let an unmapped taxonomy leak through under its raw disk name | `newSubTaxonomyIsReportedNotSilentlyDropped` **FAIL** (3 issues) |
| change the recorded reason off `no_panel_taxonomy_route` | `newSubTaxonomyIsReportedNotSilentlyDropped` **FAIL** |
| drop `Studio Horns` from the oracle | `installedLibraryEmitsOnlyPanelCategories` **FAIL** |

## Verification

- Full suite: **`Test run with 3371 tests passed`, exit 0.** It was **red on `main`** with 15 issues in this one test.
- `Scripts/ci-forbid-dead-expect.sh`: clean.
- No production behaviour changes; the only `Sources` edit is a doc comment.