### PR TITLE
fix(#480): an ambiguous track name is not a stale reference

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -323,9 +323,20 @@ enum TargetRefResolver {
             "write_attempted": false,
         ]
         if !ambiguousIndices.isEmpty {
+            // Nothing is stale here and nothing was reordered: the reference still names the right
+            // index and the right name, but that name is shared, so no evidence can say WHICH track
+            // is meant. Refusing is right; calling it staleness sent callers after a reorder that
+            // never happened, and the way out — make the name unique — was not discoverable from
+            // the message.
             extras["ambiguous_live_track_name"] = true
             extras["ambiguous_track_indices"] = ambiguousIndices
             extras["what_was_observed"] = "live track name '\(expected)' also appeared at indices \(ambiguousIndices.map(String.init).joined(separator: ", "))"
+            return toolStateCResult(
+                .ambiguousTargetName,
+                hint: "'\(expected)' names more than one live track, so the target cannot be "
+                    + "identified. Rename one of them, or address the track by an unambiguous name.",
+                extras: extras
+            )
         }
         return toolStateCResult(
             .staleTargetReference,

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -103,6 +103,11 @@ enum HonestContract {
         case trackSelectionFailed = "track_selection_failed"
         case staleSnapshot = "stale_snapshot"
         case staleTargetReference = "stale_target_reference"
+        /// The reference still names the right index and the right name, but that name is not
+        /// unique, so nothing can prove WHICH track is meant. Deliberately distinct from
+        /// `.staleTargetReference`: nothing is stale and nothing was reordered, and reporting it as
+        /// staleness sent callers looking for a reorder that never happened.
+        case ambiguousTargetName = "ambiguous_target_name"
         case targetRefUnavailable = "target_ref_unavailable"
 
         // PRD-007 (ADR-002 #285) — index-binding ratchet. These describe the

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -1081,7 +1081,12 @@ struct TargetRefResolutionTests {
                 liveTrackName: { idx in [0: "Drums", 1: "Bass", 2: "Bass"][idx] },
                 liveTrackNames: { [0: "Drums", 1: "Bass", 2: "Bass"] }
             )
-            #expect(errorCode(result) == "stale_target_reference")
+            // Nothing here is stale and nothing was reordered: two live tracks share the name,
+            // so the target cannot be identified. Reporting that as staleness sent callers
+            // looking for a reorder that never happened, so it has its own code.
+            #expect(errorCode(result) == "ambiguous_target_name")
+            let hint = try #require(body(result)["hint"] as? String)
+            #expect(hint.contains("more than one live track"))
             let v1 = try #require(body(result)["write_attempted"] as? Bool)
             #expect(!v1)
             #expect(body(result)["expected_track_name"] as? String == "Bass")


### PR DESCRIPTION
Closes #480.

## The problem

When two live tracks share a name, a `target_ref` that still names the right index and the right name
cannot prove *which* track is meant, so the write is refused. Refusing is correct. Reporting it as
`stale_target_reference` was not:

```
error: stale_target_reference
what_was_observed: live track name 'Studio Grand' also appeared at indices 1, 5, 6, 7, 8
hint: target_ref no longer names the live track at its bound index (out-of-band reorder)
```

Nothing was stale and nothing was reordered. The observation was right and the refusal was right;
only the name of the failure was wrong, and it sends the caller looking for a reorder that never
happened. The remedy — make the name unique — was not discoverable from the message either, and
`expected_name` cannot help, since it is required to be unique and the duplicates are exactly what
makes it non-unique.

This is reachable in ordinary use: `record_sequence` creates a new track per call, all with the same
name, and none of them can then be addressed.

## What changes

Ambiguity gets its own code and a hint that names the real problem and the remedy:

```
error: ambiguous_target_name
hint : 'Studio Grand' names more than one live track, so the target cannot be identified.
        Rename one of them, or address the track by an unambiguous name.
ambiguous_track_indices: [4]
write_attempted: false
```

The genuine staleness path is untouched. The fail-closed behaviour is unchanged — this is a naming
and diagnosability fix, not a permission one.

## Live verification

Driven through the real MCP transport against the release artifact, screen recorded, Logic's window
surface captured: two tracks were made to share a name, a mute by `target_ref` returned
`ambiguous_target_name` with the sharing index listed and `write_attempted: false`, and the track name
was restored afterwards.

The existing duplicate-name test kept its real property — fails closed, does not write — and now also
pins the hint, so the diagnostic value is held rather than just the code string. Folding the case back
into `stale_target_reference` fails it.

Full suite 3379 passing, dead-expect gate clean, public-surface preflight PASS.