### PR TITLE
feat(#293): make the Event List readable through the provider protocol

### DIFF
--- a/Sources/LogicProMCP/MIDIReadback/EventListMIDINoteReadbackProvider.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListMIDINoteReadbackProvider.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Bridges Event List AX evidence into the shared MIDI note readback contract.
+///
+/// This adapter owns neither parsing nor completeness: `assessReadback` remains
+/// the single sealed conversion chokepoint. Its closure initializer keeps the
+/// live collector independently testable while the parameterized initializer
+/// below calls `EventListReadbackCollector` directly.
+struct EventListMIDINoteReadbackProvider: MIDINoteReadbackProvider {
+    typealias Collector = @Sendable (
+        _ target: MIDIRegionReference,
+        _ context: ReadbackContext
+    ) async throws -> EventListReadbackEvidence
+
+    let provenance: MIDIReadbackProvenance = .eventListAX
+    private let collector: Collector
+
+    init(collector: @escaping Collector) {
+        self.collector = collector
+    }
+
+    init(
+        resolvedIdentity: RegistryResolvedIdentityProof,
+        projectEpochBefore: UInt64,
+        projectEpochAfter: UInt64,
+        ppq: Int,
+        runtime: AXLogicProElements.Runtime = .production
+    ) {
+        self.collector = { target, _ in
+            try EventListReadbackCollector.collect(
+                requestedRegion: target,
+                resolvedIdentity: resolvedIdentity,
+                projectEpochBefore: projectEpochBefore,
+                projectEpochAfter: projectEpochAfter,
+                ppq: ppq,
+                runtime: runtime
+            )
+        }
+    }
+
+    func readNotes(
+        target: MIDIRegionReference,
+        context: ReadbackContext
+    ) async throws -> MIDIRegionNoteSnapshot {
+        do {
+            // Do not canonicalize or otherwise collapse this list here. The
+            // assessment preserves harvested row order and multiplicity, which
+            // lets a later diff distinguish a duplicated write from one note.
+            return assessReadback(try await collector(target, context))
+        } catch let error as EventListReadbackCollectorError {
+            throw EventListMIDINoteReadbackProviderError(collectorError: error)
+        }
+    }
+}
+
+/// Provider-facing failures preserve the collector's individual recovery
+/// semantics. In particular, a caller can navigate away from
+/// `paneAtRegionLevel`, whereas `headerMismatch` is a Logic-layout drift that
+/// must not be treated as a recoverable short read.
+enum EventListMIDINoteReadbackProviderError: Error, Equatable, Sendable {
+    case mainWindowUnavailable
+    case eventTabNotFound
+    case eventTabAmbiguous(count: Int)
+    case eventTabStateUnavailable
+    case eventTabActivationFailed
+    case eventTableNotFound
+    case eventTableAmbiguous(count: Int)
+    case headerUnavailable
+    case headerSortButtonsUnavailable
+    case paneAtRegionLevel
+    case headerMismatch(expected: String, actual: String?)
+    case filterEvidenceIncomplete(title: String)
+    case itemCountMissing
+    case regionPathMissing
+    case rowsUnavailable
+    case rowSelectionFailed(index: Int)
+    case rowCellCountMismatch(row: Int, expected: Int, actual: Int)
+    case cellChildCountMismatch(row: Int, column: String, actual: Int)
+    case harvestIncomplete(populated: Int, total: Int, passes: Int)
+    case displayModeUnavailable
+    case timeDisplayEnabled
+    case displayModeDisagreement(markedAsTime: Bool, positionsAreBBT: Bool)
+
+    init(collectorError: EventListReadbackCollectorError) {
+        switch collectorError {
+        case .mainWindowUnavailable:
+            self = .mainWindowUnavailable
+        case .eventTabNotFound:
+            self = .eventTabNotFound
+        case let .eventTabAmbiguous(count):
+            self = .eventTabAmbiguous(count: count)
+        case .eventTabStateUnavailable:
+            self = .eventTabStateUnavailable
+        case .eventTabActivationFailed:
+            self = .eventTabActivationFailed
+        case .eventTableNotFound:
+            self = .eventTableNotFound
+        case let .eventTableAmbiguous(count):
+            self = .eventTableAmbiguous(count: count)
+        case .headerUnavailable:
+            self = .headerUnavailable
+        case .headerSortButtonsUnavailable:
+            self = .headerSortButtonsUnavailable
+        case .paneAtRegionLevel:
+            self = .paneAtRegionLevel
+        case let .headerMismatch(expected, actual):
+            self = .headerMismatch(expected: expected, actual: actual)
+        case let .filterEvidenceIncomplete(title):
+            self = .filterEvidenceIncomplete(title: title)
+        case .itemCountMissing:
+            self = .itemCountMissing
+        case .regionPathMissing:
+            self = .regionPathMissing
+        case .rowsUnavailable:
+            self = .rowsUnavailable
+        case let .rowSelectionFailed(index):
+            self = .rowSelectionFailed(index: index)
+        case let .rowCellCountMismatch(row, expected, actual):
+            self = .rowCellCountMismatch(row: row, expected: expected, actual: actual)
+        case let .cellChildCountMismatch(row, column, actual):
+            self = .cellChildCountMismatch(row: row, column: column, actual: actual)
+        case let .harvestIncomplete(populated, total, passes):
+            self = .harvestIncomplete(populated: populated, total: total, passes: passes)
+        case .displayModeUnavailable:
+            self = .displayModeUnavailable
+        case .timeDisplayEnabled:
+            self = .timeDisplayEnabled
+        case let .displayModeDisagreement(markedAsTime, positionsAreBBT):
+            self = .displayModeDisagreement(
+                markedAsTime: markedAsTime,
+                positionsAreBBT: positionsAreBBT
+            )
+        }
+    }
+}

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -92,6 +92,12 @@ enum EventListReadbackCollector {
     private static let expectedHeaderTitles = [
         "L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info",
     ]
+    /// Logic uses this distinct schema while the Event List is showing regions
+    /// instead of the selected region's events. It is a recoverable navigation
+    /// failure, not a column-layout drift.
+    private static let regionLevelHeaderTitles = [
+        "L", "M", "Position", "Name", "Trk", "Length",
+    ]
     private static let maximumMaterializationPasses = 64
 
     private struct HeaderBinding {
@@ -235,6 +241,10 @@ enum EventListReadbackCollector {
             throw EventListReadbackCollectorError.headerSortButtonsUnavailable
         }
         let titles = sortButtons.map { AXHelpers.getTitle($0, runtime: runtime) }
+
+        if titles == regionLevelHeaderTitles {
+            throw EventListReadbackCollectorError.paneAtRegionLevel
+        }
 
         for index in expectedHeaderTitles.indices {
             let expected = expectedHeaderTitles[index]
@@ -527,6 +537,7 @@ enum EventListReadbackCollectorError: Error, Equatable, Sendable, CustomStringCo
     case eventTableAmbiguous(count: Int)
     case headerUnavailable
     case headerSortButtonsUnavailable
+    case paneAtRegionLevel
     case headerMismatch(expected: String, actual: String?)
     case filterEvidenceIncomplete(title: String)
     case itemCountMissing
@@ -551,6 +562,7 @@ enum EventListReadbackCollectorError: Error, Equatable, Sendable, CustomStringCo
         case let .eventTableAmbiguous(count): return "Event List table is ambiguous (\(count) matches)."
         case .headerUnavailable: return "Event List table has no AXHeader."
         case .headerSortButtonsUnavailable: return "Event List header does not expose only sort-button columns."
+        case .paneAtRegionLevel: return "Event List is at region level; event-level rows are unavailable."
         case let .headerMismatch(expected, actual):
             return "Event List column mismatch at \(expected): found \(actual ?? "<missing>")."
         case let .filterEvidenceIncomplete(title): return "Event List filter evidence is incomplete: \(title)."

--- a/Tests/LogicProMCPTests/Issue293EventListProviderTests.swift
+++ b/Tests/LogicProMCPTests/Issue293EventListProviderTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+#if QUALIFICATION_FAULT_SEAM
+@Suite struct Issue293EventListProviderTests {
+    private static let region = MIDIRegionReference(
+        targetRef: TargetReference(rawValue: "trk_issue_293"),
+        regionIndex: 2
+    )
+    private static let identity = ResolvedRegionIdentity(
+        name: "Issue 293 Region",
+        ordinal: 2,
+        startTick: 0
+    )
+    private static let positionColumn = AXColumnID(id: "position")
+    private static let channelColumn = AXColumnID(id: "channel")
+    private static let pitchColumn = AXColumnID(id: "pitch")
+    private static let velocityColumn = AXColumnID(id: "velocity")
+    private static let lengthColumn = AXColumnID(id: "length")
+
+    private enum ProviderTestError: Error {
+        case expectedProviderError
+    }
+
+    private static func rawRow(
+        pitch: Double = 60,
+        velocity: String = "100",
+        channel: Double = 1,
+        position: [Double] = [1, 1, 1, 1],
+        length: [Double] = [0, 1, 0, 0]
+    ) -> RawEventRow {
+        [
+            positionColumn: RawCell(groupSliderValues: position),
+            channelColumn: RawCell(sliderValue: channel),
+            pitchColumn: RawCell(sliderValue: pitch),
+            velocityColumn: RawCell(valueDescription: velocity),
+            lengthColumn: RawCell(groupSliderValues: length),
+        ]
+    }
+
+    private static func completeFilter() -> FilterEvidence {
+        FilterEvidence(checkboxes: [
+            .init(id: "noteEvents", checked: true),
+            .init(id: "programChange", checked: false),
+            .init(id: "pitchBend", checked: false),
+            .init(id: "controller", checked: false),
+            .init(id: "aftertouch", checked: false),
+            .init(id: "polyAftertouch", checked: false),
+            .init(id: "systemExclusive", checked: false),
+            .init(id: "additionalInfo", checked: false),
+        ])
+    }
+
+    private static func evidence(
+        rows: [RawEventRow],
+        observedRegion: ObservedRegionIdentityProof = .proven(identity),
+        itemCount: Int? = nil
+    ) -> EventListReadbackEvidence {
+        let keyedRows = Dictionary(uniqueKeysWithValues: rows.enumerated().map { index, row in
+            (RowKey(index: index), row)
+        })
+        return EventListReadbackEvidence(
+            requestedRegion: region,
+            resolvedIdentity: RegionIdentityRegistrySeam.mint(
+                boundRegion: region,
+                identity: identity
+            ),
+            observedRegion: observedRegion,
+            projectEpochBefore: 17,
+            projectEpochAfter: 17,
+            ppq: 480,
+            columnBinding: .headerIdentity(.proven([
+                .position: positionColumn,
+                .channel: channelColumn,
+                .pitch: pitchColumn,
+                .velocity: velocityColumn,
+                .length: lengthColumn,
+            ])),
+            filter: completeFilter(),
+            itemCount: ItemCountEvidence(
+                rawCountText: "\(itemCount ?? rows.count) Events",
+                semanticsProof: .provenAllEventsInRegion
+            ),
+            harvest: RowHarvest(
+                orderedRowKeys: rows.indices.map(RowKey.init(index:)),
+                passA: keyedRows,
+                passB: keyedRows,
+                exhaustion: .proven
+            ),
+            timing: .proven,
+            calibration: CalibrationTriple(pitch: 60, velocity: 100, startTickValue: 1)
+        )
+    }
+
+    private static func provider(
+        returning evidence: EventListReadbackEvidence
+    ) -> EventListMIDINoteReadbackProvider {
+        EventListMIDINoteReadbackProvider { _, _ in evidence }
+    }
+
+    private static func thrownProviderError(
+        for collectorError: EventListReadbackCollectorError
+    ) async throws -> EventListMIDINoteReadbackProviderError {
+        let provider = EventListMIDINoteReadbackProvider { _, _ in
+            throw collectorError
+        }
+        do {
+            _ = try await provider.readNotes(target: region, context: ReadbackContext())
+        } catch let error as EventListMIDINoteReadbackProviderError {
+            return error
+        } catch {
+            throw ProviderTestError.expectedProviderError
+        }
+        throw ProviderTestError.expectedProviderError
+    }
+
+    @Test func completeEvidenceProducesCompleteOrderedSnapshot() async throws {
+        let rows = [
+            Self.rawRow(),
+            Self.rawRow(
+                pitch: 64,
+                velocity: "90",
+                channel: 2,
+                position: [1, 1, 1, 2],
+                length: [0, 1, 0, 1]
+            ),
+        ]
+
+        let snapshot = try await Self.provider(returning: Self.evidence(rows: rows)).readNotes(
+            target: Self.region,
+            context: ReadbackContext(localeIdentifier: "en_US", viewIdentifier: "event-list")
+        )
+
+        #expect(snapshot.complete)
+        #expect(snapshot.provenance == MIDIReadbackProvenance.eventListAX)
+        #expect(snapshot.notes == [
+            MIDINoteEvent(
+                pitch: 60,
+                startTicks: 4,
+                durationTicks: 1,
+                velocity: 100,
+                channel: 1
+            ),
+            MIDINoteEvent(
+                pitch: 64,
+                startTicks: 5,
+                durationTicks: 2,
+                velocity: 90,
+                channel: 2
+            ),
+        ])
+    }
+
+    @Test func duplicateNotesArePreservedWithTheirCount() async throws {
+        let duplicate = Self.rawRow()
+        let snapshot = try await Self.provider(returning: Self.evidence(rows: [duplicate, duplicate])).readNotes(
+            target: Self.region,
+            context: ReadbackContext()
+        )
+
+        #expect(snapshot.complete)
+        #expect(snapshot.notes.count == 2)
+        #expect(snapshot.notes == [
+            MIDINoteEvent(
+                pitch: 60,
+                startTicks: 4,
+                durationTicks: 1,
+                velocity: 100,
+                channel: 1
+            ),
+            MIDINoteEvent(
+                pitch: 60,
+                startTicks: 4,
+                durationTicks: 1,
+                velocity: 100,
+                channel: 1
+            ),
+        ])
+    }
+
+    @Test func partialEvidenceProducesIncompleteSnapshot() async throws {
+        let partialEvidence = Self.evidence(
+            rows: [Self.rawRow()],
+            itemCount: 2
+        )
+
+        let snapshot = try await Self.provider(returning: partialEvidence).readNotes(
+            target: Self.region,
+            context: ReadbackContext()
+        )
+
+        #expect(!snapshot.complete)
+        #expect(snapshot.noteCompleteness.partialReason == PartialReason.countMismatch)
+        #expect(snapshot.notes.isEmpty)
+    }
+
+    @Test func collectorFailuresRemainTypedAndDistinct() async throws {
+        let collectorErrors: [EventListReadbackCollectorError] = [
+            .mainWindowUnavailable,
+            .eventTabNotFound,
+            .eventTabAmbiguous(count: 2),
+            .eventTabStateUnavailable,
+            .eventTabActivationFailed,
+            .eventTableNotFound,
+            .eventTableAmbiguous(count: 2),
+            .headerUnavailable,
+            .headerSortButtonsUnavailable,
+            .paneAtRegionLevel,
+            .headerMismatch(expected: "Val", actual: "Velocity"),
+            .filterEvidenceIncomplete(title: "Notes"),
+            .itemCountMissing,
+            .regionPathMissing,
+            .rowsUnavailable,
+            .rowSelectionFailed(index: 3),
+            .rowCellCountMismatch(row: 3, expected: 8, actual: 7),
+            .cellChildCountMismatch(row: 3, column: "Val", actual: 2),
+            .harvestIncomplete(populated: 4, total: 5, passes: 64),
+            .displayModeUnavailable,
+            .timeDisplayEnabled,
+            .displayModeDisagreement(markedAsTime: true, positionsAreBBT: true),
+        ]
+        let expectedProviderErrors: [EventListMIDINoteReadbackProviderError] = [
+            .mainWindowUnavailable,
+            .eventTabNotFound,
+            .eventTabAmbiguous(count: 2),
+            .eventTabStateUnavailable,
+            .eventTabActivationFailed,
+            .eventTableNotFound,
+            .eventTableAmbiguous(count: 2),
+            .headerUnavailable,
+            .headerSortButtonsUnavailable,
+            .paneAtRegionLevel,
+            .headerMismatch(expected: "Val", actual: "Velocity"),
+            .filterEvidenceIncomplete(title: "Notes"),
+            .itemCountMissing,
+            .regionPathMissing,
+            .rowsUnavailable,
+            .rowSelectionFailed(index: 3),
+            .rowCellCountMismatch(row: 3, expected: 8, actual: 7),
+            .cellChildCountMismatch(row: 3, column: "Val", actual: 2),
+            .harvestIncomplete(populated: 4, total: 5, passes: 64),
+            .displayModeUnavailable,
+            .timeDisplayEnabled,
+            .displayModeDisagreement(markedAsTime: true, positionsAreBBT: true),
+        ]
+
+        var mappedErrors: [EventListMIDINoteReadbackProviderError] = []
+        for collectorError in collectorErrors {
+            mappedErrors.append(try await Self.thrownProviderError(for: collectorError))
+        }
+
+        #expect(mappedErrors == expectedProviderErrors)
+        for index in mappedErrors.indices {
+            for priorIndex in 0..<index {
+                #expect(mappedErrors[index] != mappedErrors[priorIndex])
+            }
+        }
+    }
+}
+#endif

