### PR TITLE
fix(#495): describe the filter controls Logic actually exposes

### DIFF
--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackEvidence.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackEvidence.swift
@@ -122,11 +122,31 @@ enum ObservedRegionIdentityProof: Sendable {
 /// see accounted for. Completeness is checked against this set: a missing,
 /// duplicated, or unrecognized control makes the filter evidence incomplete
 /// (fail-closed) rather than silently assuming an unseen control is "off".
+///
+/// #495 — this list is the set Logic actually exposes, measured live 2026-08-10 by
+/// enumerating every `AXCheckBox` in the Event pane. The earlier list named
+/// `channel`, `scope` and `takeFolder`, none of which exist as filter controls: the
+/// pane has eight event-type checkboxes and nothing else. A collector reporting the
+/// real surface was therefore rejected as incomplete, and the only way to satisfy the
+/// old list was to fabricate ids — the exact failure this check exists to prevent.
+///
+/// Scope is NOT represented here, deliberately. It is not a checkbox, and the
+/// assessment already binds scope through region identity (`resolvedIdentity` /
+/// `observedRegion`), which is a stronger check than a toggle would be. Encoding it
+/// twice would let a weak signal stand in for the strong one.
+///
+/// Three further checkboxes share the pane and are NOT filters — `Catch Playhead`,
+/// `MIDI In`, `MIDI Out` — so a collector must enumerate by audited title, not by role.
 enum FilterControlID: String, CaseIterable, Sendable {
+    /// `Notes` — the only one whose state can hide a note event.
     case noteEvents
-    case channel
-    case scope
-    case takeFolder
+    case programChange
+    case pitchBend
+    case controller
+    case aftertouch
+    case polyAftertouch
+    case systemExclusive
+    case additionalInfo
 }
 
 /// Raw Event-List filter checkbox states. The chokepoint DERIVES whether all

--- a/Sources/LogicProMCP/MIDIReadback/MIDIReadbackAssessment.swift
+++ b/Sources/LogicProMCP/MIDIReadback/MIDIReadbackAssessment.swift
@@ -244,10 +244,12 @@ private func filterCompleteness(_ filter: FilterEvidence) -> FilterAssessment {
     for control in FilterControlID.allCases where seen[control] == nil {
         return .incomplete
     }
+    // #495 — only `Notes` governs whether note events are shown. The other seven
+    // control event classes that are not notes, so their state cannot hide a note and
+    // must not be read as a scoping filter. They are still REQUIRED to be observed:
+    // a collector that cannot see the whole control set has not established that the
+    // one control it does care about is the only one that matters.
     guard seen[.noteEvents] == true else { return .filtered }
-    if seen[.channel] == true || seen[.scope] == true || seen[.takeFolder] == true {
-        return .filtered
-    }
     return .allNotesVisible
 }
 

--- a/Tests/LogicProMCPTests/MIDIReadbackAssessmentTests.swift
+++ b/Tests/LogicProMCPTests/MIDIReadbackAssessmentTests.swift
@@ -43,16 +43,28 @@ import Testing
         [.position: posCol, .channel: chCol, .pitch: pitchCol, .velocity: velCol, .length: lenCol]
     }
 
-    /// The complete, well-formed filter control set (all note events visible, no
-    /// scoping filter). Individual tests override one control to exercise a case.
+    /// The complete, well-formed filter control set — the eight event-type checkboxes
+    /// the Event pane actually exposes (#495, measured live 2026-08-10). Individual
+    /// tests override one control to exercise a case.
     static func completeFilter(
-        noteEvents: Bool = true, channel: Bool = false, scope: Bool = false, takeFolder: Bool = false
+        noteEvents: Bool = true,
+        programChange: Bool = true,
+        pitchBend: Bool = true,
+        controller: Bool = true,
+        aftertouch: Bool = true,
+        polyAftertouch: Bool = true,
+        systemExclusive: Bool = true,
+        additionalInfo: Bool = false
     ) -> FilterEvidence {
         FilterEvidence(checkboxes: [
             .init(id: "noteEvents", checked: noteEvents),
-            .init(id: "channel", checked: channel),
-            .init(id: "scope", checked: scope),
-            .init(id: "takeFolder", checked: takeFolder),
+            .init(id: "programChange", checked: programChange),
+            .init(id: "pitchBend", checked: pitchBend),
+            .init(id: "controller", checked: controller),
+            .init(id: "aftertouch", checked: aftertouch),
+            .init(id: "polyAftertouch", checked: polyAftertouch),
+            .init(id: "systemExclusive", checked: systemExclusive),
+            .init(id: "additionalInfo", checked: additionalInfo),
         ])
     }
 
@@ -179,17 +191,83 @@ import Testing
         #expect(snap.noteCompleteness.partialReason == .filterNotAllNotes)
     }
 
