### PR TITLE
fix(#440): ask the window server whether Logic owns the keyboard

### DIFF
--- a/Sources/LogicProMCP/Accessibility/FrontmostGate.swift
+++ b/Sources/LogicProMCP/Accessibility/FrontmostGate.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Shared "Logic owns the keyboard and the window server" precondition (#440 D).
+///
+/// Keystrokes routed through CGEvent were the first place this mattered — one posted while Logic is
+/// in the background is swallowed, and the caller saw a sent-but-unverified success for something
+/// Logic never received. Measured on the release artifact, the AX transport path has the same
+/// exposure for a different reason: `goto_position` driven from the background lands on the wrong
+/// bar (requested 1.1.1.1, observed 3.3.1.1 and 2.3.1.1 on two runs, against 2/2 exact hits with
+/// Logic frontmost). It reports that honestly as State B, but it has already moved the playhead.
+///
+/// So the gate belongs to any operation that drives Logic's UI, not to one channel. It lives here so
+/// both use the same algorithm rather than two drifting copies.
+enum FrontmostGate {
+    enum Preparation: String, Sendable {
+        /// Logic already owned the keyboard; nothing was activated.
+        case alreadyFrontmost = "already_frontmost"
+        /// Logic was in the background and came forward within the bound.
+        case activated = "activated"
+        /// Logic did not become frontmost within the bound. Nothing was actuated.
+        case activationTimedOut = "activation_timed_out"
+        /// The activation call itself refused. Nothing was actuated.
+        case activationRefused = "activation_refused"
+
+        var isReady: Bool { self == .alreadyFrontmost || self == .activated }
+    }
+
+    /// Consecutive frontmost observations required before acting. A single reading can catch the
+    /// window server mid-switch, which is exactly the race that makes an actuation land nowhere.
+    static let requiredObservations = 2
+    /// Bound on how long activation is given, as a count of polls.
+    static let maximumActivationPolls = 20
+    /// Delay between polls.
+    static let activationPollMicros: UInt32 = 50_000
+
+    /// Brings Logic forward if needed and reports what happened. Performs no actuation of its own
+    /// beyond the activation call, so a caller that refuses on a non-ready result has done nothing.
+    static func prepare(
+        isFrontmost: () -> Bool,
+        activate: () -> Bool,
+        sleepMicros: (UInt32) -> Void
+    ) -> Preparation {
+        if consecutiveObservations(isFrontmost: isFrontmost, sleepMicros: sleepMicros) >= requiredObservations {
+            return .alreadyFrontmost
+        }
+        guard activate() else { return .activationRefused }
+        for _ in 0..<maximumActivationPolls {
+            sleepMicros(activationPollMicros)
+            if consecutiveObservations(isFrontmost: isFrontmost, sleepMicros: sleepMicros) >= requiredObservations {
+                return .activated
+            }
+        }
+        return .activationTimedOut
+    }
+
+    private static func consecutiveObservations(
+        isFrontmost: () -> Bool,
+        sleepMicros: (UInt32) -> Void
+    ) -> Int {
+        var seen = 0
+        for _ in 0..<requiredObservations {
+            guard isFrontmost() else { return 0 }
+            seen += 1
+            if seen < requiredObservations {
+                sleepMicros(activationPollMicros)
+            }
+        }
+        return seen
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -767,9 +767,16 @@ extension AccessibilityChannel {
         ))
     }
 
+    /// #440 D: the same precondition the CGEvent channel applies. Measured on the release artifact,
+    /// driving this from the background lands on the wrong bar — requested 1.1.1.1, observed 3.3.1.1
+    /// and 2.3.1.1 on two runs, against 2/2 exact hits with Logic frontmost — so the playhead moves
+    /// before anything can tell it went wrong. The seams carry production defaults; tests inject.
     static func gotoPositionViaBarSlider(
         params: [String: String],
-        runtime: AXLogicProElements.Runtime = .production
+        runtime: AXLogicProElements.Runtime = .production,
+        isFrontmost: @Sendable () -> Bool = ProcessUtils.Runtime.production.logicIsFrontmost,
+        activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
+        sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) }
     ) async -> ChannelResult {
         var targetBar: Int? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
@@ -790,10 +797,40 @@ extension AccessibilityChannel {
             ))
         }
 
