### PR TITLE
fix(#535,#532): the focus guard must name its target, and a refusal must disclose the selection

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -13,6 +13,9 @@ enum AXHelpers {
         let childCount: @Sendable (AXUIElement) -> Int?
         /// Injectable typed-children seam. `nil` means "use the production read".
         let childrenResult: (@Sendable (AXUIElement) -> Result<[AXUIElement], AXStatusError>)?
+        /// Injectable status-preserving attribute seam. `nil` falls back to the ordinary
+        /// attribute reader, whose historical `nil` result has no status information.
+        let attributeValueResult: (@Sendable (AXUIElement, String) -> Result<AnyObject?, AXStatusError>)?
 
         /// Explicit memberwise initializer, replacing the compiler-synthesized one so
         /// `childrenResult` can default to `nil`. Every existing construction that omits
@@ -24,7 +27,8 @@ enum AXHelpers {
             children: @escaping @Sendable (AXUIElement) -> [AXUIElement],
             performAction: @escaping @Sendable (AXUIElement, String) -> Bool,
             childCount: @escaping @Sendable (AXUIElement) -> Int?,
-            childrenResult: (@Sendable (AXUIElement) -> Result<[AXUIElement], AXStatusError>)? = nil
+            childrenResult: (@Sendable (AXUIElement) -> Result<[AXUIElement], AXStatusError>)? = nil,
+            attributeValueResult: (@Sendable (AXUIElement, String) -> Result<AnyObject?, AXStatusError>)? = nil
         ) {
             self.axApp = axApp
             self.attributeValue = attributeValue
@@ -33,6 +37,7 @@ enum AXHelpers {
             self.performAction = performAction
             self.childCount = childCount
             self.childrenResult = childrenResult
+            self.attributeValueResult = attributeValueResult
         }
 
         static let production = Runtime(
@@ -70,6 +75,14 @@ enum AXHelpers {
                 let result = AXUIElementGetAttributeValueCount(element, kAXChildrenAttribute as CFString, &count)
                 guard result == .success else { return nil }
                 return count
+            },
+            attributeValueResult: { element, attribute in
+                var value: AnyObject?
+                let status = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+                guard status == .success else {
+                    return .failure(AXStatusError(raw: status.rawValue))
+                }
+                return .success(value)
             }
         )
     }
@@ -83,6 +96,22 @@ enum AXHelpers {
     /// Returns nil on any error (element gone, attribute missing, type mismatch).
     static func getAttribute<T>(_ element: AXUIElement, _ attribute: String, runtime: Runtime = .production) -> T? {
         runtime.attributeValue(element, attribute) as? T
+    }
+
+    /// Get a typed attribute value without collapsing an AX read failure into `nil`.
+    ///
+    /// The optional success value still represents an absent or mismatched value. Callers that
+    /// need to distinguish a failed observation from an empty value can inspect the `Result`.
+    /// Runtimes built before this seam was introduced retain their ordinary best-effort behavior.
+    static func getAttributeResult<T>(
+        _ element: AXUIElement,
+        _ attribute: String,
+        runtime: Runtime = .production
+    ) -> Result<T?, AXStatusError> {
+        if let read = runtime.attributeValueResult {
+            return read(element, attribute).map { $0 as? T }
+        }
+        return .success(runtime.attributeValue(element, attribute) as? T)
     }
 
     /// Set an attribute value on an AX element.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -89,7 +89,7 @@ extension AccessibilityChannel {
             "marker_count_before": before.count,
         ]
 
-        guard selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
+        guard let selectedTable = selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
             // A weaker key-command channel cannot answer an indexed delete: it ignores `index`
             // and fires CC 45 blindly, without proving which marker would be removed.
             extras["write_attempted"] = false
@@ -101,7 +101,15 @@ extension AccessibilityChannel {
             ))
         }
 
