### PR TITLE
fix(#476): let logic://tracks say whether it has looked yet

### DIFF
--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -212,7 +212,22 @@ extension ResourceHandlers {
         } else {
             body = encodeJSON(tracksOut)
         }
-        var extras: [String: Any] = ["source": source]
+        // Say whether this was observed, the way logic://markers already does. Without these a
+        // consumer reading `data` cannot tell "the project has no tracks" from "nothing has been
+        // read yet" — and before the first live read this document answers `data: []` for a project
+        // that demonstrably has tracks. `ax_live` is the only source that saw the real thing; the
+        // file-count tiers synthesise placeholder names from a count.
+        let observedLive = source == "ax_live"
+        var extras: [String: Any] = [
+            "source": source,
+            "readable": observedLive,
+            "verified_empty": observedLive && tracksOut.isEmpty,
+        ]
+        if !observedLive {
+            extras["reason"] = tracksOut.isEmpty
+                ? "no_live_track_read_yet"
+                : "track_names_synthesised_from_project_file"
+        }
         if FeatureFlags.adr006VersionedCache {
             extras.merge(versionedCacheExtras(
                 projectEpoch: await targetRegistry?.currentProjectEpoch ?? 0,

--- a/Tests/LogicProMCPTests/Issue476TracksReadabilityTests.swift
+++ b/Tests/LogicProMCPTests/Issue476TracksReadabilityTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import LogicProMCP
+
+/// #476 — `logic://tracks` answered `data: []` before its first live read, with no field saying so.
+///
+/// Measured against a project with two visible tracks: a cold read returned
+/// `{"source":"default","fetched_at":null,"data":[]}` while `logic_tracks select {"track":0}` was
+/// returning State A against those same tracks. The information that nothing had been read was
+/// present only implicitly, in `source` and a null `fetched_at`. `logic://markers`, in the same
+/// session, refused to be misread: `readable:false`, an explicit `reason`, and `verified_empty:false`.
+@Suite("#476 logic://tracks says whether it observed anything")
+struct Issue476TracksReadabilityTests {
+    private func document(_ result: ReadResource.Result) throws -> [String: Any] {
+        try #require(sharedJSONObject(sharedResourceText(result)))
+    }
+
+    /// No project file, so the file-count tier cannot fire and the two states under test are the
+    /// ones that matter: nothing read yet, and a real live read.
+    private let headlessFileReader = LogicProjectFileReader.Runtime(
+        currentDocumentPath: { nil },
+        now: Date.init,
+        readPlistData: { _ in nil },
+        mtime: { _ in nil },
+        sleep: { _ in }
+    )
+
+    @Test("a cold read is marked unreadable and is not a verified empty project")
+    func coldReadIsNotAnObservation() async throws {
+        let cache = StateCache()
+        let result = try await ResourceHandlers.readTracks(
+            cache: cache, uri: "logic://tracks", fileReader: headlessFileReader
+        )
+        let doc = try document(result)
+
+        #expect(try #require(doc["source"] as? String) == "default")
+        #expect(!(try #require(doc["readable"] as? Bool)))
+        #expect(!(try #require(doc["verified_empty"] as? Bool)))
+        #expect(try #require(doc["reason"] as? String) == "no_live_track_read_yet")
+    }
+
+    @Test("a live read of a real project is readable and not a verified empty")
+    func liveReadIsAnObservation() async throws {
+        let cache = StateCache()
+        await cache.updateTracks([
+            TrackState(id: 0, name: "Sum 1", type: .unknown),
+            TrackState(id: 1, name: "Studio Grand", type: .unknown),
+        ])
+        let result = try await ResourceHandlers.readTracks(
+            cache: cache, uri: "logic://tracks", fileReader: headlessFileReader
+        )
+        let doc = try document(result)
+
+        #expect(try #require(doc["source"] as? String) == "ax_live")
+        #expect(try #require(doc["readable"] as? Bool))
+        #expect(!(try #require(doc["verified_empty"] as? Bool)))
+        #expect(doc["reason"] == nil)
+    }
+
+    // The third tier — placeholder names synthesised from a project-file track count — reports
+    // `readable: false` with `track_names_synthesised_from_project_file` for the same reason, but it
+    // needs a parsable .logicx on disk that this seam cannot fabricate, so it is covered by the live
+    // check rather than here.
+}

--- a/Tests/LogicProMCPTests/VersionedCacheEnvelopeTests.swift
+++ b/Tests/LogicProMCPTests/VersionedCacheEnvelopeTests.swift
@@ -65,6 +65,13 @@ struct VersionedCacheEnvelopeTests {
     /// SHIPPED default of every other flag (this deliberately does not pin
     /// `adr002TargetRef`, so the baseline tracks what users actually receive).
     ///
+    /// #476 — DELIBERATE PIN DIFF: `readable`, `verified_empty` and `reason` are now present.
+    /// Before this, a cold `logic://tracks` answered `data: []` with nothing saying it had never
+    /// looked, so a consumer reading `data` saw an empty project where one had tracks. The sibling
+    /// `logic://markers` already carried these three fields. This is an additive wire change and is
+    /// noted rather than hidden; ADR-006 OFF still contributes nothing of its own, which is what
+    /// this test exists to pin.
+    ///
     /// PRD-007 Part 2 — DELIBERATE PIN DIFF, `"data":[\n\n]` -> `"data":[]`.
     /// The expectation moved because `adr002TargetRef` is now default ON, which
     /// routes `logic://tracks` through the ref-capable `JSONSerialization`
@@ -82,7 +89,7 @@ struct VersionedCacheEnvelopeTests {
                 fileReader: headlessFileReader
             )
 
-            #expect(sharedResourceText(result) == "{\"cache_age_sec\":null,\"fetched_at\":null,\"ax_occluded\":false,\"source\":\"default\",\"data\":[]}")
+            #expect(sharedResourceText(result) == "{\"cache_age_sec\":null,\"fetched_at\":null,\"ax_occluded\":false,\"readable\":false,\"reason\":\"no_live_track_read_yet\",\"source\":\"default\",\"verified_empty\":false,\"data\":[]}")
         }
     }
 


### PR DESCRIPTION
Closes #476.

## The problem

Before its first live read, `logic://tracks` answered:

```json
{"cache_age_sec":null,"fetched_at":null,"ax_occluded":false,"source":"default","data":[]}
```

Measured against a project with five tracks, while `logic_tracks select {"track":0}` returned State A
against those same tracks in the same session. The information that nothing had been read was present
— `source: "default"`, `fetched_at: null` — but only implicitly. A consumer reading `data` sees a
project with no tracks.

`logic://markers` already refuses to be misread. It carries `readable`, an explicit `reason`, and
`verified_empty`, so an empty array can never be mistaken for an observation. `logic://tracks` now
carries the same three.

`ax_live` is the only source that saw the real thing; the file-count tiers synthesise placeholder
names from a count and report `readable: false` with `track_names_synthesised_from_project_file`
rather than presenting a guess as a reading.

## Live verification

Driven through the real MCP transport against the release artifact, screen recorded, Logic's window
surface captured at each step:

| read | source | readable | verified_empty | reason | tracks |
| --- | --- | --- | --- | --- | ---: |
| cold | `default` | false | false | `no_live_track_read_yet` | 0 |
| after refresh | `ax_live` | true | false | — | 5 |
| `logic://markers` (shape comparison) | `ax_live` | true | false | — | — |

## The envelope pin

`VersionedCacheEnvelopeTests.flagOffStateResourceEnvelopeIsByteIdentical` pins the exact bytes and
therefore moves. It is updated in that file's own convention — the previous author recorded a
deliberate pin diff with its reason, and this one is recorded the same way. The change is additive,
and ADR-006 OFF still contributes nothing of its own, which is what that test exists to pin.

Full suite 3386 passing, dead-expect gate clean, public-surface preflight PASS.