### PR TITLE
fix(#497): the ambiguity hint names a route that actually works

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
+++ b/Sources/LogicProMCP/Dispatchers/TargetRefResolution.swift
@@ -333,7 +333,8 @@ enum TargetRefResolver {
             return toolStateCResult(
                 .ambiguousTargetName,
                 hint: "'\(expected)' names more than one live track, so the target cannot be "
-                    + "identified. Rename one of them, or address the track by an unambiguous name.",
+                    + "identified. Rename it with rename {name, index} — the index form is not "
+                    + "blocked by name ambiguity — then retry with the new name.",
                 extras: extras
             )
         }

--- a/Tests/LogicProMCPTests/Issue497AmbiguityHintTests.swift
+++ b/Tests/LogicProMCPTests/Issue497AmbiguityHintTests.swift
@@ -1,0 +1,43 @@
+import MCP
+import Testing
+
+@testable import LogicProMCP
+
+@Test("Issue497: ambiguity hint names the working index rename route")
+func Issue497AmbiguityHintNamesIndexRenameRoute() async throws {
+    let name = "Studio Grand"
+    let liveNames: [Int: String] = [
+        1: name,
+        5: name,
+        6: name,
+    ]
+
+    let registry = TargetRegistry()
+    let descriptor = TargetDescriptor(trackIndex: 6, trackName: name)
+    let reference = await registry.bind(
+        kind: .track,
+        descriptor: descriptor,
+        fingerprint: descriptor.fingerprint
+    )
+    let cache = StateCache()
+    await cache.updateTracks(liveNames.map { TrackState(id: $0.key, name: $0.value, type: .audio) })
+
+    try await FeatureFlags.withAdr002TargetRefForTests(true) {
+        let result = await TrackDispatcher.handle(
+            command: "rename",
+            params: [
+                "name": .string("Renamed Studio Grand"),
+                "target_ref": .string(reference.rawValue),
+            ],
+            router: ChannelRouter(),
+            cache: cache,
+            targetRegistry: registry,
+            liveTrackNames: { liveNames }
+        )
+
+        let body = try #require(sharedJSONObject(sharedToolText(result)))
+        let hint = try #require(body["hint"] as? String)
+        #expect(hint.contains("rename {name, index}"))
+        #expect(!hint.contains("or address the track by an unambiguous name"))
+    }
+}


### PR DESCRIPTION
When a track name matches several live tracks, the refusal said:

> Rename one of them, or address the track by an unambiguous name.

Following that literally does not work. Measured live:

```
rename {name, target_ref}  -> ambiguous_target_name   the SAME guard blocks the remedy
rename {name, index}       -> succeeds, state A
```

The remedy exists only through the bare-index form, which the hint did not mention — and it is refused through the identity-bound form a caller holding a `target_ref` would reach for first. A caller following the hint gets refused twice with no indication of the way out.

## Now

> '<name>' names more than one live track, so the target cannot be identified. Rename it with `rename {name, index}` — the index form is not blocked by name ambiguity — then retry with the new name.

## Verification

Live, against the release artifact built from this branch, driving a project with duplicate track names:

```
LIVE HINT: 'Studio Grand' names more than one live track, so the target cannot be
identified. Rename it with rename {name, index} — the index form is not blocked by
name ambiguity — then retry with the new name.
```

Mutation-checked: reverting the hint text to the old wording fails `Issue497AmbiguityHintNamesIndexRenameRoute`. The old wording appears in no source file.

Closes #497