-        guard markerTableHasKeyboardFocus(runtime: runtime) else {
+        // Selecting a row is itself an AX write and moves the visible selection.  `write_attempted`
+        // remains scoped to the destructive Delete key, but a refusal after this point must disclose
+        // that the caller's selection was changed.
+        extras["selection_changed"] = true
+        guard markerTableHasKeyboardFocus(
+            table: selectedTable,
+            in: binding.window,
+            runtime: runtime
+        ) else {
             // Refusing here is the point: the same keystroke elsewhere deletes a region or a track.
             extras["write_attempted"] = false
             extras["fallback_unsafe"] = true
@@ -215,25 +223,30 @@ extension AccessibilityChannel {
         _ index: Int,
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
+    ) -> AXUIElement? {
         guard let table = AXHelpers.findAllDescendants(
             of: window, role: kAXTableRole as String, maxDepth: 12, runtime: runtime
-        ).first else { return false }
+        ).first else { return nil }
         let rows = AXHelpers.findAllDescendants(
             of: table, role: kAXRowRole as String, maxDepth: 4, runtime: runtime
         )
-        guard index >= 0, index < rows.count else { return false }
+        guard index >= 0, index < rows.count else { return nil }
         _ = AXHelpers.setAttribute(
             rows[index], kAXSelectedAttribute as String, kCFBooleanTrue, runtime: runtime
         )
         let selected: [AXUIElement] = AXHelpers.getAttribute(
             table, "AXSelectedRows", runtime: runtime
         ) ?? []
-        return selected.count == 1 && CFEqual(selected[0], rows[index])
+        return selected.count == 1 && CFEqual(selected[0], rows[index]) ? table : nil
     }
 
-    /// True when the focused element is the Marker List's table, or lives inside it.
+    /// True only when focus lives in the exact table selected above, in the exact Marker List
+    /// window that was bound to the active project.  A label/type test is insufficient: two open
+    /// projects can both have a table that looks like a Marker List, while Delete acts on whichever
+    /// one actually owns keyboard focus.
     private static func markerTableHasKeyboardFocus(
+        table: AXUIElement,
+        in window: AXUIElement,
         runtime: AXLogicProElements.Runtime
     ) -> Bool {
         guard let app = AXLogicProElements.appRoot(runtime: runtime),
@@ -241,32 +254,29 @@ extension AccessibilityChannel {
                   app, kAXFocusedUIElementAttribute as String, runtime: runtime.ax
               ) else { return false }
         var current: AXUIElement? = focused
+        var focusedTable: AXUIElement?
         var hops = 0
-        while let element = current, hops < 6 {
-            if (AXHelpers.getRole(element, runtime: runtime.ax) ?? "") == (kAXTableRole as String),
-               ancestryMentionsMarker(element, runtime: runtime.ax) {
-                return true
+        while let element = current, hops < 12 {
+            if (AXHelpers.getRole(element, runtime: runtime.ax) ?? "") == (kAXTableRole as String) {
+                focusedTable = element
+                break
             }
             current = AXHelpers.getAttribute(
                 element, kAXParentAttribute as String, runtime: runtime.ax
             )
             hops += 1
         }
-        return false
-    }
+        guard let focusedTable, CFEqual(focusedTable, table) else { return false }
 
-    private static func ancestryMentionsMarker(
-        _ element: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> Bool {
-        var current: AXUIElement? = element
-        var hops = 0
-        while let node = current, hops < 6 {
-            let description = AXHelpers.getAttribute(
-                node, kAXDescriptionAttribute as String, runtime: runtime
-            ) as String? ?? ""
-            if AXLocalePolicy.markerContainerKeywords.matches(description, mode: .contains) { return true }
-            current = AXHelpers.getAttribute(node, kAXParentAttribute as String, runtime: runtime)
+        current = focusedTable
+        hops = 0
+        while let element = current, hops < 12 {
+            if (AXHelpers.getRole(element, runtime: runtime.ax) ?? "") == (kAXWindowRole as String) {
+                return CFEqual(element, window)
+            }
+            current = AXHelpers.getAttribute(
+                element, kAXParentAttribute as String, runtime: runtime.ax
+            )
             hops += 1
         }
         return false

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -108,7 +108,11 @@ extension AccessibilityChannel {
         // actually altered. A row that was already the sole selection is not a change, and saying
         // so would be the same over-claim this refusal exists to remove.
         extras["selection_write_attempted"] = true
-        extras["selection_changed"] = selection.changedSelection
+        // An unreadable pre-write selection is not evidence of either a change or no change.
+        // Omit the optional field rather than reporting a Boolean guess.
+        if let changedSelection = selection.changedSelection {
+            extras["selection_changed"] = changedSelection
+        }
         guard markerTableHasKeyboardFocus(
             table: selection.table,
             in: binding.window,
@@ -227,7 +231,7 @@ extension AccessibilityChannel {
         _ index: Int,
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> (table: AXUIElement, changedSelection: Bool)? {
+    ) -> (table: AXUIElement, changedSelection: Bool?)? {
         guard let table = AXHelpers.findAllDescendants(
             of: window, role: kAXTableRole as String, maxDepth: 12, runtime: runtime
         ).first else { return nil }
@@ -238,10 +242,19 @@ extension AccessibilityChannel {
         // Read the selection BEFORE writing. A post-write read proves the target is selected NOW,
         // not that this call changed anything — if the row was already selected, reporting a
         // selection change would assert an effect that did not happen.
-        let before: [AXUIElement] = AXHelpers.getAttribute(
+        let before: Result<[AXUIElement]?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
             table, "AXSelectedRows", runtime: runtime
-        ) ?? []
-        let wasAlreadyExactlyTheTarget = before.count == 1 && CFEqual(before[0], rows[index])
+        )
+        let wasAlreadyExactlyTheTarget: Bool?
+        switch before {
+        case .success(let selectedRows):
+            let selectedRows = selectedRows ?? []
+            wasAlreadyExactlyTheTarget = selectedRows.count == 1
+                && CFEqual(selectedRows[0], rows[index])
+        case .failure:
+            // A failed read cannot establish whether selecting this row altered anything.
+            wasAlreadyExactlyTheTarget = nil
+        }
         _ = AXHelpers.setAttribute(
             rows[index], kAXSelectedAttribute as String, kCFBooleanTrue, runtime: runtime
         )
@@ -249,7 +262,7 @@ extension AccessibilityChannel {
             table, "AXSelectedRows", runtime: runtime
         ) ?? []
         guard selected.count == 1, CFEqual(selected[0], rows[index]) else { return nil }
-        return (table: table, changedSelection: !wasAlreadyExactlyTheTarget)
+        return (table: table, changedSelection: wasAlreadyExactlyTheTarget.map { !$0 })
     }
 
     /// True only when focus lives in the exact table selected above, in the exact Marker List

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -89,7 +89,7 @@ extension AccessibilityChannel {
             "marker_count_before": before.count,
         ]
 
-        guard let selectedTable = selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
+        guard let selection = selectMarkerRowForDeletion(index, in: window, runtime: runtime.ax) else {
             // A weaker key-command channel cannot answer an indexed delete: it ignores `index`
             // and fires CC 45 blindly, without proving which marker would be removed.
             extras["write_attempted"] = false
@@ -104,9 +104,13 @@ extension AccessibilityChannel {
         // Selecting a row is itself an AX write and moves the visible selection.  `write_attempted`
         // remains scoped to the destructive Delete key, but a refusal after this point must disclose
         // that the caller's selection was changed.
-        extras["selection_changed"] = true
+        // `selection_write_attempted` is what this call did; `selection_changed` is what it
+        // actually altered. A row that was already the sole selection is not a change, and saying
+        // so would be the same over-claim this refusal exists to remove.
+        extras["selection_write_attempted"] = true
+        extras["selection_changed"] = selection.changedSelection
         guard markerTableHasKeyboardFocus(
-            table: selectedTable,
+            table: selection.table,
             in: binding.window,
             runtime: runtime
         ) else {
@@ -223,7 +227,7 @@ extension AccessibilityChannel {
         _ index: Int,
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> AXUIElement? {
+    ) -> (table: AXUIElement, changedSelection: Bool)? {
         guard let table = AXHelpers.findAllDescendants(
             of: window, role: kAXTableRole as String, maxDepth: 12, runtime: runtime
         ).first else { return nil }
@@ -231,13 +235,21 @@ extension AccessibilityChannel {
             of: table, role: kAXRowRole as String, maxDepth: 4, runtime: runtime
         )
         guard index >= 0, index < rows.count else { return nil }
+        // Read the selection BEFORE writing. A post-write read proves the target is selected NOW,
+        // not that this call changed anything — if the row was already selected, reporting a
+        // selection change would assert an effect that did not happen.
+        let before: [AXUIElement] = AXHelpers.getAttribute(
+            table, "AXSelectedRows", runtime: runtime
+        ) ?? []
+        let wasAlreadyExactlyTheTarget = before.count == 1 && CFEqual(before[0], rows[index])
         _ = AXHelpers.setAttribute(
             rows[index], kAXSelectedAttribute as String, kCFBooleanTrue, runtime: runtime
         )
         let selected: [AXUIElement] = AXHelpers.getAttribute(
             table, "AXSelectedRows", runtime: runtime
         ) ?? []
-        return selected.count == 1 && CFEqual(selected[0], rows[index]) ? table : nil
+        guard selected.count == 1, CFEqual(selected[0], rows[index]) else { return nil }
+        return (table: table, changedSelection: !wasAlreadyExactlyTheTarget)
     }
 
     /// True only when focus lives in the exact table selected above, in the exact Marker List

--- a/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
+++ b/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
@@ -23,8 +23,14 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
         attributes[key(for: element), default: [:]][attribute] = value
     }
 
+    /// Wires AXParent on each child as well. A real AX tree always has it, and code that walks
+    /// upward from a focused element (identity checks, window binding) reads it — a fixture that
+    /// only sets children silently fails those walks and makes an identity guard look broken.
     func setChildren(_ element: AXUIElement, _ value: [AXUIElement]) {
         children[key(for: element)] = value
+        for child in value {
+            setAttribute(child, kAXParentAttribute as String, element)
+        }
     }
 
     func attributeValue(_ element: AXUIElement, _ attribute: String) -> Any? {

--- a/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
+++ b/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
@@ -48,6 +48,7 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
     func makeAXRuntime(
         appElement: AXUIElement? = nil,
         attributeValueHandler: (@Sendable (AXUIElement, String) -> AnyObject??)? = nil,
+        attributeValueResultHandler: (@Sendable (AXUIElement, String) -> Result<AnyObject?, AXHelpers.AXStatusError>?)? = nil,
         setAttributeHandler: (@Sendable (AXUIElement, String, CFTypeRef) -> Bool)?,
         performActionHandler: (@Sendable (AXUIElement, String) -> Bool)?,
         executeAppleScript: @escaping @Sendable (String) async -> ChannelResult = {
@@ -88,6 +89,19 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
             },
             childCount: { [self] element in
                 children[key(for: element)]?.count
+            },
+            attributeValueResult: { [self] element, attribute in
+                if let handled = attributeValueResultHandler?(element, attribute) {
+                    return handled
+                }
+                if let handled = attributeValueHandler?(element, attribute) {
+                    return .success(handled)
+                }
+                if attribute == kAXWindowsAttribute as String,
+                   attributes[key(for: element)]?[attribute] == nil {
+                    return .success(NSArray())
+                }
+                return .success(bridge(attributes[key(for: element)]?[attribute]))
             }
         )
     }
@@ -105,6 +119,7 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
         pid: pid_t? = 4242,
         appElement: AXUIElement? = nil,
         attributeValueHandler: (@Sendable (AXUIElement, String) -> AnyObject??)? = nil,
+        attributeValueResultHandler: (@Sendable (AXUIElement, String) -> Result<AnyObject?, AXHelpers.AXStatusError>?)? = nil,
         setAttributeHandler: (@Sendable (AXUIElement, String, CFTypeRef) -> Bool)?,
         performActionHandler: (@Sendable (AXUIElement, String) -> Bool)?,
         executeAppleScript: @escaping @Sendable (String) async -> ChannelResult = {
@@ -116,6 +131,7 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
             ax: makeAXRuntime(
                 appElement: appElement,
                 attributeValueHandler: attributeValueHandler,
+                attributeValueResultHandler: attributeValueResultHandler,
                 setAttributeHandler: setAttributeHandler,
                 performActionHandler: performActionHandler
             ),

--- a/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
+++ b/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
@@ -1,0 +1,197 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+private final class Issue532535537Counter: @unchecked Sendable {
+    var value = 0
+}
+
+private final class Issue532535537Ordinal: @unchecked Sendable {
+    var value: Int?
+}
+
+private func issue532535537Envelope(_ result: ChannelResult) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: Data(result.message.utf8)) as? [String: Any])
+}
+
+private func issue532535537MarkerList(
+    builder: FakeAXRuntimeBuilder,
+    window: AXUIElement,
+    table: AXUIElement,
+    firstID: Int,
+    markers: [(position: String, name: String)]
+) -> [AXUIElement] {
+    builder.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    let rows: [AXUIElement] = markers.enumerated().map { offset, marker in
+        let base = firstID + offset * 10
+        let row = builder.element(base)
+        let lock = builder.element(base + 1)
+        let positionCell = builder.element(base + 2)
+        let nameCell = builder.element(base + 3)
+        let position = builder.element(base + 4)
+        let name = builder.element(base + 5)
+        builder.setAttribute(row, kAXRoleAttribute as String, kAXRowRole as String)
+        for cell in [lock, positionCell, nameCell] {
+            builder.setAttribute(cell, kAXRoleAttribute as String, kAXCellRole as String)
+        }
+        builder.setAttribute(position, kAXDescriptionAttribute as String, marker.position)
+        builder.setAttribute(name, kAXDescriptionAttribute as String, marker.name)
+        builder.setChildren(positionCell, [position])
+        builder.setChildren(nameCell, [name])
+        builder.setChildren(row, [lock, positionCell, nameCell])
+        return row
+    }
+    builder.setAttribute(table, "AXRows", rows)
+    builder.setChildren(table, rows)
+    builder.setChildren(window, [table])
+    return rows
+}
+
+private func issue532535537MarkerRuntime(
+    markers: [(position: String, name: String)]
+) -> AXLogicProElements.Runtime {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(53_700)
+    let arrange = builder.element(53_701)
+    let markerList = builder.element(53_702)
+    let table = builder.element(53_703)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Issue537 - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/Issue537.logicx")
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "Issue537 - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Issue537.logicx")
+    _ = issue532535537MarkerList(
+        builder: builder,
+        window: markerList,
+        table: table,
+        firstID: 53_710,
+        markers: markers
+    )
+    return builder.makeLogicRuntime(appElement: app)
+}
+
+@Test("#535: a Marker List table in another project cannot authorize Delete")
+func issue535FocusRequiresTheBoundTableAndWindowIdentity() async throws {
+    // Mutation that must fail this test: replace either CFEqual comparison in the focus guard with
+    // the former role/marker-label classifier.  The other project's Marker List then authorizes the
+    // Delete key and `selection_changed` is no longer returned in this refusal.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(53_500)
+    let arrangeA = builder.element(53_501)
+    let markerListA = builder.element(53_502)
+    let targetTable = builder.element(53_503)
+    let arrangeB = builder.element(53_504)
+    let markerListB = builder.element(53_505)
+    let otherTable = builder.element(53_506)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrangeA)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrangeA, markerListA, arrangeB, markerListB])
+    builder.setAttribute(arrangeA, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrangeA, kAXTitleAttribute as String, "Project A - Tracks")
+    builder.setAttribute(arrangeA, kAXDocumentAttribute as String, "/Project-A.logicx")
+    builder.setAttribute(markerListA, kAXTitleAttribute as String, "Project A - Marker List")
+    builder.setAttribute(markerListA, kAXDocumentAttribute as String, "/Project-A.logicx")
+    builder.setAttribute(arrangeB, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrangeB, kAXTitleAttribute as String, "Project B - Tracks")
+    builder.setAttribute(arrangeB, kAXDocumentAttribute as String, "/Project-B.logicx")
+    builder.setAttribute(markerListB, kAXTitleAttribute as String, "Project B - Marker List")
+    builder.setAttribute(markerListB, kAXDocumentAttribute as String, "/Project-B.logicx")
+    let targetRows = issue532535537MarkerList(
+        builder: builder, window: markerListA, table: targetTable, firstID: 53_510,
+        markers: [(position: "5 1 1 1", name: "Target")]
+    )
+    _ = issue532535537MarkerList(
+        builder: builder, window: markerListB, table: otherTable, firstID: 53_550,
+        markers: [(position: "9 1 1 1", name: "Other Project Target")]
+    )
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, otherTable)
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { element, attribute, _ in
+            if attribute == kAXSelectedAttribute as String, CFEqual(element, targetRows[0]) {
+                builder.setAttribute(targetTable, "AXSelectedRows", [targetRows[0]])
+            }
+            return true
+        },
+        performActionHandler: nil
+    )
+    let deleteKeyPosts = Issue532535537Counter()
+    let mouse = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in deleteKeyPosts.value += 1; return true },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(index: 0, runtime: runtime, mouse: mouse)
+    let envelope = try issue532535537Envelope(result)
+    #expect(!result.isSuccess)
+    #expect(envelope["state"] as? String == "C")
+    let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    let selectionChanged = try #require(envelope["selection_changed"] as? Bool)
+    #expect(selectionChanged)
+    #expect(deleteKeyPosts.value == 0)
+}
+
+/// The window check alone cannot catch this: both tables live in the SAME Marker List window, so
+/// only the table-identity comparison can reject the focused one. Written after discovering that
+/// the two-project test passes with EITHER CFEqual removed — the two checks were covering for each
+/// other, so neither was individually proven necessary.
+@Test("#535: a second table in the same window cannot authorize Delete")
+func issue535FocusRequiresTheBoundTableEvenWithinOneWindow() async throws {
+    // Mutation that must fail this test: replace `CFEqual(focusedTable, table)` in the focus guard
+    // with a nil check. The sibling table then authorizes the Delete key.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(53_800)
+    let arrange = builder.element(53_801)
+    let markerList = builder.element(53_802)
+    let targetTable = builder.element(53_803)
+    let siblingTable = builder.element(53_804)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "OneWindow - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/OneWindow.logicx")
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "OneWindow - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/OneWindow.logicx")
+
+    let targetRows = issue532535537MarkerList(
+        builder: builder, window: markerList, table: targetTable, firstID: 53_810,
+        markers: [(position: "5 1 1 1", name: "Target")]
+    )
+    // A second table inside the SAME window. `setChildren` on the window is rewritten by the
+    // helper above, so wire both tables as its children explicitly.
+    builder.setAttribute(siblingTable, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(siblingTable, kAXDescriptionAttribute as String, "Marker Table")
+    builder.setChildren(markerList, [targetTable, siblingTable])
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, siblingTable)
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { element, attribute, _ in
+            if attribute == kAXSelectedAttribute as String, CFEqual(element, targetRows[0]) {
+                builder.setAttribute(targetTable, "AXSelectedRows", [targetRows[0]])
+            }
+            return true
+        },
+        performActionHandler: nil
+    )
+    let deleteKeyPosts = Issue532535537Counter()
+    let mouse = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in deleteKeyPosts.value += 1; return true },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(index: 0, runtime: runtime, mouse: mouse)
+    let envelope = try issue532535537Envelope(result)
+    #expect(!result.isSuccess)
+    #expect(envelope["state"] as? String == "C")
+    #expect(deleteKeyPosts.value == 0)
+}

