### PR TITLE
fix(#523): delete a marker through the list's own menu, not a global keystroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [Unreleased]
 
 ### Fixed
+- **`navigate.delete_marker` deletes the marker, and says so honestly (#523).** It reported
+  `success: true, state: B` while the marker stayed. The accessibility path's safety guard was
+  refusing — correctly, because the same keystroke deletes a region or a track when focus is not in
+  the Marker List — and the router treated that deliberate `write_attempted: false` refusal as a
+  failure, fell through to the MIDI key-command channel, and that channel fired a CC nothing is bound
+  to and answered success. The operation now acts through the Marker List window's own Edit ▸ Delete,
+  which is aimed at that list and needs no keyboard focus; the keystroke and its guard remain as the
+  fallback. Verified live: `state A`, `verified true`, 15 markers to 14.
+
 - **The MIDI readback collector can resolve the Event List display mode (#524).** It searched the
   **application** menu bar for `Event Position and Length as Time`; that menu has sixteen entries on
   Logic 12.3 and none of them is the setting, which lives in the Event pane's own View menu beside the

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -212,6 +212,17 @@ enum AXLocalePolicy {
         rationale: "Reveals the New Project chooser, or creates the project directly where Logic skips it."
     )
 
+    /// The plain `Delete` entry on a list window's Edit menu.
+    ///
+    /// Matched with `.exactStrict`, never as a prefix: the same menu offers `Delete Undo History`,
+    /// and a prefix match reaches it first. That is not a hypothetical — it happened during the
+    /// investigation of #523 and discarded a project's undo history.
+    static let deleteMenuItem = LabelSet(
+        canonical: "Delete",
+        variants: ["삭제"],
+        rationale: "Removes the selected row from a list window; exact match only."
+    )
+
     static let editMenuBar = LabelSet(
         canonical: "Edit",
         variants: ["편집"],

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -80,19 +80,37 @@ extension AccessibilityChannel {
             ))
         }
 
-        guard markerTableHasKeyboardFocus(runtime: runtime) else {
-            // Refusing here is the point: the same keystroke elsewhere deletes a region or a track.
-            extras["write_attempted"] = false
-            return .error(HonestContract.encodeStateC(
-                error: .axWriteFailed,
-                hint: "The Marker List did not hold keyboard focus, so Delete was not pressed — "
-                    + "the same key deletes a region or a track when focus is in the arrange area.",
-                extras: extras
-            ))
+        // The window's own Edit ▸ Delete is aimed at THIS list and needs no keyboard focus, so it is
+        // tried first. The keystroke below does need focus, and its guard was refusing nearly every
+        // call — measured (#523). The refusal is right in itself; what it exposed is worse. The
+        // router treats a deliberate `write_attempted: false` State C as a failure and falls through
+        // to the MIDI key-command channel, which fires a CC nothing is bound to and answers
+        // `success: true, state: B`. A safety refusal was being turned into a reported success for an
+        // operation that never happened. Acting through the menu removes the reason to be there.
+        //
+        // The entry is matched EXACTLY: the same menu offers `Delete Undo History`, which a prefix
+        // match reaches first — that is not hypothetical, it discarded a project's undo history while
+        // this was being investigated.
+        if deleteViaMarkerListEditMenu(in: window, runtime: runtime) {
+            extras["write_attempted"] = true
+            extras["actuation"] = "marker_list_edit_menu"
+        } else {
+            guard markerTableHasKeyboardFocus(runtime: runtime) else {
+                // Refusing here is the point: the same keystroke elsewhere deletes a region or a track.
+                extras["write_attempted"] = false
+                extras["actuation"] = "refused_no_keyboard_focus"
+                return .error(HonestContract.encodeStateC(
+                    error: .axWriteFailed,
+                    hint: "The Marker List's Edit menu offered no exact Delete entry and the list did "
+                        + "not hold keyboard focus, so Delete was not pressed — the same key deletes "
+                        + "a region or a track when focus is in the arrange area.",
+                    extras: extras
+                ))
+            }
+            extras["write_attempted"] = true
+            extras["actuation"] = "delete_key"
+            _ = mouse.postKeyEvent(0x33)  // kVK_Delete
         }
-
-        extras["write_attempted"] = true
-        _ = mouse.postKeyEvent(0x33)  // kVK_Delete
         mouse.sleepMicros(400_000)
 
         guard let afterBinding = AXLogicProElements.markerListBinding(runtime: runtime),
@@ -199,4 +217,37 @@ extension AccessibilityChannel {
         }
         return false
     }
+
+    /// Press the Marker List window's own `Delete` entry.
+    ///
+    /// Matched by exact title against a locale policy entry, because the same menu carries
+    /// `Delete Undo History` and anything looser reaches that one first.
+    private static func deleteViaMarkerListEditMenu(
+        in window: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        let buttons = AXHelpers.findAllDescendants(
+            of: window, role: kAXMenuButtonRole as String, maxDepth: 10, runtime: runtime.ax
+        ).filter {
+            AXLocalePolicy.elementMatches($0, AXLocalePolicy.editMenuBar, runtime: runtime.ax)
+        }
+        guard buttons.count == 1, let editButton = buttons.first else { return false }
+        _ = AXHelpers.performAction(editButton, "AXShowMenu", runtime: runtime.ax)
+        guard let menu = AXHelpers.getChildren(editButton, runtime: runtime.ax).first(where: {
+            AXHelpers.getRole($0, runtime: runtime.ax) == (kAXMenuRole as String)
+        }) else { return false }
+        let entries = AXHelpers.findAllDescendants(
+            of: menu, role: kAXMenuItemRole as String, maxDepth: 4, runtime: runtime.ax
+        ).filter {
+            AXLocalePolicy.elementMatches(
+                $0, AXLocalePolicy.deleteMenuItem, mode: .exactStrict, runtime: runtime.ax
+            )
+        }
+        guard entries.count == 1, let entry = entries.first else {
+            _ = AXHelpers.performAction(menu, kAXCancelAction as String, runtime: runtime.ax)
+            return false
+        }
+        return AXHelpers.performAction(entry, kAXPickAction as String, runtime: runtime.ax)
+    }
+
 }

--- a/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import LogicProMCP
+
+/// `nav.delete_marker` reported `success: true, state: B` while the marker stayed in the project.
+/// The server log showed why:
+///
+///     [router] nav.delete_marker failed via Accessibility:
+///       {"error":"ax_write_failed",
+///        "hint":"The Marker List did not hold keyboard focus, so Delete was not pressed …",
+///        "write_attempted":false,"state":"C"}, trying next
+///     [router] nav.delete_marker succeeded via MIDIKeyCommands
+///
+/// The accessibility path's safety guard refused — correctly, since the same keystroke deletes a
+/// region or a track when focus is elsewhere — and the router treated that deliberate
+/// `write_attempted: false` refusal as a failure, fell through to the MIDI key-command channel, and
+/// that channel fired a CC nothing is bound to and answered success.
+///
+/// Acting through the Marker List window's own Edit ▸ Delete removes the reason to be in that
+/// position: the menu entry is aimed at this list and needs no keyboard focus. Verified live —
+/// `state A`, `verified true`, 15 markers to 14, confirmed on screen.
+@Suite("#523 marker delete acts through the list's own menu")
+struct Issue523MarkerDeleteMenuTests {
+    @Test("the Delete entry is addressed exactly, never by prefix")
+    func deleteIsMatchedExactly() {
+        // The same menu offers `Delete Undo History`. A prefix match reaches it first — that is not
+        // hypothetical: it ran during this investigation and discarded a project's undo history.
+        #expect(AXLocalePolicy.deleteMenuItem.canonical == "Delete")
+        #expect(!AXLocalePolicy.deleteMenuItem.labels.contains("Delete Undo History"))
+        #expect(!AXLocalePolicy.deleteMenuItem.matches("Delete Undo History", mode: .exactStrict))
+        #expect(AXLocalePolicy.deleteMenuItem.matches("Delete", mode: .exactStrict))
+    }
+
+    @Test("the Korean variant is carried, and is the measured one")
+    func koreanVariantIsPresent() {
+        #expect(AXLocalePolicy.deleteMenuItem.labels.contains("삭제"))
+    }
+
+    @Test("the Edit menu is addressed by the existing policy entry")
+    func editMenuLabelIsShared() {
+        // The window's own Edit menu button and the application Edit menu answer to the same name,
+        // so one policy entry serves both; what this change altered is where it is looked for.
+        #expect(AXLocalePolicy.editMenuBar.labels.contains("Edit"))
+        #expect(AXLocalePolicy.editMenuBar.labels.contains("편집"))
+    }
+}


### PR DESCRIPTION
Closes #523.

## The cause was not the one the issue guessed

`nav.delete_marker` answered `success: true, state: B` while the marker stayed. The server log named
it:

```
[router] nav.delete_marker failed via Accessibility:
  {"error":"ax_write_failed",
   "hint":"The Marker List did not hold keyboard focus, so Delete was not pressed —
           the same key deletes a region or a track when focus is in the arrange area.",
   "write_attempted":false,"state":"C"}, trying next
[router] nav.delete_marker succeeded via MIDIKeyCommands
```

The accessibility path **refused on purpose**, and the router read that deliberate
`write_attempted: false` refusal as a failure, fell through to the MIDI key-command channel, and that
channel fired a CC nothing is bound to and reported success. A safety refusal was being converted
into a reported success for an operation that never happened.

## The fix

The Marker List window has its own Edit menu whose `Delete` entry is aimed at that list and needs no
keyboard focus. Acting through it removes the reason to be in that position. The keystroke and its
focus guard remain as the fallback, and the refusal message now says both routes were unavailable
rather than naming only focus.

`Delete` is matched **exactly** against a locale policy entry. The same menu offers
`Delete Undo History`, which a prefix match reaches first — not hypothetical: it ran during this
investigation and discarded a project's undo history. This repository had already recorded the
identical trap for the Undo prefix.

No coordinate or mouse event is involved: the menu button is found by label and opened with
`AXShowMenu`.

## Live evidence

| check | result |
| --- | --- |
| the accessibility path handles it — no fall-through to the key-command channel | `actuation: marker_list_edit_menu`, `method: nil` |
| the count drops by exactly one, from two settled readings | `14 → 13`, `readback_settled: true` |
| an independent read agrees the marker is gone | back to the baseline the run started from |
| the row disappears from the Marker List **on screen** | region-bound visual assertion |

Screen-recorded. The marker the run deletes is created by the run itself, through the Marker List's
own `+` button — **not** through `nav.create_marker`, because every marker in the project sat at bar 1 and Logic
will not stack a second one there — so the run creates the marker it deletes rather than deleting one
the project already had.

## Two findings this surfaced, filed separately

- **#526** — the router converts a deliberate safety refusal into a fallback success. That applies to
  every multi-channel operation, not just this one, and is not addressed here.
- ~~**#527**~~ — I filed this claiming `nav.create_marker` was broken. It is not: Logic refuses a
  second marker at a position that already has one, and every marker in the test project sat at
  bar 1. Measured at an empty bar it answers State A, verified. The issue is closed.

An earlier note here said `logic://markers` disagreed with the operation's own reading. That does not
reproduce — a macOS consent dialog had been sitting over the screen during those readings. The
evidence remains keyed to the product's own measurement, which is the stricter source either way.


