### PR TITLE
fix(#524): resolve the Event List display mode from the pane's own View menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 
 ### Fixed
+- **The MIDI readback collector can resolve the Event List display mode (#524).** It searched the
+  **application** menu bar for `Event Position and Length as Time`; that menu has sixteen entries on
+  Logic 12.3 and none of them is the setting, which lives in the Event pane's own View menu beside the
+  column toggles. Every `collect()` therefore threw `displayModeUnavailable` before it could return
+  evidence. Nothing caught it because the collector is reachable from no dispatcher and the unit tests
+  supplied the mode through a seam; the fixture placed the item on the menu bar too, so it agreed with
+  the bug.
+
 - **MIDI readback evidence states which Logic product produced it (#293).** Qualification is judged
   per axis — variant crossed with locale, profile, cache state and fixture — and a reading that cannot
   name its product cannot be placed on that grid. `EventListReadbackEvidence` now carries the

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -189,6 +189,17 @@ enum AXLocalePolicy {
     static let eventListColumnLength = LabelSet(canonical: "Length", variants: ["길이"],
         rationale: "Region-level length column; distinguishes the region list from the event list.")
 
+    /// The Event pane's "position and length as Time" toggle. Matched by title on the pane's own View
+    /// menu; a Time-mode reading is refused because the collector's tick arithmetic assumes bars and
+    /// beats. Korean variant to be measured before it is claimed — this entry has not been read on a
+    /// non-English Logic yet, and an invented translation is worse than an English-only match that
+    /// fails closed.
+    static let eventPositionAsTimeMenuItem = LabelSet(
+        canonical: "Event Position and Length as Time",
+        variants: [],
+        rationale: "Decides whether Event List positions are bar/beat or timecode; read-only."
+    )
+
     static let fileMenuBar = LabelSet(
         canonical: "File",
         variants: ["파일", "ファイル"],

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -69,7 +69,12 @@ enum EventListReadbackCollector {
             headers: headers,
             runtime: runtime.ax
         )
-        try refuseTimeDisplayIfNeeded(runtime: runtime, rows: harvest.passA, positionColumn: headers.positionID)
+        try refuseTimeDisplayIfNeeded(
+            pane: paneAndTable.pane,
+            runtime: runtime,
+            rows: harvest.passA,
+            positionColumn: headers.positionID
+        )
 
         return EventListReadbackEvidence(
             // Resolved from the process actually being read, not from a build-time assumption. On an
@@ -510,18 +515,45 @@ enum EventListReadbackCollector {
 
     // MARK: - Display mode
 
+    /// The Event pane's own View menu, opened so its items are readable.
+    ///
+    /// The menu has to be shown before its entries materialise; the mark character that says whether
+    /// the Time display is active is only meaningful once they have. The menu is cancelled again by
+    /// the caller's `defer` so the pane is left as it was found.
+    private static func paneViewMenu(
+        in pane: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        let buttons = AXHelpers.findAllDescendants(
+            of: pane, role: kAXMenuButtonRole as String, maxDepth: 8, runtime: runtime
+        ).filter {
+            AXLocalePolicy.elementMatches($0, AXLocalePolicy.viewMenuBar, runtime: runtime)
+        }
+        guard buttons.count == 1, let button = buttons.first else { return nil }
+        if let existing = AXHelpers.getChildren(button, runtime: runtime).first(where: {
+            AXHelpers.getRole($0, runtime: runtime) == (kAXMenuRole as String)
+        }) {
+            return existing
+        }
+        _ = AXHelpers.performAction(button, "AXShowMenu", runtime: runtime)
+        return AXHelpers.getChildren(button, runtime: runtime).first {
+            AXHelpers.getRole($0, runtime: runtime) == (kAXMenuRole as String)
+        }
+    }
+
     private static func refuseTimeDisplayIfNeeded(
+        pane: AXUIElement,
         runtime: AXLogicProElements.Runtime,
         rows: [RowKey: RawEventRow],
         positionColumn: AXColumnID
     ) throws {
-        guard let menuBar = AXLogicProElements.getMenuBar(runtime: runtime),
-              let viewMenu = AXLocalePolicy.findMenuBarItem(
-                in: menuBar,
-                matching: AXLocalePolicy.viewMenuBar,
-                runtime: runtime.ax
-              )
-        else {
+        // The setting lives in the EVENT PANE's own View menu, together with the column toggles —
+        // not in the application menu bar. Measured on Logic 12.3: the app View menu holds sixteen
+        // entries (Library, Inspector, Mixer, … Enter Full Screen) and none of them is this one, so
+        // searching there found zero matches and every collect() threw displayModeUnavailable before
+        // it could return evidence. Nothing caught it because the collector is reachable from no
+        // dispatcher, and the unit tests supply the mode through a seam rather than a live menu.
+        guard let viewMenu = paneViewMenu(in: pane, runtime: runtime.ax) else {
             throw EventListReadbackCollectorError.displayModeUnavailable
         }
         let menuItems = AXHelpers.findAllDescendants(
@@ -530,7 +562,9 @@ enum EventListReadbackCollector {
             maxDepth: 8,
             runtime: runtime.ax
         ).filter {
-            AXHelpers.getTitle($0, runtime: runtime.ax) == "Event Position and Length as Time"
+            AXLocalePolicy.elementMatches(
+                $0, AXLocalePolicy.eventPositionAsTimeMenuItem, runtime: runtime.ax
+            )
         }
         guard menuItems.count == 1, let menuItem = menuItems.first else {
             throw EventListReadbackCollectorError.displayModeUnavailable

--- a/Tests/LogicProMCPTests/EventListReadbackCollectorTests.swift
+++ b/Tests/LogicProMCPTests/EventListReadbackCollectorTests.swift
@@ -146,16 +146,24 @@ import Testing
             builder.setChildren(pane, AXHelpers.getChildren(pane, runtime: builder.makeAXRuntime()) + [text])
         }
 
-        let menuBar = element()
+        // The display-mode setting hangs off the EVENT PANE's own View menu button, beside the
+        // column toggles — not the application menu bar. This fixture used to place it on the menu
+        // bar, which is why the collector could search there and pass here while failing on every
+        // real Logic (#524). Measured on 12.3: the app View menu has sixteen entries and none is
+        // this one.
+        let viewButton = element()
         let viewMenu = element()
         let displayMode = element()
-        builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
-        builder.setAttribute(viewMenu, kAXTitleAttribute as String, "View")
+        builder.setRole(viewButton, kAXMenuButtonRole as String)
+        builder.setAttribute(viewButton, kAXTitleAttribute as String, "View")
+        builder.setAttribute(viewButton, kAXParentAttribute as String, pane)
+        builder.setRole(viewMenu, kAXMenuRole as String)
         builder.setRole(displayMode, kAXMenuItemRole as String)
         builder.setAttribute(displayMode, kAXTitleAttribute as String, "Event Position and Length as Time")
         builder.setAttribute(displayMode, kAXMenuItemMarkCharAttribute as String, timeMark)
-        builder.setChildren(menuBar, [viewMenu])
         builder.setChildren(viewMenu, [displayMode])
+        builder.setChildren(viewButton, [viewMenu])
+        builder.setChildren(pane, AXHelpers.getChildren(pane, runtime: builder.makeAXRuntime()) + [viewButton])
 
         return Fixture(
             builder: builder,

--- a/Tests/LogicProMCPTests/Issue524DisplayModeMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue524DisplayModeMenuTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import LogicProMCP
+
+/// `refuseTimeDisplayIfNeeded` resolved the position display mode from the **application** menu bar.
+/// Measured live on Logic 12.3, that menu holds sixteen entries and none of them is the setting:
+///
+///     Library · Inspector · Mixer · Smart Controls · Editor · List Editors · Note Pads ·
+///     Loop Browser · Browsers · Control Bar · Customize Control Bar and Display… · Toolbar ·
+///     Customize Toolbar… · Movie Window · Colors · Enter Full Screen
+///
+/// It lives in the Event pane's own View menu, beside the column toggles:
+///
+///     Link · Relative Position · Event Position and Length as Time · Length as Absolute Position ·
+///     SysEx in Hex Format · Locked ✓ · Muted ✓ · Position ✓ · Status ✓ · Channel ✓ · Number ✓ ·
+///     Value ✓ · Articulation · Length/Info ✓ · Off · Same Level · Content ✓
+///
+/// So the search found zero matches and every `collect()` threw `displayModeUnavailable` before it
+/// could return evidence. Nothing caught it: the collector is reachable from no dispatcher, and the
+/// unit tests supply the mode through a seam rather than a live menu.
+@Suite("#524 display mode is resolved from the pane's own View menu")
+struct Issue524DisplayModeMenuTests {
+    @Test("the setting is addressed by a locale policy entry, not an inline literal")
+    func settingHasAPolicyEntry() {
+        #expect(AXLocalePolicy.eventPositionAsTimeMenuItem.canonical
+            == "Event Position and Length as Time")
+        #expect(AXLocalePolicy.eventPositionAsTimeMenuItem.labels
+            .contains("Event Position and Length as Time"))
+    }
+
+    @Test("no locale variant is claimed for it yet")
+    func noInventedTranslation() {
+        // This entry has NOT been read on a non-English Logic. An English-only match fails closed,
+        // which is honest; an invented translation would match nothing and look like a Logic change.
+        // When it is measured, this expectation is what has to be updated deliberately.
+        #expect(AXLocalePolicy.eventPositionAsTimeMenuItem.labels.count == 1)
+    }
+
+    @Test("the pane's View menu is addressed by the same policy entry as the app menu")
+    func viewMenuLabelIsShared() {
+        // The pane's menu button and the application menu bar item both answer to "View", so one
+        // policy entry serves both — what changed is WHERE it is looked for, not what it is called.
+        #expect(AXLocalePolicy.viewMenuBar.labels.contains("View"))
+        #expect(AXLocalePolicy.viewMenuBar.labels.contains("보기"))
+    }
+}


### PR DESCRIPTION
Closes #524.

## The collector could not succeed on a real Logic

`refuseTimeDisplayIfNeeded` resolved the position display mode by searching the **application** menu
bar for an item titled `Event Position and Length as Time`. Measured on Logic 12.3, that menu holds
sixteen entries and none of them is the setting:

```
Library · Inspector · Mixer · Smart Controls · Editor · List Editors · Note Pads · Loop Browser ·
Browsers · Control Bar · Customize Control Bar and Display… · Toolbar · Customize Toolbar… ·
Movie Window · Colors · Enter Full Screen
```

It lives in the **Event pane's own View menu**, beside the column toggles:

```
Link · Relative Position · Event Position and Length as Time · Length as Absolute Position ·
SysEx in Hex Format · Locked ✓ · Muted ✓ · Position ✓ · Status ✓ · Channel ✓ · Number ✓ ·
Value ✓ · Articulation · Length/Info ✓ · Off · Same Level · Content ✓
```

So the filter matched zero items and the guard threw `displayModeUnavailable` **before any evidence
could be returned** — on every call.

## Why nothing caught it

The collector is reachable from no dispatcher, so the release artifact is byte-identical with and
without it and no end-to-end path exercises this. The unit fixture built the setting onto the menu
bar as well, so the test **agreed with the bug** instead of contradicting it. The fixture now models
where the control actually is, and the same tests pass against the corrected lookup.

## What is unchanged, deliberately

The cross-check after the lookup: the menu's mark character against whether every position cell
carries four slider groups, refusing on disagreement rather than trusting either signal alone. That
design is the reason this was worth getting right rather than deleting.

## Locale

The title moves into `AXLocalePolicy` with **no variants claimed**. It has not been read on a
non-English Logic, and an English-only match that fails closed is honest where an invented translation
would match nothing and look like a Logic change. A test asserts no variant is present, so adding one
is a deliberate act rather than a drive-by.

## Live evidence

Both halves are measured against the running application, because "we moved the lookup" needs the old
location shown **empty** or it is just a rearrangement:

| check | result |
| --- | --- |
| the application View menu does **not** contain the entry | 16 entries read, absent |
| the Event pane's View menu **does** | present |
| the entry is unmarked, i.e. bar/beat mode | as required by the collector |

Screen-recorded, with the pane asserted on a bound region and a positive twin proving the camera
registers it. No coordinate or mouse event is used anywhere: the menu button is found by
`AXLocalePolicy` label match and opened with `AXShowMenu`.
