### PR TITLE
test(#502): the scratch-root rejection test no longer depends on where the checkout lives

### DIFF
--- a/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
+++ b/Tests/LogicProMCPTests/RegionDragSpikeTests.swift
@@ -126,12 +126,16 @@ private func assertRegionDragSpikeBlocked(
     )
 }
 
-@Test func regionDragSpikeBlocksCurrentWorkingDirectoryExportDir() throws {
+/// The positive twin is `regionDragSpikeAcceptsControlledTmpExportDirBeforeCoordinateGate`,
+/// which already asserts that a scratch-root path gets past this gate — so this rejection
+/// test cannot be passing merely because everything is rejected.
+@Test func regionDragSpikeBlocksAnExportDirOutsideTheScratchRoot() throws {
     try assertRegionDragSpikeBlocked(
-        exportDir: FileManager.default.currentDirectoryPath,
+        exportDir: NSHomeDirectory(),
         noteContains: "controlled_scratch_root"
     )
 }
+
 
 @Test func regionDragSpikeBlocksTmpSymlinkEscapeOutsideScratchRoot() throws {
     let link = URL(fileURLWithPath: "/tmp/LogicProMCP-region-drag-spike-link-\(UUID().uuidString)")


### PR DESCRIPTION
`regionDragSpikeBlocksCurrentWorkingDirectoryExportDir` passed the current working directory as `--export-dir` and asserted the spike blocks it. Whether that is true depends on where the tests run.

The guard requires `--export-dir` to resolve under `/tmp`, `/private/tmp` or `NSTemporaryDirectory()` before it will arm a live mouse drag. **The guard is correct.** From a worktree under `/private/tmp` the working directory *is* a legitimate scratch path, so the guard allowed it and the test failed:

```
Expectation failed: (record["status"] as? String → "armed") == "blocked"
```

"The checkout is outside the scratch root" is not a property of the system — it is an accident of location, and any worktree or CI workspace under a temp directory flips it.

## Change

Renamed to `regionDragSpikeBlocksAnExportDirOutsideTheScratchRoot` and given `NSHomeDirectory()`, which is outside the scratch root wherever the tests run. Now the test exercises the guard rather than the checkout's path.

**No positive twin was added.** `regionDragSpikeAcceptsControlledTmpExportDirBeforeCoordinateGate` already asserts that a scratch-root path gets past this gate, so the rejection test cannot be passing merely because everything is rejected. I initially added a second twin, found it duplicated that one, and removed it — the existing test is now named in a comment so it is not re-added.

## Verification

Full suite: **3417 tests, all passing.** This was the last remaining failure across several branches, so "the suite is green" is now unambiguous — it had been failing identically on `origin/main` from any worktree path, which is what made it look like a regression on every branch that touched nothing near it.

`Scripts/ci-forbid-dead-expect.sh` exits 0.

Closes #502