### PR TITLE
fix(#533): teach the modal classifier the Japanese New Track sheet

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -244,27 +244,28 @@ enum AXLocalePolicy {
 
     static let cancelButton = LabelSet(
         canonical: "Cancel",
-        variants: ["취소"],
-        rationale: "Dialog dismissal fallback; no success state is inferred from this click."
+        variants: ["취소", "キャンセル"],
+        rationale: "Dialog dismissal fallback; no success state is inferred from this click. JA live-confirmed (Logic 12.3: `キャンセル`)."
     )
 
     /// #346/#350: the mandatory New Track sheet's only exit ("Create"). The modal
     /// reconciler clicks it to un-wedge Logic, then verifies via track-count
     /// readback — the click itself gates no State-A success. KO live-confirmed
-    /// (Logic 12.3: `생성`).
+    /// (Logic 12.3: `생성`); JA live-confirmed (Logic 12.3: `作成`).
     static let createButton = LabelSet(
         canonical: "Create",
-        variants: ["생성"],
-        rationale: "Mandatory New Track sheet's only exit; reconciler-clicked, then verified by track-count readback. KO live-confirmed (Logic 12.3)."
+        variants: ["생성", "作成"],
+        rationale: "Mandatory New Track sheet's only exit; reconciler-clicked, then verified by track-count readback. KO live-confirmed (Logic 12.3); JA live-confirmed (Logic 12.3: `作成`)."
     )
 
     /// #346/#350: `AXDescription` that identifies the mandatory New Track sheet.
     /// One of two signals (with disabled-Cancel) the reconciler uses to classify
-    /// the sheet; read-only classifier. KO live-confirmed (Logic 12.3: `새로운 트랙`).
+    /// the sheet; read-only classifier. KO live-confirmed (Logic 12.3: `새로운 트랙`);
+    /// JA live-confirmed (Logic 12.3: `新規トラック`).
     static let newTrackSheetDescription = LabelSet(
         canonical: "New Track",
-        variants: ["새로운 트랙"],
-        rationale: "Identifies the mandatory New Track sheet by AXDescription (with disabled-Cancel); read-only classifier. KO live-confirmed (Logic 12.3)."
+        variants: ["새로운 트랙", "新規トラック"],
+        rationale: "Identifies the mandatory New Track sheet by AXDescription (with disabled-Cancel); read-only classifier. KO live-confirmed (Logic 12.3); JA live-confirmed (Logic 12.3: `新規トラック`)."
     )
 
     /// #346/#350: primary destructive button on the "delete channel strips that

--- a/Tests/LogicProMCPTests/Issue533JapaneseNewTrackSheetTests.swift
+++ b/Tests/LogicProMCPTests/Issue533JapaneseNewTrackSheetTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import LogicProMCP
+
+@Suite("Issue #533 Japanese New Track sheet")
+struct Issue533JapaneseNewTrackSheetTests {
+    private func sheetSignals(
+        description: String,
+        createTitle: String,
+        cancelTitle: String,
+        cancelEnabled: Bool
+    ) -> ModalReconciliation.ModalSignals {
+        ModalReconciliation.ModalSignals(
+            sheetPresent: true,
+            sheetDescription: description,
+            createButtonPresent: true,
+            cancelButtonPresent: true,
+            cancelButtonEnabled: cancelEnabled,
+            deleteConfirmButtonPresent: false,
+            strayMenuOpen: false,
+            topLevelAlertPresent: false,
+            topLevelAlertButtonCount: 0,
+            topLevelAlertPrimaryButton: "",
+            createButtonTitle: createTitle,
+            cancelButtonTitle: cancelTitle,
+            deletePrimaryTitle: ""
+        )
+    }
+
+    @Test("Issue533 classifies the measured Japanese sheet with an enabled Cancel")
+    func measuredJapaneseSheetClassifiesViaDescription() {
+        let signals = sheetSignals(
+            description: "新規トラック",
+            createTitle: "作成",
+            cancelTitle: "キャンセル",
+            cancelEnabled: true
+        )
+
+        #expect(ModalReconciliation.classify(signals) == .mandatoryNewTrack)
+    }
+
+    @Test("Issue533 retains English and Korean New Track classification")
+    func existingLocalesStillClassifyViaDescription() {
+        let english = sheetSignals(
+            description: "New Track",
+            createTitle: "Create",
+            cancelTitle: "Cancel",
+            cancelEnabled: true
+        )
+        let korean = sheetSignals(
+            description: "새로운 트랙",
+            createTitle: "생성",
+            cancelTitle: "취소",
+            cancelEnabled: true
+        )
+
+        #expect(ModalReconciliation.classify(english) == .mandatoryNewTrack)
+        #expect(ModalReconciliation.classify(korean) == .mandatoryNewTrack)
+    }
+
+    @Test("Issue533 keeps an enabled-Cancel unrelated sheet fail-closed")
+    func unrelatedEnabledCancelSheetIsUnknown() {
+        let signals = sheetSignals(
+            description: "Some Other Sheet",
+            createTitle: "作成",
+            cancelTitle: "キャンセル",
+            cancelEnabled: true
+        )
+
+        #expect(ModalReconciliation.classify(signals) == .unknownSheet)
+    }
+
+    @Test("Issue533 stores only the measured Japanese New Track labels")
+    func measuredJapaneseLabelsAreExact() {
+        #expect(AXLocalePolicy.newTrackSheetDescription.variants.contains("新規トラック"))
+        #expect(AXLocalePolicy.createButton.variants.contains("作成"))
+        #expect(AXLocalePolicy.cancelButton.variants.contains("キャンセル"))
+        #expect(!AXLocalePolicy.newTrackSheetDescription.variants.contains("新しいトラック"))
+    }
+}


### PR DESCRIPTION
Closes #533.

## The defect

`project.new` failed closed on Japanese Logic. The mandatory New Track sheet that every new project
presents was classified `.unknownSheet`, so the operation reported failure — **for a project it had
in fact created**.

Same precondition (Logic running, no project open), same release artifact, minutes apart:

```
English    isError false   mandatory_track_created: true, "Untitled 56 - Tracks"
Japanese   isError true    unexpected_blocking_sheet, sheet_kind: unknownSheet
```

`ModalReconciliation.classify` identifies that sheet by its `AXDescription` or by its button shape,
and all three inputs carried English and Korean only.

## The fix, and why it is the description and not the buttons

Measured on the live Japanese sheet rather than translated:

| | measured |
| --- | --- |
| sheet `AXDescription` | `新規トラック` |
| Create button | `作成` |
| Cancel button | `キャンセル` |
| Cancel enabled? | **yes** |

That last row decides it. With Cancel enabled the button-shape disjunct
`(createButtonPresent && cancelButtonPresent && !cancelButtonEnabled)` cannot fire, so the
description match is the only path — which is exactly how English already passes. Adding the
description variant makes Japanese behave as English does; it does not widen the classifier, and a
test asserts an unrelated sheet with an enabled Cancel is still `.unknownSheet`.

The button variants are still needed, because the reconciler clicks the real localized title rather
than a hardcoded English one.

**Nothing else Japanese is added.** Other label sets in that file have the same gap. A guessed string
is worse than a visibly missing one — a test asserts `newTrackSheetDescription` does not contain the
plausible-but-wrong `新しいトラック`.

## Live evidence

Bound to this head, on a Japanese Logic Pro 12.3 with no project open:

```
{"mandatory_track_created": true, "phase": "created_project_window_observed",
 "window_title": "名称未設定 - トラック"}     isError: false
```

Three mutation-backed checks — the sheet is recognised, no sheet is left blocking the project, and
the menu bar really is Japanese so the Japanese path was the one exercised. Plus a visual assertion
that the created project **accepts an edit**: a marker made through Logic's own `移動 ▸ マーカーを作成`
appears in that window's ruler. I looked at the two crops rather than trusting the hash — `マーカー1`
is there in the second and absent in the first.

The visual is driven by Logic's own menu, not by this product, and that is deliberate. On Japanese
Logic almost nothing in the product is localized yet, so it cannot supply its own proof here:

- `nav.goto_bar` finds no `移動 ▸ 移動 ▸ 位置…` chain, falls to the slider, and does not move
  (documented on #531);
- `track.create_instrument` routes to a MIDI key command, fires CC 21 on a binding nothing listens
  to, and answers `state B, success: true` while the screen does not change — the same class of
  defect as #526, observed during this run and recorded rather than used as proof of anything.

Full suite: 3477 tests pass.
