### PR TITLE
Revert PR #466 — merged without a recorded exact-head PASS

### DIFF
--- a/Sources/LogicProMCP/Accessibility/LibraryDiskScanner.swift
+++ b/Sources/LogicProMCP/Accessibility/LibraryDiskScanner.swift
@@ -69,11 +69,7 @@ enum LibraryDiskScanner {
     /// 1-segment Panel path `Acoustic Drums/...` before the fallback
     /// `Drums & Percussion` → (no-match) check runs.
     ///
-    /// The combined range of this table and `identityCategories` is pinned
-    /// against the v3.0.4 Panel inventory by `LibraryDiskScannerTests`. It is
-    /// not verified against `Resources/library-inventory.json`: that path is
-    /// matched by `.gitignore`, so it is absent on CI and is a stale local AX
-    /// probe artifact anywhere else.
+    /// Verified against `Resources/library-inventory.json` (AX panel snapshot).
     /// Panel categories: Bass, Acoustic Drums, Electronic Drums, Percussion,
     /// Guitar, Acoustic Piano, Clavinet, Electric Piano, Mellotron, Organ,
     /// Mallet, Studio Horns, Studio Strings, Synthesizer, Orchestral, World.

--- a/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
+++ b/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
@@ -2,14 +2,6 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
-/// Whether this machine has the Logic factory Library installed. Used as an
-/// `.enabled(if:)` trait so an absent Library is reported as a skipped test
-/// rather than as a body that returns early and counts as a pass.
-private let installedLogicLibraryExists: Bool = FileManager.default.fileExists(
-    atPath: URL(fileURLWithPath: NSHomeDirectory())
-        .appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath).path
-)
-
 /// v3.0.5 — filesystem-backed library scan tests. Uses a real temp dir
 /// populated with fixture `.patch` bundles (empty directories suffixed with
 /// `.patch`) so the production code path under `FileManager.default` is