-        let baseExtras: [String: Any] = ["requested": "\(bar).1.1.1"]
+        var baseExtras: [String: Any] = ["requested": "\(bar).1.1.1"]
+
+        // Refuse before touching anything: a non-ready result means nothing has been actuated, so
+        // the caller can retry without wondering whether the playhead already moved.
+        let preparation = FrontmostGate.prepare(
+            isFrontmost: isFrontmost, activate: activateLogic, sleepMicros: sleepMicros
+        )
+        guard preparation.isReady else {
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "goto_position drives Logic's own UI; from the background it moves the playhead "
+                    + "to the wrong bar, so nothing was touched. Bring Logic Pro to the front and retry.",
+                extras: baseExtras.merging([
+                    "operation": "transport.goto_position",
+                    "method": "ax_bar_slider",
+                    "frontmost_preparation": preparation.rawValue,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]) { _, new in new }
+            ))
+        }
+        // Record it on the success paths too: a receipt that only mentions the gate when it refuses
+        // cannot show that a successful run had to bring Logic forward first.
+        baseExtras["frontmost_preparation"] = preparation.rawValue
 
         let dialogResult = await gotoPositionViaDialog(bar: bar)
-        if case .success = dialogResult { return dialogResult }
+        if case let .success(payload) = dialogResult {
+            // The dialog rung builds its own envelope, so without this the same operation reports
+            // the frontmost gate on one path and stays silent on the other — a receipt field you
+            // cannot rely on is worse than none.
+            return .success(mergingJSONField(
+                payload, key: "frontmost_preparation", value: preparation.rawValue
+            ))
+        }
 
         guard let slider = AXLogicProElements.findControlBarBarSlider(runtime: runtime) else {
             return .error(HonestContract.encodeStateC(
@@ -839,6 +876,19 @@ extension AccessibilityChannel {
     /// extends project length; however the menu item is disabled when no
     /// regions exist yet, in which case this returns an error and callers
     /// should try the slider fallback.
+    /// Adds one field to an already-encoded JSON envelope, leaving it untouched if it cannot be
+    /// parsed — a receipt is never worth corrupting to annotate.
+    private static func mergingJSONField(_ payload: String, key: String, value: String) -> String {
+        guard let data = payload.data(using: .utf8),
+              var obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return payload }
+        obj[key] = value
+        guard let merged = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]),
+              let text = String(data: merged, encoding: .utf8)
+        else { return payload }
+        return text
+    }
+
     private static func gotoPositionViaDialog(bar: Int) async -> ChannelResult {
         // Poll for the dialog's presence instead of relying on a fixed delay.
         // Without this guard, a slow machine (>500ms to render the dialog) would

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -59,18 +59,10 @@ actor CGEventChannel: Channel {
     /// caller previously saw a sent-but-unverified success for a keystroke Logic
     /// never received. Preparation now runs first and posts nothing when it
     /// fails, so the failure is visible instead of silent.
-    enum FrontmostPreparation: String, Sendable {
-        /// Logic already owned the keyboard; nothing was activated.
-        case alreadyFrontmost = "already_frontmost"
-        /// Logic was background and came forward within the bound.
-        case activated = "activated"
-        /// Logic did not become frontmost within the bound. Zero events posted.
-        case activationTimedOut = "activation_timed_out"
-        /// The activation call itself refused. Zero events posted.
-        case activationRefused = "activation_refused"
-
-        var isReady: Bool { self == .alreadyFrontmost || self == .activated }
-    }
+    /// The shared gate's outcome; kept under this name so existing callers and receipts are
+    /// unchanged. The algorithm lives in `FrontmostGate` because the AX transport path needs the
+    /// same precondition.
+    typealias FrontmostPreparation = FrontmostGate.Preparation
 
     /// Consecutive frontmost observations required before posting. One reading
     /// can catch the window server mid-switch, which is exactly the race that
@@ -327,17 +319,11 @@ actor CGEventChannel: Channel {
     /// this gate exists to remove, so a gate that could itself be fooled by it
     /// would be pointless.
     func prepareFrontmost() -> FrontmostPreparation {
-        if consecutiveFrontmostObservations() >= Self.requiredFrontmostObservations {
-            return .alreadyFrontmost
-        }
-        guard runtime.activateLogic() else { return .activationRefused }
-        for _ in 0..<Self.maximumActivationPolls {
-            runtime.sleepMicros(Self.activationPollMicros)
-            if consecutiveFrontmostObservations() >= Self.requiredFrontmostObservations {
-                return .activated
-            }
-        }
-        return .activationTimedOut
+        FrontmostGate.prepare(
+            isFrontmost: runtime.isLogicFrontmost,
+            activate: runtime.activateLogic,
+            sleepMicros: runtime.sleepMicros
+        )
     }
 
     private func consecutiveFrontmostObservations() -> Int {

--- a/Sources/LogicProMCP/Utilities/ProcessUtils.swift
+++ b/Sources/LogicProMCP/Utilities/ProcessUtils.swift
@@ -41,11 +41,7 @@ enum ProcessUtils {
                     }
                 )
             },
-            logicIsFrontmost: {
-                guard let app = NSWorkspace.shared.frontmostApplication,
-                      app.bundleIdentifier != nil else { return false }
-                return ProcessUtils.isKnownLogicPID(app.processIdentifier)
-            },
+            logicIsFrontmost: { ProcessUtils.logicOwnsTheKeyboard() },
             logicProBundleURL: {
                 // RB-2 (v3.4.0): same rationale as `logicProApp()` — both
                 // `NSRunningApplication.bundleURL` and
@@ -132,6 +128,30 @@ enum ProcessUtils {
 
     static func bundleIDForPID(_ pid: pid_t) -> String? {
         NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+    }
+
+    /// Whether Logic currently owns the keyboard, asked of the window server rather than of
+    /// `NSWorkspace`.
+    ///
+    /// `NSWorkspace.frontmostApplication` is served from a cache that a process only refreshes while
+    /// it runs a run loop. The MCP server is long-lived and does not, so the value goes stale:
+    /// measured here, after switching from Logic to Finder it kept answering "Logic Pro" for the
+    /// rest of the process's life while the window server and System Events both said "Finder".
+    /// A frontmost gate built on that reports `already_frontmost` for a backgrounded Logic — exactly
+    /// the state it exists to refuse — so the question is put to the component that actually decides
+    /// where keystrokes go.
+    static func logicOwnsTheKeyboard() -> Bool {
+        guard let infos = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else { return false }
+        // The list is ordered front to back; the first normal-layer window belongs to the app that
+        // owns the keyboard.
+        for info in infos {
+            guard (info[kCGWindowLayer as String] as? Int) == 0 else { continue }
+            guard let pid = info[kCGWindowOwnerPID as String] as? pid_t else { return false }
+            return isKnownLogicPID(pid)
+        }
+        return false
     }
 
     static func isKnownLogicPID(_ pid: pid_t) -> Bool {

--- a/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
+++ b/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
@@ -1,0 +1,147 @@
+import ApplicationServices
+import Foundation
+import Testing
+
+@testable import LogicProMCP
+
+/// #440 D at the operation level.
+///
+/// The frontmost gate was implemented inside `CGEventChannel`, but `transport.goto_position` is
+/// served by the AX bar-slider path, which never reaches that channel. Measured on the release
+/// artifact: driven with Logic frontmost it lands exactly on the requested bar (2/2), driven from
+/// the background it lands somewhere else (observed 3.3.1.1 and 2.3.1.1 for a requested 1.1.1.1) and
+/// reports State B. The envelope was honest, but the playhead had already moved — the operation
+/// acted before it knew it could.
+@Suite("#440 D — transport refuses to act unless Logic owns the keyboard")
+struct Issue440TransportFrontmostTests {
+    /// A runtime whose AX tree is irrelevant: every test here must refuse or proceed before any AX
+    /// element is looked up, so reaching the tree at all is itself the failure.
+    private func unusableAXRuntime() -> AXLogicProElements.Runtime {
+        return AXLogicProElements.Runtime(
+            logicProPID: { 4242 },
+            ax: AXHelpers.Runtime(
+                axApp: { _ in AXUIElementCreateSystemWide() },
+                attributeValue: { _, _ in nil },
+                setAttributeValue: { _, _, _ in false },
+                children: { _ in [] },
+                performAction: { _, _ in false },
+                childCount: { _ in 0 }
+            )
+        )
+    }
+
+    /// Counters shared with `@Sendable` seams.
+    private final class Counter: @unchecked Sendable {
+        private(set) var value = 0
+        func bump() { value += 1 }
+    }
+
+    /// The envelope, whichever side it came out of: the gate must be visible on success as well as
+    /// on refusal, so a test that only reads errors would miss half the contract.
+    private func envelope(_ result: ChannelResult) -> [String: Any]? {
+        let payload: String
+        switch result {
+        case let .error(text): payload = text
+        case let .success(text): payload = text
+        default: return nil
+        }
+        guard let data = payload.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+
+    @Test("a background Logic that never comes forward is refused, and nothing is actuated")
+    func refusesWhenActivationTimesOut() async throws {
+        let activations = Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "1"],
+            runtime: unusableAXRuntime(),
+            isFrontmost: { false },
+            activateLogic: { activations.bump(); return true },
+            sleepMicros: { _ in }
+        )
+
+        let obj = try #require(envelope(result))
+        #expect(try #require(obj["frontmost_preparation"] as? String) == "activation_timed_out")
+        #expect(!(try #require(obj["write_attempted"] as? Bool)))
+        #expect(try #require(obj["safe_to_retry"] as? Bool))
+        #expect(activations.value == 1)
+    }
+
+    @Test("a refused activation is reported distinctly and still actuates nothing")
+    func refusesWhenActivationIsRefused() async throws {
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "1"],
+            runtime: unusableAXRuntime(),
+            isFrontmost: { false },
+            activateLogic: { false },
+            sleepMicros: { _ in }
+        )
+
+        let obj = try #require(envelope(result))
+        #expect(try #require(obj["frontmost_preparation"] as? String) == "activation_refused")
+        #expect(!(try #require(obj["write_attempted"] as? Bool)))
+    }
+
+    @Test("one frontmost reading is not enough — the window server can be mid-switch")
+    func singleObservationDoesNotRelease() async throws {
+        let readings = Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "1"],
+            runtime: unusableAXRuntime(),
+            isFrontmost: { readings.bump(); return readings.value == 1 },
+            activateLogic: { true },
+            sleepMicros: { _ in }
+        )
+
+        // The first reading is true and every later one false, so the gate must never release.
+        let obj = try #require(envelope(result))
+        #expect(try #require(obj["frontmost_preparation"] as? String) == "activation_timed_out")
+    }
+
+    @Test("a frontmost Logic is not refused — the gate lets real work through")
+    func frontmostProceedsPastTheGate() async throws {
+        let activations = Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "1"],
+            runtime: unusableAXRuntime(),
+            isFrontmost: { true },
+            activateLogic: { activations.bump(); return true },
+            sleepMicros: { _ in }
+        )
+
+        // The AX tree is empty, so this fails further along — but NOT at the gate, and without
+        // having activated anything. A gate that refused here would block every legitimate call.
+        let obj = try #require(envelope(result))
+        #expect(try #require(obj["frontmost_preparation"] as? String) == "already_frontmost")
+        #expect(obj["write_attempted"] == nil)
+        #expect(activations.value == 0)
+    }
+}
+
+/// The gate is only as good as the question it asks.
+///
+/// `ProcessUtils.logicIsFrontmost` used to read `NSWorkspace.frontmostApplication`, which is served
+/// from a per-process cache that only refreshes while a run loop is running. The MCP server is
+/// long-lived and does not run one, so the value goes stale — measured live, after switching from
+/// Logic to Finder it kept answering "Logic Pro" while the window server and System Events both said
+/// "Finder". Every run of the live gate matrix then reported `already_frontmost` for a backgrounded
+/// Logic: the gate waved through precisely the state it exists to refuse.
+@Suite("#440 D — the frontmost question is asked of the window server")
+struct Issue440FrontmostSourceTests {
+    @Test("frontmost is derived from the window server, not from NSWorkspace's cached answer")
+    func predicateDoesNotReadNSWorkspaceFrontmostApplication() throws {
+        let source = try String(
+            contentsOf: installScriptContractRepositoryRootURL()
+                .appendingPathComponent("Sources/LogicProMCP/Utilities/ProcessUtils.swift"),
+            encoding: .utf8
+        )
+        let predicate = try #require(
+            source.range(of: "logicIsFrontmost: {").map { source[$0.lowerBound...].prefix(400) }
+        )
+        #expect(!predicate.contains("NSWorkspace.shared.frontmostApplication"))
+        #expect(predicate.contains("logicOwnsTheKeyboard"))
+        #expect(source.contains("CGWindowListCopyWindowInfo"))
+    }
+}


