### PR TITLE
fix(#479): a sequence ending on a bar line ends on that line, not in the next bar

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift
@@ -563,16 +563,27 @@ extension TrackDispatcher {
         }
     }
 
-    private static func recordSequenceExpectedEndBar(
+    /// The bar Logic will report as the region's end.
+    ///
+    /// Logic numbers a region's end as the bar line it stops on: a region filling exactly bar 1 is
+    /// "1 to 2". The previous integer division added 2 unconditionally, which pushed a sequence
+    /// ending exactly ON a bar line into the next bar. Measured live at 120 BPM 4/4, four quarter
+    /// notes — the most ordinary sequence there is — produced expected 3 against Logic's observed 2
+    /// and the write was reported as `timing_mismatch`; shortening the last note by 100 ms made the
+    /// same sequence verify. Rounding up and adding one matches Logic in both cases and for
+    /// multi-bar sequences.
+    static func recordSequenceExpectedEndBar(
         for events: [SMFWriter.NoteEvent],
         requestedBar: Int,
         timeSignatureNumerator: Int = 4,
         ticksPerQuarter: Int = 480
     ) -> Int {
         let ticksPerBar = timeSignatureNumerator * ticksPerQuarter
+        guard ticksPerBar > 0 else { return 2 }
         let maxEndTicks = events.map { $0.offsetTicks + $0.durationTicks }.max() ?? 0
         let absoluteEndTicks = maxEndTicks + max(0, requestedBar - 1) * ticksPerBar
-        return max(2, (absoluteEndTicks / ticksPerBar) + 2)
+        let barsSpanned = (absoluteEndTicks + ticksPerBar - 1) / ticksPerBar
+        return max(2, barsSpanned + 1)
     }
 
     private static func recordSequenceRegionKey(_ region: RegionInfo) -> String {

--- a/Tests/LogicProMCPTests/Issue479RecordSequenceEndBarTests.swift
+++ b/Tests/LogicProMCPTests/Issue479RecordSequenceEndBarTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+
+@testable import LogicProMCP
+
+/// #479 — a sequence ending exactly on a bar line was reported `timing_mismatch`.
+///
+/// Every expectation here is pinned to a live measurement on Logic 12.3 at 120 BPM 4/4, where one bar
+/// is 2000 ms and a quarter note is 480 ticks. Four quarter notes fill bar 1 exactly; Logic reports
+/// that region as bars 1 to 2, while the old calculation expected 3 and failed the write. Shortening
+/// the last note by 100 ms made the identical sequence verify, which is what isolated the boundary.
+@Suite("#479 record_sequence end-bar expectation")
+struct Issue479RecordSequenceEndBarTests {
+    private func notes(_ spans: [(offset: Int, duration: Int)]) -> [SMFWriter.NoteEvent] {
+        spans.map {
+            SMFWriter.NoteEvent(
+                pitch: 60, offsetTicks: $0.offset, durationTicks: $0.duration, velocity: 100, channel: 0
+            )
+        }
+    }
+
+    @Test("four quarter notes fill bar 1 and end at bar 2, not bar 3")
+    func exactBarBoundaryEndsOnTheLine() {
+        let events = notes([(0, 480), (480, 480), (960, 480), (1440, 480)])
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: events, requestedBar: 1) == 2)
+    }
+
+    @Test("the same sequence 100ms shorter also ends at bar 2 — the fix must not move this case")
+    func justInsideTheBarStillEndsAtTwo() {
+        // 400 ms at 120 BPM is 384 ticks, so the last note stops short of the line.
+        let events = notes([(0, 480), (480, 480), (960, 480), (1440, 384)])
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: events, requestedBar: 1) == 2)
+    }
+
+    @Test("a sequence filling two whole bars ends at bar 3")
+    func twoFullBarsEndAtThree() {
+        let events = notes([(0, 1920), (1920, 1920)])
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: events, requestedBar: 1) == 3)
+    }
+
+    @Test("spilling one tick past a bar line pushes the end into the following bar")
+    func oneTickPastTheLineTakesTheNextBar() {
+        let events = notes([(0, 1921)])
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: events, requestedBar: 1) == 3)
+    }
+
+    @Test("requestedBar shifts the whole span")
+    func startBarOffsetsTheResult() {
+        let events = notes([(0, 480), (480, 480), (960, 480), (1440, 480)])
+        // Starting at bar 5, one full bar of notes ends on the bar-6 line.
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: events, requestedBar: 5) == 6)
+    }
+
+    @Test("an empty sequence keeps the minimum of two rather than collapsing to one")
+    func emptySequenceKeepsTheFloor() {
+        #expect(TrackDispatcher.recordSequenceExpectedEndBar(for: [], requestedBar: 1) == 2)
+    }
+
+    @Test("a non-4/4 signature is measured in its own bar length")
+    func threeFourIsMeasuredInThreeQuarterBars() {
+        // Three quarter notes fill a 3/4 bar exactly.
+        let events = notes([(0, 480), (480, 480), (960, 480)])
+        #expect(
+            TrackDispatcher.recordSequenceExpectedEndBar(
+                for: events, requestedBar: 1, timeSignatureNumerator: 3
+            ) == 2
+        )
+    }
+}


### PR DESCRIPTION
Closes #479.

## The defect

`record_sequence` computed the expected region end as `(absoluteEndTicks / ticksPerBar) + 2`. Integer
division adds a whole bar whenever the sequence stops exactly on a bar line, so the most ordinary MIDI
write there is — four quarter notes into a 4/4 bar — expected bar 3 while Logic reported bar 2, and a
region that landed correctly came back as `timing_mismatch`.

Measured live at 120 BPM 4/4, where one bar is 2000 ms:

| notes | expected_end_bar | end_bar | result |
| --- | ---: | ---: | --- |
| `60,0,500;62,500,500;64,1000,500;65,1500,500` (ends on the line) | 3 | 2 | timing_mismatch, twice |
| same with the last note 400 ms instead of 500 | 2 | 2 | verified |

That 100 ms is the entire difference, which is what isolated the boundary.

Logic numbers a region's end as the bar line it stops on — a region filling bar 1 exactly is "1 to 2".
Rounding up and adding one matches that for a sequence ending on the line, for one ending just inside
it, and for multi-bar sequences.

## Live verification

Driven through the real MCP transport against the release artifact, with the screen recorded and each
case photographed from Logic's own window surface:

| case | expected_end_bar | end_bar | verified |
| --- | ---: | ---: | --- |
| exact bar (previously failing) | 2 | 2 | yes |
| 100 ms short | 2 | 2 | yes |
| two full bars | 3 | 3 | yes |

The window hash changed on every case, so the writes are visible rather than inferred, and the
arrange-area screenshot shows the regions at bar 1. The three tracks the run created were removed
afterwards and the project is back to its original five.

## Tests

Seven cases, each pinned to a measurement rather than to the formula: the exact boundary, just inside
it, two full bars, one tick past a line, a `requestedBar` offset, the empty-sequence floor, and a 3/4
signature. Restoring the old formula fails four of them.

Full suite 3384 passing, dead-expect gate clean, public-surface preflight PASS.

The `created_track`-per-call behaviour noted in #479 is unchanged here; it is documented as intended
in the tool description.