@@ -233,9 +225,14 @@ struct LibraryDiskScannerTests {
     /// on the machine. Verifies that a full scan returns a clinically
     /// implausible-low count (e.g. under 1000 leaves) does NOT ship — the
     /// whole point of v3.0.5 is to fix the 345-leaf undercount.
-    @Test("local-machine integration: factory Library reports at least 1000 leaves when present",
-          .enabled(if: installedLogicLibraryExists))
+    @Test("local-machine integration: factory Library reports at least 1000 leaves when present")
     func scanLocalFactoryLibraryReportsFullCoverage() throws {
+        let home = URL(fileURLWithPath: NSHomeDirectory())
+        let bundleURL = home.appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath)
+        guard FileManager.default.fileExists(atPath: bundleURL.path) else {
+            // Expected in CI; skip silently.
+            return
+        }
         let root = try LibraryDiskScanner.scan()
         #expect(
             root.leafCount >= 1000,
@@ -543,78 +540,53 @@ struct LibraryDiskScannerTests {
         #expect(kit.path == "Acoustic Drums/Multi-Channel Kits/8-Bit+")
     }
 
-    /// The v3.0.4 AX Panel inventory, as the sixteen category names the Panel
-    /// exposes. This lives here, in a committed file, because the machine-local
-    /// `Resources/library-inventory.json` it used to be read from is matched by
-    /// `.gitignore` and therefore can never be a shared oracle: on CI it is
-    /// absent, and on a developer machine it is whatever the last AX probe left
-    /// behind, which is not a Panel snapshot at all.
-    private static let panelCategoriesV304: Set<String> = [
-        "Bass", "Acoustic Drums", "Electronic Drums", "Percussion",
-        "Guitar", "Acoustic Piano", "Clavinet", "Electric Piano",
-        "Mellotron", "Organ", "Mallet", "Studio Horns",
-        "Studio Strings", "Synthesizer", "Orchestral", "World",
-    ]
+    /// v3.0.6 contract assertion: every emitted top-level category must exist
+    /// in the v3.0.4 AX Panel snapshot's `categories` array. This is the
+    /// "mapping bug detector" — if a new disk taxonomy slips through without
+    /// a `diskToPanel` entry, this test starts failing.
+    @Test("scan result: every emitted category exists in Resources/library-inventory.json Panel snapshot")
+    func everyEmittedCategoryExistsInPanelInventory() throws {
+        let home = URL(fileURLWithPath: NSHomeDirectory())
+        let bundleURL = home.appendingPathComponent(LibraryDiskScanner.defaultBundleRelativePath)
+        guard FileManager.default.fileExists(atPath: bundleURL.path) else {
+            // Expected in CI; skip silently.
+            return
+        }
 
-    /// The mapping tables are the only two ways a category can be emitted, so
-    /// their combined range **is** the set of categories the scanner can
-    /// produce. Pinning that range against the Panel inventory catches a table
-    /// edit that invents a category `selectPath` could never navigate to —
-    /// which is the failure the old subset check was named for but could not
-    /// detect, because a path with no table entry is dropped rather than
-    /// emitted under its raw disk name.
-    @Test("the mapping tables can only ever emit v3.0.4 Panel categories")
-    func mappingTableRangeEqualsPanelInventory() {
-        let emittable = Set(LibraryDiskScanner.diskToPanel.values)
-            .union(LibraryDiskScanner.identityCategories)
-        #expect(
-            emittable == Self.panelCategoriesV304,
-            """
-            emittable-but-not-Panel: \(emittable.subtracting(Self.panelCategoriesV304).sorted()); \
-            Panel-but-unreachable: \(Self.panelCategoriesV304.subtracting(emittable).sorted())
-            """
-        )
-    }
+        // Load Panel snapshot from committed resource. Scan-result
+        // categories must be a subset.
+        let panelCategories = try loadPanelCategoriesFromResource()
+        guard !panelCategories.isEmpty else {
+            // Fixture missing — skip rather than misreport.
+            return
+        }
 
-    /// The real mapping-drift detector, and the one the old test could not be:
-    /// when Logic ships a new sub-taxonomy under a category the table already
-    /// knows, the scanner drops it. A silent drop costs the user library
-    /// content with no signal, so the drop must be counted and reported.
-    ///
-    /// This runs everywhere, including CI, because it drives a fixture rather
-    /// than the installed Library.
-    @Test("a new sub-taxonomy under a known parent is dropped, counted, and reported")
-    func newSubTaxonomyIsReportedNotSilentlyDropped() throws {
-        let (bundle, tmp) = try makeFixture(tree: [
-            "Keyboard/Acoustic Piano/Grand.patch",
-            "Keyboard/Harpsichord/Flemish.patch",
-        ])
-        defer { try? FileManager.default.removeItem(at: tmp) }
-
-        let root = try LibraryDiskScanner.scan(bundleURL: bundle)
-
-        #expect(root.categories == ["Acoustic Piano"])
-        #expect(!root.categories.contains("Harpsichord"))
-        #expect(root.candidatePatchCount == 2)
-        #expect(root.nonApplicablePatchCount == 1)
-        #expect(root.scanWarnings.contains { warning in
-            warning.contains("unmapped_patch")
-                && warning.contains("Keyboard/Harpsichord/Flemish")
-                && warning.contains("no_panel_taxonomy_route")
-        })
-    }
-
-    /// The subset property on the installed Library. It is environment-bound,
-    /// so the condition is a trait: where no Library exists the framework
-    /// reports the test as skipped instead of running a body that returns
-    /// early. An early return reads as a pass, which is how the previous
-    /// version of this test asserted nothing on CI for its whole life.
-    @Test("installed Library emits no category outside the Panel inventory",
-          .enabled(if: installedLogicLibraryExists))
-    func installedLibraryEmitsOnlyPanelCategories() throws {
         let root = try LibraryDiskScanner.scan()
-        let unexpected = Set(root.categories).subtracting(Self.panelCategoriesV304)
-        #expect(unexpected.isEmpty, "emitted outside the Panel inventory: \(unexpected.sorted())")
+        for cat in root.categories {
+            #expect(
+                panelCategories.contains(cat),
+                "Disk scan emitted `\(cat)` which is not in the v3.0.4 AX Panel snapshot (\(panelCategories.sorted()))"
+            )
+        }
+    }
+
+    private func loadPanelCategoriesFromResource() throws -> Set<String> {
+        // Tests run from the package root by default; try a couple of
+        // candidate paths so either a raw `swift test` invocation or one
+        // launched from a subdirectory still resolves the resource.
+        let fm = FileManager.default
+        let candidates = [
+            fm.currentDirectoryPath + "/Resources/library-inventory.json",
+            fm.currentDirectoryPath + "/../Resources/library-inventory.json",
+        ]
+        for path in candidates where fm.fileExists(atPath: path) {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let cats = obj["categories"] as? [String] {
+                return Set(cats)
+            }
+        }
+        return []
     }
 
     @Test("scan handles symlink cycles via visited-set guard (no runaway recursion)")

--- a/Tests/LogicProMCPTests/ProcessUtilsStdioParityTests.swift
+++ b/Tests/LogicProMCPTests/ProcessUtilsStdioParityTests.swift
@@ -19,16 +19,17 @@ import Testing
 // Logic Pro), so this guard is most useful on developer machines and
 // any future macOS runner with Logic available.
 
