### PR TITLE
test(e2e): assert on the concurrent results instead of discarding them

### DIFF
--- a/Tests/LogicProMCPTests/EndToEndTests.swift
+++ b/Tests/LogicProMCPTests/EndToEndTests.swift
@@ -1079,16 +1079,34 @@ func testE2EResourceHealthMatchesToolHealth() async throws {
 @Test(codexSeatbeltProcessInspectionDisabled)
 func testE2EConcurrentMixedToolsAndResourcesAreSafe() async throws {
     let h = await makeE2EHandlers()
-    try await withThrowingTaskGroup(of: Void.self) { group in
-        for i in 0..<10 {
+    var toolResults: [String] = []
+    var resourceResults: [String] = []
+    try await withThrowingTaskGroup(of: (isTool: Bool, text: String).self) { group in
+        for _ in 0..<10 {
             group.addTask {
-                let _ = await e2eCall(h, tool: "logic_system", command: "health")
+                (true, e2eText(await e2eCall(h, tool: "logic_system", command: "health")))
             }
             group.addTask {
-                let _ = try await h.readResource(.init(uri: "logic://system/health"))
+                (false, e2eResourceText(try await h.readResource(.init(uri: "logic://system/health"))))
             }
         }
-        try await group.waitForAll()
+        for try await result in group {
+            if result.isTool {
+                toolResults.append(result.text)
+            } else {
+                resourceResults.append(result.text)
+            }
+        }
+    }
+    #expect(toolResults.count == 10)
+    #expect(resourceResults.count == 10)
+    for text in toolResults {
+        let json = try #require(e2eJSON(text))
+        #expect(json["logic_pro_running"] != nil)
+    }
+    for text in resourceResults {
+        let json = try #require(e2eJSON(text))
+        #expect(json["logic_pro_running"] != nil)
     }
 }
 


### PR DESCRIPTION
Closes #473.

**Head:** `bd2914c48d58de884647025da6ca7198cca2860a`
**Base:** `57579b450015a0e19044589e0125850ce503420d` (current `main`)

> Body corrected at the reviewed head. The earlier body carried figures from superseded head `14c995e9` (3371 tests) and did not name a head or base. Every number below is measured at `bd2914c4`.

## The defect

`testE2EConcurrentMixedToolsAndResourcesAreSafe` ran twenty concurrent calls and discarded every result with `let _ =`. **Zero assertions.**

```swift
group.addTask { let _ = await e2eCall(h, tool: "logic_system", command: "health") }
group.addTask { let _ = try await h.readResource(.init(uri: "logic://system/health")) }
```

The name claims a safety property; the body proved only that nothing crashed and nothing threw. A spliced or truncated payload from concurrent interleaving passed it.

## The change

All twenty results are collected and checked: each payload parses as JSON and carries `logic_pro_running`, and both arrival counts must be exactly ten so a dropped task cannot pass. The concurrency shape is unchanged — ten of each in one group, still interleaved. Assertions inside the function: **0 → 6**.

Scope: **one test file**, `Tests/LogicProMCPTests/EndToEndTests.swift`, +23/−5. No production-source change.

## Acceptance (#473)

| criterion | evidence at `bd2914c4` |
|---|---|
| all twenty results checked, JSON + `logic_pro_running` | 6 assertions in the function; focused test passes |
| both arrival counts asserted as ten | mutation M2 below kills the count assertion |
| concurrency shape preserved | one `withThrowingTaskGroup`, ten of each, not serialised |
| mutation evidence on this head | both kills below, restored byte-identical |
| `ci-forbid-dead-expect.sh` | clean |
| full suite green | 3377 passed, exit 0 |

## Mutation evidence — rerun on this exact head

Snapshot before mutating: `EndToEndTests.swift` sha256 `06aa0f57a12bed31a18fc74b1224a903fb14b32690566c5daf2f22085f850980`.

| step | result |
|---|---|
| baseline focused | **1 test passed** |
| M1 — one of the twenty tasks returns a non-JSON payload | **1 test failed, 1 issue** |
| M2 — drop one task from the group (9 instead of 10) | **1 test failed, 2 issues** |
| restored | `cmp` **identical**, sha256 back to `06aa0f57…`, **1 test passed** |

Head before and after the mutation runs: `bd2914c4` — unchanged.

## Release artifact, bound to this head

Built `-c release` at `bd2914c4`:

| artifact | bytes | sha256 |
|---|---:|---|
| `LogicProMCP` | 20333208 | `3261162a2f767f874b5a288d50057409454527b586e3c9cb9acc29ebca664604` |
| `trusted-verifier` | 20332464 | `b13b51b91dcd57bc6a4f49a7e00d52727cf9a2bca094410441aee7e4c5e540cc` |

No-drift after the release build: head still `bd2914c4`, working tree clean, test-file sha256 unchanged at `06aa0f57…`.

## Lanes at this head

| lane | result |
|---|---|
| build | exit 0 |
| full suite | **3377 passed, exit 0** |
| `ci-forbid-dead-expect.sh` | clean |
| preflight (base `57579b45`) | **PASS** |
| CI | run [31253874868](https://github.com/MongLong0214/logic-pro-mcp/actions/runs/31253874868), `headSha` verified equal to `bd2914c4`, conclusion **success** |
| LIVE_NA | test-only; drives in-process handlers, not Logic |

## Stale-head invalidation

Previous head `8b81b610` merged the **old** main `c2b733b2` and is not a descendant of the current base — confirmed by `merge-base`. It and every measurement on it are discarded, including its artifact hash. Original commit `14c995e9` remains an ancestor.