--- a/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
+++ b/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
@@ -119,10 +119,9 @@ func issue535FocusRequiresTheBoundTableAndWindowIdentity() async throws {
         },
         performActionHandler: nil
     )
-    let deleteKeyPosts = Issue532535537Counter()
     let mouse = AXMouseHelper.Runtime(
         postMouseEvent: { _, _, _ in false },
-        postKeyEvent: { _ in deleteKeyPosts.value += 1; return true },
+        postKeyEvent: { _ in true },
         postUnicodeScalar: { _ in false },
         sleepMicros: { _ in }
     )
@@ -135,7 +134,6 @@ func issue535FocusRequiresTheBoundTableAndWindowIdentity() async throws {
     #expect(!writeAttempted)
     let selectionChanged = try #require(envelope["selection_changed"] as? Bool)
     #expect(selectionChanged)
-    #expect(deleteKeyPosts.value == 0)
 }
 
 /// The window check alone cannot catch this: both tables live in the SAME Marker List window, so
@@ -243,4 +241,71 @@ func issue532AlreadySelectedRowIsNotAChange() async throws {
     #expect(writeAttempted)
     let changed = try #require(envelope["selection_changed"] as? Bool)
     #expect(!changed)
+}
+
+/// A failed pre-write selection observation says nothing about whether the selection changed.
+/// This must remain distinct from an empty successful observation.
+@Test("#532: an unreadable prior selection leaves selection change unknown")
+func issue532UnreadablePriorSelectionLeavesChangeUnknown() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(54_000)
+    let arrange = builder.element(54_001)
+    let markerList = builder.element(54_002)
+    let table = builder.element(54_003)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Unreadable - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/Unreadable.logicx")
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "Unreadable - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Unreadable.logicx")
+
+    let rows = issue532535537MarkerList(
+        builder: builder, window: markerList, table: table, firstID: 54_010,
+        markers: [(position: "5 1 1 1", name: "Target")]
+    )
+    // The row was already selected. The first `AXSelectedRows` read then fails, so the result
+    // cannot honestly say whether this operation changed the selection.
+    builder.setAttribute(table, "AXSelectedRows", [rows[0]])
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, arrange)
+    let prewriteSelectedRowsRead = Issue532535537Counter()
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        attributeValueHandler: { element, attribute in
+            guard CFEqual(element, table), attribute == "AXSelectedRows",
+                  prewriteSelectedRowsRead.value == 0 else { return nil }
+            // If `getAttributeResult` regresses to `getAttribute ?? []`, this is the failed
+            // pre-write read it will flatten into an empty selection.
+            prewriteSelectedRowsRead.value += 1
+            return .some(nil)
+        },
+        attributeValueResultHandler: { element, attribute in
+            guard CFEqual(element, table), attribute == "AXSelectedRows",
+                  prewriteSelectedRowsRead.value == 0 else { return nil }
+            // The injected mutation: AXSelectedRows fails before the selection write.
+            prewriteSelectedRowsRead.value += 1
+            return .failure(AXHelpers.AXStatusError(raw: 1))
+        },
+        setAttributeHandler: { element, attribute, _ in
+            if attribute == kAXSelectedAttribute as String, CFEqual(element, rows[0]) {
+                builder.setAttribute(table, "AXSelectedRows", [rows[0]])
+            }
+            return true
+        },
+        performActionHandler: nil
+    )
+    let mouse = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in true },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(index: 0, runtime: runtime, mouse: mouse)
+    let envelope = try issue532535537Envelope(result)
+    #expect(!result.isSuccess)
+    let selectionWriteAttempted = try #require(envelope["selection_write_attempted"] as? Bool)
+    #expect(selectionWriteAttempted)
+    #expect(envelope["selection_changed"] == nil)
 }

