### PR TITLE
fix(#526): let a channel forbid fallback when trying another one would be unsafe

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -72,7 +72,10 @@ extension AccessibilityChannel {
         ]
 
         guard selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
+            // A weaker key-command channel cannot answer an indexed delete: it ignores `index`
+            // and fires CC 45 blindly, without proving which marker would be removed.
             extras["write_attempted"] = false
+            extras["fallback_unsafe"] = true
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "Marker index \(index) could not be selected, so nothing was pressed",

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -73,11 +73,19 @@ extension AccessibilityChannel {
         let expectedSurvivors = expectedSurvivorMarkers
             .map { canonicalMarkerIdentity(name: $0.name, position: $0.position) }
             .sorted()
+        let targetPositionMatchCount = before.filter { $0.position == target.position }.count
+        let targetPositionUnique = targetPositionMatchCount == 1
+        // A parse fallback manufactures `ordinal + 1.1.1.1`, which can happen to equal a
+        // different marker's parsed position. Do not let a synthetic position participate in a
+        // State-A identity proof, even if it happens not to collide in this particular reading.
+        let prewritePositionEvidenceCanonical = before.allSatisfy { $0.positionSource == .parser }
         var extras: [String: Any] = [
             "operation": "nav.delete_marker",
             "requested_index": index,
             "target_name": target.name,
             "target_position": target.position,
+            "target_position_unique": targetPositionUnique,
+            "prewrite_position_evidence_canonical": prewritePositionEvidenceCanonical,
             "marker_count_before": before.count,
         ]
 
@@ -121,6 +129,7 @@ extension AccessibilityChannel {
         // report State B when they will not settle rather than certifying a guess.
         var observedSurvivorPositions: [String] = []
         var observedSurvivors: [String] = []
+        var observedPositionEvidenceCanonical = false
         var settled = false
         var previousPositions: [String]?
         for _ in 0..<6 {
@@ -133,6 +142,9 @@ extension AccessibilityChannel {
                 observedSurvivors = reading
                     .map { canonicalMarkerIdentity(name: $0.name, position: $0.position) }
                     .sorted()
+                observedPositionEvidenceCanonical = reading.allSatisfy {
+                    $0.positionSource == .parser
+                }
                 settled = true
                 break
             }
@@ -145,6 +157,9 @@ extension AccessibilityChannel {
         }
         extras["readback_settled"] = true
         extras["marker_count_after"] = observedSurvivorPositions.count
+        extras["observed_position_evidence_canonical"] = observedPositionEvidenceCanonical
+        extras["position_evidence_canonical"] = prewritePositionEvidenceCanonical
+            && observedPositionEvidenceCanonical
 
         // This proves that precisely one position occurrence disappeared and that it was an
         // occurrence at the target's position. It cannot establish WHICH marker was removed when
@@ -162,6 +177,18 @@ extension AccessibilityChannel {
         // position multiset in State A. Names are not exposed here because Logic may renumber them.
         extras["expected_survivor_position_multiset"] = expectedSurvivorPositions.joined()
         extras["observed_survivor_position_multiset"] = observedSurvivorPositions.joined()
+        guard targetPositionUnique else {
+            extras["reason_detail"] = "Delete was attempted and the marker count moved, but "
+                + "\(targetPositionMatchCount) pre-write markers shared target position "
+                + "\(target.position), so this readback cannot establish which marker was deleted."
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        guard prewritePositionEvidenceCanonical, observedPositionEvidenceCanonical else {
+            extras["reason_detail"] = "Delete was attempted and the marker count moved, but at "
+                + "least one marker position came from an ordinal parse fallback; synthetic "
+                + "positions cannot support a verified target identity."
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
         return .success(HonestContract.encodeStateA(extras: extras))
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -58,10 +58,20 @@ extension AccessibilityChannel {
             ))
         }
 
-        // Identify the survivor set by name+position rather than by index: indices renumber when a
-        // row disappears, so comparing indices after the write would prove nothing.
-        let expectedSurvivors = before.filter { $0.id != index }
-            .map { "\($0.name)@\($0.position)" }
+        // Indices renumber when a row disappears, so comparing them after the write would prove
+        // nothing. Instead, expect the pre-write POSITION multiset with exactly one instance of
+        // the target's position removed. Position entries are length-prefixed before sorting and
+        // joining, so their concatenation has unambiguous boundaries.
+        let expectedSurvivorMarkers = before.filter { $0.id != index }
+        let expectedSurvivorPositions = expectedSurvivorMarkers
+            .map(\.position)
+            .map(canonicalMarkerPosition)
+            .sorted()
+        // Names are deliberately not part of the State-A proof: Logic renumbers its generated
+        // marker names after a delete. Retain unambiguous name/position identities for a State-B
+        // mismatch diagnostic, where they help a human understand what was read back.
+        let expectedSurvivors = expectedSurvivorMarkers
+            .map { canonicalMarkerIdentity(name: $0.name, position: $0.position) }
             .sorted()
         var extras: [String: Any] = [
             "operation": "nav.delete_marker",
@@ -109,19 +119,24 @@ extension AccessibilityChannel {
         // name. Verifying against a single read produced a State A for a marker that was still
         // there. So require two consecutive identical readings before believing either of them, and
         // report State B when they will not settle rather than certifying a guess.
-        var survivors: [String] = []
+        var observedSurvivorPositions: [String] = []
+        var observedSurvivors: [String] = []
         var settled = false
-        var previous: [String]?
+        var previousPositions: [String]?
         for _ in 0..<6 {
             let reading = AXLogicProElements.enumerateMarkersFromListWindow(
                 afterBinding.window, runtime: runtime.ax
-            ).map { "\($0.name)@\($0.position)" }.sorted()
-            if let previous, previous == reading {
-                survivors = reading
+            )
+            let positions = reading.map(\.position).map(canonicalMarkerPosition).sorted()
+            if let previousPositions, previousPositions == positions {
+                observedSurvivorPositions = positions
+                observedSurvivors = reading
+                    .map { canonicalMarkerIdentity(name: $0.name, position: $0.position) }
+                    .sorted()
                 settled = true
                 break
             }
-            previous = reading
+            previousPositions = positions
             mouse.sleepMicros(250_000)
         }
         guard settled else {
@@ -129,16 +144,42 @@ extension AccessibilityChannel {
             return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
         }
         extras["readback_settled"] = true
-        extras["marker_count_after"] = survivors.count
+        extras["marker_count_after"] = observedSurvivorPositions.count
 
-        guard survivors == expectedSurvivors else {
-            // Either the target survived, or something else went with it. Both are mismatches, and
-            // saying which is more useful than a bare count.
-            extras["observed_survivors"] = survivors
+        // This proves that precisely one position occurrence disappeared and that it was an
+        // occurrence at the target's position. It cannot establish WHICH marker was removed when
+        // multiple markers share that position; the position multiset contains no such identity.
+        guard observedSurvivorPositions.count == before.count - 1,
+              observedSurvivorPositions == expectedSurvivorPositions else {
+            // Either the target position survived, or another position disappeared. The
+            // name-carrying diagnostics make that mismatch useful to a human without making names
+            // part of the stable State-A comparison.
+            extras["observed_survivors"] = observedSurvivors
             extras["expected_survivors"] = expectedSurvivors
             return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
         }
+        // Bind the request-derived position-multiset expectation to the independently read-back
+        // position multiset in State A. Names are not exposed here because Logic may renumber them.
+        extras["expected_survivor_position_multiset"] = expectedSurvivorPositions.joined()
+        extras["observed_survivor_position_multiset"] = observedSurvivorPositions.joined()
         return .success(HonestContract.encodeStateA(extras: extras))
+    }
+
+    /// An unambiguous element of a position multiset.
+    ///
+    /// The wire form is `<position UTF-8 byte count>:<position>`. Sorting these elements and
+    /// concatenating them creates an unambiguous multiset encoding without trusting a delimiter.
+    private static func canonicalMarkerPosition(_ position: String) -> String {
+        "\(position.lengthOfBytes(using: .utf8)):\(position)"
+    }
+
+    /// An unambiguous, stable marker identity for survivor-set comparison and reporting.
+    ///
+    /// The wire form is `<name UTF-8 byte count>:<name><position UTF-8 byte count>:<position>`.
+    /// Because the two payload strings are length-prefixed, concatenating sorted entries cannot
+    /// be forged by putting a former joining character (such as `@`) in a marker name.
+    private static func canonicalMarkerIdentity(name: String, position: String) -> String {
+        "\(name.lengthOfBytes(using: .utf8)):\(name)\(position.lengthOfBytes(using: .utf8)):\(position)"
     }
 
     /// Selects the row and confirms the table agrees, since a write that reports success without

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -83,6 +83,7 @@ extension AccessibilityChannel {
         guard markerTableHasKeyboardFocus(runtime: runtime) else {
             // Refusing here is the point: the same keystroke elsewhere deletes a region or a track.
             extras["write_attempted"] = false
+            extras["fallback_unsafe"] = true
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "The Marker List did not hold keyboard focus, so Delete was not pressed — "

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -195,6 +195,18 @@ actor ChannelRouter {
                 Log.debug("\(operation) succeeded via \(channelID.rawValue)", subsystem: "router")
                 return result
             case .error(let msg):
+                // A channel can deliberately refuse an operation when trying
+                // it through another channel would be unsafe (for example, a
+                // keystroke whose target focus cannot be proved). This is
+                // separate from terminal error-code classification and must
+                // preserve the original State C envelope verbatim.
+                if HonestContract.isFallbackUnsafeStateC(msg) {
+                    Log.debug(
+                        "\(operation) State C via \(channelID.rawValue) forbids fallback",
+                        subsystem: "router"
+                    )
+                    return result
+                }
                 // v3.1.2 (P1-1) — terminal State C means no other channel can
                 // improve on this answer (`element_not_found`, `invalid_params`,
                 // `not_implemented`). Falling through to the next channel

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -200,6 +200,12 @@ actor ChannelRouter {
                 // keystroke whose target focus cannot be proved). This is
                 // separate from terminal error-code classification and must
                 // preserve the original State C envelope verbatim.
+                // This check intentionally precedes terminal-State-C handling, so a marked
+                // terminal `element_not_found` would bypass `shouldContinueAfterTerminalStateC`.
+                // The two envelopes carrying the marker today — both marker-delete refusals — use
+                // `ax_write_failed`, which is NOT terminal, so the ordering changes no current
+                // behaviour. Do not reorder this, and do not put the marker on a terminal code,
+                // without revisiting that consequence.
                 if HonestContract.isFallbackUnsafeStateC(msg) {
                     Log.debug(
                         "\(operation) State C via \(channelID.rawValue) forbids fallback",

--- a/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
+++ b/Sources/LogicProMCP/Channels/MIDIKeyCommandsChannel.swift
@@ -557,7 +557,7 @@ actor MIDIKeyCommandsChannel: KeyCmdCCChannel {
         "Manual MIDI Learn required — see docs/SETUP.md §4. " +
         "Effectively keycmd-only (no working non-keycmd fallback on Logic 12.2): " +
         "edit.duplicate, edit.normalize, " +
-        "nav.goto_marker, nav.delete_marker, transport.capture_recording. " +
+        "nav.goto_marker, transport.capture_recording. " +
         "Other preset ops have an AX/MCU/AppleScript/CGEvent fallback and do not require keycmd binding. " +
         "Orphans (in mappingTable + routingTable but no MCP tool exposes a call path): " +
         "automation.set_mode, note.up_semitone, note.up_octave, note.down_semitone, note.down_octave, " +

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -169,10 +169,11 @@ extension ChannelRouter {
         "nav.goto_marker":            [.midiKeyCommands, .cgEvent],
         "nav.open_marker_list":       [.accessibility],
         "nav.create_marker":          [.accessibility],
-        // AX first: the keycmd rung only works after the operator installs the preset and performs a
-        // manual MIDI Learn, so on a default install this operation used to do nothing at all while
-        // reporting a readback problem. The AX rung drives the Marker List directly.
-        "nav.delete_marker":          [.accessibility, .midiKeyCommands, .cgEvent],
+        // A channel that cannot express the operation's target must not be in that operation's chain.
+        // `delete_marker` takes an `index`; the MIDI key-command rung has no way to carry it and can
+        // only fire CC 45 at whichever marker happens to be selected. It also requires a manual MIDI
+        // Learn, so on a default install it did nothing while reporting a readback problem.
+        "nav.delete_marker":          [.accessibility],
         "nav.rename_marker":          [.accessibility],
         "nav.get_markers":            [.accessibility],
         "nav.zoom_to_fit":            [.midiKeyCommands, .cgEvent],

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1591,12 +1591,16 @@ enum SemanticOracleTable {
 
     // AccessibilityChannel+MarkerDelete `defaultDeleteMarker` is accessibility-only.
     // Its State-A gate is stronger than a count check: it reads the marker list
-    // after the delete until two consecutive readings settle, then compares the
-    // complete observed survivor set (`name@position` for every remaining marker)
-    // with the full expected set captured before the write. Only an exact match
-    // emits State A. The survivor set itself is the handler's State-A gate rather
-    // than a response field, so this oracle pins the stable-readback signal and
-    // the target/count identity carried by that verified envelope.
+    // after the delete until two consecutive POSITION multisets settle. State A
+    // requires the expected pre-write positions with one target-position instance
+    // removed, the observed positions to equal that expectation, and the count to
+    // decrease by one. Each position is length-prefixed before the entries are
+    // sorted and joined, so the envelope's strings have unambiguous boundaries.
+    // The oracle binds that independently read-back multiset to the
+    // request-derived expectation. This proves a position occurrence disappeared,
+    // but cannot tell WHICH marker disappeared when multiple markers share that
+    // position; marker names are intentionally only State-B diagnostics because
+    // Logic can renumber auto-generated names after deletion.
     static let navigateDeleteMarker = SafeMutationOracle.oracle(
         .navigateDeleteMarker,
         semantics: [
@@ -1607,6 +1611,10 @@ enum SemanticOracleTable {
             .typedField(key: "marker_count_before", type: .number),
             .valueEquals(key: "readback_settled", expected: .bool(true)),
             .typedField(key: "marker_count_after", type: .number),
+            .fieldsEqual(
+                keyA: "expected_survivor_position_multiset",
+                keyB: "observed_survivor_position_multiset"
+            ),
         ]
     )
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -113,8 +113,8 @@ enum SemanticOracleTable {
     ///
     /// DELIBERATELY ABSENT (audited, no State-A envelope to verify — see
     /// `structurallyUnverifiedMutatingOperationIDs`): transport.rewind,
-    /// transport.fast_forward, navigate.zoom_to_fit, navigate.delete_marker,
-    /// navigate.toggle_view. Every one routes ONLY to send-only channels
+    /// transport.fast_forward, navigate.zoom_to_fit, navigate.toggle_view.
+    /// Every one routes ONLY to send-only channels
     /// (MCU / MIDIKeyCommands / CGEvent) whose handlers emit State B
     /// `readback_unavailable` with no read-back — there is no State A to pin, so a
     /// verified-write oracle would have to invent a contract the handler can never
@@ -126,9 +126,9 @@ enum SemanticOracleTable {
         .transportPlay, .transportStop, .transportRecord, .transportPause,
         .transportToggleCycle, .transportToggleMetronome, .transportToggleCountIn,
         .transportToggleAutopunch, .transportSetTempo, .transportGotoPosition,
-        // navigate (5 of the 8 audited — zoom_to_fit/delete_marker/toggle_view are send-only)
+        // navigate (6 of the 8 audited — zoom_to_fit/toggle_view are send-only)
         .navigateGotoBar, .navigateGotoMarker, .navigateCreateMarker,
-        .navigateRenameMarker, .navigateSetZoom,
+        .navigateDeleteMarker, .navigateRenameMarker, .navigateSetZoom,
     ]
 
     /// The mutating operations B3 covers with a verified-write (State A) oracle:
@@ -271,11 +271,6 @@ enum SemanticOracleTable {
             "send-only — routes to [.midiKeyCommands, .cgEvent]; both fire a blind key "
             + "command (CC 46 / key Z) with no arrange-zoom read-back, so the op is honestly "
             + "State B and never reaches a verified State A",
-        .navigateDeleteMarker:
-            "send-only — routes to [.midiKeyCommands, .cgEvent] (CC 45 / keystroke); the "
-            + "keycmd channel gives no marker-list read-back, so a delete is State B only. "
-            + "(Availability is .requiresKeyBinding, but that is a SETUP axis — the reason "
-            + "it has no State A is the echo-less channel, not the keybinding requirement.)",
         .navigateToggleView:
             "send-only — routes each view to [.midiKeyCommands, .cgEvent] (view.toggle_*); "
             + "the key command fires blind with no view-state read-back, so no State A exists",
@@ -472,6 +467,7 @@ enum SemanticOracleTable {
         navigateGotoBar,
         navigateGotoMarker,
         navigateCreateMarker,
+        navigateDeleteMarker,
         navigateRenameMarker,
         navigateSetZoom,
         // #373 Phase B3 — project/tracks/system/midi verified-write oracles.
@@ -1590,6 +1586,27 @@ enum SemanticOracleTable {
             .typedField(key: "observed_marker_id", type: .number),
             .typedField(key: "marker_count_after", type: .number),
             .typedField(key: "marker_count_before", type: .number),
+        ]
+    )
+
+    // AccessibilityChannel+MarkerDelete `defaultDeleteMarker` is accessibility-only.
+    // Its State-A gate is stronger than a count check: it reads the marker list
+    // after the delete until two consecutive readings settle, then compares the
+    // complete observed survivor set (`name@position` for every remaining marker)
+    // with the full expected set captured before the write. Only an exact match
+    // emits State A. The survivor set itself is the handler's State-A gate rather
+    // than a response field, so this oracle pins the stable-readback signal and
+    // the target/count identity carried by that verified envelope.
+    static let navigateDeleteMarker = SafeMutationOracle.oracle(
+        .navigateDeleteMarker,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("nav.delete_marker")),
+            .typedField(key: "requested_index", type: .number),
+            .typedField(key: "target_name", type: .string),
+            .typedField(key: "target_position", type: .string),
+            .typedField(key: "marker_count_before", type: .number),
+            .valueEquals(key: "readback_settled", expected: .bool(true)),
+            .typedField(key: "marker_count_after", type: .number),
         ]
     )
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1592,15 +1592,16 @@ enum SemanticOracleTable {
     // AccessibilityChannel+MarkerDelete `defaultDeleteMarker` is accessibility-only.
     // Its State-A gate is stronger than a count check: it reads the marker list
     // after the delete until two consecutive POSITION multisets settle. State A
-    // requires the expected pre-write positions with one target-position instance
-    // removed, the observed positions to equal that expectation, and the count to
-    // decrease by one. Each position is length-prefixed before the entries are
-    // sorted and joined, so the envelope's strings have unambiguous boundaries.
+    // requires a unique, canonically parsed target position; the expected pre-write
+    // positions with one target-position instance removed; the observed positions
+    // to equal that expectation; and the count to decrease by one. Each position
+    // is length-prefixed before the entries are sorted and joined, so the envelope's
+    // strings have unambiguous boundaries and can be checked against both counts.
     // The oracle binds that independently read-back multiset to the
-    // request-derived expectation. This proves a position occurrence disappeared,
-    // but cannot tell WHICH marker disappeared when multiple markers share that
-    // position; marker names are intentionally only State-B diagnostics because
-    // Logic can renumber auto-generated names after deletion.
+    // request-derived expectation. A shared or synthetic target position is State B:
+    // a position occurrence can disappear without identifying which marker it was.
+    // Marker names remain only State-B diagnostics because Logic can renumber
+    // auto-generated names after deletion.
     static let navigateDeleteMarker = SafeMutationOracle.oracle(
         .navigateDeleteMarker,
         semantics: [
@@ -1608,9 +1609,21 @@ enum SemanticOracleTable {
             .typedField(key: "requested_index", type: .number),
             .typedField(key: "target_name", type: .string),
             .typedField(key: "target_position", type: .string),
+            .valueEquals(key: "target_position_unique", expected: .bool(true)),
+            .valueEquals(key: "position_evidence_canonical", expected: .bool(true)),
             .typedField(key: "marker_count_before", type: .number),
             .valueEquals(key: "readback_settled", expected: .bool(true)),
             .typedField(key: "marker_count_after", type: .number),
+            .lengthPrefixedEntryCountEquals(
+                key: "expected_survivor_position_multiset",
+                countKey: "marker_count_before",
+                offset: -1
+            ),
+            .lengthPrefixedEntryCountEquals(
+                key: "observed_survivor_position_multiset",
+                countKey: "marker_count_after",
+                offset: 0
+            ),
             .fieldsEqual(
                 keyA: "expected_survivor_position_multiset",
                 keyB: "observed_survivor_position_multiset"

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -75,6 +75,11 @@ enum OracleConstraint: Sendable {
     case nonEmptyArray(key: String)
     /// Field must be present with the given JSON type.
     case typedField(key: String, type: JSONType)
+    /// A joined `<utf8-byte-count>:<entry>` wire field contains exactly the
+    /// number of entries declared by another numeric field, plus `offset`.
+    /// The empty string is the canonical zero-entry encoding. Malformed prefixes,
+    /// fractional/negative counts, and byte-length overruns fail closed.
+    case lengthPrefixedEntryCountEquals(key: String, countKey: String, offset: Int)
     /// Two key paths WITHIN THE SAME payload resolve to equal leaf values. The
     /// load-bearing safe-mutation invariant: a verified write echoes what was
     /// requested as what was observed, so `requested == observed` proves the
@@ -125,6 +130,7 @@ enum OracleConstraint: Sendable {
              .enumMember(let key, _),
              .nonEmptyArray(let key),
              .typedField(let key, _),
+             .lengthPrefixedEntryCountEquals(let key, _, _),
              .fieldsEqual(let key, _),
              .crossCheck(let key, _),
              .numericNear(let key, _, _),
@@ -141,8 +147,8 @@ enum OracleConstraint: Sendable {
     /// oracle carrying one is never a checkbox oracle.
     var isValueConstraint: Bool {
         switch self {
-        case .valueEquals, .numericRange, .enumMember, .fieldsEqual, .crossCheck, .numericNear,
-             .booleanFlipped:
+        case .valueEquals, .numericRange, .enumMember, .lengthPrefixedEntryCountEquals,
+             .fieldsEqual, .crossCheck, .numericNear, .booleanFlipped:
             return true
         case .nonEmptyArray, .typedField, .emptyArray:
             return false
@@ -171,6 +177,16 @@ enum OracleConstraint: Sendable {
         case .typedField(let key, let type):
             guard let value = JSONPath.resolve(root, keyPath: key) else { return false }
             return JSONInspector.type(of: value) == type
+        case .lengthPrefixedEntryCountEquals(let key, let countKey, let offset):
+            guard let wire = JSONPath.resolve(root, keyPath: key) as? String,
+                  let rawCount = JSONPath.resolve(root, keyPath: countKey),
+                  let count = JSONInspector.number(of: rawCount),
+                  count >= 0,
+                  count.rounded(.towardZero) == count,
+                  count <= Double(Int.max),
+                  let entryCount = Self.lengthPrefixedEntryCount(in: wire) else { return false }
+            let (expected, overflow) = Int(count).addingReportingOverflow(offset)
+            return !overflow && expected >= 0 && entryCount == expected
         case .fieldsEqual(let keyA, let keyB):
             guard let a = JSONPath.resolve(root, keyPath: keyA),
                   let b = JSONPath.resolve(root, keyPath: keyB) else { return false }
@@ -215,6 +231,34 @@ enum OracleConstraint: Sendable {
                   let b = (bValue as? NSNumber)?.boolValue else { return false }
             return a != b
         }
+    }
+
+    /// Counts concatenated `<utf8-byte-count>:<entry>` records without decoding
+    /// the entries themselves. That keeps the parser faithful to the wire rule:
+    /// lengths measure UTF-8 bytes, rather than Swift character counts.
+    private static func lengthPrefixedEntryCount(in wire: String) -> Int? {
+        let bytes = Array(wire.utf8)
+        var offset = 0
+        var entries = 0
+        while offset < bytes.count {
+            var length = 0
+            let lengthStart = offset
+            while offset < bytes.count, bytes[offset] >= 48, bytes[offset] <= 57 {
+                let digit = Int(bytes[offset] - 48)
+                guard length <= (Int.max - digit) / 10 else { return nil }
+                length = length * 10 + digit
+                offset += 1
+            }
+            guard offset > lengthStart,
+                  offset < bytes.count,
+                  bytes[offset] == 58,
+                  length > 0 else { return nil }
+            offset += 1
+            guard length <= bytes.count - offset else { return nil }
+            offset += length
+            entries += 1
+        }
+        return entries
     }
 }
 

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -586,7 +586,7 @@ enum OperationRegistry {
         (.navigateGotoBar, "goto_bar", .readbackRequired, .defaultInstall, ["bar"]),
         (.navigateGotoMarker, "goto_marker", .readbackRequired, .defaultInstall, ["index", "name"]),
         (.navigateCreateMarker, "create_marker", .readbackRequired, .defaultInstall, ["name"]),
-        (.navigateDeleteMarker, "delete_marker", .none, .requiresKeyBinding, ["index"]),
+        (.navigateDeleteMarker, "delete_marker", .readbackRequired, .defaultInstall, ["index"]),
         (.navigateRenameMarker, "rename_marker", .readbackRequired, .defaultInstall, ["index", "name"]),
         (.navigateZoomToFit, "zoom_to_fit", .readbackRequired, .defaultInstall, []),
         (.navigateSetZoom, "set_zoom", .readbackRequired, .defaultInstall, ["direction", "level"]),

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -494,6 +494,25 @@ enum HonestContract {
         return obj["error"] as? String
     }
 
+    /// Returns true when a valid State C envelope explicitly forbids the
+    /// router from attempting the operation through another channel. This is
+    /// distinct from `safe_to_retry`: callers may safely retry after changing
+    /// state (for example, restoring keyboard focus) while a fallback channel
+    /// would still be unsafe to invoke.
+    static func isFallbackUnsafeStateC(_ message: String) -> Bool {
+        guard message.hasPrefix("{") else { return false }
+        guard let data = message.data(using: .utf8),
+              let raw = try? JSONSerialization.jsonObject(with: data),
+              let obj = raw as? [String: Any] else {
+            return false
+        }
+        // State A / B both carry `success:true`; only State C is `false`.
+        guard let success = obj["success"] as? Bool, success == false else {
+            return false
+        }
+        return obj["fallback_unsafe"] as? Bool == true
+    }
+
     // MARK: - JSON serialization
 
     /// Serialize a dictionary deterministically (sorted keys) so snapshots

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -506,8 +506,11 @@ enum HonestContract {
               let obj = raw as? [String: Any] else {
             return false
         }
-        // State A / B both carry `success:true`; only State C is `false`.
-        guard let success = obj["success"] as? Bool, success == false else {
+        // Encoders merge extras after their canonical fields, so `success:false` alone does not
+        // prove State C. Require the complete State C shape before honoring this router directive.
+        guard let success = obj["success"] as? Bool, success == false,
+              let state = obj["state"] as? String, state == "C",
+              obj["error"] as? String != nil else {
             return false
         }
         return obj["fallback_unsafe"] as? Bool == true

--- a/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
+++ b/Tests/LogicProMCPTests/HealthDispatcherKeyCmdDetailTests.swift
@@ -55,7 +55,7 @@ private func t7StartedChannel(tag: String) async throws -> ChannelHealth {
     #expect(health.detail.contains("edit.normalize"))
     #expect(!health.detail.contains("edit.toggle_step_input"))
     #expect(health.detail.contains("nav.goto_marker"))
-    #expect(health.detail.contains("nav.delete_marker"))
+    #expect(!health.detail.contains("nav.delete_marker"))
     #expect(!health.detail.contains("nav.set_zoom_level"))
     #expect(!health.detail.contains("project.bounce"))
 }

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -115,14 +115,12 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
 /// operator installed the key-command preset and performed a manual MIDI Learn inside Logic. Until
 /// then the CC went out, Logic had nothing bound to it, the marker survived, and the caller was told
 /// `readback_unavailable` — a setup prerequisite reported as a readback problem.
-@Suite("nav.delete_marker has a route that needs no manual MIDI binding")
+@Suite("nav.delete_marker has a target-faithful route")
 struct MarkerDeleteRoutingTests {
-    @Test("the AX channel is the first rung, so a default install can delete a marker")
-    func deleteMarkerRoutesThroughAccessibilityFirst() throws {
+    @Test("only AX can delete the requested marker index")
+    func deleteMarkerRoutesOnlyThroughAccessibility() throws {
         let route = try #require(ChannelRouter.v2RoutingTable["nav.delete_marker"])
-        #expect(route.first == .accessibility)
-        // The keycmd rung stays as a fallback rather than being removed.
-        #expect(route.contains(.midiKeyCommands))
+        #expect(route == [.accessibility])
     }
 
     @Test("the marker-list rungs the AX path depends on are all AX-routed")

--- a/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
+++ b/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
@@ -77,6 +77,8 @@ private func issue526SelectionFailureRuntime() -> AXLogicProElements.Runtime {
     builder.setAttribute(markerList, kAXTitleAttribute as String, "Issue526 - Marker List")
     builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Issue526.logicx")
     builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(table, kAXDescriptionAttribute as String, "Marker Table")
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, table)
     builder.setAttribute(row, kAXRoleAttribute as String, kAXRowRole as String)
     for cell in [lockCell, positionCell, markerNameCell] {
         builder.setAttribute(cell, kAXRoleAttribute as String, kAXCellRole as String)
@@ -117,7 +119,7 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     await router.register(accessibility)
     await router.register(keyCommands)
 
-    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+    let result = await router.route(operation: "nav.set_zoom_level", params: ["level": "50"])
 
     #expect(!result.isSuccess)
     #expect(result.message == envelope)
@@ -138,7 +140,7 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     await router.register(accessibility)
     await router.register(keyCommands)
 
-    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+    let result = await router.route(operation: "nav.set_zoom_level", params: ["level": "50"])
 
     #expect(result.isSuccess)
     #expect(!HonestContract.isFallbackUnsafeStateC(envelope))
@@ -146,11 +148,11 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     #expect(await keyCommands.executions() == 1)
 }
 
-@Test func testIssue526FallbackUnsafeTerminalStateCRemainsVerbatim() async {
+@Test func testIssue526FallbackUnsafeNonTerminalStateCStopsMultiChannelFallback() async {
     let router = ChannelRouter()
     let envelope = HonestContract.encodeStateC(
-        error: .elementNotFound,
-        hint: "Marker List row was not found",
+        error: .axWriteFailed,
+        hint: "Marker List selection is unsafe to fall back from",
         extras: ["fallback_unsafe": true]
     )
     let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: envelope)
@@ -158,11 +160,11 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     await router.register(accessibility)
     await router.register(keyCommands)
 
-    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+    let result = await router.route(operation: "nav.set_zoom_level", params: ["level": "50"])
 
     #expect(!result.isSuccess)
     #expect(result.message == envelope)
-    #expect(HonestContract.isTerminalStateC(result.message))
+    #expect(!HonestContract.isTerminalStateC(result.message))
     #expect(HonestContract.isFallbackUnsafeStateC(result.message))
     #expect(await accessibility.executions() == 1)
     #expect(await keyCommands.executions() == 0)
@@ -207,9 +209,10 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     await router.register(accessibility)
     await router.register(keyCommands)
 
-    let result = await router.route(operation: "nav.delete_marker", params: ["index": "0"])
+    let result = await router.route(operation: "nav.set_zoom_level", params: ["level": "50"])
 
     #expect(HonestContract.isFallbackUnsafeStateC(refusal.message))
+    #expect(refusal.message.contains("could not be selected"))
     #expect(!result.isSuccess)
     #expect(result.message == refusal.message)
     #expect(await accessibility.executions() == 1)

--- a/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
+++ b/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
@@ -164,7 +164,6 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
 
     #expect(!result.isSuccess)
     #expect(result.message == envelope)
-    #expect(!HonestContract.isTerminalStateC(result.message))
     #expect(HonestContract.isFallbackUnsafeStateC(result.message))
     #expect(await accessibility.executions() == 1)
     #expect(await keyCommands.executions() == 0)
@@ -203,6 +202,7 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
         runtime: issue526SelectionFailureRuntime(),
         mouse: issue526NoOpMouseRuntime
     )
+    #expect(!refusal.isSuccess)
     let router = ChannelRouter()
     let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: refusal.message)
     let keyCommands = Issue526SuccessProbeChannel(id: .midiKeyCommands)

--- a/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
+++ b/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
@@ -1,0 +1,120 @@
+import Testing
+@testable import LogicProMCP
+
+private actor Issue526ErrorChannel: Channel {
+    nonisolated let id: ChannelID
+    private let envelope: String
+    private var executionCount = 0
+
+    init(id: ChannelID, envelope: String) {
+        self.id = id
+        self.envelope = envelope
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executionCount += 1
+        return .error(envelope)
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "Issue526 error channel")
+    }
+
+    func executions() -> Int {
+        executionCount
+    }
+}
+
+private actor Issue526SuccessProbeChannel: Channel {
+    nonisolated let id: ChannelID
+    private var executionCount = 0
+
+    init(id: ChannelID) {
+        self.id = id
+    }
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        executionCount += 1
+        return .success("Issue526 fallback executed")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "Issue526 success probe")
+    }
+
+    func executions() -> Int {
+        executionCount
+    }
+}
+
+@Test func testIssue526FallbackUnsafeStateCStopsMultiChannelFallback() async {
+    let router = ChannelRouter()
+    let envelope = HonestContract.encodeStateC(
+        error: .axWriteFailed,
+        hint: "Delete is unsafe without Marker List keyboard focus",
+        extras: [
+            "fallback_unsafe": true,
+            "write_attempted": false,
+        ]
+    )
+    let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: envelope)
+    let keyCommands = Issue526SuccessProbeChannel(id: .midiKeyCommands)
+    await router.register(accessibility)
+    await router.register(keyCommands)
+
+    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+
+    #expect(!result.isSuccess)
+    #expect(result.message == envelope)
+    #expect(HonestContract.isFallbackUnsafeStateC(result.message))
+    #expect(await accessibility.executions() == 1)
+    #expect(await keyCommands.executions() == 0)
+}
+
+@Test func testIssue526StateCWithoutFallbackUnsafeStillFallsThrough() async {
+    let router = ChannelRouter()
+    let envelope = HonestContract.encodeStateC(
+        error: .axWriteFailed,
+        hint: "AX write failed for a channel-local reason",
+        extras: ["write_attempted": false]
+    )
+    let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: envelope)
+    let keyCommands = Issue526SuccessProbeChannel(id: .midiKeyCommands)
+    await router.register(accessibility)
+    await router.register(keyCommands)
+
+    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+
+    #expect(result.isSuccess)
+    #expect(!HonestContract.isFallbackUnsafeStateC(envelope))
+    #expect(await accessibility.executions() == 1)
+    #expect(await keyCommands.executions() == 1)
+}
+
+@Test func testIssue526FallbackUnsafeTerminalStateCRemainsVerbatim() async {
+    let router = ChannelRouter()
+    let envelope = HonestContract.encodeStateC(
+        error: .elementNotFound,
+        hint: "Marker List row was not found",
+        extras: ["fallback_unsafe": true]
+    )
+    let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: envelope)
+    let keyCommands = Issue526SuccessProbeChannel(id: .midiKeyCommands)
+    await router.register(accessibility)
+    await router.register(keyCommands)
+
+    let result = await router.route(operation: "nav.delete_marker", params: ["index": "1"])
+
+    #expect(!result.isSuccess)
+    #expect(result.message == envelope)
+    #expect(HonestContract.isTerminalStateC(result.message))
+    #expect(HonestContract.isFallbackUnsafeStateC(result.message))
+    #expect(await accessibility.executions() == 1)
+    #expect(await keyCommands.executions() == 0)
+}

--- a/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
+++ b/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
@@ -1,3 +1,5 @@
+@preconcurrency import ApplicationServices
+import Foundation
 import Testing
 @testable import LogicProMCP
 
@@ -52,6 +54,53 @@ private actor Issue526SuccessProbeChannel: Channel {
         executionCount
     }
 }
+
+private func issue526SelectionFailureRuntime() -> AXLogicProElements.Runtime {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(52_600)
+    let arrange = builder.element(52_601)
+    let markerList = builder.element(52_602)
+    let table = builder.element(52_603)
+    let row = builder.element(52_604)
+    let lockCell = builder.element(52_605)
+    let positionCell = builder.element(52_606)
+    let markerNameCell = builder.element(52_607)
+    let position = builder.element(52_608)
+    let markerName = builder.element(52_609)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Issue526 - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/Issue526.logicx")
+    builder.setAttribute(markerList, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "Issue526 - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Issue526.logicx")
+    builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(row, kAXRoleAttribute as String, kAXRowRole as String)
+    for cell in [lockCell, positionCell, markerNameCell] {
+        builder.setAttribute(cell, kAXRoleAttribute as String, kAXCellRole as String)
+    }
+    builder.setAttribute(position, kAXDescriptionAttribute as String, "1 1 1 1")
+    builder.setAttribute(markerName, kAXDescriptionAttribute as String, "Target")
+    builder.setChildren(positionCell, [position])
+    builder.setChildren(markerNameCell, [markerName])
+    builder.setChildren(row, [lockCell, positionCell, markerNameCell])
+    builder.setAttribute(table, "AXRows", [row])
+    builder.setChildren(table, [row])
+    builder.setChildren(markerList, [table])
+
+    // The row's selected attribute may be set, but the table never confirms it in
+    // AXSelectedRows, which makes selectMarkerRowForDeletion refuse to press Delete.
+    return builder.makeLogicRuntime(appElement: app)
+}
+
+private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
+    postMouseEvent: { _, _, _ in false },
+    postKeyEvent: { _ in false },
+    postUnicodeScalar: { _ in false },
+    sleepMicros: { _ in }
+)
 
 @Test func testIssue526FallbackUnsafeStateCStopsMultiChannelFallback() async {
     let router = ChannelRouter()
@@ -115,6 +164,54 @@ private actor Issue526SuccessProbeChannel: Channel {
     #expect(result.message == envelope)
     #expect(HonestContract.isTerminalStateC(result.message))
     #expect(HonestContract.isFallbackUnsafeStateC(result.message))
+    #expect(await accessibility.executions() == 1)
+    #expect(await keyCommands.executions() == 0)
+}
+
+@Test func testIssue526StateAExtrasCannotMasqueradeAsFallbackUnsafeStateC() {
+    let envelope = HonestContract.encodeStateA(extras: [
+        "success": false,
+        "fallback_unsafe": true,
+    ])
+
+    #expect(!HonestContract.isFallbackUnsafeStateC(envelope))
+}
+
+@Test func testIssue526StateBEnvelopeWithMarkerIsNotFallbackUnsafeStateC() {
+    let envelope = HonestContract.encodeStateB(
+        reason: .readbackUnavailable,
+        extras: [
+            "success": false,
+            "fallback_unsafe": true,
+        ]
+    )
+
+    #expect(!HonestContract.isFallbackUnsafeStateC(envelope))
+}
+
+@Test func testIssue526FallbackUnsafeMarkerWithoutErrorStringIsNotFallbackUnsafeStateC() {
+    let envelope = #"{"success":false,"state":"C","fallback_unsafe":true}"#
+
+    #expect(!HonestContract.isFallbackUnsafeStateC(envelope))
+}
+
+@Test func testIssue526SelectionFailureRefusalIsFallbackUnsafeAndStopsChain() async {
+    let refusal = await AccessibilityChannel.defaultDeleteMarker(
+        index: 0,
+        runtime: issue526SelectionFailureRuntime(),
+        mouse: issue526NoOpMouseRuntime
+    )
+    let router = ChannelRouter()
+    let accessibility = Issue526ErrorChannel(id: .accessibility, envelope: refusal.message)
+    let keyCommands = Issue526SuccessProbeChannel(id: .midiKeyCommands)
+    await router.register(accessibility)
+    await router.register(keyCommands)
+
+    let result = await router.route(operation: "nav.delete_marker", params: ["index": "0"])
+
+    #expect(HonestContract.isFallbackUnsafeStateC(refusal.message))
+    #expect(!result.isSuccess)
+    #expect(result.message == refusal.message)
     #expect(await accessibility.executions() == 1)
     #expect(await keyCommands.executions() == 0)
 }

--- a/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
+++ b/Tests/LogicProMCPTests/Issue526FallbackUnsafeTests.swift
@@ -104,6 +104,81 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     sleepMicros: { _ in }
 )
 
+/// Builds a Marker List whose Delete key removes `actualDeleteIndex`. Keeping that
+/// distinct from the requested index lets this fixture exercise the verification
+/// proof without using a coordinate click.
+private func issue526MarkerDeleteReadbackRuntime(
+    markers: [(position: String, name: String)],
+    actualDeleteIndex: Int
+) -> (runtime: AXLogicProElements.Runtime, mouse: AXMouseHelper.Runtime) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(52_700)
+    let arrange = builder.element(52_701)
+    let markerList = builder.element(52_702)
+    let table = builder.element(52_703)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Issue526 - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/Issue526.logicx")
+    builder.setAttribute(markerList, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "Issue526 - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Issue526.logicx")
+    builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(table, kAXDescriptionAttribute as String, "Marker Table")
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, table)
+
+    let rows: [AXUIElement] = markers.enumerated().map { index, marker in
+        let base = 52_710 + index * 10
+        let row = builder.element(base)
+        let lockCell = builder.element(base + 1)
+        let positionCell = builder.element(base + 2)
+        let markerNameCell = builder.element(base + 3)
+        let position = builder.element(base + 4)
+        let markerName = builder.element(base + 5)
+        builder.setAttribute(row, kAXRoleAttribute as String, kAXRowRole as String)
+        for cell in [lockCell, positionCell, markerNameCell] {
+            builder.setAttribute(cell, kAXRoleAttribute as String, kAXCellRole as String)
+        }
+        builder.setAttribute(position, kAXDescriptionAttribute as String, marker.position)
+        builder.setAttribute(markerName, kAXDescriptionAttribute as String, marker.name)
+        builder.setChildren(positionCell, [position])
+        builder.setChildren(markerNameCell, [markerName])
+        builder.setChildren(row, [lockCell, positionCell, markerNameCell])
+        return row
+    }
+    builder.setAttribute(table, "AXRows", rows)
+    builder.setChildren(table, rows)
+    builder.setChildren(markerList, [table])
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { element, attribute, _ in
+            if attribute == kAXSelectedAttribute as String {
+                builder.setAttribute(table, "AXSelectedRows", [element])
+            }
+            return true
+        },
+        performActionHandler: nil
+    )
+    let mouse = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { keyCode in
+            guard keyCode == 0x33 else { return false }
+            let postDeleteRows = rows.enumerated()
+                .filter { $0.offset != actualDeleteIndex }
+                .map { $0.element }
+            builder.setAttribute(table, "AXRows", postDeleteRows)
+            builder.setChildren(table, postDeleteRows)
+            return true
+        },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    )
+    return (runtime, mouse)
+}
+
 @Test func testIssue526FallbackUnsafeStateCStopsMultiChannelFallback() async {
     let router = ChannelRouter()
     let envelope = HonestContract.encodeStateC(
@@ -217,4 +292,63 @@ private let issue526NoOpMouseRuntime = AXMouseHelper.Runtime(
     #expect(result.message == refusal.message)
     #expect(await accessibility.executions() == 1)
     #expect(await keyCommands.executions() == 0)
+}
+
+@Test func testIssue526DuplicateTargetPositionReturnsStateBWhenWrongRowWasDeleted() async throws {
+    // The requested target at index 1 and the actually deleted row at index 2
+    // share 5.1.1.1. Their position multisets are therefore identical after
+    // either deletion; the old gate returned State A for this wrong-target write.
+    let fixture = issue526MarkerDeleteReadbackRuntime(
+        markers: [
+            (position: "1 1 1 1", name: "Intro"),
+            (position: "5 1 1 1", name: "Requested Target"),
+            (position: "5 1 1 1", name: "Wrong Row"),
+            (position: "9 1 1 1", name: "Outro"),
+        ],
+        actualDeleteIndex: 2
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "B")
+    #expect(envelope["reason"] as? String == "readback_unavailable")
+    #expect(try #require(envelope["write_attempted"] as? Bool))
+    #expect(envelope["marker_count_before"] as? Int == 4)
+    #expect(envelope["marker_count_after"] as? Int == 3)
+    #expect(!(try #require(envelope["target_position_unique"] as? Bool)))
+    #expect(try #require(envelope["position_evidence_canonical"] as? Bool))
+    #expect(try #require(envelope["reason_detail"] as? String).contains("cannot establish which marker"))
+}
+
+@Test func testIssue526FallbackPositionCollisionAlsoReturnsStateB() async throws {
+    // A failed parse manufactures ordinal 1 as 1.1.1.1, which collides with
+    // the next row's genuine 1.1.1.1. Deleting that next row reproduces the
+    // same multiset expected after deleting the requested fallback row.
+    let fixture = issue526MarkerDeleteReadbackRuntime(
+        markers: [
+            (position: "not a position", name: "Fallback Target"),
+            (position: "1 1 1 1", name: "Parsed Same Position"),
+            (position: "9 1 1 1", name: "Outro"),
+        ],
+        actualDeleteIndex: 1
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 0, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "B")
+    #expect(!(try #require(envelope["target_position_unique"] as? Bool)))
+    #expect(!(try #require(envelope["prewrite_position_evidence_canonical"] as? Bool)))
+    #expect(try #require(envelope["reason_detail"] as? String).contains("cannot establish which marker"))
 }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -43,11 +43,11 @@ struct OperationRegistryTests {
     ]
 
     private static let unverifiedNavigateCommands: Set<String> = [
-        "delete_marker", "toggle_view",
+        "toggle_view",
     ]
 
     private static let navigateAvailabilityOverrides: [String: AvailabilityPolicy] = [
-        "delete_marker": .requiresKeyBinding,
+        "delete_marker": .defaultInstall,
     ]
 
     private static let smallToolCount = 19

--- a/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
+++ b/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
@@ -93,15 +93,30 @@ struct RoutingAuditInvariantTests {
         )
     }
 
-    @Test("MIDIKeyCommandsChannel health detail enumerates every keycmd-only op")
-    func healthDetailMentionsEveryKeycmdOnlyOp() {
+    @Test("MIDIKeyCommandsChannel health detail exactly enumerates keycmd-only ops")
+    func healthDetailExactlyMatchesKeycmdOnlyOps() throws {
         let detail = MIDIKeyCommandsChannel.manualValidationDetailSuffix
-        let missing = Self.expectedKeycmdOnlyOps
-            .filter { !detail.contains($0) }
-            .sorted()
+        let effectivePrefix = "Effectively keycmd-only (no working non-keycmd fallback on Logic 12.2): "
+        let effectiveSection = try #require(
+            detail.components(separatedBy: effectivePrefix).dropFirst().first?
+                .components(separatedBy: ". Other preset ops").first
+        )
+        let orphanPrefix = "Orphans (in mappingTable + routingTable but no MCP tool exposes a call path): "
+        let orphanSection = try #require(
+            detail.components(separatedBy: orphanPrefix).dropFirst().first?
+                .components(separatedBy: ". Tracked in NG6 follow-up.").first
+        )
+        let declared = Set(
+            (effectiveSection + "," + orphanSection)
+                .split(separator: ",")
+                .map { entry in
+                    entry.trimmingCharacters(in: .whitespacesAndNewlines)
+                        .components(separatedBy: " ").first ?? ""
+                }
+        )
         #expect(
-            missing.isEmpty,
-            "expectedKeycmdOnlyOps has ops the health detail does not mention — SETUP.md §4.1 and the runtime health string would disagree: \(missing)"
+            declared == Self.expectedKeycmdOnlyOps,
+            "health detail's declared keycmd-only set must exactly match expectedKeycmdOnlyOps — declared: \(declared.sorted()), expected: \(Self.expectedKeycmdOnlyOps.sorted())"
         )
     }
 

--- a/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
+++ b/Tests/LogicProMCPTests/RoutingAuditInvariantTests.swift
@@ -38,7 +38,6 @@ struct RoutingAuditInvariantTests {
         "edit.duplicate",                 // logic_edit.duplicate
         "edit.normalize",                 // logic_edit.normalize
         "nav.goto_marker",                // logic_navigate.goto_marker (with index)
-        "nav.delete_marker",              // logic_navigate.delete_marker
         // Channel-only router op — no public MCP tool command exposes it, but
         // it remains a real mappingTable/routingTable path if a future surface
         // promotes it.

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -767,16 +767,19 @@ enum SemanticOracleFixtures {
             """,
             readback: "{}"
         ),
-        // defaultDeleteMarker State A: the settled AX marker-list readback exactly
-        // matched the complete expected survivor set (name@position for every
-        // marker except the requested target).
+        // defaultDeleteMarker State A: the settled AX marker-list POSITION multiset
+        // exactly matched the pre-write positions with the target occurrence
+        // removed. Each sorted position entry is length-prefixed, then the entries
+        // join without an ambiguous delimiter.
         .navigateDeleteMarker: SemanticOracleFixture(
             response: """
                 {"success":true,"verified":true,"state":"A",\
                 "operation":"nav.delete_marker","requested_index":1,\
                 "target_name":"Verse","target_position":"5.1.1.1",\
                 "marker_count_before":3,"write_attempted":true,\
-                "readback_settled":true,"marker_count_after":2}
+                "readback_settled":true,"marker_count_after":2,\
+                "expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1",\
+                "observed_survivor_position_multiset":"7:1.1.1.18:12.1.1.1"}
                 """,
             readback: "{}"
         ),

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -764,6 +764,19 @@ enum SemanticOracleFixtures {
                 "marker_count_after":3,"requested_name":"Chorus",\
                 "observed_marker_id":2,"observed_marker_name":"Chorus",\
                 "observed_marker_position":"12.1.1.1","observed_marker_position_source":"parser"}
+            """,
+            readback: "{}"
+        ),
+        // defaultDeleteMarker State A: the settled AX marker-list readback exactly
+        // matched the complete expected survivor set (name@position for every
+        // marker except the requested target).
+        .navigateDeleteMarker: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"nav.delete_marker","requested_index":1,\
+                "target_name":"Verse","target_position":"5.1.1.1",\
+                "marker_count_before":3,"write_attempted":true,\
+                "readback_settled":true,"marker_count_after":2}
                 """,
             readback: "{}"
         ),

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -776,6 +776,7 @@ enum SemanticOracleFixtures {
                 {"success":true,"verified":true,"state":"A",\
                 "operation":"nav.delete_marker","requested_index":1,\
                 "target_name":"Verse","target_position":"5.1.1.1",\
+                "target_position_unique":true,"position_evidence_canonical":true,\
                 "marker_count_before":3,"write_attempted":true,\
                 "readback_settled":true,"marker_count_after":2,\
                 "expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1",\

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -397,12 +397,15 @@ struct SemanticOracleCensusTests {
     /// a count) is what makes the increment a deliberate, reviewable diff. B1, B2,
     /// B3 and B4 are each pinned by count so a premature or miscounted oracle in any
     /// fails here.
+    /// B2 went 15 -> 16 and the total 48 -> 49 when `navigate.delete_marker` stopped being
+    /// structurally unverifiable: its chain is accessibility-only, and that path reads the
+    /// surviving marker set back, so it has a State A to pin and an oracle to pin it with.
     @Test func mutatingOraclesAreExactlyTheDeclaredIncrement() {
         let mutatingOracles = Set(SemanticOracleTable.byOperationID.keys)
             .intersection(SemanticOracleTable.mutatingSpecIDs)
         #expect(mutatingOracles == SemanticOracleTable.coveredMutatingOperationIDs)
         #expect(SemanticOracleTable.phaseB1MutatingOperationIDs.count == 12)
-        #expect(SemanticOracleTable.phaseB2MutatingOperationIDs.count == 15)
+        #expect(SemanticOracleTable.phaseB2MutatingOperationIDs.count == 16)
         #expect(SemanticOracleTable.phaseB3MutatingOperationIDs.count == 15)
         #expect(SemanticOracleTable.phaseB4MutatingOperationIDs.count == 6)
         // B1, B2, B3 and B4 are PAIRWISE-DISJOINT increments — no op claimed twice.
@@ -420,7 +423,7 @@ struct SemanticOracleCensusTests {
                 )
             }
         }
-        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 48)
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 49)
     }
 
     /// #373 B4 — the mutating oracle inventory is CLOSED. Every supported
@@ -488,13 +491,15 @@ struct SemanticOracleCensusTests {
         let exclusions = SemanticOracleTable.structurallyUnverifiedMutatingOperationIDs
         #expect(!exclusions.isEmpty)
         #expect(exclusions[.mixerSetPluginParam] != nil)
-        // The five B2 send-only ops that structurally cannot reach State A.
+        // The four B2 send-only ops that structurally cannot reach State A.
         for id in [
             OperationID.transportRewind, .transportFastForward,
-            .navigateZoomToFit, .navigateDeleteMarker, .navigateToggleView,
+            .navigateZoomToFit, .navigateToggleView,
         ] {
             #expect(exclusions[id] != nil, "\(id.rawValue) missing its send-only exclusion reason")
         }
+        #expect(exclusions[.navigateDeleteMarker] == nil)
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.contains(.navigateDeleteMarker))
         // The B3 audited exclusions: project lifecycle ops with no State A
         // (new/open/close State-B ceiling, launch/quit prose), the send-only
         // tracks.duplicate, and the send-only midi surface (a representative

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -85,6 +85,23 @@ struct SemanticOracleEngineTests {
         #expect(!OracleConstraint.typedField(key: "missing", type: .string).isSatisfied(by: object))
     }
 
+    @Test func lengthPrefixedEntryCountChecksUTF8BoundariesAndNumericCount() {
+        let entryCount = OracleConstraint.lengthPrefixedEntryCountEquals(
+            key: "positions", countKey: "marker_count", offset: 0
+        )
+        #expect(entryCount.isSatisfied(by: root(#"{"positions":"7:1.1.1.18:12.1.1.1","marker_count":2}"#)))
+        #expect(entryCount.isSatisfied(by: root(#"{"positions":"2:é","marker_count":1}"#)))
+        #expect(!entryCount.isSatisfied(by: root(#"{"positions":"7:1.1.1.18:12.1.1.1","marker_count":3}"#)))
+        #expect(!entryCount.isSatisfied(by: root(#"{"positions":"8:5.1.1.1","marker_count":1}"#)))
+        #expect(!entryCount.isSatisfied(by: root(#"{"positions":"7:1.1.1.1","marker_count":1.5}"#)))
+
+        let survivors = OracleConstraint.lengthPrefixedEntryCountEquals(
+            key: "positions", countKey: "marker_count_before", offset: -1
+        )
+        #expect(survivors.isSatisfied(by: root(#"{"positions":"7:1.1.1.1","marker_count_before":2}"#)))
+        #expect(!survivors.isSatisfied(by: root(#"{"positions":"7:1.1.1.1","marker_count_before":3}"#)))
+    }
+
     // MARK: - relational constraints (Phase B0)
 
     @Test func fieldsEqualHoldsWhenTwoKeyPathsAgreeAndFailsWhenTheyDiverge() {
@@ -725,7 +742,7 @@ struct SemanticOracleMutationTests {
         // A settled no-op must be rejected even though the rest of State-A's
         // envelope shape is intact.
         let noOp = try #require(oracle.evaluate(
-            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.18:12.1.1.1"}"#.utf8),
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.18:12.1.1.1"}"#.utf8),
             readbackData: Data("{}".utf8)
         ))
         #expect(!noOp, "delete_marker accepted a settled State A whose position multiset lost no target occurrence")
@@ -733,7 +750,7 @@ struct SemanticOracleMutationTests {
         // Mutation: replace the expected 12.1.1.1 survivor with the target's
         // 5.1.1.1 position. Count-only validation would accept this wrong delete.
         let wrongPositions = try #require(oracle.evaluate(
-            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.1"}"#.utf8),
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.1"}"#.utf8),
             readbackData: Data("{}".utf8)
         ))
         #expect(!wrongPositions, "delete_marker accepted a settled readback with wrong positions")
@@ -743,10 +760,19 @@ struct SemanticOracleMutationTests {
         // not normally carry these State-B diagnostic fields; including them here
         // proves the oracle deliberately binds the position multiset, not names.
         let namesShifted = try #require(oracle.evaluate(
-            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"1.1.1.1","marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.18:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.18:5.1.1.1","expected_survivors":["8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 48:5.1.1.1"],"observed_survivors":["8:Marker 17:1.1.1.1","8:Marker 27:1.1.1.1","8:Marker 38:5.1.1.1"]}"#.utf8),
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"2.1.1.1","target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","expected_survivors":["8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"observed_survivors":["8:Marker 17:1.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:5.1.1.1"]}"#.utf8),
             readbackData: Data("{}".utf8)
         ))
         #expect(namesShifted, "delete_marker rejected correct positions solely because default names shifted")
+
+        // Mutation: both self-reported multisets carry the same valid wire value,
+        // but it contains only one entry while both counts require two. Equality
+        // alone would accept this shared arbitrary value.
+        let selfReportedMultisets = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:arbitrary","observed_survivor_position_multiset":"7:arbitrary"}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        #expect(!selfReportedMultisets, "delete_marker accepted equal multiset fields whose entry counts contradict the marker counts")
     }
 
     /// #373 B3 — project.save_as is envelope-only because its
@@ -1246,6 +1272,18 @@ enum JSONMutator {
             mutants.append(contentsOf: replacements(root, key, [("emptied", [Any]())]))
         case .typedField(_, let type):
             mutants.append(contentsOf: replacements(root, key, [("wrong type", wrongTyped(type))]))
+        case .lengthPrefixedEntryCountEquals(let wireKey, let countKey, _):
+            // Corrupt the self-describing wire field and independently make its
+            // declared numeric cardinality disagree. (`drop wireKey` is generic.)
+            mutants.append(contentsOf: replacements(root, wireKey, [
+                ("malformed length prefix", "not-a-length-prefixed-entry"),
+            ]))
+            if let current = JSONPath.resolve(root, keyPath: countKey),
+               let count = JSONInspector.number(of: current) {
+                mutants.append(contentsOf: replacements(root, countKey, [
+                    ("wrong entry count", count + 1),
+                ]))
+            }
         case .fieldsEqual(let keyA, let keyB):
             // Break the equality by diverging EITHER side; each must sink the
             // oracle. (`drop keyA` is already added generically via `key`.)

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -708,6 +708,47 @@ struct SemanticOracleMutationTests {
         #expect(!failure, "metronome oracle accepted a State C failure")
     }
 
+    /// `nav.delete_marker` reaches State A only after the settled marker-list
+    /// POSITION multiset equals the pre-write expectation with one instance of
+    /// the target position removed. The envelope must bind that equality:
+    /// otherwise stable reads, typed counts, and echoed target metadata can
+    /// falsely certify a no-op or the deletion of a marker at another position.
+    @Test func deleteMarkerOracleRequiresTheExactSettledPositionMultiset() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.navigateDeleteMarker])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[.navigateDeleteMarker])
+
+        let honest = try #require(oracle.evaluate(
+            responseData: fixture.responseData, readbackData: fixture.readbackData))
+        #expect(honest, "delete_marker rejected its honest settled position multiset")
+
+        // Mutation: put the target-position entry back into observed positions.
+        // A settled no-op must be rejected even though the rest of State-A's
+        // envelope shape is intact.
+        let noOp = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.18:12.1.1.1"}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        #expect(!noOp, "delete_marker accepted a settled State A whose position multiset lost no target occurrence")
+
+        // Mutation: replace the expected 12.1.1.1 survivor with the target's
+        // 5.1.1.1 position. Count-only validation would accept this wrong delete.
+        let wrongPositions = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:5.1.1.1"}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        #expect(!wrongPositions, "delete_marker accepted a settled readback with wrong positions")
+
+        // Mutation: every remaining default marker name shifted down by one after
+        // deleting index 0, but their positions are exactly right. State A does
+        // not normally carry these State-B diagnostic fields; including them here
+        // proves the oracle deliberately binds the position multiset, not names.
+        let namesShifted = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"1.1.1.1","marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.18:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.18:5.1.1.1","expected_survivors":["8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 48:5.1.1.1"],"observed_survivors":["8:Marker 17:1.1.1.1","8:Marker 27:1.1.1.1","8:Marker 38:5.1.1.1"]}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        #expect(namesShifted, "delete_marker rejected correct positions solely because default names shifted")
+    }
+
     /// #373 B3 — project.save_as is envelope-only because its
     /// [.accessibility, .appleScript] chain reaches State A in two shapes with
     /// DISJOINT non-envelope keys (AX-dialog: requested/observed/via; AppleScript:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -108,7 +108,6 @@ Manual binding is only needed for remaining keycmd-only/channel-only paths:
 - `edit.duplicate`
 - `edit.normalize`
 - `nav.goto_marker`
-- `nav.delete_marker`
 - `transport.capture_recording`
 
 Most normal tool calls route through Accessibility, AppleScript, MCU, CoreMIDI, or CGEvent without manual MIDI Learn.


### PR DESCRIPTION
Closes #526.

## The defect

`ChannelRouter` decided whether to fall through to the next channel by asking whether the error
**code** was terminal. A channel that refuses an operation for safety emits `ax_write_failed` with
`write_attempted: false` — which by code alone is indistinguishable from "this channel could not
reach the control, try another". So a deliberate refusal was routed to a weaker channel, which fired
blindly and reported success.

```
[router] nav.delete_marker failed via Accessibility:
  {"error":"ax_write_failed","write_attempted":false,"state":"C"}, trying next
[router] nav.delete_marker succeeded via MIDIKeyCommands
```

`ax_write_failed` has to stay non-terminal: for other operations another channel genuinely can
deliver. The information the router is missing is not *what went wrong* but *may another channel try
at all*.

## The change

A State C envelope may carry `fallback_unsafe: true`, and the router returns such an envelope
verbatim instead of continuing. Absent or false, behaviour is byte-for-byte what it was.

Deliberately narrow, and each of these was a live option that was rejected:

- **`safe_to_retry` is not reused.** It answers whether the *caller* may retry. A safety refusal is
  usually safe for the caller to retry after fixing focus while still being unsafe to route to
  another channel. Widening a shared field to carry a second meaning would have made both weaker.
- **Nothing is added to `terminalErrorCodes`.** The code is the wrong axis; a code that is
  legitimately recoverable elsewhere must stay recoverable.

The marker-delete focus refusal is the single call site that sets it.

## Live evidence

Release artifact built from this head, driven over real stdio MCP against Logic Pro 12.3, with the
Marker List deliberately not holding keyboard focus.

| | guard on (this branch) | guard off (same source, one line) |
| --- | --- | --- |
| MCP `isError` | `true` | `false` |
| envelope | State C verbatim, `fallback_unsafe: true`, `write_attempted: false` | `success: true`, State B, `method: midi_key_command`, CC 45 CH 16 |
| Logic's own marker count | 15 → 15 | 15 → 15 — **nothing was deleted either way** |

The negative control is the point: with the guard removed the caller is told a delete was attempted
and is retryable, while a CC nothing is bound to was fired and no marker moved.

Evidence document: 3 checks, all three mutation-backed; 3 settled captures wholly within one display;
1 visual assertion; 1 screen recording; marker count restored. The visual assertion expects the row
region to be **unchanged**, so it was separately controlled — adding one marker through the Marker
List's own `+` button changes that same region's pixel hash, which is what makes "unchanged" a
result rather than an artefact.

## Tests

`Issue526FallbackUnsafeTests` — three cases: a multi-channel chain whose first channel sets the flag
never executes the second and returns verbatim; the same chain without the flag still falls through;
the flag alongside an already-terminal code stays verbatim.

Mutation-tested rather than assumed: disabling the router guard fails the first test on four
assertions, including `keyCommands.executions() == 0`. The other two still pass under that mutation —
they are regression guards for the paths this change must not disturb, not evidence for it.

Full suite: 3476 tests pass.
