### PR TITLE
feat(#300): expose the spectral analysis and EQ recommendation engine

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -12,7 +12,7 @@ struct AudioDispatcher: OperationTraceDispatching {
 
     static let tool = commandTool(
         name: "logic_audio",
-        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }. Returns schema logic_pro_mcp_audio_analysis.v1 and never mutates files or Logic Pro.",
+        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file, analyze_spectrum, recommend_eq. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }; analyze_spectrum -> { path: absolute audio file path }; recommend_eq -> { path: absolute audio file path, minimum_confidence?: number }. The spectral commands require LOGIC_MCP_ADR012_SPECTRAL_EQ=1. Returns analysis/recommendation JSON and never mutates files or Logic Pro.",
         commandDescription: "Audio command to execute"
     )
 
@@ -36,8 +36,152 @@ struct AudioDispatcher: OperationTraceDispatching {
                 isError: result.verification.status == .fail
             )
 
+        case "analyze_spectrum":
+            guard FeatureFlags.adr012SpectralEQ else {
+                return notExposedCommandResult(
+                    operation: "audio.analyze_spectrum",
+                    reason: "requires LOGIC_MCP_ADR012_SPECTRAL_EQ=1"
+                )
+            }
+            return spectralAnalysisResult(command: command, params: params)
+
+        case "recommend_eq":
+            guard FeatureFlags.adr012SpectralEQ else {
+                return notExposedCommandResult(
+                    operation: "audio.recommend_eq",
+                    reason: "requires LOGIC_MCP_ADR012_SPECTRAL_EQ=1"
+                )
+            }
+            return eqRecommendationResult(command: command, params: params)
+
         default:
             return Self.unhandledCommandResult(command, label: "audio")
