### PR TITLE
fix(#474): an unreadable enabled state must not authorise a pick

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2507,6 +2507,9 @@ extension AccessibilityChannel {
         runtime: AXHelpers.Runtime,
         coordFree: Bool
     ) async -> Bool {
+        // A disabled entry cannot act, so pressing it produces a silent no-op that the caller then
+        // has to distinguish from a real failure downstream. Refuse before touching it.
+        guard menuItemEnabledForActuation(item, runtime: runtime) else { return false }
         if coordFree {
             return await pressPopupPluginLeaf(item, runtime: runtime)
         }
@@ -2640,12 +2643,29 @@ extension AccessibilityChannel {
         return nil
     }
 
+    /// Lenient: an unreadable state counts as enabled. Used by READ-ONLY discovery, where refusing to
+    /// descend on an unreadable attribute would hide reachable plug-ins and actuates nothing.
     private static func menuItemEnabled(
         _ item: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> Bool {
         let enabled: Bool? = AXHelpers.getAttribute(item, kAXEnabledAttribute as String, runtime: runtime)
         return enabled ?? true
+    }
+
+    /// Strict: only an explicitly readable `true` authorises a pick.
+    ///
+    /// `AXEnabled` is the one pre-press signal that separates "will act" from "will do nothing", so
+    /// guessing it while about to actuate is the wrong place to be lenient. Measured on Logic 12.3
+    /// with the menu chain open: all 1090 items expose a readable value and 264 of them are disabled
+    /// — section headers such as "Recent" among them. So there is a real population this can land on,
+    /// and no legitimate entry that the strictness excludes.
+    private static func menuItemEnabledForActuation(
+        _ item: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let enabled: Bool? = AXHelpers.getAttribute(item, kAXEnabledAttribute as String, runtime: runtime)
+        return enabled == true
     }
 
     private static func visibleSubmenu(

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -53,11 +53,17 @@ private func addMenuItem(
     _ b: FakeAXRuntimeBuilder,
     _ id: Int,
     title: String,
-    children: [AXUIElement] = []
+    children: [AXUIElement] = [],
+    enabled: Bool = true
 ) -> AXUIElement {
     let item = b.element(id)
     b.setAttribute(item, kAXRoleAttribute as String, kAXMenuItemRole as String)
     b.setAttribute(item, kAXTitleAttribute as String, title)
+    // Measured on Logic 12.3: every one of the 1090 items in an open plug-in menu exposes a readable
+    // AXEnabled, and 264 of them are disabled — section headers like "Recent" among them. A fixture
+    // that leaves the attribute unset models a tree Logic does not produce, and it was the reason a
+    // strict pre-pick check could not be adopted.
+    b.setAttribute(item, kAXEnabledAttribute as String, enabled as CFTypeRef)
     b.setChildren(item, children)
     return item
 }
@@ -930,6 +936,9 @@ private func makeSlotPopupInsertFixture(
     // the recursive coordinate fallback.
     b.setAttribute(gainItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
     b.setAttribute(gainItem, kAXTitleAttribute as String, "Gain")
+    // Live Logic exposes AXEnabled on every menu item in an open chain, so a fixture item without it
+    // models a tree that does not occur.
+    b.setAttribute(gainItem, kAXEnabledAttribute as String, true as CFTypeRef)
     b.setAttribute(searchField, kAXRoleAttribute as String, kAXTextFieldRole as String)
     b.setAttribute(popupMenu, kAXRoleAttribute as String, kAXMenuRole as String)
     b.setAttribute(popupMenu, kAXPositionAttribute as String, axPoint(410, 320))
@@ -1099,4 +1108,65 @@ private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String
     #expect(coordState == "C")
     let coordCommit = try #require(coordObj["commit_strategy"] as? String)
     #expect(coordCommit == "slot_popup_physical_menu_click")
+}
+
+/// #474 — an entry whose enabled state cannot be read must not be pressed.
+///
+/// `AXEnabled` is the one signal that distinguishes "will act" from "will do nothing" before the
+/// press, and the pick path used to treat an unreadable value as enabled. Measured on Logic 12.3 with
+/// the plug-in menu chain open, all 1090 items expose a readable value and 264 are disabled —
+/// section headers such as "Recent" among them — so this is a population the picker can land on.
+@Test func testPlugin474LeafWithUnreadableEnabledStateIsNotPressed() async throws {
+    // The gap is an UNREADABLE attribute, not a readable false: a readable false is already refused
+    // by the lenient discovery check, so a fixture that sets `enabled: false` tests behaviour that
+    // already worked. Build the item without the attribute at all, which is what "unreadable" means.
+    let b = FakeAXRuntimeBuilder()
+    let unreadable = b.element(9500)
+    b.setAttribute(unreadable, kAXRoleAttribute as String, kAXMenuItemRole as String)
+    b.setAttribute(unreadable, kAXTitleAttribute as String, "Gain")
+    let rootMenu = addMenu(b, 9501, children: [unreadable])
+    let recorder = AXPressRecorder()
+    let runtime = b.makeAXRuntime(
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            recorder.record(b.elementID(element))
+            return true
+        }
+    )
+
+    let click = await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+        pluginID: "logic.stock.effect.gain",
+        displayName: "Gain",
+        rootMenu: rootMenu,
+        runtime: runtime
+    )
+
+    #expect(click == nil)
+    #expect(!recorder.pressedElementIDs.contains(b.elementID(unreadable)))
+}
+
+/// The same fixture with the entry enabled must succeed, so the test above fails for the reason it
+/// names rather than because nothing could ever be picked.
+@Test func testPlugin474EnabledLeafIsStillPressed() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let target = addMenuItem(b, 9510, title: "Gain")
+    let rootMenu = addMenu(b, 9511, children: [target])
+    let recorder = AXPressRecorder()
+    let runtime = b.makeAXRuntime(
+        setAttributeHandler: nil,
+        performActionHandler: { element, action in
+            recorder.record(b.elementID(element))
+            return true
+        }
+    )
+
+    let click = await AccessibilityChannel.clickPluginInAnchoredSlotPopup(
+        pluginID: "logic.stock.effect.gain",
+        displayName: "Gain",
+        rootMenu: rootMenu,
+        runtime: runtime
+    )
+
+    #expect(click != nil)
+    #expect(recorder.pressedElementIDs.contains(b.elementID(target)))
 }


### PR DESCRIPTION
Closes #474.

## The gap

The pick path read `AXEnabled` leniently — an unreadable value counted as enabled. That is right for
read-only discovery, where refusing to descend on an unreadable attribute would hide reachable
plug-ins and actuates nothing. It also reached the actuation, which is the one place the signal
matters: `AXEnabled` is what separates "will act" from "will do nothing" before the press.

## Measured first

An earlier attempt at this check was abandoned because 21 tests failed. Those failures were against
the fixtures, not against a defect — the fixtures left `AXEnabled` unset, modelling a tree Logic does
not produce. So the tree was measured before touching the code.

Logic 12.3, plug-in menu chain open:

- **1090** menu items expose a readable `AXEnabled`
- **0** are missing it
- **264** of the readable ones are disabled — section headers such as `Recent` among them

A strict check therefore excludes no legitimate entry, and there is a real population a name match can
land on. The fixtures now carry the attribute, as measured; the lenient helper stays for discovery and
actuation gets a strict one.

## The first test was useless, and mutation testing said so

The first version built the disabled item with a **readable false** — which the lenient discovery
check already refuses — so removing the gate and restoring the leniency both left it green. A control
that cannot fail is not a control.

The gap is an **unreadable** attribute. The test now builds an item with no `AXEnabled` at all;
restoring leniency fails it. A positive twin asserts an enabled entry is still pressed, so the refusal
is a result rather than a path that could never pick anything.

Full suite 3379 passing, dead-expect gate clean, public-surface preflight PASS.

This touches the same file as #472; whichever lands second will need a trivial rebase.