-    @Test func scopeFilterActiveRejected() {
-        let snap = assessReadback(Self.evidence(filter: Self.completeFilter(scope: true)))
+    // `scopeFilterActiveRejected` is retired, not dropped. It asserted that an active
+    // `scope` filter makes the readback filtered — but the Event pane has no scope
+    // checkbox (#495, measured), so the test exercised a control that does not exist and
+    // could never fire against a faithful collector.
+    //
+    // The concern it protected — the list showing something other than the region the
+    // caller named — is carried by the region-identity predicates, and that coverage was
+    // checked rather than assumed: neutralising the `observed == resolvedIdentity`
+    // comparison makes `mismatchedObservedIdentityRejected` fail. That is a stronger
+    // check than a toggle, because it compares two independently obtained identities
+    // instead of trusting a boolean.
+
+    /// #495 — the enum must describe the controls Logic actually shows.
+    ///
+    /// Measured live 2026-08-10: the Event pane exposes eight event-type checkboxes —
+    /// Notes, Progr. Change, Pitch Bend, Controller, Aftertouch, Poly Aftertouch,
+    /// Syst. Exclusive, Additional Info — and no channel, scope or take-folder filter.
+    /// A collector that reports what it sees must be accepted; today it is rejected as
+    /// incomplete, and the only way to pass is to invent ids for controls that are not there.
+    @Test func filterAcceptsTheControlSetLogicActuallyExposes() {
+        let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
+            .init(id: "noteEvents", checked: true),
+            .init(id: "programChange", checked: true),
+            .init(id: "pitchBend", checked: true),
+            .init(id: "controller", checked: true),
+            .init(id: "aftertouch", checked: true),
+            .init(id: "polyAftertouch", checked: true),
+            .init(id: "systemExclusive", checked: true),
+            .init(id: "additionalInfo", checked: false),
+        ])))
+        #expect(snap.noteCompleteness.partialReason != .filterEvidenceIncomplete)
+    }
+
+    /// The other seven filters govern event classes that are not notes, so their state
+    /// cannot make a note readback "filtered" — only Notes being off can.
+    @Test func filterOtherEventTypesOffDoesNotHideNotes() {
+        let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
+            .init(id: "noteEvents", checked: true),
+            .init(id: "programChange", checked: false),
+            .init(id: "pitchBend", checked: false),
+            .init(id: "controller", checked: false),
+            .init(id: "aftertouch", checked: false),
+            .init(id: "polyAftertouch", checked: false),
+            .init(id: "systemExclusive", checked: false),
+            .init(id: "additionalInfo", checked: false),
+        ])))
+        #expect(snap.noteCompleteness.partialReason != .filterNotAllNotes)
+        #expect(snap.noteCompleteness.partialReason != .filterEvidenceIncomplete)
+    }
+
+    /// Notes off is the one filter state that does hide notes.
+    @Test func filterNotesOffIsStillFiltered() {
+        let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
+            .init(id: "noteEvents", checked: false),
+            .init(id: "programChange", checked: true),
+            .init(id: "pitchBend", checked: true),
+            .init(id: "controller", checked: true),
+            .init(id: "aftertouch", checked: true),
+            .init(id: "polyAftertouch", checked: true),
+            .init(id: "systemExclusive", checked: true),
+            .init(id: "additionalInfo", checked: false),
+        ])))
         #expect(snap.noteCompleteness.partialReason == .filterNotAllNotes)
     }
 
