### PR TITLE
fix(#478): delete a marker without requiring a hand-configured MIDI binding

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -1,0 +1,202 @@
+import ApplicationServices
+import Foundation
+
+extension AccessibilityChannel {
+    /// Delete a marker through the Marker List itself, so the operation works on a default install.
+    ///
+    /// `nav.delete_marker` previously routed only to `[.midiKeyCommands, .cgEvent]`, which means it
+    /// does nothing until the operator has installed the key-command preset AND performed a manual
+    /// MIDI Learn inside Logic. Until then the CC goes out, Logic has nothing bound to it, the marker
+    /// survives, and the caller is told `readback_unavailable` — a setup prerequisite reported as a
+    /// readback problem. Deleting a marker should not require a hand-configured MIDI binding.
+    ///
+    /// Measured on Logic 12.3 while building this path:
+    ///   * each Marker List row carries a custom `Delete` action, and performing it does **nothing** —
+    ///     the return code says success and the marker stays. Only the observed effect counts.
+    ///   * selecting the row does work: the table reports it in `AXSelectedRows`.
+    ///   * with the row selected AND keyboard focus inside the Marker table, a Delete key removes it.
+    ///
+    /// That last condition is the whole safety story. The same keystroke sent while focus sits in the
+    /// arrange area deletes the selected REGION or TRACK instead. So focus is verified to be inside
+    /// the marker table immediately before the key is posted, and the operation refuses otherwise
+    /// rather than pressing Delete somewhere unknown.
+    static func defaultDeleteMarker(
+        index: Int,
+        runtime: AXLogicProElements.Runtime = .production,
+        mouse: AXMouseHelper.Runtime = .production
+    ) async -> ChannelResult {
+        guard index >= 0 else {
+            return .error(HonestContract.encodeStateC(
+                error: .invalidParams,
+                hint: "nav.delete_marker requires an index >= 0",
+                extras: ["operation": "nav.delete_marker", "write_attempted": false]
+            ))
+        }
+
+        let openResult = await defaultOpenMarkerList(runtime: runtime)
+        guard openResult.isSuccess else { return openResult }
+
+        guard let binding = AXLogicProElements.markerListBinding(runtime: runtime) else {
+            return .error(HonestContract.encodeStateC(
+                error: .readbackUnavailable,
+                hint: "The Marker List could not be bound after opening.",
+                extras: ["operation": "nav.delete_marker", "requested_index": index, "write_attempted": false]
+            ))
+        }
+        let window = binding.window
+        let before = AXLogicProElements.enumerateMarkersFromListWindow(window, runtime: runtime.ax)
+        guard let target = before.first(where: { $0.id == index }) else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Marker index \(index) was not found in the Marker List",
+                extras: [
+                    "operation": "nav.delete_marker",
+                    "requested_index": index,
+                    "marker_count": before.count,
+                    "write_attempted": false,
+                ]
+            ))
+        }
+
+        // Identify the survivor set by name+position rather than by index: indices renumber when a
+        // row disappears, so comparing indices after the write would prove nothing.
+        let expectedSurvivors = before.filter { $0.id != index }
+            .map { "\($0.name)@\($0.position)" }
+            .sorted()
+        var extras: [String: Any] = [
+            "operation": "nav.delete_marker",
+            "requested_index": index,
+            "target_name": target.name,
+            "target_position": target.position,
+            "marker_count_before": before.count,
+        ]
+
+        guard selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
+            extras["write_attempted"] = false
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "Marker index \(index) could not be selected, so nothing was pressed",
+                extras: extras
+            ))
+        }
+
+        guard markerTableHasKeyboardFocus(runtime: runtime) else {
+            // Refusing here is the point: the same keystroke elsewhere deletes a region or a track.
+            extras["write_attempted"] = false
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "The Marker List did not hold keyboard focus, so Delete was not pressed — "
+                    + "the same key deletes a region or a track when focus is in the arrange area.",
+                extras: extras
+            ))
+        }
+
+        extras["write_attempted"] = true
+        _ = mouse.postKeyEvent(0x33)  // kVK_Delete
+        mouse.sleepMicros(400_000)
+
+        guard let afterBinding = AXLogicProElements.markerListBinding(runtime: runtime),
+              afterBinding.projectDocument == binding.projectDocument,
+              CFEqual(afterBinding.window, binding.window) else {
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        // The Marker List enumeration is not stable immediately after a write: measured live, two
+        // reads taken back to back can disagree, and a blank row keeps rendering the previous row's
+        // name. Verifying against a single read produced a State A for a marker that was still
+        // there. So require two consecutive identical readings before believing either of them, and
+        // report State B when they will not settle rather than certifying a guess.
+        var survivors: [String] = []
+        var settled = false
+        var previous: [String]?
+        for _ in 0..<6 {
+            let reading = AXLogicProElements.enumerateMarkersFromListWindow(
+                afterBinding.window, runtime: runtime.ax
+            ).map { "\($0.name)@\($0.position)" }.sorted()
+            if let previous, previous == reading {
+                survivors = reading
+                settled = true
+                break
+            }
+            previous = reading
+            mouse.sleepMicros(250_000)
+        }
+        guard settled else {
+            extras["readback_settled"] = false
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        extras["readback_settled"] = true
+        extras["marker_count_after"] = survivors.count
+
+        guard survivors == expectedSurvivors else {
+            // Either the target survived, or something else went with it. Both are mismatches, and
+            // saying which is more useful than a bare count.
+            extras["observed_survivors"] = survivors
+            extras["expected_survivors"] = expectedSurvivors
+            return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
+        }
+        return .success(HonestContract.encodeStateA(extras: extras))
+    }
+
+    /// Selects the row and confirms the table agrees, since a write that reports success without
+    /// changing the selection would leave Delete pointed at whatever was selected before.
+    private static func selectMarkerRowForDeletion(
+        _ index: Int,
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        guard let table = AXHelpers.findAllDescendants(
+            of: window, role: kAXTableRole as String, maxDepth: 12, runtime: runtime
+        ).first else { return false }
+        let rows = AXHelpers.findAllDescendants(
+            of: table, role: kAXRowRole as String, maxDepth: 4, runtime: runtime
+        )
+        guard index >= 0, index < rows.count else { return false }
+        _ = AXHelpers.setAttribute(
+            rows[index], kAXSelectedAttribute as String, kCFBooleanTrue, runtime: runtime
+        )
+        let selected: [AXUIElement] = AXHelpers.getAttribute(
+            table, "AXSelectedRows", runtime: runtime
+        ) ?? []
+        return selected.count == 1 && CFEqual(selected[0], rows[index])
+    }
+
+    /// True when the focused element is the Marker List's table, or lives inside it.
+    private static func markerTableHasKeyboardFocus(
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime),
+              let focused: AXUIElement = AXHelpers.getAttribute(
+                  app, kAXFocusedUIElementAttribute as String, runtime: runtime.ax
+              ) else { return false }
+        var current: AXUIElement? = focused
+        var hops = 0
+        while let element = current, hops < 6 {
+            if (AXHelpers.getRole(element, runtime: runtime.ax) ?? "") == (kAXTableRole as String),
+               ancestryMentionsMarker(element, runtime: runtime.ax) {
+                return true
+            }
+            current = AXHelpers.getAttribute(
+                element, kAXParentAttribute as String, runtime: runtime.ax
+            )
+            hops += 1
+        }
+        return false
+    }
+
+    private static func ancestryMentionsMarker(
+        _ element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        var current: AXUIElement? = element
+        var hops = 0
+        while let node = current, hops < 6 {
+            let description = AXHelpers.getAttribute(
+                node, kAXDescriptionAttribute as String, runtime: runtime
+            ) as String? ?? ""
+            if AXLocalePolicy.markerContainerKeywords.matches(description, mode: .contains) { return true }
+            current = AXHelpers.getAttribute(node, kAXParentAttribute as String, runtime: runtime)
+            hops += 1
+        }
+        return false
+    }
+}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -105,6 +105,7 @@ actor AccessibilityChannel: Channel {
         let openMarkerList: @Sendable () async -> ChannelResult
         let createMarker: @Sendable ([String: String]) async -> ChannelResult
         let renameMarker: @Sendable ([String: String]) async -> ChannelResult
+        let deleteMarker: @Sendable ([String: String]) async -> ChannelResult
         let importMIDIFile: @Sendable (String) async -> ChannelResult
         let confirmNewTrackDialog: @Sendable () -> Void
         let canPostEvents: @Sendable () -> Bool
@@ -139,6 +140,7 @@ actor AccessibilityChannel: Channel {
             openMarkerList: @escaping @Sendable () async -> ChannelResult = { .error("openMarkerList not wired") },
             createMarker: @escaping @Sendable ([String: String]) async -> ChannelResult = { _ in .error("createMarker not wired") },
             renameMarker: @escaping @Sendable ([String: String]) async -> ChannelResult = { _ in .error("renameMarker not wired") },
+            deleteMarker: @escaping @Sendable ([String: String]) async -> ChannelResult = { _ in .error("deleteMarker not wired") },
             importMIDIFile: @escaping @Sendable (String) async -> ChannelResult = { _ in .error("importMIDIFile not wired") },
             confirmNewTrackDialog: @escaping @Sendable () -> Void = {
                 AccessibilityChannel.sendReturnKey()
@@ -171,6 +173,7 @@ actor AccessibilityChannel: Channel {
             self.openMarkerList = openMarkerList
             self.createMarker = createMarker
             self.renameMarker = renameMarker
+            self.deleteMarker = deleteMarker
             self.importMIDIFile = importMIDIFile
             self.confirmNewTrackDialog = confirmNewTrackDialog
             self.canPostEvents = canPostEvents
@@ -257,6 +260,12 @@ actor AccessibilityChannel: Channel {
                 renameMarker: {
                     await AccessibilityChannel.defaultRenameMarker(
                         params: $0,
+                        runtime: logicRuntime
+                    )
+                },
+                deleteMarker: { params in
+                    await AccessibilityChannel.defaultDeleteMarker(
+                        index: Int(params["index"] ?? "") ?? -1,
                         runtime: logicRuntime
                     )
                 },
@@ -621,6 +630,14 @@ actor AccessibilityChannel: Channel {
                 ))
             }
             return await runtime.renameMarker(["index": String(index), "name": name])
+        case "nav.delete_marker":
+            guard let rawIndex = params["index"], let index = Int(rawIndex), index >= 0 else {
+                return .error(HonestContract.encodeStateC(
+                    error: .invalidParams,
+                    hint: "nav.delete_marker requires 'index' as an integer >= 0"
+                ))
+            }
+            return await runtime.deleteMarker(["index": String(index)])
 
         // MARK: - Project
         case "project.get_info":

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -165,7 +165,10 @@ extension ChannelRouter {
         "nav.goto_marker":            [.midiKeyCommands, .cgEvent],
         "nav.open_marker_list":       [.accessibility],
         "nav.create_marker":          [.accessibility],
-        "nav.delete_marker":          [.midiKeyCommands, .cgEvent],
+        // AX first: the keycmd rung only works after the operator installs the preset and performs a
+        // manual MIDI Learn, so on a default install this operation used to do nothing at all while
+        // reporting a readback problem. The AX rung drives the Marker List directly.
+        "nav.delete_marker":          [.accessibility, .midiKeyCommands, .cgEvent],
         "nav.rename_marker":          [.accessibility],
         "nav.get_markers":            [.accessibility],
         "nav.zoom_to_fit":            [.midiKeyCommands, .cgEvent],

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -3206,6 +3206,9 @@ private actor SelectiveFailChannel: Channel {
         ("nav.open_marker_list", [:]),
         ("nav.get_markers", [:]),
         ("nav.create_marker", ["name": "Bridge"]),
+        // nav.delete_marker moved to the AX rung: the keycmd path only works after a manual MIDI
+        // Learn, so on a default install it deleted nothing while reporting a readback problem.
+        ("nav.delete_marker", ["index": "1"]),
         ("nav.rename_marker", ["index": "2", "name": "Big Chorus"]),
         // #109 — set_zoom is now AX-first (writable Horizontal-Zoom slider);
         // zoom_to_fit stays on the key-command path (no slider equivalent).
@@ -3217,7 +3220,6 @@ private actor SelectiveFailChannel: Channel {
         // v3.1.10 — `nav.goto_marker` keycmd path is reserved for the
         // cold-cache fallback (cache empty, index supplied). Cached path
         // routes to AX `transport.goto_position` (see axOps above).
-        ("nav.delete_marker", ["index": "1"]),
         ("nav.zoom_to_fit", [:]),
     ])
 }

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -108,3 +108,28 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     #expect((data.first?["name"] as? String) == "Cached Marker")
     #expect(await cache.getMarkers().first?.name == "Cached Marker")
 }
+
+/// `nav.delete_marker` must work on a default install.
+///
+/// It used to route only to `[.midiKeyCommands, .cgEvent]`, so it did nothing at all until the
+/// operator installed the key-command preset and performed a manual MIDI Learn inside Logic. Until
+/// then the CC went out, Logic had nothing bound to it, the marker survived, and the caller was told
+/// `readback_unavailable` — a setup prerequisite reported as a readback problem.
+@Suite("nav.delete_marker has a route that needs no manual MIDI binding")
+struct MarkerDeleteRoutingTests {
+    @Test("the AX channel is the first rung, so a default install can delete a marker")
+    func deleteMarkerRoutesThroughAccessibilityFirst() throws {
+        let route = try #require(ChannelRouter.v2RoutingTable["nav.delete_marker"])
+        #expect(route.first == .accessibility)
+        // The keycmd rung stays as a fallback rather than being removed.
+        #expect(route.contains(.midiKeyCommands))
+    }
+
+    @Test("the marker-list rungs the AX path depends on are all AX-routed")
+    func supportingMarkerOperationsAreAXRouted() throws {
+        for operation in ["nav.open_marker_list", "nav.get_markers"] {
+            let route = try #require(ChannelRouter.v2RoutingTable[operation])
+            #expect(route.contains(.accessibility))
+        }
+    }
+}


### PR DESCRIPTION
Closes #478.

## The problem

`nav.delete_marker` routed only to `[.midiKeyCommands, .cgEvent]`. That path does nothing until the
operator has installed the key-command preset **and** performed a manual MIDI Learn inside Logic.
Until then the CC goes out, Logic has nothing bound to it, the marker survives, and the caller is
told `readback_unavailable` — a setup prerequisite reported as a readback problem, which sends them
to inspect a surface that is working fine. `doctor` already knew: `channels.keycmd_reference` is
`manual` with `preset_staged: false`.

Deleting a marker should not require a hand-configured MIDI binding.

## What the Marker List actually supports

Measured on Logic 12.3 while building this:

- each Marker List row carries a custom `Delete` action, and performing it **does nothing** — the
  return code reports success and the marker stays. Only the observed effect counts.
- selecting the row does work; the table reports it in `AXSelectedRows`.
- with the row selected **and keyboard focus inside the Marker table**, a Delete key removes it.

That last condition is the whole safety story. The same keystroke sent while focus is in the arrange
area deletes the selected region or track instead. So focus is verified to be inside the marker table
immediately before the key is posted, and the operation refuses with `write_attempted: false` rather
than pressing Delete somewhere unknown.

## Verification needed care too

The list enumeration is not stable right after a write: two reads taken back to back can disagree, and
a blank row keeps rendering the previous row's name. A first attempt verified against a single read
and **certified State A for a marker that was still present** — caught during live testing before it
went anywhere. The readback now requires two consecutive identical readings and reports State B when
they will not settle, rather than certifying a guess.

Survivors are compared by name and position rather than by index, since indices renumber when a row
disappears.

## Live evidence

Three create/delete rounds through the real MCP transport against the release artifact; all three
markers actually removed, cross-checked three ways — the operation's own readback, the AX row dump,
and a screenshot of the empty Marker List. During that cross-check `logic://markers` was observed
returning a marker that AX and the screenshot both showed as gone, which is why the ground truth here
is not taken from that resource alone.

The keycmd rung stays as a fallback rather than being removed. Tests assert the AX rung is first and
that the marker-list operations it depends on are AX-routed; the dispatcher expectation that pinned
`nav.delete_marker` to the keycmd channel is updated, since that pinning is the defect.

Full suite 3379 passing, dead-expect gate clean, public-surface preflight PASS.

`nav.goto_marker`, `edit.duplicate` and `edit.normalize` sit in the same keycmd-only list and have the
same exposure; they are not touched here.