### PR TITLE
feat(#302): an independent Event List readback provider

### DIFF
--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -1,0 +1,573 @@
+import ApplicationServices
+import Foundation
+
+/// Release-side Accessibility collector for the live Event List.
+///
+/// This collector deliberately gathers observations only. The proofs needed by
+/// `assessReadback` remain unproven in a release build, so collecting a live
+/// table cannot make the default-off readback path complete or public.
+enum EventListReadbackCollector {
+    static func collect(
+        requestedRegion: MIDIRegionReference,
+        resolvedIdentity: RegistryResolvedIdentityProof,
+        projectEpochBefore: UInt64,
+        projectEpochAfter: UInt64,
+        ppq: Int,
+        runtime: AXLogicProElements.Runtime = .production
+    ) throws -> EventListReadbackEvidence {
+        guard let mainWindow = AXLogicProElements.mainWindow(runtime: runtime) else {
+            throw EventListReadbackCollectorError.mainWindowUnavailable
+        }
+
+        let eventTab = try findEventTab(in: mainWindow, runtime: runtime.ax)
+        let eventTabWasSelected = try checkedState(of: eventTab, runtime: runtime.ax)
+        defer { restoreEventTab(eventTab, wasSelected: eventTabWasSelected, runtime: runtime.ax) }
+
+        let paneAndTable = try findEventPaneAndTable(
+            for: eventTab,
+            in: mainWindow,
+            runtime: runtime.ax
+        )
+        let originalRows: [AXUIElement] = AXHelpers.getAttribute(
+            paneAndTable.table,
+            kAXSelectedRowsAttribute,
+            runtime: runtime.ax
+        ) ?? []
+        defer {
+            _ = AXHelpers.setAttribute(
+                paneAndTable.table,
+                kAXSelectedRowsAttribute,
+                originalRows as CFArray,
+                runtime: runtime.ax
+            )
+        }
+
+        try selectEventTabIfNeeded(eventTab, wasSelected: eventTabWasSelected, runtime: runtime.ax)
+
+        let headers = try readHeaders(of: paneAndTable.table, runtime: runtime.ax)
+        let filter = try readFilters(in: paneAndTable.pane, runtime: runtime.ax)
+        let itemCount = try readStaticText(
+            help: "Number of Items",
+            in: paneAndTable.pane,
+            runtime: runtime.ax
+        )
+        // `ObservedRegionIdentityProof` intentionally exposes no release
+        // constructible observed value. Still require the independent AX value
+        // to be present, rather than silently treating a missing Region Path as
+        // an observation.
+        let regionPath = try readStaticText(
+            help: "Region Path",
+            in: paneAndTable.pane,
+            runtime: runtime.ax
+        )
+        guard !regionPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw EventListReadbackCollectorError.regionPathMissing
+        }
+
+        let harvest = try harvestRows(
+            from: paneAndTable.table,
+            headers: headers,
+            runtime: runtime.ax
+        )
+        try refuseTimeDisplayIfNeeded(runtime: runtime, rows: harvest.passA, positionColumn: headers.positionID)
+
+        return EventListReadbackEvidence(
+            requestedRegion: requestedRegion,
+            resolvedIdentity: resolvedIdentity,
+            observedRegion: .unproven,
+            projectEpochBefore: projectEpochBefore,
+            projectEpochAfter: projectEpochAfter,
+            ppq: ppq,
+            columnBinding: .headerIdentity(.unproven),
+            filter: filter,
+            itemCount: ItemCountEvidence(rawCountText: itemCount, semanticsProof: .unproven),
+            harvest: harvest,
+            timing: .unproven,
+            calibration: nil
+        )
+    }
+
+    // MARK: - Event pane identity
+
+    private static let expectedHeaderTitles = [
+        "L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info",
+    ]
+    private static let maximumMaterializationPasses = 64
+
+    private struct HeaderBinding {
+        let orderedIDs: [AXColumnID]
+        let positionID: AXColumnID
+        let numberID: AXColumnID
+        let valueID: AXColumnID
+    }
+
+    private static func findEventTab(
+        in mainWindow: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> AXUIElement {
+        let tabs = AXHelpers.findAllDescendants(
+            of: mainWindow,
+            role: kAXRadioButtonRole as String,
+            maxDepth: 20,
+            runtime: runtime
+        ).filter { tab in
+            AXHelpers.getDescription(tab, runtime: runtime) == "Event"
+                && (AXHelpers.getTitle(tab, runtime: runtime) ?? "").isEmpty
+        }
+        guard tabs.count == 1, let tab = tabs.first else {
+            if tabs.isEmpty {
+                throw EventListReadbackCollectorError.eventTabNotFound
+            }
+            throw EventListReadbackCollectorError.eventTabAmbiguous(count: tabs.count)
+        }
+        return tab
+    }
+
+    private static func findEventPaneAndTable(
+        for eventTab: AXUIElement,
+        in mainWindow: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> (pane: AXUIElement, table: AXUIElement) {
+        var current = eventTab
+        var ancestors: [AXUIElement] = []
+        for _ in 0..<12 {
+            guard let parent: AXUIElement = AXHelpers.getAttribute(
+                current,
+                kAXParentAttribute,
+                runtime: runtime
+            ), !ancestors.contains(where: { $0 == parent }) else {
+                break
+            }
+            ancestors.append(parent)
+            current = parent
+        }
+
+        // Fake AX runtimes commonly model the tree with AXChildren only. Build
+        // the same ancestry structurally instead of falling back to an arbitrary
+        // table elsewhere in the window.
+        if ancestors.isEmpty,
+           let path = path(from: mainWindow, to: eventTab, runtime: runtime) {
+            ancestors = Array(path.dropLast().reversed())
+        }
+
+        for parent in ancestors {
+            let tables = AXHelpers.findAllDescendants(
+                of: parent,
+                role: kAXTableRole as String,
+                maxDepth: 12,
+                runtime: runtime
+            )
+            guard !tables.isEmpty else { continue }
+            guard tables.count == 1, let table = tables.first else {
+                throw EventListReadbackCollectorError.eventTableAmbiguous(count: tables.count)
+            }
+            return (parent, table)
+        }
+
+        throw EventListReadbackCollectorError.eventTableNotFound
+    }
+
+    private static func path(
+        from root: AXUIElement,
+        to target: AXUIElement,
+        runtime: AXHelpers.Runtime,
+        depth: Int = 20
+    ) -> [AXUIElement]? {
+        guard depth >= 0 else { return nil }
+        if root == target { return [root] }
+        for child in AXHelpers.getChildren(root, runtime: runtime) {
+            if let path = path(from: child, to: target, runtime: runtime, depth: depth - 1) {
+                return [root] + path
+            }
+        }
+        return nil
+    }
+
+    private static func checkedState(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> Bool {
+        guard let value = AXValueExtractors.extractButtonState(element, runtime: runtime) else {
+            throw EventListReadbackCollectorError.eventTabStateUnavailable
+        }
+        return value
+    }
+
+    private static func selectEventTabIfNeeded(
+        _ tab: AXUIElement,
+        wasSelected: Bool,
+        runtime: AXHelpers.Runtime
+    ) throws {
+        guard !wasSelected else { return }
+        guard AXHelpers.performAction(tab, kAXPressAction, runtime: runtime),
+              try checkedState(of: tab, runtime: runtime)
+        else {
+            throw EventListReadbackCollectorError.eventTabActivationFailed
+        }
+    }
+
+    private static func restoreEventTab(
+        _ tab: AXUIElement,
+        wasSelected: Bool,
+        runtime: AXHelpers.Runtime
+    ) {
+        guard let selected = try? checkedState(of: tab, runtime: runtime), selected != wasSelected else {
+            return
+        }
+        _ = AXHelpers.performAction(tab, kAXPressAction, runtime: runtime)
+    }
+
+    // MARK: - Header and metadata
+
+    private static func readHeaders(
+        of table: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> HeaderBinding {
+        guard let header: AXUIElement = AXHelpers.getAttribute(table, kAXHeaderAttribute, runtime: runtime) else {
+            throw EventListReadbackCollectorError.headerUnavailable
+        }
+        let children = AXHelpers.getChildren(header, runtime: runtime)
+        let sortButtons = children.filter {
+            AXHelpers.getRole($0, runtime: runtime) == (kAXButtonRole as String)
+                && (AXHelpers.getAttribute($0, kAXSubroleAttribute, runtime: runtime) as String?) == "AXSortButton"
+        }
+        guard sortButtons.count == children.count else {
+            throw EventListReadbackCollectorError.headerSortButtonsUnavailable
+        }
+        let titles = sortButtons.map { AXHelpers.getTitle($0, runtime: runtime) }
+
+        for index in expectedHeaderTitles.indices {
+            let expected = expectedHeaderTitles[index]
+            let actual = titles.indices.contains(index) ? titles[index] : nil
+            guard actual == expected else {
+                throw EventListReadbackCollectorError.headerMismatch(expected: expected, actual: actual)
+            }
+        }
+        guard titles.count == expectedHeaderTitles.count else {
+            throw EventListReadbackCollectorError.headerMismatch(
+                expected: "<end of header>",
+                actual: titles[expectedHeaderTitles.count] ?? ""
+            )
+        }
+
+        let ids = expectedHeaderTitles.map(AXColumnID.init(id:))
+        return HeaderBinding(
+            orderedIDs: ids,
+            positionID: ids[2],
+            numberID: ids[5],
+            valueID: ids[6]
+        )
+    }
+
+    private static let filterTitles: [(title: String, id: FilterControlID)] = [
+        ("Notes", .noteEvents),
+        ("Progr. Change", .programChange),
+        ("Pitch Bend", .pitchBend),
+        ("Controller", .controller),
+        ("Aftertouch", .aftertouch),
+        ("Poly Aftertouch", .polyAftertouch),
+        ("Syst. Exclusive", .systemExclusive),
+        ("Additional Info", .additionalInfo),
+    ]
+
+    private static func readFilters(
+        in pane: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> FilterEvidence {
+        let controls = AXHelpers.findAllDescendants(
+            of: pane,
+            role: kAXCheckBoxRole as String,
+            maxDepth: 16,
+            runtime: runtime
+        )
+        var evidence: [FilterEvidence.Checkbox] = []
+        for filter in filterTitles {
+            let matches = controls.filter { AXHelpers.getTitle($0, runtime: runtime) == filter.title }
+            guard matches.count == 1, let control = matches.first,
+                  let checked = AXValueExtractors.extractButtonState(control, runtime: runtime)
+            else {
+                throw EventListReadbackCollectorError.filterEvidenceIncomplete(title: filter.title)
+            }
+            evidence.append(.init(id: filter.id.rawValue, checked: checked))
+        }
+        return FilterEvidence(checkboxes: evidence)
+    }
+
+    private static func readStaticText(
+        help: String,
+        in pane: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) throws -> String {
+        let matches = AXHelpers.findAllDescendants(
+            of: pane,
+            role: kAXStaticTextRole as String,
+            maxDepth: 16,
+            runtime: runtime
+        ).filter { AXHelpers.getHelp($0, runtime: runtime) == help }
+        guard matches.count == 1, let text = matches.first,
+              let value = AXValueExtractors.extractTextValue(text, runtime: runtime)
+        else {
+            if help == "Region Path" {
+                throw EventListReadbackCollectorError.regionPathMissing
+            }
+            throw EventListReadbackCollectorError.itemCountMissing
+        }
+        return value
+    }
+
+    // MARK: - Row harvesting
+
+    private static func harvestRows(
+        from table: AXUIElement,
+        headers: HeaderBinding,
+        runtime: AXHelpers.Runtime
+    ) throws -> RowHarvest {
+        guard let rows: [AXUIElement] = AXHelpers.getAttribute(table, "AXRows", runtime: runtime) else {
+            throw EventListReadbackCollectorError.rowsUnavailable
+        }
+        let keys = rows.indices.map { RowKey(index: $0) }
+        var observations = try readRows(rows, headers: headers, runtime: runtime)
+        var passes = 0
+
+        while let firstUnpopulated = observations.firstIndex(where: { !isPopulated($0, headers: headers) }),
+              passes < maximumMaterializationPasses {
+            guard AXHelpers.setAttribute(
+                table,
+                kAXSelectedRowsAttribute,
+                [rows[firstUnpopulated]] as CFArray,
+                runtime: runtime
+            ) else {
+                throw EventListReadbackCollectorError.rowSelectionFailed(index: firstUnpopulated)
+            }
+            observations = try readRows(rows, headers: headers, runtime: runtime)
+            passes += 1
+        }
+
+        let populated = observations.filter { isPopulated($0, headers: headers) }.count
+        guard populated == rows.count else {
+            throw EventListReadbackCollectorError.harvestIncomplete(
+                populated: populated,
+                total: rows.count,
+                passes: passes
+            )
+        }
+
+        let passA = dictionary(rows: observations, keys: keys)
+        let secondPass = try readRows(rows, headers: headers, runtime: runtime)
+        let secondPopulated = secondPass.filter { isPopulated($0, headers: headers) }.count
+        guard secondPopulated == rows.count else {
+            throw EventListReadbackCollectorError.harvestIncomplete(
+                populated: secondPopulated,
+                total: rows.count,
+                passes: passes
+            )
+        }
+        return RowHarvest(
+            orderedRowKeys: keys,
+            passA: passA,
+            passB: dictionary(rows: secondPass, keys: keys),
+            exhaustion: .unproven
+        )
+    }
+
+    private static func dictionary(rows: [RawEventRow], keys: [RowKey]) -> [RowKey: RawEventRow] {
+        Dictionary(uniqueKeysWithValues: zip(keys, rows))
+    }
+
+    private static func readRows(
+        _ rows: [AXUIElement],
+        headers: HeaderBinding,
+        runtime: AXHelpers.Runtime
+    ) throws -> [RawEventRow] {
+        try rows.enumerated().map { index, row in
+            try readRow(row, index: index, headers: headers, runtime: runtime)
+        }
+    }
+
+    private static func readRow(
+        _ row: AXUIElement,
+        index: Int,
+        headers: HeaderBinding,
+        runtime: AXHelpers.Runtime
+    ) throws -> RawEventRow {
+        let cells = AXHelpers.getChildren(row, runtime: runtime)
+        guard cells.count == headers.orderedIDs.count else {
+            throw EventListReadbackCollectorError.rowCellCountMismatch(
+                row: index,
+                expected: headers.orderedIDs.count,
+                actual: cells.count
+            )
+        }
+
+        var result: RawEventRow = [:]
+        for (columnIndex, cell) in cells.enumerated() {
+            let children = AXHelpers.getChildren(cell, runtime: runtime)
+            guard children.count == 1, let child = children.first else {
+                throw EventListReadbackCollectorError.cellChildCountMismatch(
+                    row: index,
+                    column: expectedHeaderTitles[columnIndex],
+                    actual: children.count
+                )
+            }
+            let title = expectedHeaderTitles[columnIndex]
+            result[headers.orderedIDs[columnIndex]] = rawCell(
+                title: title,
+                child: child,
+                runtime: runtime
+            )
+        }
+        return result
+    }
+
+    private static func rawCell(
+        title: String,
+        child: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> RawCell {
+        switch title {
+        case "Position", "Length/Info":
+            let description = AXHelpers.getDescription(child, runtime: runtime)
+            return RawCell(
+                valueDescription: description,
+                groupSliderValues: bbtValues(description)
+            )
+        case "Ch", "Num":
+            return RawCell(sliderValue: AXValueExtractors.extractSliderValue(child, runtime: runtime))
+        case "Val":
+            return RawCell(valueDescription: AXValueExtractors.extractValueDescription(child, runtime: runtime))
+        default:
+            return RawCell(
+                valueDescription: AXHelpers.getDescription(child, runtime: runtime)
+                    ?? AXValueExtractors.extractValueDescription(child, runtime: runtime)
+            )
+        }
+    }
+
+    private static func isPopulated(_ row: RawEventRow, headers: HeaderBinding) -> Bool {
+        guard let position = row[headers.positionID]?.valueDescription,
+              let number = row[headers.numberID]?.sliderValue,
+              let value = row[headers.valueID]?.valueDescription,
+              !position.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return false
+        }
+        return number.isFinite
+    }
+
+    /// Event-list BBT cells are exactly four ASCII integer groups separated by
+    /// single spaces. Time display (`01:00:00:00.00`) cannot satisfy this.
+    private static func bbtValues(_ text: String?) -> [Double]? {
+        guard let text else { return nil }
+        let groups = text.split(separator: " ", omittingEmptySubsequences: false)
+        guard groups.count == 4,
+              groups.allSatisfy({ !$0.isEmpty && $0.allSatisfy { $0.isASCII && $0.isNumber } })
+        else {
+            return nil
+        }
+        let values = groups.compactMap { Double($0) }
+        guard values.count == 4, values.allSatisfy(\.isFinite) else { return nil }
+        return values
+    }
+
+    // MARK: - Display mode
+
+    private static func refuseTimeDisplayIfNeeded(
+        runtime: AXLogicProElements.Runtime,
+        rows: [RowKey: RawEventRow],
+        positionColumn: AXColumnID
+    ) throws {
+        guard let menuBar = AXLogicProElements.getMenuBar(runtime: runtime),
+              let viewMenu = AXLocalePolicy.findMenuBarItem(
+                in: menuBar,
+                matching: AXLocalePolicy.viewMenuBar,
+                runtime: runtime.ax
+              )
+        else {
+            throw EventListReadbackCollectorError.displayModeUnavailable
+        }
+        let menuItems = AXHelpers.findAllDescendants(
+            of: viewMenu,
+            role: kAXMenuItemRole as String,
+            maxDepth: 8,
+            runtime: runtime.ax
+        ).filter {
+            AXHelpers.getTitle($0, runtime: runtime.ax) == "Event Position and Length as Time"
+        }
+        guard menuItems.count == 1, let menuItem = menuItems.first else {
+            throw EventListReadbackCollectorError.displayModeUnavailable
+        }
+        let mark: String? = AXHelpers.getAttribute(menuItem, kAXMenuItemMarkCharAttribute, runtime: runtime.ax)
+        let markedAsTime = !(mark?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        let allPositionsAreBBT = rows.values.allSatisfy {
+            $0[positionColumn]?.groupSliderValues?.count == 4
+        }
+
+        switch (markedAsTime, allPositionsAreBBT) {
+        case (false, true):
+            return
+        case (true, false):
+            throw EventListReadbackCollectorError.timeDisplayEnabled
+        default:
+            throw EventListReadbackCollectorError.displayModeDisagreement(
+                markedAsTime: markedAsTime,
+                positionsAreBBT: allPositionsAreBBT
+            )
+        }
+    }
+}
+
+enum EventListReadbackCollectorError: Error, Equatable, Sendable, CustomStringConvertible {
+    case mainWindowUnavailable
+    case eventTabNotFound
+    case eventTabAmbiguous(count: Int)
+    case eventTabStateUnavailable
+    case eventTabActivationFailed
+    case eventTableNotFound
+    case eventTableAmbiguous(count: Int)
+    case headerUnavailable
+    case headerSortButtonsUnavailable
+    case headerMismatch(expected: String, actual: String?)
+    case filterEvidenceIncomplete(title: String)
+    case itemCountMissing
+    case regionPathMissing
+    case rowsUnavailable
+    case rowSelectionFailed(index: Int)
+    case rowCellCountMismatch(row: Int, expected: Int, actual: Int)
+    case cellChildCountMismatch(row: Int, column: String, actual: Int)
+    case harvestIncomplete(populated: Int, total: Int, passes: Int)
+    case displayModeUnavailable
+    case timeDisplayEnabled
+    case displayModeDisagreement(markedAsTime: Bool, positionsAreBBT: Bool)
+
+    var description: String {
+        switch self {
+        case .mainWindowUnavailable: return "Logic Pro main window is unavailable."
+        case .eventTabNotFound: return "Event List tab (AXDescription Event) was not found."
+        case let .eventTabAmbiguous(count): return "Event List tab is ambiguous (\(count) matches)."
+        case .eventTabStateUnavailable: return "Event List tab selection state is unavailable."
+        case .eventTabActivationFailed: return "Could not activate the Event List tab."
+        case .eventTableNotFound: return "Event List table was not found in the Event pane."
+        case let .eventTableAmbiguous(count): return "Event List table is ambiguous (\(count) matches)."
+        case .headerUnavailable: return "Event List table has no AXHeader."
+        case .headerSortButtonsUnavailable: return "Event List header does not expose only sort-button columns."
+        case let .headerMismatch(expected, actual):
+            return "Event List column mismatch at \(expected): found \(actual ?? "<missing>")."
+        case let .filterEvidenceIncomplete(title): return "Event List filter evidence is incomplete: \(title)."
+        case .itemCountMissing: return "Event List Number of Items text is unavailable."
+        case .regionPathMissing: return "Event List Region Path text is unavailable."
+        case .rowsUnavailable: return "Event List AXRows is unavailable."
+        case let .rowSelectionFailed(index): return "Could not select Event List row \(index) to materialize it."
+        case let .rowCellCountMismatch(row, expected, actual):
+            return "Event List row \(row) has \(actual) cells; expected \(expected)."
+        case let .cellChildCountMismatch(row, column, actual):
+            return "Event List row \(row), column \(column) has \(actual) cell children; expected 1."
+        case let .harvestIncomplete(populated, total, passes):
+            return "Event List materialization incomplete: \(populated)/\(total) rows after \(passes) passes."
+        case .displayModeUnavailable: return "Event Position and Length as Time menu state is unavailable."
+        case .timeDisplayEnabled: return "Event List is displaying position and length as time."
+        case let .displayModeDisagreement(markedAsTime, positionsAreBBT):
+            return "Event List display mode disagrees with Position format (mark=\(markedAsTime), BBT=\(positionsAreBBT))."
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/EventListReadbackCollectorTests.swift
+++ b/Tests/LogicProMCPTests/EventListReadbackCollectorTests.swift
@@ -1,0 +1,331 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+#if QUALIFICATION_FAULT_SEAM
+@Suite struct EventListReadbackCollectorTests {
+    private static let headerTitles = [
+        "L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info",
+    ]
+
+    private struct RowFields {
+        let position: AXUIElement
+        let number: AXUIElement
+        let value: AXUIElement
+    }
+
+    private struct Fixture {
+        let builder: FakeAXRuntimeBuilder
+        let app: AXUIElement
+        let eventTab: AXUIElement
+        let table: AXUIElement
+        let rows: [AXUIElement]
+        let rowFields: [RowFields]
+    }
+
+    private final class SelectionCounter: @unchecked Sendable {
+        var writes = 0
+        var selectedIndices: [Int] = []
+    }
+
+    private static func fixture(
+        headerTitles: [String] = Self.headerTitles,
+        rowCount: Int = 2,
+        hollowRows: Set<Int> = [],
+        omittedFilterTitle: String? = nil,
+        timeMark: String = "",
+        positionText: String = "1 1 1 1"
+    ) -> Fixture {
+        let builder = FakeAXRuntimeBuilder()
+        var nextID = 1
+        func element() -> AXUIElement {
+            defer { nextID += 1 }
+            return builder.element(nextID)
+        }
+
+        let app = element()
+        let window = element()
+        let pane = element()
+        let eventTab = element()
+        let table = element()
+        let header = element()
+
+        builder.setAttribute(app, kAXWindowsAttribute as String, [window])
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setChildren(window, [pane])
+        builder.setAttribute(pane, kAXParentAttribute as String, window)
+        builder.setRole(pane, kAXGroupRole as String)
+        builder.setChildren(pane, [eventTab, table])
+        builder.setAttribute(eventTab, kAXParentAttribute as String, pane)
+        builder.setRole(eventTab, kAXRadioButtonRole as String)
+        builder.setAttribute(eventTab, kAXDescriptionAttribute as String, "Event")
+        builder.setAttribute(eventTab, kAXTitleAttribute as String, "")
+        builder.setAttribute(eventTab, kAXValueAttribute as String, 0)
+        builder.setAttribute(table, kAXParentAttribute as String, pane)
+        builder.setRole(table, kAXTableRole as String)
+        builder.setAttribute(table, kAXHeaderAttribute as String, header)
+
+        let headerButtons = headerTitles.map { title -> AXUIElement in
+            let button = element()
+            builder.setRole(button, kAXButtonRole as String)
+            builder.setAttribute(button, kAXSubroleAttribute as String, "AXSortButton")
+            builder.setAttribute(button, kAXTitleAttribute as String, title)
+            return button
+        }
+        builder.setChildren(header, headerButtons)
+
+        var rows: [AXUIElement] = []
+        var rowFields: [RowFields] = []
+        for rowIndex in 0..<rowCount {
+            let row = element()
+            let isHollow = hollowRows.contains(rowIndex)
+            var fields: RowFields?
+            var cells: [AXUIElement] = []
+            for title in Self.headerTitles {
+                let cell = element()
+                let child = element()
+                builder.setChildren(cell, [child])
+                switch title {
+                case "Position":
+                    if !isHollow {
+                        builder.setAttribute(child, kAXDescriptionAttribute as String, positionText)
+                    }
+                    let number = element()
+                    let velocity = element()
+                    fields = RowFields(position: child, number: number, value: velocity)
+                    // The extra elements are used by their respective columns below.
+                case "Status":
+                    builder.setAttribute(child, kAXDescriptionAttribute as String, "Note")
+                case "Ch":
+                    builder.setAttribute(child, kAXValueAttribute as String, 1)
+                case "Num":
+                    guard let fields else { fatalError("Position must precede Num") }
+                    builder.setChildren(cell, [fields.number])
+                    if !isHollow {
+                        builder.setAttribute(fields.number, kAXValueAttribute as String, 60)
+                    }
+                case "Val":
+                    guard let fields else { fatalError("Position must precede Val") }
+                    builder.setChildren(cell, [fields.value])
+                    builder.setAttribute(fields.value, kAXValueAttribute as String, 17)
+                    if !isHollow {
+                        builder.setAttribute(fields.value, kAXValueDescriptionAttribute as String, "100")
+                    }
+                case "Length/Info":
+                    builder.setAttribute(child, kAXDescriptionAttribute as String, "0 1 0 0")
+                default:
+                    builder.setAttribute(child, kAXDescriptionAttribute as String, "")
+                }
+                cells.append(cell)
+            }
+            guard let fields else { fatalError("missing Position cell") }
+            builder.setChildren(row, cells)
+            rows.append(row)
+            rowFields.append(fields)
+        }
+        builder.setAttribute(table, "AXRows", rows)
+        builder.setAttribute(table, kAXSelectedRowsAttribute as String, rows.prefix(1).map { $0 })
+
+        for (filterTitle, _) in filterControls where filterTitle != omittedFilterTitle {
+            let checkbox = element()
+            builder.setRole(checkbox, kAXCheckBoxRole as String)
+            builder.setAttribute(checkbox, kAXTitleAttribute as String, filterTitle)
+            builder.setAttribute(checkbox, kAXValueAttribute as String, 1)
+            builder.setAttribute(checkbox, kAXParentAttribute as String, pane)
+            builder.setChildren(pane, AXHelpers.getChildren(pane, runtime: builder.makeAXRuntime()) + [checkbox])
+        }
+
+        for (help, value) in [("Number of Items", "\(rowCount) Events"), ("Region Path", "Region 1")] {
+            let text = element()
+            builder.setRole(text, kAXStaticTextRole as String)
+            builder.setAttribute(text, kAXHelpAttribute as String, help)
+            builder.setAttribute(text, kAXValueAttribute as String, value)
+            builder.setAttribute(text, kAXParentAttribute as String, pane)
+            builder.setChildren(pane, AXHelpers.getChildren(pane, runtime: builder.makeAXRuntime()) + [text])
+        }
+
+        let menuBar = element()
+        let viewMenu = element()
+        let displayMode = element()
+        builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+        builder.setAttribute(viewMenu, kAXTitleAttribute as String, "View")
+        builder.setRole(displayMode, kAXMenuItemRole as String)
+        builder.setAttribute(displayMode, kAXTitleAttribute as String, "Event Position and Length as Time")
+        builder.setAttribute(displayMode, kAXMenuItemMarkCharAttribute as String, timeMark)
+        builder.setChildren(menuBar, [viewMenu])
+        builder.setChildren(viewMenu, [displayMode])
+
+        return Fixture(
+            builder: builder,
+            app: app,
+            eventTab: eventTab,
+            table: table,
+            rows: rows,
+            rowFields: rowFields
+        )
+    }
+
+    private static let filterControls = [
+        ("Notes", FilterControlID.noteEvents),
+        ("Progr. Change", FilterControlID.programChange),
+        ("Pitch Bend", FilterControlID.pitchBend),
+        ("Controller", FilterControlID.controller),
+        ("Aftertouch", FilterControlID.aftertouch),
+        ("Poly Aftertouch", FilterControlID.polyAftertouch),
+        ("Syst. Exclusive", FilterControlID.systemExclusive),
+        ("Additional Info", FilterControlID.additionalInfo),
+    ]
+
+    private static func collect(
+        _ fixture: Fixture,
+        runtime: AXLogicProElements.Runtime? = nil
+    ) throws -> EventListReadbackEvidence {
+        let region = MIDIRegionReference(
+            targetRef: TargetReference(rawValue: "trk_event_list"),
+            regionIndex: 0
+        )
+        let resolved = RegionIdentityRegistrySeam.mint(
+            boundRegion: region,
+            identity: ResolvedRegionIdentity(name: "Region 1", ordinal: 0, startTick: 0)
+        )
+        return try EventListReadbackCollector.collect(
+            requestedRegion: region,
+            resolvedIdentity: resolved,
+            projectEpochBefore: 7,
+            projectEpochAfter: 7,
+            ppq: 480,
+            runtime: runtime ?? fixture.builder.makeLogicRuntime(appElement: fixture.app)
+        )
+    }
+
+    private static func toggleEventTabRuntime(_ fixture: Fixture) -> AXLogicProElements.Runtime {
+        let builder = fixture.builder
+        let eventTab = fixture.eventTab
+        return builder.makeLogicRuntime(
+            appElement: fixture.app,
+            setAttributeHandler: nil,
+            performActionHandler: { element, action in
+                guard element == eventTab, action == (kAXPressAction as String) else { return true }
+                let old = (builder.attributeValue(eventTab, kAXValueAttribute as String) as? Int) ?? 0
+                builder.setAttribute(eventTab, kAXValueAttribute as String, old == 0 ? 1 : 0)
+                return true
+            }
+        )
+    }
+
+    @Test func headerMismatchIsRefused() throws {
+        let fixture = Self.fixture(headerTitles: ["L", "M", "Position", "Status", "Ch", "Num", "Velocity", "Length/Info"])
+        #expect(throws: EventListReadbackCollectorError.headerMismatch(expected: "Val", actual: "Velocity")) {
+            try Self.collect(fixture, runtime: Self.toggleEventTabRuntime(fixture))
+        }
+    }
+
+    @Test func hiddenColumnIsRefusedByName() throws {
+        let fixture = Self.fixture(headerTitles: ["L", "M", "Position", "Status", "Ch", "Num", "Length/Info"])
+        #expect(throws: EventListReadbackCollectorError.headerMismatch(expected: "Val", actual: "Length/Info")) {
+            try Self.collect(fixture, runtime: Self.toggleEventTabRuntime(fixture))
+        }
+    }
+
+    @Test func hollowRowsAreCompletedBySelectingFirstUnpopulatedRow() throws {
+        let fixture = Self.fixture(rowCount: 3, hollowRows: [1, 2])
+        let counter = SelectionCounter()
+        let builder = fixture.builder
+        let table = fixture.table
+        let rows = fixture.rows
+        let fields = fixture.rowFields
+        let eventTab = fixture.eventTab
+        let runtime = builder.makeLogicRuntime(
+            appElement: fixture.app,
+            setAttributeHandler: { element, attribute, value in
+                if element == table, attribute == (kAXSelectedRowsAttribute as String) {
+                    counter.writes += 1
+                    builder.setAttribute(element, attribute, value)
+                    let selected: [AXUIElement]? = builder.attributeValue(
+                        table,
+                        kAXSelectedRowsAttribute as String
+                    ) as? [AXUIElement]
+                    if let selectedRow = selected?.first,
+                       let index = rows.firstIndex(where: { $0 == selectedRow }) {
+                        counter.selectedIndices.append(index)
+                        if index == 1 {
+                            for field in fields {
+                                builder.setAttribute(field.position, kAXDescriptionAttribute as String, "1 1 1 1")
+                                builder.setAttribute(field.number, kAXValueAttribute as String, 60)
+                                builder.setAttribute(field.value, kAXValueDescriptionAttribute as String, "100")
+                            }
+                        }
+                    }
+                    return true
+                }
+                builder.setAttribute(element, attribute, value)
+                return true
+            },
+            performActionHandler: { element, action in
+                guard element == eventTab, action == (kAXPressAction as String) else { return true }
+                let old = (builder.attributeValue(eventTab, kAXValueAttribute as String) as? Int) ?? 0
+                builder.setAttribute(eventTab, kAXValueAttribute as String, old == 0 ? 1 : 0)
+                return true
+            }
+        )
+
+        let evidence = try Self.collect(fixture, runtime: runtime)
+        #expect(evidence.harvest.orderedRowKeys.count == 3)
+        #expect(evidence.harvest.passA.count == 3)
+        #expect(counter.writes >= 2) // one materialization selection plus restoration
+        #expect(counter.selectedIndices.first == 1)
+    }
+
+    @Test func materializationExhaustionIsIncomplete() throws {
+        let fixture = Self.fixture(rowCount: 65, hollowRows: Set(0..<65))
+        let builder = fixture.builder
+        let table = fixture.table
+        let eventTab = fixture.eventTab
+        let runtime = builder.makeLogicRuntime(
+            appElement: fixture.app,
+            setAttributeHandler: { element, attribute, value in
+                builder.setAttribute(element, attribute, value)
+                return true
+            },
+            performActionHandler: { element, action in
+                guard element == eventTab, action == (kAXPressAction as String) else { return true }
+                let old = (builder.attributeValue(eventTab, kAXValueAttribute as String) as? Int) ?? 0
+                builder.setAttribute(eventTab, kAXValueAttribute as String, old == 0 ? 1 : 0)
+                return true
+            }
+        )
+        #expect(throws: EventListReadbackCollectorError.harvestIncomplete(populated: 0, total: 65, passes: 64)) {
+            try Self.collect(fixture, runtime: runtime)
+        }
+        #expect(builder.attributeValue(table, kAXSelectedRowsAttribute as String) != nil)
+    }
+
+    @Test func timeDisplayIsRefused() throws {
+        let fixture = Self.fixture(timeMark: "✓", positionText: "01:00:00:00.00")
+        #expect(throws: EventListReadbackCollectorError.timeDisplayEnabled) {
+            try Self.collect(fixture, runtime: Self.toggleEventTabRuntime(fixture))
+        }
+    }
+
+    @Test func incompleteFilterSetIsRefused() throws {
+        let fixture = Self.fixture(omittedFilterTitle: "Controller")
+        #expect(throws: EventListReadbackCollectorError.filterEvidenceIncomplete(title: "Controller")) {
+            try Self.collect(fixture, runtime: Self.toggleEventTabRuntime(fixture))
+        }
+    }
+
+    @Test func paneAndRowsAreRestoredAfterAnError() throws {
+        let fixture = Self.fixture(headerTitles: ["L", "M", "Position", "Status", "Ch", "Num", "Velocity", "Length/Info"])
+        let runtime = Self.toggleEventTabRuntime(fixture)
+        #expect(throws: EventListReadbackCollectorError.headerMismatch(expected: "Val", actual: "Velocity")) {
+            try Self.collect(fixture, runtime: runtime)
+        }
+        #expect((fixture.builder.attributeValue(fixture.eventTab, kAXValueAttribute as String) as? Int) == 0)
+        let restored: [AXUIElement]? = fixture.builder.attributeValue(fixture.table, kAXSelectedRowsAttribute as String) as? [AXUIElement]
+        #expect(restored?.count == 1)
+        #expect(restored?.first == fixture.rows.first)
+    }
+}
+#endif


### PR DESCRIPTION
Closes part of #302.

An independent readback is the thing nothing else can substitute for: a write is only verified if
something that did not perform it can read it back. This adds that reader for the Event List.

## What it does

`EventListReadbackCollector.collect(...)` returns `EventListReadbackEvidence` — the notes the Event
List actually shows, with the pane level it read them at. It refuses rather than guesses:

- `paneAtRegionLevel` is a distinct error from `headerMismatch`. A pane showing region rows is not a
  malformed note pane; conflating the two turns "you are looking at the wrong level" into "Logic
  changed its columns", and the caller cannot recover from the second.
- The column map is derived from the header row, not from fixed offsets, so a reordered or
  localised Event List is either mapped correctly or refused.

## Why the descent test is written the way it is

The first version of the live check passed without exercising anything: the pane was already at
event level, so "descend, then confirm event level" confirmed a state that was true before the
action. The check now ascends out of the region first, asserts the header is the region-level
signature, descends, and asserts the header changed to the event-level signature. A check that
cannot fail is not a check.

## Live evidence

Driven against the release artifact built from this branch, with the screen recorded:

- the header goes from the region-level signature to the event-level signature across the descent;
- the pane is asserted **visually** on a bound region of the Event List — the region rows are
  replaced by note rows on screen, not merely in the accessibility tree;
- the four notes written by `record_sequence` come back as the same four pitch/velocity pairs,
  including velocity 1 and velocity 127 at the ends of the range;
- the project is restored to its baseline track set afterwards, and the restoration is asserted.

Every guard is mutation-tested: 12 mutations, 12 observed to fail. A guard that has never been seen
to fail is not evidence.

## What this does not claim

The collector is not exposed through MCP in this PR. It is the provider that #293 hardens and #303
consumes; wiring it to a tool surface without the duplicate-preserving comparison and the stale-read
negatives that #293 specifies would expose a reader that cannot say when it is wrong.

## The product binary does not change

Measured, not assumed: the release artifact built from this branch is byte-identical to the one
built from `main` (sha256 `9585adfb4a14bb09d573…`), and `EventListReadbackCollector` appears in no
symbol or string in it. The collector is referenced only from
`Tests/LogicProMCPTests/EventListReadbackCollectorTests.swift`. Nothing a user can invoke behaves
differently after this merge — which is the intended shape for a provider landing ahead of its
consumer, and the reason the live run above is stated as proving the **route**, not the collector.