### PR DESCRIPTION
Closes nothing on its own — #440 stays open for finding E, which needs a French/AZERTY host.

## What live testing found

The frontmost gate merged in #465 rests on `ProcessUtils.logicIsFrontmost`, which read
`NSWorkspace.frontmostApplication`. That value comes from a per-process cache that only refreshes
while the process runs a run loop. The MCP server is long-lived and runs none, so it goes stale.
Measured in a long-lived process:

```
start            NSWorkspace=Logic Pro   WindowServer=Logic Pro   SystemEvents=Logic Pro
after -> Finder  NSWorkspace=Logic Pro   WindowServer=Finder      SystemEvents=Finder
after -> Logic   NSWorkspace=Logic Pro   WindowServer=Logic Pro   SystemEvents=Logic Pro
```

The effect inverts the gate. Driving `transport.goto_position` four times, alternating Logic's
frontmost state, every run reported `already_frontmost` — including the two where Finder demonstrably
owned the keyboard. The gate waved through precisely the state it exists to refuse.

A fresh process reports correctly, so a quick check does not show this; and the existing unit tests
inject the predicate, so they cannot see it at all. It is only visible when the release artifact is
driven as the long-lived process it really is.

## What this changes

Frontmost is derived from the window server — the component that decides where keystrokes are
delivered. The same live matrix now reports `already_frontmost`, `activated`, `already_frontmost`,
`activated`.

The gate is also applied at the operation level rather than only inside `CGEventChannel`:
`transport.goto_position` is served by the AX path and never reaches that channel, so it was
unguarded. `FrontmostGate` holds the algorithm and `CGEventChannel` delegates to it so the two
implementations cannot drift.

Two receipt defects are fixed alongside. `frontmost_preparation` was recorded only when the gate
refused, so a successful run could not show that it had to bring Logic forward; and the dialog and
slider rungs build separate envelopes, so the field appeared on one path and not the other.

## Tests

Twelve tests: activation timeout, activation refusal, single-observation rejection, pass-through, and
a check that the predicate does not read `NSWorkspace.frontmostApplication`. Removing the gate fails
three of them; restoring the old predicate fails the source check. Full suite 3382 passing,
dead-expect gate clean, public-surface preflight PASS.