### PR TITLE
fix(#446): give verifyTransform an independent expected and a canonical compare

### DIFF
--- a/Sources/LogicProMCP/PianoRoll/TransformVerification.swift
+++ b/Sources/LogicProMCP/PianoRoll/TransformVerification.swift
@@ -6,7 +6,8 @@ enum TransformVerdict: Equatable, Sendable {
 
 func verifyTransform(
     plan: RegionTransformPlan,
-    observedAfter: MIDIRegionNoteSnapshot
+    observedAfter: MIDIRegionNoteSnapshot,
+    expected: IndependentExpectedProof
 ) -> TransformVerdict {
     guard observedAfter.complete else {
         return .stateBUnverified(
@@ -20,30 +21,49 @@ func verifyTransform(
     guard !overflow, observedAfter.projectEpoch == expectedGeneration else {
         return .stateBUnverified(reason: "Post-write generation transition is not verified")
     }
+    guard let independent = expected.independentPayload else {
+        return .stateBUnverified(reason: "expected must carry a sealed independent provenance proof")
+    }
+    guard independent.rootID != observedAfter.conversionPipelineID else {
+        return .stateBUnverified(reason: "expected root shares the observed conversion pipeline")
+    }
+    guard independent.region == observedAfter.regionReference else {
+        return .stateBUnverified(reason: "expected proof is not bound to the observed region")
+    }
+    guard independent.contentBinding == midiRegionNoteDigest(independent.notes, ppq: independent.ppq) else {
+        return .stateBUnverified(reason: "expected proof content binding is invalid")
+    }
+    guard observedAfter.ppq > 0, independent.ppq > 0 else {
+        return .stateBUnverified(reason: "PPQ must be positive")
+    }
 
-    let expected = sortedNotes(plan.predictedAfter)
-    let observed = sortedNotes(observedAfter.notes)
-    guard observed != expected else { return .stateA }
+    let actual = canonicalize(observedAfter.notes, ppq: observedAfter.ppq)
+    guard let normalized = normalizePPQ(
+        independent.notes,
+        from: independent.ppq,
+        to: observedAfter.ppq
+    ) else {
+        return .stateBUnverified(reason: "PPQ normalization overflow")
+    }
+    let wanted = canonicalize(normalized, ppq: observedAfter.ppq)
+    guard actual != wanted else {
+        return .stateBUnverified(
+            reason: "R1 grants no positive match; independent positive verification is R2 live-ingestion"
+        )
+    }
 
-    var unmatchedExpected = expected
-    let unexpected = observed.filter { note in
-        guard let index = unmatchedExpected.firstIndex(of: note) else { return true }
-        unmatchedExpected.remove(at: index)
-        return false
+    var unmatched = wanted
+    var unexpected: [MIDINoteEvent] = []
+    for note in actual {
+        if let index = unmatched.firstIndex(of: note) {
+            unmatched.remove(at: index)
+        } else {
+            unexpected.append(note)
+        }
     }
     return .mismatch(unexpected: unexpected)
 }
 
 func compensationNotes(plan: RegionTransformPlan) -> [MIDINoteEvent] {
     plan.beforeSnapshot.notes
-}
-
-private func sortedNotes(_ notes: [MIDINoteEvent]) -> [MIDINoteEvent] {
-    notes.sorted { lhs, rhs in
-        if lhs.pitch != rhs.pitch { return lhs.pitch < rhs.pitch }
-        if lhs.startTicks != rhs.startTicks { return lhs.startTicks < rhs.startTicks }
-        if lhs.durationTicks != rhs.durationTicks { return lhs.durationTicks < rhs.durationTicks }
-        if lhs.velocity != rhs.velocity { return lhs.velocity < rhs.velocity }
-        return lhs.channel < rhs.channel
-    }
 }

--- a/Tests/LogicProMCPTests/PianoRollTransformTests.swift
+++ b/Tests/LogicProMCPTests/PianoRollTransformTests.swift
@@ -125,7 +125,7 @@ struct PianoRollTransformTests {
         )
     }
 
-    @Test func exactCompleteNextGenerationMultisetIsStateA() throws {
+    @Test func exactCompleteNextGenerationMultisetIsR1Unverified() throws {
         let target = region()
         let duplicate = note(pitch: 60, start: 120)
         let other = note(pitch: 64, start: 0)
@@ -147,7 +147,15 @@ struct PianoRollTransformTests {
             notes: [other, duplicate, duplicate]
         )
 
-        #expect(verifyTransform(plan: plan, observedAfter: observed) == .stateA)
+        guard case .stateBUnverified(let reason) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: independentExpected(region: target, notes: [other, duplicate, duplicate])
+        ) else {
+            Issue.record("An R1 exact match must not be granted State A")
+            return
+        }
+        #expect(reason == "R1 grants no positive match; independent positive verification is R2 live-ingestion")
     }
 
     @Test func incompleteObservedSnapshotIsNeverStateA() throws {
@@ -159,7 +167,11 @@ struct PianoRollTransformTests {
             notes: plan.predictedAfter
         )
 
-        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+        guard case .stateBUnverified = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: .unproven
+        ) else {
             Issue.record("An incomplete post-write snapshot must never be State A")
             return
         }
@@ -173,7 +185,11 @@ struct PianoRollTransformTests {
             notes: plan.predictedAfter
         )
 
-        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+        guard case .stateBUnverified = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: .unproven
+        ) else {
             Issue.record("State A requires the expected generation transition")
             return
         }
@@ -187,7 +203,11 @@ struct PianoRollTransformTests {
             notes: plan.predictedAfter
         )
 
-        guard case .stateBUnverified = verifyTransform(plan: plan, observedAfter: observed) else {
+        guard case .stateBUnverified = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: .unproven
+        ) else {
             Issue.record("State A requires the same region reference")
             return
         }
@@ -210,10 +230,145 @@ struct PianoRollTransformTests {
         )
 
         #expect(
-            verifyTransform(plan: plan, observedAfter: observed) == .mismatch(
+            verifyTransform(
+                plan: plan,
+                observedAfter: observed,
+                expected: independentExpected(region: plan.regionRef, notes: [expected, expected])
+            ) == .mismatch(
                 unexpected: [unexpected]
             )
         )
+    }
+
+    @Test func samePathRederivationIsRejected() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: plan.predictedAfter
+        )
+
+        guard case .stateBUnverified(let reason) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: independentExpected(
+                rootID: observed.conversionPipelineID,
+                region: plan.regionRef,
+                notes: plan.predictedAfter
+            )
+        ) else {
+            Issue.record("An expected derived from the observed conversion pipeline must be rejected")
+            return
+        }
+        #expect(reason.contains("expected root shares the observed conversion pipeline"))
+    }
+
+    @Test func ppqSkewedBareSortedMatchIsRejected() throws {
+        let plan = try #require(makePlan())
+        let unscaled = note(pitch: 60, start: 120, duration: 120)
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: [unscaled]
+        )
+
+        // The two raw events are equal, so the former bare sorted comparison would
+        // match. Their tick values differ after a 960→480 PPQ normalization.
+        guard case .mismatch(let unexpected) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: independentExpected(region: plan.regionRef, notes: [unscaled], ppq: 960)
+        ) else {
+            Issue.record("A PPQ-skewed raw match must be a mismatch, never State A or the R1 refusal")
+            return
+        }
+        #expect(unexpected == [unscaled])
+    }
+
+    @Test func unprovenExpectedIsRejected() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: plan.predictedAfter
+        )
+
+        guard case .stateBUnverified(let reason) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: .unproven
+        ) else {
+            Issue.record("An unproven expected sequence must be rejected")
+            return
+        }
+        #expect(reason.contains("expected must carry a sealed independent provenance proof"))
+    }
+
+    @Test func corruptedExpectedContentBindingIsRejected() throws {
+        let plan = try #require(makePlan())
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: plan.predictedAfter
+        )
+        let corrupted = IndependentExpectedSeam.makeCorruptedTestFixture(
+            root: .authoredIntent,
+            rootID: "authored.intent.v1",
+            region: plan.regionRef,
+            notes: plan.predictedAfter,
+            ppq: 480,
+            digest: "forged-binding"
+        )
+
+        guard case .stateBUnverified(let reason) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: corrupted
+        ) else {
+            Issue.record("A corrupted expected content binding must be rejected")
+            return
+        }
+        #expect(reason.contains("expected proof content binding is invalid"))
+    }
+
+    @Test func independentlySourcedCanonicalizedMatchReachesR1Refusal() throws {
+        let plan = try #require(makePlan())
+        let observedNotes = [
+            note(pitch: 60, start: 0, duration: 240),
+            note(pitch: 60, start: 120, duration: 120),
+        ]
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: observedNotes
+        )
+
+        guard case .stateBUnverified(let reason) = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: independentExpected(region: plan.regionRef, notes: observedNotes.reversed())
+        ) else {
+            Issue.record("A valid independent canonicalized match must reach the R1 refusal")
+            return
+        }
+        #expect(reason == "R1 grants no positive match; independent positive verification is R2 live-ingestion")
+    }
+
+    @Test func stateAIsUnreachableForFullyValidIndependentExpected() throws {
+        let plan = try #require(makePlan())
+        let notes = [note(pitch: 60), note(pitch: 64, start: 120)]
+        let observed = snapshot(
+            region: plan.regionRef,
+            generation: plan.boundGeneration + 1,
+            notes: notes
+        )
+        let verdict = verifyTransform(
+            plan: plan,
+            observedAfter: observed,
+            expected: independentExpected(region: plan.regionRef, notes: notes.reversed())
+        )
+
+        #expect(verdict != .stateA)
     }
 
     @Test func compensationRestoresExactBeforeSnapshot() throws {
@@ -271,6 +426,22 @@ struct PianoRollTransformTests {
         return complete
             ? .makeCompleteForTesting(regionReference: ref, projectEpoch: generation, ppq: 480, notes: notes)
             : .makeIncompleteForTesting(regionReference: ref, projectEpoch: generation, ppq: 480)
+    }
+
+    private func independentExpected(
+        root: IndependentExpectedRoot = .authoredIntent,
+        rootID: String = "authored.intent.v1",
+        region: MIDIRegionReference,
+        notes: [MIDINoteEvent],
+        ppq: Int = 480
+    ) -> IndependentExpectedProof {
+        IndependentExpectedSeam.makeTestFixture(
+            root: root,
+            rootID: rootID,
+            region: region,
+            notes: notes,
+            ppq: ppq
+        )
     }
 
     private func note(


### PR DESCRIPTION
Closes #446.

## The two weaknesses

`verifyTransform` decided Piano-Roll transform **State-A** by comparing `plan.predictedAfter` — the server's own plan, the same one that drove the write — against the post-write snapshot, with a bare `sortedNotes` comparison.

- **No independent expected.** A re-derivation carrying the write path's own bug would have been accepted as a match.
- **Weaker comparison.** `sortedNotes` skips `canonicalize` + PPQ normalization, so note sets differing only after PPQ scaling, or in overlap / zero-length handling, compared equal.

## The change

`verifyTransform` now takes an `IndependentExpectedProof` and applies the region verifier's guards in the same order:

| # | guard | verdict |
|---|---|---|
| 1–3 | complete / region matches plan / generation transition | unchanged |
| 4 | proof present | `stateBUnverified` |
| 5 | `independent.rootID != observedAfter.conversionPipelineID` | `stateBUnverified` |
| 6 | proof bound to the observed region | `stateBUnverified` |
| 7 | content binding matches its own notes + PPQ | `stateBUnverified` |
| 8 | both PPQ positive | `stateBUnverified` |
| 9 | PPQ normalization overflow | `stateBUnverified` |
| 10 | canonicalized match | **R1 refusal**, not State-A |
| 11 | otherwise | duplicate-preserving `mismatch` |

Comparison runs `canonicalize(observed)` against `canonicalize(normalizePPQ(independent))`. `predictedAfter` no longer participates in the verdict at all.

**State-A is unreachable in this build**, returning the same R1 refusal the region verifier returns. The case stays in the enum because it is the R2 target — `grep -c 'return .stateA'` is `0`, and there is no production call site (`grep -rn 'verifyTransform' Sources` minus the definition: 0 hits).

## Mutation evidence

Each guard the issue names was broken in the source and its test observed to fail, then the source restored from a snapshot and verified byte-identical:

| mutation | test | result |
|---|---|---|
| drop the pipeline-root guard | `samePathRederivationIsRejected` | **1 test failed** |
| revert comparison to bare sorted notes | `ppqSkewedBareSortedMatchIsRejected` | **1 test failed** |
| drop the content-binding guard | `corruptedExpectedContentBindingIsRejected` | **1 test failed** |

The PPQ-skew case is built from two byte-identical raw events at PPQ 960 against an observed PPQ, so the previous bare comparison would have called them equal. That is what makes it load-bearing rather than incidentally green.

## Verification

| check | result |
|---|---|
| build | exit 0 |
| full suite | **`3377 tests passed`, exit 0** |
| `Scripts/ci-forbid-dead-expect.sh` | clean |
| `sortedNotes` remaining | 0 |
| production call sites | 0 |
| `Package.resolved` | untouched |
| preflight | **PASS** |

## Scope

`MIDINoteIndependentVerification.swift`, `MIDINoteCanonicalizer.swift`, and `Package.swift` are unchanged; the region verifier is the pattern being mirrored, not a thing being edited. No production call site was added.