### PR TITLE
fix(#498): the Go-to-Position dismissal requires a role, modality and an exact title

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -177,7 +177,7 @@ enum AXLocalePolicy {
     )
 
     static let goToPositionDialogTitle = LabelSet(
-        canonical: "Go to Position",
+        canonical: "Go To Position",
         variants: ["위치로 이동"],
         rationale: "Used only to dismiss a stale dialog before another verified operation."
     )

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -3047,20 +3047,28 @@ extension AccessibilityChannel {
         return (first.key, first.value.pluginID, first.value.name)
     }
 
-    /// Close a leftover "위치로 이동" / "Go to Position" floating dialog (a prior
+    /// Close a leftover "위치로 이동" / "Go To Position" floating dialog (a prior
     /// AX side effect) so it cannot steal focus / keep the Mix menu disabled.
     /// Best-effort via AX + CGEvent only: click Cancel/close if present, otherwise
     /// Escape. Returns whether a matching dialog was found.
     @discardableResult
-    private static func closeGoToPositionDialog(runtime: AXLogicProElements.Runtime) -> Bool {
+    static func closeGoToPositionDialog(runtime: AXLogicProElements.Runtime) -> Bool {
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return false }
         let windows: [AXUIElement] = AXHelpers.getAttribute(
             app, kAXWindowsAttribute as String, runtime: runtime.ax
         ) ?? []
         var found = false
         for window in windows {
+            let subrole: String? = AXHelpers.getAttribute(
+                window, kAXSubroleAttribute as String, runtime: runtime.ax
+            )
+            let isModal: Bool? = AXHelpers.getAttribute(
+                window, kAXModalAttribute as String, runtime: runtime.ax
+            )
             let title = AXHelpers.getTitle(window, runtime: runtime.ax) ?? ""
-            guard AXLocalePolicy.goToPositionDialogTitle.matches(title, mode: .contains) else {
+            guard subrole == kAXFloatingWindowSubrole as String,
+                  isModal == true,
+                  AXLocalePolicy.goToPositionDialogTitle.matches(title, mode: .exactStrict) else {
                 continue
             }
             found = true

--- a/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
+++ b/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
@@ -56,6 +56,36 @@ func issue498DoesNotTouchStandardNonModalProjectWindow() {
     #expect(fixture.builder.actionCalls.isEmpty)
 }
 
+/// Each guard needs a fixture that ONLY it can reject, or the three cannot be told
+/// apart. The window below is modal and titled exactly right, so the subrole check is
+/// the only thing standing between it and a keypress — mutation-tested: removing that
+/// check makes this test, and only this test, fail.
+@Test("Issue498: a modal, exactly-titled window that is not floating is not touched")
+func issue498SubroleAloneRejectsAStandardModalWindow() {
+    let fixture = makeIssue498Fixture(
+        title: "Go To Position",
+        subrole: kAXStandardWindowSubrole as String,
+        isModal: true
+    )
+
+    #expect(!AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime))
+    #expect(fixture.builder.actionCalls.isEmpty)
+}
+
+/// The same isolation for modality: floating and exactly titled, so only AXModal can
+/// reject it.
+@Test("Issue498: a floating, exactly-titled window that is not modal is not touched")
+func issue498ModalityAloneRejectsANonModalFloatingWindow() {
+    let fixture = makeIssue498Fixture(
+        title: "Go To Position",
+        subrole: kAXFloatingWindowSubrole as String,
+        isModal: false
+    )
+
+    #expect(!AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime))
+    #expect(fixture.builder.actionCalls.isEmpty)
+}
+
 @Test("Issue498: floating modal window with title suffix is not touched")
 func issue498DoesNotTouchFloatingModalTitleSuffix() {
     let fixture = makeIssue498Fixture(

--- a/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
+++ b/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
@@ -1,0 +1,69 @@
+@preconcurrency import ApplicationServices
+import Testing
+@testable import LogicProMCP
+
+private func makeIssue498Fixture(
+    title: String,
+    subrole: String,
+    isModal: Bool
+) -> (
+    builder: FakeAXRuntimeBuilder,
+    runtime: AXLogicProElements.Runtime,
+    cancel: AXUIElement
+) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(498_001)
+    let window = builder.element(498_002)
+    let cancel = builder.element(498_003)
+    let ok = builder.element(498_004)
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window])
+    builder.setAttribute(window, kAXTitleAttribute as String, title)
+    builder.setAttribute(window, kAXSubroleAttribute as String, subrole)
+    builder.setAttribute(window, kAXModalAttribute as String, isModal)
+    builder.setAttribute(cancel, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(cancel, kAXTitleAttribute as String, "Cancel")
+    builder.setAttribute(ok, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(ok, kAXTitleAttribute as String, "OK")
+    builder.setChildren(window, [cancel, ok])
+
+    return (builder, builder.makeLogicRuntime(appElement: app), cancel)
+}
+
+@Test("Issue498: exact floating modal Go To Position dialog is dismissed")
+func issue498DismissesExactFloatingModalDialog() {
+    let fixture = makeIssue498Fixture(
+        title: "Go To Position",
+        subrole: kAXFloatingWindowSubrole as String,
+        isModal: true
+    )
+
+    #expect(AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime))
+    #expect(fixture.builder.actionCalls.count == 1)
+    #expect(fixture.builder.actionCalls.first?.elementID == fixture.builder.elementID(fixture.cancel))
+    #expect(fixture.builder.actionCalls.first?.action == kAXPressAction as String)
+}
+
+@Test("Issue498: standard non-modal project window is not touched")
+func issue498DoesNotTouchStandardNonModalProjectWindow() {
+    let fixture = makeIssue498Fixture(
+        title: "My Go To Position Project - Tracks",
+        subrole: kAXStandardWindowSubrole as String,
+        isModal: false
+    )
+
+    #expect(!AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime))
+    #expect(fixture.builder.actionCalls.isEmpty)
+}
+
+@Test("Issue498: floating modal window with title suffix is not touched")
+func issue498DoesNotTouchFloatingModalTitleSuffix() {
+    let fixture = makeIssue498Fixture(
+        title: "Go To Position Extra",
+        subrole: kAXFloatingWindowSubrole as String,
+        isModal: true
+    )
+
+    #expect(!AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime))
+    #expect(fixture.builder.actionCalls.isEmpty)
+}


### PR DESCRIPTION
The stale-dialog cleanup matched **any window whose title contained** the label, with no role or modality check, then pressed Cancel / the close button / Escape on it. A project named so that the arrange window's title contains the label would have had Escape sent to the arrange window.

## Measured, live

Opened through Logic's own `Navigate ▸ Go To ▸ Position…` and enumerated every window:

| window | `AXSubrole` | `AXModal` | title |
| --- | --- | --- | --- |
| the dialog | **`AXFloatingWindow`** | **`true`** | **`Go To Position`** |
| Marker List | `AXStandardWindow` | `false` | `Untitled 55 - Marker List` |
| Tracks | `AXStandardWindow` | `false` | `Untitled 55 - Tracks` |

Two things that would have broken a naive fix:

- The subrole is **not** `AXDialog`. I had previously written that the fix should "require a dialog role"; a classifier built to that wording would never match the real dialog and would silently stop dismissing it.
- The real title is `Go To Position` with a **capital T**, while the audited label spelled it `Go to Position`. That worked only because the comparison was case-insensitive — moving to exact matching without correcting the label would have broken it. The label is corrected here.

## Change

All three must hold: `AXSubrole == AXFloatingWindow`, `AXModal == true`, and an **exact** (not containment) title match.

## Controls

The three original tests all passed with the subrole check removed — their rejection fixture was wrong on subrole, modality *and* title at once, so any one guard catching it made the test green. Two fixtures were added that isolate a single guard each: a modal, exactly-titled window that is not floating, and a floating, exactly-titled window that is not modal.

With those in place, neutralising **each** of the three guards fails three tests. Before them, neutralising the subrole check failed none.

Closes #498