### PR TITLE
DO NOT MERGE — proof that the required aggregator fails closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  compile:
     runs-on: macos-15
     timeout-minutes: 60
     steps:
@@ -201,3 +201,19 @@ jobs:
             exit 1
           fi
           echo "Coverage gate passed: region $REGION_PCT% / line $LINE_PCT%."
+
+  # The branch ruleset requires the context `build` and nothing else. This job IS that context: it
+  # does no work and exists so that one required name transitively requires every real gate. It must
+  # run with `if: always()` and inspect results explicitly — a job skipped because a dependency
+  # failed reports as skipped, and GitHub does not treat a skipped required check as a failure.
+  build:
+    runs-on: ubuntu-latest
+    needs: [compile, test]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Every gate must have passed
+        run: |
+          echo "compile=${{ needs.compile.result }} test=${{ needs.test.result }}"
+          [ "${{ needs.compile.result }}" = "success" ] || { echo "::error::compile did not succeed"; exit 1; }
+          [ "${{ needs.test.result }}" = "success" ] || { echo "::error::test did not succeed"; exit 1; }

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -131,3 +131,4 @@ enum FeatureFlags: Sendable {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR018_HOST_PARAMS"] == "1"
     }
 }
+let thisDoesNotCompile: Int = "x"


### PR DESCRIPTION
Temporary. A deliberate compile error, opened only to observe whether the `build` aggregator reports **failure** or silently reports **skipped** when a dependency fails. Closed once the result is recorded on #512. Nothing here is intended for main.