### PR TITLE
fix(#293): match Event List headers by locale, keep column identity canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 
 ### Fixed
+- **MIDI note readback works on a Korean Logic (#293).** The Event List collector compared its column
+  headers positionally against English literals, so every read outside English threw
+  `headerMismatch` and the readback could not run at all — one of the two `ABSENT` proofs
+  `MIDIProviderGate` requires of this provider. Headers are now matched through `AXLocalePolicy`,
+  with the **canonical English form kept as the column identity** so a snapshot taken in one language
+  stays comparable with one taken in another. Measured on Logic 12.3 in Korean: event level
+  `["L","M","위치","상태","채널","번호","값","길이/정보"]`, region level
+  `["L","M","위치","이름","트랙","길이"]`.
+
+### Fixed
 - **`project.new` works on a Logic that is not in English (#519).** The menu drive named the English
   menu-bar item, so on a Korean Logic it returned `channels_exhausted` in 2.8 s with "Could not
   reveal Creator Studio chooser through exact File > New" — never reaching either creation branch.

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -155,6 +155,40 @@ enum AXLocalePolicy {
     /// Variants are READ FROM THE LIVE MENU BAR, never translated by hand. Measured on a Korean
     /// Logic 12.3: the File menu is `파일` and its first entry is `신규` (U+C2E0 U+ADDC) — not the
     /// `새로 만들기` a translator would reach for, which is the whole reason these are measured.
+    /// Event List column headers. Every variant is READ FROM A LIVE LOGIC, never translated.
+    /// Measured 2026-08-11 on Logic 12.3 in Korean; the English forms stay the canonical column
+    /// identity, so a snapshot taken in one language is comparable with one taken in another.
+    ///
+    /// The collector compared these positionally against English literals, so on a Korean Logic it
+    /// threw `headerMismatch` and the note readback could not run at all — the `English and Korean
+    /// locale coverage` proof `MIDIProviderGate` requires of this provider.
+    static let eventListColumnL = LabelSet(canonical: "L", variants: [],
+        rationale: "Event List lock column; unlabelled in every locale measured.")
+    static let eventListColumnM = LabelSet(canonical: "M", variants: [],
+        rationale: "Event List mute column; unlabelled in every locale measured.")
+    static let eventListColumnPosition = LabelSet(canonical: "Position", variants: ["위치"],
+        rationale: "Event List position column; identity is the canonical English form.")
+    static let eventListColumnStatus = LabelSet(canonical: "Status", variants: ["상태"],
+        rationale: "Event List status column; identity is the canonical English form.")
+    static let eventListColumnChannel = LabelSet(canonical: "Ch", variants: ["채널"],
+        rationale: "Event List channel column; identity is the canonical English form.")
+    static let eventListColumnNumber = LabelSet(canonical: "Num", variants: ["번호"],
+        rationale: "Event List number column; identity is the canonical English form.")
+    static let eventListColumnValue = LabelSet(canonical: "Val", variants: ["값"],
+        rationale: "Event List value column; identity is the canonical English form.")
+    static let eventListColumnLengthInfo = LabelSet(canonical: "Length/Info", variants: ["길이/정보"],
+        rationale: "Event List length column; identity is the canonical English form.")
+
+    /// The region-level header, which is how the collector tells "you are looking at the wrong level"
+    /// apart from "Logic changed its columns". Measured in Korean as
+    /// `["L","M","위치","이름","트랙","길이"]`.
+    static let eventListColumnName = LabelSet(canonical: "Name", variants: ["이름"],
+        rationale: "Region-level name column; distinguishes the region list from the event list.")
+    static let eventListColumnTrack = LabelSet(canonical: "Trk", variants: ["트랙"],
+        rationale: "Region-level track column; distinguishes the region list from the event list.")
+    static let eventListColumnLength = LabelSet(canonical: "Length", variants: ["길이"],
+        rationale: "Region-level length column; distinguishes the region list from the event list.")
+
     static let fileMenuBar = LabelSet(
         canonical: "File",
         variants: ["파일", "ファイル"],

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -89,15 +89,27 @@ enum EventListReadbackCollector {
 
     // MARK: - Event pane identity
 
-    private static let expectedHeaderTitles = [
-        "L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info",
+    /// Column identity is the CANONICAL English form; the locale variants only widen what the live
+    /// header is allowed to say. Measured on a Korean Logic 12.3 the same columns read
+    /// `["L","M","위치","상태","채널","번호","값","길이/정보"]`, and comparing those against English
+    /// literals threw `headerMismatch` — the readback could not run at all outside English.
+    private static let expectedHeaderColumns: [AXLocalePolicy.LabelSet] = [
+        AXLocalePolicy.eventListColumnL, AXLocalePolicy.eventListColumnM,
+        AXLocalePolicy.eventListColumnPosition, AXLocalePolicy.eventListColumnStatus,
+        AXLocalePolicy.eventListColumnChannel, AXLocalePolicy.eventListColumnNumber,
+        AXLocalePolicy.eventListColumnValue, AXLocalePolicy.eventListColumnLengthInfo,
     ]
+    private static let expectedHeaderTitles = expectedHeaderColumns.map(\.canonical)
     /// Logic uses this distinct schema while the Event List is showing regions
     /// instead of the selected region's events. It is a recoverable navigation
     /// failure, not a column-layout drift.
-    private static let regionLevelHeaderTitles = [
-        "L", "M", "Position", "Name", "Trk", "Length",
+    /// Measured in Korean as `["L","M","위치","이름","트랙","길이"]`.
+    private static let regionLevelHeaderColumns: [AXLocalePolicy.LabelSet] = [
+        AXLocalePolicy.eventListColumnL, AXLocalePolicy.eventListColumnM,
+        AXLocalePolicy.eventListColumnPosition, AXLocalePolicy.eventListColumnName,
+        AXLocalePolicy.eventListColumnTrack, AXLocalePolicy.eventListColumnLength,
     ]
+    private static let regionLevelHeaderTitles = regionLevelHeaderColumns.map(\.canonical)
     private static let maximumMaterializationPasses = 64
 
     private struct HeaderBinding {
@@ -242,15 +254,27 @@ enum EventListReadbackCollector {
         }
         let titles = sortButtons.map { AXHelpers.getTitle($0, runtime: runtime) }
 
-        if titles == regionLevelHeaderTitles {
+        func matchesAll(_ columns: [AXLocalePolicy.LabelSet]) -> Bool {
+            guard titles.count == columns.count else { return false }
+            for (index, column) in columns.enumerated() where !column.matches(titles[index]) {
+                return false
+            }
+            return true
+        }
+
+        if matchesAll(regionLevelHeaderColumns) {
             throw EventListReadbackCollectorError.paneAtRegionLevel
         }
 
-        for index in expectedHeaderTitles.indices {
-            let expected = expectedHeaderTitles[index]
+        for index in expectedHeaderColumns.indices {
+            let column = expectedHeaderColumns[index]
             let actual = titles.indices.contains(index) ? titles[index] : nil
-            guard actual == expected else {
-                throw EventListReadbackCollectorError.headerMismatch(expected: expected, actual: actual)
+            guard column.matches(actual) else {
+                // The reported `expected` stays canonical so the error names one thing across
+                // locales, while `actual` carries whatever Logic really rendered.
+                throw EventListReadbackCollectorError.headerMismatch(
+                    expected: column.canonical, actual: actual
+                )
             }
         }
         guard titles.count == expectedHeaderTitles.count else {

--- a/Tests/LogicProMCPTests/Issue293EventListLocaleTests.swift
+++ b/Tests/LogicProMCPTests/Issue293EventListLocaleTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import LogicProMCP
+
+/// `MIDIProviderGate` requires "English and Korean locale coverage" of the Event List provider before
+/// it can be qualified. The collector compared its column headers positionally against English
+/// literals, so on a Korean Logic every read threw `headerMismatch` and the note readback could not
+/// run at all.
+///
+/// The variants are read from a live Logic 12.3 in Korean, never translated — the same discipline
+/// that caught `New = 신규` rather than the `새로 만들기` a translation produces.
+@Suite("#293 Event List headers are locale-aware")
+struct Issue293EventListLocaleTests {
+    private static let koreanEventHeader = ["L", "M", "위치", "상태", "채널", "번호", "값", "길이/정보"]
+    private static let koreanRegionHeader = ["L", "M", "위치", "이름", "트랙", "길이"]
+
+    private static func binds(_ columns: [AXLocalePolicy.LabelSet], _ titles: [String]) -> Bool {
+        guard titles.count == columns.count else { return false }
+        for (index, column) in columns.enumerated() where !column.matches(titles[index]) {
+            return false
+        }
+        return true
+    }
+
+    private static let eventColumns: [AXLocalePolicy.LabelSet] = [
+        AXLocalePolicy.eventListColumnL, AXLocalePolicy.eventListColumnM, AXLocalePolicy.eventListColumnPosition, AXLocalePolicy.eventListColumnStatus,
+        AXLocalePolicy.eventListColumnChannel, AXLocalePolicy.eventListColumnNumber, AXLocalePolicy.eventListColumnValue,
+        AXLocalePolicy.eventListColumnLengthInfo,
+    ]
+    private static let regionColumns: [AXLocalePolicy.LabelSet] = [
+        AXLocalePolicy.eventListColumnL, AXLocalePolicy.eventListColumnM, AXLocalePolicy.eventListColumnPosition, AXLocalePolicy.eventListColumnName,
+        AXLocalePolicy.eventListColumnTrack, AXLocalePolicy.eventListColumnLength,
+    ]
+
+    @Test("both levels bind in English and in Korean")
+    func bothLevelsBindInBothLanguages() {
+        #expect(Self.binds(Self.eventColumns, Self.eventColumns.map(\.canonical)))
+        #expect(Self.binds(Self.regionColumns, Self.regionColumns.map(\.canonical)))
+        #expect(Self.binds(Self.eventColumns, Self.koreanEventHeader))
+        #expect(Self.binds(Self.regionColumns, Self.koreanRegionHeader))
+    }
+
+    @Test("no header binds both levels, in either language")
+    func levelsNeverCross() {
+        // If a region header bound the event columns, "you are looking at the wrong level" would be
+        // reported as "Logic changed its columns" — a recoverable condition turned unrecoverable.
+        #expect(!Self.binds(Self.eventColumns, Self.koreanRegionHeader))
+        #expect(!Self.binds(Self.regionColumns, Self.koreanEventHeader))
+        #expect(!Self.binds(Self.eventColumns, Self.regionColumns.map(\.canonical)))
+        #expect(!Self.binds(Self.regionColumns, Self.eventColumns.map(\.canonical)))
+    }
+
+    @Test("column identity stays canonical English across locales")
+    func identityIsCanonical() {
+        // A snapshot taken on a Korean Logic must be comparable with one taken on an English Logic,
+        // so the column IDs are the canonical forms and only the accepted rendering widens.
+        #expect(AXLocalePolicy.eventListColumnPosition.canonical == "Position")
+        #expect(AXLocalePolicy.eventListColumnValue.canonical == "Val")
+        #expect(AXLocalePolicy.eventListColumnPosition.labels.contains("위치"))
+        #expect(AXLocalePolicy.eventListColumnValue.labels.contains("값"))
+    }
+}


### PR DESCRIPTION
Closes one of the eleven proofs #293 requires. The provider stays **unqualified**; this is one line
of that program, not the program.

## The proof this closes

`MIDIProviderGate` registers `.eventListAX` with `requiredProofs`, one of which is **"English and
Korean locale coverage"**. A survey of all eleven found it `ABSENT`: the collector compared its column
headers positionally against English literals, so on a Korean Logic every read threw `headerMismatch`
and the note readback could not run at all.

Measured on Logic 12.3 switched to Korean:

| level | English | Korean |
| --- | --- | --- |
| event | `L M Position Status Ch Num Val Length/Info` | `L M 위치 상태 채널 번호 값 길이/정보` |
| region | `L M Position Name Trk Length` | `L M 위치 이름 트랙 길이` |

## What changed, and what deliberately did not

Headers now match through `AXLocalePolicy` label sets. **The canonical English form stays the column
identity** — only the accepted rendering widens — so a snapshot taken on a Korean Logic remains
comparable with one taken on an English Logic. That was the point of the `column identity binding`
proof and it is preserved rather than traded away.

The region-level header keeps its own set for the reason it exists: if a region header bound the event
columns, `paneAtRegionLevel` — which the caller can recover from — would be reported as
`headerMismatch`, which it cannot. All four cross combinations are asserted not to bind.

## Variants are measured, never translated

Every string was read from a live Logic. The same discipline earlier in this session caught
`New = 신규`, where a translation gives `새로 만들기`. Reading the Korean labels also required
localizing the probes themselves — the arrange window is `- 트랙`, the Event pane is `이벤트`, and its
ascend button is `폴더 나가기`.

## Live evidence

Driven against the release artifact, screen-recorded, with the pane asserted on a bound region and a
positive twin proving the camera registers change on those same pixels. The English arm executes here;
the Korean strings were read from this same Logic earlier — changing Logic's language requires
restarting it, so the two arms cannot share a process, and that limit is recorded in the bundle rather
than papered over.

One check in that run was rewritten twice, and both rewrites are worth naming. It first asserted the
pane **level** was restored after a tab round trip; measured, Logic resets a region-level pane to
event level, so that was asserting something false and calling it a restoration. It then asserted the
level *changed*, which was true only when the run happened to start at region level — an assertion
about my run order rather than about Logic. It now asserts what holds from either starting point: a
tab round trip leaves the pane at event level.

## Still open on this provider

`Desktop variant coverage` remains `ABSENT`, and the other nine proofs remain `PARTIAL` — the
mechanisms exist and fail closed, but the live evidence that each guard is correct does not. The
survey table is on #293.
