### PR TITLE
docs: drop internal review-workflow citations from public comments

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -257,7 +257,7 @@ extension AccessibilityChannel {
     /// (when 12.2 has dropped the arrangement-area identifier). Pre-v3.1.9
     /// this function did its own copy of the marker-list-window strategy
     /// AND then called `enumerateMarkers(in:)` which redundantly retried
-    /// the same lookup — boomer review flagged the double scrape.
+    /// the same lookup.
     /// v3.1.9-final puts strategy ordering in `enumerateMarkers` and uses
     /// the in-window helper directly only when there is no arrangement
     /// area to pass.

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -259,7 +259,7 @@ actor ChannelRouter {
         // on a structured error code instead of regex-matching a free-form
         // string. Uses the dedicated `.channelsExhausted` error rather than
         // `.portUnavailable` (which is reserved for the bypass-op "this
-        // channel's port is unwired" semantic;
+        // channel's port is unwired" semantic; see
         // v3.4.5-rc5). `last_error` carries the original chain detail for
         // debugging; `operation` lets the harness route to per-op recovery.
         return .error(HonestContract.encodeStateC(

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -259,7 +259,7 @@ actor ChannelRouter {
         // on a structured error code instead of regex-matching a free-form
         // string. Uses the dedicated `.channelsExhausted` error rather than
         // `.portUnavailable` (which is reserved for the bypass-op "this
-        // channel's port is unwired" semantic — see Boomer BOOMER-6 / U,
+        // channel's port is unwired" semantic;
         // v3.4.5-rc5). `last_error` carries the original chain detail for
         // debugging; `operation` lets the harness route to per-op recovery.
         return .error(HonestContract.encodeStateC(

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -102,7 +102,7 @@ actor MCUChannel: Channel {
         let pollIntervalNs: UInt64 = 25_000_000
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
         while Date() < deadline {
-            // v3.4.5-rc5 (Boomer BOOMER-6 / B2): read volume + timestamp
+            // v3.4.5-rc5: read volume + timestamp
             // in a single actor turn. Two separate awaits left a TOCTOU
             // window where a concurrent `updateFader` could pair an old
             // value with a new timestamp and false-positive State A.
@@ -159,7 +159,7 @@ actor MCUChannel: Channel {
         let pollIntervalNs: UInt64 = 25_000_000
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
         while Date() < deadline {
-            // v3.4.5-rc5 (Boomer BOOMER-6 / B2): atomic (pan, updatedAt)
+            // v3.4.5-rc5: atomic (pan, updatedAt)
             // snapshot — same TOCTOU rationale as pollFaderEcho.
             let snapshot = await cache.getPanEchoSnapshot(strip: strip)
             if let observed = snapshot.pan, abs(observed - target) <= tolerance {

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -50,7 +50,7 @@ struct NavigateDispatcher: OperationTraceDispatching {
             return await finalizeTrace(finalized, traceID: traceID)
 
         case "goto_marker":
-            // v3.1.10 (boomer P1-1) — resolve the target marker from cache and
+            // v3.1.10: resolve the target marker from cache and
             // navigate via `transport.goto_position` using its `position`
             // string. Pre-v3.1.10 this routed to `nav.goto_marker` →
             // `MIDIKeyCommandsChannel` CC 38 (Logic's "go to next marker"

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -949,7 +949,7 @@ struct ProjectDispatcher: OperationTraceDispatching {
     /// commands. Splits the prior single `executed` line into three signals
     /// a SIEM can filter on.
     ///
-    /// **Contract — v3.4.1 (Boomer P2-3):** `executed` is emitted
+    /// **Contract — v3.4.1:** `executed` is emitted
     /// **immediately before** `router.route(...)` fires, not after. This
     /// records *invocation intent* rather than *outcome*. The reasons:
     ///   - Outcome lives in the channel response (success / hard error).

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -130,7 +130,7 @@ extension ResourceHandlers {
     ///      came up empty; "project_file" if poller never ran.
     ///   3. Empty array. Source: "default".
     ///
-    /// Inspector contamination guard (boomer P0 / E10): when AX traversal
+    /// Inspector contamination guard: when AX traversal
     /// returns >= 3 entries whose names ALL end in `:`, treat the data as the
     /// Inspector subtree leaking through (Logic Pro 12.x failure mode where a
     /// non-arrange panel is focused). Drop those rows and fall to Tier 2/3.
@@ -406,7 +406,7 @@ extension ResourceHandlers {
         let cacheFresh = projectFetchedAt > .distantPast || cached.lastUpdated > .distantPast
         let transportFresh = cachedTransport.lastUpdated > .distantPast
 
-        // Per-field merge (boomer P0): the existing AX `defaultGetProjectInfo`
+        // Per-field merge: the existing AX `defaultGetProjectInfo`
         // populates ONLY `name` + `lastUpdated`; tempo / timeSignature /
         // trackCount stay at struct defaults (120, "4/4", 0). A whole-record
         // "cache fresh wins" rule would therefore mask the file's correct

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -378,7 +378,7 @@ actor StateCache {
         return cs.pan
     }
 
-    /// v3.4.5-rc5 (Boomer BOOMER-6 / B2 — TOCTOU race fix). Atomic snapshot
+    /// v3.4.5-rc5 — TOCTOU race fix. Atomic snapshot
     /// of (volume, faderUpdatedAt) for a strip in a single actor turn.
     ///
     /// Background: `pollFaderEcho` previously read the volume and the
@@ -394,7 +394,7 @@ actor StateCache {
                 faderUpdatedAt[strip])
     }
 
-    /// v3.4.5-rc5 (Boomer BOOMER-6 / B2). Pan counterpart to
+    /// v3.4.5-rc5. Pan counterpart to
     /// `getFaderEchoSnapshot`. Same atomicity rationale.
     func getPanEchoSnapshot(strip: Int) -> (pan: Double?, updatedAt: Date?) {
         return (channelStrips.indices.contains(strip) ? channelStrips[strip].pan : nil,

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -145,8 +145,7 @@ struct MarkerState: Sendable, Codable, Identifiable, Equatable {
     var positionSource: PositionSource
 
     /// `positionSource` 기본값은 `.unknown` — 호출 site가 명시적으로 `.parser`/
-    /// `.fallback` 을 지정하지 않으면 silent false provenance 발생을 방지한다
-    /// (boomer Phase G P2-1).
+    /// `.fallback` 을 지정하지 않으면 silent false provenance 발생을 방지한다.
     init(id: Int, name: String, position: String, positionSource: PositionSource = .unknown) {
         self.id = id
         self.name = name
@@ -155,7 +154,7 @@ struct MarkerState: Sendable, Codable, Identifiable, Equatable {
     }
 
     // v3.2 — Codable backward compat. v3.1.x snapshot 에 positionSource field 없음 →
-    // `.unknown` 으로 decode (false provenance 차단; boomer Phase C P1-2).
+    // `.unknown` 으로 decode (false provenance 차단).
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try c.decode(Int.self, forKey: .id)

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -78,7 +78,7 @@ enum HonestContract {
         /// candidate. Distinct from `.portUnavailable` (a specific channel's
         /// port is missing) and `.logicNotRunning` (a single channel's
         /// process gone): exhaustion is the chain-level aggregate signal.
-        /// v3.4.5-rc5 (Boomer BOOMER-6 / U — fixes semantic overload where
+        /// v3.4.5-rc5 (to fix semantic overload where
         /// every router fallthrough was being mis-classified as
         /// `port_unavailable` regardless of root cause).
         case channelsExhausted = "channels_exhausted"

--- a/Tests/LogicProMCPTests/ChannelRouterBypassReadinessTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterBypassReadinessTests.swift
@@ -169,7 +169,7 @@ private func parseEnvelope(_ msg: String) -> [String: Any]? {
     // channel reports available:false (the specific port for that op is
     // missing). When a non-bypass op exhausts every channel in its chain,
     // the wire surfaces `channels_exhausted` instead — the two States are
-    // now semantically distinct (Boomer BOOMER-6 / U, v3.4.5-rc5):
+    // now semantically distinct (v3.4.5-rc5):
     //   - portUnavailable: scoped to a bypass op whose dedicated channel
     //     reports its port is unwired (e.g. KeyCmd port not published).
     //   - channelsExhausted: chain-level aggregate when no channel could

--- a/Tests/LogicProMCPTests/CommercialReadinessTests.swift
+++ b/Tests/LogicProMCPTests/CommercialReadinessTests.swift
@@ -54,7 +54,7 @@ private let toolText = sharedToolText
 }
 
 @Test func testNavigateDispatcherGotoMarkerByNameUsesCachedMarker() async {
-    // v3.1.10 (boomer P1-1) — name-based goto resolves the marker from
+    // v3.1.10: name-based goto resolves the marker from
     // cache, then routes via `transport.goto_position` using the
     // marker's `position` string. Pre-v3.1.10 routed via the keycmd
     // `nav.goto_marker` (CC 38) which ignores params and just fires the
@@ -80,7 +80,7 @@ private let toolText = sharedToolText
 }
 
 @Test func testNavigateDispatcherGotoMarkerByIndexUsesCachedPosition() async {
-    // v3.1.10 (boomer P1-1) — index-based goto also resolves from cache
+    // v3.1.10: index-based goto also resolves from cache
     // and routes via position when the marker is present.
     let router = ChannelRouter()
     let ax = MockChannel(id: .accessibility)

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -3198,7 +3198,7 @@ private actor SelectiveFailChannel: Channel {
     #expect(mcuOps.isEmpty)
     expectExecutedOps(axOps, equals: [
         ("transport.goto_position", ["position": "12.1.1.1"]),
-        // v3.1.10 (boomer P1-1) — both index- and name-based goto_marker
+        // v3.1.10: both index- and name-based goto_marker
         // now resolve from cache and route via transport.goto_position
         // using the marker's `position` string (chorus at 17.1.1.1).
         ("transport.goto_position", ["position": "17.1.1.1"]),

--- a/Tests/LogicProMCPTests/IntegrationTests.swift
+++ b/Tests/LogicProMCPTests/IntegrationTests.swift
@@ -93,7 +93,7 @@ import Foundation
     // No channels registered → error but no crash. v3.4.5-rc5 (Issues
     // #10/#11): the router now wraps chain exhaustion in a HC State C
     // `channels_exhausted` envelope (semantically distinct from
-    // `port_unavailable` per Boomer BOOMER-6 / U) instead of the legacy
+    // `port_unavailable`) instead of the legacy
     // free-form "All channels exhausted" string so harnesses can branch
     // on a stable error code.
     #expect(!result.isSuccess)

--- a/Tests/LogicProMCPTests/MCUMixerWriteDiagnosticsTests.swift
+++ b/Tests/LogicProMCPTests/MCUMixerWriteDiagnosticsTests.swift
@@ -184,7 +184,7 @@ private actor SlowSendMCUTransport: MCUTransportProtocol {
     #expect(obj["mcu_last_feedback_age_ms"] is NSNull)
 }
 
-// v3.4.5-rc5 (Boomer BOOMER-6 / B2) — regression guard for the TOCTOU
+// v3.4.5-rc5 — regression guard for the TOCTOU
 // race that previously let `pollFaderEcho` pair an old value with a new
 // timestamp and false-positive State A. The fix routes both reads
 // through `StateCache.getFaderEchoSnapshot` so they happen in the same
@@ -248,7 +248,7 @@ private actor SlowSendMCUTransport: MCUTransportProtocol {
 }
 
 @Test func testMCUDiagnosticsClampsNegativeAgeFromClockJump() async {
-    // Boomer P2 (BOOMER-6 / E): if the system clock slews backwards between
+    // If the system clock slews backwards between
     // the feedback timestamp and the diagnostic read, `Date.timeIntervalSince`
     // returns a negative interval. The wire format must never carry a
     // negative age — clamp to 0 so harnesses can rely on the field being a

--- a/Tests/LogicProMCPTests/MarkerProvenanceTests.swift
+++ b/Tests/LogicProMCPTests/MarkerProvenanceTests.swift
@@ -23,7 +23,7 @@ func markerState_codableRoundTrip(_ source: PositionSource) throws {
 }
 
 // v3.1.x cache snapshot 디코딩 — positionSource field 없음 → .unknown
-// (Boomer P1-2: false provenance 차단).
+// false provenance 차단.
 @Test("MarkerState legacy snapshot decode → .unknown")
 func markerState_legacySnapshot_decodesAsUnknown() throws {
     let legacyJSON = #"{"id":0,"name":"VOCALS","position":"146.4.4.240"}"#

--- a/Tests/LogicProMCPTests/PluginInspectorPathTests.swift
+++ b/Tests/LogicProMCPTests/PluginInspectorPathTests.swift
@@ -113,7 +113,7 @@ struct PluginInspectorPathTests {
     }
 
     @Test func resolveNegativeDisambigIndexReturnsNil() throws {
-        // Regression: negative index must not crash (P0 from Phase 6 boomer review)
+        // Regression: negative index must not crash.
         let hops = try PluginInspector.resolveMenuPath("Synth/Pad[-1]", in: fixture())
         #expect(hops == nil)
     }

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -885,7 +885,7 @@ private func runChannelEQFixture(
     #expect(!((obj["write_attempted"] as? Bool)!))
 }
 
-// MARK: - #234 zero-slot slot-addressing diagnostics (AC-5 / boomer R2-#2)
+// MARK: - #234 zero-slot slot-addressing diagnostics (AC-5)
 
 @Test func testSetParamVerifiedZeroSlotsStateCDistinctDiagnostics() async {
     // A zero-slot (Master-shaped) target strip through set_param_verified's slot-

--- a/Tests/LogicProMCPTests/PluginWindowLifecycleTests.swift
+++ b/Tests/LogicProMCPTests/PluginWindowLifecycleTests.swift
@@ -111,7 +111,7 @@ struct PluginWindowLifecycleTests {
     }
 
     @Test func openWindowTimeoutExactBoundaryThrows() async {
-        // Regression: at exactly timeoutMs elapsed, must throw (P2 from Phase 6 boomer review)
+        // Regression: at exactly timeoutMs elapsed, must throw.
         let clock = MutableBox(0)
         let win = wrapper()
         let runtime = PluginWindowRuntime(

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -116,7 +116,7 @@ struct SemanticOracleEngineTests {
     }
 
     /// #373 B1 equality-matrix — pins the exact `.fieldsEqual` contract every
-    /// safe-mutation oracle's requested==observed leans on (grok-ratified). It
+    /// safe-mutation oracle's requested==observed check relies on. It
     /// must accept `3`/`3.0` (JSON does not distinguish int/double), reject a
     /// number-vs-string `3`/`"3"`, and — crucially — never read an ABSENT key as
     /// agreement: `null`/missing and `""`/missing both fail closed.

--- a/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
+++ b/Tests/LogicProMCPTests/SetupDoctorEnterpriseTests.swift
@@ -571,7 +571,7 @@ private func runEntrypoint(
 // MARK: - Phase-6 final-review hardening
 
 @Test func test_t4_normalize_version_strips_prerelease_suffix() {
-    // boomer-1: a pre-release tag must not be ranked newer than its GA release.
+    // A pre-release tag must not be ranked newer than its GA release.
     #expect(SetupDoctor.normalizeVersion("v4.0.0-beta.1") == "4.0.0")
     #expect(SetupDoctor.normalizeVersion("4.0.0-rc.2") == "4.0.0")
     #expect(SetupDoctor.compareVersions(SetupDoctor.normalizeVersion("4.0.0"), SetupDoctor.normalizeVersion("4.0.0-beta.1")) == 0)
@@ -604,7 +604,7 @@ private func runEntrypoint(
 }
 
 @Test func test_t3_headline_not_healthy_when_degraded_skipped_only() {
-    // boomer-E2 / guardian-P2-1: a skipped-only degraded report must not claim "healthy".
+    // A skipped-only degraded report must not claim "healthy".
     // macOS unreadable → skipped (info severity, no actionable check) but aggregate degraded.
     let report = makeReport(runtime: enterpriseRuntime(macOSVersion: nil))
     #expect(report.status == .degraded)
@@ -614,7 +614,7 @@ private func runEntrypoint(
 // MARK: - Final merge-gate hardening (zero-edge-case pass)
 
 @Test func test_t4_update_unparseable_tag_is_skipped_not_false_pass() throws {
-    // boomer-B1/B5: a tag with no numeric major (bare "v", pure pre-release, "latest")
+    // A tag with no numeric major (bare "v", pure pre-release, "latest")
     // must NOT be reported "up to date" — it normalizes to no version and is unparseable.
     for raw in ["v", "-beta.1", "latest", ""] {
         let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: raw) }))
@@ -625,7 +625,7 @@ private func runEntrypoint(
 }
 
 @Test func test_t1_summary_counts_invariant_with_update_check_14() {
-    // boomer-B2-3: invariant must hold with the opt-in update check present (14 checks).
+    // The invariant must hold with the opt-in update check present (14 checks).
     let report = makeReport(runtime: enterpriseRuntime(latestReleaseLookup: { .found(version: ServerConfig.serverVersion) }))
     #expect(report.checks.count == 27)
     let s = report.summary
@@ -634,7 +634,7 @@ private func runEntrypoint(
 }
 
 @Test func test_t4_entrypoint_check_updates_flag_surfaces_update_check() async {
-    // boomer-B2-2: the --check-updates flag path is wired through MainEntrypoint end-to-end.
+    // The --check-updates flag path is wired through MainEntrypoint end-to-end.
     // (Inject a fake lookup so the test is hermetic — no network.)
     let (_, out) = await runEntrypoint(
         ["LogicProMCP", "doctor", "--check-updates", "--json"],


### PR DESCRIPTION
Closes #467.

## What

`Sources/` and `Tests/` carried **30 comment lines across 20 files** citing an internal review workflow by name and tag scheme. The citations mean nothing to a reader outside that workflow; the sentences around them usually state a real reason worth keeping.

Each citation is removed and its rationale kept in place. Version tags sitting beside a citation stay — those are real provenance.

```
-    // v3.4.5-rc5 (<workflow tag>): read volume + timestamp
+    // v3.4.5-rc5: read volume + timestamp

-    /// **Contract — v3.4.1 (<workflow tag>):** `executed` is emitted
+    /// **Contract — v3.4.1:** `executed` is emitted
```

**Where the citation was the entire content of a clause, the clause is deleted rather than refilled.** A first pass replaced three of them with paraphrase, which is how a comment acquires a claim nobody checked — one invented `cost two traversals`, a quantity nothing in the repo establishes; one restated in English the Korean sentence it was attached to; one repeated a version tag already two lines above. All three are plain deletions now.

## Evidence

| check | result |
|---|---|
| `git grep -inE '(boomer\|grok)' -- Sources Tests \| wc -l` | **0** |
| same pattern outside scope (`Scripts`, `docs`) | **9 hits** — the 0 above is a real absence, not a broken pattern |
| added/removed lines that are **not** comments | **0** |
| diff | 20 files, **30 insertions, 31 deletions** (one line fewer: a two-line comment collapses to one) |
| `Package.resolved` | untouched |
| build | exit 0 |
| full suite | **`3371 tests passed`, exit 0** |
| preflight | **PASS** (C1a, C1b, C1c, C2, C3a, C3b) |

Every changed line pair was diffed at word level; the only two that introduce a word absent from the original are grammar repairs left behind by a removal (`— fixes` → `(to fix`, `leans on` → `check relies on`). Neither adds a claim.

## Not in scope, deliberately unchanged

- The vendor bundle identifiers the product matches on — real values, not workflow references.
- The sandbox environment variable the tests read to skip process inspection — names a real condition.

## Note on the preflight

`C1b` exists to stop exactly this class of text entering `Sources`/`Tests`, but it scans **added** lines only, so the 30 already on `main` were invisible to it for as long as they stood. The gate prevents growth; it does not measure the standing balance. Worth a standing-balance mode if the same debt reappears.