--- a/Tests/LogicProMCPTests/MIDIReadbackCallSiteLintTests.swift
+++ b/Tests/LogicProMCPTests/MIDIReadbackCallSiteLintTests.swift
@@ -9,15 +9,16 @@ import Testing
 // fileprivate to the assessment file, so no other file can construct one, and there
 // is no public/internal initializer, factory, or decoder — so no production
 // `.complete` can be minted outside `assessReadback`. This scan is a SECONDARY aid:
-// it hard-fails on unreadable sources and flags an `assessReadback` production
-// reference or an unexpected count of `CompleteProof` construction sites in the
-// assessment file, over the construction forms it recognizes. It does NOT claim to
-// census every possible future Swift alias/factory form — a same-file `typealias`
-// or helper mint is caught by source review of the change, not by this heuristic. The
-// scan is syntax-aware (string content is `.stringSegment`, comments are trivia),
-// so it is not defeated by strings/comments the way a hand lexer would be.
+// it hard-fails on unreadable sources and permits exactly one production caller —
+// the Event List provider adapter — plus the expected `CompleteProof` construction
+// sites in the assessment file. It does NOT claim to census every possible future
+// Swift alias/factory form — a same-file `typealias` or helper mint is caught by
+// source review of the change, not by this heuristic. The scan is syntax-aware
+// (string content is `.stringSegment`, comments are trivia), so it is not defeated
+// by strings/comments the way a hand lexer would be.
 @Suite struct MIDIReadbackCallSiteLintTests {
     private static let assessmentFile = "MIDIReadbackAssessment.swift"
+    private static let providerFile = "EventListMIDINoteReadbackProvider.swift"
     // The only permitted `CompleteProof()` mint sites, both in the assessment
     // file: the production return of `assessReadback` and the debug-only seam.
     private static let expectedProofMintSites = 2
@@ -50,7 +51,7 @@ import Testing
         return counter.count
     }
 
