### PR TITLE
fix(#494): refuse to select a name that identifies more than one track

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -127,7 +127,20 @@ struct TrackDispatcher: OperationTraceDispatching {
             let name = stringParam(params, "name")
             if !name.isEmpty {
                 let tracks = await cache.getTracks()
-                if let track = tracks.first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
+                let matchingTracks = tracks.filter { $0.name.localizedCaseInsensitiveContains(name) }
+                if matchingTracks.count > 1 {
+                    return toolStateCResult(
+                        .ambiguousTargetName,
+                        hint: "'\(name)' matches more than one live track, so the target cannot be identified. Use an unambiguous name or select by index.",
+                        extras: [
+                            "operation": "track.select",
+                            "requested_name": name,
+                            "ambiguous_track_indices": matchingTracks.map(\.id).sorted(),
+                            "write_attempted": false,
+                        ]
+                    )
+                }
+                if let track = matchingTracks.first {
                     let traceID = await startTraceIfEnabled(command: command)
                     let result = await withWriteBoundaryArmed(traceID) {
                         await router.route(

--- a/Tests/LogicProMCPTests/Issue494SelectAmbiguityTests.swift
+++ b/Tests/LogicProMCPTests/Issue494SelectAmbiguityTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private actor Issue494StateASelectChannel: Channel {
+    nonisolated let id: ChannelID = .mcu
+    var executedOps: [(String, [String: String])] = []
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executedOps.append((operation, params))
+        return .success(HonestContract.encodeStateA(extras: [
+            "requested": Int(params["index"] ?? "0") ?? 0,
+            "observed": Int(params["index"] ?? "0") ?? 0,
+        ]))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "Issue #494 State A select fixture")
+    }
+}
+
+@Test("Issue494: track.select by ambiguous name fails closed")
+func issue494SelectByAmbiguousNameFailsClosed() async throws {
+    let router = ChannelRouter()
+    let channel = Issue494StateASelectChannel()
+    await router.register(channel)
+    let cache = StateCache()
+    await cache.updateTracks([
+        TrackState(id: 1, name: "Studio Grand", type: .softwareInstrument),
+        TrackState(id: 4, name: "Studio Grand", type: .softwareInstrument),
+    ])
+
+    let result = await TrackDispatcher.handle(
+        command: "select",
+        params: ["name": .string("Studio Grand")],
+        router: router,
+        cache: cache
+    )
+
+    let isError = try #require(result.isError as Bool?)
+    #expect(isError, "ambiguous Studio Grand name must not return State A / verified true")
+    guard isError else { return }
+
+    let response = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(response["error"] as? String == "ambiguous_target_name")
+    #expect(response["ambiguous_track_indices"] as? [Int] == [1, 4])
+    #expect(await channel.executedOps.isEmpty, "ambiguous selection must not reach the router")
+}
+
+@Test("Issue494: track.select by unique name keeps State A")
+func issue494SelectByUniqueNameKeepsStateA() async throws {
+    let router = ChannelRouter()
+    let channel = Issue494StateASelectChannel()
+    await router.register(channel)
+    let cache = StateCache()
+    await cache.updateTracks([
+        TrackState(id: 7, name: "Studio Grand", type: .softwareInstrument),
+    ])
+
+    let result = await TrackDispatcher.handle(
+        command: "select",
+        params: ["name": .string("Studio Grand")],
+        router: router,
+        cache: cache
+    )
+
+    let isError = try #require(result.isError as Bool?)
+    #expect(!isError)
+    let response = try #require(sharedJSONObject(sharedToolText(result)))
+    #expect(try #require(response["success"] as? Bool))
+    #expect(try #require(response["verified"] as? Bool))
+    #expect(response["state"] as? String == "A")
+    let operations = await channel.executedOps
+    #expect(operations.count == 1)
+    let operation = try #require(operations.first)
+    #expect(operation.0 == "track.select")
+    #expect(operation.1 == ["index": "7"])
+}


### PR DESCRIPTION
`track.select` by a name matching several live tracks selected one of them and returned `state: A, verified: true`. Narrowly that was true — it really did select track 1, and the readback really confirmed it. The problem is that the caller asked for a name identifying three tracks and was handed a confident success on one, with no signal that a choice had been made for them.

This is not an edge case a user has to construct. `record_sequence` creates a new track per call and names them all `Studio Grand`, so duplicates are the ordinary state of a driven project — the live measurement on #494 found eighteen.

And `select` is a positioning operation: whatever runs next acts on wherever it landed. A silent pick here is a wrong-target write later, and that write will also report `state: A`, because it really did do what it did to the track it was pointed at.

The delete paths already refuse this exact condition (#480, #493). `select` was the one that did not.

## Change

Select by an ambiguous name now fails closed with `ambiguous_target_name`, carrying the colliding indices — the same code and the same field semantics the delete paths use after #493. Selecting by `index` or `target_ref` is unchanged.

## Verification

Verified in an isolated git worktree.

- `Issue494SelectAmbiguityTests` fails on `main` for the stated reason: an ambiguous name returned State A with `verified: true`
- a positive twin asserts a unique name still selects and still reaches State A, so the refusal is a decision rather than a path that can never succeed
- `Scripts/ci-forbid-dead-expect.sh` exits 0
- full suite: 3414 tests passed

Closes #494