### PR TITLE
ci(#505): run the release build and the coverage suite at the same time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
           path: |
             .build
             ~/Library/Caches/org.swift.swiftpm
-          key: spm-macos15-xcode164-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: spm-macos15-xcode164-release-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            spm-macos15-xcode164-
+            spm-macos15-xcode164-release-
 
       - name: Select Xcode
         # Xcode 16.4 ships Swift 6.2 — required by swift-sdk 0.11.0+ which
@@ -49,6 +49,34 @@ jobs:
 
       - name: Verify Package.resolved is unchanged
         run: git diff --exit-code Package.resolved
+
+
+  test:
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Forbid dead boolean #expect (#393 test-integrity)
+        # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
+        # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
+        run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Cache SwiftPM and build products
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-macos15-xcode164-debug-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            spm-macos15-xcode164-debug-
+
+      - name: Select Xcode
+        # Xcode 16.4 ships Swift 6.2 — required by swift-sdk 0.11.0+ which
+        # adopts the short-form `withThrowingTaskGroup { ... }` syntax. The
+        # previous 16.2 pin (Swift 6.0) cannot compile that form.
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Coverage report
         # H-4 (2026-05-08 enterprise review) closed in v3.4.0: re-armed


### PR DESCRIPTION
Closes the remaining half of #505. The cache half shipped in #509.

## What was slow

CI was a single job running two things one after the other:

| step | time |
| --- | --- |
| `swift build -c release` | 281s |
| whole suite under coverage instrumentation | 1114s |
| everything else | 5s |

They share no build products — one is release, the other debug — so the coverage run was queued
behind a build it could not use. This splits them into `build` and `test`, which run at the same
time, so a verdict arrives in the time of the slower one rather than their sum.

The single cache key was wrong for the same reason: both configurations write `.build`, so whichever
job saved last clobbered the other's products and neither got a warm cache on the next run. Each job
now keys on its own configuration.

## A measurement I am not acting on

Dropping `--no-parallel` runs the suite in **90s instead of 403s** — 4.5x — and it is **red**. Four
suites reach process-global state (the verified-op gate, the trace registry, the command-deadline
timing) and interfere across suite boundaries. `@Suite(.serialized)` does not help: it orders tests
within one suite, and the collisions are between suites.

So the flag is load-bearing and stays. The 4.5x is real and is available behind decoupling that
state, which is a separate piece of work rather than a flag deletion. Recording it here so it is not
rediscovered as a surprise.

## The required check must move with the job

The `release-qualification-trust-boundary` ruleset requires exactly one context: `build`. After this
split, `build` no longer runs the suite or the coverage gate — so if the ruleset is left alone, the
coverage gate silently stops blocking anything. `test` is added to the ruleset's required contexts
together with this merge; the split is not complete without it.
