### PR TITLE
fix(#425): drive plugin-insert popup navigation without coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed — plugin-insert actuation
 
-- **#425 current behavior supersedes the 3.13.0 #425 entry below.** Slot-open performs the measured custom action; category and leaf selection use `AXPick`. `LOGIC_MCP_INSERT_COORD_FREE` / `insertCoordFree` is removed, not a kill switch. The coordinate click remains only as a fallback when the custom action is absent, and that fallback is recorded in the trace.
+- **#425 current behavior supersedes the 3.13.0 #425 entry below.** Slot-open uses the measured custom action. Discovery is read-only and recurses through each already-attached `AXMenu` child; `AXPick` is dispatched only to the exact target leaf. `LOGIC_MCP_INSERT_COORD_FREE` / `insertCoordFree` is removed, not a kill switch. The coordinate click remains only when action enumeration succeeds and the custom action is absent; enumeration failure fails closed as `slot_action_enumeration_failed` and is recorded in the trace.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
-(No unreleased changes yet.)
+### Changed — plugin-insert actuation
+
+- **#425 current behavior supersedes the 3.13.0 #425 entry below.** Slot-open performs the measured custom action; category and leaf selection use `AXPick`. `LOGIC_MCP_INSERT_COORD_FREE` / `insertCoordFree` is removed, not a kill switch. The coordinate click remains only as a fallback when the custom action is absent, and that fallback is recorded in the trace.
 
 ---
 
@@ -18,7 +20,7 @@ Small follow-on release: the coordinate-free actuation campaign now covers plugi
 
 ### Changed — coordinate-free actuation
 
-- **`logic_plugins.insert_verified` leaf selection is coordinate-free by default.** The direct/search leaf-selection path now presses the target plugin's entry in the AX-children format submenu (`AXPress`) instead of a synthetic coordinate click; `LOGIC_MCP_INSERT_COORD_FREE=0` is the kill-switch back to the coordinate path. The recursive category-hover fallback stays coordinate-only by governed waiver — reachable in principle but unexercised in practice for the three supported plugins — and the response's `select_trace.leaf_select_coord_free` is sourced from the winning strategy rather than the raw flag, so a recursive win still honestly reports `false` even with the flag on. Slot-open remains a coordinate click (AXPress was live-probed and rejected: it either no-ops or opens an `AXShowMenu` tracking loop that wedges Logic). A DEBUG-only test seam deterministically exercises the honest `commit_strategy` on a forced post-commit timeout; it is compiled out of release builds. ([#425](https://github.com/MongLong0214/logic-pro-mcp/issues/425))
+- **`logic_plugins.insert_verified` leaf selection is coordinate-free by default.** The direct/search leaf-selection path now presses the target plugin's entry in the AX-children format submenu (`AXPress`) instead of a synthetic coordinate click; `LOGIC_MCP_INSERT_COORD_FREE=0` is the kill-switch back to the coordinate path. The recursive category-hover fallback stays coordinate-only by governed waiver — reachable in principle but unexercised in practice for the three supported plugins — and the response's `select_trace.leaf_select_coord_free` is sourced from the winning strategy rather than the raw flag, so a recursive win still honestly reports `false` even with the flag on. Slot-open remains a coordinate click (AXPress was live-probed and rejected: it either no-ops or opens an `AXShowMenu` tracking loop that wedges Logic). A DEBUG-only test seam deterministically exercises the honest `commit_strategy` on a forced post-commit timeout; it is compiled out of release builds. ([#425](https://github.com/MongLong0214/logic-pro-mcp/issues/425)) (Historical 3.13.0 behavior; superseded for current code by the Unreleased #425 entry above.)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed — plugin-insert actuation
 
 - **#425 current behavior supersedes the 3.13.0 #425 entry below.** Slot-open uses the measured custom action. Discovery is read-only and recurses through each already-attached `AXMenu` child; `AXPick` is dispatched only to the exact target leaf. `LOGIC_MCP_INSERT_COORD_FREE` / `insertCoordFree` is removed, not a kill switch. The coordinate click remains only when action enumeration succeeds and the custom action is absent; enumeration failure fails closed as `slot_action_enumeration_failed` and is recorded in the trace.
+- **`select_trace.leaf_select_coord_free` is a published compatibility receipt emitted as the literal `true`: every leaf-selection strategy is `AXPick`, so the field is constant rather than a strategy discriminator.**
 
 ---
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1825,6 +1825,15 @@ extension AccessibilityChannel {
     static let slotPopupOpenCustomAction =
         "Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)"
 
+    /// The custom-action enumeration outcome. Only an explicit successful
+    /// enumeration that omits the action may use the coordinate compatibility
+    /// path; an unreadable enumeration must fail closed before any write.
+    enum SlotPopupOpenCustomActionEnumerationResult: Sendable {
+        case enumeratedAndPresent
+        case enumeratedAndAbsent
+        case enumerationFailed
+    }
+
     /// Production exact-slot popup insert driver. Drives the target insert slot's
     /// own popup menu and returns a structured outcome plus a `select_trace`
     /// diagnostic dict. This is the default path that uses coordinate-free AX
@@ -1896,7 +1905,8 @@ extension AccessibilityChannel {
         }
         trace["target_slot_found"] = true
 
-        if slotPopupOpenCustomActionIsAvailable(on: targetSlot.element, runtime: runtime.ax) {
+        switch slotPopupOpenCustomActionEnumerationResult(on: targetSlot.element, runtime: runtime.ax) {
+        case .enumeratedAndPresent:
             // Live evidence: this can return `cannotComplete` (-25204) even when
             // it opens the popup. Dispatch it through the same runtime seam as
             // AXPress, but let the observed popup poll below make the decision.
@@ -1905,15 +1915,25 @@ extension AccessibilityChannel {
             )
             trace["slot_popup_open_fallback_taken"] = false
             trace["slot_popup_open_action"] = "custom_action"
-        } else {
+            trace["slot_popup_open_action_enumeration"] = "present"
+        case .enumeratedAndAbsent:
             // Compatibility path for builds that do not expose the measured custom
             // action. This is intentionally recorded: a coordinate fallback is not
             // silently treated as the preferred coordinate-free actuation.
             trace["slot_popup_open_fallback_taken"] = true
             trace["slot_popup_open_action"] = "coordinate_fallback"
+            trace["slot_popup_open_action_enumeration"] = "absent"
             guard clickElementCenter(targetSlot.element, runtime: runtime.ax) else {
                 return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
             }
+        case .enumerationFailed:
+            // An AX read failure does not prove that this build lacks the custom
+            // action, so it must not downgrade to the coordinate write path.
+            trace["slot_popup_open_fallback_taken"] = false
+            trace["slot_popup_open_action"] = "action_enumeration_failed"
+            trace["slot_popup_open_action_enumeration"] = "failed"
+            trace["slot_popup_open_setup_stage"] = "slot_action_enumeration_failed"
+            return (.transientSetupFailure(stage: "slot_action_enumeration_failed"), trace)
         }
         try? await Task.sleep(for: .milliseconds(250))
 
@@ -2282,16 +2302,16 @@ extension AccessibilityChannel {
         return nil
     }
 
-    /// Whether this specific slot currently exposes Logic's custom popup opener.
-    /// Action discovery is separate from action execution because the latter can
-    /// report failure after the popup is already open.
-    private static func slotPopupOpenCustomActionIsAvailable(
+    /// Enumerates the custom popup opener on this specific slot. Action discovery
+    /// is separate from action execution because the latter can report failure
+    /// after the popup is already open.
+    private static func slotPopupOpenCustomActionEnumerationResult(
         on element: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
+    ) -> SlotPopupOpenCustomActionEnumerationResult {
         #if DEBUG
-        if let actionNames = slotPopupOpenActionNamesForTests {
-            return actionNames.contains(slotPopupOpenCustomAction)
+        if let result = slotPopupOpenCustomActionEnumerationResultForTests {
+            return result
         }
         #endif
         _ = runtime // action enumeration has no existing runtime hook.
@@ -2299,21 +2319,39 @@ extension AccessibilityChannel {
         guard AXUIElementCopyActionNames(element, &actionNames) == .success,
               let actionNames,
               let actions = actionNames as? [String] else {
-            return false
+            return .enumerationFailed
         }
         return actions.contains(slotPopupOpenCustomAction)
+            ? .enumeratedAndPresent
+            : .enumeratedAndAbsent
     }
 
     #if DEBUG
-    /// Test-only action-name discovery override. The action itself is still
+    /// Test-only action-enumeration override. The action itself is still
     /// dispatched through `AXHelpers.performAction` and the shared fake runtime.
-    @TaskLocal static var slotPopupOpenActionNamesForTests: [String]?
+    @TaskLocal static var slotPopupOpenCustomActionEnumerationResultForTests:
+        SlotPopupOpenCustomActionEnumerationResult?
 
+    static func withSlotPopupOpenCustomActionEnumerationResultForTests<Result>(
+        _ result: SlotPopupOpenCustomActionEnumerationResult,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $slotPopupOpenCustomActionEnumerationResultForTests.withValue(
+            result, operation: operation
+        )
+    }
+
+    /// Retained action-name test seam for present/absent compatibility fixtures.
     static func withSlotPopupOpenActionNamesForTests<Result>(
         _ actionNames: [String],
         operation: () async throws -> Result
     ) async rethrows -> Result {
-        try await $slotPopupOpenActionNamesForTests.withValue(actionNames, operation: operation)
+        let result: SlotPopupOpenCustomActionEnumerationResult = actionNames.contains(slotPopupOpenCustomAction)
+            ? .enumeratedAndPresent
+            : .enumeratedAndAbsent
+        return try await withSlotPopupOpenCustomActionEnumerationResultForTests(
+            result, operation: operation
+        )
     }
     #endif
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -11,7 +11,7 @@ import Foundation
 ///     Unsupported or unverified parameters fail closed at capability preflight.
 ///   - `plugin.insert_verified` — live validation gates (schema/mode/path/
 ///     identity/inventory-complete/slot-empty) followed by the
-///     target slot's own popup menu, driven by CGEvent clicks. The
+///     target slot's own popup menu, driven by AX actions. The
 ///     slot-popup path preserves the target slot context, and
 ///     a post-insert `get_inventory` readback is the SOLE State A precondition —
 ///     State A is reachable only when the requested plugin is observed at the
@@ -1819,10 +1819,16 @@ extension AccessibilityChannel {
 
     // MARK: - insert_verified live drivers
 
+    /// Logic's empty insert slot exposes this custom action verbatim, including
+    /// the metadata lines. It opens the legacy-inclusive plug-in popup even
+    /// though the AX call can report `cannotComplete` after opening it.
+    private static let slotPopupOpenCustomAction =
+        "Name:Open plug-in menu with legacy plug-ins\\nTarget:0x0\\nSelector:(null)"
+
     /// Production exact-slot popup insert driver. Drives the target insert slot's
     /// own popup menu and returns a structured outcome plus a `select_trace`
-    /// diagnostic dict. This is the default path that issues real slot/menu
-    /// CGEvents; `defaultInsertVerified` is unit-tested against an injected fake.
+    /// diagnostic dict. This is the default path that uses coordinate-free AX
+    /// actions; `defaultInsertVerified` is unit-tested against an injected fake.
     ///
     /// Sequence:
     ///   0. hide any stray plugin windows (a front plugin window from a prior
@@ -1830,11 +1836,12 @@ extension AccessibilityChannel {
     ///      instrument window instead of the search dialog);
     ///   1. select the target track and verify `AXSelected` readback;
     ///   2. raise the mixer/main window and read the full pre-insert inventory;
-    ///   3. locate the requested filtered insert slot and click its center to open
-    ///      that slot's popup;
+    ///   3. locate the requested filtered insert slot and invoke its discovered
+    ///      custom action to open that slot's popup (coordinate fallback only when
+    ///      the action is absent);
     ///   4. prove the popup is anchored to the target slot, then choose the stock
     ///      plugin by exact leaf title from that anchored popup (direct/search/
-    ///      recursive discovery), not by localized category names or AXPress;
+    ///      recursive discovery), not by localized category names;
     ///   5. CONDITION-poll the inventory (wait for an actual change, not the first
     ///      readable snapshot) and diff against the pre-snapshot to detect WHERE
     ///      the requested plugin landed;
@@ -1889,15 +1896,25 @@ extension AccessibilityChannel {
         }
         trace["target_slot_found"] = true
 
-        // #425 note: the empty-slot picker is opened by a coordinate click. Coord-free
-        // alternatives were live-probed and rejected: AXPress on the slot element is a
-        // no-op (picker never opens), and AXShowMenu opens the picker into an NSMenu
-        // tracking loop that WEDGES Logic (AX blocks). The slot-open therefore stays a
-        // coordinate click (governed waiver); only the leaf SELECTION is coord-free.
-        guard clickElementCenter(targetSlot.element, runtime: runtime.ax) else {
-            return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
+        if slotPopupOpenCustomActionIsAvailable(on: targetSlot.element, runtime: runtime.ax) {
+            // Live evidence: this can return `cannotComplete` (-25204) even when
+            // it opens the popup. Dispatch it through the same runtime seam as
+            // AXPress, but let the observed popup poll below make the decision.
+            _ = AXHelpers.performAction(
+                targetSlot.element, slotPopupOpenCustomAction, runtime: runtime.ax
+            )
+            trace["slot_popup_open_fallback_taken"] = false
+            trace["slot_popup_open_action"] = "custom_action"
+        } else {
+            // Compatibility path for builds that do not expose the measured custom
+            // action. This is intentionally recorded: a coordinate fallback is not
+            // silently treated as the preferred coordinate-free actuation.
+            trace["slot_popup_open_fallback_taken"] = true
+            trace["slot_popup_open_action"] = "coordinate_fallback"
+            guard clickElementCenter(targetSlot.element, runtime: runtime.ax) else {
+                return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
+            }
         }
-        trace["slot_popup_open_clicked"] = true
         try? await Task.sleep(for: .milliseconds(250))
 
         guard let rootMenu = await pollSlotPopupMenu(runtime: runtime, timeoutMs: 1_200) else {
@@ -1928,11 +1945,9 @@ extension AccessibilityChannel {
         trace["winning_strategy"] = pluginClick.strategy
         trace["winning_menu_path"] = pluginClick.path.joined(separator: " > ")
         trace["plugin_selection_id"] = pluginID
-        // #425: record which leaf-selection path ACTUALLY executed so the receipt
-        // self-attests coordinate-free (AXPress) vs the legacy coordinate click.
-        // Sourced from the winning strategy via `leafSelectCoordFree(for:)`, not the
-        // raw flag, so a recursive (coordinate-only) win reports false even when the
-        // flag is on — the discriminator can never be falsely pinned to the flag.
+        // Every popup-navigation strategy above is coordinate-free AXPick. Keep the
+        // receipt field for compatibility, sourced from the winning action rather
+        // than from a feature flag.
         trace["leaf_select_coord_free"] = leafSelectCoordFree(for: pluginClick)
 
         #if DEBUG
@@ -1993,9 +2008,8 @@ extension AccessibilityChannel {
         }
 
         if poll.satisfied == nil {
-            // #425: report the actuation that ACTUALLY selected the leaf, derived
-            // from the winning strategy — a coord-free (AXPress) win must not
-            // misreport a physical/coordinate menu commit.
+            // #425: report the coordinate-free AXPick actuation that actually
+            // selected the leaf; the inventory observation remains the gate.
             return (
                 .postCommitTimeout(strategy: postCommitTimeoutStrategy(coordFree: pluginClick.coordFree)),
                 trace
@@ -2006,12 +2020,11 @@ extension AccessibilityChannel {
 
     // MARK: - insert_verified live driver helpers
 
-    /// The honest commit-strategy label for a post-commit timeout, derived from
-    /// the winning actuation (coord-free AXPress vs the legacy coordinate menu
-    /// click). Single source of truth so the live timeout path and the DEBUG
-    /// force-timeout QA seam can never report different strategies.
+    /// The honest commit-strategy label for a post-commit timeout. The popup path
+    /// now uses AXPick throughout; this remains a single source of truth for the
+    /// live timeout path and the DEBUG force-timeout QA seam.
     static func postCommitTimeoutStrategy(coordFree: Bool) -> String {
-        coordFree ? "slot_popup_axpress_menu_select" : "slot_popup_physical_menu_click"
+        coordFree ? "slot_popup_axpick_menu_select" : "slot_popup_physical_menu_click"
     }
 
     #if DEBUG
@@ -2269,6 +2282,41 @@ extension AccessibilityChannel {
         return nil
     }
 
+    /// Whether this specific slot currently exposes Logic's custom popup opener.
+    /// Action discovery is separate from action execution because the latter can
+    /// report failure after the popup is already open.
+    private static func slotPopupOpenCustomActionIsAvailable(
+        on element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        #if DEBUG
+        if let actionNames = slotPopupOpenActionNamesForTests {
+            return actionNames.contains(slotPopupOpenCustomAction)
+        }
+        #endif
+        _ = runtime // action enumeration has no existing runtime hook.
+        var actionNames: CFArray?
+        guard AXUIElementCopyActionNames(element, &actionNames) == .success,
+              let actionNames,
+              let actions = actionNames as? [String] else {
+            return false
+        }
+        return actions.contains(slotPopupOpenCustomAction)
+    }
+
+    #if DEBUG
+    /// Test-only action-name discovery override. The action itself is still
+    /// dispatched through `AXHelpers.performAction` and the shared fake runtime.
+    @TaskLocal static var slotPopupOpenActionNamesForTests: [String]?
+
+    static func withSlotPopupOpenActionNamesForTests<Result>(
+        _ actionNames: [String],
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $slotPopupOpenActionNamesForTests.withValue(actionNames, operation: operation)
+    }
+    #endif
+
     private static func slotPopupMenu(runtime: AXLogicProElements.Runtime) -> AXUIElement? {
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return nil }
         let menus = AXHelpers.findAllDescendants(
@@ -2348,21 +2396,13 @@ extension AccessibilityChannel {
         let strategy: String
         let path: [String]
         let strategies: [String]
-        /// The coord-free value the WINNING strategy actually used. Direct/search
-        /// carry `FeatureFlags.insertCoordFree`; the recursive category-hover
-        /// fallback is coordinate-only and always carries `false`. The caller
-        /// records THIS (not the raw flag) as `trace["leaf_select_coord_free"]`, so
-        /// a recursive win truthfully reports `false` even when the flag is on.
+        /// Every winning popup strategy uses AXPick, so this remains true. The
+        /// caller records the actual winning actuation, never a feature flag.
         let coordFree: Bool
     }
 
-    /// The single source of truth for the `leaf_select_coord_free` discriminator:
-    /// the coord-free value the WINNING strategy actually used, read off the result
-    /// — NOT the raw `FeatureFlags.insertCoordFree` flag. A recursive
-    /// (coordinate-only) win carries `false` here even when the flag is on, so the
-    /// receipt can never be falsely pinned to the flag. Extracted (and `internal`)
-    /// so the flag-vs-path divergence is unit-testable without the CGEvent-bound
-    /// live insert flow.
+    /// The single source of truth for the backwards-compatible
+    /// `leaf_select_coord_free` receipt field.
     static func leafSelectCoordFree(for click: SlotPopupPluginClick) -> Bool {
         click.coordFree
     }
@@ -2376,20 +2416,15 @@ extension AccessibilityChannel {
         runtime: AXHelpers.Runtime
     ) async -> SlotPopupPluginClick? {
         var strategies: [String] = []
-        // Direct/search honor the #425 flag; the recursive fallback below is
-        // coordinate-only. Captured once so the value passed to the leaf click and
-        // the value recorded on the winning result cannot diverge.
-        let coordFree = FeatureFlags.insertCoordFree
-
         strategies.append("slot_popup_direct_exact_leaf")
         if let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
            let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime, coordFree: coordFree) {
+           await clickPopupPluginLeaf(item, runtime: runtime) {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_direct_exact_leaf",
                 path: [label],
                 strategies: strategies,
-                coordFree: coordFree
+                coordFree: true
             )
         }
 
@@ -2397,12 +2432,12 @@ extension AccessibilityChannel {
         if await filterSlotPopupSearchField(displayName: displayName, rootMenu: rootMenu, runtime: runtime),
            let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
            let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime, coordFree: coordFree) {
+           await clickPopupPluginLeaf(item, runtime: runtime) {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_search_exact_leaf",
                 path: [label],
                 strategies: strategies,
-                coordFree: coordFree
+                coordFree: true
             )
         }
 
@@ -2418,7 +2453,7 @@ extension AccessibilityChannel {
                 strategy: "slot_popup_recursive_exact_leaf",
                 path: result,
                 strategies: strategies,
-                coordFree: false
+                coordFree: true
             )
         }
 
@@ -2464,7 +2499,7 @@ extension AccessibilityChannel {
 
         if let direct = directExactPopupMenuItem(displayName: displayName, in: menu, runtime: runtime),
            let label = popupMenuItemLabel(direct, runtime: runtime),
-           await clickPopupPluginLeaf(direct, runtime: runtime, coordFree: false) {
+           await clickPopupPluginLeaf(direct, runtime: runtime) {
             return path + [label]
         }
 
@@ -2472,10 +2507,13 @@ extension AccessibilityChannel {
         for item in items {
             guard let label = popupMenuItemLabel(item, runtime: runtime),
                   !popupMenuItemMatches(item, displayName: displayName, runtime: runtime),
-                  menuItemEnabled(item, runtime: runtime),
-                  moveElementCenter(item, runtime: runtime) else {
+                  menuItemEnabled(item, runtime: runtime) else {
                 continue
             }
+            // AXPick reveals Logic's already-attached AXMenu child without a
+            // hover. Its return code is untrustworthy, so only the observed menu
+            // visibility below is allowed to choose whether we descend.
+            _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
             try? await Task.sleep(for: .milliseconds(140))
             guard let submenu = visibleSubmenu(of: item, runtime: runtime) else {
                 continue
@@ -2493,48 +2531,20 @@ extension AccessibilityChannel {
         return nil
     }
 
-    /// Select the matched plugin leaf. `coordFree == true` (the #425 default) uses
-    /// AXPress over the AX-children format submenu (`pressPopupPluginLeaf`, no
-    /// coordinates); `coordFree == false` uses the legacy coordinate path
-    /// (moveElementCenter/clickElementCenter). The mode is a PARAMETER rather than a
-    /// direct `FeatureFlags.insertCoordFree` read so the recursive category-hover
-    /// fallback can force the coordinate path (it always passes `coordFree: false`),
-    /// while direct/search honor the flag. `internal` (was `private`) so the
-    /// coord-free-vs-coordinate contract is unit-testable without the CGEvent-bound
-    /// live insert flow.
+    /// Dispatch AXPick to the matched plugin leaf (or its preferred format leaf).
+    /// AX's return code is deliberately ignored: the caller's post-insert inventory
+    /// diff is the only acceptance signal.
     static func clickPopupPluginLeaf(
-        _ item: AXUIElement,
-        runtime: AXHelpers.Runtime,
-        coordFree: Bool
-    ) async -> Bool {
-        if coordFree {
-            return await pressPopupPluginLeaf(item, runtime: runtime)
-        }
-        guard moveElementCenter(item, runtime: runtime) else { return false }
-        try? await Task.sleep(for: .milliseconds(120))
-        if let submenu = visibleSubmenu(of: item, runtime: runtime),
-           let leaf = preferredFormatLeaf(in: submenu, runtime: runtime) {
-            return clickElementCenter(leaf, runtime: runtime)
-        }
-        return clickElementCenter(item, runtime: runtime)
-    }
-
-    /// #425: coordinate-free leaf selection. Reads the plugin's format submenu (if
-    /// any) as an AX child — populated without a hover, per `popupExactLeafPaths` —
-    /// and AXPresses the preferred-format leaf; otherwise AXPresses the item itself.
-    /// If a format submenu exists but AXPress on its leaf did not take, fall through
-    /// to pressing the item (which on many builds opens the submenu / selects the
-    /// default format). Fail-closed: no coordinate fallback.
-    private static func pressPopupPluginLeaf(
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
     ) async -> Bool {
         if let submenu = axChildMenu(of: item, runtime: runtime),
-           let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime),
-           pressElement(leaf, runtime: runtime) {
+           let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime) {
+            _ = AXHelpers.performAction(leaf, kAXPickAction as String, runtime: runtime)
             return true
         }
-        return pressElement(item, runtime: runtime)
+        _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
+        return true
     }
 
     /// A submenu exposed as an AX child of `item`, regardless of visual visibility.
@@ -2658,31 +2668,10 @@ extension AccessibilityChannel {
         }
     }
 
-    private static func preferredFormatLeaf(
-        in submenu: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> AXUIElement? {
-        let items = AXHelpers.getChildren(submenu, runtime: runtime).filter {
-            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
-                && elementCenter($0, runtime: runtime) != nil
-        }
-        for labels in AXLocalePolicy.pluginFormatLeafPriority {
-            if let match = items.first(where: {
-                AXLocalePolicy.elementMatches($0, labels, runtime: runtime)
-            }) {
-                return match
-            }
-        }
-        return items.first
-    }
-
     #if DEBUG
-    /// Test seam (coord-free #425 durability): when set, the coordinate hover/click
-    /// primitives below return this value INSTEAD of computing an element centre and
-    /// posting a real CGEvent. It lets a hermetic test drive the coordinate-only
-    /// recursive-win path — proving the discriminator reports `coordFree == false`
-    /// even with the flag on — without moving the physical mouse. Never compiled
-    /// into release; production always posts the real CGEvent.
+    /// Test seam for the documented absent-custom-action coordinate fallback. When
+    /// set, the retained coordinate primitives return this value without posting a
+    /// real CGEvent. It is never compiled into release.
     @TaskLocal static var forceCoordinateActuationForTests: Bool?
 
     static func withForceCoordinateActuationForTests<Result>(
@@ -2692,23 +2681,6 @@ extension AccessibilityChannel {
         try await $forceCoordinateActuationForTests.withValue(value, operation: operation)
     }
     #endif
-
-    @discardableResult
-    private static func moveElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
-        #if DEBUG
-        if let forceCoordinateActuationForTests { return forceCoordinateActuationForTests }
-        #endif
-        guard let center = elementCenter(element, runtime: runtime) else { return false }
-        let source = CGEventSource(stateID: .combinedSessionState)
-        guard let move = CGEvent(
-            mouseEventSource: source,
-            mouseType: .mouseMoved,
-            mouseCursorPosition: center,
-            mouseButton: .left
-        ) else { return false }
-        move.post(tap: .cghidEventTap)
-        return true
-    }
 
     @discardableResult
     private static func clickElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2508,7 +2508,8 @@ extension AccessibilityChannel {
             guard let label = popupMenuItemLabel(item, runtime: runtime),
                   !popupMenuItemMatches(item, displayName: displayName, runtime: runtime),
                   menuItemEnabled(item, runtime: runtime),
-                  axChildMenu(of: item, runtime: runtime) != nil else {
+                  let submenu = axChildMenu(of: item, runtime: runtime),
+                  !submenuIsPluginFormatMenu(submenu, runtime: runtime) else {
                 continue
             }
             // Only an item with Logic's already-attached AXMenu child is a proven
@@ -2556,6 +2557,23 @@ extension AccessibilityChannel {
     ) -> AXUIElement? {
         AXHelpers.getChildren(item, runtime: runtime).first {
             (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuRole as String)
+        }
+    }
+
+    /// True only for a non-empty submenu whose every menu item is a known plugin
+    /// format label. Requiring every item avoids classifying a category as a
+    /// format menu merely because one plugin happens to share a format label.
+    private static func submenuIsPluginFormatMenu(
+        _ submenu: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let items = AXHelpers.getChildren(submenu, runtime: runtime).filter {
+            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
+        }
+        return !items.isEmpty && items.allSatisfy { item in
+            AXLocalePolicy.pluginFormatLeafPriority.contains { labels in
+                AXLocalePolicy.elementMatches(item, labels, runtime: runtime)
+            }
         }
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2507,12 +2507,14 @@ extension AccessibilityChannel {
         for item in items {
             guard let label = popupMenuItemLabel(item, runtime: runtime),
                   !popupMenuItemMatches(item, displayName: displayName, runtime: runtime),
-                  menuItemEnabled(item, runtime: runtime) else {
+                  menuItemEnabled(item, runtime: runtime),
+                  axChildMenu(of: item, runtime: runtime) != nil else {
                 continue
             }
-            // AXPick reveals Logic's already-attached AXMenu child without a
-            // hover. Its return code is untrustworthy, so only the observed menu
-            // visibility below is allowed to choose whether we descend.
+            // Only an item with Logic's already-attached AXMenu child is a proven
+            // category. AXPick reveals that child without a hover. Its return code
+            // is untrustworthy, so only the observed menu visibility below is
+            // allowed to choose whether we descend.
             _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
             try? await Task.sleep(for: .milliseconds(140))
             guard let submenu = visibleSubmenu(of: item, runtime: runtime) else {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2659,17 +2659,36 @@ extension AccessibilityChannel {
     /// real CGEvent. It is never compiled into release.
     @TaskLocal static var forceCoordinateActuationForTests: Bool?
 
+    /// A test-only coordinate-click effect. This is invoked only after the
+    /// fallback reaches `clickElementCenter`, so fixtures can model an observable
+    /// consequence of the coordinate click without a real CGEvent.
+    private struct CoordinateActuationTestEffect: @unchecked Sendable {
+        let perform: () -> Bool
+    }
+
+    @TaskLocal private static var coordinateActuationTestEffect: CoordinateActuationTestEffect?
+
     static func withForceCoordinateActuationForTests<Result>(
         _ value: Bool,
         operation: () async throws -> Result
     ) async rethrows -> Result {
         try await $forceCoordinateActuationForTests.withValue(value, operation: operation)
     }
+
+    static func withCoordinateActuationForTests<Result>(
+        _ effect: @escaping () -> Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $coordinateActuationTestEffect.withValue(
+            CoordinateActuationTestEffect(perform: effect), operation: operation
+        )
+    }
     #endif
 
     @discardableResult
     private static func clickElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
         #if DEBUG
+        if let coordinateActuationTestEffect { return coordinateActuationTestEffect.perform() }
         if let forceCoordinateActuationForTests { return forceCoordinateActuationForTests }
         #endif
         guard let center = elementCenter(element, runtime: runtime) else { return false }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1823,7 +1823,7 @@ extension AccessibilityChannel {
     /// the metadata lines. It opens the legacy-inclusive plug-in popup even
     /// though the AX call can report `cannotComplete` after opening it.
     private static let slotPopupOpenCustomAction =
-        "Name:Open plug-in menu with legacy plug-ins\\nTarget:0x0\\nSelector:(null)"
+        "\"Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)\""
 
     /// Production exact-slot popup insert driver. Drives the target insert slot's
     /// own popup menu and returns a structured outcome plus a `select_trace`

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1822,8 +1822,8 @@ extension AccessibilityChannel {
     /// Logic's empty insert slot exposes this custom action verbatim, including
     /// the metadata lines. It opens the legacy-inclusive plug-in popup even
     /// though the AX call can report `cannotComplete` after opening it.
-    private static let slotPopupOpenCustomAction =
-        "\"Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)\""
+    static let slotPopupOpenCustomAction =
+        "Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)"
 
     /// Production exact-slot popup insert driver. Drives the target insert slot's
     /// own popup menu and returns a structured outcome plus a `select_trace`

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2508,19 +2508,11 @@ extension AccessibilityChannel {
             guard let label = popupMenuItemLabel(item, runtime: runtime),
                   !popupMenuItemMatches(item, displayName: displayName, runtime: runtime),
                   menuItemEnabled(item, runtime: runtime),
-                  let submenu = axChildMenu(of: item, runtime: runtime),
-                  !submenuIsPluginFormatMenu(submenu, runtime: runtime) else {
+                  let submenu = axChildMenu(of: item, runtime: runtime) else {
                 continue
             }
-            // Only an item with Logic's already-attached AXMenu child is a proven
-            // category. AXPick reveals that child without a hover. Its return code
-            // is untrustworthy, so only the observed menu visibility below is
-            // allowed to choose whether we descend.
-            _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
-            try? await Task.sleep(for: .milliseconds(140))
-            guard let submenu = visibleSubmenu(of: item, runtime: runtime) else {
-                continue
-            }
+            // Logic already exposes this submenu as an AX child, so discovery can
+            // recurse through the read-only tree without actuating the category.
             if let found = await clickPopupExactLeafRecursively(
                 displayName: displayName,
                 menu: submenu,
@@ -2557,23 +2549,6 @@ extension AccessibilityChannel {
     ) -> AXUIElement? {
         AXHelpers.getChildren(item, runtime: runtime).first {
             (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuRole as String)
-        }
-    }
-
-    /// True only for a non-empty submenu whose every menu item is a known plugin
-    /// format label. Requiring every item avoids classifying a category as a
-    /// format menu merely because one plugin happens to share a format label.
-    private static func submenuIsPluginFormatMenu(
-        _ submenu: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> Bool {
-        let items = AXHelpers.getChildren(submenu, runtime: runtime).filter {
-            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
-        }
-        return !items.isEmpty && items.allSatisfy { item in
-            AXLocalePolicy.pluginFormatLeafPriority.contains { labels in
-                AXLocalePolicy.elementMatches(item, labels, runtime: runtime)
-            }
         }
     }
 
@@ -2676,16 +2651,6 @@ extension AccessibilityChannel {
     ) -> Bool {
         let enabled: Bool? = AXHelpers.getAttribute(item, kAXEnabledAttribute as String, runtime: runtime)
         return enabled ?? true
-    }
-
-    private static func visibleSubmenu(
-        of item: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> AXUIElement? {
-        AXHelpers.getChildren(item, runtime: runtime).first {
-            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuRole as String)
-                && isVisibleMenu($0, runtime: runtime)
-        }
     }
 
     #if DEBUG

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1801,8 +1801,8 @@ extension AccessibilityChannel {
             ))
 
         case let .transientSetupFailure(stage):
-            // A pre-mount UI-setup step did not complete (menu/search-field/results
-            // not ready). No write attempted → retry-able (P2-3), distinct from the
+            // A pre-mount UI-setup step did not complete (slot popup, anchor, or
+            // exact leaf not ready). No write attempted → retry-able (P2-3), distinct from the
             // permanent insert_not_ax_automatable.
             return .error(HonestContract.encodeV2StateC(
                 error: .insertSetupFailed,
@@ -1845,15 +1845,15 @@ extension AccessibilityChannel {
     /// Sequence:
     ///   0. hide any stray plugin windows (a front plugin window from a prior
     ///      attempt steals the menu — R14 live: AXPress menu nav opened the track
-    ///      instrument window instead of the search dialog);
+    ///      instrument window instead of the requested slot popup);
     ///   1. select the target track and verify `AXSelected` readback;
     ///   2. raise the mixer/main window and read the full pre-insert inventory;
     ///   3. locate the requested filtered insert slot and invoke its discovered
     ///      custom action to open that slot's popup (coordinate fallback only when
     ///      the action is absent);
     ///   4. prove the popup is anchored to the target slot, then choose the stock
-    ///      plugin by exact leaf title from that anchored popup (direct/search/
-    ///      recursive discovery), not by localized category names;
+    ///      plugin by exact leaf title from that anchored popup (direct/recursive
+    ///      discovery), not by localized category names;
     ///   5. CONDITION-poll the inventory (wait for an actual change, not the first
     ///      readable snapshot) and diff against the pre-snapshot to detect WHERE
     ///      the requested plugin landed;
@@ -1914,14 +1914,20 @@ extension AccessibilityChannel {
         }
         trace["target_slot_found"] = true
 
+        var popupAnchorSlot = targetSlot.element
         switch slotPopupOpenCustomActionEnumerationResult(on: targetSlot.element, runtime: runtime.ax) {
         case .enumeratedAndPresent:
             // Live evidence: this can return `cannotComplete` (-25204) even when
             // it opens the popup. Dispatch it through the same runtime seam as
             // AXPress, but let the observed popup poll below make the decision.
+            guard let liveTargetSlot = liveInsertSlot(track: track, insert: insert, runtime: runtime),
+                  liveTargetSlot.isEmpty else {
+                return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+            }
             _ = AXHelpers.performAction(
-                targetSlot.element, slotPopupOpenCustomAction, runtime: runtime.ax
+                liveTargetSlot.element, slotPopupOpenCustomAction, runtime: runtime.ax
             )
+            popupAnchorSlot = liveTargetSlot.element
             trace["slot_popup_open_fallback_taken"] = false
             trace["slot_popup_open_action"] = "custom_action"
             trace["slot_popup_open_action_enumeration"] = "present"
@@ -1932,9 +1938,14 @@ extension AccessibilityChannel {
             trace["slot_popup_open_fallback_taken"] = true
             trace["slot_popup_open_action"] = "coordinate_fallback"
             trace["slot_popup_open_action_enumeration"] = "absent"
-            guard clickElementCenter(targetSlot.element, runtime: runtime.ax) else {
+            guard let liveTargetSlot = liveInsertSlot(track: track, insert: insert, runtime: runtime),
+                  liveTargetSlot.isEmpty else {
+                return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+            }
+            guard clickElementCenter(liveTargetSlot.element, runtime: runtime.ax) else {
                 return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
             }
+            popupAnchorSlot = liveTargetSlot.element
         case .enumerationFailed:
             // An AX read failure does not prove that this build lacks the custom
             // action, so it must not downgrade to the coordinate write path.
@@ -1953,7 +1964,7 @@ extension AccessibilityChannel {
         trace["slot_popup_menu_found"] = true
 
         let anchorVerified = slotPopupMenuIsAnchored(
-            rootMenu, toSlot: targetSlot.element, runtime: runtime.ax
+            rootMenu, toSlot: popupAnchorSlot, runtime: runtime.ax
         )
         trace["slot_popup_anchor_verified"] = anchorVerified
         guard anchorVerified else {
@@ -2310,6 +2321,7 @@ extension AccessibilityChannel {
     ) -> SlotPopupOpenCustomActionEnumerationResult {
         #if DEBUG
         if let result = slotPopupOpenCustomActionEnumerationResultForTests {
+            slotPopupOpenActionEnumerationHookForTests?()
             return result
         }
         #endif
@@ -2331,6 +2343,11 @@ extension AccessibilityChannel {
     @TaskLocal static var slotPopupOpenCustomActionEnumerationResultForTests:
         SlotPopupOpenCustomActionEnumerationResult?
 
+    /// Test-only hook that runs after a deterministic enumeration result and
+    /// before the selected slot-opening write. It models live UI drift in the
+    /// otherwise unobservable AX action-enumeration interval.
+    @TaskLocal static var slotPopupOpenActionEnumerationHookForTests: (@Sendable () -> Void)?
+
     static func withSlotPopupOpenCustomActionEnumerationResultForTests<Result>(
         _ result: SlotPopupOpenCustomActionEnumerationResult,
         operation: () async throws -> Result
@@ -2338,6 +2355,13 @@ extension AccessibilityChannel {
         try await $slotPopupOpenCustomActionEnumerationResultForTests.withValue(
             result, operation: operation
         )
+    }
+
+    static func withSlotPopupOpenActionEnumerationHookForTests<Result>(
+        _ hook: @escaping @Sendable () -> Void,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $slotPopupOpenActionEnumerationHookForTests.withValue(hook, operation: operation)
     }
 
     /// Retained action-name test seam for present/absent compatibility fixtures.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1454,7 +1454,7 @@ extension AccessibilityChannel {
     /// The injectable live-insert seam. Performs the live insert sequence and
     /// returns a structured outcome plus a `select_trace` diagnostic dict. Injected
     /// so the gate→outcome→envelope mapping is unit-testable without ever issuing
-    /// real CGEvent/menu actions; the production default (`liveExactSlotPopupInsert`)
+    /// real AX actions (custom opener + AXPick); the production default (`liveExactSlotPopupInsert`)
     /// is the only path that touches the live UI.
     typealias PluginInsertDriver = @Sendable (
         _ track: Int,
@@ -1914,41 +1914,57 @@ extension AccessibilityChannel {
         }
         trace["target_slot_found"] = true
 
-        var popupAnchorSlot = targetSlot.element
-        switch slotPopupOpenCustomActionEnumerationResult(on: targetSlot.element, runtime: runtime.ax) {
+        // One element must carry BOTH the authorisation and the actuation. Enumerating the custom
+        // action on one resolution and acting on a later one authorised an element that is not the
+        // element being driven: if the AX tree replaces the still-empty slot in between, the
+        // replacement may expose the action, or have an unreadable action list — the case the
+        // three-state enumeration exists to refuse — and would be actuated anyway.
+        //
+        // So re-resolve as late as possible, prove it is still the empty slot the attempt was
+        // authorised to use, and from here on read and act only through `slot`.
+        guard let slot = liveInsertSlot(track: track, insert: insert, runtime: runtime),
+              slot.isEmpty else {
+            return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+        }
+        let popupAnchorSlot = slot.element
+        let authorisation = slotPopupOpenCustomActionEnumerationResult(on: slot.element, runtime: runtime.ax)
+
+        // Enumeration is a read and takes time, so the slot may be occupied by the time we act.
+        // Re-read it — but require the SAME element, not merely an empty one: a replacement element
+        // was never the subject of `authorisation`, and it may expose the custom action or refuse to
+        // enumerate at all. Occupancy and identity are reported separately so the receipt says which
+        // one refused.
+        guard let fresh = liveInsertSlot(track: track, insert: insert, runtime: runtime) else {
+            return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+        }
+        guard fresh.isEmpty else {
+            return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+        }
+        guard CFEqual(fresh.element, slot.element) else {
+            return (.transientSetupFailure(stage: "target_slot_element_replaced"), trace)
+        }
+
+        switch authorisation {
         case .enumeratedAndPresent:
-            // Live evidence: this can return `cannotComplete` (-25204) even when
-            // it opens the popup. Dispatch it through the same runtime seam as
-            // AXPress, but let the observed popup poll below make the decision.
-            guard let liveTargetSlot = liveInsertSlot(track: track, insert: insert, runtime: runtime),
-                  liveTargetSlot.isEmpty else {
-                return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
-            }
-            _ = AXHelpers.performAction(
-                liveTargetSlot.element, slotPopupOpenCustomAction, runtime: runtime.ax
-            )
-            popupAnchorSlot = liveTargetSlot.element
+            // Live evidence: this can return `cannotComplete` (-25204) even when it opens the popup.
+            // Dispatch it through the same runtime seam as AXPress, and let the observed popup poll
+            // below make the decision.
+            _ = AXHelpers.performAction(slot.element, slotPopupOpenCustomAction, runtime: runtime.ax)
             trace["slot_popup_open_fallback_taken"] = false
             trace["slot_popup_open_action"] = "custom_action"
             trace["slot_popup_open_action_enumeration"] = "present"
         case .enumeratedAndAbsent:
-            // Compatibility path for builds that do not expose the measured custom
-            // action. This is intentionally recorded: a coordinate fallback is not
-            // silently treated as the preferred coordinate-free actuation.
+            // Compatibility path for builds that do not expose the measured custom action. Recorded
+            // deliberately: a coordinate fallback is never reported as the coordinate-free path.
             trace["slot_popup_open_fallback_taken"] = true
             trace["slot_popup_open_action"] = "coordinate_fallback"
             trace["slot_popup_open_action_enumeration"] = "absent"
-            guard let liveTargetSlot = liveInsertSlot(track: track, insert: insert, runtime: runtime),
-                  liveTargetSlot.isEmpty else {
-                return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
-            }
-            guard clickElementCenter(liveTargetSlot.element, runtime: runtime.ax) else {
+            guard clickElementCenter(slot.element, runtime: runtime.ax) else {
                 return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
             }
-            popupAnchorSlot = liveTargetSlot.element
         case .enumerationFailed:
-            // An AX read failure does not prove that this build lacks the custom
-            // action, so it must not downgrade to the coordinate write path.
+            // An AX read failure does not prove that this build lacks the custom action, so it must
+            // not downgrade to the coordinate write path.
             trace["slot_popup_open_fallback_taken"] = false
             trace["slot_popup_open_action"] = "action_enumeration_failed"
             trace["slot_popup_open_action_enumeration"] = "failed"
@@ -2452,7 +2468,7 @@ extension AccessibilityChannel {
     }
 
     /// `internal` (was `private`) so popup-navigation results are unit-testable
-    /// without driving the CGEvent-bound live insert flow.
+    /// without driving the live insert flow.
     struct SlotPopupPluginClick: Sendable {
         let strategy: String
         let path: [String]
@@ -2460,7 +2476,7 @@ extension AccessibilityChannel {
     }
 
     /// `internal` (was `private`) so popup navigation is unit-testable without
-    /// driving the CGEvent-bound live insert flow.
+    /// driving the live insert flow.
     static func clickPluginInAnchoredSlotPopup(
         pluginID: String,
         displayName: String,
@@ -2470,8 +2486,11 @@ extension AccessibilityChannel {
         var strategies: [String] = []
         strategies.append("slot_popup_direct_exact_leaf")
         if let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
-           let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime) {
+           let label = popupMenuItemLabel(item, runtime: runtime) {
+            // The pick dispatches and returns nothing: acceptance is the caller's post-insert
+            // inventory diff, never this call. It used to return a Bool that was always true and sat
+            // in this condition, reading like a gate that could not deny.
+            await clickPopupPluginLeaf(item, runtime: runtime)
             return SlotPopupPluginClick(
                 strategy: "slot_popup_direct_exact_leaf",
                 path: [label],
@@ -2508,8 +2527,8 @@ extension AccessibilityChannel {
         guard maxDepth >= 0 else { return nil }
 
         if let direct = directExactPopupMenuItem(displayName: displayName, in: menu, runtime: runtime),
-           let label = popupMenuItemLabel(direct, runtime: runtime),
-           await clickPopupPluginLeaf(direct, runtime: runtime) {
+           let label = popupMenuItemLabel(direct, runtime: runtime) {
+            await clickPopupPluginLeaf(direct, runtime: runtime)
             return path + [label]
         }
 
@@ -2542,14 +2561,14 @@ extension AccessibilityChannel {
     static func clickPopupPluginLeaf(
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) async -> Bool {
+    ) async {
         if let submenu = axChildMenu(of: item, runtime: runtime),
+           submenuIsPluginFormatMenu(submenu, runtime: runtime),
            let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime) {
             _ = AXHelpers.performAction(leaf, kAXPickAction as String, runtime: runtime)
-            return true
+            return
         }
         _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
-        return true
     }
 
     /// A submenu exposed as an AX child of `item`, regardless of visual visibility.
@@ -2574,11 +2593,31 @@ extension AccessibilityChannel {
         for labels in AXLocalePolicy.pluginFormatLeafPriority {
             if let match = items.first(where: {
                 AXLocalePolicy.elementMatches($0, labels, runtime: runtime)
+                    && axChildMenu(of: $0, runtime: runtime) == nil
             }) {
                 return match
             }
         }
-        return items.first
+        // No "whatever is first" fallback. An entry that matches no known format label is an entry
+        // nothing identified, and picking it would actuate a target the caller never asked for.
+        return nil
+    }
+
+    /// True when every entry of `submenu` is a known plug-in format label. Logic exposes category
+    /// entries named like formats, so descending into "the first AXMenu child" is not enough to know
+    /// the submenu is a format chooser rather than more of the plug-in tree.
+    private static func submenuIsPluginFormatMenu(
+        _ submenu: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let items = AXHelpers.getChildren(submenu, runtime: runtime).filter {
+            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXMenuItemRole as String)
+        }
+        return !items.isEmpty && items.allSatisfy { item in
+            AXLocalePolicy.pluginFormatLeafPriority.contains { labels in
+                AXLocalePolicy.elementMatches(item, labels, runtime: runtime)
+            }
+        }
     }
 
     private static func popupExactLeafPaths(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1935,7 +1935,9 @@ extension AccessibilityChannel {
         let popupAnchorSlot = slot.element
         // Anything already open belongs to someone else; only a menu that appears after we actuate
         // can be evidence that WE opened this slot's pop-up.
-        let preexistingMenus = visibleSlotPopupMenus(runtime: runtime)
+        guard let preexistingMenus = visibleSlotPopupMenus(runtime: runtime) else {
+            return (.transientSetupFailure(stage: "popup_snapshot_unreadable"), trace)
+        }
         trace["slot_popup_preexisting_menus"] = preexistingMenus.count
         let authorisation = slotPopupOpenCustomActionEnumerationResult(on: slot.element, runtime: runtime.ax)
 
@@ -1969,7 +1971,13 @@ extension AccessibilityChannel {
             trace["slot_popup_open_fallback_taken"] = true
             trace["slot_popup_open_action"] = "coordinate_fallback"
             trace["slot_popup_open_action_enumeration"] = "absent"
-            guard clickElementCenter(slot.element, runtime: runtime.ax) else {
+            switch clickElementCenterOutcome(slot.element, runtime: runtime.ax) {
+            case .posted:
+                break
+            case .noTargetPoint:
+                // Nothing was created or posted, so the envelope must not claim a write.
+                return (.transientSetupFailure(stage: "target_slot_click_failed", actuated: false), trace)
+            case .postFailed:
                 return (.transientSetupFailure(stage: "target_slot_click_failed", actuated: true), trace)
             }
         case .enumerationFailed:
@@ -2341,7 +2349,7 @@ extension AccessibilityChannel {
     ) async -> AXUIElement? {
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
         repeat {
-            let fresh = visibleSlotPopupMenus(runtime: runtime).filter { menu in
+            let fresh = (visibleSlotPopupMenus(runtime: runtime) ?? []).filter { menu in
                 !preexisting.contains { CFEqual($0, menu) }
             }
             if let menu = fresh.first {
@@ -2420,10 +2428,12 @@ extension AccessibilityChannel {
 
     /// Every currently visible plug-in pop-up, so a caller can tell a menu that was already there
     /// from one its own actuation opened.
+    /// nil when the tree could not be read. An unreadable snapshot must not be mistaken for "nothing
+    /// was open": that would let a pop-up that existed all along be accepted as newly created.
     private static func visibleSlotPopupMenus(
         runtime: AXLogicProElements.Runtime
-    ) -> [AXUIElement] {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return [] }
+    ) -> [AXUIElement]? {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return nil }
         let menus = AXHelpers.findAllDescendants(
             of: app, role: kAXMenuRole as String, maxDepth: 9, runtime: runtime.ax
         )
@@ -2530,11 +2540,8 @@ extension AccessibilityChannel {
         var strategies: [String] = []
         strategies.append("slot_popup_direct_exact_leaf")
         if let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
-           let label = popupMenuItemLabel(item, runtime: runtime) {
-            // The pick dispatches and returns nothing: acceptance is the caller's post-insert
-            // inventory diff, never this call. It used to return a Bool that was always true and sat
-            // in this condition, reading like a gate that could not deny.
-            await clickPopupPluginLeaf(item, runtime: runtime)
+           let label = popupMenuItemLabel(item, runtime: runtime),
+           await clickPopupPluginLeaf(item, runtime: runtime) {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_direct_exact_leaf",
                 path: [label],
@@ -2571,8 +2578,8 @@ extension AccessibilityChannel {
         guard maxDepth >= 0 else { return nil }
 
         if let direct = directExactPopupMenuItem(displayName: displayName, in: menu, runtime: runtime),
-           let label = popupMenuItemLabel(direct, runtime: runtime) {
-            await clickPopupPluginLeaf(direct, runtime: runtime)
+           let label = popupMenuItemLabel(direct, runtime: runtime),
+           await clickPopupPluginLeaf(direct, runtime: runtime) {
             return path + [label]
         }
 
@@ -2602,17 +2609,25 @@ extension AccessibilityChannel {
     /// Dispatch AXPick to the matched plugin leaf (or its preferred format leaf).
     /// AX's return code is deliberately ignored: the caller's post-insert inventory
     /// diff is the only acceptance signal.
+    /// Dispatches `AXPick` at the plug-in, and reports whether it dispatched anything.
+    ///
+    /// The result CAN be false, and that is the point: an entry that owns a submenu we cannot
+    /// identify as a channel-format chooser is a category wearing a plug-in's name, and picking it
+    /// would actuate a category. Refusing lets the caller keep looking instead.
     static func clickPopupPluginLeaf(
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) async {
-        if let submenu = axChildMenu(of: item, runtime: runtime),
-           submenuIsPluginFormatMenu(submenu, runtime: runtime),
-           let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime) {
+    ) async -> Bool {
+        if let submenu = axChildMenu(of: item, runtime: runtime) {
+            guard submenuIsPluginFormatMenu(submenu, runtime: runtime),
+                  let leaf = preferredFormatLeafByLabel(in: submenu, runtime: runtime) else {
+                return false
+            }
             _ = AXHelpers.performAction(leaf, kAXPickAction as String, runtime: runtime)
-            return
+            return true
         }
         _ = AXHelpers.performAction(item, kAXPickAction as String, runtime: runtime)
+        return true
     }
 
     /// A submenu exposed as an AX child of `item`, regardless of visual visibility.
@@ -2738,6 +2753,8 @@ extension AccessibilityChannel {
         return nil
     }
 
+    /// Lenient: an unreadable state counts as enabled. Used by READ-ONLY discovery, where refusing
+    /// to descend on an unreadable attribute would hide reachable plug-ins and actuates nothing.
     private static func menuItemEnabled(
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -2777,6 +2794,31 @@ extension AccessibilityChannel {
         )
     }
     #endif
+
+    /// Outcome of a coordinate click, distinguishing "we never posted anything" from "we posted and
+    /// the post failed". The Honest Contract must not claim a write for the former.
+    enum CoordinateClickOutcome {
+        case posted
+        case noTargetPoint
+        case postFailed
+    }
+
+    private static func clickElementCenterOutcome(
+        _ element: AXUIElement, runtime: AXHelpers.Runtime
+    ) -> CoordinateClickOutcome {
+        #if DEBUG
+        if let coordinateActuationTestEffect { return coordinateActuationTestEffect.perform() ? .posted : .postFailed }
+        if let forceCoordinateActuationForTests { return forceCoordinateActuationForTests ? .posted : .postFailed }
+        #endif
+        guard let center = elementCenter(element, runtime: runtime) else { return .noTargetPoint }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let down = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
+              let up = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left)
+        else { return .postFailed }
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+        return .posted
+    }
 
     @discardableResult
     private static func clickElementCenter(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1412,10 +1412,11 @@ extension AccessibilityChannel {
     // MARK: - insert_verified (exact slot popup insert → readback-gated State A)
 
     /// Structured result of one live insert attempt. The production driver opens
-    /// the requested slot's own popup and physically clicks the plugin menu item,
-    /// then diffs the pre- vs post-insert inventory to detect WHERE the requested
-    /// plugin actually landed. Only `.mounted` whose `slot` equals the requested
-    /// `insert` becomes State A; a different slot is honest State C
+    /// the requested slot's own popup with its measured custom AX action (or the
+    /// coordinate fallback when that action is absent) and selects the exact
+    /// plugin leaf with `AXPick`, then diffs the pre- vs post-insert inventory to
+    /// detect WHERE the requested plugin actually landed. Only `.mounted` whose
+    /// `slot` equals the requested `insert` becomes State A; a different slot is honest State C
     /// (`insert_landed_at_different_slot`), so a slot is never falsely confirmed.
     enum InsertDriverOutcome: Sendable {
         /// The requested plugin (`pluginID`) was observed newly mounted at the
@@ -1482,9 +1483,11 @@ extension AccessibilityChannel {
 
     /// Guarded verified insert entry. The write-preceding gates run live and are
     /// honest: schema → mode → project path → identity → inventory `complete:true`
-    /// → slot-empty. Only after every gate passes does the op drive the requested
-    /// slot's own popup menu by physical CGEvent clicks, then a post-insert
-    /// `get_inventory` readback (pre/post diff) is the SOLE State A precondition.
+    /// → slot-empty. Only after every gate passes does the op open the requested
+    /// slot's own popup with its custom AX action (falling back to a coordinate
+    /// click only when that action is absent), select the exact leaf with `AXPick`,
+    /// then use a post-insert `get_inventory` readback (pre/post diff) as the SOLE
+    /// State A precondition.
     ///
     /// State A is reachable ONLY when the readback observes the requested plugin
     /// newly mounted at the requested slot — a false verified insert is
@@ -1903,6 +1906,12 @@ extension AccessibilityChannel {
         guard let targetSlot = liveInsertSlot(track: track, insert: insert, runtime: runtime) else {
             return (.transientSetupFailure(stage: "target_slot_not_found"), trace)
         }
+        // The initial write gate and the just-read snapshot may already be stale.
+        // Re-resolve and require the physical target is still the empty slot the
+        // attempt was authorized to use before any popup-opening actuation.
+        guard preInventory[insert] == nil, targetSlot.isEmpty else {
+            return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
+        }
         trace["target_slot_found"] = true
 
         switch slotPopupOpenCustomActionEnumerationResult(on: targetSlot.element, runtime: runtime.ax) {
@@ -1965,10 +1974,9 @@ extension AccessibilityChannel {
         trace["winning_strategy"] = pluginClick.strategy
         trace["winning_menu_path"] = pluginClick.path.joined(separator: " > ")
         trace["plugin_selection_id"] = pluginID
-        // Every popup-navigation strategy above is coordinate-free AXPick. Keep the
-        // receipt field for compatibility, sourced from the winning action rather
-        // than from a feature flag.
-        trace["leaf_select_coord_free"] = leafSelectCoordFree(for: pluginClick)
+        // Published compatibility receipt: every leaf-selection strategy at this
+        // head is AXPick, so this is constant and not a discriminator.
+        trace["leaf_select_coord_free"] = true
 
         #if DEBUG
         // QA/test-only seam (#425): after a winning leaf select, deterministically
@@ -1981,7 +1989,7 @@ extension AccessibilityChannel {
         // release (`#if DEBUG`).
         if forcePostCommitTimeoutForTestsActive {
             return (
-                .postCommitTimeout(strategy: postCommitTimeoutStrategy(coordFree: pluginClick.coordFree)),
+                .postCommitTimeout(strategy: "slot_popup_axpick_menu_select"),
                 trace
             )
         }
@@ -2028,10 +2036,8 @@ extension AccessibilityChannel {
         }
 
         if poll.satisfied == nil {
-            // #425: report the coordinate-free AXPick actuation that actually
-            // selected the leaf; the inventory observation remains the gate.
             return (
-                .postCommitTimeout(strategy: postCommitTimeoutStrategy(coordFree: pluginClick.coordFree)),
+                .postCommitTimeout(strategy: "slot_popup_axpick_menu_select"),
                 trace
             )
         }
@@ -2039,13 +2045,6 @@ extension AccessibilityChannel {
     }
 
     // MARK: - insert_verified live driver helpers
-
-    /// The honest commit-strategy label for a post-commit timeout. The popup path
-    /// now uses AXPick throughout; this remains a single source of truth for the
-    /// live timeout path and the DEBUG force-timeout QA seam.
-    static func postCommitTimeoutStrategy(coordFree: Bool) -> String {
-        coordFree ? "slot_popup_axpick_menu_select" : "slot_popup_physical_menu_click"
-    }
 
     #if DEBUG
     /// QA/test seam (#425): when set, `liveExactSlotPopupInsert` short-circuits to
@@ -2428,25 +2427,16 @@ extension AccessibilityChannel {
         return popupExactLeafPaths(displayName: displayName, rootMenu: rootMenu, runtime: runtime).first
     }
 
-    /// `internal` (was `private`) so the coord-free discriminator is unit-testable
+    /// `internal` (was `private`) so popup-navigation results are unit-testable
     /// without driving the CGEvent-bound live insert flow.
     struct SlotPopupPluginClick: Sendable {
         let strategy: String
         let path: [String]
         let strategies: [String]
-        /// Every winning popup strategy uses AXPick, so this remains true. The
-        /// caller records the actual winning actuation, never a feature flag.
-        let coordFree: Bool
     }
 
-    /// The single source of truth for the backwards-compatible
-    /// `leaf_select_coord_free` receipt field.
-    static func leafSelectCoordFree(for click: SlotPopupPluginClick) -> Bool {
-        click.coordFree
-    }
-
-    /// `internal` (was `private`) so the coord-free discriminator is unit-testable
-    /// without driving the CGEvent-bound live insert flow.
+    /// `internal` (was `private`) so popup navigation is unit-testable without
+    /// driving the CGEvent-bound live insert flow.
     static func clickPluginInAnchoredSlotPopup(
         pluginID: String,
         displayName: String,
@@ -2461,21 +2451,7 @@ extension AccessibilityChannel {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_direct_exact_leaf",
                 path: [label],
-                strategies: strategies,
-                coordFree: true
-            )
-        }
-
-        strategies.append("slot_popup_search_exact_leaf")
-        if await filterSlotPopupSearchField(displayName: displayName, rootMenu: rootMenu, runtime: runtime),
-           let item = directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime),
-           let label = popupMenuItemLabel(item, runtime: runtime),
-           await clickPopupPluginLeaf(item, runtime: runtime) {
-            return SlotPopupPluginClick(
-                strategy: "slot_popup_search_exact_leaf",
-                path: [label],
-                strategies: strategies,
-                coordFree: true
+                strategies: strategies
             )
         }
 
@@ -2490,40 +2466,12 @@ extension AccessibilityChannel {
             return SlotPopupPluginClick(
                 strategy: "slot_popup_recursive_exact_leaf",
                 path: result,
-                strategies: strategies,
-                coordFree: true
+                strategies: strategies
             )
         }
 
         _ = pluginID // kept in the trace by the caller; selection is by exact display leaf.
         return nil
-    }
-
-    private static func filterSlotPopupSearchField(
-        displayName: String,
-        rootMenu: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) async -> Bool {
-        guard let field = AXHelpers.findDescendant(
-            of: rootMenu, role: kAXTextFieldRole as String, maxDepth: 4, runtime: runtime
-        ) else {
-            return false
-        }
-        _ = AXHelpers.setAttribute(field, kAXFocusedAttribute as String, true as CFTypeRef, runtime: runtime)
-        _ = AXHelpers.setAttribute(field, kAXValueAttribute as String, "" as CFTypeRef, runtime: runtime)
-        guard AXHelpers.setAttribute(
-            field, kAXValueAttribute as String, displayName as CFTypeRef, runtime: runtime
-        ) else {
-            return false
-        }
-        let deadline = Date().addingTimeInterval(0.9)
-        repeat {
-            if directExactPopupMenuItem(displayName: displayName, in: rootMenu, runtime: runtime) != nil {
-                return true
-            }
-            try? await Task.sleep(for: .milliseconds(90))
-        } while Date() < deadline
-        return false
     }
 
     private static func clickPopupExactLeafRecursively(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1448,7 +1448,11 @@ extension AccessibilityChannel {
         /// attempted. Distinct from the
         /// permanent `.mountMismatch` (every strategy ran but the plugin never
         /// mounted) — these are retry-able (`safe_to_retry:true`), P2-3.
-        case transientSetupFailure(stage: String)
+        /// `actuated` records whether anything was already dispatched at the target when this
+        /// failure was raised. Several setup stages are only reachable after the slot's opener has
+        /// been performed or clicked, and reporting those as "no write attempted" denies an
+        /// actuation that did happen.
+        case transientSetupFailure(stage: String, actuated: Bool = false)
     }
 
     /// The injectable live-insert seam. Performs the live insert sequence and
@@ -1800,7 +1804,7 @@ extension AccessibilityChannel {
                 ]
             ))
 
-        case let .transientSetupFailure(stage):
+        case let .transientSetupFailure(stage, actuated):
             // A pre-mount UI-setup step did not complete (slot popup, anchor, or
             // exact leaf not ready). No write attempted → retry-able (P2-3), distinct from the
             // permanent insert_not_ax_automatable.
@@ -1812,9 +1816,11 @@ extension AccessibilityChannel {
                     "setup_stage": stage,
                     "select_trace": trace,
                     "what_was_attempted": "open the requested slot popup and choose \(pluginID)",
-                    "what_was_observed": "the exact slot popup UI was not ready at stage '\(stage)' — no insert was attempted",
+                    "what_was_observed": actuated
+                        ? "the slot's opener was dispatched, then setup stopped at stage '\(stage)' before any plugin was chosen"
+                        : "the exact slot popup UI was not ready at stage '\(stage)' — nothing was dispatched at the slot",
                     "safe_to_retry": true,
-                    "write_attempted": false,
+                    "write_attempted": actuated,
                 ]
             ))
         }
@@ -1927,6 +1933,10 @@ extension AccessibilityChannel {
             return (.transientSetupFailure(stage: "target_slot_no_longer_empty"), trace)
         }
         let popupAnchorSlot = slot.element
+        // Anything already open belongs to someone else; only a menu that appears after we actuate
+        // can be evidence that WE opened this slot's pop-up.
+        let preexistingMenus = visibleSlotPopupMenus(runtime: runtime)
+        trace["slot_popup_preexisting_menus"] = preexistingMenus.count
         let authorisation = slotPopupOpenCustomActionEnumerationResult(on: slot.element, runtime: runtime.ax)
 
         // Enumeration is a read and takes time, so the slot may be occupied by the time we act.
@@ -1960,7 +1970,7 @@ extension AccessibilityChannel {
             trace["slot_popup_open_action"] = "coordinate_fallback"
             trace["slot_popup_open_action_enumeration"] = "absent"
             guard clickElementCenter(slot.element, runtime: runtime.ax) else {
-                return (.transientSetupFailure(stage: "target_slot_click_failed"), trace)
+                return (.transientSetupFailure(stage: "target_slot_click_failed", actuated: true), trace)
             }
         case .enumerationFailed:
             // An AX read failure does not prove that this build lacks the custom action, so it must
@@ -1973,9 +1983,11 @@ extension AccessibilityChannel {
         }
         try? await Task.sleep(for: .milliseconds(250))
 
-        guard let rootMenu = await pollSlotPopupMenu(runtime: runtime, timeoutMs: 1_200) else {
+        guard let rootMenu = await pollSlotPopupMenu(
+            runtime: runtime, timeoutMs: 1_200, excluding: preexistingMenus
+        ) else {
             AXMouseHelper.pressEscape()
-            return (.transientSetupFailure(stage: "slot_popup_menu_not_found"), trace)
+            return (.transientSetupFailure(stage: "slot_popup_menu_not_found", actuated: true), trace)
         }
         trace["slot_popup_menu_found"] = true
 
@@ -1985,7 +1997,7 @@ extension AccessibilityChannel {
         trace["slot_popup_anchor_verified"] = anchorVerified
         guard anchorVerified else {
             AXMouseHelper.pressEscape()
-            return (.transientSetupFailure(stage: "slot_popup_not_anchored_to_target_slot"), trace)
+            return (.transientSetupFailure(stage: "slot_popup_not_anchored_to_target_slot", actuated: true), trace)
         }
 
         guard let pluginClick = await clickPluginInAnchoredSlotPopup(
@@ -1995,7 +2007,7 @@ extension AccessibilityChannel {
             runtime: runtime.ax
         ) else {
             AXMouseHelper.pressEscape()
-            return (.transientSetupFailure(stage: "plugin_exact_leaf_not_found"), trace)
+            return (.transientSetupFailure(stage: "plugin_exact_leaf_not_found", actuated: true), trace)
         }
         trace["strategies_attempted"] = pluginClick.strategies
         trace["winning_strategy"] = pluginClick.strategy
@@ -2314,13 +2326,25 @@ extension AccessibilityChannel {
         return slots[insert]
     }
 
+    /// Waits for a plug-in pop-up that was NOT already open before the caller actuated.
+    ///
+    /// Geometry alone cannot establish which slot a menu belongs to: insert slots in a strip sit
+    /// ~17px apart, while the anchor test accepts a menu anywhere within ±96px of its own height and
+    /// a ~500px horizontal band. A leftover menu from a neighbouring slot — or from a previous
+    /// attempt — therefore passes that test and would be navigated as though it were ours, mounting
+    /// the plug-in on somebody else's slot. Requiring the menu to have APPEARED after our actuation
+    /// is causal evidence that geometry cannot supply.
     private static func pollSlotPopupMenu(
         runtime: AXLogicProElements.Runtime,
-        timeoutMs: Int
+        timeoutMs: Int,
+        excluding preexisting: [AXUIElement] = []
     ) async -> AXUIElement? {
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
         repeat {
-            if let menu = slotPopupMenu(runtime: runtime) {
+            let fresh = visibleSlotPopupMenus(runtime: runtime).filter { menu in
+                !preexisting.contains { CFEqual($0, menu) }
+            }
+            if let menu = fresh.first {
                 return menu
             }
             try? await Task.sleep(for: .milliseconds(80))
@@ -2393,6 +2417,26 @@ extension AccessibilityChannel {
         )
     }
     #endif
+
+    /// Every currently visible plug-in pop-up, so a caller can tell a menu that was already there
+    /// from one its own actuation opened.
+    private static func visibleSlotPopupMenus(
+        runtime: AXLogicProElements.Runtime
+    ) -> [AXUIElement] {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return [] }
+        let menus = AXHelpers.findAllDescendants(
+            of: app, role: kAXMenuRole as String, maxDepth: 9, runtime: runtime.ax
+        )
+        return menus.filter { menu in
+            isVisibleMenu(menu, runtime: runtime.ax)
+                && AXHelpers.findDescendant(
+                    of: menu, role: kAXTextFieldRole as String, maxDepth: 3, runtime: runtime.ax
+                ) != nil
+                && AXHelpers.getChildren(menu, runtime: runtime.ax).contains(where: {
+                    (AXHelpers.getRole($0, runtime: runtime.ax) ?? "") == (kAXMenuItemRole as String)
+                })
+        }
+    }
 
     private static func slotPopupMenu(runtime: AXLogicProElements.Runtime) -> AXUIElement? {
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return nil }

--- a/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
@@ -27,7 +27,7 @@ enum VerifiedPluginCatalog {
 
     /// Display-name / alias → canonical `logic.stock.*` id table.
     ///
-    /// MVP scope (R5): the four allowlisted stock plugins. Compressor `threshold`
+    /// MVP scope (R5): the three allowlisted stock plugins. Compressor `threshold`
     /// is the first verified parameter-write target (audit #28); the others
     /// (including Gain) are identity/insert only. Display
     /// names are accepted as user-facing aliases but never become the identity

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -6,7 +6,6 @@ enum FeatureFlags: Sendable {
     @TaskLocal static var adr003StrictParamsOverride: Bool?
     @TaskLocal static var adr004MutationSagaOverride: Bool?
     @TaskLocal static var adr005OperationTraceOverride: Bool?
-    @TaskLocal static var insertCoordFreeOverride: Bool?
     #endif
 
     /// PRD-007 Part 2 (ADR-002 #285): promoted from opt-in to DEFAULT ON, so the
@@ -87,33 +86,6 @@ enum FeatureFlags: Sendable {
     static var adr006VersionedCache: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR006_VERSIONED_CACHE"] == "1"
     }
-
-    /// #425 (Option B): coordinate-free plugin-insert LEAF selection (AXPress over an
-    /// AX-children format submenu) in place of coordinate actuation.
-    /// Live-verified during the spike, so promoted from opt-in to DEFAULT ON: the
-    /// variable is now a kill-switch — read with `!= "0"` because an absent variable
-    /// must mean ON. Only the exact string "0" rolls back to the legacy coordinate
-    /// leaf click. Slot-open and the recursive category-hover fallback stay
-    /// coordinate (governed waiver): AXPress on the empty slot is a no-op and
-    /// AXShowMenu wedges Logic; the recursive path is a REACHABLE coordinate-only
-    /// fallback (tried after direct+search) that is unreachable IN PRACTICE for the
-    /// Release-1 plugins (Gain/Channel EQ/Compressor, always reached by
-    /// direct/search) — see `clickPopupPluginLeaf` / `pressPopupPluginLeaf`.
-    static var insertCoordFree: Bool {
-        #if DEBUG
-        if let insertCoordFreeOverride { return insertCoordFreeOverride }
-        #endif
-        return ProcessInfo.processInfo.environment["LOGIC_MCP_INSERT_COORD_FREE"] != "0"
-    }
-
-    #if DEBUG
-    static func withInsertCoordFree<Result>(
-        _ value: Bool,
-        operation: () async throws -> Result
-    ) async rethrows -> Result {
-        try await $insertCoordFreeOverride.withValue(value, operation: operation)
-    }
-    #endif
 
     static var adr007SelectorAtlas: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR007_SELECTOR_ATLAS"] == "1"

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -89,7 +89,7 @@ enum FeatureFlags: Sendable {
     }
 
     /// #425 (Option B): coordinate-free plugin-insert LEAF selection (AXPress over an
-    /// AX-children format submenu) in place of moveElementCenter/clickElementCenter.
+    /// AX-children format submenu) in place of coordinate actuation.
     /// Live-verified during the spike, so promoted from opt-in to DEFAULT ON: the
     /// variable is now a kill-switch — read with `!= "0"` because an absent variable
     /// must mean ON. Only the exact string "0" rolls back to the legacy coordinate

--- a/Tests/LogicProMCPTests/FeatureFlagsTests.swift
+++ b/Tests/LogicProMCPTests/FeatureFlagsTests.swift
@@ -125,41 +125,4 @@ struct FeatureFlagEnvironmentTests {
         }
     }
 
-    // #425 (Option B): `LOGIC_MCP_INSERT_COORD_FREE` is DEFAULT ON — coordinate-free
-    // plugin-insert LEAF selection is the shipped default, the variable now a
-    // kill-switch read with `!= "0"`. Same kill-switch shape as ADR-002/005 above;
-    // bare / negated `#expect` only (`== true/false` is DEAD under this toolchain
-    // and would pass against the pre-promotion `== "1"` source these guard against).
-    @Test("(a) #425 no env and no override reads as ON — the shipped default")
-    func insertCoordFreeDefaultsToOn() {
-        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", nil) {
-            #expect(FeatureFlags.insertCoordFree)
-        }
-    }
-
-    @Test("(b) #425 the =0 kill-switch restores the legacy coordinate leaf click")
-    func insertCoordFreeKillSwitchZeroDisables() {
-        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", "0") {
-            #expect(!FeatureFlags.insertCoordFree)
-        }
-    }
-
-    @Test("(c) #425 the pre-promotion =1 opt-in spelling still reads as ON")
-    func insertCoordFreeExplicitOneStaysOn() {
-        Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", "1") {
-            #expect(FeatureFlags.insertCoordFree)
-        }
-    }
-
-    @Test("#425 kill-switch matches \"0\" exactly — =false does NOT disable")
-    func insertCoordFreeKillSwitchMatchesZeroExactly() {
-        for notDisabled in ["false", "off", "no", "", " 0", "00"] {
-            Self.withEnv("LOGIC_MCP_INSERT_COORD_FREE", notDisabled) {
-                #expect(
-                    FeatureFlags.insertCoordFree,
-                    "LOGIC_MCP_INSERT_COORD_FREE=\(notDisabled) must NOT read as disabled — only \"0\" is the kill-switch"
-                )
-            }
-        }
-    }
 }

--- a/Tests/LogicProMCPTests/Issue425ContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue425ContractTests.swift
@@ -94,6 +94,10 @@ struct Issue425ContractTests {
         let unreleasedStatesRemoval = unreleased.contains("LOGIC_MCP_INSERT_COORD_FREE")
             && unreleased.contains("insertCoordFree")
             && unreleased.localizedCaseInsensitiveContains("removed")
+        let categoryPickPattern = #"(?:`?AXPick`?[^.\n]*\bcategory\b|\bcategory\b[^.\n]*`?AXPick`?)"#
+        let unreleasedClaimsCategoryPick = unreleased.range(
+            of: categoryPickPattern, options: .regularExpression
+        ) != nil
 
         #expect(unreleasedIsNonEmpty, "CHANGELOG.md ## [Unreleased] must not be empty")
         #expect(
@@ -103,6 +107,10 @@ struct Issue425ContractTests {
         #expect(
             !hasRemovedControlToken || unreleasedStatesRemoval,
             "Historical coordinate-free control tokens require ## [Unreleased] to state their removal"
+        )
+        #expect(
+            !unreleasedClaimsCategoryPick,
+            "CHANGELOG.md ## [Unreleased] must not claim that a category is AXPick'ed"
         )
     }
 }

--- a/Tests/LogicProMCPTests/Issue425ContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue425ContractTests.swift
@@ -23,6 +23,15 @@ struct Issue425ContractTests {
         return texts
     }
 
+    private static func markdownSection(named heading: String, in markdown: String) -> String? {
+        let lines = markdown.components(separatedBy: .newlines)
+        guard let headingIndex = lines.firstIndex(of: heading) else { return nil }
+
+        return lines[(headingIndex + 1)...]
+            .prefix { !$0.hasPrefix("## ") }
+            .joined(separator: "\n")
+    }
+
     @Test("#425 flag is absent from Sources or has a production consumer")
     func insertCoordinateFreeFlagIsNotInert() throws {
         let sources = try Self.sourceTexts()
@@ -55,5 +64,29 @@ struct Issue425ContractTests {
         #expect(!ticket.contains("LOGIC_MCP_INSERT_COORD_FREE"))
         #expect(ticket.contains("slot-open uses the exact custom action"))
         #expect(ticket.contains("`AXPick` for category and leaf selection"))
+    }
+
+    @Test("#425 changelog supersedes the removed coordinate-free control")
+    func changelogSupersedesRemovedCoordinateFreeControl() throws {
+        let changelog = try scriptContents("CHANGELOG.md")
+        let unreleased = try #require(
+            Self.markdownSection(named: "## [Unreleased]", in: changelog),
+            "CHANGELOG.md must contain an ## [Unreleased] section"
+        )
+        let hasRemovedControlToken = Self.inertFlagTokens.contains { changelog.contains($0) }
+        let unreleasedIsNonEmpty = !unreleased.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let unreleasedStatesRemoval = unreleased.contains("LOGIC_MCP_INSERT_COORD_FREE")
+            && unreleased.contains("insertCoordFree")
+            && unreleased.localizedCaseInsensitiveContains("removed")
+
+        #expect(unreleasedIsNonEmpty, "CHANGELOG.md ## [Unreleased] must not be empty")
+        #expect(
+            !unreleased.contains("(No unreleased changes yet.)"),
+            "CHANGELOG.md ## [Unreleased] must describe this branch's changes"
+        )
+        #expect(
+            !hasRemovedControlToken || unreleasedStatesRemoval,
+            "Historical coordinate-free control tokens require ## [Unreleased] to state their removal"
+        )
     }
 }

--- a/Tests/LogicProMCPTests/Issue425ContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue425ContractTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@Suite("#425 shipped-design contract")
+struct Issue425ContractTests {
+    private static let inertFlagTokens = [
+        "insertCoordFree",
+        "LOGIC_MCP_INSERT_COORD_FREE",
+    ]
+
+    private static func sourceTexts() throws -> [(url: URL, text: String)] {
+        let sources = installScriptContractRepositoryRootURL().appendingPathComponent("Sources")
+        let enumerator = FileManager.default.enumerator(
+            at: sources,
+            includingPropertiesForKeys: nil
+        )
+
+        var texts: [(url: URL, text: String)] = []
+        while let url = enumerator?.nextObject() as? URL {
+            guard url.pathExtension == "swift" else { continue }
+            texts.append((url, try String(contentsOf: url, encoding: .utf8)))
+        }
+        return texts
+    }
+
+    @Test("#425 flag is absent from Sources or has a production consumer")
+    func insertCoordinateFreeFlagIsNotInert() throws {
+        let sources = try Self.sourceTexts()
+        let featureFlagsURL = installScriptContractRepositoryRootURL()
+            .appendingPathComponent("Sources/LogicProMCP/Utilities/FeatureFlags.swift")
+            .standardizedFileURL
+
+        let flagExists = sources.contains { source in
+            Self.inertFlagTokens.contains { source.text.contains($0) }
+        }
+        let productionConsumerCount = sources
+            .filter { $0.url.standardizedFileURL != featureFlagsURL }
+            .reduce(0) { count, source in
+                count + Self.inertFlagTokens.reduce(0) { tokenCount, token in
+                    tokenCount + source.text.components(separatedBy: token).count - 1
+                }
+            }
+
+        #expect(
+            !flagExists || productionConsumerCount > 0,
+            "#425 insert-coordinate-free flag exists in Sources but has no production consumer outside FeatureFlags.swift"
+        )
+    }
+
+    @Test("#425 ticket documents the shipped custom-action and AXPick design")
+    func ticketMatchesShippedDesign() throws {
+        let ticket = try scriptContents("docs/tickets/issue-425-coord-free-insert.md")
+
+        #expect(!ticket.contains("Slot-open stays a coordinate click."))
+        #expect(!ticket.contains("LOGIC_MCP_INSERT_COORD_FREE"))
+        #expect(ticket.contains("slot-open uses the exact custom action"))
+        #expect(ticket.contains("`AXPick` for category and leaf selection"))
+    }
+}

--- a/Tests/LogicProMCPTests/Issue425ContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue425ContractTests.swift
@@ -56,14 +56,30 @@ struct Issue425ContractTests {
         )
     }
 
-    @Test("#425 ticket documents the shipped custom-action and AXPick design")
+    @Test("#425 ticket documents the shipped custom-action and read-only discovery design")
     func ticketMatchesShippedDesign() throws {
         let ticket = try scriptContents("docs/tickets/issue-425-coord-free-insert.md")
+        let categoryPickPattern = #"(?:`?AXPick`?[^.\n]*\bcategory\b|\bcategory\b[^.\n]*`?AXPick`?)"#
+        let ticketClaimsCategoryPick = ticket.range(
+            of: categoryPickPattern, options: .regularExpression
+        ) != nil
 
         #expect(!ticket.contains("Slot-open stays a coordinate click."))
         #expect(!ticket.contains("LOGIC_MCP_INSERT_COORD_FREE"))
         #expect(ticket.contains("slot-open uses the exact custom action"))
-        #expect(ticket.contains("`AXPick` for category and leaf selection"))
+        #expect(ticket.contains("Discovery is read-only"))
+        #expect(ticket.contains("already-attached `AXMenu` child"))
+        #expect(ticket.contains("performs no AX action on any non-target item"))
+        #expect(ticket.contains("`AXPick` is dispatched only to the leaf"))
+        #expect(!ticketClaimsCategoryPick, "#425 ticket must not claim that a category is AXPick'ed")
+        #expect(ticket.contains("| Gain | 2 | 2 |"))
+        #expect(ticket.contains("| Compressor | 1 | 1 |"))
+        #expect(ticket.contains("| Channel EQ | 1 | 1 |"))
+        #expect(ticket.contains("| Tremolo | 2 | 2 |"))
+        #expect(ticket.contains("| Flanger | 2 | 2 |"))
+        #expect(ticket.contains("| Amps and Pedals | 4 | 4 |"))
+        #expect(ticket.contains("not lazy"))
+        #expect(ticket.contains("one Logic version and locale"))
     }
 
     @Test("#425 changelog supersedes the removed coordinate-free control")

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -965,6 +965,28 @@ private func run425Insert(
     #expect(!fallbackTaken)
 }
 
+@Test func testPlugin425SlotOpenFailsClosedWhenActionEnumerationFails() async throws {
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let obj = await AccessibilityChannel.withSlotPopupOpenCustomActionEnumerationResultForTests(
+        .enumerationFailed
+    ) {
+        await AccessibilityChannel.withCoordinateActuationForTests(fixture.coordinateFallbackClick) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "slot_action_enumeration_failed")
+    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
+    #expect(!fallbackTaken)
+    let slotOpenAction = try #require(trace["slot_popup_open_action"] as? String)
+    #expect(slotOpenAction == "action_enumeration_failed")
+}
+
 @Test func testPlugin425SlotOpenSuccessFailsClosedWhenPopupIsNotObserved() async throws {
     let fixture = makeSlotPopupInsertFixture(popupAppearsAfterSlotOpen: false)
     let obj = await run425Insert(

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -816,6 +816,8 @@ private struct SlotPopupInsertFixture {
     let replacementSlotID: Int
     let nonFormatSubmenuItemIDs: [Int]
     let nonTerminalFormatEntryID: Int?
+    let searchFieldID: Int
+    let leftoverMenuItemID: Int?
     let coordinateFallbackClick: () -> Bool
 }
 
@@ -836,7 +838,8 @@ private func makeSlotPopupInsertFixture(
     mountGainOnLeafPick: Bool = false,
     occupySlotOnWindowRaise: Bool = false,
     includeNonFormatSubmenu: Bool = false,
-    includeNonTerminalFormatEntry: Bool = false
+    includeNonTerminalFormatEntry: Bool = false,
+    leftoverNeighbourMenuVisible: Bool = false
 ) -> SlotPopupInsertFixture {
     let b = FakeAXRuntimeBuilder()
     let app = b.element(9000)
@@ -856,6 +859,9 @@ private func makeSlotPopupInsertFixture(
     let nonMatchingFormatMono = includeNonMatchingLeafFormatMenu ? b.element(9018) : nil
     let nonMatchingFormatMonoToStereo = includeNonMatchingLeafFormatMenu ? b.element(9019) : nil
     let formatNamedCategoryItem = includeFormatNamedCategoryEntry ? b.element(9020) : nil
+    let leftoverMenu = leftoverNeighbourMenuVisible ? b.element(9040) : nil
+    let leftoverSearch = leftoverNeighbourMenuVisible ? b.element(9041) : nil
+    let leftoverItem = leftoverNeighbourMenuVisible ? b.element(9042) : nil
     let nonTerminalFormatMenu = includeNonTerminalFormatEntry ? b.element(9034) : nil
     let nonTerminalFormatEntry = includeNonTerminalFormatEntry ? b.element(9035) : nil
     let nonTerminalFormatChild = includeNonTerminalFormatEntry ? b.element(9036) : nil
@@ -894,6 +900,18 @@ private func makeSlotPopupInsertFixture(
     // Slot popup: visible + anchored after the modeled custom slot-open action.
     b.setAttribute(gainItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
     b.setAttribute(gainItem, kAXTitleAttribute as String, "Gain")
+    if let leftoverMenu, let leftoverSearch, let leftoverItem {
+        // A pop-up left open by a neighbouring slot. It is a plug-in menu, it is visible, and it sits
+        // close enough that the geometric anchor test accepts it for our slot too — so only its
+        // having been there BEFORE we actuated distinguishes it from ours.
+        b.setAttribute(leftoverSearch, kAXRoleAttribute as String, kAXTextFieldRole as String)
+        b.setAttribute(leftoverItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(leftoverItem, kAXTitleAttribute as String, "Gain")
+        b.setAttribute(leftoverMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        b.setAttribute(leftoverMenu, kAXPositionAttribute as String, axPoint(400, 290))
+        b.setAttribute(leftoverMenu, kAXSizeAttribute as String, axSize(300, 400))
+        b.setChildren(leftoverMenu, [leftoverSearch, leftoverItem])
+    }
     if let nonTerminalFormatMenu, let nonTerminalFormatEntry, let nonTerminalFormatChild,
        let nonTerminalFormatChildMenu {
         // Every entry carries a real format label, so the submenu passes the format discriminator —
@@ -969,7 +987,11 @@ private func makeSlotPopupInsertFixture(
     // the (top-level) popup menu.
     b.setAttribute(app, kAXWindowsAttribute as String, [window])
     b.setAttribute(app, kAXMainWindowAttribute as String, window)
-    b.setChildren(app, popupInitiallyVisible ? [window, popupMenu] : [window])
+    // The leftover menu is present from the start: that is what makes it "already open".
+    var initialAppChildren: [AXUIElement] = [window]
+    if let leftoverMenu { initialAppChildren.append(leftoverMenu) }
+    if popupInitiallyVisible { initialAppChildren.append(popupMenu) }
+    b.setChildren(app, initialAppChildren)
 
     let slotKey = b.elementID(slot)
     let windowKey = b.elementID(window)
@@ -1022,7 +1044,7 @@ private func makeSlotPopupInsertFixture(
             }
             if elementID == slotKey, action == slotPopupOpenCustomAction {
                 if popupAppearsAfterSlotOpen {
-                    b.setChildren(app, [window, popupMenu])
+                    b.setChildren(app, leftoverMenu.map { [window, $0, popupMenu] } ?? [window, popupMenu])
                 }
                 return slotOpenResult
             }
@@ -1058,8 +1080,10 @@ private func makeSlotPopupInsertFixture(
         replacementSlotID: b.elementID(replacementSlot),
         nonFormatSubmenuItemIDs: [nonFormatEntryA, nonFormatEntryB].compactMap { $0 }.map(b.elementID),
         nonTerminalFormatEntryID: nonTerminalFormatEntry.map(b.elementID),
+        searchFieldID: b.elementID(searchField),
+        leftoverMenuItemID: leftoverItem.map(b.elementID),
         coordinateFallbackClick: {
-            b.setChildren(app, [window, popupMenu])
+            b.setChildren(app, leftoverMenu.map { [window, $0, popupMenu] } ?? [window, popupMenu])
             return true
         }
     )
@@ -1319,13 +1343,46 @@ private func run425Insert(
     #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
 }
 
+@Test func testPlugin425NeverNavigatesAPopupThatWasAlreadyOpen() async throws {
+    // A menu left open by a neighbouring slot passes the geometric anchor test — slots sit ~17px
+    // apart while the bands are ±96px and ~500px. Only "it appeared after we actuated" separates it
+    // from ours, and navigating the wrong one mounts the plug-in on somebody else's slot.
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true, leftoverNeighbourMenuVisible: true)
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await runRealInsert(runtime: fixture.runtime)
+    }
+    let leftoverID = try #require(fixture.leftoverMenuItemID)
+    #expect(!fixture.actions.touched(elementID: leftoverID))
+    // and the run still did its real work, so this is not an absence caused by nothing happening
+    #expect(try #require(obj["state"] as? String) == "A")
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+}
+
+@Test func testPlugin425FullInsertWritesNoAttributesAnywhereInThePopup() async throws {
+    // The unit-level discovery test proves the recursive walk writes nothing. This asserts the same
+    // property end-to-end through the real driver, where the pop-up carries a search field: a whole
+    // successful insert must not set a single attribute on any pop-up element.
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await runRealInsert(runtime: fixture.runtime)
+    }
+    #expect(try #require(obj["state"] as? String) == "A")
+    #expect(!fixture.actions.touched(elementID: fixture.searchFieldID))
+    #expect(fixture.actions.attributeWrites.isEmpty)
+}
+
 @Test func testPlugin425NeverPicksAFormatLabelledEntryThatOwnsItsOwnMenu() async throws {
     // A "Mono" entry that owns a submenu is a category wearing a format name. It satisfies the
     // format-label check, so only the terminal requirement keeps AXPick off it.
     let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true, includeNonTerminalFormatEntry: true)
-    _ = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
         await runRealInsert(runtime: fixture.runtime)
     }
+    // Same reasoning: show the flow reached the pick, so "the category was untouched" is a result
+    // rather than a consequence of nothing having happened.
+    #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(try #require(obj["state"] as? String) == "A")
     let entryID = try #require(fixture.nonTerminalFormatEntryID)
     #expect(!fixture.actions.touched(elementID: entryID))
 }
@@ -1335,9 +1392,14 @@ private func run425Insert(
     // not mean that menu is a channel-format chooser. Entering it and picking whatever sits first
     // would actuate a target nothing identified.
     let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true, includeNonFormatSubmenu: true)
-    _ = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
         await runRealInsert(runtime: fixture.runtime)
     }
+    // An absence assertion proves nothing if the flow never got there, so prove it did: the slot was
+    // opened and the exact Gain entry — not anything inside the foreign submenu — was picked.
+    #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(try #require(obj["state"] as? String) == "A")
     for id in fixture.nonFormatSubmenuItemIDs {
         #expect(!fixture.actions.touched(elementID: id))
     }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -682,7 +682,7 @@ private func insertParams(
 // MARK: - #425: coordinate-free slot-popup navigation
 
 private let slotPopupOpenCustomAction =
-    "Name:Open plug-in menu with legacy plug-ins\\nTarget:0x0\\nSelector:(null)"
+    "\"Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)\""
 
 /// Captures calls that pass through the injected AX action runtime seam. The
 /// tests run sequentially, so this deliberately lightweight recorder is safe.

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -721,12 +721,29 @@ private final class AXActionRecorder: @unchecked Sendable {
         calls.count { $0.elementID == elementID && $0.action == action }
     }
 
+    func touched(elementID: Int) -> Bool {
+        calls.contains { $0.elementID == elementID }
+            || attributeWrites.contains { $0.elementID == elementID }
+    }
+
     func nonTargetActionCount(targetElementID: Int) -> Int {
         calls.count { $0.elementID != targetElementID }
     }
 
     func nonTargetAttributeWriteCount(targetElementID: Int) -> Int {
         attributeWrites.count { $0.elementID != targetElementID }
+    }
+}
+
+private final class SlotOccupier: @unchecked Sendable {
+    private let performOccupancy: () -> Void
+
+    init(_ performOccupancy: @escaping () -> Void) {
+        self.performOccupancy = performOccupancy
+    }
+
+    func occupy() {
+        performOccupancy()
     }
 }
 
@@ -790,8 +807,11 @@ private struct SlotPopupInsertFixture {
     let slotItemID: Int
     let categoryItemID: Int?
     let nonMatchingLeafItemID: Int?
+    let nonMatchingFormatLeafItemIDs: [Int]
+    let formatNamedCategoryItemID: Int?
     let leafItemID: Int
     let actions: AXActionRecorder
+    let slotOccupier: SlotOccupier
     let coordinateFallbackClick: () -> Bool
 }
 
@@ -913,27 +933,36 @@ private func makeSlotPopupInsertFixture(
     let leafKey = formatLeafItem.map(b.elementID) ?? b.elementID(gainItem)
     let categoryKey = categoryItem.map(b.elementID)
     let nonMatchingLeafKey = nonMatchingLeafItem.map(b.elementID)
+    let nonMatchingFormatLeafKeys = [nonMatchingFormatMono, nonMatchingFormatMonoToStereo]
+        .compactMap { $0.map(b.elementID) }
+    let formatNamedCategoryKey = formatNamedCategoryItem.map(b.elementID)
     let actions = AXActionRecorder()
     let pickAction = kAXPickAction as String
+    let slotOccupier = SlotOccupier {
+        let bypass = b.element(9021)
+        let open = b.element(9022)
+        b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(slot, kAXDescriptionAttribute as String, "Compressor")
+        b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
+        b.setAttribute(bypass, kAXValueAttribute as String, 0)
+        b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
+        b.setChildren(slot, [bypass, open])
+    }
     let runtime = b.makeLogicRuntime(
         appElement: app,
-        setAttributeHandler: nil,
+        setAttributeHandler: { element, attribute, _ in
+            actions.recordAttributeWrite(elementID: b.elementID(element), attribute: attribute)
+            return true
+        },
         performActionHandler: { element, action in
             let elementID = b.elementID(element)
             actions.record(elementID: elementID, action: action)
             if occupySlotOnWindowRaise,
                elementID == windowKey,
                action == (kAXRaiseAction as String) {
-                let bypass = b.element(9021)
-                let open = b.element(9022)
-                b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
-                b.setAttribute(slot, kAXDescriptionAttribute as String, "Compressor")
-                b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
-                b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
-                b.setAttribute(bypass, kAXValueAttribute as String, 0)
-                b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
-                b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
-                b.setChildren(slot, [bypass, open])
+                slotOccupier.occupy()
             }
             if elementID == slotKey, action == slotPopupOpenCustomAction {
                 if popupAppearsAfterSlotOpen {
@@ -964,8 +993,11 @@ private func makeSlotPopupInsertFixture(
         slotItemID: slotKey,
         categoryItemID: categoryKey,
         nonMatchingLeafItemID: nonMatchingLeafKey,
+        nonMatchingFormatLeafItemIDs: nonMatchingFormatLeafKeys,
+        formatNamedCategoryItemID: formatNamedCategoryKey,
         leafItemID: leafKey,
         actions: actions,
+        slotOccupier: slotOccupier,
         coordinateFallbackClick: {
             b.setChildren(app, [window, popupMenu])
             return true
@@ -1027,7 +1059,7 @@ private func run425Insert(
     #expect(state == "C")
     let stage = try #require(obj["setup_stage"] as? String)
     #expect(stage == "slot_action_enumeration_failed")
-    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
     #expect(!fallbackTaken)
@@ -1060,7 +1092,7 @@ private func run425Insert(
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
-    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
+    #expect(!fixture.actions.touched(elementID: categoryID))
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let strategy = try #require(trace["winning_strategy"] as? String)
@@ -1086,8 +1118,8 @@ private func run425Insert(
     #expect(stage == "target_slot_no_longer_empty")
     let writeAttempted = try #require(obj["write_attempted"] as? Bool)
     #expect(!writeAttempted)
-    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
-    #expect(!fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
+    #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
 }
 
 @Test func testPlugin425RecursiveWalkOnlyPicksExactLeaf() async throws {
@@ -1104,9 +1136,9 @@ private func run425Insert(
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
     let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
-    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
+    #expect(!fixture.actions.touched(elementID: categoryID))
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
-    #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
+    #expect(!fixture.actions.touched(elementID: nonMatchingLeafID))
 }
 
 @Test func testPlugin425RecursiveWalkSkipsNonMatchingFormatLeafWithoutActuation() async throws {
@@ -1124,9 +1156,12 @@ private func run425Insert(
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
     let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
-    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
+    #expect(!fixture.actions.touched(elementID: categoryID))
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
-    #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
+    #expect(!fixture.actions.touched(elementID: nonMatchingLeafID))
+    for formatLeafID in fixture.nonMatchingFormatLeafItemIDs {
+        #expect(!fixture.actions.touched(elementID: formatLeafID))
+    }
 }
 
 @Test func testPlugin425RecursiveWalkDescendsPastFormatNamedCategoryEntryWithoutActuation() async throws {
@@ -1142,7 +1177,9 @@ private func run425Insert(
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
-    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
+    let formatNamedCategoryID = try #require(fixture.formatNamedCategoryItemID)
+    #expect(!fixture.actions.touched(elementID: categoryID))
+    #expect(!fixture.actions.touched(elementID: formatNamedCategoryID))
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
 }
 
@@ -1191,10 +1228,54 @@ private func run425Insert(
 
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
-    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
     #expect(fallbackTaken)
     let slotOpenAction = try #require(trace["slot_popup_open_action"] as? String)
     #expect(slotOpenAction == "coordinate_fallback")
+}
+
+@Test func testPlugin425CoordinateFallbackFailsClosedWhenSlotBecomesOccupiedDuringEnumeration() async throws {
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let slotOccupier = fixture.slotOccupier
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([]) {
+        await AccessibilityChannel.withSlotPopupOpenActionEnumerationHookForTests {
+            slotOccupier.occupy()
+        } operation: {
+            await AccessibilityChannel.withCoordinateActuationForTests(fixture.coordinateFallbackClick) {
+                await runRealInsert(runtime: fixture.runtime)
+            }
+        }
+    }
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "target_slot_no_longer_empty")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
+    #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
+}
+
+@Test func testPlugin425CustomSlotOpenFailsClosedWhenSlotBecomesOccupiedDuringEnumeration() async throws {
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let slotOccupier = fixture.slotOccupier
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await AccessibilityChannel.withSlotPopupOpenActionEnumerationHookForTests {
+            slotOccupier.occupy()
+        } operation: {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "target_slot_no_longer_empty")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
+    #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -706,6 +706,10 @@ private final class AXActionRecorder: @unchecked Sendable {
     func contains(elementID: Int, action: String) -> Bool {
         calls.contains { $0.elementID == elementID && $0.action == action }
     }
+
+    func count(elementID: Int, action: String) -> Int {
+        calls.count { $0.elementID == elementID && $0.action == action }
+    }
 }
 
 private let coordFreeExpectedPath = "/Users/me/Music/CoordFree425 copy.logicx"
@@ -714,6 +718,7 @@ private struct SlotPopupInsertFixture {
     let runtime: AXLogicProElements.Runtime
     let slotItemID: Int
     let categoryItemID: Int?
+    let nonMatchingLeafItemID: Int?
     let leafItemID: Int
     let actions: AXActionRecorder
 }
@@ -727,6 +732,7 @@ private func makeSlotPopupInsertFixture(
     popupInitiallyVisible: Bool = false,
     slotOpenResult: Bool = true,
     includeCategory: Bool = false,
+    includeNonMatchingLeaf: Bool = false,
     includeFormatLeaf: Bool = false,
     revealCategorySubmenuOnPick: Bool = true,
     categoryPickResult: Bool = true,
@@ -746,6 +752,7 @@ private func makeSlotPopupInsertFixture(
     let searchField = b.element(9009)
     let categoryItem = includeCategory ? b.element(9010) : nil
     let categoryMenu = includeCategory ? b.element(9011) : nil
+    let nonMatchingLeafItem = includeNonMatchingLeaf ? b.element(9016) : nil
     let formatLeafItem = includeFormatLeaf ? b.element(9014) : nil
     let formatMenu = includeFormatLeaf ? b.element(9015) : nil
 
@@ -788,6 +795,10 @@ private func makeSlotPopupInsertFixture(
     b.setAttribute(popupMenu, kAXRoleAttribute as String, kAXMenuRole as String)
     b.setAttribute(popupMenu, kAXPositionAttribute as String, axPoint(410, 320))
     b.setAttribute(popupMenu, kAXSizeAttribute as String, axSize(240, 420))
+    if let nonMatchingLeafItem {
+        b.setAttribute(nonMatchingLeafItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(nonMatchingLeafItem, kAXTitleAttribute as String, "Compressor")
+    }
     if let categoryItem, let categoryMenu {
         b.setAttribute(categoryItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
         b.setAttribute(categoryItem, kAXTitleAttribute as String, "Utility")
@@ -796,9 +807,9 @@ private func makeSlotPopupInsertFixture(
         // but starts invisible until the category action's observed effect.
         b.setChildren(categoryMenu, [gainItem])
         b.setChildren(categoryItem, [categoryMenu])
-        b.setChildren(popupMenu, [searchField, categoryItem])
+        b.setChildren(popupMenu, [searchField] + (nonMatchingLeafItem.map { [$0] } ?? []) + [categoryItem])
     } else {
-        b.setChildren(popupMenu, [searchField, gainItem])
+        b.setChildren(popupMenu, [searchField] + (nonMatchingLeafItem.map { [$0] } ?? []) + [gainItem])
     }
 
     // App: AXWindows for mainWindow; children so slotPopupMenu's app-descent finds
@@ -810,6 +821,7 @@ private func makeSlotPopupInsertFixture(
     let slotKey = b.elementID(slot)
     let leafKey = formatLeafItem.map(b.elementID) ?? b.elementID(gainItem)
     let categoryKey = categoryItem.map(b.elementID)
+    let nonMatchingLeafKey = nonMatchingLeafItem.map(b.elementID)
     let actions = AXActionRecorder()
     let pickAction = kAXPickAction as String
     let runtime = b.makeLogicRuntime(
@@ -852,6 +864,7 @@ private func makeSlotPopupInsertFixture(
         runtime: runtime,
         slotItemID: slotKey,
         categoryItemID: categoryKey,
+        nonMatchingLeafItemID: nonMatchingLeafKey,
         leafItemID: leafKey,
         actions: actions
     )
@@ -928,6 +941,25 @@ private func run425Insert(
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let strategy = try #require(trace["winning_strategy"] as? String)
     #expect(strategy == "slot_popup_recursive_exact_leaf")
+}
+
+@Test func testPlugin425RecursiveWalkNeverPicksNonMatchingLeafBeforeCategory() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        includeCategory: true,
+        includeNonMatchingLeaf: true,
+        mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    let categoryID = try #require(fixture.categoryItemID)
+    let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
+    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
 }
 
 @Test func testPlugin425LeafPickFailureProceedsWhenInventoryDiffIsObserved() async throws {

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -760,6 +760,7 @@ private struct SlotPopupInsertFixture {
     let nonMatchingLeafItemID: Int?
     let leafItemID: Int
     let actions: AXActionRecorder
+    let coordinateFallbackClick: () -> Bool
 }
 
 /// The full AX tree the real insert driver walks. The action handler models the
@@ -916,7 +917,11 @@ private func makeSlotPopupInsertFixture(
         categoryItemID: categoryKey,
         nonMatchingLeafItemID: nonMatchingLeafKey,
         leafItemID: leafKey,
-        actions: actions
+        actions: actions,
+        coordinateFallbackClick: {
+            b.setChildren(app, [window, popupMenu])
+            return true
+        }
     )
 }
 
@@ -1083,11 +1088,13 @@ private func run425Insert(
 
 @Test func testPlugin425SlotOpenFallsBackToCoordinateClickWhenCustomActionIsAbsent() async throws {
     let fixture = makeSlotPopupInsertFixture(
-        popupInitiallyVisible: true, mountGainOnLeafPick: true
+        popupInitiallyVisible: false, mountGainOnLeafPick: true
     )
-    let obj = await run425Insert(
-        fixture: fixture, slotOpenActions: [], coordinateFallbackResult: true
-    )
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([]) {
+        await AccessibilityChannel.withCoordinateActuationForTests(fixture.coordinateFallbackClick) {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
 
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
@@ -1095,4 +1102,6 @@ private func run425Insert(
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
     #expect(fallbackTaken)
+    let slotOpenAction = try #require(trace["slot_popup_open_action"] as? String)
+    #expect(slotOpenAction == "coordinate_fallback")
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -685,6 +685,7 @@ private let slotPopupOpenCustomAction = AccessibilityChannel.slotPopupOpenCustom
 
 @Test func testSlotPopupOpenCustomActionMatchesLiveAXMeasurement() {
     let action = AccessibilityChannel.slotPopupOpenCustomAction
+    let metadataLines = action.components(separatedBy: "\n")
 
     #expect(action.utf8.count == 70)
     #expect(!action.hasPrefix("\""))
@@ -692,6 +693,10 @@ private let slotPopupOpenCustomAction = AccessibilityChannel.slotPopupOpenCustom
     #expect(action.contains("\n"))
     #expect(!action.contains("\\n"))
     #expect(action.hasPrefix("Name:Open plug-in menu with legacy plug-ins"))
+    #expect(metadataLines.count == 3)
+    #expect(metadataLines[0] == "Name:Open plug-in menu with legacy plug-ins")
+    #expect(metadataLines[1] == "Target:0x0")
+    #expect(metadataLines[2] == "Selector:(null)")
 }
 
 /// Captures calls that pass through the injected AX action runtime seam. The
@@ -710,6 +715,40 @@ private final class AXActionRecorder: @unchecked Sendable {
     func count(elementID: Int, action: String) -> Int {
         calls.count { $0.elementID == elementID && $0.action == action }
     }
+
+    func nonTargetCount(targetElementID: Int) -> Int {
+        calls.count { $0.elementID != targetElementID }
+    }
+}
+
+@Test func testPlugin425RecursiveDiscoveryReadsAttachedSubmenusWithoutActuatingThem() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let target = addMenuItem(b, 9100, title: "Gain")
+    let vendorMenu = addMenu(b, 9101, children: [target])
+    let vendor = addMenuItem(b, 9102, title: "Fabricant", children: [vendorMenu])
+    let categoryMenu = addMenu(b, 9103, children: [vendor])
+    let category = addMenuItem(b, 9104, title: "Dienstprogramme", children: [categoryMenu])
+    let rootMenu = addMenu(b, 9105, children: [category])
+    let actions = AXActionRecorder()
+    let runtime = b.makeAXRuntime(
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            actions.record(elementID: b.elementID(element), action: action)
+            return true
+        }
+    )
+
+    let click = await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+        pluginID: "logic.stock.effect.gain",
+        displayName: "Gain",
+        rootMenu: rootMenu,
+        runtime: runtime
+    )
+
+    #expect(actions.nonTargetCount(targetElementID: b.elementID(target)) == 0)
+    let result = try #require(click)
+    #expect(result.path == ["Dienstprogramme", "Fabricant", "Gain"])
+    #expect(actions.count(elementID: b.elementID(target), action: kAXPickAction as String) == 1)
 }
 
 private let coordFreeExpectedPath = "/Users/me/Music/CoordFree425 copy.logicx"
@@ -736,8 +775,6 @@ private func makeSlotPopupInsertFixture(
     includeNonMatchingLeafFormatMenu: Bool = false,
     includeFormatNamedCategoryEntry: Bool = false,
     includeFormatLeaf: Bool = false,
-    revealCategorySubmenuOnPick: Bool = true,
-    categoryPickResult: Bool = true,
     leafPickResult: Bool = true,
     mountGainOnLeafPick: Bool = false
 ) -> SlotPopupInsertFixture {
@@ -822,8 +859,8 @@ private func makeSlotPopupInsertFixture(
             b.setAttribute(formatNamedCategoryItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
             b.setAttribute(formatNamedCategoryItem, kAXTitleAttribute as String, "Mono")
         }
-        // AXPick controls visual exposure. The submenu is already an AX child,
-        // but starts invisible until the category action's observed effect.
+        // The submenu is already an AX child but has no visible frame. Recursive
+        // discovery must read this child directly without actuating the category.
         b.setChildren(categoryMenu, (formatNamedCategoryItem.map { [$0] } ?? []) + [gainItem])
         b.setChildren(categoryItem, [categoryMenu])
         b.setChildren(popupMenu, [searchField] + (nonMatchingLeafItem.map { [$0] } ?? []) + [categoryItem])
@@ -854,12 +891,6 @@ private func makeSlotPopupInsertFixture(
                     b.setChildren(app, [window, popupMenu])
                 }
                 return slotOpenResult
-            }
-            if let categoryKey, elementID == categoryKey, action == pickAction {
-                if revealCategorySubmenuOnPick, let categoryMenu {
-                    b.setFrame(categoryMenu, x: 620, y: 320, width: 240, height: 420)
-                }
-                return categoryPickResult
             }
             if elementID == leafKey, action == pickAction {
                 if mountGainOnLeafPick {
@@ -942,10 +973,9 @@ private func run425Insert(
     #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
 }
 
-@Test func testPlugin425CategoryPickFailureProceedsOnlyAfterObservedSubmenu() async throws {
+@Test func testPlugin425AttachedCategoryDiscoveryDoesNotNeedCategoryPick() async throws {
     let fixture = makeSlotPopupInsertFixture(
         includeCategory: true,
-        categoryPickResult: false,
         mountGainOnLeafPick: true
     )
     let obj = await run425Insert(
@@ -955,14 +985,14 @@ private func run425Insert(
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
-    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let strategy = try #require(trace["winning_strategy"] as? String)
     #expect(strategy == "slot_popup_recursive_exact_leaf")
 }
 
-@Test func testPlugin425RecursiveWalkNeverPicksNonMatchingLeafBeforeCategory() async throws {
+@Test func testPlugin425RecursiveWalkOnlyPicksExactLeaf() async throws {
     let fixture = makeSlotPopupInsertFixture(
         includeCategory: true,
         includeNonMatchingLeaf: true,
@@ -976,12 +1006,12 @@ private func run425Insert(
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
     let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
-    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
 }
 
-@Test func testPlugin425RecursiveWalkNeverPicksNonMatchingFormatLeafBeforeCategory() async throws {
+@Test func testPlugin425RecursiveWalkSkipsNonMatchingFormatLeafWithoutActuation() async throws {
     let fixture = makeSlotPopupInsertFixture(
         includeCategory: true,
         includeNonMatchingLeaf: true,
@@ -996,12 +1026,12 @@ private func run425Insert(
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
     let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
-    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
 }
 
-@Test func testPlugin425RecursiveWalkDescendsIntoCategoryWithFormatNamedPluginEntry() async throws {
+@Test func testPlugin425RecursiveWalkDescendsPastFormatNamedCategoryEntryWithoutActuation() async throws {
     let fixture = makeSlotPopupInsertFixture(
         includeCategory: true,
         includeFormatNamedCategoryEntry: true,
@@ -1014,7 +1044,7 @@ private func run425Insert(
     let state = try #require(obj["state"] as? String)
     #expect(state == "A")
     let categoryID = try #require(fixture.categoryItemID)
-    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: categoryID, action: kAXPickAction as String) == 0)
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
 }
 

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -733,6 +733,8 @@ private func makeSlotPopupInsertFixture(
     slotOpenResult: Bool = true,
     includeCategory: Bool = false,
     includeNonMatchingLeaf: Bool = false,
+    includeNonMatchingLeafFormatMenu: Bool = false,
+    includeFormatNamedCategoryEntry: Bool = false,
     includeFormatLeaf: Bool = false,
     revealCategorySubmenuOnPick: Bool = true,
     categoryPickResult: Bool = true,
@@ -753,6 +755,10 @@ private func makeSlotPopupInsertFixture(
     let categoryItem = includeCategory ? b.element(9010) : nil
     let categoryMenu = includeCategory ? b.element(9011) : nil
     let nonMatchingLeafItem = includeNonMatchingLeaf ? b.element(9016) : nil
+    let nonMatchingFormatMenu = includeNonMatchingLeafFormatMenu ? b.element(9017) : nil
+    let nonMatchingFormatMono = includeNonMatchingLeafFormatMenu ? b.element(9018) : nil
+    let nonMatchingFormatMonoToStereo = includeNonMatchingLeafFormatMenu ? b.element(9019) : nil
+    let formatNamedCategoryItem = includeFormatNamedCategoryEntry ? b.element(9020) : nil
     let formatLeafItem = includeFormatLeaf ? b.element(9014) : nil
     let formatMenu = includeFormatLeaf ? b.element(9015) : nil
 
@@ -798,14 +804,27 @@ private func makeSlotPopupInsertFixture(
     if let nonMatchingLeafItem {
         b.setAttribute(nonMatchingLeafItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
         b.setAttribute(nonMatchingLeafItem, kAXTitleAttribute as String, "Compressor")
+        if let nonMatchingFormatMenu, let nonMatchingFormatMono, let nonMatchingFormatMonoToStereo {
+            b.setAttribute(nonMatchingFormatMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+            b.setAttribute(nonMatchingFormatMono, kAXRoleAttribute as String, kAXMenuItemRole as String)
+            b.setAttribute(nonMatchingFormatMono, kAXTitleAttribute as String, "Mono")
+            b.setAttribute(nonMatchingFormatMonoToStereo, kAXRoleAttribute as String, kAXMenuItemRole as String)
+            b.setAttribute(nonMatchingFormatMonoToStereo, kAXTitleAttribute as String, "Mono->Stereo")
+            b.setChildren(nonMatchingFormatMenu, [nonMatchingFormatMono, nonMatchingFormatMonoToStereo])
+            b.setChildren(nonMatchingLeafItem, [nonMatchingFormatMenu])
+        }
     }
     if let categoryItem, let categoryMenu {
         b.setAttribute(categoryItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
         b.setAttribute(categoryItem, kAXTitleAttribute as String, "Utility")
         b.setAttribute(categoryMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        if let formatNamedCategoryItem {
+            b.setAttribute(formatNamedCategoryItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+            b.setAttribute(formatNamedCategoryItem, kAXTitleAttribute as String, "Mono")
+        }
         // AXPick controls visual exposure. The submenu is already an AX child,
         // but starts invisible until the category action's observed effect.
-        b.setChildren(categoryMenu, [gainItem])
+        b.setChildren(categoryMenu, (formatNamedCategoryItem.map { [$0] } ?? []) + [gainItem])
         b.setChildren(categoryItem, [categoryMenu])
         b.setChildren(popupMenu, [searchField] + (nonMatchingLeafItem.map { [$0] } ?? []) + [categoryItem])
     } else {
@@ -960,6 +979,43 @@ private func run425Insert(
     #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
     #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
+}
+
+@Test func testPlugin425RecursiveWalkNeverPicksNonMatchingFormatLeafBeforeCategory() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        includeCategory: true,
+        includeNonMatchingLeaf: true,
+        includeNonMatchingLeafFormatMenu: true,
+        mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    let categoryID = try #require(fixture.categoryItemID)
+    let nonMatchingLeafID = try #require(fixture.nonMatchingLeafItemID)
+    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(fixture.actions.count(elementID: nonMatchingLeafID, action: kAXPickAction as String) == 0)
+}
+
+@Test func testPlugin425RecursiveWalkDescendsIntoCategoryWithFormatNamedPluginEntry() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        includeCategory: true,
+        includeFormatNamedCategoryEntry: true,
+        mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    let categoryID = try #require(fixture.categoryItemID)
+    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
 }
 
 @Test func testPlugin425LeafPickFailureProceedsWhenInventoryDiffIsObserved() async throws {

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1381,10 +1381,11 @@ private func run425Insert(
     // Same reasoning: show the flow reached the pick, so "the category was untouched" is a result
     // rather than a consequence of nothing having happened.
     #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
-    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
-    #expect(try #require(obj["state"] as? String) == "A")
     let entryID = try #require(fixture.nonTerminalFormatEntryID)
     #expect(!fixture.actions.touched(elementID: entryID))
+    // No terminal format leaf exists here, so nothing may be picked and no insert may be claimed.
+    #expect(!fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    #expect(try #require(obj["state"] as? String) != "A")
 }
 
 @Test func testPlugin425NeverActuatesInsideANonFormatSubmenu() async throws {
@@ -1397,12 +1398,19 @@ private func run425Insert(
     }
     // An absence assertion proves nothing if the flow never got there, so prove it did: the slot was
     // opened and the exact Gain entry — not anything inside the foreign submenu — was picked.
+    // The slot really was opened, so the refusals below are results rather than a run that did
+    // nothing.
     #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
-    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
-    #expect(try #require(obj["state"] as? String) == "A")
+    // Nothing inside the foreign submenu may be actuated...
     for id in fixture.nonFormatSubmenuItemIDs {
         #expect(!fixture.actions.touched(elementID: id))
     }
+    // ...and neither may its OWNER. An entry that owns a submenu we cannot identify as channel
+    // formats is a category wearing the plug-in's name; picking it actuates a category. The earlier
+    // revision of this test asserted that pick as the expected behaviour.
+    #expect(!fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    // With no terminal target identified, the operation must not claim a verified insert.
+    #expect(try #require(obj["state"] as? String) != "A")
 }
 
 @Test func testPlugin425FailsClosedWhenTheSlotElementIsReplacedDuringEnumeration() async throws {

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -679,212 +679,49 @@ private func insertParams(
     #expect(hint.contains("no enumerable insert slots"))
 }
 
-// MARK: - #425 (Option B): coordinate-free leaf selection contract
-//
-// The four assertions below pin the contract for promoting the leaf SELECTION
-// to coordinate-free-by-default (kill-switch: insertCoordFree).
-// They exercise the real leaf-select seam (`clickPopupPluginLeaf` /
-// `clickPluginInAnchoredSlotPopup`) directly — a focused unit — because the
-// insert-entry tests above inject a fake driver that REPLACES the entire live
-// path (so they never reach leaf-select). The full `liveExactSlotPopupInsert`
-// flow (including its governed slot-open coordinate click) is driven end to end
-// by the RESPONSE-LEVEL tests further below via the DEBUG
-// `forceCoordinateActuationForTests` seam, so no CGEvent / physical mouse is
-// issued there either. In these focused tests the coordinate leaf primitives
-// (moveElementCenter/clickElementCenter) simply short-circuit to `false` when an
-// element has no on-screen geometry, before posting any CGEvent.
-// `clickPopupPluginLeaf` / `clickPluginInAnchoredSlotPopup` / `SlotPopupPluginClick`
-// were relaxed from `private` to `internal` solely so this contract is testable.
+// MARK: - #425: coordinate-free slot-popup navigation
 
-/// Records which elements received a `kAXPress` when the default action-
-/// recording is bypassed by an injected `performActionHandler` (contract C).
-/// Invoked sequentially within one test (awaited), so plain mutation is
-/// race-free here; `@unchecked Sendable` documents that.
-private final class AXPressRecorder: @unchecked Sendable {
-    private(set) var pressedElementIDs: [Int] = []
-    func record(_ id: Int) { pressedElementIDs.append(id) }
-}
+private let slotPopupOpenCustomAction =
+    "Name:Open plug-in menu with legacy plug-ins\\nTarget:0x0\\nSelector:(null)"
 
-/// A plugin menu item whose format submenu is exposed as an AX child (as Logic
-/// exposes it without a hover) with a single preferred-format leaf ("Stereo").
-private func addPluginItemWithFormatLeaf(
-    _ b: FakeAXRuntimeBuilder,
-    itemID: Int,
-    title: String,
-    formatLeafTitle: String = "Stereo"
-) -> (item: AXUIElement, formatLeaf: AXUIElement) {
-    let formatLeaf = addMenuItem(b, itemID * 10 + 1, title: formatLeafTitle)
-    let submenu = addMenu(b, itemID * 10 + 2, children: [formatLeaf])
-    let item = addMenuItem(b, itemID, title: title, children: [submenu])
-    return (item, formatLeaf)
-}
+/// Captures calls that pass through the injected AX action runtime seam. The
+/// tests run sequentially, so this deliberately lightweight recorder is safe.
+private final class AXActionRecorder: @unchecked Sendable {
+    private(set) var calls: [(elementID: Int, action: String)] = []
 
-// Contract A (mechanism): coordFree:true selects the matched leaf via kAXPress.
-@Test func test425ContractA_coordFreeTruePressesMatchedLeafViaAXPress() async {
-    let b = FakeAXRuntimeBuilder()
-    let (gain, formatLeaf) = addPluginItemWithFormatLeaf(b, itemID: 8210, title: "Gain")
-
-    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
-        gain, runtime: b.makeAXRuntime(), coordFree: true
-    )
-
-    #expect(ok)
-    let pressAction = kAXPressAction as String
-    let leafID = b.elementID(formatLeaf)
-    // The preferred-format leaf was AXPressed …
-    #expect(b.actionCalls.contains { $0.elementID == leafID && $0.action == pressAction })
-    // … and NOTHING else happened via a non-AXPress action (no coordinate path).
-    #expect(b.actionCalls.allSatisfy { $0.action == pressAction })
-}
-
-// Contract A (discriminator): a coord-free DIRECT win reports coordFree == true.
-// `SlotPopupPluginClick.coordFree` is the exact value the production flow assigns
-// to `select_trace["leaf_select_coord_free"]` (liveExactSlotPopupInsert ~L1933),
-// so asserting it here asserts the discriminator's truth value for a coord-free
-// win — and it is sourced from the winning strategy, not the raw flag.
-@Test func test425ContractA_discriminatorTrueForCoordFreeDirectWin() async throws {
-    let b = FakeAXRuntimeBuilder()
-    let (gain, formatLeaf) = addPluginItemWithFormatLeaf(b, itemID: 8220, title: "Gain")
-    let root = addMenu(b, 8229, children: [gain])
-    let runtime = b.makeAXRuntime()
-
-    let click = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
-            pluginID: "logic.stock.effect.gain",
-            displayName: "Gain",
-            rootMenu: root,
-            runtime: runtime
-        )
+    func record(elementID: Int, action: String) {
+        calls.append((elementID, action))
     }
 
-    let winner = try #require(click)
-    #expect(winner.strategy == "slot_popup_direct_exact_leaf")
-    #expect(winner.coordFree)
-    let pressAction = kAXPressAction as String
-    let leafID = b.elementID(formatLeaf)
-    #expect(b.actionCalls.contains { $0.elementID == leafID && $0.action == pressAction })
-}
-
-// Contracts B & D: coordFree:false takes the COORDINATE path — never AXPress.
-// This is the exact mode the recursive category-hover fallback forces (it always
-// passes coordFree:false), so it also covers the "recursive is coordinate-only"
-// half of contract D at the helper level. A WINNING recursive path is exercised
-// end to end by the response-level
-// `test425ResponseTraceCoordFreeFalseOnRecursiveWinUnderFlagOn` (via the DEBUG
-// coordinate-actuation seam), which asserts the assembled response reports
-// coordFree == false even with the flag ON.
-@Test func test425ContractBD_coordFreeFalseUsesCoordinateNeverAXPress() async {
-    let b = FakeAXRuntimeBuilder()
-    // Deliberately NO kAXPosition/kAXSize: the coordinate primitives return false
-    // before posting a CGEvent, so the load-bearing assertion is the ABSENCE of
-    // AXPress, proving coordFree:false does not use the coord-free press path.
-    let (gain, _) = addPluginItemWithFormatLeaf(b, itemID: 8240, title: "Gain")
-
-    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
-        gain, runtime: b.makeAXRuntime(), coordFree: false
-    )
-
-    #expect(!ok)
-    let pressAction = kAXPressAction as String
-    #expect(!b.actionCalls.contains { $0.action == pressAction })
-}
-
-// Contract C: if AXPress is neutralized, coord-free leaf select FAILS CLOSED —
-// it must not silently "succeed", and it must genuinely have attempted AXPress.
-@Test func test425ContractC_failsClosedWhenAXPressNeutralized() async {
-    let b = FakeAXRuntimeBuilder()
-    let (gain, _) = addPluginItemWithFormatLeaf(b, itemID: 8250, title: "Gain")
-    let recorder = AXPressRecorder()
-    let pressAction = kAXPressAction as String
-    let runtime = b.makeAXRuntime(
-        setAttributeHandler: nil,
-        performActionHandler: { element, action in
-            if action == pressAction { recorder.record(b.elementID(element)) }
-            return false // AXPress refused everywhere
-        }
-    )
-
-    let ok = await AccessibilityChannel.clickPopupPluginLeaf(
-        gain, runtime: runtime, coordFree: true
-    )
-
-    #expect(!ok)
-    #expect(!recorder.pressedElementIDs.isEmpty)
-}
-
-// Contract #3 (discriminator honesty) — the DIVERGENCE case. A recursive
-// (coordinate-only) win under the flag ON must report `coordFree == false`, NOT
-// the flag. This is the ONLY case where the honest value diverges from the raw
-// flag, so it is what makes the discriminator sourcing mutation-provable. The 4
-// tests above all use a direct win with the flag on, where pluginClick.coordFree
-// and FeatureFlags.insertCoordFree are BOTH true — they cannot catch a re-pin to
-// the flag. This one can, driven hermetically via the DEBUG coordinate-actuation
-// seam (no CGEvent / physical mouse): direct+search fail because AXPress is
-// refused, so the recursive strategy wins ONLY via the coordinate path. It kills:
-//   (i)   trace repinned to the flag        → leafSelectCoordFree(for:) returns false, not the flag
-//   (ii)  recursive SlotPopupPluginClick(coordFree:) flipped to the flag → winner.coordFree
-//   (iii) recursive clickPopupPluginLeaf(coordFree:) flipped to the flag → it would AXPress
-//         (refused) → no recursive win → #require fails
-@Test func test425Contract3_recursiveWinReportsCoordFreeFalseUnderFlagOn() async throws {
-    let b = FakeAXRuntimeBuilder()
-    // Exact-match leaf at the ROOT, no format submenu / text field / geometry.
-    let gain = addMenuItem(b, 8260, title: "Gain")
-    let root = addMenu(b, 8269, children: [gain])
-    let pressAction = kAXPressAction as String
-    let runtime = b.makeAXRuntime(
-        setAttributeHandler: nil,
-        // Refuse AXPress everywhere so the ONLY route to a win is the coordinate
-        // path — a win therefore PROVES the recursive coordinate route executed.
-        performActionHandler: { _, action in action == pressAction ? false : true }
-    )
-
-    let click = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
-                pluginID: "logic.stock.effect.gain",
-                displayName: "Gain",
-                rootMenu: root,
-                runtime: runtime
-            )
-        }
+    func contains(elementID: Int, action: String) -> Bool {
+        calls.contains { $0.elementID == elementID && $0.action == action }
     }
-
-    let winner = try #require(click)
-    #expect(winner.strategy == "slot_popup_recursive_exact_leaf")
-    // The divergence: flag override is true, honest path is coordinate → false.
-    #expect(!winner.coordFree)
-    #expect(!AccessibilityChannel.leafSelectCoordFree(for: winner))
 }
-
-// MARK: - #425 (Option B) RESPONSE-LEVEL coverage (real defaultInsertVerified flow)
-//
-// These drive the REAL `liveExactSlotPopupInsert` driver end to end (no injected
-// fake driver), so they traverse the ACTUAL trace assignment at
-// VerifiedPlugins ~L1936 (`trace["leaf_select_coord_free"] = leafSelectCoordFree(
-// for: pluginClick)`) AND the response serialization — which the helper-level
-// tests above cannot. The DEBUG `forceCoordinateActuationForTests` seam makes
-// every coordinate primitive (the governed slot-OPEN click AND the coordinate
-// leaf path) succeed WITHOUT posting a CGEvent, so no physical mouse moves. The
-// fake's post-inventory never changes, so a win settles on `postCommitTimeout`
-// (State C operation_timeout) carrying the populated select_trace + commit_strategy.
 
 private let coordFreeExpectedPath = "/Users/me/Music/CoordFree425 copy.logicx"
 
 private struct SlotPopupInsertFixture {
     let runtime: AXLogicProElements.Runtime
+    let slotItemID: Int
+    let categoryItemID: Int?
     let leafItemID: Int
-    let presses: AXPressRecorder
+    let actions: AXActionRecorder
 }
 
-/// The full AX tree the real slot-popup insert flow walks: a track header
-/// (AXSelected, so selection verifies) → mixer → strip → ONE empty target slot
-/// (with geometry for the anchor check) → an app-reachable, slot-anchored popup
-/// menu holding the exact "Gain" leaf. `refuseLeafAXPress` makes AXPress on the
-/// leaf fail (forcing direct/search to fall through to the recursive coordinate
-/// path); track-header AXPress stays allowed so track selection still verifies.
+/// The full AX tree the real insert driver walks. The action handler models the
+/// separately-observed effects of opening a popup, revealing a submenu, and
+/// mounting a plugin, while its Bool return independently models AX's unreliable
+/// status code.
 private func makeSlotPopupInsertFixture(
-    refuseLeafAXPress: Bool,
-    mountGainOnLeafAXPress: Bool = false
+    popupAppearsAfterSlotOpen: Bool = true,
+    popupInitiallyVisible: Bool = false,
+    slotOpenResult: Bool = true,
+    includeCategory: Bool = false,
+    includeFormatLeaf: Bool = false,
+    revealCategorySubmenuOnPick: Bool = true,
+    categoryPickResult: Bool = true,
+    leafPickResult: Bool = true,
+    mountGainOnLeafPick: Bool = false
 ) -> SlotPopupInsertFixture {
     let b = FakeAXRuntimeBuilder()
     let app = b.element(9000)
@@ -897,6 +734,10 @@ private func makeSlotPopupInsertFixture(
     let popupMenu = b.element(9007)
     let gainItem = b.element(9008)
     let searchField = b.element(9009)
+    let categoryItem = includeCategory ? b.element(9010) : nil
+    let categoryMenu = includeCategory ? b.element(9011) : nil
+    let formatLeafItem = includeFormatLeaf ? b.element(9014) : nil
+    let formatMenu = includeFormatLeaf ? b.element(9015) : nil
 
     // Track header rail (getTrackHeaders matches the "트랙 헤더" group), one
     // selected row so verifiedTrackSelected reads AXSelected == true.
@@ -923,59 +764,87 @@ private func makeSlotPopupInsertFixture(
     b.setAttribute(window, kAXTitleAttribute as String, "CoordFree425 — Tracks")
     b.setChildren(window, [headersGroup, mixer])
 
-    // Slot popup: visible (geometry) + anchored to the slot + holds the exact leaf.
-    // slotPopupMenu recognizes a slot popup by a search text field AND a menu item,
-    // so the fixture carries both (as the live Logic popup does). Refusing the leaf
-    // AXPress still fails the direct+search strategies at the CLICK step, forcing
-    // the recursive coordinate fallback.
+    // Slot popup: visible + anchored after the modeled custom slot-open action.
     b.setAttribute(gainItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
     b.setAttribute(gainItem, kAXTitleAttribute as String, "Gain")
+    if let formatLeafItem, let formatMenu {
+        b.setAttribute(formatLeafItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(formatLeafItem, kAXTitleAttribute as String, "Audio Unit")
+        b.setAttribute(formatMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        b.setChildren(formatMenu, [formatLeafItem])
+        b.setChildren(gainItem, [formatMenu])
+    }
     b.setAttribute(searchField, kAXRoleAttribute as String, kAXTextFieldRole as String)
     b.setAttribute(popupMenu, kAXRoleAttribute as String, kAXMenuRole as String)
     b.setAttribute(popupMenu, kAXPositionAttribute as String, axPoint(410, 320))
     b.setAttribute(popupMenu, kAXSizeAttribute as String, axSize(240, 420))
-    b.setChildren(popupMenu, [searchField, gainItem])
+    if let categoryItem, let categoryMenu {
+        b.setAttribute(categoryItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(categoryItem, kAXTitleAttribute as String, "Utility")
+        b.setAttribute(categoryMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        // AXPick controls visual exposure. The submenu is already an AX child,
+        // but starts invisible until the category action's observed effect.
+        b.setChildren(categoryMenu, [gainItem])
+        b.setChildren(categoryItem, [categoryMenu])
+        b.setChildren(popupMenu, [searchField, categoryItem])
+    } else {
+        b.setChildren(popupMenu, [searchField, gainItem])
+    }
 
     // App: AXWindows for mainWindow; children so slotPopupMenu's app-descent finds
     // the (top-level) popup menu.
     b.setAttribute(app, kAXWindowsAttribute as String, [window])
     b.setAttribute(app, kAXMainWindowAttribute as String, window)
-    b.setChildren(app, [window, popupMenu])
+    b.setChildren(app, popupInitiallyVisible ? [window, popupMenu] : [window])
 
-    let leafKey = b.elementID(gainItem)
-    let presses = AXPressRecorder()
-    let pressAction = kAXPressAction as String
+    let slotKey = b.elementID(slot)
+    let leafKey = formatLeafItem.map(b.elementID) ?? b.elementID(gainItem)
+    let categoryKey = categoryItem.map(b.elementID)
+    let actions = AXActionRecorder()
+    let pickAction = kAXPickAction as String
     let runtime = b.makeLogicRuntime(
         appElement: app,
         setAttributeHandler: nil,
         performActionHandler: { element, action in
-            if action == pressAction {
-                presses.record(b.elementID(element))
-                if b.elementID(element) == leafKey {
-                    if refuseLeafAXPress { return false }
-                    if mountGainOnLeafAXPress {
-                        // Model Logic mounting the plugin at the empty slot on the
-                        // leaf AXPress: swap the empty-button slot to an occupied
-                        // "Gain" group so a NON-seamed run reads back State A. This
-                        // lets the force-timeout seam be mutation-proved (seam OFF →
-                        // State A, seam ON → forced State-C timeout).
-                        b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
-                        b.setAttribute(slot, kAXDescriptionAttribute as String, "Gain")
-                        let bypass = b.element(9010)
-                        let open = b.element(9011)
-                        b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
-                        b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
-                        b.setAttribute(bypass, kAXValueAttribute as String, 0)
-                        b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
-                        b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
-                        b.setChildren(slot, [bypass, open])
-                    }
+            let elementID = b.elementID(element)
+            actions.record(elementID: elementID, action: action)
+            if elementID == slotKey, action == slotPopupOpenCustomAction {
+                if popupAppearsAfterSlotOpen {
+                    b.setChildren(app, [window, popupMenu])
                 }
+                return slotOpenResult
+            }
+            if let categoryKey, elementID == categoryKey, action == pickAction {
+                if revealCategorySubmenuOnPick, let categoryMenu {
+                    b.setFrame(categoryMenu, x: 620, y: 320, width: 240, height: 420)
+                }
+                return categoryPickResult
+            }
+            if elementID == leafKey, action == pickAction {
+                if mountGainOnLeafPick {
+                    b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+                    b.setAttribute(slot, kAXDescriptionAttribute as String, "Gain")
+                    let bypass = b.element(9012)
+                    let open = b.element(9013)
+                    b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                    b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
+                    b.setAttribute(bypass, kAXValueAttribute as String, 0)
+                    b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
+                    b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
+                    b.setChildren(slot, [bypass, open])
+                }
+                return leafPickResult
             }
             return true
         }
     )
-    return SlotPopupInsertFixture(runtime: runtime, leafItemID: leafKey, presses: presses)
+    return SlotPopupInsertFixture(
+        runtime: runtime,
+        slotItemID: slotKey,
+        categoryItemID: categoryKey,
+        leafItemID: leafKey,
+        actions: actions
+    )
 }
 
 private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String: Any] {
@@ -990,113 +859,112 @@ private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String
     return try! JSONSerialization.jsonObject(with: result.message.data(using: .utf8)!) as! [String: Any]
 }
 
-// The ASSEMBLED RESPONSE's select_trace["leaf_select_coord_free"] is false for a
-// recursive (coordinate-only) win under the flag ON — this traverses the real
-// trace assignment, so re-pinning it to the raw flag turns this RED.
-@Test func test425ResponseTraceCoordFreeFalseOnRecursiveWinUnderFlagOn() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: true)
-    let obj = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
+private func run425Insert(
+    fixture: SlotPopupInsertFixture,
+    slotOpenActions: [String],
+    coordinateFallbackResult: Bool = false
+) async -> [String: Any] {
+    await AccessibilityChannel.withSlotPopupOpenActionNamesForTests(slotOpenActions) {
+        await AccessibilityChannel.withForceCoordinateActuationForTests(coordinateFallbackResult) {
             await runRealInsert(runtime: fixture.runtime)
         }
     }
+}
+
+@Test func testPlugin425SlotOpenCustomActionFailureProceedsWhenPopupIsObserved() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        slotOpenResult: false, mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
+    #expect(!fallbackTaken)
+}
+
+@Test func testPlugin425SlotOpenSuccessFailsClosedWhenPopupIsNotObserved() async throws {
+    let fixture = makeSlotPopupInsertFixture(popupAppearsAfterSlotOpen: false)
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "slot_popup_menu_not_found")
+    #expect(fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+}
+
+@Test func testPlugin425CategoryPickFailureProceedsOnlyAfterObservedSubmenu() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        includeCategory: true,
+        categoryPickResult: false,
+        mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    let categoryID = try #require(fixture.categoryItemID)
+    #expect(fixture.actions.contains(elementID: categoryID, action: kAXPickAction as String))
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let strategy = try #require(trace["winning_strategy"] as? String)
     #expect(strategy == "slot_popup_recursive_exact_leaf")
-    // Divergence: flag ON, but the actual winning actuation is coordinate → false.
-    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
-    #expect(!coordFree)
-    // Coordinate win → physical commit strategy (pins the coordFree:false branch).
-    let commit = try #require(obj["commit_strategy"] as? String)
-    #expect(commit == "slot_popup_physical_menu_click")
 }
 
-// Flag ON (default): the kill-switch routes a direct/search win through the
-// AXPress path — leaf selected via kAXPress, response reports coordFree true.
-@Test func test425ResponseFlagOnSelectsLeafViaAXPress() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
-    let obj = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await runRealInsert(runtime: fixture.runtime)
-        }
-    }
-    let trace = try #require(obj["select_trace"] as? [String: Any])
-    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
-    #expect(coordFree)
-    #expect(fixture.presses.pressedElementIDs.contains(fixture.leafItemID))
+@Test func testPlugin425LeafPickFailureProceedsWhenInventoryDiffIsObserved() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        includeCategory: true,
+        includeFormatLeaf: true,
+        leafPickResult: false,
+        mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(verified)
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
 }
 
-// Flag OFF: LOGIC_MCP_INSERT_COORD_FREE=0 routes the SAME direct win through the
-// COORDINATE path — no kAXPress on the leaf, response reports false.
-@Test func test425ResponseFlagOffUsesCoordinateNotAXPress() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
-    let obj = await FeatureFlags.withInsertCoordFree(false) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await runRealInsert(runtime: fixture.runtime)
-        }
-    }
-    let trace = try #require(obj["select_trace"] as? [String: Any])
-    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
-    #expect(!coordFree)
-    #expect(!fixture.presses.pressedElementIDs.contains(fixture.leafItemID))
-}
+@Test func testPlugin425LeafPickSuccessWithoutInventoryDiffFailsClosed() async throws {
+    let fixture = makeSlotPopupInsertFixture(leafPickResult: true)
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
 
-// A coord-free (AXPress) win that times out post-commit must report an AXPress
-// commit strategy, NOT the physical/coordinate one (commit_strategy honesty).
-@Test func test425ResponseAXPressWinReportsAXPressCommitStrategy() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
-    let obj = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await runRealInsert(runtime: fixture.runtime)
-        }
-    }
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
     let error = try #require(obj["error"] as? String)
     #expect(error == "operation_timeout")
-    let commit = try #require(obj["commit_strategy"] as? String)
-    #expect(commit == "slot_popup_axpress_menu_select")
-    let trace = try #require(obj["select_trace"] as? [String: Any])
-    let coordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
-    #expect(coordFree)
+    #expect(fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(!verified)
 }
 
-// The DEBUG force-postcommit-timeout QA seam (LOGIC_MCP_FORCE_POSTCOMMIT_TIMEOUT
-// / @TaskLocal) deterministically routes a WINNING insert to the honest
-// postCommitTimeout envelope, reporting the commit_strategy of the actual
-// actuation. Fail-closed: State-C timeout, NEVER a false State-A verified mount —
-// proved by mounting Gain on the leaf press (so WITHOUT the seam this fixture
-// would read back State A; disabling the seam turns the State-C assertion RED).
-@Test func test425ForcePostCommitTimeoutSeamIsHonestAndFailsClosed() async throws {
-    // Coord-free (AXPress) win under flag ON; the fixture MOUNTS Gain on the leaf
-    // press, so a non-seamed run would reach State A. The seam forces the honest
-    // AXPress-commit timeout instead.
-    let axFixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
-    let axObj = await FeatureFlags.withInsertCoordFree(true) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await AccessibilityChannel.withForcePostCommitTimeoutForTests(true) {
-                await runRealInsert(runtime: axFixture.runtime)
-            }
-        }
-    }
-    let axState = try #require(axObj["state"] as? String)
-    #expect(axState == "C")
-    let axError = try #require(axObj["error"] as? String)
-    #expect(axError == "operation_timeout")
-    let axVerified = try #require(axObj["verified"] as? Bool)
-    #expect(!axVerified)
-    let axCommit = try #require(axObj["commit_strategy"] as? String)
-    #expect(axCommit == "slot_popup_axpress_menu_select")
+@Test func testPlugin425SlotOpenFallsBackToCoordinateClickWhenCustomActionIsAbsent() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        popupInitiallyVisible: true, mountGainOnLeafPick: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [], coordinateFallbackResult: true
+    )
 
-    // Coordinate win under flag OFF + seam → the physical commit strategy.
-    let coordFixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false)
-    let coordObj = await FeatureFlags.withInsertCoordFree(false) {
-        await AccessibilityChannel.withForceCoordinateActuationForTests(true) {
-            await AccessibilityChannel.withForcePostCommitTimeoutForTests(true) {
-                await runRealInsert(runtime: coordFixture.runtime)
-            }
-        }
-    }
-    let coordState = try #require(coordObj["state"] as? String)
-    #expect(coordState == "C")
-    let coordCommit = try #require(coordObj["commit_strategy"] as? String)
-    #expect(coordCommit == "slot_popup_physical_menu_click")
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "A")
+    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    let trace = try #require(obj["select_trace"] as? [String: Any])
+    let fallbackTaken = try #require(trace["slot_popup_open_fallback_taken"] as? Bool)
+    #expect(fallbackTaken)
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1467,6 +1467,15 @@ private func run425Insert(
     #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
 }
 
+/// Records which elements received a `kAXPress` when the default action-
+/// recording is bypassed by an injected `performActionHandler` (contract C).
+/// Invoked sequentially within one test (awaited), so plain mutation is
+/// race-free here; `@unchecked Sendable` documents that.
+private final class AXPressRecorder: @unchecked Sendable {
+    private(set) var pressedElementIDs: [Int] = []
+    func record(_ id: Int) { pressedElementIDs.append(id) }
+}
+
 /// #474 — an entry whose enabled state cannot be read must not be pressed.
 ///
 /// `AXEnabled` is the one signal that distinguishes "will act" from "will do nothing" before the

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -812,6 +812,10 @@ private struct SlotPopupInsertFixture {
     let leafItemID: Int
     let actions: AXActionRecorder
     let slotOccupier: SlotOccupier
+    let slotReplacer: SlotOccupier
+    let replacementSlotID: Int
+    let nonFormatSubmenuItemIDs: [Int]
+    let nonTerminalFormatEntryID: Int?
     let coordinateFallbackClick: () -> Bool
 }
 
@@ -830,7 +834,9 @@ private func makeSlotPopupInsertFixture(
     includeFormatLeaf: Bool = false,
     leafPickResult: Bool = true,
     mountGainOnLeafPick: Bool = false,
-    occupySlotOnWindowRaise: Bool = false
+    occupySlotOnWindowRaise: Bool = false,
+    includeNonFormatSubmenu: Bool = false,
+    includeNonTerminalFormatEntry: Bool = false
 ) -> SlotPopupInsertFixture {
     let b = FakeAXRuntimeBuilder()
     let app = b.element(9000)
@@ -850,6 +856,13 @@ private func makeSlotPopupInsertFixture(
     let nonMatchingFormatMono = includeNonMatchingLeafFormatMenu ? b.element(9018) : nil
     let nonMatchingFormatMonoToStereo = includeNonMatchingLeafFormatMenu ? b.element(9019) : nil
     let formatNamedCategoryItem = includeFormatNamedCategoryEntry ? b.element(9020) : nil
+    let nonTerminalFormatMenu = includeNonTerminalFormatEntry ? b.element(9034) : nil
+    let nonTerminalFormatEntry = includeNonTerminalFormatEntry ? b.element(9035) : nil
+    let nonTerminalFormatChild = includeNonTerminalFormatEntry ? b.element(9036) : nil
+    let nonTerminalFormatChildMenu = includeNonTerminalFormatEntry ? b.element(9037) : nil
+    let nonFormatSubmenu = includeNonFormatSubmenu ? b.element(9031) : nil
+    let nonFormatEntryA = includeNonFormatSubmenu ? b.element(9032) : nil
+    let nonFormatEntryB = includeNonFormatSubmenu ? b.element(9033) : nil
     let formatLeafItem = includeFormatLeaf ? b.element(9014) : nil
     let formatMenu = includeFormatLeaf ? b.element(9015) : nil
 
@@ -881,9 +894,39 @@ private func makeSlotPopupInsertFixture(
     // Slot popup: visible + anchored after the modeled custom slot-open action.
     b.setAttribute(gainItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
     b.setAttribute(gainItem, kAXTitleAttribute as String, "Gain")
+    if let nonTerminalFormatMenu, let nonTerminalFormatEntry, let nonTerminalFormatChild,
+       let nonTerminalFormatChildMenu {
+        // Every entry carries a real format label, so the submenu passes the format discriminator —
+        // but the matching entry owns a menu of its own, i.e. it is a category wearing a format
+        // name. Picking it would actuate before any terminal target is known.
+        b.setAttribute(nonTerminalFormatChild, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(nonTerminalFormatChild, kAXTitleAttribute as String, "Gain")
+        b.setAttribute(nonTerminalFormatChildMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        b.setChildren(nonTerminalFormatChildMenu, [nonTerminalFormatChild])
+        b.setAttribute(nonTerminalFormatEntry, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(nonTerminalFormatEntry, kAXTitleAttribute as String, "Mono")
+        b.setChildren(nonTerminalFormatEntry, [nonTerminalFormatChildMenu])
+        b.setAttribute(nonTerminalFormatMenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        b.setChildren(nonTerminalFormatMenu, [nonTerminalFormatEntry])
+        b.setChildren(gainItem, [nonTerminalFormatMenu])
+    }
+    if let nonFormatSubmenu, let nonFormatEntryA, let nonFormatEntryB {
+        // Entries a format chooser would never contain; the discriminator must refuse this submenu.
+        b.setAttribute(nonFormatEntryA, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(nonFormatEntryA, kAXTitleAttribute as String, "Legacy")
+        b.setAttribute(nonFormatEntryB, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        b.setAttribute(nonFormatEntryB, kAXTitleAttribute as String, "Utility")
+        b.setAttribute(nonFormatSubmenu, kAXRoleAttribute as String, kAXMenuRole as String)
+        b.setChildren(nonFormatSubmenu, [nonFormatEntryA, nonFormatEntryB])
+        b.setChildren(gainItem, [nonFormatSubmenu])
+    }
     if let formatLeafItem, let formatMenu {
         b.setAttribute(formatLeafItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
-        b.setAttribute(formatLeafItem, kAXTitleAttribute as String, "Audio Unit")
+        // Measured live on this Logic build: a plug-in entry's submenu contains only channel-format
+        // entries (Gain -> "Mono", "Mono->Stereo"; Compressor and Channel EQ -> "Mono"). The former
+        // "Audio Unit" label modelled no real entry and only kept the arbitrary items.first fallback
+        // looking justified.
+        b.setAttribute(formatLeafItem, kAXTitleAttribute as String, "Mono")
         b.setAttribute(formatMenu, kAXRoleAttribute as String, kAXMenuRole as String)
         b.setChildren(formatMenu, [formatLeafItem])
         b.setChildren(gainItem, [formatMenu])
@@ -938,6 +981,19 @@ private func makeSlotPopupInsertFixture(
     let formatNamedCategoryKey = formatNamedCategoryItem.map(b.elementID)
     let actions = AXActionRecorder()
     let pickAction = kAXPickAction as String
+    // The AX tree can hand back a DIFFERENT element for the same still-empty slot. Anything the
+    // driver learned about the old element — notably whether it exposes the custom opener — was
+    // never about this one.
+    let replacementSlot = b.element(9030)
+    let slotReplacer = SlotOccupier {
+        b.setAttribute(replacementSlot, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setAttribute(replacementSlot, kAXDescriptionAttribute as String, "오디오 플러그인")
+        b.setAttribute(replacementSlot, kAXHelpAttribute as String, "오디오 이펙트 슬롯. 오디오 이펙트를 삽입합니다.")
+        b.setAttribute(replacementSlot, kAXPositionAttribute as String, axPoint(400, 300))
+        b.setAttribute(replacementSlot, kAXSizeAttribute as String, axSize(70, 18))
+        b.setChildren(strip, [replacementSlot])
+    }
+
     let slotOccupier = SlotOccupier {
         let bypass = b.element(9021)
         let open = b.element(9022)
@@ -998,6 +1054,10 @@ private func makeSlotPopupInsertFixture(
         leafItemID: leafKey,
         actions: actions,
         slotOccupier: slotOccupier,
+        slotReplacer: slotReplacer,
+        replacementSlotID: b.elementID(replacementSlot),
+        nonFormatSubmenuItemIDs: [nonFormatEntryA, nonFormatEntryB].compactMap { $0 }.map(b.elementID),
+        nonTerminalFormatEntryID: nonTerminalFormatEntry.map(b.elementID),
         coordinateFallbackClick: {
             b.setChildren(app, [window, popupMenu])
             return true
@@ -1257,6 +1317,54 @@ private func run425Insert(
     #expect(!writeAttempted)
     #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
     #expect(!fixture.actions.touched(elementID: fixture.leafItemID))
+}
+
+@Test func testPlugin425NeverPicksAFormatLabelledEntryThatOwnsItsOwnMenu() async throws {
+    // A "Mono" entry that owns a submenu is a category wearing a format name. It satisfies the
+    // format-label check, so only the terminal requirement keeps AXPick off it.
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true, includeNonTerminalFormatEntry: true)
+    _ = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await runRealInsert(runtime: fixture.runtime)
+    }
+    let entryID = try #require(fixture.nonTerminalFormatEntryID)
+    #expect(!fixture.actions.touched(elementID: entryID))
+}
+
+@Test func testPlugin425NeverActuatesInsideANonFormatSubmenu() async throws {
+    // Logic exposes category entries named like plug-ins, so "the matched item owns an AXMenu" does
+    // not mean that menu is a channel-format chooser. Entering it and picking whatever sits first
+    // would actuate a target nothing identified.
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true, includeNonFormatSubmenu: true)
+    _ = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await runRealInsert(runtime: fixture.runtime)
+    }
+    for id in fixture.nonFormatSubmenuItemIDs {
+        #expect(!fixture.actions.touched(elementID: id))
+    }
+}
+
+@Test func testPlugin425FailsClosedWhenTheSlotElementIsReplacedDuringEnumeration() async throws {
+    // Whether the custom opener is present was read from ONE element. If the AX tree hands back a
+    // different element for the same still-empty slot, that answer was never about the element we
+    // are about to drive — so the attempt must refuse rather than actuate on an unexamined element.
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let replacer = fixture.slotReplacer
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests([slotPopupOpenCustomAction]) {
+        await AccessibilityChannel.withSlotPopupOpenActionEnumerationHookForTests {
+            replacer.occupy()
+        } operation: {
+            await runRealInsert(runtime: fixture.runtime)
+        }
+    }
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "target_slot_element_replaced")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(!fixture.actions.touched(elementID: fixture.slotItemID))
+    #expect(!fixture.actions.touched(elementID: fixture.replacementSlotID))
 }
 
 @Test func testPlugin425CustomSlotOpenFailsClosedWhenSlotBecomesOccupiedDuringEnumeration() async throws {

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -284,12 +284,12 @@ private func insertParams(
     // The live driver stops after a strategy appears to dismiss/commit the dialog
     // but readback never observes the requested plugin. This prevents stale
     // stale clicks after a popup/menu commit changed the UI.
-    let fake = FakeInsertDriver(outcome: .postCommitTimeout(strategy: "slot_popup_physical_menu_click"))
+    let fake = FakeInsertDriver(outcome: .postCommitTimeout(strategy: "slot_popup_axpick_menu_select"))
     let obj = await runInsert(insertParams(insert: "0"), runtime: runtime, driver: fake.driver)
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "operation_timeout")
-    #expect(obj["commit_strategy"] as? String == "slot_popup_physical_menu_click")
+    #expect(obj["commit_strategy"] as? String == "slot_popup_axpick_menu_select")
     #expect((obj["safe_to_retry"] as? Bool)!)
     #expect((obj["write_attempted"] as? Bool)!)
 }
@@ -703,9 +703,14 @@ private let slotPopupOpenCustomAction = AccessibilityChannel.slotPopupOpenCustom
 /// tests run sequentially, so this deliberately lightweight recorder is safe.
 private final class AXActionRecorder: @unchecked Sendable {
     private(set) var calls: [(elementID: Int, action: String)] = []
+    private(set) var attributeWrites: [(elementID: Int, attribute: String)] = []
 
     func record(elementID: Int, action: String) {
         calls.append((elementID, action))
+    }
+
+    func recordAttributeWrite(elementID: Int, attribute: String) {
+        attributeWrites.append((elementID, attribute))
     }
 
     func contains(elementID: Int, action: String) -> Bool {
@@ -716,8 +721,12 @@ private final class AXActionRecorder: @unchecked Sendable {
         calls.count { $0.elementID == elementID && $0.action == action }
     }
 
-    func nonTargetCount(targetElementID: Int) -> Int {
+    func nonTargetActionCount(targetElementID: Int) -> Int {
         calls.count { $0.elementID != targetElementID }
+    }
+
+    func nonTargetAttributeWriteCount(targetElementID: Int) -> Int {
+        attributeWrites.count { $0.elementID != targetElementID }
     }
 }
 
@@ -728,10 +737,15 @@ private final class AXActionRecorder: @unchecked Sendable {
     let vendor = addMenuItem(b, 9102, title: "Fabricant", children: [vendorMenu])
     let categoryMenu = addMenu(b, 9103, children: [vendor])
     let category = addMenuItem(b, 9104, title: "Dienstprogramme", children: [categoryMenu])
-    let rootMenu = addMenu(b, 9105, children: [category])
+    let searchField = b.element(9106)
+    b.setAttribute(searchField, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    let rootMenu = addMenu(b, 9105, children: [searchField, category])
     let actions = AXActionRecorder()
     let runtime = b.makeAXRuntime(
-        setAttributeHandler: nil,
+        setAttributeHandler: { element, attribute, _ in
+            actions.recordAttributeWrite(elementID: b.elementID(element), attribute: attribute)
+            return true
+        },
         performActionHandler: { element, action in
             actions.record(elementID: b.elementID(element), action: action)
             return true
@@ -745,10 +759,28 @@ private final class AXActionRecorder: @unchecked Sendable {
         runtime: runtime
     )
 
-    #expect(actions.nonTargetCount(targetElementID: b.elementID(target)) == 0)
+    #expect(actions.nonTargetActionCount(targetElementID: b.elementID(target)) == 0)
+    #expect(actions.nonTargetAttributeWriteCount(targetElementID: b.elementID(target)) == 0)
+    #expect(actions.attributeWrites.isEmpty)
     let result = try #require(click)
     #expect(result.path == ["Dienstprogramme", "Fabricant", "Gain"])
     #expect(actions.count(elementID: b.elementID(target), action: kAXPickAction as String) == 1)
+}
+
+@Test func testPlugin425LeafSelectionHasNoCoordFreeStrategyDiscriminator() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let target = addMenuItem(b, 9110, title: "Gain")
+    let rootMenu = addMenu(b, 9111, children: [target])
+    let click = await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+        pluginID: "logic.stock.effect.gain",
+        displayName: "Gain",
+        rootMenu: rootMenu,
+        runtime: b.makeAXRuntime()
+    )
+
+    let result = try #require(click)
+    let storedPropertyNames = Mirror(reflecting: result).children.compactMap(\.label)
+    #expect(!storedPropertyNames.contains("coordFree"))
 }
 
 private let coordFreeExpectedPath = "/Users/me/Music/CoordFree425 copy.logicx"
@@ -777,7 +809,8 @@ private func makeSlotPopupInsertFixture(
     includeFormatNamedCategoryEntry: Bool = false,
     includeFormatLeaf: Bool = false,
     leafPickResult: Bool = true,
-    mountGainOnLeafPick: Bool = false
+    mountGainOnLeafPick: Bool = false,
+    occupySlotOnWindowRaise: Bool = false
 ) -> SlotPopupInsertFixture {
     let b = FakeAXRuntimeBuilder()
     let app = b.element(9000)
@@ -876,6 +909,7 @@ private func makeSlotPopupInsertFixture(
     b.setChildren(app, popupInitiallyVisible ? [window, popupMenu] : [window])
 
     let slotKey = b.elementID(slot)
+    let windowKey = b.elementID(window)
     let leafKey = formatLeafItem.map(b.elementID) ?? b.elementID(gainItem)
     let categoryKey = categoryItem.map(b.elementID)
     let nonMatchingLeafKey = nonMatchingLeafItem.map(b.elementID)
@@ -887,6 +921,20 @@ private func makeSlotPopupInsertFixture(
         performActionHandler: { element, action in
             let elementID = b.elementID(element)
             actions.record(elementID: elementID, action: action)
+            if occupySlotOnWindowRaise,
+               elementID == windowKey,
+               action == (kAXRaiseAction as String) {
+                let bypass = b.element(9021)
+                let open = b.element(9022)
+                b.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+                b.setAttribute(slot, kAXDescriptionAttribute as String, "Compressor")
+                b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                b.setAttribute(bypass, kAXDescriptionAttribute as String, "바이패스")
+                b.setAttribute(bypass, kAXValueAttribute as String, 0)
+                b.setAttribute(open, kAXRoleAttribute as String, kAXButtonRole as String)
+                b.setAttribute(open, kAXDescriptionAttribute as String, "열기")
+                b.setChildren(slot, [bypass, open])
+            }
             if elementID == slotKey, action == slotPopupOpenCustomAction {
                 if popupAppearsAfterSlotOpen {
                     b.setChildren(app, [window, popupMenu])
@@ -1017,6 +1065,29 @@ private func run425Insert(
     let trace = try #require(obj["select_trace"] as? [String: Any])
     let strategy = try #require(trace["winning_strategy"] as? String)
     #expect(strategy == "slot_popup_recursive_exact_leaf")
+    let leafSelectCoordFree = try #require(trace["leaf_select_coord_free"] as? Bool)
+    #expect(leafSelectCoordFree)
+}
+
+@Test func testPlugin425FailsClosedWhenTargetSlotBecomesOccupiedBeforeActuation() async throws {
+    let fixture = makeSlotPopupInsertFixture(
+        mountGainOnLeafPick: true,
+        occupySlotOnWindowRaise: true
+    )
+    let obj = await run425Insert(
+        fixture: fixture, slotOpenActions: [slotPopupOpenCustomAction]
+    )
+
+    let state = try #require(obj["state"] as? String)
+    #expect(state == "C")
+    let error = try #require(obj["error"] as? String)
+    #expect(error == "insert_setup_failed")
+    let stage = try #require(obj["setup_stage"] as? String)
+    #expect(stage == "target_slot_no_longer_empty")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(!fixture.actions.contains(elementID: fixture.slotItemID, action: slotPopupOpenCustomAction))
+    #expect(!fixture.actions.contains(elementID: fixture.leafItemID, action: kAXPickAction as String))
 }
 
 @Test func testPlugin425RecursiveWalkOnlyPicksExactLeaf() async throws {

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -681,8 +681,18 @@ private func insertParams(
 
 // MARK: - #425: coordinate-free slot-popup navigation
 
-private let slotPopupOpenCustomAction =
-    "\"Name:Open plug-in menu with legacy plug-ins\nTarget:0x0\nSelector:(null)\""
+private let slotPopupOpenCustomAction = AccessibilityChannel.slotPopupOpenCustomAction
+
+@Test func testSlotPopupOpenCustomActionMatchesLiveAXMeasurement() {
+    let action = AccessibilityChannel.slotPopupOpenCustomAction
+
+    #expect(action.utf8.count == 70)
+    #expect(!action.hasPrefix("\""))
+    #expect(!action.hasSuffix("\""))
+    #expect(action.contains("\n"))
+    #expect(!action.contains("\\n"))
+    #expect(action.hasPrefix("Name:Open plug-in menu with legacy plug-ins"))
+}
 
 /// Captures calls that pass through the injected AX action runtime seam. The
 /// tests run sequentially, so this deliberately lightweight recorder is safe.

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -1,63 +1,50 @@
-# #425 — Coordinate-free plugin-insert (Option B)
+# #425 — Custom-action slot open and `AXPick` plugin selection
 
-Status: leaf selection coordinate-free by DEFAULT; slot-open and the recursive
-category-hover fallback remain coordinate by **governed waiver**.
+Status: shipped. Plugin insertion opens the requested slot with its measured
+custom action and selects popup categories and leaves with `AXPick`.
 
-## Decision (CEO-ratified Option B)
+## Shipped design
 
-The plugin-insert leaf SELECTION is coordinate-free by default: it reads the
-plugin's format submenu as an AX child and `AXPress`es the preferred-format leaf
-(`pressPopupPluginLeaf`), with no `moveElementCenter`/`clickElementCenter`. The
-`FeatureFlags.insertCoordFree` flag is retained as a **kill-switch** —
-`LOGIC_MCP_INSERT_COORD_FREE=0` rolls back to the legacy coordinate leaf click.
+When the target empty slot exposes the measured opener, slot-open uses the exact custom action name below. It is 70 UTF-8 bytes, has real newline characters, and has no surrounding quote characters:
 
-`clickPopupPluginLeaf` takes an explicit `coordFree` argument (not a direct flag
-read) so the two supported paths (direct / search) honor the flag while the
-recursive fallback can force the coordinate path.
+```
+Name:Open plug-in menu with legacy plug-ins
+Target:0x0
+Selector:(null)
+```
 
-## Governed coordinate waivers (live-probed, documented)
+The custom action's return code is not an acceptance signal. After dispatch, the
+driver polls for the popup and verifies that the popup is anchored to the target
+slot; those observations decide whether slot-open succeeded. On 2026-08-08, AX
+action return codes were observed to disagree with the effect in both directions:
+an action can report failure after opening the popup, and can report success
+without the required observed effect.
 
-1. **Slot-open stays a coordinate click.** Opening a slot's empty picker is a
-   coordinate click on the slot element (`liveExactSlotPopupInsert`). Coord-free
-   alternatives were live-probed and rejected:
-   - `AXPress` on the empty-slot element is a **no-op** — the picker never opens.
-   - `AXShowMenu` opens the picker into an **NSMenu tracking loop that wedges
-     Logic** (AX calls block).
+Popup navigation uses `AXPick` for category and leaf selection. Picking a category
+reveals its already-attached submenu without hover. Picking the exact plugin leaf
+(or its preferred format leaf) likewise ignores the AX action return code. The
+post-insert strip inventory diff decides the leaf outcome: it detects a mount in
+the requested slot, detects and rolls back a stray mount, or produces the
+appropriate fail-closed result when no verified change is observed.
 
-2. **Recursive category-hover fallback stays coordinate.** The recursive
-   discovery path (`clickPopupExactLeafRecursively`) hovers categories with
-   `moveElementCenter` and always selects the matched leaf with `coordFree:
-   false`. It is a **reachable** coordinate-only failure fallback — tried after
-   the direct and search strategies — but is **unreachable in practice for the
-   Release-1 supported plugins**: Gain, Channel EQ, and Compressor
-   (`insertableAllowlist`) are always found by the direct or search strategy, so
-   the recursive branch is a coordinate-only safety net the supported set never
-   exercises.
+## Narrow coordinate compatibility path
 
-## Discriminator honesty
+A coordinate click survives only when the target slot does not expose the custom
+action. This compatibility fallback is recorded in the trace as
+`slot_popup_open_fallback_taken: true` and
+`slot_popup_open_action: "coordinate_fallback"`. The custom-action path records
+`slot_popup_open_fallback_taken: false` and
+`slot_popup_open_action: "custom_action"`, so receipts say which path ran.
 
-`select_trace["leaf_select_coord_free"]` is sourced from the WINNING strategy
-(`SlotPopupPluginClick.coordFree`) via `leafSelectCoordFree(for:)`, not the raw
-flag. A recursive (coordinate-only) win therefore reports `false` even when the
-flag is on, so the receipt can never be falsely pinned to the flag value.
+There is no feature flag or coordinate leaf-selection fallback: category and leaf
+selection are `AXPick` actions, and the observed inventory diff remains the
+acceptance gate.
 
-## Tests
+## Coverage
 
-`Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` covers, at the helper
-level, leaf press via `kAXPress`, the discriminator's value on a coord-free
-direct win, `coordFree:false` taking the coordinate path (never `AXPress`), and
-fail-closed behavior when `AXPress` is neutralized.
-
-Response-level tests drive the real `defaultInsertVerified` flow (fake AX runtime
-plus a DEBUG-only coordinate-actuation seam, `forceCoordinateActuationForTests`,
-so no CGEvent / physical mouse is issued) and assert the assembled response's
-`select_trace["leaf_select_coord_free"]`:
-
-- a recursive (coordinate-only) win under the flag ON reports `false` — the
-  flag-vs-path divergence is exercised hermetically end to end, not merely
-  structurally;
-- a direct win selects the leaf via `kAXPress` under the flag ON
-  (`leaf_select_coord_free == true`) and via the coordinate primitives under the
-  flag OFF (`false`, with no `kAXPress` on the leaf);
-- an AXPress win that times out post-commit reports an AXPress commit strategy
-  (`commit_strategy`), never a physical/coordinate one.
+`Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` verifies that the custom
+action can report failure while the observed popup permits progress, that a
+success-looking action with no popup fails closed, that category `AXPick` reveals
+the submenu without hover, and that leaf `AXPick` is accepted only when the
+post-insert inventory observation supports it. It also verifies the trace values
+for both the custom-action and absent-action coordinate-fallback slot-open paths.

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -68,3 +68,27 @@ discovery reaches an already-attached submenu with neither non-target AX actions
 nor attribute writes, and that leaf `AXPick` is accepted only when the post-insert
 inventory observation supports it. It also verifies the trace values for both the
 custom-action and absent-action coordinate-fallback slot-open paths.
+
+## What State A does not prove
+
+These are limits of the verification, not open work items. They are written down so a reader does not
+read more into a State A receipt than it carries.
+
+**Product identity is a display string.** The leaf is chosen by exact title match and the mount is
+confirmed by mapping the observed slot name back to the requested id. Two products exposing the same
+AX title are indistinguishable to both steps, so State A certifies "a plug-in presenting this name is
+now at the requested slot", not "this exact product is". AX exposes no stable product identifier on
+these menu entries on the measured build.
+
+**Attribution is a diff, not a transaction.** Acceptance is a pre/post inventory diff taken around
+this call. If the requested plug-in arrives at the requested slot from another source inside that
+window, the diff cannot tell that apart from our own pick. A wrong SLOT is caught — the observed slot
+must equal the requested one and is rolled back otherwise — but a concurrent identical mount at the
+same slot is not distinguishable.
+
+**Check-and-act is not atomic.** Every guard here reads AX and then acts; macOS offers no way to hold
+the tree between the two. The window is now as small as the code can make it — the slot is re-read
+and required to be both still empty and still the same element immediately before actuation, and the
+pop-up must be one that appeared after that actuation — but a change landing inside that remaining
+window is not detectable from this process.
+

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -21,9 +21,9 @@ action return codes were observed to disagree with the effect in both directions
 an action can report failure after opening the popup, and can report success
 without the required observed effect.
 
-Discovery is read-only: it recurses through the already-attached `AXMenu` child
-and performs no AX action on any non-target item. `AXPick` is dispatched only to the leaf
-whose name matched the request exactly, and to its preferred-format leaf. As with
+Discovery is read-only: it uses no popup-search strategy or search-field writes,
+recurses through the already-attached `AXMenu` child, and performs no AX action on any non-target item.
+`AXPick` is dispatched only to the leaf whose name matched the request exactly, and to its preferred-format leaf. As with
 the slot opener, its return code is not accepted as success by itself. The
 post-insert strip inventory diff decides the leaf outcome: it detects a mount in
 the requested slot, detects and rolls back a stray mount, or produces the
@@ -64,7 +64,7 @@ inventory diff remains the acceptance gate.
 `Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` verifies that the custom
 action can report failure while the observed popup permits progress, that a
 success-looking action with no popup fails closed, that read-only category
-discovery reaches an already-attached submenu, and that leaf `AXPick` is accepted
-only when the post-insert inventory observation supports it. It also verifies the
-trace values for both the custom-action and absent-action coordinate-fallback
-slot-open paths.
+discovery reaches an already-attached submenu with neither non-target AX actions
+nor attribute writes, and that leaf `AXPick` is accepted only when the post-insert
+inventory observation supports it. It also verifies the trace values for both the
+custom-action and absent-action coordinate-fallback slot-open paths.

--- a/docs/tickets/issue-425-coord-free-insert.md
+++ b/docs/tickets/issue-425-coord-free-insert.md
@@ -1,7 +1,8 @@
-# #425 — Custom-action slot open and `AXPick` plugin selection
+# #425 — Custom-action slot open and read-only plugin discovery
 
 Status: shipped. Plugin insertion opens the requested slot with its measured
-custom action and selects popup categories and leaves with `AXPick`.
+custom action, discovers popup entries without actuating categories, and selects
+only the requested plugin leaf with `AXPick`.
 
 ## Shipped design
 
@@ -20,12 +21,30 @@ action return codes were observed to disagree with the effect in both directions
 an action can report failure after opening the popup, and can report success
 without the required observed effect.
 
-Popup navigation uses `AXPick` for category and leaf selection. Picking a category
-reveals its already-attached submenu without hover. Picking the exact plugin leaf
-(or its preferred format leaf) likewise ignores the AX action return code. The
+Discovery is read-only: it recurses through the already-attached `AXMenu` child
+and performs no AX action on any non-target item. `AXPick` is dispatched only to the leaf
+whose name matched the request exactly, and to its preferred-format leaf. As with
+the slot opener, its return code is not accepted as success by itself. The
 post-insert strip inventory diff decides the leaf outcome: it detects a mount in
 the requested slot, detects and rolls back a stray mount, or produces the
 appropriate fail-closed result when no verified change is observed.
+
+Read-only discovery is sufficient on the measured Logic configuration because
+category submenus were already populated before any pick. Measured against the
+running application, the attached child counts were:
+
+| Category | Children before pick | Children after pick |
+| --- | ---: | ---: |
+| Gain | 2 | 2 |
+| Compressor | 1 | 1 |
+| Channel EQ | 1 | 1 |
+| Tremolo | 2 | 2 |
+| Flanger | 2 | 2 |
+| Amps and Pedals | 4 | 4 |
+
+Each category was therefore not lazy. This was measured on one Logic version and locale;
+it records why a read-only recursive walk is sufficient for that observed version,
+rather than assuming that every future version or locale behaves alike.
 
 ## Narrow coordinate compatibility path
 
@@ -36,15 +55,16 @@ action. This compatibility fallback is recorded in the trace as
 `slot_popup_open_fallback_taken: false` and
 `slot_popup_open_action: "custom_action"`, so receipts say which path ran.
 
-There is no feature flag or coordinate leaf-selection fallback: category and leaf
-selection are `AXPick` actions, and the observed inventory diff remains the
-acceptance gate.
+There is no feature flag or coordinate leaf-selection fallback: the exact
+matching leaf and its preferred-format leaf use `AXPick`, and the observed
+inventory diff remains the acceptance gate.
 
 ## Coverage
 
 `Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift` verifies that the custom
 action can report failure while the observed popup permits progress, that a
-success-looking action with no popup fails closed, that category `AXPick` reveals
-the submenu without hover, and that leaf `AXPick` is accepted only when the
-post-insert inventory observation supports it. It also verifies the trace values
-for both the custom-action and absent-action coordinate-fallback slot-open paths.
+success-looking action with no popup fails closed, that read-only category
+discovery reaches an already-attached submenu, and that leaf `AXPick` is accepted
+only when the post-insert inventory observation supports it. It also verifies the
+trace values for both the custom-action and absent-action coordinate-fallback
+slot-open paths.


### PR DESCRIPTION
Closes #425.

**Head:** `1bc37a46f2acb983e479923f3bd942f0ec1a8926`
**Base:** `04f33244f9a8d5c7486bcb6d5f96709c8039b42f` (current `main`)

> Every figure below was measured on this head. Evidence from `f9cbecf0`, `700117`, and every earlier head is discarded, including their suite counts, artifact hashes, mutation runs, and live probes.

## What this removes

The last synthetic-mouse surface: the plugin-insert popup. Slot open was a centre click; category and format navigation were hover-to-reveal plus centre click.

| stage | before | after | what decides the outcome |
|---|---|---|---|
| slot open | `clickElementCenter` | measured custom action | popup poll + slot anchor |
| category | `moveElementCenter` hover | `AXPick` | observed submenu |
| leaf / format | `clickElementCenter` | `AXPick` | post-insert inventory diff |

**No stage gates on an AX return value.** `moveElementCenter` is deleted — zero occurrences in `Sources` and `Tests`. `clickElementCenter` keeps exactly one call site: the fallback taken when the custom action is absent, which the trace records as `slot_popup_open_fallback_taken: true` / `slot_popup_open_action: "coordinate_fallback"`, so a fallback can never be reported as coordinate-free actuation.

## The action name

The opener is registered under this exact string. **The fenced block below delimits the value; the fence is representation and the value has no surrounding quote characters:**

```
Name:Open plug-in menu with legacy plug-ins
Target:0x0
Selector:(null)
```

70 UTF-8 bytes, real newline characters, no literal backslash-n, no leading or trailing `"`.

Two spellings were previously committed and **neither matched** — one used literal `\n`, the other wrapped the value in quote characters. Membership against the live action array is false for both. The tests passed either way because the fixture repeated the same literal as the source: self-consistent, both wrong. The test constant is now **derived from the production one**, so there is a single definition, and a test pins the properties measured from the running application rather than a copy of the literal.

## Inert flag removed

`FeatureFlags.insertCoordFree` and `LOGIC_MCP_INSERT_COORD_FREE` had **zero production consumers** after this branch moved slot-open to the custom action, so the documented kill switch changed nothing while presenting itself as a rollback control. The flag, its override helper, and its unit coverage are removed. It was **not** given an effect by restoring the coordinate leaf path, which live probing disproved. The #425 ticket, which still described the superseded design, now describes what ships.

## Product-path live qualification — exact release artifact

Run through `TmuxMCPClient` against `LogicProMCP` sha256 `2331bf7b6066168bb327fe2f29906f666cf0efc4cde0a46a3fe1cbe3f03c4da6`. Every parameter derived from measured state, none hardcoded: `project_expected_path` from the front document, `insert` from the first `read_status: empty` slot, `target_ref` from a `logic://tracks` read.

| step | evidence |
|---|---|
| pre-inventory | slots 0/1/2 all `read_status: empty`, `occupied: false` |
| `insert_verified` Gain | **`state: A`, `verified: true`**, `observed_slot: 0`, `observed_plugin_id: logic.stock.effect.gain`, `verify_source: ax_plugin_inventory` |
| custom-action trace | `slot_popup_open_action: "custom_action"`, `slot_popup_open_fallback_taken: false`, `slot_popup_anchor_verified: true`, `leaf_select_coord_free: true`, `write_source: ax_exact_slot_popup` |
| post-inventory | slot 0 `read_status: ok, name: Gain`; 1 and 2 still empty |
| recovery | exact `Undo Insert Plug-in in Channel Strip`; independent re-read on a fresh client: slots 0/1/2 all empty, `occupied: false` |

**Negative evidence** (fail-closed, not positive proof): a bare index is refused with `index_binding_corroboration_required`; a wrong `expected_name` is refused with `target_identity_mismatch` and `safe_to_retry: false`; a missing mode is refused with `unsupported_mode`. All three are pre-write with `write_attempted: false`.

**Direct AX corroboration only**: the artifact-extracted string is present in the live slot's action array, and the opener returns `-25204` while the anchored popup opens — the return-code disagreement this design refuses to gate on.

## Lanes on this head

| lane | result |
|---|---|
| focused: contract | 2 passed; restoring the pre-fix flag and ticket makes them fail, 2 tests / 5 issues |
| focused: plugin | 267 passed |
| mutation — gate slot-open on the return code | **1 failed, 2 issues**; restored byte-identical, passes |
| mutation — gate the leaf `AXPick` on the return code | **1 failed, 2 issues**; restored byte-identical, passes |
| mutation — action name with quotes | **fails** on byte count, both quote checks, prefix |
| mutation — action name with literal `\n` | **fails** on byte count, newline check, backslash check |
| full suite | **3372 passed, exit 0**, clean tree |
| `ci-forbid-dead-expect.sh` | clean |
| preflight vs `04f33244` | **PASS** — C1a, C1b, C1c, C2, C3a, C3b |
| `Package.resolved` | untouched |

### Release artifacts

| artifact | bytes | sha256 | codesign |
|---|---:|---|---|
| `LogicProMCP` | 20306872 | `2331bf7b6066168bb327fe2f29906f666cf0efc4cde0a46a3fe1cbe3f03c4da6` | verified |
| `trusted-verifier` | 20306128 | `63503f07886e45e30e0d2414c8598e303cb139aa24e222d0e98fd8d19224583e` | verified |

The artifact contains the 70-byte form and neither wrong spelling, and no `insertCoordFree` / `LOGIC_MCP_INSERT_COORD_FREE` symbol.

## Not converted

Coordinate-free **removal** is unproven — an occupied slot's popup has no `No Plug-in` entry.