### PR TITLE
fix(#516): project.new must not fail for a project it just created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+- **`project.new` no longer fails for a project it just created (#516).** It required Logic to answer
+  `File ▸ New` with the template chooser. Where the chooser is skipped — Logic creates the untitled
+  project immediately and shows only its mandatory New Track sheet — the operation polled ten seconds
+  for a window that was never coming and returned `channels_exhausted`, while the requested project
+  sat on screen. Both outcomes are now accepted: the chooser route is unchanged, and a created arrange
+  window completes through the same sheet-reconciliation and arrange-window witness the chooser route
+  already used. Measured live: `state C / channels_exhausted` after 14.9 s becomes `state B /
+  created_project_window_observed` after 5.7 s, with the project confirmed at
+  `logic://project/info`.
+
 ### Added
 - `logic://` resource envelopes served under `LOGIC_MCP_ADR006_VERSIONED_CACHE=1` now carry
   `dropped_stale_writes` beside `section_revision`: the number of refreshes whose value was refused

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -47,8 +47,19 @@ extension AccessibilityChannel {
             if exactEmptyProjectChooserIsVisible(runtime: runtime) {
                 return await createEmptyProjectFromChooser(runtime: runtime)
             }
+            // Logic does not always answer File > New with the chooser. Where the chooser is skipped
+            // it creates the untitled project immediately and presents only the mandatory New Track
+            // sheet — measured live: the arrange window read "Untitled 56 - Tracks" while this loop
+            // was still waiting for a chooser that was never coming, and the operation then reported
+            // failure for a project it had just created. A created project IS the requested outcome,
+            // so accept it here rather than timing out beside it.
+            if exactCreatedProjectWindow(runtime: runtime) != nil {
+                return await observeProjectCreationOutcome(runtime: runtime, selection: "direct")
+            }
         }
-        return .error("Exact File > New did not expose the Creator Studio chooser")
+        return .error(
+            "Exact File > New exposed neither the Creator Studio chooser nor a created project window"
+        )
     }
 
     static func exactEmptyProjectChooserIsVisible(
@@ -212,7 +223,28 @@ extension AccessibilityChannel {
         guard AXHelpers.performAction(chooseButton, kAXPressAction as String, runtime: runtime.ax) else {
             return .error("Failed to press the exact Creator Studio Choose button")
         }
+        return await observeProjectCreationOutcome(
+            runtime: runtime,
+            selection: "Empty Project",
+            observationAttempts: observationAttempts,
+            observationDelayNanoseconds: observationDelayNanoseconds
+        )
+    }
 
+    /// Watch for the project a `project.new` was asked to create, from whichever route produced it.
+    ///
+    /// Split out of `createEmptyProjectFromChooser` so the direct-creation route can reuse it. Logic
+    /// does not always answer `File ▸ New` with the template chooser: on a machine where the chooser
+    /// is skipped it creates the untitled project immediately and presents only the mandatory New
+    /// Track sheet. That is the SAME outcome the chooser route reaches one step later, and it needs
+    /// the same handling — the sheet reconciliation, the arrange-window witness, and the honest
+    /// State B that leaves the independent Project-resource readback to the caller.
+    static func observeProjectCreationOutcome(
+        runtime: AXLogicProElements.Runtime,
+        selection: String,
+        observationAttempts: Int = 80,
+        observationDelayNanoseconds: UInt64 = 250_000_000
+    ) async -> ChannelResult {
         // Some Creator Studio builds open a zero-track Project directly, while
         // others expose Logic's mandatory New Track sheet. Reuse the existing
         // structural classifier for the sheet path: it only clicks Create when
@@ -234,7 +266,7 @@ extension AccessibilityChannel {
                         extras: [
                             "operation": "project.new",
                             "method": "accessibility",
-                            "selection": "Empty Project",
+                            "selection": selection,
                             "phase": "mandatory_track_create_unconfirmed",
                             "write_attempted": true,
                             "safe_to_retry": false,
@@ -248,7 +280,7 @@ extension AccessibilityChannel {
                     extras: [
                         "operation": "project.new",
                         "method": "accessibility",
-                        "selection": "Empty Project",
+                        "selection": selection,
                         "phase": "unexpected_blocking_sheet",
                         "sheet_kind": String(describing: outcome.kind),
                         "write_attempted": true,
@@ -264,7 +296,7 @@ extension AccessibilityChannel {
                     extras: [
                         "operation": "project.new",
                         "method": "accessibility",
-                        "selection": "Empty Project",
+                        "selection": selection,
                         "phase": "created_project_window_observed",
                         "window_title": AXHelpers.getTitle(current, runtime: runtime.ax) ?? "",
                         "mandatory_track_created": createdTrack,

--- a/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
+++ b/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import LogicProMCP
+
+/// `project.new` used to succeed only if Logic answered `File ▸ New` with the template chooser.
+/// Measured live on 2026-08-11: Logic can skip the chooser entirely, create the untitled project
+/// immediately and present only its mandatory New Track sheet. The operation then polled ten seconds
+/// for a chooser that was never coming and reported `channels_exhausted` — for a project it had just
+/// created. The arrange window read `Untitled 56 - Tracks` the whole time.
+///
+/// These lock the pieces that decide whether that outcome is recognised. The end-to-end behaviour is
+/// covered by the live run recorded on #516, because which of the two routes Logic takes is a
+/// property of the host's settings and cannot be produced from a unit test.
+@Suite("#516 direct project creation")
+struct Issue516DirectProjectCreationTests {
+    @Test("an arrange window title is accepted as the created-project witness")
+    func arrangeTitleIsTheWitness() {
+        // The exact title observed live when the chooser was skipped.
+        #expect(AccessibilityChannel.isCreatedProjectWindowTitle("Untitled 56 - Tracks"))
+        #expect(AccessibilityChannel.createdProjectWindowSelectionIsUnambiguous(
+            windowTitle: "Untitled 56 - Tracks",
+            windowRole: "AXWindow",
+            windowSubrole: "AXStandardWindow"
+        ))
+    }
+
+    @Test("the chooser window itself is never mistaken for a created project")
+    func chooserIsNotAProject() {
+        #expect(!AccessibilityChannel.isCreatedProjectWindowTitle("Choose a Project"))
+        // A dialog carrying an arrange-shaped title must still be refused on its subrole, so a sheet
+        // or panel cannot stand in for the document window.
+        #expect(!AccessibilityChannel.createdProjectWindowSelectionIsUnambiguous(
+            windowTitle: "Untitled 56 - Tracks",
+            windowRole: "AXWindow",
+            windowSubrole: "AXDialog"
+        ))
+        #expect(!AccessibilityChannel.createdProjectWindowSelectionIsUnambiguous(
+            windowTitle: "Untitled 56 - Tracks",
+            windowRole: "AXSheet",
+            windowSubrole: "AXStandardWindow"
+        ))
+    }
+
+    @Test("File > New is only driven from a blank application")
+    func onlyFromZeroWindows() {
+        // The precondition that keeps this route from acting on a session that already has a
+        // document open — the case where a second, ambiguous project could be created.
+        #expect(AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: 0))
+        #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: 1))
+        #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: nil))
+    }
+}


### PR DESCRIPTION
Closes #516.

## Reproduced live, against the release artifact

`project.new` only acts from a blank application, so that is where the defect lives. Brought Logic to
zero windows and called it through the shipped binary:

```
14.9 s → success: false   state: C   error: channels_exhausted
         hint: "Exact File > New did not expose the Creator Studio chooser"
```

While it said that, the screen showed **`Untitled 56 - Tracks`** with Logic's mandatory *Create New
Track* sheet on it. The project had been created. The operation did what it was asked and reported
failure — Logic on this machine skips the template chooser entirely, and the code waited ten seconds
for a window that was never coming.

This is the failure an outside integrator reported before ending their Logic Pro integration: *"Logic
created an untitled project without exposing the chooser expected by the Provider."* It reproduces on
my desk.

## The fix

The observation phase is **split out of** `createEmptyProjectFromChooser` rather than duplicated, so
the direct route completes through the same sheet reconciliation, the same arrange-window witness and
the same honest State B the chooser route already used. Nothing about the chooser route changes.

```
5.7 s → success: true   state: B   phase: created_project_window_observed
        window_title: "Untitled 56 - Tracks"   selection: "direct"   mandatory_track_created: true
```

## What was deliberately not done

The AppleScript + CGEvent fallback `project.new` had before it was narrowed to one channel is **not**
restored. That narrowing exists so a fallback cannot create a second, ambiguous document after the
exact path refused, and reinstating it would trade this bug for that one. The single channel now
simply recognises both shapes Logic actually produces.

## Every scenario this operation has, driven end to end

| # | scenario | result |
| --- | --- | --- |
| S1 | blank application, chooser skipped | **succeeds**, names the window it observed, 5.6 s |
| S2 | a document is already open | **refuses** — `"non-chooser window; refusing project.new"` |
| S3 | immediately called again | **refuses identically** — the refusal does not leak on retry |
| S4 | the bundle it reported | **exists on disk**, checked with the filesystem, not the receipt |
| S5 | why S2 refused | one window open at the moment of refusal — the real precondition fired |

S2 is the common case — a user asking for a new project without closing the current one — and it is
the one the single-channel design exists to protect. It is verified here rather than assumed.

Unit tests lock the classifiers that decide all of this: the arrange-window title as the created-
project witness, a dialog or sheet subrole never standing in for the document window, and the
zero-window precondition. Which of the two routes Logic takes is a property of the host's settings
and cannot be produced from a unit test, which is why the end-to-end evidence is live.
