### PR TITLE
fix(#293): record which Logic product a readback came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 
 ### Fixed
+- **MIDI readback evidence states which Logic product produced it (#293).** Qualification is judged
+  per axis — variant crossed with locale, profile, cache state and fixture — and a reading that cannot
+  name its product cannot be placed on that grid. `EventListReadbackEvidence` now carries the
+  `LogicProVariant` resolved from the process actually being read, `.unknown` included rather than
+  guessed. Creator Studio is not installed on the verifying host, so nothing is claimed about it.
+
 - **MIDI note readback works on a Korean Logic (#293).** The Event List collector compared its column
   headers positionally against English literals, so every read outside English threw
   `headerMismatch` and the readback could not run at all — one of the two `ABSENT` proofs

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -72,6 +72,10 @@ enum EventListReadbackCollector {
         try refuseTimeDisplayIfNeeded(runtime: runtime, rows: harvest.passA, positionColumn: headers.positionID)
 
         return EventListReadbackEvidence(
+            // Resolved from the process actually being read, not from a build-time assumption. On an
+            // unrecognised bundle identifier this is `.unknown`, which is the honest answer and keeps
+            // the reading off a coverage axis it did not earn.
+            variant: LogicProTarget.current.variant,
             requestedRegion: requestedRegion,
             resolvedIdentity: resolvedIdentity,
             observedRegion: .unproven,

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackEvidence.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackEvidence.swift
@@ -230,6 +230,16 @@ enum TimingEvidence: Sendable {
 // MARK: - Evidence package
 
 struct EventListReadbackEvidence: Sendable {
+    /// Which Logic product this reading came from.
+    ///
+    /// `MIDIProviderGate` requires "Desktop variant coverage" of this provider, and qualification is
+    /// judged per axis — variant crossed with locale, profile, cache state and fixture. Evidence that
+    /// does not say which product produced it cannot be placed on that grid, so a desktop reading
+    /// could be counted as covering Creator Studio, whose Event List this project has never observed.
+    /// `.unknown` is carried rather than guessed: a reading from an unrecognised bundle identifier is
+    /// still a reading, and saying so is what stops it from being filed under a product it did not
+    /// come from.
+    let variant: LogicProVariant
     let requestedRegion: MIDIRegionReference
     let resolvedIdentity: RegistryResolvedIdentityProof
     let observedRegion: ObservedRegionIdentityProof

--- a/Tests/LogicProMCPTests/Issue293DesktopVariantTests.swift
+++ b/Tests/LogicProMCPTests/Issue293DesktopVariantTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import LogicProMCP
+
+/// `MIDIProviderGate` requires "Desktop variant coverage" of the Event List provider. A survey found
+/// it `ABSENT`: no Event List production code or test handled `LogicProVariant` at all, so a reading
+/// carried no record of which Logic product produced it.
+///
+/// Qualification is judged per axis — variant crossed with locale, profile, cache state and fixture
+/// (`QualificationAxis`). Evidence that cannot say which product it came from cannot be placed on
+/// that grid, and a desktop reading would silently count as covering Creator Studio, whose Event List
+/// this project has never observed.
+@Suite("#293 readback evidence states its Logic variant")
+struct Issue293DesktopVariantTests {
+    @Test("the variant is part of the evidence, and desktop and Creator Studio are distinguishable")
+    func evidenceCarriesTheVariant() {
+        let desktop = Issue293DesktopVariantTests.evidence(variant: .desktop)
+        let creator = Issue293DesktopVariantTests.evidence(variant: .creatorStudio)
+        #expect(desktop.variant == .desktop)
+        #expect(creator.variant == .creatorStudio)
+        #expect(desktop.variant != creator.variant)
+    }
+
+    @Test("an unrecognised product is recorded as unknown rather than assumed to be desktop")
+    func unknownIsNotDesktop() {
+        // The failure this forbids: a reading from a Logic this build does not recognise being filed
+        // under the variant that happens to be most common.
+        let unknown = Issue293DesktopVariantTests.evidence(variant: .unknown)
+        #expect(unknown.variant == .unknown)
+        #expect(unknown.variant != .desktop)
+    }
+
+    @Test("this machine's bundle identifier resolves to desktop")
+    func thisHostIsDesktop() {
+        // Measured: the Logic under test here is `com.apple.logic10`, the desktop product. If the
+        // mapping ever stops resolving it, every live proof gathered on this machine would be filed
+        // as `unknown` and stop counting toward Desktop coverage — which should be loud, not silent.
+        #expect(LogicProVariant.from(bundleID: "com.apple.logic10") == .desktop)
+    }
+
+    /// Reuses the shape the provider tests already build, so this suite tests the variant record and
+    /// not my guess at the surrounding types.
+    /// Built from the real declarations, not from a guess at them: `MIDIRegionReference` takes a
+    /// `TargetReference` and an optional index, and `FilterEvidence` takes checkboxes.
+    private static func evidence(variant: LogicProVariant) -> EventListReadbackEvidence {
+        let region = MIDIRegionReference(
+            targetRef: TargetReference(rawValue: "trk_variant"), regionIndex: 0
+        )
+        let identity = ResolvedRegionIdentity(name: "r", ordinal: 0, startTick: 0)
+        return EventListReadbackEvidence(
+            variant: variant,
+            requestedRegion: region,
+            resolvedIdentity: RegionIdentityRegistrySeam.mint(boundRegion: region, identity: identity),
+            observedRegion: .proven(identity),
+            projectEpochBefore: 1,
+            projectEpochAfter: 1,
+            ppq: 480,
+            columnBinding: .headerIdentity(.unproven),
+            filter: FilterEvidence(checkboxes: []),
+            itemCount: ItemCountEvidence(rawCountText: "0 Events", semanticsProof: .unproven),
+            harvest: RowHarvest(orderedRowKeys: [], passA: [:], passB: [:], exhaustion: .unproven),
+            timing: .unproven,
+            calibration: nil
+        )
+    }
+}

--- a/Tests/LogicProMCPTests/Issue293EventListProviderTests.swift
+++ b/Tests/LogicProMCPTests/Issue293EventListProviderTests.swift
@@ -61,6 +61,7 @@ import Testing
             (RowKey(index: index), row)
         })
         return EventListReadbackEvidence(
+            variant: .desktop,
             requestedRegion: region,
             resolvedIdentity: RegionIdentityRegistrySeam.mint(
                 boundRegion: region,

--- a/Tests/LogicProMCPTests/MIDIReadbackAssessmentTests.swift
+++ b/Tests/LogicProMCPTests/MIDIReadbackAssessmentTests.swift
@@ -89,6 +89,7 @@ import Testing
         calibration: CalibrationTriple? = CalibrationTriple(pitch: 60, velocity: 100, startTickValue: 1)
     ) -> EventListReadbackEvidence {
         EventListReadbackEvidence(
+            variant: .desktop,
             requestedRegion: requestedRegion,
             resolvedIdentity: resolved ?? RegionIdentityRegistrySeam.mint(boundRegion: region, identity: identity),
             observedRegion: observed,


### PR DESCRIPTION
Closes the second of the two `ABSENT` proofs on #293. The provider stays **unqualified**; nine
`PARTIAL` proofs remain.

## The proof

`MIDIProviderGate` requires **"Desktop variant coverage"** of this provider. The survey found it
`ABSENT`: no Event List production code or test handled `LogicProVariant` at all, so a reading carried
no record of which Logic product produced it.

That matters because qualification is judged **per axis** — variant crossed with locale, profile,
cache state and fixture. Evidence that cannot name its product cannot be placed on that grid, and a
desktop reading would silently count as covering Creator Studio, whose Event List this project has
never observed.

## What changed

`EventListReadbackEvidence` carries the variant, resolved from the process actually being read rather
than from a build-time assumption. An unrecognised bundle identifier yields `.unknown` — the honest
answer, and what keeps such a reading off a coverage axis it did not earn. A test asserts `.unknown`
is not silently filed as `.desktop`.

## Creator Studio is excluded, and says so

It is **not installed on the verifying host**. Nothing here claims anything about it. The proof under
test is Desktop, this machine is the Desktop product, and the evidence bundle records the exclusion
with the applications actually present rather than leaving a reader to assume coverage.

## Live evidence

Driven against the release artifact, screen-recorded. The product is read **three ways that could
disagree** — the bundle identifier of the live process, the application menu Logic renders in its own
menu bar, and the bundle present on disk — and all three name Logic Pro desktop. A record that agrees
only with itself proves nothing.

Two things in that run are worth naming because both were mistakes I made and then measured:

- The menu-bar assertion first used **window-relative** coordinates and called them "the application
  menu". `ev.shot` captures Logic's window, so those pixels are the window's traffic-light buttons.
  It passed while measuring something else — worse than failing. The assertion now reads a display
  capture, and the crop was inspected to confirm ` Logic Pro  File  Edit  Track` is inside it.
- A rail capture never settled. With a track soloed, Logic pulses the Mute glyph of every other track;
  the capture now settles on the track-name band, which carries the change under test and no
  indicator.