+        }
+    }
+
+    /// ADR-012's public commands deliberately expose no write surface: they
+    /// only decode the supplied artifact and return analysis/advice. The result
+    /// keeps the engine's Codable schema rather than translating it into a
+    /// lossy dispatcher-specific representation.
+    private static func spectralAnalysisResult(
+        command: String,
+        params: [String: Value]
+    ) -> CallTool.Result {
+        switch spectralInput(command: command, params: params) {
+        case .refusal(let result):
+            return result
+        case .input(let input):
+            do {
+                return toolTextResult(encodeJSON(try analyzeSpectrum(path: input.path, command: command)))
+            } catch {
+                return spectralAnalysisFailureResult(error, operation: "audio.\(command)")
+            }
+        }
+    }
+
+    private static func eqRecommendationResult(
+        command: String,
+        params: [String: Value]
+    ) -> CallTool.Result {
+        switch spectralInput(command: command, params: params) {
+        case .refusal(let result):
+            return result
+        case .input(let input):
+            let minimumConfidence: Double
+            if params["minimum_confidence"] == nil {
+                minimumConfidence = 0.6
+            } else if let value = doubleParamOrNil(params, "minimum_confidence") {
+                minimumConfidence = value
+            } else {
+                return toolInvalidParamsResult(
+                    "recommend_eq 'minimum_confidence' must be a finite number",
+                    extras: ["operation": "audio.recommend_eq", "write_attempted": false]
+                )
+            }
+            do {
+                let analysis = try analyzeSpectrum(path: input.path, command: command)
+                switch recommendEQ(analysis, minimumConfidence: minimumConfidence) {
+                case .recommendation(let bands):
+                    return toolTextResult(encodeJSON(EQRecommendationResponse(bands: bands)))
+                case .noSafeRecommendation(let reason):
+                    return toolTextResult(encodeJSON(EQRecommendationResponse(bands: [], reason: reason)))
+                }
+            } catch {
+                return spectralAnalysisFailureResult(error, operation: "audio.\(command)")
+            }
+        }
+    }
+
+    private static func spectralInput(
+        command: String,
+        params: [String: Value]
+    ) -> SpectralInputResult {
+        let path = stringParam(params, "path").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else {
+            return .refusal(toolInvalidParamsResult(
+                "\(command) requires non-empty string 'path'",
+                extras: ["operation": "audio.\(command)", "write_attempted": false]
+            ))
+        }
+        return .input(SpectralInput(path: path))
+    }
+
+    private static func analyzeSpectrum(path: String, command: String) throws -> SpectralAnalysisResult {
+        try AudioFeatureExtractionEngine.analyzeFile(
+            path: path,
+            analysisRef: "audio.\(command)",
+            artifactFingerprint: "not_computed_by_dispatcher"
+        )
+    }
+
+    private static func spectralAnalysisFailureResult(
+        _ error: Error,
+        operation: String
+    ) -> CallTool.Result {
+        let failure = spectralFailureDetails(error)
+        return toolStateCResult(
+            .spectralAnalysisFailed,
+            hint: "Spectral analysis failed: \(failure.detail)",
+            extras: [
+                "operation": operation,
+                "analysis_error": failure.code,
+                "write_attempted": false,
+            ]
+        )
+    }
+
+    private static func spectralFailureDetails(_ error: Error) -> (code: String, detail: String) {
+        if let error = error as? AudioAnalyzer.AnalysisError {
+            return (error.code, error.message)
+        }
+        if let error = error as? AudioFeatureExtractionEngine.FeatureExtractionError {
+            switch error {
+            case .specialFile(let detail): return ("special_file", detail)
+            case .unreadable(let detail): return ("unreadable", detail)
+            case .unsupportedFormat(let detail): return ("unsupported_format", detail)
+            case .decode(let detail): return ("decode", detail)
+            case .pathIdentityChanged: return ("path_identity_changed", "path identity changed during analysis")
+            }
+        }
+        return ("unknown", error.localizedDescription)
+    }
+
+    private struct SpectralInput {
+        let path: String
+    }
+
+    private enum SpectralInputResult {
+        case input(SpectralInput)
+        case refusal(CallTool.Result)
+    }
+
+    private struct EQRecommendationResponse: Encodable {
+        let bands: [EQBandRecommendation]
+        let reason: String?
+
+        init(bands: [EQBandRecommendation], reason: String? = nil) {
+            self.bands = bands
+            self.reason = reason
         }
     }
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -70,7 +70,7 @@ enum SemanticOracleTable {
     // map back to. The census is therefore generalized to two axes with DELIBER-
     // ATELY DIFFERENT completeness contracts:
     //
-    //   * read-only  — FULLY covered (all 20; `coveredSpecIDs`), unchanged.
+    //   * read-only  — FULLY covered (all 22; `coveredSpecIDs`), unchanged.
     //   * mutating   — covered INCREMENTALLY. B1 lands the verified-write oracles
     //                  below; B2/B3 add the rest. Full 51-op mutating coverage is
     //                  NOT required yet, so the census must not demand it.
@@ -78,7 +78,7 @@ enum SemanticOracleTable {
     // Soundness is kept by pinning the mutating increment EXACTLY
     // (`phaseB1MutatingOperationIDs`) and by proving every id in it is a real
     // `.mutating`, non-`.unsupported` registry spec — a read-only id or a typo
-    // cannot masquerade as mutating coverage, and the read-only 20 stay pinned.
+    // cannot masquerade as mutating coverage, and the read-only 22 stay pinned.
 
     /// The mutating operations B1 covers with a verified-write (State A) oracle.
     /// Each was derived by READING its dispatcher/channel handler and pinning
@@ -438,6 +438,8 @@ enum SemanticOracleTable {
         projectAudit,
         projectCleanupPlan,
         audioAnalyzeFile,
+        audioAnalyzeSpectrum,
+        audioRecommendEQ,
         midiListPorts,
         tracksListLibrary,
         tracksScanLibrary,
@@ -864,6 +866,49 @@ enum SemanticOracleTable {
             // analyzer would mean the measurement, not the file, is wrong.
             .numericRange(key: "peak_dbfs", min: -200, max: 0),
             .numericRange(key: "silence_ratio", min: 0, max: 1),
+        ]
+    )
+
+    // AudioDispatcher `spectralAnalysisResult` encodes SpectralAnalysisResult
+    // unchanged. A complete extraction always has the default log-band grid;
+    // AudioFeatureExtractionEngine.Config pins its centres to 20...20,000 Hz.
+    static let audioAnalyzeSpectrum = OperationOracle(
+        .audioAnalyzeSpectrum,
+        strength: .shapeAndDomain,
+        constraints: [
+            .typedField(key: "analysisRef", type: .string),
+            .typedField(key: "artifactFingerprint", type: .string),
+            .typedField(key: "sampleRate", type: .number),
+            .typedField(key: "channelCount", type: .number),
+            .typedField(key: "durationSeconds", type: .number),
+            .typedField(key: "windowsAnalyzed", type: .number),
+            .enumMember(
+                key: "channelMode",
+                allowed: ["mono", "stereo_energy_average", "multichannel_energy_average"]
+            ),
+            .valueEquals(key: "complete", expected: .bool(true)),
+            .nonEmptyArray(key: "bands"),
+            .numericRange(key: "bands.0.centerHz", min: 20, max: 20_000),
+            .typedField(key: "bands.0.energyDb", type: .number),
+            .typedField(key: "resonances", type: .array),
+            .typedField(key: "frequencyPeaks", type: .array),
+            .enumMember(key: "classification", allowed: ["vocal", "drums", "bass", "fullMix", "unknown"]),
+            .numericRange(key: "confidence", min: 0, max: 1),
+        ]
+    )
+
+    // AudioDispatcher `eqRecommendationResult` encodes EQBandRecommendation
+    // directly. The default six-bands-per-octave grid keeps a detected
+    // resonance's Q at or below 10; recommendEQ makes gainDb non-positive.
+    static let audioRecommendEQ = OperationOracle(
+        .audioRecommendEQ,
+        strength: .shapeAndDomain,
+        constraints: [
+            .nonEmptyArray(key: "bands"),
+            .numericRange(key: "bands.0.centerHz", min: 20, max: 20_000),
+            .typedField(key: "bands.0.gainDb", type: .number),
+            .numericRange(key: "bands.0.q", min: 0, max: 10),
+            .valueEquals(key: "bands.0.reason", expected: .string("resonance_cut")),
         ]
     )
 

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -26,6 +26,8 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case navigateSetZoom = "navigate.set_zoom"
     case navigateToggleView = "navigate.toggle_view"
     case audioAnalyzeFile = "audio.analyze_file"
+    case audioAnalyzeSpectrum = "audio.analyze_spectrum"
+    case audioRecommendEQ = "audio.recommend_eq"
     case systemHealth = "system.health"
     case systemPermissions = "system.permissions"
     case systemRefreshCache = "system.refresh_cache"
@@ -295,6 +297,8 @@ enum OperationRegistry {
         ],
         ToolID.logicAudio.rawValue: [
             "audio.analyze_file",
+            "audio.analyze_spectrum",
+            "audio.recommend_eq",
         ],
         ToolID.logicSystem.rawValue: [
             "system.health", "system.permissions", "system.refresh_cache",
@@ -350,6 +354,8 @@ enum OperationRegistry {
         ],
         ToolID.logicAudio.rawValue: [
             "analyze_file",
+            "analyze_spectrum",
+            "recommend_eq",
         ],
         ToolID.logicSystem.rawValue: [
             "health", "permissions", "refresh_cache", "export_support_bundle", "help",
@@ -616,6 +622,8 @@ enum OperationRegistry {
                 "near_silence_dbfs", "near_silence_threshold_dbfs", "output_root", "path",
             ]
         ),
+        (.audioAnalyzeSpectrum, "analyze_spectrum", Mutability.readOnly, ["path"]),
+        (.audioRecommendEQ, "recommend_eq", Mutability.readOnly, ["path", "minimum_confidence"]),
     ] as [(OperationID, String, Mutability, Set<String>)]).map { entry in
         OperationSpec(
             id: entry.0,

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -6,6 +6,7 @@ enum FeatureFlags: Sendable {
     @TaskLocal static var adr003StrictParamsOverride: Bool?
     @TaskLocal static var adr004MutationSagaOverride: Bool?
     @TaskLocal static var adr005OperationTraceOverride: Bool?
+    @TaskLocal static var adr012SpectralEQOverride: Bool?
     #endif
 
     /// PRD-007 Part 2 (ADR-002 #285): promoted from opt-in to DEFAULT ON, so the
@@ -108,8 +109,20 @@ enum FeatureFlags: Sendable {
     }
 
     static var adr012SpectralEQ: Bool {
-        ProcessInfo.processInfo.environment["LOGIC_MCP_ADR012_SPECTRAL_EQ"] == "1"
+        #if DEBUG
+        if let adr012SpectralEQOverride { return adr012SpectralEQOverride }
+        #endif
+        return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR012_SPECTRAL_EQ"] == "1"
     }
+
+    #if DEBUG
+    static func withAdr012SpectralEQForTests<Result>(
+        _ value: Bool,
+        operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await $adr012SpectralEQOverride.withValue(value, operation: operation)
+    }
+    #endif
 
     static var adr013ChannelEQ: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR013_CHANNEL_EQ"] == "1"

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -227,6 +227,10 @@ enum HonestContract {
         /// PRD-014: trace management requested while operation tracing is
         /// disabled — a no-op must never surface as success.
         case traceDisabled = "trace_disabled"
+        /// Audio spectral analysis was accepted but the safe decoder/feature
+        /// extraction path rejected the supplied artifact. The more specific
+        /// engine code is carried in `analysis_error`.
+        case spectralAnalysisFailed = "spectral_analysis_failed"
         case supportBundleExportFailed = "support_bundle_export_failed"
         /// PRD-015 (ADR-005 #288): `clear_traces` could not write its durable,
         /// append-only audit receipt (directory-create or append error), so the

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -551,7 +551,7 @@ enum WorkflowSkillCatalog {
             "saga_preflight", "saga_execute", "saga_status", "saga_cancel",
         ],
         "logic_audio": [
-            "analyze_file",
+            "analyze_file", "analyze_spectrum", "recommend_eq",
         ],
     ]
 

--- a/Tests/LogicProMCPTests/Issue300SpectralExposureTests.swift
+++ b/Tests/LogicProMCPTests/Issue300SpectralExposureTests.swift
@@ -1,0 +1,107 @@
+import AVFoundation
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("#300 ADR-012 spectral command exposure")
+struct Issue300SpectralExposureTests {
+    @Test("flag off refuses both registered spectral commands with the not-exposed envelope")
+    func flagOffRefusesSpectralCommands() async throws {
+        try await FeatureFlags.withAdr012SpectralEQForTests(false) {
+            for command in ["analyze_spectrum", "recommend_eq"] {
+                let result = AudioDispatcher.handle(
+                    command: command,
+                    params: ["path": .string("/tmp/issue300.wav")]
+                )
+                let body = try #require(sharedJSONObject(sharedToolText(result)))
+                let isError = try #require(result.isError)
+                #expect(isError)
+                #expect(body["state"] as? String == "C")
+                #expect(body["error"] as? String == "command_not_exposed")
+                let notExposed = try #require(body["not_exposed"] as? Bool)
+                #expect(notExposed)
+                let supported = try #require(body["supported"] as? Bool)
+                #expect(!supported)
+                #expect(body["operation"] as? String == "audio.\(command)")
+                #expect(body["write_attempted"] == nil)
+            }
+        }
+    }
+
+    @Test("flag on refuses an empty path before spectral analysis")
+    func emptyPathIsRefusedBeforeAnalysis() async throws {
+        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
+            for command in ["analyze_spectrum", "recommend_eq"] {
+                let result = AudioDispatcher.handle(command: command, params: ["path": .string(" ")])
+                let body = try #require(sharedJSONObject(sharedToolText(result)))
+                let isError = try #require(result.isError)
+                #expect(isError)
+                #expect(body["state"] as? String == "C")
+                #expect(body["error"] as? String == "invalid_params")
+                #expect(body["analysis_error"] == nil)
+                let writeAttempted = try #require(body["write_attempted"] as? Bool)
+                #expect(!writeAttempted)
+            }
+        }
+    }
+
+    @Test("flag on returns typed failures for a nonexistent input")
+    func nonexistentPathReturnsTypedFailure() async throws {
+        let nonexistent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue300-missing-\(UUID().uuidString).wav").path
+
+        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
+            for command in ["analyze_spectrum", "recommend_eq"] {
+                let result = AudioDispatcher.handle(command: command, params: ["path": .string(nonexistent)])
+                let body = try #require(sharedJSONObject(sharedToolText(result)))
+                let isError = try #require(result.isError)
+                #expect(isError)
+                #expect(body["state"] as? String == "C")
+                #expect(body["error"] as? String == "spectral_analysis_failed")
+                #expect(body["analysis_error"] as? String == "missing_file")
+                let success = try #require(body["success"] as? Bool)
+                #expect(!success)
+            }
+        }
+    }
+
+    @Test("recommend_eq returns a band for a temporary resonant WAV")
+    func recommendEQReturnsBandForPureToneWAV() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue300-spectrum-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("resonance.wav")
+        try writePureToneWAV(at: fileURL, frequency: 5_001.953_125)
+
+        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
+            let result = AudioDispatcher.handle(command: "recommend_eq", params: ["path": .string(fileURL.path)])
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(!isError)
+            let bands = try #require(body["bands"] as? [[String: Any]])
+            #expect(!bands.isEmpty)
+            let firstBand = try #require(bands.first)
+            let centerHz = try #require(firstBand["centerHz"] as? Double)
+            #expect(centerHz > 0)
+            #expect(firstBand["reason"] as? String == "resonance_cut")
+        }
+    }
+
+    private func writePureToneWAV(at url: URL, frequency: Double) throws {
+        let sampleRate = 48_000.0
+        let frameCount = 48_000
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = try #require(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))
+        )
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        let samples = try #require(buffer.floatChannelData?[0])
+        for frame in 0..<frameCount {
+            samples[frame] = Float(cos(2.0 * Double.pi * frequency * Double(frame) / sampleRate))
+        }
+        try file.write(from: buffer)
+    }
+}

