### PR TITLE
ci(#496): run the release suite with the same flags as CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Run test suite
-        run: swift test --no-parallel
+        # Keep release logs bounded. The codebase still contains deprecated
+        # Swift Testing APIs, and unsuppressed diagnostics can expand to
+        # hundreds of megabytes before the actual test result is visible.
+        # CI's coverage test already uses the same compiler flag.
+        run: swift test -Xswiftc -suppress-warnings --no-parallel
 
       - name: Detect release mode
         id: mode

--- a/Tests/LogicProMCPTests/ReleasePipelineContractTests.swift
+++ b/Tests/LogicProMCPTests/ReleasePipelineContractTests.swift
@@ -29,7 +29,13 @@ import Testing
     let workflow = try scriptContents(".github/workflows/release.yml")
 
     let selectXcode = try #require(workflow.range(of: "name: Select Xcode"))
-    let testStep = try #require(workflow.range(of: "swift test --no-parallel"))
+    // release.yml runs the suite with the same flags as ci.yml (#496). The full
+    // invocation is asserted, not a prefix: "swift test --no-parallel" would still
+    // match after the flags diverged again, which is the drift this contract exists
+    // to catch — and it did catch it, twice, in both directions.
+    let testStep = try #require(workflow.range(
+        of: "swift test -Xswiftc -suppress-warnings --no-parallel"
+    ))
     let buildUniversal = try #require(workflow.range(of: "name: Build universal binary"))
     let package = try #require(workflow.range(of: "name: Package"))
 


### PR DESCRIPTION
`release.yml` ran `swift test --no-parallel`. `ci.yml:69` runs `swift test --enable-code-coverage -Xswiftc -suppress-warnings --no-parallel`. The release path was differently strict from the gate every PR already passes, in a way nobody chose.

The practical cost is the log. Deprecated Swift Testing APIs are still compiled, and their unsuppressed diagnostics can reach hundreds of megabytes before the actual test result appears — on the release path that is exactly the log a human reads when deciding whether a tag ships.

## This does not weaken the release gate

Checked rather than asserted:

- `-Xswiftc -suppress-warnings` is a **compile-time** flag. It suppresses compiler diagnostics, not test results — a failing test still fails the job.
- `warnings-as-errors` appears **nowhere** in `.github/`, `Package.swift` or `Scripts/`, so no policy that previously failed a build stops failing it.
- `ci.yml` already runs with the flag, so this makes release **match** the gate every PR passes rather than diverge from it.

## Why this is a separate PR

Written by @narukijima as part of #481. I separated it because a token without the `workflow` scope cannot merge a pull request that touches a workflow file — GitHub refuses the whole merge — and four unrelated fixes (#489, #490, #491, #492) should not wait on four lines.

**@MongLong0214 — this one needs you to merge it**; I cannot, for the same scope reason.

Closes #496