+    /// One control of the eight omitted. Every id present IS recognised, so this
+    /// exercises the missing-control rule rather than the unknown-id rule.
     @Test func filterMissingControlRejected() {
         let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
             .init(id: "noteEvents", checked: true),
-            .init(id: "channel", checked: false),
-            .init(id: "scope", checked: false),
-            // takeFolder omitted → incomplete
+            .init(id: "programChange", checked: true),
+            .init(id: "pitchBend", checked: true),
+            .init(id: "controller", checked: true),
+            .init(id: "aftertouch", checked: true),
+            .init(id: "polyAftertouch", checked: true),
+            .init(id: "systemExclusive", checked: true),
+            // additionalInfo omitted → incomplete
         ])))
         #expect(snap.noteCompleteness.partialReason == .filterEvidenceIncomplete)
     }
@@ -198,9 +276,13 @@ import Testing
         let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
             .init(id: "noteEvents", checked: true),
             .init(id: "noteEvents", checked: true),
-            .init(id: "channel", checked: false),
-            .init(id: "scope", checked: false),
-            .init(id: "takeFolder", checked: false),
+            .init(id: "programChange", checked: true),
+            .init(id: "pitchBend", checked: true),
+            .init(id: "controller", checked: true),
+            .init(id: "aftertouch", checked: true),
+            .init(id: "polyAftertouch", checked: true),
+            .init(id: "systemExclusive", checked: true),
+            .init(id: "additionalInfo", checked: false),
         ])))
         #expect(snap.noteCompleteness.partialReason == .filterEvidenceIncomplete)
     }
@@ -208,9 +290,13 @@ import Testing
     @Test func filterUnknownControlRejected() {
         let snap = assessReadback(Self.evidence(filter: FilterEvidence(checkboxes: [
             .init(id: "noteEvents", checked: true),
-            .init(id: "channel", checked: false),
-            .init(id: "scope", checked: false),
-            .init(id: "takeFolder", checked: false),
+            .init(id: "programChange", checked: true),
+            .init(id: "pitchBend", checked: true),
+            .init(id: "controller", checked: true),
+            .init(id: "aftertouch", checked: true),
+            .init(id: "polyAftertouch", checked: true),
+            .init(id: "systemExclusive", checked: true),
+            .init(id: "additionalInfo", checked: false),
             .init(id: "mysteryControl", checked: false),
         ])))
         #expect(snap.noteCompleteness.partialReason == .filterEvidenceIncomplete)


### PR DESCRIPTION
FilterControlID named noteEvents, channel, scope and takeFolder. Enumerating the
Event pane live shows eight event-type checkboxes and none of those last three, so
a collector reporting the real surface was rejected as incomplete and the only way
to pass was to invent ids for controls that are not there — the exact fabrication
this check exists to prevent.

Scope is deliberately not represented as a filter. It is not a checkbox, and the
assessment already binds it through region identity, which compares two
independently obtained identities instead of trusting a boolean. Encoding it twice
would let the weaker signal stand in for the stronger one.

scopeFilterActiveRejected is retired rather than dropped: it asserted behaviour for
a control that does not exist. Its replacement was checked, not assumed —
neutralising the observed-vs-resolved identity comparison fails
mismatchedObservedIdentityRejected.

Three existing filter tests used the old ids and were therefore passing through the
unknown-id rule rather than the rule their names claim. Retargeted, then each of
the four rules mutated independently: missing-control, duplicate-control,
unknown-id and Notes-off all fail as designed.

Closes #495

Closes #495

## Evidence

Live enumeration of the Event pane, recorded on #495 with each checkbox's title, state and help text.

## Controls

Each of the four rules was mutated independently and the covering test observed to fail:

| rule | mutation | result |
| --- | --- | --- |
| missing control | drop the all-cases-present loop | `filterMissingControlRejected` fails |
| duplicate control | drop the seen-twice check | `filterDuplicateControlRejected` fails |
| unknown id | ignore unknown ids instead of rejecting | `filterUnknownControlRejected` fails |
| Notes off | accept Notes in any state | `filterNotesOffIsStillFiltered` and `filterHidingNotesRejected` fail |

Two mutations initially reported "did not flip" and both were my instrument, not the tests: one never applied (shell escaping broke the edit) and one did not compile. The runner now verifies the anchor was found, that the mutation compiled, and that the test actually ran, before reading a pass as meaningful.

Full suite: 0 failures.