-/// Evaluated once, and used as an `.enabled(if:)` trait rather than as a guard
-/// inside each body. A body that returns early on a missing Logic install is
-/// reported as a passing test, so on a host without Logic these two would have
-/// claimed to pin the post-fix behaviour while asserting nothing at all.
-private let logicProInstalled: Bool = FileManager.default.fileExists(
-    atPath: "/Applications/Logic Pro.app"
-)
+private func logicProInstalled() -> Bool {
+    return FileManager.default.fileExists(atPath: "/Applications/Logic Pro.app")
+}
 
-@Test(codexSeatbeltProcessInspectionDisabled, .enabled(if: logicProInstalled))
+@Test(codexSeatbeltProcessInspectionDisabled)
 func testProcessUtilsBundleURLResolvesWithoutAppKitRunloop() async {
+    guard logicProInstalled() else {
+        // CI without Logic Pro — the assertion below would fail on
+        // missing bundle, not on the bug under test. Skip cleanly.
+        return
+    }
 
     // Run the lookup on a detached cooperative-pool task — no main
     // runloop, no AppKit context. Pre-fix this returned nil because
@@ -43,8 +44,10 @@ func testProcessUtilsBundleURLResolvesWithoutAppKitRunloop() async {
     #expect(url?.lastPathComponent == "Logic Pro.app")
 }
 
-@Test(codexSeatbeltProcessInspectionDisabled, .enabled(if: logicProInstalled))
+@Test(codexSeatbeltProcessInspectionDisabled)
 func testProcessUtilsLogicProVersionResolvesOffMain() async {
+    guard logicProInstalled() else { return }
+
     let version: String? = await Task.detached(priority: .userInitiated) {
         ProcessUtils.logicProVersion(runtime: .production)
     }.value


### PR DESCRIPTION
Reverts the merge commit `da9ca1f4a0a7f4db1774afec4d613582556f4f7b` (PR #466), which reached `main` without a recorded exact-head final PASS. This is the revert executed through the PR and verification path rather than a direct push to `main`.

## What this restores

`git revert -m 1 da9ca1f4`. The resulting tree is **byte-identical to pre-merge `main`** for the whole of `Sources/` and `Tests/`:

```
$ git diff --stat da9ca1f4^1 HEAD -- Sources Tests
(no output)
```

Three files return to their pre-#466 content: `LibraryDiskScanner.swift` (6 lines, comment only), `LibraryDiskScannerTests.swift` (128), `ProcessUtilsStdioParityTests.swift` (21). 63 insertions, 92 deletions.

## Verification, including the consequence

| | pre-merge `main` (`da9ca1f4^1`) | `main` at `da9ca1f4` | this revert (`98b57116`) |
|---|---|---|---|
| build | — | — | **exit 0** |
| full suite | RED | `3371 tests passed`, exit 0 | **`3369 tests failed`, exit 1** |
| issues | 15 | 0 | **15** |

**The revert re-opens a red suite.** All 15 issues are in one test, `scan result: every emitted category exists in Resources/library-inventory.json Panel snapshot`, and they are the same 15 that stood on `main` before #466. That is the faithful consequence of restoring the prior state, not a defect in the revert — reported here rather than left for the reviewer to discover.

The underlying defect is therefore back on `main` if this merges:

- the test's oracle is read from a path matched by `.gitignore:29`, so on CI it is absent and the body returns early, asserting nothing;
- on a host with a stale `Resources/library-inventory.json` it compares the real Library against that artifact and fails;
- and its stated purpose is unreachable either way, because `mapDiskPathToPanel` returns `nil` for an unmapped path and the caller drops it, so no raw disk name is ever emitted.

I am not folding a re-fix into this PR. The revert should land or not land on its own, and any successor fix goes through its own review.

## Preflight

`C1a`, `C1c`, `C2`, `C3a`, `C3b` clean. **`C1b` reports FAIL** on two lines:

```
+@Test(codexSeatbeltProcessInspectionDisabled)
```

Both are byte-identical to lines already present in pre-merge `main` — `Tests/LogicProMCPTests/ProcessUtilsStdioParityTests.swift` lines 26 and 47 at `da9ca1f4^1`. This branch adds 2 occurrences and removes 2: **net zero**. `C1b` matches added lines without checking whether the token is new, so a revert to a state that already existed on `main` trips it structurally.

I have not modified the preflight script to clear this. The standing debt it is pointing at is tracked separately in #467.