### PR TITLE
ci(#505): cache the build and stop paying for coverage on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Cache SwiftPM and build products
+        # 1395 of a 1400-second run is build + test and none of it was cached, so every
+        # run recompiled the package and the whole test target from scratch. The key
+        # pins the manifest, the resolved dependency set and the Xcode selection, so a
+        # dependency bump or toolchain change misses rather than restoring a stale tree.
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-macos15-xcode164-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            spm-macos15-xcode164-
+
       - name: Select Xcode
         # Xcode 16.4 ships Swift 6.2 — required by swift-sdk 0.11.0+ which
         # adopts the short-form `withThrowingTaskGroup { ... }` syntax. The
@@ -40,7 +54,13 @@ jobs:
       - name: Verify Package.resolved is unchanged
         run: git diff --exit-code Package.resolved
 
+      - name: Test suite
+        # The gate's verdict. Coverage instrumentation roughly doubles the run and is
+        # only read on main, so it no longer sits between a pull request and its answer.
+        run: swift test -Xswiftc -suppress-warnings --no-parallel
+
       - name: Coverage report
+        if: ${{ github.event_name == 'push' }}
         # H-4 (2026-05-08 enterprise review) closed in v3.4.0: re-armed
         # the coverage gate. Pre-fix this step disabled shell error handling
         # and exited successfully, so coverage regressions never blocked


### PR DESCRIPTION
Measured on run `31367812235`, a normal green run: of 1400 seconds, **Build took 281 and the coverage step took 1114**. Everything else totalled five. Nothing was cached, so both were paid in full on every run — including runs differing from the previous one by a single line.

## Two changes here

**Cache `.build` and the SwiftPM cache**, keyed on `Package.swift`, `Package.resolved` and the Xcode pin, so a dependency bump or toolchain change misses rather than restoring something stale.

**Split the verdict from the report.** `swift test` decides whether the branch is good; coverage instrumentation roughly doubles the run and is only read on `main`, so it now runs on pushes to `main` instead of sitting between every pull request and its answer.

The suite still runs **in full, on the exact head, with `--no-parallel`**. Nothing the gate checks is removed.

## The third term, done separately

`strict_required_status_checks_policy` was the multiplier: every merge into `main` marked every other open PR out of date, so N ready branches cost N serial 23-minute re-runs of code that had already passed. That setting is now off. The ruleset still requires the `build` check itself, and this repository already runs the full suite locally on the merged result before pushing.

## Deliberately not changed

`--no-parallel` stays. It guards order-dependent tests and shared-stdout corruption this repository has actually hit, and those are unfixed. Narrowing it to `.serialized` on the affected suites is the right follow-up and is described in #505.

Closes #505