### PR TITLE
fix(#289): a refresh that finished late must not overwrite newer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+- `logic://` resource envelopes served under `LOGIC_MCP_ADR006_VERSIONED_CACHE=1` now carry
+  `dropped_stale_writes` beside `section_revision`: the number of refreshes whose value was refused
+  for that section because it finished after the section had already moved on (#289). The field is
+  always present and starts at zero, so a client can tell "the guard never had to fire" apart from
+  "this build does not report it".
+
 ### Changed — three operations lose their fallback channels
 
 Each of these narrows an operation to a single channel. In an environment where that

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+CacheEnvelope.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+CacheEnvelope.swift
@@ -68,11 +68,18 @@ extension ResourceHandlers {
     static func versionedCacheExtras(
         projectEpoch: UInt64,
         sectionRevision: UInt64,
+        droppedStaleWrites: UInt64 = 0,
         bodyJSON: String
     ) -> [String: Any] {
         [
             "project_epoch": projectEpoch,
             "section_revision": sectionRevision,
+            // How many times a refresh finished so late that its value was refused for this section
+            // (#289). A guard whose only evidence is the absence of a symptom cannot be checked: the
+            // symptom is transient and rare, so "we saw no corruption" is equally consistent with the
+            // guard working and with it never running. Counting refusals turns that into something a
+            // client — or a live test — can observe directly at the boundary where it matters.
+            "dropped_stale_writes": droppedStaleWrites,
             "etag": etag(of: bodyJSON),
         ]
     }

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -33,6 +33,7 @@ extension ResourceHandlers {
             extras.merge(versionedCacheExtras(
                 projectEpoch: await targetRegistry?.currentProjectEpoch ?? 0,
                 sectionRevision: await cache.sectionRevision(.transport),
+                droppedStaleWrites: await cache.droppedStaleWriteCount(for: .transport),
                 bodyJSON: body
             )) { _, new in new }
         }
@@ -232,6 +233,7 @@ extension ResourceHandlers {
             extras.merge(versionedCacheExtras(
                 projectEpoch: await targetRegistry?.currentProjectEpoch ?? 0,
                 sectionRevision: await cache.sectionRevision(.tracks),
+                droppedStaleWrites: await cache.droppedStaleWriteCount(for: .tracks),
                 bodyJSON: body
             )) { _, new in new }
         }
@@ -366,6 +368,7 @@ extension ResourceHandlers {
             versionedFragment = encodeExtrasFragment(versionedCacheExtras(
                 projectEpoch: await targetRegistry?.currentProjectEpoch ?? 0,
                 sectionRevision: await cache.sectionRevision(.mixer),
+                droppedStaleWrites: await cache.droppedStaleWriteCount(for: .mixer),
                 bodyJSON: stripsJSON
             ))
         } else {
@@ -561,6 +564,7 @@ extension ResourceHandlers {
             extras.merge(versionedCacheExtras(
                 projectEpoch: await targetRegistry?.currentProjectEpoch ?? 0,
                 sectionRevision: await cache.sectionRevision(.project),
+                droppedStaleWrites: await cache.droppedStaleWriteCount(for: .project),
                 bodyJSON: body
             )) { _, new in new }
         }

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -281,6 +281,12 @@ actor StateCache {
         guard projectEpoch == observed.projectEpoch,
               sectionRevisions[section, default: 0] == observed.sectionRevision else {
             droppedStaleWriteCounts[section, default: 0] += 1
+            Log.debug(
+                "stale write refused for \(section.rawValue): observed "
+                + "(epoch \(observed.projectEpoch), rev \(observed.sectionRevision)) vs current "
+                + "(epoch \(projectEpoch), rev \(sectionRevisions[section, default: 0]))",
+                subsystem: "cache"
+            )
             return false
         }
         return true

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -3,6 +3,14 @@ import Foundation
 /// Thread-safe in-memory cache for Logic Pro project state.
 /// Read by tools for instant response; written by the StatePoller.
 actor StateCache {
+    /// The cache version a reader captures immediately before starting a
+    /// section refresh. Present it to a conditional write when the refresh
+    /// completes so the actor can reject a value from a superseded read.
+    struct SectionVersion: Sendable, Equatable {
+        let projectEpoch: UInt64
+        let sectionRevision: UInt64
+    }
+
     private(set) var transport = TransportState()
     private(set) var tracks: [TrackState] = []
     private(set) var channelStrips: [ChannelStripState] = []
@@ -13,7 +21,9 @@ actor StateCache {
     private(set) var project = ProjectInfo()
     private(set) var mcuConnection = MCUConnectionState()
     private(set) var mcuDisplay = MCUDisplayState()
+    private var projectEpoch: UInt64 = 0
     private var sectionRevisions: [CacheSectionID: UInt64] = [:]
+    private var droppedStaleWriteCounts: [CacheSectionID: UInt64] = [:]
 
     /// Whether Logic Pro has an open document with a visible window.
     /// Defaults to true (optimistic) — StatePoller sets to false when no document detected.
@@ -112,6 +122,22 @@ actor StateCache {
         sectionRevisions[section, default: 0]
     }
 
+    /// Atomically captures the project epoch and one section's revision.
+    /// Call this immediately before beginning an asynchronous refresh, then
+    /// present the result to that section's `ifCurrent` write overload.
+    func currentVersion(for section: CacheSectionID) -> SectionVersion {
+        SectionVersion(
+            projectEpoch: projectEpoch,
+            sectionRevision: sectionRevisions[section, default: 0]
+        )
+    }
+
+    /// Number of conditional writes rejected because their observed version
+    /// no longer matches this section. This counter never decreases.
+    func droppedStaleWriteCount(for section: CacheSectionID) -> UInt64 {
+        droppedStaleWriteCounts[section, default: 0]
+    }
+
     /// v3.1.4 (#4) — current AX occlusion flag. See field comment for
     /// semantics; flips to true when StatePoller detects a dialog/plugin
     /// window suppressing AX project/track reads, false on the next clean
@@ -201,6 +227,7 @@ actor StateCache {
         // combine hasDocument with transport_age_sec to distinguish
         // "no project open" from "project open, idle playback".
         transport = TransportState()
+        advanceProjectEpoch()
         advanceSectionRevision(.transport)
         advanceSectionRevision(.tracks)
         advanceSectionRevision(.mixer)
@@ -235,9 +262,42 @@ actor StateCache {
         sectionRevisions[section, default: 0] += 1
     }
 
+    /// Advances the cache's project epoch without changing section content.
+    /// Project lifecycle invalidation normally reaches this through
+    /// `clearProjectState`; the standalone operation is useful when an
+    /// authoritative project identity change has already been applied by a
+    /// different cache owner.
+    func advanceProjectEpoch() {
+        projectEpoch += 1
+    }
+
+    /// Returns whether a refresh that began at `observed` can still write the
+    /// given section. A rejected refresh changes no section state; only the
+    /// per-section diagnostic counter records the drop.
+    private func accepts(
+        _ observed: SectionVersion,
+        for section: CacheSectionID
+    ) -> Bool {
+        guard projectEpoch == observed.projectEpoch,
+              sectionRevisions[section, default: 0] == observed.sectionRevision else {
+            droppedStaleWriteCounts[section, default: 0] += 1
+            return false
+        }
+        return true
+    }
+
     func updateTransport(_ state: TransportState) {
         transport = state
         advanceSectionRevision(.transport)
+    }
+
+    /// Applies `state` only if the transport has not changed since `observed`
+    /// was captured before the read that produced it.
+    @discardableResult
+    func updateTransport(_ state: TransportState, ifCurrent observed: SectionVersion) -> Bool {
+        guard accepts(observed, for: .transport) else { return false }
+        updateTransport(state)
+        return true
     }
 
     func updateTracks(_ newTracks: [TrackState]) {
@@ -264,6 +324,15 @@ actor StateCache {
         advanceSectionRevision(.tracks)
     }
 
+    /// Applies `newTracks` only if the tracks section has not moved on since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateTracks(_ newTracks: [TrackState], ifCurrent observed: SectionVersion) -> Bool {
+        guard accepts(observed, for: .tracks) else { return false }
+        updateTracks(newTracks)
+        return true
+    }
+
     /// v3.1.1 (P1-3) — exposed for diagnostics and tests. Returns the number
     /// of consecutive empty `updateTracks([])` calls suppressed since the
     /// last non-empty update. Resets to 0 once any non-empty update lands or
@@ -283,6 +352,19 @@ actor StateCache {
         advanceSectionRevision(.tracks)
     }
 
+    /// Applies the track mutation only if the tracks section has not moved on
+    /// since `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateTrack(
+        at index: Int,
+        ifCurrent observed: SectionVersion,
+        mutator: (inout TrackState) -> Void
+    ) -> Bool {
+        guard accepts(observed, for: .tracks) else { return false }
+        updateTrack(at: index, mutator: mutator)
+        return true
+    }
+
     /// Mark exactly one track as selected, clearing the flag on every other
     /// track. Mirrors Logic Pro's single-selection model so the cache never
     /// reports two tracks selected at once.
@@ -295,10 +377,31 @@ actor StateCache {
         advanceSectionRevision(.tracks)
     }
 
+    /// Applies the selection only if the tracks section has not moved on since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func selectOnly(trackAt index: Int, ifCurrent observed: SectionVersion) -> Bool {
+        guard accepts(observed, for: .tracks) else { return false }
+        selectOnly(trackAt: index)
+        return true
+    }
+
     func updateChannelStrips(_ strips: [ChannelStripState]) {
         channelStrips = strips
         mixerFetchedAt = Date()
         advanceSectionRevision(.mixer)
+    }
+
+    /// Applies `strips` only if the mixer has not changed since `observed` was
+    /// captured before the read that produced it.
+    @discardableResult
+    func updateChannelStrips(
+        _ strips: [ChannelStripState],
+        ifCurrent observed: SectionVersion
+    ) -> Bool {
+        guard accepts(observed, for: .mixer) else { return false }
+        updateChannelStrips(strips)
+        return true
     }
 
     func updateRegions(_ newRegions: [RegionState], complete: Bool) {
@@ -334,6 +437,15 @@ actor StateCache {
         advanceSectionRevision(.project)
     }
 
+    /// Applies `info` only if the project section has not changed since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateProject(_ info: ProjectInfo, ifCurrent observed: SectionVersion) -> Bool {
+        guard accepts(observed, for: .project) else { return false }
+        updateProject(info)
+        return true
+    }
+
     // MARK: - MCU Feedback Write
 
     func updateFader(strip: Int, volume: Double) {
@@ -345,6 +457,19 @@ actor StateCache {
         // identical-value set_volume call.
         faderUpdatedAt[strip] = Date()
         advanceSectionRevision(.mixer)
+    }
+
+    /// Applies the fader value only if the mixer has not changed since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateFader(
+        strip: Int,
+        volume: Double,
+        ifCurrent observed: SectionVersion
+    ) -> Bool {
+        guard accepts(observed, for: .mixer) else { return false }
+        updateFader(strip: strip, volume: volume)
+        return true
     }
 
     /// v3.1.0 (Ralph-2 / C1) — last time an MCU echo (or any other caller)
@@ -363,6 +488,19 @@ actor StateCache {
         channelStrips[strip].pan = min(max(value, -1.0), 1.0)
         panUpdatedAt[strip] = Date()
         advanceSectionRevision(.mixer)
+    }
+
+    /// Applies the pan value only if the mixer has not changed since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func updatePan(
+        strip: Int,
+        value: Double,
+        ifCurrent observed: SectionVersion
+    ) -> Bool {
+        guard accepts(observed, for: .mixer) else { return false }
+        updatePan(strip: strip, value: value)
+        return true
     }
 
     /// v3.1.3 (#1) — last time a V-Pot LED-ring echo wrote a pan into this
@@ -406,6 +544,18 @@ actor StateCache {
         advanceSectionRevision(.mixer)
     }
 
+    /// Applies the connection state only if the mixer has not changed since
+    /// `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateMCUConnection(
+        _ state: MCUConnectionState,
+        ifCurrent observed: SectionVersion
+    ) -> Bool {
+        guard accepts(observed, for: .mixer) else { return false }
+        updateMCUConnection(state)
+        return true
+    }
+
     /// v3.8.0 (WS6 / AC3, audit #7) — atomic read-modify-write of the MCU
     /// connection state within a single actor turn. The MCU feedback parser
     /// and the channel's start()/stop() both touch this struct; a
@@ -416,6 +566,18 @@ actor StateCache {
     func updateMCUConnection(mutator: (inout MCUConnectionState) -> Void) {
         mutator(&mcuConnection)
         advanceSectionRevision(.mixer)
+    }
+
+    /// Applies the connection mutation only if the mixer has not changed
+    /// since `observed` was captured before the read that produced it.
+    @discardableResult
+    func updateMCUConnection(
+        ifCurrent observed: SectionVersion,
+        mutator: (inout MCUConnectionState) -> Void
+    ) -> Bool {
+        guard accepts(observed, for: .mixer) else { return false }
+        updateMCUConnection(mutator: mutator)
+        return true
     }
 
     func updateMCUDisplay(_ display: MCUDisplayState) {

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -191,18 +191,27 @@ actor StatePoller {
 
         let projectReady = await poll(
             operation: "project.get_info", label: "ProjectInfo",
+            section: .project,
             axChannel: axChannel, cache: cache, as: ProjectInfo.self
-        ) { cache, info in await cache.updateProject(info) }
+        ) { cache, info, observed in
+            await cache.updateProject(info, ifCurrent: observed)
+        }
         if projectReady { cacheKeys.append(.project) }
         let tracksReady: Bool
+        let tracksVersion = await cache.currentVersion(for: .tracks)
         if let tracks = await axChannel.readTrackStates() {
-            await cache.updateTracks(tracks)
+            // Same reasoning as `poll`: the read succeeded, so tracks are readable. Whether this
+            // particular value was applied or dropped in favour of a newer one does not change that.
+            _ = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
             tracksReady = true
         } else {
             tracksReady = await poll(
                 operation: "track.get_tracks", label: "Track",
+                section: .tracks,
                 axChannel: axChannel, cache: cache, as: [TrackState].self
-            ) { cache, tracks in await cache.updateTracks(tracks) }
+            ) { cache, tracks, observed in
+                await cache.updateTracks(tracks, ifCurrent: observed)
+            }
         }
         if tracksReady { cacheKeys.append(.tracks) }
         let hasDocument = projectReady || tracksReady
@@ -250,21 +259,29 @@ actor StatePoller {
 
         let transportReady = await poll(
             operation: "transport.get_state", label: "Transport",
+            section: .transport,
             axChannel: axChannel, cache: cache, as: TransportState.self
-        ) { cache, state in await cache.updateTransport(state) }
+        ) { cache, state, observed in
+            await cache.updateTransport(state, ifCurrent: observed)
+        }
         if transportReady { cacheKeys.append(.transport) }
         let mixerReady = await poll(
             operation: "mixer.get_state", label: "Mixer",
+            section: .mixer,
             axChannel: axChannel, cache: cache, as: [ChannelStripState].self
-        ) { cache, strips in await cache.updateChannelStrips(strips) }
+        ) { cache, strips, observed in
+            await cache.updateChannelStrips(strips, ifCurrent: observed)
+        }
         if mixerReady { cacheKeys.append(.mixer) }
         markerPollTick += 1
         if markerPollTick >= Self.markerPollInterval {
             markerPollTick = 0
-            let markersReady = await poll(
+            let markersReady = await pollUnversioned(
                 operation: "nav.get_markers", label: "Marker",
                 axChannel: axChannel, cache: cache, as: [MarkerState].self
-            ) { cache, markers in await cache.updateMarkers(markers) }
+            ) { cache, markers in
+                await cache.updateMarkers(markers)
+            }
             if markersReady {
                 cacheKeys.append(.markers)
             } else {
@@ -301,6 +318,40 @@ actor StatePoller {
     /// `ResourceHandlers.readProjectInfo` against `MetaData.plist`.
     @discardableResult
     private func poll<T: Decodable & Sendable>(
+        operation: String,
+        label: String,
+        section: CacheSectionID,
+        axChannel: AccessibilityChannel,
+        cache: StateCache,
+        as type: T.Type,
+        update: (StateCache, T, StateCache.SectionVersion) async -> Bool
+    ) async -> Bool {
+        // This must happen before `execute`: observing after the AX read
+        // returns would make a stale result look current and reintroduce the
+        // overwrite race this guard is meant to prevent.
+        let observed = await cache.currentVersion(for: section)
+        let result = await axChannel.execute(operation: operation, params: [:])
+        guard case .success(let json) = result else { return false }
+        guard let data = json.data(using: .utf8) else { return false }
+        do {
+            let value = try Self.iso8601Decoder.decode(T.self, from: data)
+            // The return value answers "does this section have a usable value", NOT "did this write
+            // land". A dropped write means the cache already holds something NEWER, so the section is
+            // if anything more current than if we had applied ours. Returning the write outcome here
+            // feeds `hasDocument`, and enough consecutive drops would make the poller declare the
+            // document closed — turning the guard into a worse bug than the race it prevents.
+            _ = await update(cache, value, observed)
+            return true
+        } catch {
+            Log.debug("\(label) poll failed: \(error)", subsystem: "poller")
+            return false
+        }
+    }
+
+    /// Poll helper for cache values that do not have a `CacheSectionID` and
+    /// therefore cannot participate in section-version rejection yet.
+    @discardableResult
+    private func pollUnversioned<T: Decodable & Sendable>(
         operation: String,
         label: String,
         axChannel: AccessibilityChannel,

--- a/Tests/LogicProMCPTests/Issue289PollerReadinessTests.swift
+++ b/Tests/LogicProMCPTests/Issue289PollerReadinessTests.swift
@@ -1,0 +1,115 @@
+import Dispatch
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// Mirrors the blocking AX probe used by StatePollerTests, but records each
+/// entry so the test can place a newer tracks value between the AX read and
+/// the conditional cache write on every poll cycle.
+private final class Issue289BlockingTracksProbe: @unchecked Sendable {
+    private let entryLock = NSLock()
+    private var entryCount = 0
+    private let release = DispatchSemaphore(value: 0)
+
+    func hasEntered(_ expectedCount: Int) -> Bool {
+        entryLock.lock()
+        defer { entryLock.unlock() }
+        return entryCount >= expectedCount
+    }
+
+    func unblock() {
+        release.signal()
+    }
+
+    func tracksResult() -> ChannelResult {
+        entryLock.lock()
+        entryCount += 1
+        entryLock.unlock()
+        release.wait()
+        return .success("[]")
+    }
+}
+
+private func issue289WaitUntil(
+    timeoutNanoseconds: UInt64 = 5_000_000_000,
+    pollIntervalNanoseconds: UInt64 = 5_000_000,
+    condition: @escaping @Sendable () async -> Bool
+) async throws -> Bool {
+    let deadline = ContinuousClock.now + .nanoseconds(Int64(timeoutNanoseconds))
+    while ContinuousClock.now < deadline {
+        if await condition() {
+            return true
+        }
+        try await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+    }
+    return await condition()
+}
+
+@Suite("Issue289PollerReadiness")
+struct Issue289PollerReadinessTests {
+    @Test("rejected tracks writes still keep the document open")
+    func staleTracksWritesDoNotCountAsDocumentPollFailures() async throws {
+        let blocker = Issue289BlockingTracksProbe()
+        let cache = StateCache()
+        let channel = AccessibilityChannel(
+            runtime: .init(
+                isTrusted: { true },
+                isLogicProRunning: { true },
+                hasVisibleWindow: { true },
+                appRoot: { nil },
+                transportState: { .success("{}") },
+                toggleTransportButton: { _ in .success("{}") },
+                setTempo: { _ in .success("{}") },
+                setCycleRange: { _ in .success("{}") },
+                tracks: { blocker.tracksResult() },
+                selectedTrack: { .success("{}") },
+                selectTrack: { _ in .success("{}") },
+                setTrackToggle: { _, _ in .success("{}") },
+                renameTrack: { _ in .success("{}") },
+                mixerState: { .success("[]") },
+                channelStrip: { _ in .success("{}") },
+                setMixerValue: { _, _ in .success("{}") },
+                projectInfo: { .error("unavailable") },
+                markers: { .success("[]") }
+            )
+        )
+        let poller = StatePoller(
+            axChannel: channel,
+            cache: cache,
+            runtime: .init(
+                hasVisibleWindow: { true },
+                sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }
+            )
+        )
+
+        await poller.start()
+        for cycle in 1...3 {
+            #expect(try await issue289WaitUntil { blocker.hasEntered(cycle) })
+            // The tracks read is now in flight. This newer write advances the
+            // section version, so releasing the AX result must reject it.
+            await cache.updateTracks([
+                TrackState(id: 0, name: "Newer tracks \(cycle)", type: .audio)
+            ])
+            blocker.unblock()
+        }
+
+        // Entry into cycle four proves the first three cycles completed. With
+        // the old `return await update(...)`, all three would have counted as
+        // failures and `failureThreshold` would already have closed the doc.
+        #expect(try await issue289WaitUntil { blocker.hasEntered(4) })
+        await poller.stopImmediately()
+
+        // Release the in-flight cycle after making it stale too, so cleanup
+        // cannot let an accepted fourth write mask the old behavior.
+        await cache.updateTracks([
+            TrackState(id: 0, name: "Newer tracks 4", type: .audio)
+        ])
+        blocker.unblock()
+
+        #expect(try await issue289WaitUntil {
+            await cache.droppedStaleWriteCount(for: .tracks) >= 4
+        })
+        #expect(await cache.getHasDocument())
+        #expect(await cache.droppedStaleWriteCount(for: .tracks) > 0)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue289StaleRefreshTests.swift
+++ b/Tests/LogicProMCPTests/Issue289StaleRefreshTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("Issue289StaleRefresh")
+struct Issue289StaleRefreshTests {
+    @Test func currentObservedVersionAppliesWrite() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 123),
+            ifCurrent: observed
+        )
+
+        #expect(applied)
+        #expect((await cache.getTransport()).tempo == 123)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 0)
+    }
+
+    @Test func staleSectionRevisionDropsWriteAndPreservesNewerValue() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+        await cache.updateTransport(transport(tempo: 130))
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 90),
+            ifCurrent: observed
+        )
+
+        #expect(!applied)
+        #expect((await cache.getTransport()).tempo == 130)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+    }
+
+    @Test func staleProjectEpochDropsWriteWhenSectionRevisionStillMatches() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+        await cache.advanceProjectEpoch()
+        let current = await cache.currentVersion(for: .transport)
+
+        #expect(current.sectionRevision == observed.sectionRevision)
+        #expect(current.projectEpoch > observed.projectEpoch)
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 90),
+            ifCurrent: observed
+        )
+
+        #expect(!applied)
+        #expect((await cache.getTransport()).tempo == 120)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+    }
+
+    @Test func concurrentWritesFromSameObservationAllowOnlyOne() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        async let first = cache.updateTransport(transport(tempo: 101), ifCurrent: observed)
+        async let second = cache.updateTransport(transport(tempo: 202), ifCurrent: observed)
+        let results = await [first, second]
+        let surviving = await cache.getTransport()
+
+        #expect(results.filter { $0 }.count == 1)
+        #expect(results.filter { !$0 }.count == 1)
+        #expect(surviving.tempo == 101 || surviving.tempo == 202)
+        #expect(await cache.sectionRevision(.transport) == 1)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+    }
+
+    private func transport(tempo: Double) -> TransportState {
+        var state = TransportState()
+        state.tempo = tempo
+        state.lastUpdated = Date()
+        return state
+    }
+}