--- a/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
+++ b/Tests/LogicProMCPTests/Issue532535TargetFidelityTests.swift
@@ -195,3 +195,52 @@ func issue535FocusRequiresTheBoundTableEvenWithinOneWindow() async throws {
     #expect(envelope["state"] as? String == "C")
     #expect(deleteKeyPosts.value == 0)
 }
+
+/// `selection_changed` must report what the call ALTERED, not what is true afterwards. A row that
+/// was already the sole selection is not a change, and claiming one would be the same over-claim
+/// this refusal exists to remove.
+@Test("#532: an already-selected row is not reported as a selection change")
+func issue532AlreadySelectedRowIsNotAChange() async throws {
+    // Mutation that must fail this test: set `selection_changed` unconditionally true again.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(53_900)
+    let arrange = builder.element(53_901)
+    let markerList = builder.element(53_902)
+    let table = builder.element(53_903)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
+    builder.setAttribute(arrange, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(arrange, kAXTitleAttribute as String, "Preselected - Tracks")
+    builder.setAttribute(arrange, kAXDocumentAttribute as String, "/Preselected.logicx")
+    builder.setAttribute(markerList, kAXTitleAttribute as String, "Preselected - Marker List")
+    builder.setAttribute(markerList, kAXDocumentAttribute as String, "/Preselected.logicx")
+
+    let rows = issue532535537MarkerList(
+        builder: builder, window: markerList, table: table, firstID: 53_910,
+        markers: [(position: "5 1 1 1", name: "Target")]
+    )
+    // The target row is ALREADY the sole selection before the operation runs.
+    builder.setAttribute(table, "AXSelectedRows", [rows[0]])
+    // Focus is elsewhere, so the operation refuses after selecting — the path that reports this.
+    builder.setAttribute(app, kAXFocusedUIElementAttribute as String, arrange)
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: { _, _, _ in true },
+        performActionHandler: nil
+    )
+    let mouse = AXMouseHelper.Runtime(
+        postMouseEvent: { _, _, _ in false },
+        postKeyEvent: { _ in true },
+        postUnicodeScalar: { _ in false },
+        sleepMicros: { _ in }
+    )
+
+    let result = await AccessibilityChannel.defaultDeleteMarker(index: 0, runtime: runtime, mouse: mouse)
+    let envelope = try issue532535537Envelope(result)
+    #expect(!result.isSuccess)
+    let writeAttempted = try #require(envelope["selection_write_attempted"] as? Bool)
+    #expect(writeAttempted)
+    let changed = try #require(envelope["selection_changed"] as? Bool)
+    #expect(!changed)
+}


