### PR TITLE
fix(#475): four ways an operation could touch, or vouch for, what the user did not ask for

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -164,6 +164,18 @@ enum AXLocalePolicy {
         rationale: "Menu item includes the operation name after the localized Undo prefix."
     )
 
+    /// What the Edit-menu Undo entry says when the thing on top of the stack is a plug-in insert.
+    ///
+    /// The rollback path matched only the "Undo" prefix, so it pressed whatever was on top. Measured
+    /// on Logic 12.3 the entry for our own insert reads "Undo Insert Plug-in in Channel Strip", and
+    /// the same menu offers unrelated entries such as "Undo selected Channel Strips" — pressing one
+    /// of those undoes the user's work instead of ours.
+    static let undoPluginInsertMenuItem = LabelSet(
+        canonical: "Insert Plug-in in Channel Strip",
+        variants: ["채널 스트립에 플러그인 삽입"],
+        rationale: "Confirms the Undo entry describes OUR insert before a rollback presses it."
+    )
+
     static let goToPositionDialogTitle = LabelSet(
         canonical: "Go to Position",
         variants: ["위치로 이동"],

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -188,11 +188,33 @@ extension AXLogicProElements {
         in mixer: AXUIElement,
         runtime: AXHelpers.Runtime = .production
     ) -> [AXUIElement] {
+        stripEnumeration(in: mixer, runtime: runtime).strips
+    }
+
+    /// The strips, plus whether any child's role could not be read.
+    ///
+    /// A child whose role is unreadable is dropped by the filter, and every later strip then moves
+    /// down one. Callers address strips by ORDINAL, so a request for track 0 would act on physical
+    /// strip 1 — a wrong-target write that no downstream readback can catch, because the readback
+    /// reads the same shifted list. The count is returned so a mutating caller can refuse instead of
+    /// addressing a list it cannot trust. A read-only caller may still use the strips.
+    static func stripEnumeration(
+        in mixer: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> (strips: [AXUIElement], unreadableChildren: Int) {
         let children = AXHelpers.getChildren(mixer, runtime: runtime)
-        let layoutItems = children.filter {
-            (AXHelpers.getRole($0, runtime: runtime) ?? "") == (kAXLayoutItemRole as String)
+        var unreadable = 0
+        var layoutItems: [AXUIElement] = []
+        for child in children {
+            guard let role = AXHelpers.getRole(child, runtime: runtime) else {
+                unreadable += 1
+                continue
+            }
+            if role == (kAXLayoutItemRole as String) { layoutItems.append(child) }
         }
-        return layoutItems.isEmpty ? children : layoutItems
+        return layoutItems.isEmpty
+            ? (children, unreadable)
+            : (layoutItems, unreadable)
     }
 
     static func findVolumeFader(

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -130,8 +130,26 @@ extension AXLogicProElements {
             return true
         }
 
-        // Step 4 — child AXPress (some rows expose a selectable name label).
+        // Step 4 — child AXPress, but only on a child that could plausibly select the track.
+        //
+        // This used to press every child in order and stop at the first one that returned true.
+        // Measured on Logic 12.3, a track header's children are, in order: "Has Focus" (radio),
+        // "Individual Track Zoom" (splitter), a disclosure triangle, then Mute, Solo, Record Enable
+        // and Input Monitoring (checkboxes), two sliders, and the name field. All of the pressable
+        // ones accept AXPress, so if the first candidate declined, the ladder went on to press a
+        // zoom splitter, a stack disclosure, and then Mute — toggling the user's mix while trying to
+        // select a track, and reporting success because the press was accepted.
+        //
+        // Role alone separates them and needs no localized labels: a radio button and the name text
+        // field are the only children that could carry selection; a checkbox, a splitter and a
+        // disclosure triangle carry state that is not ours to change.
+        let selectableRoles: Set<String> = [
+            kAXRadioButtonRole as String,
+            kAXTextFieldRole as String,
+        ]
         for child in AXHelpers.getChildren(header, runtime: runtime.ax) {
+            guard let role = AXHelpers.getRole(child, runtime: runtime.ax),
+                  selectableRoles.contains(role) else { continue }
             if AXHelpers.performAction(child, kAXPressAction, runtime: runtime.ax) {
                 return true
             }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1709,6 +1709,38 @@ extension AccessibilityChannel {
                     extras: extras
                 ))
             }
+            // The front document was checked once, before any of this: track select, mixer raise,
+            // inventory, pop-up, discovery, pick and poll all happen after it. Switching project
+            // during that window would put the write — and this readback — in a different document
+            // than the caller named, and every check above would still agree with itself. Re-read it
+            // before certifying, so State A is never granted to a document we cannot still name.
+            if let expectedPath = params["project_expected_path"],
+               !expectedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let stillObserved = await frontDocumentPath()
+                guard let stillObserved,
+                      AppleScriptChannel.projectPathsMatch(expectedPath, stillObserved) else {
+                    var driftIdentity = identity
+                    driftIdentity["project_path_expected"] = expectedPath
+                    driftIdentity["project_path_observed"] = stillObserved ?? NSNull()
+                    return .error(HonestContract.encodeV2StateC(
+                        error: .projectIdentityMismatch,
+                        extras: [
+                            "operation": operation,
+                            "target_identity": driftIdentity,
+                            "observed_plugin_id": observedID,
+                            "observed_plugin_name": observedName ?? NSNull(),
+                            "observed_slot": observedSlot,
+                            "select_trace": trace,
+                            "what_was_attempted": "confirm the front document is still the expected one before certifying the insert",
+                            "what_was_observed": stillObserved == nil
+                                ? "no front document path could be read after the write"
+                                : "the front document changed while the insert was in progress",
+                            "safe_to_retry": false,
+                            "write_attempted": true,
+                        ]
+                    ))
+                }
+            }
             return .success(HonestContract.encodeV2StateA(extras: [
                 "operation": operation,
                 "target_identity": identity,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2165,6 +2165,9 @@ extension AccessibilityChannel {
         case ok
         case disabled
         case missing
+        /// The Edit menu offered an Undo entry, but it does not describe our plug-in insert. Nothing
+        /// was pressed: undoing it would revert the user's work.
+        case notOurs = "not_ours"
     }
 
     private static func clickEditUndoViaAXMenuClick(
@@ -2187,6 +2190,21 @@ extension AccessibilityChannel {
             ) else {
                 AXMouseHelper.pressEscape()
                 continue
+            }
+            // Only undo OUR insert. The prefix match above finds whatever sits on top of the stack,
+            // and pressing that undoes the user's last action when it is not ours. Measured live:
+            // Logic offers "Undo Insert Plug-in in Channel Strip" for our own write, and entries such
+            // as "Undo selected Channel Strips" for things we must not touch.
+            let offered: String = AXHelpers.getAttribute(
+                item, kAXTitleAttribute, runtime: runtime.ax
+            ) ?? ""
+            guard AXLocalePolicy.undoPluginInsertMenuItem.containsAny(in: offered) else {
+                Log.warn(
+                    "rollback refused: Edit menu offers \(offered.isEmpty ? "an unreadable entry" : "'\(offered)'"), not our plug-in insert",
+                    subsystem: "ax"
+                )
+                AXMouseHelper.pressEscape()
+                return .notOurs
             }
             if let enabled: Bool = AXHelpers.getAttribute(
                 item, kAXEnabledAttribute, runtime: runtime.ax
@@ -2933,6 +2951,12 @@ extension AccessibilityChannel {
         if menuResult == .ok || menuResult == .disabled {
             return menuResult.rawValue
         }
+        // A refusal must not fall through to the blind Cmd+Z below: we already read the entry and
+        // it was not ours, so sending the shortcut would undo the user's work anyway and make the
+        // check pointless.
+        if menuResult == .notOurs {
+            return menuResult.rawValue
+        }
         if postCommandZToLogic() {
             return "ok"
         }
@@ -3020,7 +3044,11 @@ extension AccessibilityChannel {
                     in: inv, strayPluginID: strayPluginID, straySlot: straySlot, strayName: strayName
                 ) == false
             } ?? false
-            if !stillDefinitelyPresent || clickRaw == "disabled" || clickRaw == "missing" {
+            // `not_ours` joins the stop list: the entry on top of the stack is not our insert, and
+            // re-reading the menu cannot change that. Retrying would only keep opening the Edit menu
+            // against the user's stack.
+            if !stillDefinitelyPresent
+                || clickRaw == "disabled" || clickRaw == "missing" || clickRaw == "not_ours" {
                 break
             }
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -2242,7 +2242,12 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime
     ) -> AXLogicProElements.PluginInsertSlot? {
         guard let mixer = AXLogicProElements.getMixerArea(runtime: runtime) else { return nil }
-        let strips = AXLogicProElements.mixerChannelStrips(in: mixer, runtime: runtime.ax)
+        // Strips are addressed by ordinal, so a child whose role could not be read moves every
+        // later strip down one and turns a request for track N into an act on physical strip N+1.
+        // A downstream readback cannot catch that: it reads the same shifted list. Refuse instead.
+        let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime.ax)
+        guard enumeration.unreadableChildren == 0 else { return nil }
+        let strips = enumeration.strips
         guard track >= 0, track < strips.count else { return nil }
         let slots = AXLogicProElements.audioPluginInsertSlots(in: strips[track], runtime: runtime.ax)
         // #234 — a zero-slot result on this mid-flight re-resolution means the
@@ -2754,7 +2759,12 @@ extension AccessibilityChannel {
         track: Int, runtime: AXLogicProElements.Runtime
     ) -> [Int: InventoryEntry]? {
         guard let mixer = AXLogicProElements.getMixerArea(runtime: runtime) else { return nil }
-        let strips = AXLogicProElements.mixerChannelStrips(in: mixer, runtime: runtime.ax)
+        // Strips are addressed by ordinal, so a child whose role could not be read moves every
+        // later strip down one and turns a request for track N into an act on physical strip N+1.
+        // A downstream readback cannot catch that: it reads the same shifted list. Refuse instead.
+        let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime.ax)
+        guard enumeration.unreadableChildren == 0 else { return nil }
+        let strips = enumeration.strips
         guard track < strips.count else { return nil }
         let slots = AXLogicProElements.audioPluginInsertSlots(in: strips[track], runtime: runtime.ax)
         guard !slots.contains(where: { $0.readStatus == .occupiedUnreadable }) else {

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -4002,3 +4002,67 @@ func testLibraryAndPluginScansAreMutuallyExclusive() async {
     let aResult = await scanA.value
     #expect(!aResult.message.contains("already in progress"))
 }
+
+private final class AXPressLog: @unchecked Sendable {
+    private(set) var ids: [Int] = []
+    func add(_ id: Int) { ids.append(id) }
+}
+
+/// #475 — selecting a track must never toggle the user's mix.
+///
+/// The selection ladder's last rung pressed every child of the track header in order and stopped at
+/// the first one that accepted the press. Measured on Logic 12.3 those children are, in order:
+/// "Has Focus" (radio), "Individual Track Zoom" (splitter), a disclosure triangle, then Mute, Solo,
+/// Record Enable and Input Monitoring (checkboxes), two sliders, and the name field — and every
+/// pressable one accepts AXPress. So a header whose radio declined would see the ladder press a zoom
+/// splitter, a stack disclosure, and then Mute, reporting success because the press was accepted.
+@Test func testTrackSelectFallbackNeverPressesMuteOrOtherStateControls() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(6200)
+    let window = builder.element(6201)
+    let trackList = builder.element(6202)
+    let header = builder.element(6203)
+    let focus = builder.element(6204)
+    let splitter = builder.element(6205)
+    let mute = builder.element(6206)
+    let name = builder.element(6207)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [trackList])
+    builder.setAttribute(trackList, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(trackList, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(trackList, [header])
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    builder.setAttribute(header, kAXTitleAttribute as String, "Track 1")
+
+    // The measured order, with the roles that matter.
+    builder.setAttribute(focus, kAXRoleAttribute as String, kAXRadioButtonRole as String)
+    builder.setAttribute(focus, kAXDescriptionAttribute as String, "Has Focus")
+    builder.setAttribute(splitter, kAXRoleAttribute as String, kAXSplitterRole as String)
+    builder.setAttribute(splitter, kAXDescriptionAttribute as String, "Individual Track Zoom")
+    builder.setAttribute(mute, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(mute, kAXDescriptionAttribute as String, "Mute")
+    builder.setAttribute(name, kAXRoleAttribute as String, kAXTextFieldRole as String)
+    builder.setAttribute(name, kAXDescriptionAttribute as String, "Sum 1")
+    builder.setChildren(header, [focus, splitter, mute, name])
+
+    let recorder = AXPressLog()
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { _, _, _ in false },   // Steps 1-2 rejected
+        performActionHandler: { element, action in
+            guard action == (kAXPressAction as String) else { return false }
+            let id = builder.elementID(element)
+            recorder.add(id)
+            // The focus radio declines, which is what used to send the ladder into the checkboxes.
+            return id != builder.elementID(header) && id != builder.elementID(focus)
+        }
+    )
+
+    _ = AXLogicProElements.selectTrackViaAX(at: 0, runtime: runtime)
+
+    #expect(!recorder.ids.contains(builder.elementID(mute)))
+    #expect(!recorder.ids.contains(builder.elementID(splitter)))
+    // and it still reaches a control that could legitimately select
+    #expect(recorder.ids.contains(builder.elementID(name)))
+}

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1100,3 +1100,50 @@ private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String
     let coordCommit = try #require(coordObj["commit_strategy"] as? String)
     #expect(coordCommit == "slot_popup_physical_menu_click")
 }
+
+/// #475 — an unreadable mixer child renumbers every later strip, so ordinal addressing stops meaning
+/// what the caller asked for.
+///
+/// `mixerChannelStrips` filters to layout items; a child whose role cannot be read is dropped and
+/// each later strip moves down one. Callers address strips by ordinal, so a request for track 0 would
+/// act on physical strip 1. No downstream readback can catch it — the readback reads the same shifted
+/// list — so the write path refuses rather than addressing a list it cannot trust.
+@Test func testPlugin475UnreadableMixerChildIsNotSilentlyRenumbered() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let mixer = b.element(9600)
+    let ghost = b.element(9601)      // role unreadable: dropped by the filter
+    let stripA = b.element(9602)
+    let stripB = b.element(9603)
+    b.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
+    b.setAttribute(mixer, kAXDescriptionAttribute as String, "Mixer")
+    // `ghost` deliberately has NO role attribute.
+    b.setAttribute(stripA, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setAttribute(stripB, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setChildren(mixer, [ghost, stripA, stripB])
+
+    let runtime = b.makeAXRuntime(setAttributeHandler: nil, performActionHandler: { _, _ in false })
+    let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime)
+
+    // The filter still yields two strips, but they are NOT at the ordinals the caller means: the
+    // caller's "strip 0" is physically the second child here.
+    #expect(enumeration.strips.count == 2)
+    #expect(enumeration.unreadableChildren == 1)
+}
+
+@Test func testPlugin475FullyReadableMixerReportsNoUnreadableChildren() async throws {
+    let b = FakeAXRuntimeBuilder()
+    let mixer = b.element(9610)
+    let stripA = b.element(9611)
+    let stripB = b.element(9612)
+    b.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
+    b.setAttribute(stripA, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setAttribute(stripB, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setChildren(mixer, [stripA, stripB])
+
+    let runtime = b.makeAXRuntime(setAttributeHandler: nil, performActionHandler: { _, _ in false })
+    let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime)
+
+    // The positive twin: a healthy mixer must not be refused, or the guard would block every write.
+    #expect(enumeration.strips.count == 2)
+    #expect(enumeration.unreadableChildren == 0)
+}

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1659,20 +1659,26 @@ private func emptyLogicRuntimeForRollbackTests() -> AXLogicProElements.Runtime {
 /// both the write and its readback in a different document than the caller named — and every check
 /// in between still agrees with itself, because they all read the new document.
 @Test func testPlugin475ProjectSwitchedMidInsertIsNotCertified() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
     let reads = AXPressLogBox()
-    let result = await AccessibilityChannel.defaultInsertVerified(
-        params: [
-            "track": "0", "insert": "0", "plugin": "Gain",
-            "mode": "duplicate_applyback", "project_expected_path": coordFreeExpectedPath,
-        ],
-        runtime: fixture.runtime,
-        frontDocumentPath: {
-            // The gate's read matches; the post-write re-read finds a different document.
-            reads.bump()
-            return reads.count == 1 ? coordFreeExpectedPath : "/Users/me/Music/Something Else.logicx"
-        }
-    )
+    // #472 made the slot-open path require the custom action; without this seam the insert bails
+    // before the write and this test would pass for the wrong reason.
+    let result = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests(
+        [slotPopupOpenCustomAction]
+    ) {
+        await AccessibilityChannel.defaultInsertVerified(
+            params: [
+                "track": "0", "insert": "0", "plugin": "Gain",
+                "mode": "duplicate_applyback", "project_expected_path": coordFreeExpectedPath,
+            ],
+            runtime: fixture.runtime,
+            frontDocumentPath: {
+                // The gate's read matches; the post-write re-read finds a different document.
+                reads.bump()
+                return reads.count == 1 ? coordFreeExpectedPath : "/Users/me/Music/Something Else.logicx"
+            }
+        )
+    }
     let obj = try! JSONSerialization.jsonObject(with: result.message.data(using: .utf8)!) as! [String: Any]
 
     #expect(try #require(obj["state"] as? String) == "C")
@@ -1685,7 +1691,11 @@ private func emptyLogicRuntimeForRollbackTests() -> AXLogicProElements.Runtime {
 /// The positive twin: an unchanged document still certifies, so the check above is a decision rather
 /// than a path that can never reach State A.
 @Test func testPlugin475UnchangedProjectStillCertifies() async throws {
-    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
-    let obj = await runRealInsert(runtime: fixture.runtime)
+    let fixture = makeSlotPopupInsertFixture(mountGainOnLeafPick: true)
+    let obj = await AccessibilityChannel.withSlotPopupOpenActionNamesForTests(
+        [slotPopupOpenCustomAction]
+    ) {
+        await runRealInsert(runtime: fixture.runtime)
+    }
     #expect(try #require(obj["state"] as? String) == "A")
 }

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1147,3 +1147,71 @@ private func runRealInsert(runtime: AXLogicProElements.Runtime) async -> [String
     #expect(enumeration.strips.count == 2)
     #expect(enumeration.unreadableChildren == 0)
 }
+
+private final class AXPressLogBox: @unchecked Sendable {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}
+
+/// #475 — a rollback must undo OUR insert, never whatever is on top of the user's undo stack.
+///
+/// The rollback matched only the localized "Undo" prefix and pressed the entry it found. Measured on
+/// Logic 12.3 the Edit menu offers "Undo Insert Plug-in in Channel Strip" for our own write, and
+/// entries such as "Undo selected Channel Strips" for actions that are not ours. Pressing the latter
+/// reverts the user's work while reporting a successful rollback.
+@Test func testPlugin475RollbackDoesNotUndoSomethingThatIsNotOurInsert() async throws {
+    let clicks = AXPressLogBox()
+    let result = await AccessibilityChannel.verifiedUndoPluginInsert(
+        track: 0,
+        strayPluginID: "logic.stock.effect.gain",
+        straySlot: 0,
+        strayName: "Gain",
+        runtime: emptyLogicRuntimeForRollbackTests(),
+        maxRetries: 4,
+        undoClick: { clicks.bump(); return "not_ours" }
+    )
+
+    // The properties that protect the user's work: the entry was looked at once, nothing was
+    // pressed, and there was no retry — a retry would keep hammering Undo at their stack.
+    //
+    // `succeeded` is not asserted here. This fixture's strip is empty, so the stray reads as already
+    // gone and removal confirms on its own; that says nothing about the refusal.
+    #expect(clicks.count == 1)
+    #expect(!result.attempted)
+    #expect(result.lastClickResult == "not_ours")
+}
+
+/// The positive twin: when the entry IS ours, the rollback proceeds, so the refusal above is a
+/// decision rather than a path that can never roll anything back.
+@Test func testPlugin475RollbackStillProceedsWhenTheEntryIsOurs() async throws {
+    let clicks = AXPressLogBox()
+    let result = await AccessibilityChannel.verifiedUndoPluginInsert(
+        track: 0,
+        strayPluginID: "logic.stock.effect.gain",
+        straySlot: 0,
+        strayName: "Gain",
+        runtime: emptyLogicRuntimeForRollbackTests(),
+        maxRetries: 4,
+        undoClick: { clicks.bump(); return "ok" }
+    )
+
+    #expect(clicks.count >= 1)
+    #expect(result.attempted)
+}
+
+/// A strip whose inventory reads empty is the removal-confirmation the rollback polls for.
+private func emptyLogicRuntimeForRollbackTests() -> AXLogicProElements.Runtime {
+    let b = FakeAXRuntimeBuilder()
+    let app = b.element(9700)
+    let window = b.element(9701)
+    let mixer = b.element(9702)
+    let strip = b.element(9703)
+    b.setAttribute(app, kAXMainWindowAttribute as String, window)
+    b.setChildren(window, [mixer])
+    b.setAttribute(mixer, kAXRoleAttribute as String, "AXLayoutArea")
+    b.setAttribute(mixer, kAXIdentifierAttribute as String, "Mixer")
+    b.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    b.setChildren(mixer, [strip])
+    b.setChildren(strip, [])
+    return b.makeLogicRuntime(appElement: app, setAttributeHandler: nil, performActionHandler: { _, _ in false })
+}

--- a/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginInsertVerifiedTests.swift
@@ -1215,3 +1215,41 @@ private func emptyLogicRuntimeForRollbackTests() -> AXLogicProElements.Runtime {
     b.setChildren(strip, [])
     return b.makeLogicRuntime(appElement: app, setAttributeHandler: nil, performActionHandler: { _, _ in false })
 }
+
+/// #475 — State A must not be granted to a document we can no longer name.
+///
+/// The front document is checked once, before the work begins. Track select, mixer raise, inventory,
+/// pop-up, discovery, pick and poll all happen after it. Switching project inside that window puts
+/// both the write and its readback in a different document than the caller named — and every check
+/// in between still agrees with itself, because they all read the new document.
+@Test func testPlugin475ProjectSwitchedMidInsertIsNotCertified() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
+    let reads = AXPressLogBox()
+    let result = await AccessibilityChannel.defaultInsertVerified(
+        params: [
+            "track": "0", "insert": "0", "plugin": "Gain",
+            "mode": "duplicate_applyback", "project_expected_path": coordFreeExpectedPath,
+        ],
+        runtime: fixture.runtime,
+        frontDocumentPath: {
+            // The gate's read matches; the post-write re-read finds a different document.
+            reads.bump()
+            return reads.count == 1 ? coordFreeExpectedPath : "/Users/me/Music/Something Else.logicx"
+        }
+    )
+    let obj = try! JSONSerialization.jsonObject(with: result.message.data(using: .utf8)!) as! [String: Any]
+
+    #expect(try #require(obj["state"] as? String) == "C")
+    #expect(try #require(obj["error"] as? String) == "project_identity_mismatch")
+    // The write did happen — denying that would be the other kind of dishonesty.
+    #expect(try #require(obj["write_attempted"] as? Bool))
+    #expect(reads.count >= 2)
+}
+
+/// The positive twin: an unchanged document still certifies, so the check above is a decision rather
+/// than a path that can never reach State A.
+@Test func testPlugin475UnchangedProjectStillCertifies() async throws {
+    let fixture = makeSlotPopupInsertFixture(refuseLeafAXPress: false, mountGainOnLeafAXPress: true)
+    let obj = await runRealInsert(runtime: fixture.runtime)
+    #expect(try #require(obj["state"] as? String) == "A")
+}


### PR DESCRIPTION
Three items from #475, each measured live before it was written. The rest of that issue
(project/track identity revalidation, the Go-to-Position title match) is untouched here.

## 1. Selecting a track could toggle the user's mix

The selection ladder's last rung pressed every child of the track header in turn and stopped at the
first that accepted the press. Measured child order:

| # | role | description |
| --- | --- | --- |
| 0 | AXRadioButton | Has Focus |
| 1 | AXSplitter | Individual Track Zoom |
| 2 | AXDisclosureTriangle | |
| 3 | AXCheckBox | **Mute** |
| 4–6 | AXCheckBox | Solo, Record Enable, Input Monitoring |
| 9 | AXTextField | track name |

Every pressable one accepts AXPress, so a header whose radio declined sent the ladder on to a zoom
splitter, a stack disclosure, and then Mute — and reported success because the press was accepted.
Role alone separates them and needs no localized labels.

Live: mute read from all five headers before and after selecting each in turn. All five verified
State A, every mute stayed 0.

## 2. An unreadable mixer child renumbered every later strip

`mixerChannelStrips` drops a child whose role cannot be read, and each later strip moves down one.
Callers address strips by ordinal, so a request for track 0 acts on physical strip 1 — and no
downstream readback catches it, because the readback reads the same shifted list. The existing
`complete` flag does not cover this: it goes false only when a slot is classified but unreadable, not
when an element fails classification and takes the numbering with it.

The enumeration now reports the unreadable count, and the two ordinal-addressing paths — the write's
slot resolution and the inventory its verification diffs — refuse rather than trust a shifted list.
Read-only callers are unaffected. Live: 7 children, 7 layout items, 0 unreadable, so a healthy tree
costs nothing.

## 3. A rollback could undo whatever the user did last

The stray-mount rollback matched only the "Undo" prefix and pressed what it found. Measured, the Edit
menu offers `Undo Insert Plug-in in Channel Strip` for our write and entries like `Undo Create
Marker`, `Undo selected Channel Strips`, `Undo Delete Track and Regions` for things that are not ours.

Two ways the check could have been hollow, both closed: a refusal used to fall through to a blind
Cmd+Z, and the retry loop would have reopened the Edit menu four times for an answer that cannot
change.

Live: with `Undo Create Marker` genuinely on top of the stack, the discriminator refuses it and the
two other real entries, and accepts the insert entry.

## Notes

Each fix has a positive twin so the refusal is a decision rather than a path that can never act, and
each mutation fails its test.

While verifying, the live insert gate failed on this branch. A control with every change stashed
failed identically on unmodified main, so it is the coordinate slot-open path that #472 replaces —
strip resolution passed (`target_slot_found`, `track_select_verified`) and the failure was
`slot_popup_menu_not_found`.

Full suite 3382 passing, dead-expect gate clean, public-surface preflight PASS.