### PR TITLE
ci(#505): cache SwiftPM and build products

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Cache SwiftPM and build products
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-macos15-xcode164-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            spm-macos15-xcode164-
+
       - name: Select Xcode
         # Xcode 16.4 ships Swift 6.2 — required by swift-sdk 0.11.0+ which
         # adopts the short-form `withThrowingTaskGroup { ... }` syntax. The


### PR DESCRIPTION
Build takes 281s of every run and nothing was cached, so every run recompiled the package and the whole test target from scratch.

Keyed on `Package.swift`, `Package.resolved` and the Xcode pin, so a dependency bump or toolchain change misses rather than restoring a stale tree. The action is pinned by SHA, as every other action in this repository is.

This is the cache half of #505 on its own. The other half — moving coverage off pull requests — was rejected by GitHub at workflow-parse time in #506 (zero jobs, no annotation), so it is isolated here to find which element it objects to.

Part of #505