--- a/Tests/LogicProMCPTests/VersionedCacheEnvelopeTests.swift
+++ b/Tests/LogicProMCPTests/VersionedCacheEnvelopeTests.swift
@@ -105,13 +105,25 @@ struct VersionedCacheEnvelopeTests {
         let extras = ResourceHandlers.versionedCacheExtras(
             projectEpoch: 7,
             sectionRevision: 11,
+            droppedStaleWrites: 5,
             bodyJSON: "{\"x\":1}"
         )
 
-        #expect(extras.count == 3)
+        #expect(extras.count == 4)
         #expect(extras["project_epoch"] as? UInt64 == 7)
         #expect(extras["section_revision"] as? UInt64 == 11)
+        #expect(extras["dropped_stale_writes"] as? UInt64 == 5)
         #expect(extras["etag"] as? String == "bdd3d53c3a0b3fd6")
+
+        // Defaulting to zero keeps the key present rather than making it appear only once something
+        // has gone wrong: a field that materialises on failure cannot be used to tell "the guard
+        // never fired" apart from "this build does not report it".
+        let quiet = ResourceHandlers.versionedCacheExtras(
+            projectEpoch: 7,
+            sectionRevision: 11,
+            bodyJSON: "{\"x\":1}"
+        )
+        #expect(quiet["dropped_stale_writes"] as? UInt64 == 0)
     }
 
     @Test func sectionRevisionsAdvanceIndependentlyOnAcceptedUpdates() async {


### PR DESCRIPTION
Closes part of #289 (ADR-006). This is the correctness half; single-flight, cancellation and
notification backpressure are not in this PR.

## The defect

`StateCache` assigned every section write unconditionally, and `StatePoller` called those writes
without comparing against anything — no request sequence, no epoch, no revision, no observation time.
A refresh that **started** before a change and **finished** after it therefore replaced the newer
value with the older one. `VersionedSnapshot` has carried `projectEpoch` and `sectionRevision` since
it was written; the write path simply never read them.

## The fix

Section writes now take the `(projectEpoch, sectionRevision)` observed at the moment the read
**started**, and apply the value only when both still match. Observing after the read returns would
make a stale result look current and reintroduce the exact race being closed, so the capture is
before `execute`, not after. Rejections are counted per section — a guard that leaves no trace cannot
be tested.

Not behind a feature flag. Overwriting fresh state with stale state is never desired, and a
correctness fix that ships disabled fixes nothing.

## A defect this fix introduced, and removed

The first version returned the write outcome from `poll()`. That value feeds
`projectReady`/`tracksReady` → `hasDocument`, and after `failureThreshold` consecutive false results
the poller calls `updateDocumentState(false)` — it declares the user's project **closed**. Since the
guard fires precisely during concurrent activity, that would have been a worse failure than the race.
`poll()` now answers "is this section readable", which a rejection does not contradict: a rejected
write means the cache already holds something newer.

`Issue289PollerReadinessTests` locks this. Reverting `poll()` to return the write outcome makes it
fail — verified by running the mutation, not by inspection.

## What the live run does and does not show

Driven against the release artifact built from this branch, screen-recorded, with the track rail
asserted on a bound region: a rename reaches State A through the guarded write path, is **visible on
screen** rather than only in the envelope, and the restore is visible too.

It does **not** demonstrate the race. The revert probe — rename a track, then read the tracks
resource 40 times across several refresh cycles looking for the old name returning — was run against
**both** binaries:

| binary | samples | reverts observed |
| --- | ---: | ---: |
| pre-fix (`origin/main`) | 40 | **0** |
| post-fix (this branch) | 40 | 0 |

The pre-fix binary never reverted either, so a zero on this branch separates nothing. The probe has no
power to distinguish them at the timing this machine produces through the public surface, and the
evidence records that rather than crediting the fix with a pass it did not earn. The race is
demonstrated at the unit level, where the interleaving can actually be forced.

## Stated limit

Markers stay on the unversioned path: `CacheSectionID` has no `markers` case, so there is no revision
to compare. Markers remain exposed to this race. That is written down here rather than left for
someone to discover.