-    @Test func noProductionAssessReadbackReferenceAndProofMintIsExact() throws {
+    @Test func onlyEventListProviderMayAssessReadbackAndProofMintIsExact() throws {
         let thisFile = URL(fileURLWithPath: #filePath)
         let repoRoot = thisFile
             .deletingLastPathComponent()  // LogicProMCPTests
@@ -70,6 +71,7 @@ import Testing
         var sawAssessmentFile = false
         var offenders: [String] = []
         var proofMintInAssessment = 0
+        var assessmentReferencesInProvider = 0
         let enumerator = fm.enumerator(at: sources, includingPropertiesForKeys: nil)
         while let url = enumerator?.nextObject() as? URL {
             guard url.pathExtension == "swift" else { continue }
@@ -89,7 +91,10 @@ import Testing
                 proofMintInAssessment = proofMints
                 continue
             }
-            if Self.identifierCount(text, "assessReadback") > 0 {
+            let assessmentReferences = Self.identifierCount(text, "assessReadback")
+            if url.lastPathComponent == Self.providerFile {
+                assessmentReferencesInProvider = assessmentReferences
+            } else if assessmentReferences > 0 {
                 offenders.append("\(url.lastPathComponent): references assessReadback")
             }
             if proofMints > 0 {
@@ -100,6 +105,8 @@ import Testing
         #expect(sawAssessmentFile, "expected the assessment file at \(assessmentPath)")
         #expect(scanned > 50, "expected to scan the LogicProMCP source tree; scanned \(scanned) files")
         #expect(offenders.isEmpty, "dark-core call-site lint offenders: \(offenders)")
+        #expect(assessmentReferencesInProvider == 1,
+                "\(Self.providerFile) must be the sole adapter call site for assessReadback")
         #expect(proofMintInAssessment == Self.expectedProofMintSites,
                 "CompleteProof mint sites in \(Self.assessmentFile) = \(proofMintInAssessment), expected \(Self.expectedProofMintSites)")
     }


### PR DESCRIPTION
Closes part of #293 (ADR-010). The provider is wired; the qualification that promotes it to a public
readback source is not in this PR.

## What was missing

`MIDINoteReadbackProvider`, `MIDINoteCanonicalizer`, `MIDIRegionDiff` and `MIDIProviderGate` have all
existed for some time. The Event List collector landed with #302 and was referenced by **nothing but
its own tests**. This is the adapter between them.

## The rules it keeps

- **A partial or refused read yields an INCOMPLETE snapshot.** It never yields a complete one with
  fewer notes — a snapshot that silently drops notes is indistinguishable from a region that really
  has fewer, which would make the readback unable to detect the write it exists to check.
- **Duplicates survive.** Two identical notes come back as two, for the same reason.
- **Collector errors stay distinct.** `paneAtRegionLevel` means the caller is looking at the wrong
  level and can recover; `headerMismatch` means Logic's columns moved and it cannot. Collapsing them
  would hand the caller one error it has no way to act on.

The collector gains the region-level header signature it needs to tell those apart —
`L / M / Position / Name / Trk / Length` — taken from live Logic rather than guessed.

## The lint was narrowed, not relaxed

`MIDIReadbackCallSiteLintTests` forbids any production reference to `assessReadback`, because the
completeness proof must not be mintable outside the assessment file. The adapter has to make exactly
one such reference. Rather than delete the rule, it now names the single permitted file and asserts
the reference count **there** is exactly one — so a second caller still fails it.

## Live evidence, and its limit stated

The release artifact built from this branch is **byte-identical to main's**: the adapter is reachable
from no dispatcher or resource, so no live run can execute it. What a live run can settle — and what
the new branch rests on — is whether the constant the collector now encodes is the header Logic really
renders. It is, read out of the source at run time and compared against the live pane.

What is **not** asserted here, and why: the level transition itself. The prober selects a region by
setting `AXSelected`, and that behaves as a **toggle** on Logic's region rows — measured directly,
`before: true` then, after the set, `after: false`. With the fixture this run records, two regions
share the name `MIDI Region`, so the prober cannot be aimed at the visible one. The transition is
already proven with screenshots in the evidence that merged #302; repeating it badly here would add
nothing. A positive twin on the same pane confirms the camera registers change, so the region-level
assertion is not resting on a dead instrument.
