### PR TITLE
ci(#505): make the required context cover every gate again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  compile:
     runs-on: macos-15
     timeout-minutes: 60
     steps:
@@ -201,3 +201,19 @@ jobs:
             exit 1
           fi
           echo "Coverage gate passed: region $REGION_PCT% / line $LINE_PCT%."
+
+  # The branch ruleset requires the context `build` and nothing else. This job IS that context: it
+  # does no work and exists so that one required name transitively requires every real gate. It must
+  # run with `if: always()` and inspect results explicitly — a job skipped because a dependency
+  # failed reports as skipped, and GitHub does not treat a skipped required check as a failure.
+  build:
+    runs-on: ubuntu-latest
+    needs: [compile, test]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Every gate must have passed
+        run: |
+          echo "compile=${{ needs.compile.result }} test=${{ needs.test.result }}"
+          [ "${{ needs.compile.result }}" = "success" ] || { echo "::error::compile did not succeed"; exit 1; }
+          [ "${{ needs.test.result }}" = "success" ] || { echo "::error::test did not succeed"; exit 1; }


### PR DESCRIPTION
Closes #505.

## The split quietly weakened the gate

The branch ruleset requires exactly one status context: `build`. Before #511 that name covered the
release build **and** the suite **and** the coverage gate, because they were one job. After #511 it
covers only the release build — so from the moment #511 merged until this lands, a red suite or a
coverage regression does not block a merge. #511 traded CI time for a weaker gate without saying so;
this is the other half of that change.

## The fix

The real work is renamed to `compile` and `test` and still runs concurrently. `build` becomes an
aggregator that does no work and exists so the one required name transitively requires both.

The aggregator carries `if: always()` and inspects each dependency's result explicitly. That is not
decoration: a job skipped because a dependency failed reports as **skipped**, and GitHub does not
treat a skipped required check as a failure. A naive `needs: [compile, test]` aggregator therefore
passes the ruleset precisely when something has gone wrong.

## Proof that it can fail

A gate that has only ever been observed passing is not a gate. PR #513 is the same workflow with a
deliberate compile error, opened only to show `build` reporting **failure** rather than skipping. It
is closed without merging once observed; its result is quoted here.
