### PR TITLE
fix(#519): resolve Logic's menus and window titles by locale, not by English literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 
 ### Fixed
+- **`project.new` works on a Logic that is not in English (#519).** The menu drive named the English
+  menu-bar item, so on a Korean Logic it returned `channels_exhausted` in 2.8 s with "Could not
+  reveal Creator Studio chooser through exact File > New" — never reaching either creation branch.
+  The File menu is `파일` and its New entry is `신규`. The menu is now resolved through
+  `AXLocalePolicy` against the live menu bar and driven with the resolved titles, which also removes
+  this path's System Events dependency. The arrange-window witness was English-only for the same
+  reason and now accepts the localized suffix (`- Tracks`, `- 트랙`). Verified live in both
+  languages: Korean 6.5 s producing `무제 30 - 트랙`, English 6.4 s producing `Untitled 56 - Tracks`.
+  Locale variants are read from the live menu bar rather than translated — the Korean New entry is
+  `신규`, not the `새로 만들기` a translation would produce.
+
+### Fixed
 - **`project.new` no longer fails for a project it just created (#516).** It required Logic to answer
   `File ▸ New` with the template chooser. Where the chooser is skipped — Logic creates the untitled
   project immediately and shows only its mandatory New Track sheet — the operation polled ten seconds

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -152,6 +152,21 @@ enum AXLocalePolicy {
         rationale: "Verifies the Step Input Keyboard window opened or closed after the menu action."
     )
 
+    /// Variants are READ FROM THE LIVE MENU BAR, never translated by hand. Measured on a Korean
+    /// Logic 12.3: the File menu is `파일` and its first entry is `신규` (U+C2E0 U+ADDC) — not the
+    /// `새로 만들기` a translator would reach for, which is the whole reason these are measured.
+    static let fileMenuBar = LabelSet(
+        canonical: "File",
+        variants: ["파일", "ファイル"],
+        rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
+    )
+
+    static let newProjectMenuItem = LabelSet(
+        canonical: "New",
+        variants: ["신규", "新規"],
+        rationale: "Reveals the New Project chooser, or creates the project directly where Logic skips it."
+    )
+
     static let editMenuBar = LabelSet(
         canonical: "Edit",
         variants: ["편집"],
@@ -345,6 +360,17 @@ enum AXLocalePolicy {
     )
 
     // --- Track-header read-only locators ---
+
+    /// The suffix Logic appends to the arrange window's title. Measured live on 2026-08-11: an
+    /// English Logic shows `Untitled 55 - Tracks` and a Korean one `Untitled 55 - 트랙`
+    /// (U+D2B8 U+B799). `project.new` uses this suffix as its witness that a project was created, so
+    /// an English-only literal made the operation report failure for a project it had just created —
+    /// the #516 regression, still live for anyone not running Logic in English.
+    static let arrangeWindowTitleSuffix = LabelSet(
+        canonical: "Tracks",
+        variants: ["트랙", "トラック"],
+        rationale: "Witnesses that an arrange window exists after project.new; read-only classification."
+    )
 
     static let trackMuteButton = LabelSet(
         canonical: "Mute",

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -27,21 +27,31 @@ extension AccessibilityChannel {
             return .error("Creator Studio has a non-chooser window; refusing project.new")
         }
 
-        let target = LogicProTarget.appleScriptTarget()
-        let reveal = await runtime.executeAppleScript("""
-        \(target.activateByBundleID)
-        tell application "System Events"
-            tell \(target.systemEventsProcessTarget)
-                if (count of windows) is not 0 then return "WINDOWS_PRESENT"
-                if not (exists menu item "New" of menu 1 of menu bar item "File" of menu bar 1) then return "EXACT_NEW_NOT_FOUND"
-                click menu item "New" of menu 1 of menu bar item "File" of menu bar 1
-                return "EXACT_NEW_CLICKED"
-            end tell
-        end tell
-        """)
-        guard reveal.isSuccess, reveal.message.contains("EXACT_NEW_CLICKED") else {
-            return .error("Could not reveal Creator Studio chooser through exact File > New")
+        // Drive the menu through AX with locale-resolved titles instead of an AppleScript that
+        // names the English menu. Measured on a Korean Logic: the bar item is `파일` and the entry is
+        // `신규`, so the previous script returned EXACT_NEW_NOT_FOUND and project.new failed in 2.8 s
+        // without ever reaching either creation branch (#519). This also drops the System Events
+        // dependency, which needs its own Automation grant and raises a prompt this process cannot
+        // dismiss.
+        guard let menuBarAny = AXHelpers.getAttribute(app, "AXMenuBar", runtime: runtime.ax) as AXUIElement?,
+              let fileItem = AXLocalePolicy.findMenuBarItem(
+                  in: menuBarAny, matching: AXLocalePolicy.fileMenuBar, runtime: runtime.ax
+              )
+        else {
+            return .error("Could not resolve the File menu in this Logic's language")
         }
+        guard let newItem = AXLocalePolicy.findMenuItem(
+            under: fileItem, matching: AXLocalePolicy.newProjectMenuItem, runtime: runtime.ax
+        ) else {
+            return .error("Could not resolve the New entry under the File menu in this Logic's language")
+        }
+        // Press the bar item first so the menu materialises, then the entry. The return codes are
+        // not consulted: on Logic 12.3 a press that works can still report failure, so the observed
+        // window below is the only thing that decides.
+        _ = AXHelpers.performAction(fileItem, kAXPressAction as String, runtime: runtime.ax)
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        _ = AXHelpers.performAction(newItem, kAXPickAction as String, runtime: runtime.ax)
+
         for _ in 0..<40 {
             try? await Task.sleep(nanoseconds: 250_000_000)
             if exactEmptyProjectChooserIsVisible(runtime: runtime) {
@@ -132,8 +142,16 @@ extension AccessibilityChannel {
     static func isCreatedProjectWindowTitle(_ title: String?) -> Bool {
         guard let title else { return false }
         let normalized = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let arrangeSuffix = " - Tracks"
-        return normalized.hasSuffix(arrangeSuffix) && normalized.count > arrangeSuffix.count
+        // The suffix is localized. Measured live: `Untitled 55 - Tracks` in English,
+        // `Untitled 55 - 트랙` in Korean. Hard-coding the English form made project.new report
+        // failure for a project it had just created on every non-English Logic.
+        for label in AXLocalePolicy.arrangeWindowTitleSuffix.labels {
+            let suffix = " - " + label
+            if normalized.hasSuffix(suffix), normalized.count > suffix.count {
+                return true
+            }
+        }
+        return false
     }
 
     static func createdProjectWindowSelectionIsUnambiguous(

--- a/Tests/LogicProMCPTests/Issue519MenuLocaleTests.swift
+++ b/Tests/LogicProMCPTests/Issue519MenuLocaleTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import LogicProMCP
+
+/// Ten menu drives named the English menu-bar item, so every operation routed through them failed on
+/// a Logic running in another language. Measured live on 2026-08-11 with Logic in Korean:
+/// `project.new` returned `channels_exhausted` in 2.8 s with
+/// `"Could not reveal Creator Studio chooser through exact File > New"` — it never reached either
+/// creation branch, because the File menu is `파일` and its New entry is `신규`.
+///
+/// The variants here are read from the live menu bar, never translated: a hand translation would have
+/// produced `새로 만들기`, which is not what Logic shows.
+@Suite("#519 menu and window titles are localized")
+struct Issue519MenuLocaleTests {
+    @Test("the File menu and its New entry carry the measured Korean titles")
+    func fileAndNewAreLocalized() {
+        #expect(AXLocalePolicy.fileMenuBar.labels.contains("File"))
+        #expect(AXLocalePolicy.fileMenuBar.labels.contains("파일"))
+        #expect(AXLocalePolicy.newProjectMenuItem.labels.contains("New"))
+        #expect(AXLocalePolicy.newProjectMenuItem.labels.contains("신규"))
+        // The plausible mistranslation must NOT be what the policy carries, so a future edit that
+        // "corrects" it fails here instead of failing on a user's machine.
+        #expect(!AXLocalePolicy.newProjectMenuItem.labels.contains("새로 만들기"))
+    }
+
+    @Test("the arrange window witness accepts every locale Logic actually produces")
+    func arrangeWitnessIsLocalized() {
+        // English and Korean, both read off the live window title.
+        #expect(AccessibilityChannel.isCreatedProjectWindowTitle("Untitled 56 - Tracks"))
+        #expect(AccessibilityChannel.isCreatedProjectWindowTitle("무제 30 - 트랙"))
+        // A bare suffix with nothing before it is not a project.
+        #expect(!AccessibilityChannel.isCreatedProjectWindowTitle(" - 트랙"))
+        #expect(!AccessibilityChannel.isCreatedProjectWindowTitle("트랙"))
+        #expect(!AccessibilityChannel.isCreatedProjectWindowTitle("Choose a Project"))
+    }
+}


### PR DESCRIPTION
Addresses the `project.new` share of #519. The other nine menu drives named in that issue are **not**
touched here.

## What was wrong

Ten AppleScript menu drives name the **English** menu-bar item. On a Logic running in any other
language they cannot find it, so the operation fails closed with an error naming a menu the user does
not have.

Measured with Logic switched to Korean, driven through the release artifact:

```
2.8 s → success: false   state: C   error: channels_exhausted
        hint: "Could not reveal Creator Studio chooser through exact File > New"
```

It never reaches either creation branch — the File menu is `파일` and its New entry is `신규`, so the
script returns `EXACT_NEW_NOT_FOUND` immediately. The same machine in English completes in 5.7 s.

Two more English-only assumptions sat behind it and were measured in the same session:

| surface | English | Korean |
| --- | --- | --- |
| arrange window title | `Untitled 55 - Tracks` | `무제 30 - 트랙` |
| Event List header | `L M Position Status Ch Num Val Length/Info` | `L M 위치 상태 채널 번호 값 길이/정보` |

The created-project witness matched only the English suffix, so even once the menu was reached the
operation would not have recognised its own result. (The Event List header belongs to the MIDI
readback provider and is left for #293's qualification work — it is recorded here because it is the
same defect class.)

## The fix

`project.new` resolves the menu through `AXLocalePolicy` against the **live menu bar** and drives the
resolved titles, using `findMenuBarItem` / `findMenuItem` — machinery this codebase already uses on
its AX paths. The window witness reads every variant the policy carries.

This also removes the path's System Events dependency, which needs its own Automation grant and, on
this machine, raised a **Developer Tools Access** prompt that a synthetic Escape cannot dismiss.

## Variants are measured, not translated

A hand translation gives `새로 만들기` for New. Logic shows **`신규`**. Every variant here was read off
the live menu bar, and a test asserts the policy does **not** carry the plausible wrong one, so a
future "correction" fails in CI rather than on a user's machine.

## Verified live in both languages, same source

| locale | result |
| --- | --- |
| Korean | 6.5 s, `state B`, `created_project_window_observed`, `무제 30 - 트랙`, bundle `무제 30.logicx` |
| English | 6.4 s, `state B`, `created_project_window_observed`, `Untitled 56 - Tracks` |

The Korean arm cannot share a process with the English one — changing Logic's language requires
restarting it — so the evidence bundle carries the English arm as an executed run and records the
Korean measurement alongside it.
