### PR TITLE
fix(#529): validate the Go To menu before reading whether it is enabled

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -971,43 +971,100 @@ extension AccessibilityChannel {
         """
     }
 
+    /// The successful AppleScript channel payload is a JSON object containing the
+    /// script's return value in `result`. Only an exact `OK` means this route
+    /// reached the dialog and submitted it; any sentinel or malformed payload
+    /// must fall through to the slider route.
+    enum GotoPositionDialogResultClassification: Equatable {
+        enum Failure: Equatable {
+            case menuNotFound
+            case menuStateUnreadable
+            case menuDisabled
+            case menuPickFailed
+            case dialogNotReady
+            case malformedPayload
+            case unexpectedResult
+        }
+
+        case driven
+        case failure(Failure)
+    }
+
+    private struct GotoPositionDialogScriptPayload: Decodable {
+        let result: String
+    }
+
+    /// Kept internal for the menu-validation regression tests. This consumes
+    /// the JSON envelope produced by `AppleScriptChannel.channelResult` rather
+    /// than inspecting its serialized representation.
+    static func classifyGotoPositionDialogResult(
+        _ output: String
+    ) -> GotoPositionDialogResultClassification {
+        guard let data = output.data(using: .utf8),
+              let payload = try? JSONDecoder().decode(GotoPositionDialogScriptPayload.self, from: data)
+        else {
+            return .failure(.malformedPayload)
+        }
+
+        switch payload.result {
+        case "OK":
+            return .driven
+        case let value where value.hasPrefix("MENU_NOT_FOUND"):
+            return .failure(.menuNotFound)
+        case "MENU_STATE_UNREADABLE":
+            return .failure(.menuStateUnreadable)
+        case "MENU_DISABLED":
+            return .failure(.menuDisabled)
+        case let value where value.hasPrefix("MENU_PICK_FAILED"):
+            return .failure(.menuPickFailed)
+        case "DIALOG_NOT_READY":
+            return .failure(.dialogNotReady)
+        default:
+            return .failure(.unexpectedResult)
+        }
+    }
+
     private static func gotoPositionViaDialog(bar: Int) async -> ChannelResult {
         let script = gotoPositionViaDialogAppleScript(bar: bar)
-        let result = await AppleScriptChannel.executeAppleScript(script)
+        // Fixed waits consume 0.8 s and the dialog poll can consume 3.0 s.
+        // Eight seconds leaves 4.2 s for osascript startup and menu traversal.
+        let result = await AppleScriptChannel.executeAppleScript(script, timeout: 8.0)
         switch result {
         case .success(let output):
-            if output.contains("MENU_DISABLED") {
-                return .error("goto-position dialog disabled (project has no regions yet)")
-            }
-            if output.contains("MENU_STATE_UNREADABLE") {
+            switch classifyGotoPositionDialogResult(output) {
+            case .driven:
+                // #105: this State B reports only that the Go-To-Position dialog
+                // keystroke was sent; the playhead is verified independently by
+                // `TransportDispatcher.finalizeGotoPositionResult` via a transport-
+                // state read-back. Earlier this carried a `note` claiming the
+                // playhead was "not read back" — which the finalize step then
+                // contradicted by reading it back and gating `verified` on it, so a
+                // verified State A shipped a self-contradictory note. The provenance
+                // (`via:"dialog"`) plus finalize's `verification_source` /
+                // `observed` / `verified` fields describe the outcome honestly
+                // without it.
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackUnavailable,
+                    extras: [
+                        "requested": "\(bar).1.1.1",
+                        "via": "dialog"
+                    ]
+                ))
+            case .failure(.menuDisabled):
+                return .error("goto-position dialog menu state did not authorize the pick")
+            case .failure(.menuStateUnreadable):
                 return .error("goto-position dialog menu enabled state unavailable")
-            }
-            if output.hasPrefix("MENU_NOT_FOUND") {
-                return .error("goto-position menu not found: \(output)")
-            }
-            if output.hasPrefix("MENU_PICK_FAILED") {
-                return .error("goto-position dialog menu pick failed: \(output)")
-            }
-            if output.contains("DIALOG_NOT_READY") {
+            case .failure(.menuNotFound):
+                return .error("goto-position menu not found")
+            case .failure(.menuPickFailed):
+                return .error("goto-position dialog menu pick failed")
+            case .failure(.dialogNotReady):
                 return .error("goto-position dialog did not appear within timeout")
+            case .failure(.malformedPayload):
+                return .error("goto-position dialog returned an invalid result payload")
+            case .failure(.unexpectedResult):
+                return .error("goto-position dialog returned an unexpected result")
             }
-            // #105: this State B reports only that the Go-To-Position dialog
-            // keystroke was sent; the playhead is verified independently by
-            // `TransportDispatcher.finalizeGotoPositionResult` via a transport-
-            // state read-back. Earlier this carried a `note` claiming the
-            // playhead was "not read back" — which the finalize step then
-            // contradicted by reading it back and gating `verified` on it, so a
-            // verified State A shipped a self-contradictory note. The provenance
-            // (`via:"dialog"`) plus finalize's `verification_source` /
-            // `observed` / `verified` fields describe the outcome honestly
-            // without it.
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackUnavailable,
-                extras: [
-                    "requested": "\(bar).1.1.1",
-                    "via": "dialog"
-                ]
-            ))
         case .error(let msg):
             return .error("goto-position dialog failed: \(msg)")
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -889,29 +889,54 @@ extension AccessibilityChannel {
         return text
     }
 
-    private static func gotoPositionViaDialog(bar: Int) async -> ChannelResult {
+    /// The script is internal so the menu-validation regression tests can assert the
+    /// exact generated AppleScript ordering without invoking Logic Pro.
+    static func gotoPositionViaDialogAppleScript(bar: Int) -> String {
         // Poll for the dialog's presence instead of relying on a fixed delay.
         // Without this guard, a slow machine (>500ms to render the dialog) would
         // send Cmd+A to the arrange area, selecting all regions unexpectedly.
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
-        let script = """
+        return """
         \(logicProAppleScript.activateByBundleID)
         delay 0.2
         tell application "System Events"
             tell \(logicProAppleScript.systemEventsProcessTarget)
                 try
+                    -- Opening each menu makes Logic validate the child item before
+                    -- AXEnabled is read. A closed menu can expose a stale value.
+                    click menu bar item "탐색" of menu bar 1
+                    click menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
                     set mi to menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
                 on error errMsg
                     try
+                        -- The Korean lookup may have opened a menu before failing.
+                        -- Dismiss it before opening the English fallback chain.
+                        key code 53
+                        click menu bar item "Navigate" of menu bar 1
+                        click menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                         set mi to menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                     on error errMsg2
+                        key code 53
                         return "MENU_NOT_FOUND: " & errMsg2
                     end try
                 end try
-                if not (enabled of mi) then
+                try
+                    set menuItemEnabled to enabled of mi
+                on error
+                    -- An unreadable AXEnabled must not authorise the pick.
+                    key code 53
+                    return "MENU_STATE_UNREADABLE"
+                end try
+                if not menuItemEnabled then
+                    key code 53
                     return "MENU_DISABLED"
                 end if
-                click mi
+                try
+                    click mi
+                on error errMsg
+                    key code 53
+                    return "MENU_PICK_FAILED: " & errMsg
+                end try
                 -- Wait up to 3s for the dialog window to appear before typing,
                 -- otherwise keystrokes would go to the arrange area and click
                 -- Cmd+A there — silently "Select All Regions".
@@ -930,6 +955,7 @@ extension AccessibilityChannel {
                     end try
                 end repeat
                 if not dialogReady then
+                    key code 53
                     return "DIALOG_NOT_READY"
                 end if
             end tell
@@ -943,14 +969,24 @@ extension AccessibilityChannel {
         end tell
         return "OK"
         """
+    }
+
+    private static func gotoPositionViaDialog(bar: Int) async -> ChannelResult {
+        let script = gotoPositionViaDialogAppleScript(bar: bar)
         let result = await AppleScriptChannel.executeAppleScript(script)
         switch result {
         case .success(let output):
             if output.contains("MENU_DISABLED") {
                 return .error("goto-position dialog disabled (project has no regions yet)")
             }
+            if output.contains("MENU_STATE_UNREADABLE") {
+                return .error("goto-position dialog menu enabled state unavailable")
+            }
             if output.hasPrefix("MENU_NOT_FOUND") {
                 return .error("goto-position menu not found: \(output)")
+            }
+            if output.hasPrefix("MENU_PICK_FAILED") {
+                return .error("goto-position dialog menu pick failed: \(output)")
             }
             if output.contains("DIALOG_NOT_READY") {
                 return .error("goto-position dialog did not appear within timeout")

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1250,8 +1250,54 @@ extension AccessibilityChannel {
                 return .failed(classification)
             }
         case .error:
-            return .failed(.failure(.executionFailed))
+            // The script died — timeout, TCC refusal, anything. It clicks menus open, so its death
+            // leaves the menu state UNKNOWN, and unknown is not safe: the slider would actuate into
+            // whatever is on screen. Try once to observe and clear any open menu; only a state
+            // observed CLOSED lets the fallback proceed.
+            switch await observeAndClearStrayMenu() {
+            case .closed:
+                return .failed(.failure(.executionFailed))
+            case .openOrUnknown:
+                return .failed(.failure(.menuCouldNotBeClosed(writeAttempted: false)))
+            }
         }
+    }
+
+
+    private enum StrayMenuOutcome { case closed, openOrUnknown }
+
+    /// Independent of the script that just died: ask System Events whether any menu bar item is
+    /// selected, send Escape if so, and observe again. Anything other than an observed CLOSED —
+    /// including an unreadable menu bar — is `openOrUnknown`, because a failed reading is not
+    /// evidence that nothing is open.
+    private static func observeAndClearStrayMenu() async -> StrayMenuOutcome {
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        tell application "System Events"
+            tell \(target.systemEventsProcessTarget)
+                try
+                    repeat 3 times
+                        set anyOpen to false
+                        repeat with menuBarItem in every menu bar item of menu bar 1
+                            if selected of menuBarItem then set anyOpen to true
+                        end repeat
+                        if not anyOpen then return "CLOSED"
+                        key code 53
+                        delay 0.1
+                    end repeat
+                    return "OPEN"
+                on error
+                    return "UNREADABLE"
+                end try
+            end tell
+        end tell
+        """
+        guard case let .success(payload) = await AppleScriptChannel.executeAppleScript(script, timeout: 4.0),
+              let data = payload.data(using: .utf8),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              (obj["result"] as? String) == "CLOSED"
+        else { return .openOrUnknown }
+        return .closed
     }
 
     // MARK: - Control-bar checkbox helpers (Logic Pro 12 transport)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -897,44 +897,118 @@ extension AccessibilityChannel {
         // send Cmd+A to the arrange area, selecting all regions unexpectedly.
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
         return """
-        \(logicProAppleScript.activateByBundleID)
-        delay 0.2
-        tell application "System Events"
-            tell \(logicProAppleScript.systemEventsProcessTarget)
-                try
-                    -- Opening each menu makes Logic validate the child item before
-                    -- AXEnabled is read. A closed menu can expose a stale value.
-                    click menu bar item "탐색" of menu bar 1
-                    click menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
-                    set mi to menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
-                on error errMsg
+        -- A selected menu-bar item is the AX observation that one of Logic's
+        -- menus is currently open. Return UNREADABLE rather than treating a
+        -- failed read as a clean menu state.
+        on menuOpenState(theProcess)
+            using terms from application "System Events"
+                tell theProcess
                     try
-                        -- The Korean lookup may have opened a menu before failing.
-                        -- Dismiss it before opening the English fallback chain.
-                        key code 53
-                        click menu bar item "Navigate" of menu bar 1
-                        click menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
-                        set mi to menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
-                    on error errMsg2
-                        key code 53
-                        return "MENU_NOT_FOUND: " & errMsg2
+                        repeat with menuBarItem in every menu bar item of menu bar 1
+                            if selected of menuBarItem then return "OPEN"
+                        end repeat
+                        return "CLOSED"
+                    on error
+                        return "UNREADABLE"
                     end try
+                end tell
+            end using terms from
+        end menuOpenState
+
+        -- Never claim that Escape cleaned up a menu until AXSelected says so.
+        -- Three attempts are enough to cover a menu/submenu chain without
+        -- turning a failed close into an unbounded retry.
+        on dismissOpenMenu(theProcess)
+            set menuState to my menuOpenState(theProcess)
+            if menuState is "CLOSED" then return "CLOSED"
+            if menuState is not "OPEN" then return menuState
+            repeat 3 times
+                using terms from application "System Events"
+                    tell theProcess to key code 53
+                end using terms from
+                delay 0.1
+                set menuState to my menuOpenState(theProcess)
+                if menuState is "CLOSED" then return "CLOSED"
+                if menuState is not "OPEN" then return menuState
+            end repeat
+            return "OPEN"
+        end dismissOpenMenu
+
+        \(logicProAppleScript.activateByBundleID)
+        tell application "System Events"
+            set logicProcess to \(logicProAppleScript.systemEventsProcessTarget)
+            tell logicProcess
+                -- A timed-out predecessor can leave a menu open. Clear and
+                -- observe that state before this run performs any menu read or
+                -- actuation, so a later fallback never inherits an open menu.
+                set entryMenuCleanup to my dismissOpenMenu(logicProcess)
+                if entryMenuCleanup is not "CLOSED" then
+                    return "MENU_PICK_FAILED: entry menu cleanup was not observed (" & entryMenuCleanup & ")"
+                end if
+                delay 0.2
+
+                -- Locale selection is a read-only path-resolution step. It
+                -- deliberately performs no click, so an AX error cannot turn a
+                -- Korean attempt into a second English menu actuation.
+                try
+                    if exists menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1 then
+                        set selectedMenuBarItem to menu bar item "탐색" of menu bar 1
+                        set selectedSubmenuItem to menu item "이동" of menu 1 of selectedMenuBarItem
+                        set mi to menu item "위치…" of menu 1 of selectedSubmenuItem
+                    else if exists menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1 then
+                        set selectedMenuBarItem to menu bar item "Navigate" of menu bar 1
+                        set selectedSubmenuItem to menu item "Go To" of menu 1 of selectedMenuBarItem
+                        set mi to menu item "Position…" of menu 1 of selectedSubmenuItem
+                    else
+                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        if cleanupState is not "CLOSED" then
+                            return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        end if
+                        return "MENU_NOT_FOUND"
+                    end if
+                on error errMsg
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "MENU_NOT_FOUND: " & errMsg
+                end try
+                try
+                    -- Opening the selected chain refreshes AXEnabled. This is
+                    -- the only menu-bar chain that can be clicked in this run.
+                    click selectedMenuBarItem
+                    click selectedSubmenuItem
+                on error errMsg
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "MENU_NOT_FOUND: " & errMsg
                 end try
                 try
                     set menuItemEnabled to enabled of mi
                 on error
                     -- An unreadable AXEnabled must not authorise the pick.
-                    key code 53
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
                     return "MENU_STATE_UNREADABLE"
                 end try
                 if not menuItemEnabled then
-                    key code 53
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
                     return "MENU_DISABLED"
                 end if
                 try
                     click mi
                 on error errMsg
-                    key code 53
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
                     return "MENU_PICK_FAILED: " & errMsg
                 end try
                 -- Wait up to 3s for the dialog window to appear before typing,
@@ -955,7 +1029,10 @@ extension AccessibilityChannel {
                     end try
                 end repeat
                 if not dialogReady then
-                    key code 53
+                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    if cleanupState is not "CLOSED" then
+                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
                     return "DIALOG_NOT_READY"
                 end if
             end tell

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -776,7 +776,10 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime = .production,
         isFrontmost: @Sendable () -> Bool = ProcessUtils.Runtime.production.logicIsFrontmost,
         activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
-        sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) }
+        sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) },
+        executeDialogScript: @escaping @Sendable (String) async -> ChannelResult = { script in
+            await AppleScriptChannel.executeAppleScript(script, timeout: 8.0)
+        }
     ) async -> ChannelResult {
         var targetBar: Int? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
@@ -822,13 +825,31 @@ extension AccessibilityChannel {
         // cannot show that a successful run had to bring Logic forward first.
         baseExtras["frontmost_preparation"] = preparation.rawValue
 
-        let dialogResult = await gotoPositionViaDialog(bar: bar)
-        if case let .success(payload) = dialogResult {
+        let dialogResult = await gotoPositionViaDialog(
+            bar: bar, executeScript: executeDialogScript
+        )
+        if case let .driven(payload) = dialogResult {
             // The dialog rung builds its own envelope, so without this the same operation reports
             // the frontmost gate on one path and stays silent on the other — a receipt field you
             // cannot rely on is worse than none.
             return .success(mergingJSONField(
                 payload, key: "frontmost_preparation", value: preparation.rawValue
+            ))
+        }
+        if case let .failed(classification) = dialogResult,
+           classification.isUnsafeToActuateAgain {
+            // `dismissOpenMenu` could not prove that the menu closed. A slider write from this
+            // state can operate on the still-open menu, so this is terminal rather than fallback.
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "The Go To Position menu could not be closed; the slider fallback was not attempted.",
+                extras: baseExtras.merging([
+                    "operation": "transport.goto_position",
+                    "method": "dialog",
+                    "menu_state": "could_not_be_closed",
+                    "write_attempted": false,
+                    "safe_to_retry": false,
+                ]) { _, new in new }
             ))
         }
 
@@ -1057,21 +1078,31 @@ extension AccessibilityChannel {
 
     /// The successful AppleScript channel payload is a JSON object containing the
     /// script's return value in `result`. Only an exact `OK` means this route
-    /// reached the dialog and submitted it; any sentinel or malformed payload
-    /// must fall through to the slider route.
+    /// reached the dialog and submitted it. Most failures may fall through to
+    /// the slider route, except a menu-close failure that leaves the UI unsafe
+    /// for further actuation.
     enum GotoPositionDialogResultClassification: Equatable {
         enum Failure: Equatable {
             case menuNotFound
             case menuStateUnreadable
             case menuDisabled
             case menuPickFailed
+            case menuCouldNotBeClosed
             case dialogNotReady
             case malformedPayload
             case unexpectedResult
+            case executionFailed
         }
 
         case driven
         case failure(Failure)
+
+        var isUnsafeToActuateAgain: Bool {
+            if case .failure(.menuCouldNotBeClosed) = self {
+                return true
+            }
+            return false
+        }
     }
 
     private struct GotoPositionDialogScriptPayload: Decodable {
@@ -1100,6 +1131,10 @@ extension AccessibilityChannel {
         case "MENU_DISABLED":
             return .failure(.menuDisabled)
         case let value where value.hasPrefix("MENU_PICK_FAILED"):
+            if value.hasPrefix("MENU_PICK_FAILED: a menu was open at entry and would not close")
+                || value.hasPrefix("MENU_PICK_FAILED: menu cleanup was not observed") {
+                return .failure(.menuCouldNotBeClosed)
+            }
             return .failure(.menuPickFailed)
         case "DIALOG_NOT_READY":
             return .failure(.dialogNotReady)
@@ -1108,14 +1143,21 @@ extension AccessibilityChannel {
         }
     }
 
-    private static func gotoPositionViaDialog(bar: Int) async -> ChannelResult {
+    private enum GotoPositionDialogRouteResult {
+        case driven(String)
+        case failed(GotoPositionDialogResultClassification)
+    }
+
+    private static func gotoPositionViaDialog(
+        bar: Int,
+        executeScript: @escaping @Sendable (String) async -> ChannelResult
+    ) async -> GotoPositionDialogRouteResult {
         let script = gotoPositionViaDialogAppleScript(bar: bar)
-        // Fixed waits consume 0.8 s and the dialog poll can consume 3.0 s.
-        // Eight seconds leaves 4.2 s for osascript startup and menu traversal.
-        let result = await AppleScriptChannel.executeAppleScript(script, timeout: 8.0)
+        let result = await executeScript(script)
         switch result {
         case .success(let output):
-            switch classifyGotoPositionDialogResult(output) {
+            let classification = classifyGotoPositionDialogResult(output)
+            switch classification {
             case .driven:
                 // #105: this State B reports only that the Go-To-Position dialog
                 // keystroke was sent; the playhead is verified independently by
@@ -1127,30 +1169,18 @@ extension AccessibilityChannel {
                 // (`via:"dialog"`) plus finalize's `verification_source` /
                 // `observed` / `verified` fields describe the outcome honestly
                 // without it.
-                return .success(HonestContract.encodeStateB(
+                return .driven(HonestContract.encodeStateB(
                     reason: .readbackUnavailable,
                     extras: [
                         "requested": "\(bar).1.1.1",
                         "via": "dialog"
                     ]
                 ))
-            case .failure(.menuDisabled):
-                return .error("goto-position dialog menu state did not authorize the pick")
-            case .failure(.menuStateUnreadable):
-                return .error("goto-position dialog menu enabled state unavailable")
-            case .failure(.menuNotFound):
-                return .error("goto-position menu not found")
-            case .failure(.menuPickFailed):
-                return .error("goto-position dialog menu pick failed")
-            case .failure(.dialogNotReady):
-                return .error("goto-position dialog did not appear within timeout")
-            case .failure(.malformedPayload):
-                return .error("goto-position dialog returned an invalid result payload")
-            case .failure(.unexpectedResult):
-                return .error("goto-position dialog returned an unexpected result")
+            case .failure:
+                return .failed(classification)
             }
-        case .error(let msg):
-            return .error("goto-position dialog failed: \(msg)")
+        case .error:
+            return .failed(.failure(.executionFailed))
         }
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -847,7 +847,11 @@ extension AccessibilityChannel {
                     "operation": "transport.goto_position",
                     "method": "dialog",
                     "menu_state": "could_not_be_closed",
-                    "write_attempted": false,
+                    // An entry-time close failure happens before this run has actuated anything;
+                    // after a menu click, however, the operation has already attempted a write.
+                    // Keep State C (the requested navigation did not land), but report that fact
+                    // honestly rather than presenting the latter as a pre-write refusal.
+                    "write_attempted": classification.writeAttemptedBeforeUnsafeRefusal,
                     "safe_to_retry": false,
                 ]) { _, new in new }
             ))
@@ -942,6 +946,10 @@ extension AccessibilityChannel {
         on dismissOpenMenu(theProcess)
             set menuState to my menuOpenState(theProcess)
             if menuState is "CLOSED" then return "CLOSED"
+            -- An unreadable state before this run has observed OPEN remains an
+            -- absent observation. The same state after Escape is different: we
+            -- know a menu was open and cannot prove the dismissal worked.
+            if menuState is "UNREADABLE" then return "UNREADABLE"
             if menuState is not "OPEN" then return menuState
             repeat 3 times
                 using terms from application "System Events"
@@ -950,10 +958,19 @@ extension AccessibilityChannel {
                 delay 0.1
                 set menuState to my menuOpenState(theProcess)
                 if menuState is "CLOSED" then return "CLOSED"
+                if menuState is "UNREADABLE" then return "OPEN_UNREADABLE"
                 if menuState is not "OPEN" then return menuState
             end repeat
             return "OPEN"
         end dismissOpenMenu
+
+        -- Appending this context lets the Swift receipt distinguish an unsafe
+        -- entry cleanup (no operation actuation) from an unsafe cleanup after a
+        -- menu click. It is deliberately attached only to refusal results.
+        on menuCleanupActuationContext(menuActuationAttempted)
+            if menuActuationAttempted then return " after menu actuation"
+            return ""
+        end menuCleanupActuationContext
 
         \(logicProAppleScript.activateByBundleID)
         tell application "System Events"
@@ -963,8 +980,8 @@ extension AccessibilityChannel {
                 -- observe that state before this run performs any menu read or
                 -- actuation, so a later fallback never inherits an open menu.
                 set entryMenuCleanup to my dismissOpenMenu(logicProcess)
-                if entryMenuCleanup is "OPEN" then
-                    return "MENU_PICK_FAILED: a menu was open at entry and would not close"
+                if entryMenuCleanup is "OPEN" or entryMenuCleanup is "OPEN_UNREADABLE" then
+                    return "MENU_PICK_FAILED: a menu was open at entry and would not close (" & entryMenuCleanup & ")"
                 end if
                 -- UNREADABLE is NOT a refusal here. Nothing has been opened by this
                 -- run yet, so an unreadable menu bar is an absent observation, not
@@ -973,6 +990,7 @@ extension AccessibilityChannel {
                 -- sent 5 of 8 fresh processes to the slider route, measured. After
                 -- this run opens a menu the same value IS a refusal, because then
                 -- there is something known to be open.
+                set menuActuationAttempted to false
                 delay 0.2
 
                 -- Locale selection is a read-only path-resolution step. It
@@ -990,26 +1008,27 @@ extension AccessibilityChannel {
                     else
                         set cleanupState to my dismissOpenMenu(logicProcess)
                         if cleanupState is not "CLOSED" then
-                            return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                         end if
                         return "MENU_NOT_FOUND"
                     end if
                 on error errMsg
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_NOT_FOUND: " & errMsg
                 end try
                 try
                     -- Opening the selected chain refreshes AXEnabled. This is
                     -- the only menu-bar chain that can be clicked in this run.
+                    set menuActuationAttempted to true
                     click selectedMenuBarItem
                     click selectedSubmenuItem
                 on error errMsg
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_NOT_FOUND: " & errMsg
                 end try
@@ -1019,14 +1038,14 @@ extension AccessibilityChannel {
                     -- An unreadable AXEnabled must not authorise the pick.
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_STATE_UNREADABLE"
                 end try
                 if not menuItemEnabled then
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_DISABLED"
                 end if
@@ -1035,7 +1054,7 @@ extension AccessibilityChannel {
                 on error errMsg
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_PICK_FAILED: " & errMsg
                 end try
@@ -1059,7 +1078,7 @@ extension AccessibilityChannel {
                 if not dialogReady then
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "DIALOG_NOT_READY"
                 end if
@@ -1087,7 +1106,7 @@ extension AccessibilityChannel {
             case menuStateUnreadable
             case menuDisabled
             case menuPickFailed
-            case menuCouldNotBeClosed
+            case menuCouldNotBeClosed(writeAttempted: Bool)
             case dialogNotReady
             case malformedPayload
             case unexpectedResult
@@ -1100,6 +1119,13 @@ extension AccessibilityChannel {
         var isUnsafeToActuateAgain: Bool {
             if case .failure(.menuCouldNotBeClosed) = self {
                 return true
+            }
+            return false
+        }
+
+        var writeAttemptedBeforeUnsafeRefusal: Bool {
+            if case let .failure(.menuCouldNotBeClosed(writeAttempted)) = self {
+                return writeAttempted
             }
             return false
         }
@@ -1133,7 +1159,11 @@ extension AccessibilityChannel {
         case let value where value.hasPrefix("MENU_PICK_FAILED"):
             if value.hasPrefix("MENU_PICK_FAILED: a menu was open at entry and would not close")
                 || value.hasPrefix("MENU_PICK_FAILED: menu cleanup was not observed") {
-                return .failure(.menuCouldNotBeClosed)
+                return .failure(.menuCouldNotBeClosed(
+                    writeAttempted: value.hasPrefix(
+                        "MENU_PICK_FAILED: menu cleanup was not observed after menu actuation"
+                    )
+                ))
             }
             return .failure(.menuPickFailed)
         case "DIALOG_NOT_READY":

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -976,17 +976,22 @@ extension AccessibilityChannel {
             return ""
         end menuCleanupActuationContext
 
-        -- AXPress can return before Logic has opened the menu. Wait for AXSelected
-        -- before clicking the submenu, or that second click can target a stale item.
-        on menuOpenedAfterClick(theProcess)
+        -- AXPress can return before Logic has opened the clicked item's own menu.
+        -- AXSelected belongs to that exact item, so an unrelated open menu cannot
+        -- authorise the next click.
+        on menuItemOpenedAfterClick(theMenuItem)
             repeat 3 times
-                set observedMenuState to my menuOpenState(theProcess)
-                if observedMenuState is "OPEN" then return "OPEN"
-                if observedMenuState is "UNREADABLE" then return "UNREADABLE"
+                using terms from application "System Events"
+                    try
+                        if selected of theMenuItem then return "OPEN"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end using terms from
                 delay 0.1
             end repeat
             return "CLOSED"
-        end menuOpenedAfterClick
+        end menuItemOpenedAfterClick
 
         \(logicProAppleScript.activateByBundleID)
         tell application "System Events"
@@ -1040,7 +1045,7 @@ extension AccessibilityChannel {
                     -- the only menu-bar chain that can be clicked in this run.
                     set menuActuationAttempted to true
                     click selectedMenuBarItem
-                    set menuBarOpenState to my menuOpenedAfterClick(logicProcess)
+                    set menuBarOpenState to my menuItemOpenedAfterClick(selectedMenuBarItem)
                     if menuBarOpenState is not "OPEN" then
                         set cleanupState to my dismissOpenMenu(logicProcess)
                         if cleanupState is not "CLOSED" then
@@ -1049,6 +1054,14 @@ extension AccessibilityChannel {
                         return "MENU_PICK_FAILED: selected menu bar item did not open (" & menuBarOpenState & ")"
                     end if
                     click selectedSubmenuItem
+                    set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)
+                    if submenuOpenState is not "OPEN" then
+                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        if cleanupState is not "CLOSED" then
+                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
+                        end if
+                        return "MENU_PICK_FAILED: selected submenu item did not open (" & submenuOpenState & ")"
+                    end if
                 on error errMsg
                     set cleanupState to my dismissOpenMenu(logicProcess)
                     if cleanupState is not "CLOSED" then

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -840,6 +840,10 @@ extension AccessibilityChannel {
            classification.isUnsafeToActuateAgain {
             // `dismissOpenMenu` could not prove that the menu closed. A slider write from this
             // state can operate on the still-open menu, so this is terminal rather than fallback.
+            // This branch runs before the dialog input is typed and submitted. Opening the menu
+            // chain is UI navigation, not a `transport.goto_position` write, so this remains a
+            // State C refusal with `write_attempted:false`. Retain that the navigation click did
+            // happen separately for diagnosis.
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
                 hint: "The Go To Position menu could not be closed; the slider fallback was not attempted.",
@@ -847,12 +851,12 @@ extension AccessibilityChannel {
                     "operation": "transport.goto_position",
                     "method": "dialog",
                     "menu_state": "could_not_be_closed",
-                    // An entry-time close failure happens before this run has actuated anything;
-                    // after a menu click, however, the operation has already attempted a write.
-                    // Keep State C (the requested navigation did not land), but report that fact
-                    // honestly rather than presenting the latter as a pre-write refusal.
-                    "write_attempted": classification.writeAttemptedBeforeUnsafeRefusal,
+                    "menu_actuation_attempted": classification.menuActuationAttemptedBeforeUnsafeRefusal,
+                    "write_attempted": false,
                     "safe_to_retry": false,
+                    // #530: even though ax_write_failed is normally non-terminal, a still-open
+                    // menu makes every weaker transport channel unsafe to invoke.
+                    "fallback_unsafe": true,
                 ]) { _, new in new }
             ))
         }
@@ -972,6 +976,18 @@ extension AccessibilityChannel {
             return ""
         end menuCleanupActuationContext
 
+        -- AXPress can return before Logic has opened the menu. Wait for AXSelected
+        -- before clicking the submenu, or that second click can target a stale item.
+        on menuOpenedAfterClick(theProcess)
+            repeat 3 times
+                set observedMenuState to my menuOpenState(theProcess)
+                if observedMenuState is "OPEN" then return "OPEN"
+                if observedMenuState is "UNREADABLE" then return "UNREADABLE"
+                delay 0.1
+            end repeat
+            return "CLOSED"
+        end menuOpenedAfterClick
+
         \(logicProAppleScript.activateByBundleID)
         tell application "System Events"
             set logicProcess to \(logicProAppleScript.systemEventsProcessTarget)
@@ -1024,6 +1040,14 @@ extension AccessibilityChannel {
                     -- the only menu-bar chain that can be clicked in this run.
                     set menuActuationAttempted to true
                     click selectedMenuBarItem
+                    set menuBarOpenState to my menuOpenedAfterClick(logicProcess)
+                    if menuBarOpenState is not "OPEN" then
+                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        if cleanupState is not "CLOSED" then
+                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
+                        end if
+                        return "MENU_PICK_FAILED: selected menu bar item did not open (" & menuBarOpenState & ")"
+                    end if
                     click selectedSubmenuItem
                 on error errMsg
                     set cleanupState to my dismissOpenMenu(logicProcess)
@@ -1123,7 +1147,7 @@ extension AccessibilityChannel {
             return false
         }
 
-        var writeAttemptedBeforeUnsafeRefusal: Bool {
+        var menuActuationAttemptedBeforeUnsafeRefusal: Bool {
             if case let .failure(.menuCouldNotBeClosed(writeAttempted)) = self {
                 return writeAttempted
             }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -947,14 +947,17 @@ extension AccessibilityChannel {
         -- Never claim that Escape cleaned up a menu until AXSelected says so.
         -- Three attempts are enough to cover a menu/submenu chain without
         -- turning a failed close into an unbounded retry.
-        on dismissOpenMenu(theProcess)
+        -- `knownOpen` says whether THIS run has already clicked a menu open. It changes what an
+        -- unreadable first read means. At entry nothing has been opened, so UNREADABLE is an absent
+        -- observation and returning it lets the run proceed — refusing there sent 5 of 8 fresh
+        -- processes to the slider route. After this run clicked, a menu IS open: an unreadable read
+        -- is not permission to skip the Escape, because skipping it can end the run with the menu
+        -- still up.
+        on dismissOpenMenu(theProcess, knownOpen)
             set menuState to my menuOpenState(theProcess)
             if menuState is "CLOSED" then return "CLOSED"
-            -- An unreadable state before this run has observed OPEN remains an
-            -- absent observation. The same state after Escape is different: we
-            -- know a menu was open and cannot prove the dismissal worked.
-            if menuState is "UNREADABLE" then return "UNREADABLE"
-            if menuState is not "OPEN" then return menuState
+            if menuState is "UNREADABLE" and not knownOpen then return "UNREADABLE"
+            if menuState is not "OPEN" and menuState is not "UNREADABLE" then return menuState
             repeat 3 times
                 using terms from application "System Events"
                     tell theProcess to key code 53
@@ -1000,7 +1003,7 @@ extension AccessibilityChannel {
                 -- A timed-out predecessor can leave a menu open. Clear and
                 -- observe that state before this run performs any menu read or
                 -- actuation, so a later fallback never inherits an open menu.
-                set entryMenuCleanup to my dismissOpenMenu(logicProcess)
+                set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)
                 if entryMenuCleanup is "OPEN" or entryMenuCleanup is "OPEN_UNREADABLE" then
                     return "MENU_PICK_FAILED: a menu was open at entry and would not close (" & entryMenuCleanup & ")"
                 end if
@@ -1027,14 +1030,14 @@ extension AccessibilityChannel {
                         set selectedSubmenuItem to menu item "Go To" of menu 1 of selectedMenuBarItem
                         set mi to menu item "Position…" of menu 1 of selectedSubmenuItem
                     else
-                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        set cleanupState to my dismissOpenMenu(logicProcess, true)
                         if cleanupState is not "CLOSED" then
                             return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                         end if
                         return "MENU_NOT_FOUND"
                     end if
                 on error errMsg
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
@@ -1047,7 +1050,7 @@ extension AccessibilityChannel {
                     click selectedMenuBarItem
                     set menuBarOpenState to my menuItemOpenedAfterClick(selectedMenuBarItem)
                     if menuBarOpenState is not "OPEN" then
-                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        set cleanupState to my dismissOpenMenu(logicProcess, true)
                         if cleanupState is not "CLOSED" then
                             return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                         end if
@@ -1056,14 +1059,14 @@ extension AccessibilityChannel {
                     click selectedSubmenuItem
                     set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)
                     if submenuOpenState is not "OPEN" then
-                        set cleanupState to my dismissOpenMenu(logicProcess)
+                        set cleanupState to my dismissOpenMenu(logicProcess, true)
                         if cleanupState is not "CLOSED" then
                             return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                         end if
                         return "MENU_PICK_FAILED: selected submenu item did not open (" & submenuOpenState & ")"
                     end if
                 on error errMsg
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
@@ -1073,14 +1076,14 @@ extension AccessibilityChannel {
                     set menuItemEnabled to enabled of mi
                 on error
                     -- An unreadable AXEnabled must not authorise the pick.
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_STATE_UNREADABLE"
                 end try
                 if not menuItemEnabled then
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
@@ -1089,7 +1092,7 @@ extension AccessibilityChannel {
                 try
                     click mi
                 on error errMsg
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
@@ -1113,7 +1116,7 @@ extension AccessibilityChannel {
                     end try
                 end repeat
                 if not dialogReady then
-                    set cleanupState to my dismissOpenMenu(logicProcess)
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1254,6 +1254,12 @@ extension AccessibilityChannel {
             // leaves the menu state UNKNOWN, and unknown is not safe: the slider would actuate into
             // whatever is on screen. Try once to observe and clear any open menu; only a state
             // observed CLOSED lets the fallback proceed.
+            // If Logic is not running at all, no menu of its can be open, and the script's death
+            // says nothing about menu state. Only when the app IS there does an unobservable menu
+            // become a reason to withhold the fallback.
+            guard ProcessUtils.logicProPID() != nil else {
+                return .failed(.failure(.executionFailed))
+            }
             switch await observeAndClearStrayMenu() {
             case .closed:
                 return .failed(.failure(.executionFailed))

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -942,9 +942,16 @@ extension AccessibilityChannel {
                 -- observe that state before this run performs any menu read or
                 -- actuation, so a later fallback never inherits an open menu.
                 set entryMenuCleanup to my dismissOpenMenu(logicProcess)
-                if entryMenuCleanup is not "CLOSED" then
-                    return "MENU_PICK_FAILED: entry menu cleanup was not observed (" & entryMenuCleanup & ")"
+                if entryMenuCleanup is "OPEN" then
+                    return "MENU_PICK_FAILED: a menu was open at entry and would not close"
                 end if
+                -- UNREADABLE is NOT a refusal here. Nothing has been opened by this
+                -- run yet, so an unreadable menu bar is an absent observation, not
+                -- evidence that something is open — and on a cold System Events
+                -- connection the first read frequently is unreadable. Refusing on it
+                -- sent 5 of 8 fresh processes to the slider route, measured. After
+                -- this run opens a menu the same value IS a refusal, because then
+                -- there is something known to be open.
                 delay 0.2
 
                 -- Locale selection is a read-only path-resolution step. It

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -1,3 +1,5 @@
+@preconcurrency import ApplicationServices
+import Foundation
 import Testing
 @testable import LogicProMCP
 
@@ -5,30 +7,6 @@ private func issue529Position(of fragment: String, in script: String) throws -> 
     let range = try #require(
         script.range(of: fragment),
         "Generated AppleScript must contain: \(fragment)"
-    )
-    return range.lowerBound
-}
-
-private func issue529Position(
-    of fragment: String,
-    after start: String.Index,
-    in script: String
-) throws -> String.Index {
-    let range = try #require(
-        script.range(of: fragment, range: start..<script.endIndex),
-        "Generated AppleScript must contain \(fragment) after the preceding guard"
-    )
-    return range.lowerBound
-}
-
-private func issue529Position(
-    of fragment: String,
-    before end: String.Index,
-    in script: String
-) throws -> String.Index {
-    let range = try #require(
-        script.range(of: fragment, options: .backwards, range: script.startIndex..<end),
-        "Generated AppleScript must contain \(fragment) before the refusal"
     )
     return range.lowerBound
 }
@@ -41,6 +19,57 @@ private func issue529Positions(of fragment: String, in script: String) -> [Strin
         searchStart = range.upperBound
     }
     return positions
+}
+
+private final class Issue529Counter: @unchecked Sendable {
+    private(set) var value = 0
+
+    func bump() {
+        value += 1
+    }
+}
+
+private func issue529SliderRuntime(sliderWrites: Issue529Counter) -> AXLogicProElements.Runtime {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(5290)
+    let window = builder.element(5291)
+    let controlBar = builder.element(5292)
+    let barSlider = builder.element(5293)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setChildren(window, [controlBar])
+    builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+    builder.setChildren(controlBar, [barSlider])
+    builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
+    builder.setAttribute(barSlider, kAXValueAttribute as String, NSNumber(value: 1))
+
+    return builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { element, attribute, value in
+            if element == barSlider, attribute == kAXValueAttribute as String {
+                sliderWrites.bump()
+            }
+            builder.setAttribute(element, attribute, value)
+            return true
+        },
+        performActionHandler: { _, _ in true }
+    )
+}
+
+private func issue529Envelope(_ result: ChannelResult) -> [String: Any]? {
+    let payload: String
+    switch result {
+    case let .success(text), let .error(text):
+        payload = text
+    }
+    guard let data = payload.data(using: .utf8),
+          let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return nil
+    }
+    return envelope
 }
 
 @Suite("Issue #529 — Go To Position menu validation")
@@ -114,28 +143,28 @@ struct Issue529MenuValidationTests {
             of: "return \"MENU_PICK_FAILED: a menu was open at entry",
             in: script
         )
-        let refusalReturns = issue529Positions(of: "return \"", in: script).filter { position in
+        let cleanupRefusalReturns = issue529Positions(of: "return \"", in: script).filter { position in
             let line = script[position...]
             return position > entryRefusal
-                && (line.hasPrefix("return \"MENU_") || line.hasPrefix("return \"DIALOG_NOT_READY"))
+                && line.hasPrefix("return \"MENU_PICK_FAILED: menu cleanup was not observed")
         }
         let escape = try issue529Position(of: "key code 53", in: script)
-        let observation = try issue529Position(
+        let menuStateObservations = issue529Positions(
             of: "set menuState to my menuOpenState(theProcess)",
-            after: escape,
             in: script
         )
 
-        #expect(refusalReturns.count > 0)
+        #expect(cleanupRefusalReturns.count > 0)
         #expect(entryCleanup < entryRefusal)
-        #expect(escape < observation)
-        for refusalReturn in refusalReturns {
-            let cleanup = try issue529Position(
+        #expect(menuStateObservations.contains { escape < $0 })
+        var previousRefusalReturn = entryRefusal
+        for refusalReturn in cleanupRefusalReturns {
+            let cleanupBetweenRefusals = issue529Positions(
                 of: "set cleanupState to my dismissOpenMenu(logicProcess)",
-                before: refusalReturn,
                 in: script
-            )
-            #expect(cleanup < refusalReturn)
+            ).contains { previousRefusalReturn < $0 && $0 < refusalReturn }
+            #expect(cleanupBetweenRefusals)
+            previousRefusalReturn = refusalReturn
         }
     }
 
@@ -155,6 +184,48 @@ struct Issue529MenuValidationTests {
         )
 
         #expect(classification == .failure(.menuPickFailed))
+    }
+
+    @Test("a menu that could not be closed returns State C without touching the slider")
+    func menuCloseFailureDoesNotFallThroughToSlider() async throws {
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"MENU_PICK_FAILED: menu cleanup was not observed (OPEN)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["menu_state"] as? String) == "could_not_be_closed")
+        let hint = try #require(envelope["hint"] as? String)
+        #expect(hint.contains("could not be closed"))
+        #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("a menu-not-found dialog result still falls through to the slider")
+    func menuNotFoundStillFallsThroughToSlider() async throws {
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"MENU_NOT_FOUND"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["via"] as? String) == "slider")
+        #expect(sliderWrites.value > 0)
     }
 
     @Test("JSON-wrapped disabled and not-ready sentinels still refuse the dialog route")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -445,7 +445,7 @@ func aDeadScriptMustNotAuthoriseTheSliderOnAnUnknownMenuState() throws {
         encoding: .utf8
     )
     let errorBranch = try #require(source.range(of: "case .error:"))
-    let tail = String(source[errorBranch.upperBound...].prefix(700))
+    let tail = String(source[errorBranch.upperBound...].prefix(1200))
 
     // The death path must consult an observation before classifying.
     #expect(tail.contains("observeAndClearStrayMenu"))
@@ -455,4 +455,7 @@ func aDeadScriptMustNotAuthoriseTheSliderOnAnUnknownMenuState() throws {
     #expect(safeAt.lowerBound < unsafeAt.lowerBound)
     #expect(tail.contains("case .closed:"))
     #expect(tail.contains("case .openOrUnknown:"))
+    // An app that is not running has no menu of its own open, so its absence must NOT be read as
+    // an unknown menu state — that is what made a Logic-less CI environment refuse the fallback.
+    #expect(tail.contains("ProcessUtils.logicProPID() != nil"))
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -86,11 +86,17 @@ struct Issue529MenuValidationTests {
             in: script
         )
         let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
+        let menuBarOpened = try issue529Position(
+            of: "set menuBarOpenState to my menuOpenedAfterClick(logicProcess)",
+            in: script
+        )
         let submenuOpen = try issue529Position(of: "click selectedSubmenuItem", in: script)
         let enabledRead = try issue529Position(of: "enabled of mi", in: script)
 
         #expect(koreanDecision < englishDecision)
         #expect(englishDecision < menuBarOpen)
+        #expect(menuBarOpen < menuBarOpened)
+        #expect(menuBarOpened < submenuOpen)
         #expect(menuBarOpen < submenuOpen)
         #expect(submenuOpen < enabledRead)
         #expect(!script.contains("click menu bar item"))
@@ -219,11 +225,11 @@ struct Issue529MenuValidationTests {
         let menuItemClick = try issue529Position(of: "click mi", in: script)
         let cleanupAfterMenuItemClick = try #require(
             issue529Positions(of: "set cleanupState to my dismissOpenMenu(logicProcess)", in: script)
-                .first { $0 > menuItemClick }
+                .last
         )
         let refusalContextAfterMenuItemClick = try #require(
             issue529Positions(of: "my menuCleanupActuationContext(menuActuationAttempted)", in: script)
-                .first { $0 > cleanupAfterMenuItemClick }
+                .last
         )
 
         #expect(attempted < menuBarClick)
@@ -270,11 +276,13 @@ struct Issue529MenuValidationTests {
         let hint = try #require(envelope["hint"] as? String)
         #expect(hint.contains("could not be closed"))
         #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(!(try #require(envelope["menu_actuation_attempted"] as? Bool)))
+        #expect(HonestContract.isFallbackUnsafeStateC(result.message))
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("a post-click menu close failure reports the attempted write")
-    func postClickMenuCloseFailureReportsAttemptedWrite() async throws {
+    @Test("a post-click menu close failure records menu navigation, not a position write")
+    func postClickMenuCloseFailureRefusesBeforePositionWrite() async throws {
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -289,7 +297,9 @@ struct Issue529MenuValidationTests {
 
         let envelope = try #require(issue529Envelope(result))
         #expect(try #require(envelope["state"] as? String) == "C")
-        #expect((try #require(envelope["write_attempted"] as? Bool)))
+        #expect(try #require(envelope["menu_actuation_attempted"] as? Bool))
+        #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(HonestContract.isFallbackUnsafeStateC(result.message))
         #expect(sliderWrites.value == 0)
     }
 

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -430,3 +430,29 @@ func dismissalContextDecidesWhetherAnUnreadableReadSkipsEscape() throws {
     // And the handler must only take the skip when knownOpen is false.
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }
+
+/// A dead script (timeout, TCC refusal, anything) leaves the menu state UNKNOWN, and this script
+/// clicks menus open. Unknown is not safe: the slider would actuate into whatever is on screen.
+/// Only a menu state observed CLOSED after the death may authorise the fallback.
+@Test("a dead script does not authorise the slider until the menu is observed closed")
+func aDeadScriptMustNotAuthoriseTheSliderOnAnUnknownMenuState() throws {
+    // Mutation that must fail this test: return `.executionFailed` directly on `.error` again.
+    let source = try String(
+        contentsOfFile: #filePath.replacingOccurrences(
+            of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
+            with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift"
+        ),
+        encoding: .utf8
+    )
+    let errorBranch = try #require(source.range(of: "case .error:"))
+    let tail = String(source[errorBranch.upperBound...].prefix(700))
+
+    // The death path must consult an observation before classifying.
+    #expect(tail.contains("observeAndClearStrayMenu"))
+    // And an unobserved / open state must be the unsafe classification, not the fallback-safe one.
+    let unsafeAt = try #require(tail.range(of: "menuCouldNotBeClosed"))
+    let safeAt = try #require(tail.range(of: "executionFailed"))
+    #expect(safeAt.lowerBound < unsafeAt.lowerBound)
+    #expect(tail.contains("case .closed:"))
+    #expect(tail.contains("case .openOrUnknown:"))
+}

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -85,6 +85,24 @@ struct Issue529MenuValidationTests {
         #expect(entryCleanup < menuBarOpen)
     }
 
+    /// Measured, not reasoned: refusing at entry on any non-CLOSED value sent 5 of 8 fresh server
+    /// processes to the slider route, because the first menu-bar read on a cold System Events
+    /// connection is frequently unreadable. Nothing has been opened at that point, so an unreadable
+    /// menu bar is an absent observation rather than evidence of an open menu. After this run opens
+    /// one, the same value IS a refusal — that asymmetry is the point.
+    @Test("entry refuses only on an observed open menu, never on an unreadable one")
+    func entryCleanupDoesNotRefuseOnAnUnreadableMenuBar() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let entryGuard = try issue529Position(of: "if entryMenuCleanup is \"OPEN\" then", in: script)
+        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
+
+        #expect(entryGuard < localeDecision)
+        #expect(!script.contains("if entryMenuCleanup is not \"CLOSED\" then"))
+        // The post-actuation refusals keep the strict form, so the asymmetry is asserted
+        // rather than assumed.
+        #expect(script.contains("if cleanupState is not \"CLOSED\" then"))
+    }
+
     @Test("every refusal uses observed menu cleanup")
     func refusalPathsUseObservedMenuCleanup() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
@@ -93,7 +111,7 @@ struct Issue529MenuValidationTests {
             in: script
         )
         let entryRefusal = try issue529Position(
-            of: "return \"MENU_PICK_FAILED: entry menu cleanup",
+            of: "return \"MENU_PICK_FAILED: a menu was open at entry",
             in: script
         )
         let refusalReturns = issue529Positions(of: "return \"", in: script).filter { position in

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -21,60 +21,104 @@ private func issue529Position(
     return range.lowerBound
 }
 
+private func issue529Position(
+    of fragment: String,
+    before end: String.Index,
+    in script: String
+) throws -> String.Index {
+    let range = try #require(
+        script.range(of: fragment, options: .backwards, range: script.startIndex..<end),
+        "Generated AppleScript must contain \(fragment) before the refusal"
+    )
+    return range.lowerBound
+}
+
+private func issue529Positions(of fragment: String, in script: String) -> [String.Index] {
+    var positions: [String.Index] = []
+    var searchStart = script.startIndex
+    while let range = script.range(of: fragment, range: searchStart..<script.endIndex) {
+        positions.append(range.lowerBound)
+        searchStart = range.upperBound
+    }
+    return positions
+}
+
 @Suite("Issue #529 — Go To Position menu validation")
 struct Issue529MenuValidationTests {
-    @Test("Korean menu chain opens before AXEnabled is read")
-    func koreanMenuOpensBeforeEnabledRead() throws {
+    @Test("locale is decided by non-actuating reads before one selected chain opens")
+    func localeIsDecidedBeforeSingleMenuChainOpens() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let menuBarOpen = try issue529Position(
-            of: "click menu bar item \"탐색\" of menu bar 1",
+        let koreanDecision = try issue529Position(
+            of: "if exists menu item \"위치…\"",
             in: script
         )
-        let submenuOpen = try issue529Position(
-            of: "click menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        let englishDecision = try issue529Position(
+            of: "else if exists menu item \"Position…\"",
             in: script
         )
-        let enabledRead = try issue529Position(of: "enabled of mi", in: script)
-        let englishMenuBarOpen = try issue529Position(
-            of: "click menu bar item \"Navigate\" of menu bar 1",
-            in: script
-        )
-
-        #expect(menuBarOpen < submenuOpen)
-        #expect(submenuOpen < enabledRead)
-        #expect(menuBarOpen < englishMenuBarOpen)
-    }
-
-    @Test("English fallback menu chain opens before AXEnabled is read")
-    func englishMenuOpensBeforeEnabledRead() throws {
-        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let menuBarOpen = try issue529Position(
-            of: "click menu bar item \"Navigate\" of menu bar 1",
-            in: script
-        )
-        let submenuOpen = try issue529Position(
-            of: "click menu item \"Go To\" of menu 1 of menu bar item \"Navigate\" of menu bar 1",
-            in: script
-        )
+        let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
+        let submenuOpen = try issue529Position(of: "click selectedSubmenuItem", in: script)
         let enabledRead = try issue529Position(of: "enabled of mi", in: script)
 
+        #expect(koreanDecision < englishDecision)
+        #expect(englishDecision < menuBarOpen)
         #expect(menuBarOpen < submenuOpen)
         #expect(submenuOpen < enabledRead)
+        #expect(!script.contains("click menu bar item"))
+        #expect(issue529Positions(of: "click selectedMenuBarItem", in: script).count == 1)
+        #expect(issue529Positions(of: "click selectedSubmenuItem", in: script).count == 1)
     }
 
-    @Test("disabled menu path dismisses the open menu before refusing")
-    func disabledMenuIsDismissedBeforeRefusal() throws {
+    @Test("entry cleanup runs before locale discovery or menu actuation")
+    func entryTimeCleanupPrecedesMenuWork() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let disabledGuard = try issue529Position(of: "if not menuItemEnabled then", in: script)
-        let dismissal = try issue529Position(of: "key code 53", after: disabledGuard, in: script)
-        let disabledReturn = try issue529Position(
-            of: "return \"MENU_DISABLED\"",
-            after: disabledGuard,
+        let entryCleanup = try issue529Position(
+            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess)",
+            in: script
+        )
+        let firstOperationalDelay = try issue529Position(of: "delay 0.2", in: script)
+        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
+        let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
+
+        #expect(entryCleanup < firstOperationalDelay)
+        #expect(entryCleanup < localeDecision)
+        #expect(entryCleanup < menuBarOpen)
+    }
+
+    @Test("every refusal uses observed menu cleanup")
+    func refusalPathsUseObservedMenuCleanup() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let entryCleanup = try issue529Position(
+            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess)",
+            in: script
+        )
+        let entryRefusal = try issue529Position(
+            of: "return \"MENU_PICK_FAILED: entry menu cleanup",
+            in: script
+        )
+        let refusalReturns = issue529Positions(of: "return \"", in: script).filter { position in
+            let line = script[position...]
+            return position > entryRefusal
+                && (line.hasPrefix("return \"MENU_") || line.hasPrefix("return \"DIALOG_NOT_READY"))
+        }
+        let escape = try issue529Position(of: "key code 53", in: script)
+        let observation = try issue529Position(
+            of: "set menuState to my menuOpenState(theProcess)",
+            after: escape,
             in: script
         )
 
-        #expect(disabledGuard < dismissal)
-        #expect(dismissal < disabledReturn)
+        #expect(refusalReturns.count > 0)
+        #expect(entryCleanup < entryRefusal)
+        #expect(escape < observation)
+        for refusalReturn in refusalReturns {
+            let cleanup = try issue529Position(
+                of: "set cleanupState to my dismissOpenMenu(logicProcess)",
+                before: refusalReturn,
+                in: script
+            )
+            #expect(cleanup < refusalReturn)
+        }
     }
 
     @Test("JSON-wrapped menu-not-found result refuses the dialog route")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import LogicProMCP
+
+private func issue529Position(of fragment: String, in script: String) throws -> String.Index {
+    let range = try #require(
+        script.range(of: fragment),
+        "Generated AppleScript must contain: \(fragment)"
+    )
+    return range.lowerBound
+}
+
+private func issue529Position(
+    of fragment: String,
+    after start: String.Index,
+    in script: String
+) throws -> String.Index {
+    let range = try #require(
+        script.range(of: fragment, range: start..<script.endIndex),
+        "Generated AppleScript must contain \(fragment) after the preceding guard"
+    )
+    return range.lowerBound
+}
+
+@Suite("Issue #529 — Go To Position menu validation")
+struct Issue529MenuValidationTests {
+    @Test("Korean menu chain opens before AXEnabled is read")
+    func koreanMenuOpensBeforeEnabledRead() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let menuBarOpen = try issue529Position(
+            of: "click menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
+        let submenuOpen = try issue529Position(
+            of: "click menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
+        let enabledRead = try issue529Position(of: "enabled of mi", in: script)
+        let englishMenuBarOpen = try issue529Position(
+            of: "click menu bar item \"Navigate\" of menu bar 1",
+            in: script
+        )
+
+        #expect(menuBarOpen < submenuOpen)
+        #expect(submenuOpen < enabledRead)
+        #expect(menuBarOpen < englishMenuBarOpen)
+    }
+
+    @Test("English fallback menu chain opens before AXEnabled is read")
+    func englishMenuOpensBeforeEnabledRead() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let menuBarOpen = try issue529Position(
+            of: "click menu bar item \"Navigate\" of menu bar 1",
+            in: script
+        )
+        let submenuOpen = try issue529Position(
+            of: "click menu item \"Go To\" of menu 1 of menu bar item \"Navigate\" of menu bar 1",
+            in: script
+        )
+        let enabledRead = try issue529Position(of: "enabled of mi", in: script)
+
+        #expect(menuBarOpen < submenuOpen)
+        #expect(submenuOpen < enabledRead)
+    }
+
+    @Test("disabled menu path dismisses the open menu before refusing")
+    func disabledMenuIsDismissedBeforeRefusal() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let disabledGuard = try issue529Position(of: "if not menuItemEnabled then", in: script)
+        let dismissal = try issue529Position(of: "key code 53", after: disabledGuard, in: script)
+        let disabledReturn = try issue529Position(
+            of: "return \"MENU_DISABLED\"",
+            after: disabledGuard,
+            in: script
+        )
+
+        #expect(disabledGuard < dismissal)
+        #expect(dismissal < disabledReturn)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -167,7 +167,7 @@ struct Issue529MenuValidationTests {
     func entryTimeCleanupPrecedesMenuWork() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let entryCleanup = try issue529Position(
-            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess)",
+            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)",
             in: script
         )
         let firstOperationalDelay = try issue529Position(of: "delay 0.2", in: script)
@@ -244,7 +244,7 @@ struct Issue529MenuValidationTests {
     func refusalPathsUseObservedMenuCleanup() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let entryCleanup = try issue529Position(
-            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess)",
+            of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)",
             in: script
         )
         let entryRefusal = try issue529Position(
@@ -268,7 +268,7 @@ struct Issue529MenuValidationTests {
         var previousRefusalReturn = entryRefusal
         for refusalReturn in cleanupRefusalReturns {
             let cleanupBetweenRefusals = issue529Positions(
-                of: "set cleanupState to my dismissOpenMenu(logicProcess)",
+                of: "set cleanupState to my dismissOpenMenu(logicProcess, true)",
                 in: script
             ).contains { previousRefusalReturn < $0 && $0 < refusalReturn }
             #expect(cleanupBetweenRefusals)
@@ -283,7 +283,7 @@ struct Issue529MenuValidationTests {
         let menuBarClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
         let menuItemClick = try issue529Position(of: "click mi", in: script)
         let cleanupAfterMenuItemClick = try #require(
-            issue529Positions(of: "set cleanupState to my dismissOpenMenu(logicProcess)", in: script)
+            issue529Positions(of: "set cleanupState to my dismissOpenMenu(logicProcess, true)", in: script)
                 .last
         )
         let refusalContextAfterMenuItemClick = try #require(
@@ -409,4 +409,24 @@ struct Issue529MenuValidationTests {
 
         #expect(classification == .failure(.malformedPayload))
     }
+}
+
+/// The entry cleanup and the post-click cleanups must not treat an unreadable menu bar the same way.
+/// Before this run clicks anything, UNREADABLE is an absent observation and the run proceeds —
+/// refusing there sent 5 of 8 fresh server processes to the slider route. After this run has clicked
+/// a menu open, an unreadable read is NOT permission to skip the Escape: skipping it can end the run
+/// with the menu still up, which is the state this branch exists to prevent.
+@Test("an unreadable read skips Escape only before this run opened anything")
+func dismissalContextDecidesWhetherAnUnreadableReadSkipsEscape() throws {
+    let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+
+    // Entry: the one call that may skip.
+    #expect(script.contains("my dismissOpenMenu(logicProcess, false)"))
+    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 1)
+
+    // Every other call knows a menu was opened by this run.
+    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, true)", in: script).count > 1)
+
+    // And the handler must only take the skip when knownOpen is false.
+    #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -87,10 +87,14 @@ struct Issue529MenuValidationTests {
         )
         let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
         let menuBarOpened = try issue529Position(
-            of: "set menuBarOpenState to my menuOpenedAfterClick(logicProcess)",
+            of: "set menuBarOpenState to my menuItemOpenedAfterClick(selectedMenuBarItem)",
             in: script
         )
         let submenuOpen = try issue529Position(of: "click selectedSubmenuItem", in: script)
+        let submenuOpened = try issue529Position(
+            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
+            in: script
+        )
         let enabledRead = try issue529Position(of: "enabled of mi", in: script)
 
         #expect(koreanDecision < englishDecision)
@@ -98,10 +102,65 @@ struct Issue529MenuValidationTests {
         #expect(menuBarOpen < menuBarOpened)
         #expect(menuBarOpened < submenuOpen)
         #expect(menuBarOpen < submenuOpen)
+        #expect(submenuOpen < submenuOpened)
+        #expect(submenuOpened < enabledRead)
         #expect(submenuOpen < enabledRead)
         #expect(!script.contains("click menu bar item"))
         #expect(issue529Positions(of: "click selectedMenuBarItem", in: script).count == 1)
         #expect(issue529Positions(of: "click selectedSubmenuItem", in: script).count == 1)
+    }
+
+    @Test("the leaf click requires the selected submenu's own open observation")
+    func leafClickRequiresSelectedSubmenuToOpen() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let submenuClick = try issue529Position(of: "click selectedSubmenuItem", in: script)
+        let submenuOpened = try issue529Position(
+            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
+            in: script
+        )
+        let submenuNotOpen = try issue529Position(
+            of: "if submenuOpenState is not \"OPEN\" then",
+            in: script
+        )
+        let submenuRefusal = try issue529Position(
+            of: "return \"MENU_PICK_FAILED: selected submenu item did not open (\"",
+            in: script
+        )
+        let leafClick = try issue529Position(of: "click mi", in: script)
+
+        #expect(submenuClick < submenuOpened)
+        #expect(submenuOpened < submenuNotOpen)
+        #expect(submenuNotOpen < submenuRefusal)
+        #expect(submenuRefusal < leafClick)
+    }
+
+    @Test("an unrelated open menu cannot satisfy the submenu observation")
+    func submenuObservationIsBoundToTheClickedItem() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let observationStart = try issue529Position(
+            of: "on menuItemOpenedAfterClick(theMenuItem)",
+            in: script
+        )
+        let observationEnd = try issue529Position(of: "end menuItemOpenedAfterClick", in: script)
+        let observation = String(script[observationStart..<observationEnd])
+        _ = try #require(
+            observation.range(of: "if selected of theMenuItem then return \"OPEN\"")
+        )
+
+        #expect(!observation.contains("menuOpenState("))
+        #expect(!observation.contains("theProcess"))
+    }
+
+    @Test("the healthy submenu path still clicks the leaf")
+    func healthySubmenuPathStillClicksLeaf() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let submenuOpened = try issue529Position(
+            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
+            in: script
+        )
+        let leafClick = try issue529Position(of: "click mi", in: script)
+
+        #expect(submenuOpened < leafClick)
     }
 
     @Test("entry cleanup runs before locale discovery or menu actuation")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -76,4 +76,51 @@ struct Issue529MenuValidationTests {
         #expect(disabledGuard < dismissal)
         #expect(dismissal < disabledReturn)
     }
+
+    @Test("JSON-wrapped menu-not-found result refuses the dialog route")
+    func jsonWrappedMenuNotFoundRefusesDialogRoute() {
+        let classification = AccessibilityChannel.classifyGotoPositionDialogResult(
+            #"{"result":"MENU_NOT_FOUND: Navigate menu missing"}"#
+        )
+
+        #expect(classification == .failure(.menuNotFound))
+    }
+
+    @Test("JSON-wrapped menu-pick-failed result refuses the dialog route")
+    func jsonWrappedMenuPickFailedRefusesDialogRoute() {
+        let classification = AccessibilityChannel.classifyGotoPositionDialogResult(
+            #"{"result":"MENU_PICK_FAILED: AXPress failed"}"#
+        )
+
+        #expect(classification == .failure(.menuPickFailed))
+    }
+
+    @Test("JSON-wrapped disabled and not-ready sentinels still refuse the dialog route")
+    func jsonWrappedExistingSentinelsRefuseDialogRoute() {
+        let disabled = AccessibilityChannel.classifyGotoPositionDialogResult(
+            #"{"result":"MENU_DISABLED"}"#
+        )
+        let notReady = AccessibilityChannel.classifyGotoPositionDialogResult(
+            #"{"result":"DIALOG_NOT_READY"}"#
+        )
+
+        #expect(disabled == .failure(.menuDisabled))
+        #expect(notReady == .failure(.dialogNotReady))
+    }
+
+    @Test("only JSON-wrapped OK counts as driving the dialog route")
+    func jsonWrappedOKDrivesDialogRoute() {
+        let classification = AccessibilityChannel.classifyGotoPositionDialogResult(
+            #"{"result":"OK"}"#
+        )
+
+        #expect(classification == .driven)
+    }
+
+    @Test("malformed result payload refuses the dialog route")
+    func malformedPayloadRefusesDialogRoute() {
+        let classification = AccessibilityChannel.classifyGotoPositionDialogResult("MENU_NOT_FOUND: unwrapped")
+
+        #expect(classification == .failure(.malformedPayload))
+    }
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -117,19 +117,62 @@ struct Issue529MenuValidationTests {
     /// Measured, not reasoned: refusing at entry on any non-CLOSED value sent 5 of 8 fresh server
     /// processes to the slider route, because the first menu-bar read on a cold System Events
     /// connection is frequently unreadable. Nothing has been opened at that point, so an unreadable
-    /// menu bar is an absent observation rather than evidence of an open menu. After this run opens
-    /// one, the same value IS a refusal — that asymmetry is the point.
-    @Test("entry refuses only on an observed open menu, never on an unreadable one")
+    /// menu bar is an absent observation rather than evidence of an open menu. `OPEN_UNREADABLE`
+    /// is distinct: this run observed OPEN, sent Escape, and then could not observe closure.
+    @Test("entry permits a fresh unreadable menu bar")
     func entryCleanupDoesNotRefuseOnAnUnreadableMenuBar() throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let entryGuard = try issue529Position(of: "if entryMenuCleanup is \"OPEN\" then", in: script)
+        let entryGuard = try issue529Position(
+            of: "if entryMenuCleanup is \"OPEN\" or entryMenuCleanup is \"OPEN_UNREADABLE\" then",
+            in: script
+        )
         let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
 
         #expect(entryGuard < localeDecision)
         #expect(!script.contains("if entryMenuCleanup is not \"CLOSED\" then"))
-        // The post-actuation refusals keep the strict form, so the asymmetry is asserted
+        #expect(!script.contains("if entryMenuCleanup is \"OPEN\" then"))
+        // Post-actuation refusals still require a confirmed close, so the asymmetry is asserted
         // rather than assumed.
         #expect(script.contains("if cleanupState is not \"CLOSED\" then"))
+    }
+
+    /// Script fixture: `menuOpenState` returns OPEN, Escape is posted, and the next read is
+    /// UNREADABLE. The distinct `OPEN_UNREADABLE` outcome must be terminal at entry; changing the
+    /// entry guard back to `entryMenuCleanup is "OPEN"` makes this test fail.
+    @Test("OPEN then Escape then UNREADABLE refuses at entry")
+    func entryCleanupRefusesUnreadableAfterObservedOpen() async throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let escape = try issue529Position(of: "key code 53", in: script)
+        let unreadableAfterEscape = try issue529Position(
+            of: "if menuState is \"UNREADABLE\" then return \"OPEN_UNREADABLE\"",
+            in: script
+        )
+        let entryGuard = try issue529Position(
+            of: "if entryMenuCleanup is \"OPEN\" or entryMenuCleanup is \"OPEN_UNREADABLE\" then",
+            in: script
+        )
+        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
+
+        #expect(escape < unreadableAfterEscape)
+        #expect(unreadableAfterEscape < entryGuard)
+        #expect(entryGuard < localeDecision)
+
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"MENU_PICK_FAILED: a menu was open at entry and would not close (OPEN_UNREADABLE)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(sliderWrites.value == 0)
     }
 
     @Test("every refusal uses observed menu cleanup")
@@ -168,6 +211,27 @@ struct Issue529MenuValidationTests {
         }
     }
 
+    @Test("cleanup after click mi is marked as an attempted menu write")
+    func menuItemClickMarksSubsequentCleanupAsAttempted() throws {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let attempted = try issue529Position(of: "set menuActuationAttempted to true", in: script)
+        let menuBarClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
+        let menuItemClick = try issue529Position(of: "click mi", in: script)
+        let cleanupAfterMenuItemClick = try #require(
+            issue529Positions(of: "set cleanupState to my dismissOpenMenu(logicProcess)", in: script)
+                .first { $0 > menuItemClick }
+        )
+        let refusalContextAfterMenuItemClick = try #require(
+            issue529Positions(of: "my menuCleanupActuationContext(menuActuationAttempted)", in: script)
+                .first { $0 > cleanupAfterMenuItemClick }
+        )
+
+        #expect(attempted < menuBarClick)
+        #expect(menuBarClick < menuItemClick)
+        #expect(menuItemClick < cleanupAfterMenuItemClick)
+        #expect(cleanupAfterMenuItemClick < refusalContextAfterMenuItemClick)
+    }
+
     @Test("JSON-wrapped menu-not-found result refuses the dialog route")
     func jsonWrappedMenuNotFoundRefusesDialogRoute() {
         let classification = AccessibilityChannel.classifyGotoPositionDialogResult(
@@ -186,8 +250,8 @@ struct Issue529MenuValidationTests {
         #expect(classification == .failure(.menuPickFailed))
     }
 
-    @Test("a menu that could not be closed returns State C without touching the slider")
-    func menuCloseFailureDoesNotFallThroughToSlider() async throws {
+    @Test("a pre-actuation menu close failure returns State C without touching the slider")
+    func preActuationMenuCloseFailureDoesNotFallThroughToSlider() async throws {
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -206,6 +270,26 @@ struct Issue529MenuValidationTests {
         let hint = try #require(envelope["hint"] as? String)
         #expect(hint.contains("could not be closed"))
         #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("a post-click menu close failure reports the attempted write")
+    func postClickMenuCloseFailureReportsAttemptedWrite() async throws {
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"MENU_PICK_FAILED: menu cleanup was not observed after menu actuation (UNREADABLE)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect((try #require(envelope["write_attempted"] as? Bool)))
         #expect(sliderWrites.value == 0)
     }
 


### PR DESCRIPTION
Closes #529.

## The defect

`gotoPositionViaDialog` gated the dialog route on `enabled of mi`, read on a **closed** menu. That
value is a cache, and a reading taken while the item is disabled sticks — outliving both the
condition and the process that took it.

Isolated cleanly on Logic Pro 12.3, each reading a separate `osascript` invocation:

```
reset (open the Navigate menu, Escape)                       → enabled=true
open the modal, cancel it, without reading while it is open   → enabled=true    (not poisoned)
reset                                                         → enabled=true
open the modal, read once while it is open, cancel it         → enabled=false   (persists)
```

**So the route poisons itself.** If a previous call leaves the `Go To Position` modal open — which
happens; I found one wedged after an interrupted run — the next call's guard reads `enabled` while
that modal is up, gets `false`, and answers `MENU_DISABLED`. The router falls through to the slider
route, which nudges the playhead **one bar per call** instead of going where it was asked. And that
read has now cached `false` for every later reader, so it keeps happening after the modal is gone.

That last part is why it looked intermittent and unconnected to the modal.

A fresh Logic launch has never opened that menu either, so the same guard reads `false` there too.

## The change

Open the menu chain before reading. That re-validates the item, which both makes the read meaningful
and replaces the poisoned value.

The guard itself stays — this repository's recorded decision is that an unreadable `AXEnabled` must
not authorise a pick — so an unreadable state becomes its own refusal (`MENU_STATE_UNREADABLE`)
rather than being conflated with "disabled". Every refusal path now dismisses the menu it opened, so
a refusal cannot leave the application wedged behind an open menu.

The slider fallback is untouched. Whether a route that cannot deliver the requested position should
refuse to move the playhead at all is a separate contract question and is not decided here.

## Live evidence

Two release artifacts, same machine, the poisoned precondition re-established immediately before each
run:

| | requested | observed | state | via |
| --- | --- | --- | --- | --- |
| parent commit | `53.1.1.1` | `46.1.1.1` | B | slider |
| this branch | `61.1.1.1` | `61.1.1.1` | **A**, verified | **dialog** |

The evidence document bound to this head records the precondition it created
(`read_after_modal_dismissed: "false"` — genuinely poisoned, not assumed), three mutation-backed
checks, three settled captures within one display, a visual assertion that the transport's BAR
readout changed, the playhead restored to where the run found it, and a screen recording.

The visual region was verified by cropping it and looking at it, so that it holds the BAR/BEAT digits
and excludes the LCD's MIDI-activity dot — which blinks on its own and stops any capture settling.

## Tests

`Issue529MenuValidationTests` asserts on the generated AppleScript by **string ordering**: the menu
bar item and the submenu parent must be opened before the first `enabled of` read, in both the Korean
and the English chain, and the disabled path must dismiss the menu before returning.

Mutation-tested rather than assumed: removing the four menu-opening clicks fails two of the three
tests. The third guards the dismissal, which that mutation does not touch.

Full suite: 3476 tests pass.