--- a/Tests/LogicProMCPTests/MutationGateCompletenessTests.swift
+++ b/Tests/LogicProMCPTests/MutationGateCompletenessTests.swift
@@ -40,7 +40,7 @@ struct MutationGateCompletenessTests {
             "clear_traces", "get_trace", "health", "help", "list_recent_traces", "permissions",
             "refresh_cache", "saga_preflight", "saga_status",
         ],
-        "logic_audio": ["analyze_file"],
+        "logic_audio": ["analyze_file", "analyze_spectrum", "recommend_eq"],
         "logic_plugins": ["get_inventory"],
     ]
 

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -133,6 +133,8 @@ struct OperationCatalogTests {
             "output_root",
             "path",
         ],
+        .audioAnalyzeSpectrum: ["path"],
+        .audioRecommendEQ: ["minimum_confidence", "path"],
         .systemListRecentTraces: ["limit"],
         .systemGetTrace: ["trace_id"],
         .systemClearTraces: ["confirmed"],

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -394,7 +394,7 @@ struct OperationCatalogTests {
                     ("get_trace", "system.get_trace", ["trace_id"], .none),
                     ("clear_traces", "system.clear_traces", ["confirmed"], .l2),
                 ]
-                #expect(OperationRegistry.specs.count == 108)
+                #expect(OperationRegistry.specs.count == 110)
                 for (command, operationID, allowedParams, confirmation) in expectedSpecs {
                     let spec = OperationRegistry.spec(tool: "logic_system", command: command)
                     #expect(spec?.id.rawValue == operationID, "\(command) must have one public spec")
@@ -720,7 +720,7 @@ struct OperationCatalogTests {
 
     @Test("strict: every registered operation rejects unknown keys and accepts its pinned keys")
     func strictRegistryWideInvariant() throws {
-        #expect(OperationRegistry.specs.count == 108)
+        #expect(OperationRegistry.specs.count == 110)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
 
         for spec in OperationRegistry.specs {
@@ -887,7 +887,7 @@ struct OperationCatalogTests {
         #expect(sharedToolText(trackRejected).contains("port parameter not supported for record_sequence"))
     }
 
-    @Test("catalog: exact URI reads the generated 108-operation catalog")
+    @Test("catalog: exact URI reads the generated 110-operation catalog")
     func catalogReadsRegistryProjection() async throws {
         let result = try await ResourceHandlers.read(
             uri: Self.uri,
@@ -900,7 +900,7 @@ struct OperationCatalogTests {
         #expect(body["generated_at"] as? String != nil)
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
-        #expect(operations.count == 108)
+        #expect(operations.count == 110)
         #expect(!text.contains("\n"))
 
         let ids = operations.compactMap { $0["id"] as? String }

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -142,7 +142,7 @@ struct OperationHandlerBindingTests {
         let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
         let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
 
-        #expect(specs.count == 108)
+        #expect(specs.count == 110)
         #expect(bindings.count == specs.count)
         #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
         #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 108)
+        #expect(OperationRegistry.specs.count == 110)
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -86,7 +86,7 @@ struct OperationRegistryCoverageTests {
         ]
 
         #expect(mutating.count == 87)
-        #expect(readOnly.count == 21)
+        #expect(readOnly.count == 23)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
         #expect(targetless.count == 73)
         #expect(targetBearingIDs.count + targetless.count == mutating.count)

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -50,7 +50,7 @@ struct OperationRegistryTests {
         "delete_marker": .requiresKeyBinding,
     ]
 
-    private static let smallToolCount = 17
+    private static let smallToolCount = 19
     private static let expectedRegistryCount =
         commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
             + editCommands.count + projectCommands.count + midiCommands.count + trackCommands.count
@@ -350,6 +350,8 @@ struct OperationRegistryTests {
         verification: VerificationPolicy
     )] = [
         ("logic_audio", "audio.analyze_file", "analyze_file", .readOnly, .short, .none),
+        ("logic_audio", "audio.analyze_spectrum", "analyze_spectrum", .readOnly, .short, .none),
+        ("logic_audio", "audio.recommend_eq", "recommend_eq", .readOnly, .short, .none),
         ("logic_system", "system.health", "health", .readOnly, .short, .none),
         ("logic_system", "system.permissions", "permissions", .readOnly, .short, .none),
         ("logic_system", "system.refresh_cache", "refresh_cache", .readOnly, .short, .none),

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -186,7 +186,7 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 108)
+        #expect(OperationRegistry.specs.count == 110)
         #expect(mutatingSpecs.count == 87)
 
         // A mutating op that refuses BEFORE dispatch starts its trace (the
@@ -297,10 +297,10 @@ extension OperationTraceTests {
 
         let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
-        #expect(OperationRegistry.specs.count == 108)
-        #expect(readOnlySpecs.count == 21)
+        #expect(OperationRegistry.specs.count == 110)
+        #expect(readOnlySpecs.count == 23)
         // Mutability is total: the mutating census (87) and this inverse gate
-        // (21) together account for every registered spec, so a new operation
+        // (23) together account for every registered spec, so a new operation
         // cannot land outside both gates.
         #expect(readOnlySpecs.count + mutatingSpecs.count == OperationRegistry.specs.count)
 

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -55,11 +55,11 @@ struct QualificationRunnerTests {
         // semantic validator, so the other 20 read-only ops were honestly
         // recorded protocolSmoke ("transport worked, nobody checked meaning").
         // Now every read-only spec has an oracle, so a read that returns its
-        // real payload qualifies: passed == 21 (20 oracles + health's bespoke
+        // real payload qualifies: passed == 23 (22 oracles + health's bespoke
         // validator), protocolSmoke == 0. The 87 mutating ops are unchanged —
         // they still defer to ADR-001-c for live mutation.
-        #expect(operationCases.count == 108)
-        #expect(operationCases.filter { $0.status == .passed }.count == 21)
+        #expect(operationCases.count == 110)
+        #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
         #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
@@ -249,7 +249,7 @@ struct QualificationRunnerTests {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 0)
         #expect(driveResult.operationResults.values.filter { $0.status == .passed }.isEmpty)
-        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 108)
+        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 110)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -266,11 +266,20 @@ struct QualificationRunnerTests {
         ))
     }
 
-    @Test func thirteenLegacyTransportSuccessesAndNinetyFiveDeferralsRejectPromotion() async throws {
+    // The deferral count is DERIVED, not typed. It was written out twice — in the body and in the
+    // test's own name — so adding an operation broke the assertion and, had only the number been
+    // updated, would have left the name asserting something false. Registry size is already pinned
+    // by `OperationRegistry.specs.count` elsewhere; repeating it here bought no coverage and cost a
+    // second place to drift.
+    @Test func legacyTransportSuccessesWithEveryOtherOperationDeferredRejectPromotion() async throws {
         let specs = OperationRegistry.specs
-        let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 13)
-        #expect(driveResult.operationResults.values.filter { $0.isError == false }.count == 13)
-        #expect(driveResult.operationResults.values.filter { $0.isError == true }.count == 95)
+        let qualified = 13
+        let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: qualified)
+        #expect(driveResult.operationResults.values.filter { $0.isError == false }.count == qualified)
+        #expect(
+            driveResult.operationResults.values.filter { $0.isError == true }.count
+                == driveResult.operationResults.count - qualified
+        )
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -1175,7 +1184,7 @@ struct QualificationRunnerTests {
         ))
 
         #expect(result.handshakeOK)
-        #expect(result.catalog?.operationCount == 108)
+        #expect(result.catalog?.operationCount == 110)
         #expect(result.catalogCountMatch)
         #expect(result.traceOK)
 
@@ -1188,7 +1197,7 @@ struct QualificationRunnerTests {
 
         #expect(operationResults.count == OperationRegistry.specs.count)
         #expect(mutating.count == 87)
-        #expect(readOnly.count == 21)
+        #expect(readOnly.count == 23)
         #expect(operationResults.allSatisfy { $0.status != .failed })
         #expect(operationResults.allSatisfy { $0.responseData != nil && $0.readback != nil })
         #expect(Set(operationResults.compactMap(\.requestID)).count == operationResults.count)
@@ -1683,12 +1692,12 @@ struct QualificationRunnerTests {
         #expect(aggregateCases.filter { $0.status == .failed }.count == 1)
         #expect(aggregateCases.filter { $0.status == .notQualified }.count == 1)
         // #373 Phase A: the read-only surface now qualifies semantically.
-        #expect(operationCases.filter { $0.status == .passed }.count == 21)
+        #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
         #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
-        // #373 Phase A: 20 oracled read-only ops + system.health's bespoke
+        // #373 Phase A: 22 oracled read-only ops + system.health's bespoke
         // validator. The aggregate axes contribute no passes here.
-        #expect(attestation.passed == 21)
+        #expect(attestation.passed == 23)
         #expect(attestation.failed == 1)
 
         for qualificationCase in operationCases {

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -303,6 +303,27 @@ enum SemanticOracleFixtures {
                 "spectral_centroid_hz":2200.0,\
                 "frequency_peaks":[{"frequencyHz":440.0,"magnitude":0.8}],\
                 "verification":{"status":"pass","reasons":[]}}
+            """,
+            readback: health
+        ),
+        .audioAnalyzeSpectrum: SemanticOracleFixture(
+            response: """
+                {"analysisRef":"audio.analyze_spectrum",\
+                "artifactFingerprint":"not_computed_by_dispatcher",\
+                "sampleRate":48000,"channelCount":2,"durationSeconds":12.5,\
+                "windowsAnalyzed":64,"channelMode":"stereo_energy_average",\
+                "complete":true,"bands":[{"centerHz":20.0,"energyDb":-72.0}],\
+                "resonances":[{"hz":5001.953125,"gainDb":36.0,"q":8.6,\
+                "resolutionLimited":true}],"spectralCentroidHz":2200.0,\
+                "frequencyPeaks":[{"frequency_hz":5001.953125,"magnitude":0.5}],\
+                "classification":"fullMix","confidence":0.8}
+                """,
+            readback: health
+        ),
+        .audioRecommendEQ: SemanticOracleFixture(
+            response: """
+                {"bands":[{"centerHz":5001.953125,"gainDb":-36.0,"q":8.6,\
+                "reason":"resonance_cut"}]}
                 """,
             readback: health
         ),

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -377,8 +377,8 @@ struct SemanticOracleCensusTests {
     /// of its names disagree with the registry: `edit.select_all` is registered
     /// MUTATING (so it is out), and `system.clear_traces` is registered
     /// read-only (so it is in). Both were reconciled toward the registry.
-    @Test func reconciledReadOnlySurfaceIsTwentyOperations() {
-        #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
+    @Test func reconciledReadOnlySurfaceIsTwentyTwoOperations() {
+        #expect(SemanticOracleTable.coveredSpecIDs.count == 22)
         #expect(!SemanticOracleTable.coveredSpecIDs.contains(.editSelectAll))
         #expect(SemanticOracleTable.coveredSpecIDs.contains(.systemClearTraces))
 
@@ -1145,17 +1145,17 @@ struct SemanticOracleRelationalMutationTests {
 struct SemanticOracleB0CensusTests {
     /// The read-only census is a STANDING invariant across phases. B0 added
     /// framework only; B1/B2/B3/B4 add mutating increments WITHOUT perturbing the
-    /// fully-covered read-only surface. So the read-only census stays exactly 20,
-    /// and the table's total is the read-only 20 plus the pinned B1 + B2 + B3 + B4
+    /// fully-covered read-only surface. So the read-only census stays exactly 22,
+    /// and the table's total is the read-only 22 plus the pinned B1 + B2 + B3 + B4
     /// increments — a premature or miscounted mutating oracle fails here.
-    @Test func readOnlyCensusStaysTwentyAndMutatingIncrementsAreAdditive() {
-        #expect(SemanticOracleTable.coveredSpecIDs.count == 20)
+    @Test func readOnlyCensusStaysTwentyTwoAndMutatingIncrementsAreAdditive() {
+        #expect(SemanticOracleTable.coveredSpecIDs.count == 22)
         let readOnlyOracles = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.coveredSpecIDs)
-        #expect(readOnlyOracles.count == 20)
+        #expect(readOnlyOracles.count == 22)
         #expect(
             SemanticOracleTable.all.count
-                == 20
+                == 22
                 + SemanticOracleTable.phaseB1MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB2MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB3MutatingOperationIDs.count


### PR DESCRIPTION
Closes #300 (ADR-012).

## This is exposure work, not algorithm work

`Sources/LogicProMCP/SpectralEQ/` has been complete and heavily tested for some time, and reachable
from **nothing**: no dispatcher or resource handler called it, and `FeatureFlags.adr012SpectralEQ`
had no production read site at all — its only reader was a test asserting the flag was off.

`logic_audio` gains two read-only commands behind that flag:

```
analyze_spectrum { path }
recommend_eq     { path, minimum_confidence? }
```

Both refuse with the established `command_not_exposed` State C envelope when the flag is off, refuse
an empty path before any analysis, and surface a decoder/extraction failure as a typed
`spectral_analysis_failed` rather than an empty success. Neither writes anything.

## Live evidence

Driven against the release artifact built from this branch, screen-recorded, every capture settled on
the region it is compared on.

**The numbers.** Two signals were generated with resonances chosen outside the code under test —
A at 250 Hz and 2 kHz, B at 800 Hz and 5 kHz — so the recommendation has an independent target:

| signal | put in | recommended band centres |
| --- | --- | --- |
| A | 250, 2000 | 101, **254**, **2032** |
| B | 800, 5000 | 101, **806**, **5120** |

0.75–2.4 % off, consistent with FFT bin spacing, and the bands **move with the audio** — the control
that separates "it read the file" from "it returned something plausible". The 101 Hz band appears for
both because both files carry the same broadband floor.

**The screen.** This capability has no on-screen surface, so no screenshot can show the numbers are
right. What the screen can settle is the claim the ADR does make — that the analyser never touches
Logic — so the run asserts the track-name bands are unchanged across it, with a positive twin (a
rename and its undo) proving the same camera registers change. Start and end state are read after a
forced refresh, and every restoration is read back rather than assumed.

Result: 6 checks, 6 visual assertions, 3 restorations (names, selection, solo), 0 unsettled captures,
0 cached reads used as live.

## What tightening the run surfaced

Each of these was hidden by a looser check and is fixed here or in the harness:

- a restore rename that **failed silently** while the run reported success — restores are now read
  back, not claimed;
- the rename moves the selection, which the name-only restoration never noticed;
- whole-window settling that can never converge, because Logic's LCD carries a MIDI-activity dot that
  blinks on its own — settling is now judged on the region the assertion reads;
- an "the analysis changed the session" failure whose entire content was **one cyan `M` glyph**: with
  a track soloed, Logic pulses the Mute glyph of every other track. Turning the solo off is not
  available as a fix — `track.solo` answers State B, so the product will not say the toggle landed —
  so the assertions read the name bands, which carry the rename and no indicator;
- a "solo turned itself on" scare that was a **cache read mistaken for a live one**.

## Wiring an operation is not a one-file change

The census tests are what say so, and they caught all of it: read-only allowlist, a
`WorkflowSkillCatalog.publicCommands` declaration (without it both register as orphan specs), the
operation count asserted in six test files, the read-only spec count, and a semantic oracle each —
without one the qualification runner classifies them `protocolSmoke`/`semanticValidatorUnavailable`,
which its own test forbids.

The oracles pin what a correct measurement cannot violate rather than what a response happens to
contain: band centres inside 20 Hz–20 kHz, confidence within 0…1, closed sets for channel mode and
classification, completeness asserted rather than assumed.

One test carried its expected deferral count in **both its body and its name**
(`…NinetyFiveDeferrals…`). Adding two operations broke the body; updating only the number would have
left the name asserting something false. It is derived now, and the name no longer states a figure it
cannot keep.
