### PR TITLE
fix(#493): one code and one meaning for an ambiguous target

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -705,12 +705,12 @@ extension AccessibilityChannel {
             ))
         }
         let ambiguousIndices = names
-            .filter { $0.key != track && $0.value == expected }
+            .filter { $0.value == expected }
             .map(\.key)
             .sorted()
-        guard ambiguousIndices.isEmpty else {
+        guard ambiguousIndices.count <= 1 else {
             return .error(HonestContract.encodeV2StateC(
-                error: .staleTargetReference,
+                error: .ambiguousTargetName,
                 extras: [
                     "operation": operation,
                     "target_identity": identity,

--- a/Sources/LogicProMCP/Dispatchers/IndexBindingGuard.swift
+++ b/Sources/LogicProMCP/Dispatchers/IndexBindingGuard.swift
@@ -170,7 +170,7 @@ enum IndexBindingGuard {
         let sameNameIndices = names.filter { $0.value == expectedName }.keys.sorted()
         guard sameNameIndices.count == 1 else {
             return toolStateCResult(
-                .targetNameAmbiguous,
+                .ambiguousTargetName,
                 hint: "\(operation) refused: '\(expectedName)' names \(sameNameIndices.count) live tracks, so matching it at index \(index) does not prove which one this is (same-named tracks can swap and stay self-consistent) — supply target_ref to bind by stable identity",
                 extras: [
                     "operation": operation,

--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -283,10 +283,10 @@ enum TargetRefResolver {
             )
         }
         let ambiguousIndices = names
-            .filter { $0.key != index && $0.value == expected }
+            .filter { $0.value == expected }
             .map(\.key)
             .sorted()
-        guard ambiguousIndices.isEmpty else {
+        guard ambiguousIndices.count <= 1 else {
             return staleLiveIdentityResult(
                 rawReference,
                 operation: operation,
@@ -325,9 +325,8 @@ enum TargetRefResolver {
         if !ambiguousIndices.isEmpty {
             // Nothing is stale here and nothing was reordered: the reference still names the right
             // index and the right name, but that name is shared, so no evidence can say WHICH track
-            // is meant. Refusing is right; calling it staleness sent callers after a reorder that
-            // never happened, and the way out — make the name unique — was not discoverable from
-            // the message.
+            // is meant. The field deliberately includes the bound index as well as every other
+            // collision, matching the explicit-index corroboration path.
             extras["ambiguous_live_track_name"] = true
             extras["ambiguous_track_indices"] = ambiguousIndices
             extras["what_was_observed"] = "live track name '\(expected)' also appeared at indices \(ambiguousIndices.map(String.init).joined(separator: ", "))"

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -103,8 +103,10 @@ enum HonestContract {
         case trackSelectionFailed = "track_selection_failed"
         case staleSnapshot = "stale_snapshot"
         case staleTargetReference = "stale_target_reference"
-        /// The reference still names the right index and the right name, but that name is not
-        /// unique, so nothing can prove WHICH track is meant. Deliberately distinct from
+        /// A binding still names the right index and the right name, but that name is not unique,
+        /// so nothing can prove WHICH track is meant. `ambiguous_track_indices` always contains
+        /// all live tracks carrying the colliding name, whether the binding came from `target_ref`
+        /// or `expected_name`. Deliberately distinct from
         /// `.staleTargetReference`: nothing is stale and nothing was reordered, and reporting it as
         /// staleness sent callers looking for a reorder that never happened.
         case ambiguousTargetName = "ambiguous_target_name"
@@ -135,11 +137,6 @@ enum HonestContract {
         /// (`reason: header_unreadable`), which is never read as agreement.
         /// Fail-closed pre-write: the wrong track was NOT touched.
         case targetIdentityMismatch = "target_identity_mismatch"
-        /// `expected_name` matched the live header at the supplied index but is
-        /// NOT unique across the live surface. Two same-named tracks can swap
-        /// positions and keep (index, name) self-consistent, so a match proves
-        /// nothing; only a `target_ref` survives the swap.
-        case targetNameAmbiguous = "target_name_ambiguous"
         /// A `.refRequired` op was called with a bare index. Unlike
         /// `.indexBindingCorroborationRequired`, no `expected_name` can rescue
         /// this — a stable `target_ref` is the only accepted binding.

--- a/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCorroborationTests.swift
@@ -17,7 +17,7 @@ import Testing
 //   - `expected_name` != live name     -> target_identity_mismatch
 //   - live header unreadable           -> target_identity_mismatch (header_unreadable)
 //   - `expected_name` matches but is
-//     NON-UNIQUE across the live surface -> target_name_ambiguous
+//     NON-UNIQUE across the live surface -> ambiguous_target_name
 //   - unique match                     -> the existing index write path, unchanged
 // Every failure is pre-write and fail-closed: `write_attempted:false` AND the
 // probe channels record zero routed operations.
@@ -174,7 +174,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     )
 
     #expect(result.isError!, "a matching name that is not unique proves nothing")
-    #expect(corroborationErrorCode(result) == "target_name_ambiguous")
+    #expect(corroborationErrorCode(result) == "ambiguous_target_name")
     let v1 = try #require(writeAttempted(result))
     #expect(!v1)
 
@@ -492,7 +492,7 @@ private func writeAttempted(_ result: CallTool.Result) -> Bool? {
     )
 
     #expect(result.isError!)
-    #expect(corroborationErrorCode(result) == "target_name_ambiguous")
+    #expect(corroborationErrorCode(result) == "ambiguous_target_name")
     let v1 = try #require(writeAttempted(result))
     #expect(!v1)
     let object = sharedJSONObject(sharedToolText(result))

--- a/Tests/LogicProMCPTests/Issue493AmbiguityConsistencyTests.swift
+++ b/Tests/LogicProMCPTests/Issue493AmbiguityConsistencyTests.swift
@@ -1,0 +1,50 @@
+import MCP
+import Testing
+
+@testable import LogicProMCP
+
+@Test("Issue #493: delete ambiguity has one code and one index-set meaning")
+func deleteAmbiguityIsConsistentAcrossTargetRefAndIndexPaths() async throws {
+    let name = "Studio Grand"
+    let liveNames: [Int: String] = [
+        1: name,
+        5: name,
+        6: name,
+    ]
+
+    let registry = TargetRegistry()
+    let descriptor = TargetDescriptor(trackIndex: 6, trackName: name)
+    let reference = await registry.bind(
+        kind: .track,
+        descriptor: descriptor,
+        fingerprint: descriptor.fingerprint
+    )
+    let cache = StateCache()
+    await cache.updateTracks(liveNames.map { TrackState(id: $0.key, name: $0.value, type: .audio) })
+
+    try await FeatureFlags.withAdr002TargetRefForTests(true) {
+        let targetRefResult = await TrackDispatcher.handle(
+            command: "delete",
+            params: ["target_ref": .string(reference.rawValue)],
+            router: ChannelRouter(),
+            cache: cache,
+            targetRegistry: registry,
+            liveTrackNames: { liveNames }
+        )
+        let indexResult = await TrackDispatcher.handle(
+            command: "delete",
+            params: [
+                "index": .int(1),
+                "expected_name": .string(name),
+            ],
+            router: ChannelRouter(),
+            cache: cache,
+            liveTrackNames: { liveNames }
+        )
+
+        let targetRefBody = try #require(sharedJSONObject(sharedToolText(targetRefResult)))
+        let indexBody = try #require(sharedJSONObject(sharedToolText(indexResult)))
+        #expect(targetRefBody["error"] as? String == indexBody["error"] as? String)
+        #expect(targetRefBody["ambiguous_track_indices"] as? [Int] == indexBody["ambiguous_track_indices"] as? [Int])
+    }
+}

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -452,12 +452,12 @@ private func runChannelEQFixture(
     let obj = await runLive(fixture: fixture, params: params)
 
     #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "stale_target_reference")
+    #expect(obj["error"] as? String == "ambiguous_target_name")
     let v1 = try #require(obj["write_attempted"] as? Bool)
     #expect(!v1)
     let v2 = try #require(obj["ambiguous_live_track_name"] as? Bool)
     #expect(v2)
-    #expect(obj["ambiguous_track_indices"] as? [Int] == [1])
+    #expect(obj["ambiguous_track_indices"] as? [Int] == [0, 1])
     #expect(fixture.currentSliderValue == 51)
 }
 

--- a/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
+++ b/Tests/LogicProMCPTests/TargetRefResolutionTests.swift
@@ -1092,7 +1092,7 @@ struct TargetRefResolutionTests {
             #expect(body(result)["expected_track_name"] as? String == "Bass")
             let v2 = try #require(body(result)["ambiguous_live_track_name"] as? Bool)
             #expect(v2)
-            #expect(body(result)["ambiguous_track_indices"] as? [Int] == [2])
+            #expect(body(result)["ambiguous_track_indices"] as? [Int] == [1, 2])
             #expect(await allOps(channels).isEmpty, "no wrong-target write")
         }
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -89,7 +89,7 @@ Every failure below is fail-closed and **pre-write**: `write_attempted: false` i
 | No `expected_name` and no `target_ref` | `index_binding_corroboration_required` | `true` — supply either binding |
 | Live name at the index ≠ `expected_name` | `target_identity_mismatch` (`reason: name_mismatch`) | `false` — re-read `logic://tracks` first |
 | Live header unreadable | `target_identity_mismatch` (`reason: header_unreadable`) | `false` — an unreadable surface is never read as agreement |
-| `expected_name` matches but names >1 live track | `target_name_ambiguous` | `false` — use `target_ref` |
+| `expected_name` matches but names >1 live track | `ambiguous_target_name` (`ambiguous_track_indices` lists all colliding indices) | `false` — use `target_ref` |
 | `expected_name` **and** `target_ref` both supplied | `invalid_params` | `true` — send exactly one binding |
 
 Uniqueness is not a nicety. Two tracks sharing a name can swap positions and leave `(index, name)` self-consistent at **both** ordinals, so a match would prove nothing; `target_ref` is the only binding a swap cannot fool. Supplying `target_ref` bypasses this path entirely — the reference machinery carries its own live-identity and ambiguity checks, and the two are never stacked.


### PR DESCRIPTION
Both corroboration paths refused the same condition — a track name matching several live tracks — with different error codes and different meanings for the same field.

```
delete {target_ref}            -> "ambiguous_target_name",  ambiguous_track_indices [1,5]
delete {index, expected_name}  -> "target_name_ambiguous",  ambiguous_track_indices [1,5,6]
```

The codes are the same words reordered, so a caller branching on the code had to know both. The index field meant *the other* colliding tracks on one path and *all* of them on the other, with nothing in the response saying which convention was used — count it and you get 2 or 3 for the same project.

Converged on `ambiguous_target_name` and on all colliding live indices. The field name already describes the complete set, and callers can now compare the two responses without path-specific interpretation.

## Verification

Verified in an isolated git worktree, not in a shared tree.

- new test `Issue493AmbiguityConsistencyTests` drives **both** paths against one ambiguous fixture and asserts they agree on the code and on the index set; it fails on `main` with `"ambiguous_target_name" != "target_name_ambiguous"` and `[1,5] != [1,5,6]`
- `target_name_ambiguous` no longer appears anywhere in `Sources/` or `Tests/`
- no test was deleted
- `Scripts/ci-forbid-dead-expect.sh` exits 0

Full suite: 3413 tests, 2 failures — both in `regionDragSpikeBlocksCurrentWorkingDirectoryExportDir`, which is **pre-existing and environment-coupled, not a regression**. Control: the same test fails identically on `origin/main` in the same worktree, and this branch does not touch that file. It passes from the main repository path and fails from a worktree path, so it depends on the working directory it runs in. Filed separately.

Closes #493