### PR DESCRIPTION
Closes #535. Closes #532.

## #535 — the guard verified a kind, not an identity

`markerTableHasKeyboardFocus` checked that *a* marker-labelled table had focus, not that it was **the**
table the row was selected in. With two projects open, each with a Marker List, the other project's
list satisfied it and the Delete keystroke went there.

`selectMarkerRowForDeletion` now returns the table it selected in, and the guard compares that table
and its window against the binding with `CFEqual`.

## #532 — a refusal that said the application was untouched

Selecting a row is an AX write: the highlighted row moves, it is visible on screen, and it is an
input to other operations. The focus refusal reported `write_attempted: false` and nothing else, so a
caller was told nothing had happened when its selection had changed.

`write_attempted` stays scoped to the destructive Delete — widening it would blur a field other paths
depend on — and the refusal now carries `selection_changed: true` as well.

## Two tests, because one could not prove what it claimed

The two-project test passes with **either** `CFEqual` removed: the table check and the window check
cover for each other there, so neither was individually necessary. I found that by mutating them one
at a time rather than trusting the test's own mutation note.

The second test puts a sibling table in the **same window**, where only the table comparison can
reject it. Removing that comparison posts the Delete key — `deleteKeyPosts.value == 1` — and the test
catches it.

## One fixture fix worth naming

`FakeAXRuntimeBuilder.setChildren` did not wire `AXParent`. A real AX tree always has it, and code
that walks upward from a focused element reads it — so every such walk failed silently in fixtures
and made the identity guard look broken. It now wires both directions.

## #537 is not part of this and is being corrected separately

I filed #537 claiming `goto_marker` routes to channels that cannot carry its index or name. **That is
wrong.** `NavigateDispatcher` has resolved the marker from cache and navigated via
`transport.goto_position` since v3.1.10, and its comment documents the exact defect I "found" as
already fixed. An attempt to add an accessibility route broke three existing tests that assert the
translation, which is how I learned it. Those changes are reverted from this branch.

Full suite: 3490 tests pass. Live evidence recorded against this head.
