### PR TITLE
fix(#534): the slider is a second actuator once the dialog route has issued one

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -238,8 +238,8 @@ enum AXLocalePolicy {
 
     static let goToPositionDialogTitle = LabelSet(
         canonical: "Go To Position",
-        variants: ["위치로 이동"],
-        rationale: "Used only to dismiss a stale dialog before another verified operation."
+        variants: ["위치로 이동", "位置の移動"],
+        rationale: "Used only to dismiss a stale dialog before another verified operation. This covers the reviewed EN/KO/JA dialog titles; broader locale/menu policy remains tracked separately."
     )
 
     static let cancelButton = LabelSet(

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -360,6 +360,12 @@ enum AXLocalePolicy {
         rationale: "Identifies the playhead position text field description; read-only."
     )
 
+    static let playheadPositionGroupLabel = LabelSet(
+        canonical: "playhead position",
+        variants: ["재생헤드 위치", "再生ヘッド位置"],
+        rationale: "Identifies Logic 12.3's Playhead Position AXGroup before resolving its bar/beat component sliders."
+    )
+
     // --- Control-bar slider locators (read-only, verbatim `.exactStrict`) ---
 
     static let controlBarGroupLabel = LabelSet(

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -114,20 +114,50 @@ extension AXLogicProElements {
         )
     }
 
-    /// Find the 마디 (bar) slider in Logic Pro's control bar. Setting this
-    /// slider's value moves the playhead to the given bar.
+    /// Find the `bar` component of Logic Pro's Control Bar playhead-position
+    /// group. Its AX value is not assumed to be an absolute bar position.
     static func findControlBarBarSlider(runtime: Runtime = .production) -> AXUIElement? {
-        guard let controlBar = getControlBar(runtime: runtime) else { return nil }
-        let sliders = AXHelpers.findAllDescendants(
-            of: controlBar, role: kAXSliderRole, maxDepth: 4, runtime: runtime.ax
+        findControlBarPlayheadPositionSlider(
+            matching: AXLocalePolicy.barSliderLabel,
+            runtime: runtime
         )
-        for s in sliders {
-            let desc = AXHelpers.getDescription(s, runtime: runtime.ax) ?? ""
-            if AXLocalePolicy.barSliderLabel.matches(desc, mode: .exactStrict) {
-                return s
-            }
-        }
-        return nil
+    }
+
+    /// Locate a component slider below the named Playhead Position group. Logic
+    /// 12.3 nests `bar` and `beat` beneath that group more deeply than the
+    /// historical four-level control-bar scan, so resolve the structural owner
+    /// first and then traverse its complete descendant subtree.
+    private static func findControlBarPlayheadPositionSlider(
+        matching labels: AXLocalePolicy.LabelSet,
+        runtime: Runtime
+    ) -> AXUIElement? {
+        guard let controlBar = getControlBar(runtime: runtime) else { return nil }
+        let groups = AXHelpers.findAllDescendants(
+            of: controlBar, role: kAXGroupRole, maxDepth: 8, runtime: runtime.ax
+        )
+        guard let playheadPosition = groups.first(where: {
+            AXLocalePolicy.playheadPositionGroupLabel.matches(
+                AXHelpers.getDescription($0, runtime: runtime.ax), mode: .exactStrict
+            )
+        }) else { return nil }
+        let componentSliders = AXHelpers.findAllDescendants(
+            of: playheadPosition, role: kAXSliderRole, maxDepth: 8, runtime: runtime.ax
+        )
+        guard componentSliders.count == 2,
+              componentSliders.contains(where: {
+                  AXLocalePolicy.barSliderLabel.matches(
+                      AXHelpers.getDescription($0, runtime: runtime.ax), mode: .exactStrict
+                  )
+              }),
+              componentSliders.contains(where: {
+                  AXLocalePolicy.beatSliderLabel.matches(
+                      AXHelpers.getDescription($0, runtime: runtime.ax), mode: .exactStrict
+                  )
+              })
+        else { return nil }
+        return componentSliders.first(where: {
+            labels.matches(AXHelpers.getDescription($0, runtime: runtime.ax), mode: .exactStrict)
+        })
     }
 
     /// Find the 템포 / Tempo slider in Logic's control bar. Double-clicking
@@ -160,19 +190,12 @@ extension AXLogicProElements {
         return nil
     }
 
-    /// Find the 비트 (beat) slider in the control bar (optional — for sub-bar positioning).
+    /// Find the `beat` component below Logic Pro 12.3's Playhead Position group.
     static func findControlBarBeatSlider(runtime: Runtime = .production) -> AXUIElement? {
-        guard let controlBar = getControlBar(runtime: runtime) else { return nil }
-        let sliders = AXHelpers.findAllDescendants(
-            of: controlBar, role: kAXSliderRole, maxDepth: 4, runtime: runtime.ax
+        findControlBarPlayheadPositionSlider(
+            matching: AXLocalePolicy.beatSliderLabel,
+            runtime: runtime
         )
-        for s in sliders {
-            let desc = AXHelpers.getDescription(s, runtime: runtime.ax) ?? ""
-            if AXLocalePolicy.beatSliderLabel.matches(desc, mode: .exactStrict) {
-                return s
-            }
-        }
-        return nil
     }
 
     /// Read the current value (0/1) of a control-bar checkbox. Returns nil if

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -9,23 +9,34 @@ enum AXLogicProElements {
         let logicProPID: @Sendable () -> pid_t?
         let ax: AXHelpers.Runtime
         let executeAppleScript: @Sendable (String) async -> ChannelResult
+        /// A timeout-aware variant for routes whose bounded UI protocol needs more than the
+        /// channel default. Test runtimes that only inject `executeAppleScript` automatically
+        /// retain control of this seam.
+        let executeAppleScriptWithTimeout: @Sendable (String, TimeInterval) async -> ChannelResult
 
         init(
             logicProPID: @escaping @Sendable () -> pid_t?,
             ax: AXHelpers.Runtime,
             executeAppleScript: @escaping @Sendable (String) async -> ChannelResult = {
                 await AppleScriptChannel.executeAppleScript($0)
-            }
+            },
+            executeAppleScriptWithTimeout: (@Sendable (String, TimeInterval) async -> ChannelResult)? = nil
         ) {
             self.logicProPID = logicProPID
             self.ax = ax
             self.executeAppleScript = executeAppleScript
+            self.executeAppleScriptWithTimeout = executeAppleScriptWithTimeout ?? { script, _ in
+                await executeAppleScript(script)
+            }
         }
 
         static let production = Runtime(
             logicProPID: { ProcessUtils.logicProPID() },
             ax: .production,
-            executeAppleScript: { await AppleScriptChannel.executeAppleScript($0) }
+            executeAppleScript: { await AppleScriptChannel.executeAppleScript($0) },
+            executeAppleScriptWithTimeout: { script, timeout in
+                await AppleScriptChannel.executeAppleScript(script, timeout: timeout)
+            }
         )
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -449,17 +449,48 @@ enum AXValueExtractors {
             }
         }
 
-        let sliders = AXHelpers.findAllDescendants(of: transport, role: kAXSliderRole, maxDepth: 4, runtime: runtime)
+        // Logic 12.3 nests the Bar/Beat controls six levels below the Control Bar. Resolve the
+        // Depth 8 covers both the measured live tree (Control Bar -> group -> Playhead Position ->
+        // sliders, three hops) and the deeper fixture topology. It is deliberately not locked by a
+        // test: the group sits within four hops in both, so lowering the bound does not fail
+        // anything. The live check that does bind it is the readback returning "37.3" rather than
+        // nothing.
+        // same named Playhead Position owner as the locator before scanning its subtree, so an
+        // unrelated Position group cannot become a transport readback.
+        let sliders = AXHelpers.findAllDescendants(
+            of: transport, role: kAXSliderRole, maxDepth: 8, runtime: runtime
+        )
+        let playheadPositionGroups = AXHelpers.findAllDescendants(
+            of: transport, role: kAXGroupRole, maxDepth: 8, runtime: runtime
+        )
+        let positionSliders = playheadPositionGroups
+            .first(where: {
+                AXLocalePolicy.playheadPositionGroupLabel.matches(
+                    AXHelpers.getDescription($0, runtime: runtime), mode: .exactStrict
+                )
+            })
+            .map {
+                AXHelpers.findAllDescendants(
+                    of: $0, role: kAXSliderRole, maxDepth: 8, runtime: runtime
+                )
+            }
+            ?? []
         var barValue: Int?
         var beatValue: Int?
         for slider in sliders {
             let desc = (AXHelpers.getDescription(slider, runtime: runtime) ?? "").lowercased()
             if AXLocalePolicy.tempoSliderContainsLabel.containsAny(in: desc), let tempo = extractSliderValue(slider, runtime: runtime) {
                 state.tempo = tempo
-            } else if AXLocalePolicy.barSliderLabel.containsAny(in: desc) {
-                barValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)
-            } else if AXLocalePolicy.beatSliderLabel.containsAny(in: desc) {
-                beatValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)
+            }
+        }
+        for slider in positionSliders {
+            let desc = (AXHelpers.getDescription(slider, runtime: runtime) ?? "").lowercased()
+            if AXLocalePolicy.barSliderLabel.containsAny(in: desc),
+               let value = extractSliderValue(slider, runtime: runtime) {
+                barValue = Int(value)
+            } else if AXLocalePolicy.beatSliderLabel.containsAny(in: desc),
+                      let value = extractSliderValue(slider, runtime: runtime) {
+                beatValue = Int(value)
             }
         }
         // The Control Bar exposes bar and beat independently. They are observations, but they

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -427,10 +427,21 @@ enum AXValueExtractors {
                 if let tempo = Double(value.replacingOccurrences(of: " BPM", with: "")) {
                     state.tempo = tempo
                 }
-            } else if AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: descLower) || value.contains(".") && value.contains(":") == false {
-                // Bar.Beat.Division.Tick format
-                if value.filter({ $0 == "." }).count >= 2 {
+            } else if AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: descLower)
+                || value.contains(".") && value.contains(":") == false {
+                // Do not turn a partial display into an invented B.B.S.T position. A labelled
+                // playhead field may faithfully expose a prefix; an unlabelled numeric string is
+                // treated as a position only when it has the historical three-dot shape.
+                let isLabelledPosition = AXLocalePolicy.playheadPositionFieldLabel.containsAny(in: descLower)
+                if let components = observedPositionComponents(
+                    in: value,
+                    allowPartial: isLabelledPosition
+                ), components.count > (state.positionReadback?.observedComponents.count ?? 0) {
                     state.position = value
+                    state.positionReadback = TransportPositionReadback(
+                        value: value,
+                        observedComponents: components
+                    )
                 }
             } else if value.contains(":") {
                 // Time format HH:MM:SS
@@ -451,12 +462,47 @@ enum AXValueExtractors {
                 beatValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)
             }
         }
-        if let barValue, let beatValue {
-            state.position = "\(barValue).\(beatValue).1.1"
+        // The Control Bar exposes bar and beat independently. They are observations, but they
+        // say nothing about subdivision or tick; preserve that boundary instead of fabricating
+        // `.1.1` and letting a four-component request verify against it.
+        if let barValue, let beatValue,
+           (state.positionReadback?.observedComponents.count ?? 0) < 2 {
+            let value = "\(barValue).\(beatValue)"
+            state.position = value
+            state.positionReadback = TransportPositionReadback(
+                value: value,
+                observedComponents: [.bar, .beat]
+            )
+        } else if let barValue, (state.positionReadback?.observedComponents.count ?? 0) < 1 {
+            let value = "\(barValue)"
+            state.position = value
+            state.positionReadback = TransportPositionReadback(
+                value: value,
+                observedComponents: [.bar]
+            )
         }
 
         state.lastUpdated = Date()
         return state
+    }
+
+    /// Returns exactly the leading musical-position components represented by an AX text value.
+    /// This deliberately accepts partial labelled fields (`37.3`) while requiring the old
+    /// four-component-like shape for unlabelled text, which avoids classifying a tempo such as
+    /// `120.0` as a playhead observation.
+    private static func observedPositionComponents(
+        in value: String,
+        allowPartial: Bool
+    ) -> [TransportPositionComponent]? {
+        let parts = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ".", omittingEmptySubsequences: false)
+        let minimumComponentCount = allowPartial ? 1 : 3
+        guard (minimumComponentCount...4).contains(parts.count),
+              parts.allSatisfy({ Int($0) != nil }) else {
+            return nil
+        }
+        return Array(TransportPositionComponent.allCases.prefix(parts.count))
     }
 
     // MARK: - Private helpers

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -860,6 +860,36 @@ extension AccessibilityChannel {
                 ]) { _, new in new }
             ))
         }
+        if case let .failed(classification) = dialogResult,
+           classification.hasIssuedGoToPositionActuator {
+            // A leaf menu click, dialog input, or Return may take effect even when the AX / AppleScript
+            // invocation says it failed.  Once one of those has been issued, the slider is a *second*
+            // goto-position actuator, not a fallback-safe retry.  This deliberately keys off issuance,
+            // never the return code, following the Delete-key path's write-attempt boundary.
+            let submissionIssued = classification.hasIssuedDialogSubmission
+            let dialogState = classification.dialogCleanupObservedClosed ? "closed" : "unobserved"
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: submissionIssued
+                    ? "Go To Position dialog input or submission was issued but did not complete; "
+                        + "the slider fallback was not attempted."
+                    : "The Go To Position menu item was issued but reported an error; "
+                        + "the slider fallback was not attempted.",
+                extras: baseExtras.merging([
+                    "operation": "transport.goto_position",
+                    "method": "dialog",
+                    "dialog_actuation_attempted": true,
+                    "dialog_submission_attempted": submissionIssued,
+                    "dialog_cleanup": dialogState,
+                    // Opening the dialog is navigation, while a submitted Return may have moved the
+                    // playhead.  Keep that distinction explicit rather than using a false AX result to
+                    // say no position write was attempted.
+                    "write_attempted": submissionIssued,
+                    "safe_to_retry": false,
+                    "fallback_unsafe": true,
+                ]) { _, new in new }
+            ))
+        }
 
         guard let slider = AXLogicProElements.findControlBarBarSlider(runtime: runtime) else {
             return .error(HonestContract.encodeStateC(
@@ -868,36 +898,118 @@ extension AccessibilityChannel {
                 extras: baseExtras
             ))
         }
-        let setOK = AXHelpers.setAttribute(
+
+        // AX setters cannot establish either outcome: Logic has returned both failure after an
+        // effective write and success after no change.  The issued write is recorded below, then
+        // every subsequent action is authorised by a status-preserving observation instead.
+        func sliderValue(_ element: AXUIElement) -> Result<Int?, AXHelpers.AXStatusError> {
+            let value: Result<NSNumber?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+                element, kAXValueAttribute as String, runtime: runtime.ax
+            )
+            return value.map { $0?.intValue }
+        }
+
+        func observedPosition(bar: Int, beat: Int?) -> String {
+            // These are slider readings, not a transport-state parse.  Do not append beat/subbeat/tick
+            // components that no AX reader supplied.
+            guard let beat else { return "\(bar)" }
+            return "\(bar).\(beat)"
+        }
+
+        func sliderExtras(observedBar: Int?, observedBeat: Int? = nil) -> [String: Any] {
+            baseExtras.merging([
+                "observed": observedBar.map { observedPosition(bar: $0, beat: observedBeat) } ?? NSNull(),
+                "via": "slider",
+                "write_attempted": true,
+            ]) { _, new in new }
+        }
+
+        _ = AXHelpers.setAttribute(
             slider, kAXValueAttribute, NSNumber(value: bar), runtime: runtime.ax
         )
-        if !setOK {
-            return .error(HonestContract.encodeStateC(
-                error: .axWriteFailed,
-                hint: "Failed to set 마디 slider value",
-                extras: baseExtras
+        let initialBar: Int?
+        switch sliderValue(slider) {
+        case .failure, .success(nil):
+            // The bar write was issued.  A failed read is not evidence that it was refused, so this
+            // must be uncertain State B rather than State C; neither beat nor Confirm is authorised.
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: sliderExtras(observedBar: nil)
+            ))
+        case let .success(value?):
+            initialBar = value
+        }
+        guard initialBar == bar else {
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackMismatch,
+                extras: sliderExtras(observedBar: initialBar)
             ))
         }
-        if let beatSlider = AXLogicProElements.findControlBarBeatSlider(runtime: runtime) {
+
+        let beatSlider = AXLogicProElements.findControlBarBeatSlider(runtime: runtime)
+        var initialBeat: Int?
+        if let beatSlider {
             _ = AXHelpers.setAttribute(
                 beatSlider, kAXValueAttribute, NSNumber(value: 1), runtime: runtime.ax
             )
+            switch sliderValue(beatSlider) {
+            case .failure, .success(nil):
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackUnavailable,
+                    extras: sliderExtras(observedBar: initialBar)
+                ))
+            case let .success(value?):
+                initialBeat = value
+            }
+            guard initialBeat == 1 else {
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackMismatch,
+                    extras: sliderExtras(observedBar: initialBar, observedBeat: initialBeat)
+                ))
+            }
         }
-        _ = AXHelpers.performAction(slider, kAXConfirmAction, runtime: runtime.ax)
 
-        let observedBar = (AXHelpers.getValue(slider, runtime: runtime.ax) as? NSNumber)?.intValue
-        let observedPos = observedBar.map { "\($0).1.1.1" }
-        let extras = baseExtras.merging([
-            "observed": observedPos ?? NSNull(),
-            "via": "slider"
-        ]) { _, new in new }
-        if let observedBar, observedBar == bar {
-            return .success(HonestContract.encodeStateA(extras: extras))
+        // Confirm is also an AX actuation whose return code is not a trustworthy outcome.  Read the
+        // actual sliders again afterwards, and certify only the components those reads vended.
+        _ = AXHelpers.performAction(slider, kAXConfirmAction, runtime: runtime.ax)
+        let finalBar: Int?
+        switch sliderValue(slider) {
+        case .failure, .success(nil):
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: sliderExtras(observedBar: initialBar, observedBeat: initialBeat)
+            ))
+        case let .success(value?):
+            finalBar = value
         }
-        if observedBar != nil {
-            return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
+        guard finalBar == bar else {
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackMismatch,
+                extras: sliderExtras(observedBar: finalBar)
+            ))
         }
-        return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+
+        var finalBeat: Int?
+        if let beatSlider {
+            switch sliderValue(beatSlider) {
+            case .failure, .success(nil):
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackUnavailable,
+                    extras: sliderExtras(observedBar: finalBar)
+                ))
+            case let .success(value?):
+                finalBeat = value
+            }
+            guard finalBeat == 1 else {
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackMismatch,
+                    extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
+                ))
+            }
+        }
+        return .success(HonestContract.encodeStateA(
+            extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
+        ))
     }
 
     /// Move the playhead to `bar` via Logic Pro 12's `탐색 → 이동 → 위치…`
@@ -996,6 +1108,82 @@ extension AccessibilityChannel {
             return "CLOSED"
         end menuItemOpenedAfterClick
 
+        -- The Go To Position floating dialog has its own lifecycle; a menu-bar
+        -- observation says nothing about whether this modal is still blocking
+        -- the arrange area.  Keep unreadable distinct from closed, just as the
+        -- #529 menu cleanup does.
+        on goToPositionDialogState(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" then return "OPEN"
+                            if dialogTitle is "Go To Position" then return "OPEN"
+                            if dialogTitle is "Go to Position" then return "OPEN"
+                        end repeat
+                        return "CLOSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionDialogState
+
+        -- Prefer this modal's localized Cancel button.  Escape is only a
+        -- fallback while this exact dialog is observed open, and every attempt
+        -- must be followed by a new exact-dialog observation before it counts
+        -- as cleanup.
+        on pressGoToPositionDialogCancel(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                if exists button "Cancel" of dialogWindow then
+                                    click button "Cancel" of dialogWindow
+                                    return "PRESSED"
+                                end if
+                                if exists button "취소" of dialogWindow then
+                                    click button "취소" of dialogWindow
+                                    return "PRESSED"
+                                end if
+                                if exists button "キャンセル" of dialogWindow then
+                                    click button "キャンセル" of dialogWindow
+                                    return "PRESSED"
+                                end if
+                                return "NO_BUTTON"
+                            end if
+                        end repeat
+                        return "NO_BUTTON"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end pressGoToPositionDialogCancel
+
+        on dismissOpenGoToPositionDialog(theProcess)
+            set dialogState to my goToPositionDialogState(theProcess)
+            if dialogState is "CLOSED" then return "CLOSED"
+            if dialogState is not "OPEN" then return dialogState
+            repeat 3 times
+                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess)
+                if cancelOutcome is "NO_BUTTON" or cancelOutcome is "UNREADABLE" then
+                    using terms from application "System Events"
+                        tell theProcess to key code 53
+                    end using terms from
+                end if
+                delay 0.1
+                set dialogState to my goToPositionDialogState(theProcess)
+                if dialogState is "CLOSED" then return "CLOSED"
+                if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
+                if dialogState is not "OPEN" then return dialogState
+            end repeat
+            return "OPEN"
+        end dismissOpenGoToPositionDialog
+
         \(logicProAppleScript.activateByBundleID)
         tell application "System Events"
             set logicProcess to \(logicProAppleScript.systemEventsProcessTarget)
@@ -1015,6 +1203,10 @@ extension AccessibilityChannel {
                 -- this run opens a menu the same value IS a refusal, because then
                 -- there is something known to be open.
                 set menuActuationAttempted to false
+                -- This marks the write boundary for actuator selection.  The
+                -- leaf may succeed even if AX reports an error, so any result
+                -- after it becomes true must not release the slider route.
+                set dialogActuationIssued to false
                 delay 0.2
 
                 -- Locale selection is a read-only path-resolution step. It
@@ -1090,13 +1282,18 @@ extension AccessibilityChannel {
                     return "MENU_DISABLED"
                 end if
                 try
+                    set dialogActuationIssued to true
                     click mi
                 on error errMsg
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
                     set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
+                        return "DIALOG_ACTUATION_ISSUED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
-                    return "MENU_PICK_FAILED: " & errMsg
+                    return "DIALOG_ACTUATION_ISSUED: " & errMsg
                 end try
                 -- Wait up to 3s for the dialog window to appear before typing,
                 -- otherwise keystrokes would go to the arrange area and click
@@ -1104,32 +1301,39 @@ extension AccessibilityChannel {
                 set dialogReady to false
                 repeat 30 times
                     delay 0.1
-                    try
-                        set _ to first window whose name is "위치로 이동"
+                    set dialogOpenState to my goToPositionDialogState(logicProcess)
+                    if dialogOpenState is "OPEN" then
                         set dialogReady to true
                         exit repeat
-                    end try
-                    try
-                        set _ to first window whose name is "Go to Position"
-                        set dialogReady to true
-                        exit repeat
-                    end try
+                    end if
                 end repeat
                 if not dialogReady then
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
                     set cleanupState to my dismissOpenMenu(logicProcess, true)
                     if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
+                        return "DIALOG_ACTUATION_ISSUED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
-                    return "DIALOG_NOT_READY"
+                    return "DIALOG_ACTUATION_ISSUED: dialog did not become ready"
                 end if
             end tell
-            delay 0.1
-            keystroke "a" using command down
-            delay 0.1
-            keystroke "\(bar)"
-            delay 0.1
-            keystroke return
-            delay 0.2
+            try
+                delay 0.1
+                keystroke "a" using command down
+                delay 0.1
+                keystroke "\(bar)"
+                delay 0.1
+                keystroke return
+                delay 0.2
+            on error errMsg
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_FAILED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_FAILED: dialog input or Return failed after the dialog opened (" & errMsg & ")"
+            end try
         end tell
         return "OK"
         """
@@ -1137,9 +1341,9 @@ extension AccessibilityChannel {
 
     /// The successful AppleScript channel payload is a JSON object containing the
     /// script's return value in `result`. Only an exact `OK` means this route
-    /// reached the dialog and submitted it. Most failures may fall through to
-    /// the slider route, except a menu-close failure that leaves the UI unsafe
-    /// for further actuation.
+    /// reached the dialog and submitted it. Only failures before the position
+    /// menu leaf is issued may fall through to the slider route.  AX return
+    /// codes do not prove whether that leaf (or later dialog input) took effect.
     enum GotoPositionDialogResultClassification: Equatable {
         enum Failure: Equatable {
             case menuNotFound
@@ -1148,6 +1352,8 @@ extension AccessibilityChannel {
             case menuPickFailed
             case menuCouldNotBeClosed(writeAttempted: Bool)
             case dialogNotReady
+            case dialogActuationIssued(cleanupObservedClosed: Bool)
+            case dialogSubmissionIssued(cleanupObservedClosed: Bool)
             case malformedPayload
             case unexpectedResult
             case executionFailed
@@ -1161,6 +1367,41 @@ extension AccessibilityChannel {
                 return true
             }
             return false
+        }
+
+        /// A menu leaf click opens the Go To Position dialog, and keyboard input / Return can
+        /// commit it.  Their status returns are not a licence to choose the slider as another
+        /// position actuator.  `dialogNotReady` is included because the generated script can only
+        /// produce it after it has issued the leaf click.
+        var hasIssuedGoToPositionActuator: Bool {
+            switch self {
+            case .failure(.dialogNotReady),
+                 .failure(.dialogActuationIssued),
+                 .failure(.dialogSubmissionIssued):
+                return true
+            default:
+                return false
+            }
+        }
+
+        var hasIssuedDialogSubmission: Bool {
+            if case .failure(.dialogSubmissionIssued) = self {
+                return true
+            }
+            return false
+        }
+
+        /// Closed is an observed result from the dialog-specific cleanup, never an inference from
+        /// a setter or an Escape return.  A leaf error / not-ready outcome has no closed-dialog
+        /// proof, so the receipt keeps that absence visible.
+        var dialogCleanupObservedClosed: Bool {
+            switch self {
+            case let .failure(.dialogActuationIssued(cleanupObservedClosed)),
+                 let .failure(.dialogSubmissionIssued(cleanupObservedClosed)):
+                return cleanupObservedClosed
+            default:
+                return false
+            }
         }
 
         var menuActuationAttemptedBeforeUnsafeRefusal: Bool {
@@ -1208,6 +1449,14 @@ extension AccessibilityChannel {
             return .failure(.menuPickFailed)
         case "DIALOG_NOT_READY":
             return .failure(.dialogNotReady)
+        case let value where value.hasPrefix("DIALOG_ACTUATION_ISSUED"):
+            return .failure(.dialogActuationIssued(
+                cleanupObservedClosed: !value.contains("dialog cleanup was not observed")
+            ))
+        case let value where value.hasPrefix("DIALOG_SUBMISSION_FAILED"):
+            return .failure(.dialogSubmissionIssued(
+                cleanupObservedClosed: !value.contains("dialog cleanup was not observed")
+            ))
         default:
             return .failure(.unexpectedResult)
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -776,9 +776,7 @@ extension AccessibilityChannel {
         isFrontmost: @Sendable () -> Bool = ProcessUtils.Runtime.production.logicIsFrontmost,
         activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
         sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) },
-        executeDialogScript: @escaping @Sendable (String) async -> ChannelResult = { script in
-            await AppleScriptChannel.executeAppleScript(script, timeout: 8.0)
-        },
+        executeDialogScript: (@Sendable (String) async -> ChannelResult)? = nil,
         reconcileAfterDialogExecutionFailure: @escaping @Sendable () async -> Bool = {
             await observeAndClearStrayGoToPositionUI() == .closed
         }
@@ -845,9 +843,21 @@ extension AccessibilityChannel {
         // cannot show that a successful run had to bring Logic forward first.
         baseExtras["frontmost_preparation"] = preparation.rawValue
 
+        // The AX runtime owns the script seam. Calling `AppleScriptChannel` here would make a
+        // custom runtime only partially injectable and could run a real Logic dialog in a unit
+        // test. Production retains this route's measured eight-second budget; a custom runtime
+        // without a timeout-specific override delegates to its injected `executeAppleScript`.
+        let dialogScriptExecutor: @Sendable (String) async -> ChannelResult
+        if let executeDialogScript {
+            dialogScriptExecutor = executeDialogScript
+        } else {
+            dialogScriptExecutor = { script in
+                await runtime.executeAppleScriptWithTimeout(script, 8.0)
+            }
+        }
         let dialogResult = await gotoPositionViaDialog(
             position: requestedPosition,
-            executeScript: executeDialogScript,
+            executeScript: dialogScriptExecutor,
             reconcileAfterExecutionFailure: reconcileAfterDialogExecutionFailure
         )
         if case let .driven(payload) = dialogResult {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -880,12 +880,17 @@ extension AccessibilityChannel {
         // Reconciliation is part of the same injected runtime as dialog execution. Otherwise a
         // fake runtime that omits this optional test seam can launch live osascript while cleaning
         // up a deliberately failed fixture.
-        let dialogFailureReconciler: @Sendable () async -> Bool
+        let dialogFailureReconciler: @Sendable (String?) async -> Bool
         if let reconcileAfterDialogExecutionFailure {
-            dialogFailureReconciler = reconcileAfterDialogExecutionFailure
+            dialogFailureReconciler = { _ in await reconcileAfterDialogExecutionFailure() }
         } else {
-            dialogFailureReconciler = {
-                await observeAndClearStrayGoToPositionUI(
+            dialogFailureReconciler = { preLeafWindowSnapshotPath in
+                // A timeout without the child-written pre-leaf snapshot cannot establish that any
+                // currently matching modal belongs to this run. Do not launch a cleanup script
+                // that could cancel a user's already-open dialog.
+                guard let preLeafWindowSnapshotPath else { return false }
+                return await observeAndClearStrayGoToPositionUI(
+                    preLeafWindowSnapshotPath: preLeafWindowSnapshotPath,
                     executeScript: { script, timeout in
                         await runtime.executeAppleScriptWithTimeout(script, timeout)
                     }
@@ -1070,13 +1075,15 @@ extension AccessibilityChannel {
     /// the child may already have issued it.
     static func gotoPositionViaDialogAppleScript(
         position: String,
-        issuanceLedgerPath: String? = nil
+        issuanceLedgerPath: String? = nil,
+        preLeafWindowSnapshotPath: String? = nil
     ) -> String {
         // Poll for the dialog's presence instead of relying on a fixed delay.
         // Without this guard, a slow machine (>500ms to render the dialog) would
         // send Cmd+A to the arrange area, selecting all regions unexpectedly.
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
         let ledgerPath = issuanceLedgerPath ?? ""
+        let snapshotPath = preLeafWindowSnapshotPath ?? ""
         return """
         -- A selected menu-bar item is the AX observation that one of Logic's
         -- menus is currently open. Return UNREADABLE rather than treating a
@@ -1167,6 +1174,42 @@ extension AccessibilityChannel {
             end try
         end recordDialogIssuance
 
+        -- The timeout reconciler runs in a fresh osascript process. Persist the exact pre-leaf
+        -- window identities before the leaf click so that process can exclude any dialog this run
+        -- did not open. An unavailable snapshot is intentionally not a clean empty snapshot.
+        on goToPositionWindowIdentifiers(preLeafWindows)
+            set windowIdentifiers to {}
+            try
+                repeat with preLeafWindow in preLeafWindows
+                    set end of windowIdentifiers to (id of contents of preLeafWindow as text)
+                end repeat
+                return windowIdentifiers
+            on error
+                return "UNREADABLE"
+            end try
+        end goToPositionWindowIdentifiers
+
+        on recordPreLeafGoToPositionWindowSnapshot(windowIdentifiers, snapshotPath)
+            if snapshotPath is "" then return true
+            set temporarySnapshotPath to ""
+            try
+                set snapshotText to "READY"
+                repeat with windowIdentifier in windowIdentifiers
+                    set snapshotText to snapshotText & linefeed & (contents of windowIdentifier as text)
+                end repeat
+                set temporarySnapshotPath to do shell script "/usr/bin/mktemp " & quoted form of (snapshotPath & ".tmp.XXXXXX")
+                do shell script "/usr/bin/printf %s " & quoted form of snapshotText & " > " & quoted form of temporarySnapshotPath & " && /bin/mv -f " & quoted form of temporarySnapshotPath & " " & quoted form of snapshotPath
+                return true
+            on error
+                if temporarySnapshotPath is not "" then
+                    try
+                        do shell script "/bin/rm -f " & quoted form of temporarySnapshotPath
+                    end try
+                end if
+                return false
+            end try
+        end recordPreLeafGoToPositionWindowSnapshot
+
         -- Appending this context lets the Swift receipt distinguish an unsafe
         -- entry cleanup (no operation actuation) from an unsafe cleanup after a
         -- menu click. It is deliberately attached only to refusal results.
@@ -1237,6 +1280,28 @@ extension AccessibilityChannel {
                 end tell
             end using terms from
         end matchingGoToPositionDialog
+
+        -- The three exact titles and measured modal class are an input-target predicate, not an
+        -- absence predicate. A newly opened localized or otherwise unfamiliar window may be this
+        -- run's dialog, but must never receive global typing.
+        on newWindowAppearedSince(theProcess, preLeafWindows)
+            if preLeafWindows is "UNREADABLE" then return "UNREADABLE"
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set candidateWindow to contents of dialogWindow
+                            if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then
+                                return "APPEARED"
+                            end if
+                        end repeat
+                        return "ABSENT"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end newWindowAppearedSince
 
         -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
         -- about whether a titled modal is still blocking the arrange area. `AXModal` answers
@@ -1430,6 +1495,13 @@ extension AccessibilityChannel {
                 if preLeafGoToPositionWindows is "UNREADABLE" then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot was unreadable before leaf click"
                 end if
+                set preLeafGoToPositionWindowIdentifiers to my goToPositionWindowIdentifiers(preLeafGoToPositionWindows)
+                if preLeafGoToPositionWindowIdentifiers is "UNREADABLE" then
+                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window identities were unreadable before leaf click"
+                end if
+                if not my recordPreLeafGoToPositionWindowSnapshot(preLeafGoToPositionWindowIdentifiers, "\(snapshotPath)") then
+                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot could not be persisted before leaf click"
+                end if
                 try
                     -- Persist before AXPress: if the child dies after the click, Swift still knows
                     -- that the dialog route may have become active and must not choose another route.
@@ -1463,6 +1535,7 @@ extension AccessibilityChannel {
                 -- same-titled window from being accepted as this request's dialog.
                 set dialogReady to false
                 set dialogAppearanceUnreadable to false
+                set dialogAppearanceUnidentified to false
                 set observedGoToPositionDialog to missing value
                 repeat 30 times
                     delay 0.1
@@ -1475,8 +1548,18 @@ extension AccessibilityChannel {
                         set dialogReady to true
                         exit repeat
                     end if
+                    set newWindowState to my newWindowAppearedSince(logicProcess, preLeafGoToPositionWindows)
+                    if newWindowState is "UNREADABLE" then
+                        set dialogAppearanceUnreadable to true
+                        exit repeat
+                    end if
+                    if newWindowState is "APPEARED" then
+                        set dialogAppearanceUnidentified to true
+                        exit repeat
+                    end if
                 end repeat
                 if not dialogReady then
+                    if dialogAppearanceUnidentified then return "DIALOG_UNIDENTIFIED_NEW_WINDOW"
                     set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
@@ -1647,15 +1730,23 @@ extension AccessibilityChannel {
 
     struct DialogIssuanceLedger: Sendable {
         let url: URL
+        let preLeafWindowSnapshotURL: URL
 
         static func create() -> DialogIssuanceLedger? {
             let url = FileManager.default.temporaryDirectory
                 .appendingPathComponent("logic-pro-mcp-goto-position-\(UUID().uuidString)")
+            let preLeafWindowSnapshotURL = url.appendingPathExtension("preleaf-windows")
             guard FileManager.default.createFile(
                 atPath: url.path,
                 contents: Data(DialogIssuanceStage.notIssued.rawValue.utf8)
-            ) else { return nil }
-            return DialogIssuanceLedger(url: url)
+            ), FileManager.default.createFile(
+                atPath: preLeafWindowSnapshotURL.path,
+                contents: Data("UNAVAILABLE".utf8)
+            ) else {
+                try? FileManager.default.removeItem(at: url)
+                return nil
+            }
+            return DialogIssuanceLedger(url: url, preLeafWindowSnapshotURL: preLeafWindowSnapshotURL)
         }
 
         var stage: DialogIssuanceStage {
@@ -1664,21 +1755,36 @@ extension AccessibilityChannel {
                 ?? .unknown
         }
 
+        /// `READY` is written atomically by the child immediately before the leaf click. Anything
+        /// else — including a killed child or a partial write — withholds reconciliation action.
+        var preLeafWindowSnapshotPath: String? {
+            guard let text = try? String(contentsOf: preLeafWindowSnapshotURL, encoding: .utf8),
+                  text.split(separator: "\n", omittingEmptySubsequences: false).first == "READY"
+            else { return nil }
+            return preLeafWindowSnapshotURL.path
+        }
+
         func remove() {
             // The child may be killed after `mktemp` and before it can rename or clean its sibling.
             // This run's UUID makes the prefix exclusive, so the parent can safely collect those
             // orphaned staging files as well as the canonical ledger.
             let directory = url.deletingLastPathComponent()
-            let temporaryPrefix = url.lastPathComponent + ".tmp."
+            let temporaryPrefixes = [
+                url.lastPathComponent + ".tmp.",
+                preLeafWindowSnapshotURL.lastPathComponent + ".tmp.",
+            ]
             if let siblings = try? FileManager.default.contentsOfDirectory(
                 at: directory,
                 includingPropertiesForKeys: nil
             ) {
-                for sibling in siblings where sibling.lastPathComponent.hasPrefix(temporaryPrefix) {
+                for sibling in siblings where temporaryPrefixes.contains(where: {
+                    sibling.lastPathComponent.hasPrefix($0)
+                }) {
                     try? FileManager.default.removeItem(at: sibling)
                 }
             }
             try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: preLeafWindowSnapshotURL)
         }
     }
 
@@ -1701,6 +1807,7 @@ extension AccessibilityChannel {
             case dialogPreexisting
             case dialogPreexistenceUnreadable
             case dialogNotReady
+            case dialogUnidentifiedNewWindow
             case dialogActuationIssued(cleanupObservedClosed: Bool)
             case dialogSubmissionNotIssued(cleanupObservedClosed: Bool)
             case dialogInputIssued(issuance: DialogIssuanceStage, cleanupObservedClosed: Bool)
@@ -1728,6 +1835,7 @@ extension AccessibilityChannel {
             case .failure(.dialogPreexisting): return "dialog_preexisting"
             case .failure(.dialogPreexistenceUnreadable): return "dialog_preexistence_unreadable"
             case .failure(.dialogNotReady): return "dialog_not_ready"
+            case .failure(.dialogUnidentifiedNewWindow): return "dialog_unidentified_new_window"
             case let .failure(.dialogActuationIssued(closed)):
                 return "dialog_actuation_issued_cleanup_closed_\(closed)"
             case let .failure(.dialogSubmissionNotIssued(closed)):
@@ -1820,6 +1928,7 @@ extension AccessibilityChannel {
             case .failure(.menuCouldNotBeClosed),
                  .failure(.dialogPreexisting),
                  .failure(.dialogPreexistenceUnreadable),
+                 .failure(.dialogUnidentifiedNewWindow),
                  .failure(.dialogActuationIssued(cleanupObservedClosed: false)),
                  .failure(.dialogSubmissionNotIssued(cleanupObservedClosed: false)),
                  .failure(.dialogNotReady),
@@ -1833,6 +1942,7 @@ extension AccessibilityChannel {
         var dialogActuationMayHaveOccurred: Bool {
             switch self {
             case .failure(.dialogNotReady),
+                 .failure(.dialogUnidentifiedNewWindow),
                  .failure(.dialogActuationIssued),
                  .failure(.dialogSubmissionNotIssued),
                  .failure(.dialogInputIssued),
@@ -1909,6 +2019,8 @@ extension AccessibilityChannel {
             return .failure(.menuPickFailed)
         case "DIALOG_NOT_READY":
             return .failure(.dialogNotReady)
+        case "DIALOG_UNIDENTIFIED_NEW_WINDOW":
+            return .failure(.dialogUnidentifiedNewWindow)
         case let value where value.hasPrefix("DIALOG_ACTUATION_ISSUED"):
             return .failure(.dialogActuationIssued(
                 // A closed dialog is insufficient if a menu cleanup remained unreadable. Both
@@ -1947,14 +2059,15 @@ extension AccessibilityChannel {
     private static func gotoPositionViaDialog(
         position: String,
         executeScript: @escaping @Sendable (String) async -> ChannelResult,
-        reconcileAfterExecutionFailure: @escaping @Sendable () async -> Bool,
+        reconcileAfterExecutionFailure: @escaping @Sendable (String?) async -> Bool,
         createIssuanceLedger: @escaping @Sendable () -> DialogIssuanceLedger?
     ) async -> GotoPositionDialogRouteResult {
         let ledger = createIssuanceLedger()
         defer { ledger?.remove() }
         let script = gotoPositionViaDialogAppleScript(
             position: position,
-            issuanceLedgerPath: ledger?.url.path
+            issuanceLedgerPath: ledger?.url.path,
+            preLeafWindowSnapshotPath: ledger?.preLeafWindowSnapshotURL.path
         )
         let result = await executeScript(script)
         switch result {
@@ -1992,7 +2105,9 @@ extension AccessibilityChannel {
             // child may have crossed a UI boundary, and a failed reconciliation is never evidence
             // that a dead child left no modal/menu behind.
             let issuance = ledger?.stage ?? .unknown
-            let cleanupObservedClosed = await reconcileAfterExecutionFailure()
+            let cleanupObservedClosed = await reconcileAfterExecutionFailure(
+                ledger?.preLeafWindowSnapshotPath
+            )
             return .failed(.failure(.executionFailed(
                 issuance: issuance,
                 cleanupObservedClosed: cleanupObservedClosed
@@ -2006,6 +2121,7 @@ extension AccessibilityChannel {
     /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise another route
     /// while the dialog remains on screen.
     private static func observeAndClearStrayGoToPositionUI(
+        preLeafWindowSnapshotPath: String,
         executeScript: @escaping @Sendable (String, TimeInterval) async -> ChannelResult
     ) async -> StrayGoToPositionUIOutcome {
         let target = LogicProTarget.appleScriptTarget()
@@ -2015,20 +2131,58 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
-        -- Reconciliation has no live AX element from the killed child, so it can only match the
-        -- measured modal class. It must never turn a same-titled normal/editor window into a
-        -- cleanup target merely because its title collides with the dialog.
-        on matchingGoToPositionDialog(theProcess)
+        -- The timeout process must not infer ownership from a title. The child persisted these IDs
+        -- immediately before its leaf click; failure to read that snapshot is unsafe, not empty.
+        on preLeafGoToPositionWindowIdentifiers(snapshotPath)
+            try
+                set snapshotText to do shell script "/bin/cat " & (quoted form of snapshotPath)
+                set originalTextItemDelimiters to AppleScript's text item delimiters
+                set AppleScript's text item delimiters to linefeed
+                set snapshotItems to text items of snapshotText
+                set AppleScript's text item delimiters to originalTextItemDelimiters
+                if (count of snapshotItems) is 0 then return "UNREADABLE"
+                if item 1 of snapshotItems is not "READY" then return "UNREADABLE"
+                set windowIdentifiers to {}
+                if (count of snapshotItems) is greater than 1 then
+                    repeat with snapshotItem from 2 to (count of snapshotItems)
+                        set windowIdentifier to item snapshotItem of snapshotItems
+                        if windowIdentifier is not "" then
+                            set end of windowIdentifiers to windowIdentifier
+                        end if
+                    end repeat
+                end if
+                return windowIdentifiers
+            on error
+                try
+                    set AppleScript's text item delimiters to originalTextItemDelimiters
+                end try
+                return "UNREADABLE"
+            end try
+        end preLeafGoToPositionWindowIdentifiers
+
+        on windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers)
+            repeat with preLeafWindowIdentifier in preLeafWindowIdentifiers
+                if contents of preLeafWindowIdentifier is windowIdentifier then return true
+            end repeat
+            return false
+        end windowWasPresentBefore
+
+        -- Reconciliation can only act on a measured dialog that was absent from this run's durable
+        -- pre-leaf snapshot. A same-titled modal from before the click is reported, never cancelled.
+        on matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
             using terms from application "System Events"
                 tell theProcess
                     try
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                set dialogSubrole to subrole of dialogWindow
-                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
-                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                    if dialogIsModal is true then return contents of dialogWindow
+                                set windowIdentifier to id of dialogWindow as text
+                                if not my windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers) then
+                                    set dialogSubrole to subrole of dialogWindow
+                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                        if dialogIsModal is true then return contents of dialogWindow
+                                    end if
                                 end if
                             end if
                         end repeat
@@ -2040,11 +2194,39 @@ extension AccessibilityChannel {
             end using terms from
         end matchingGoToPositionDialog
 
-        on goToPositionDialogState(theProcess)
-            set dialogWindow to my matchingGoToPositionDialog(theProcess)
+        on preexistingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set windowIdentifier to id of dialogWindow as text
+                                if my windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers) then
+                                    set dialogSubrole to subrole of dialogWindow
+                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                        if dialogIsModal is true then return contents of dialogWindow
+                                    end if
+                                end if
+                            end if
+                        end repeat
+                        return missing value
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end preexistingGoToPositionDialog
+
+        on goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
+            set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
             if dialogWindow is "UNREADABLE" then return "UNREADABLE"
-            if dialogWindow is missing value then return "CLOSED"
-            return "OPEN"
+            if dialogWindow is not missing value then return "OPEN"
+            set preexistingDialogWindow to my preexistingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+            if preexistingDialogWindow is "UNREADABLE" then return "UNREADABLE"
+            if preexistingDialogWindow is not missing value then return "PREEXISTING"
+            return "CLOSED"
         end goToPositionDialogState
 
         -- System Events keystrokes are global. Re-check frontmost after proving the exact modal
@@ -2096,14 +2278,14 @@ extension AccessibilityChannel {
             end using terms from
         end menuEscapeFocusState
 
-        on dismissGoToPositionDialog(theProcess)
-            set dialogState to my goToPositionDialogState(theProcess)
+        on dismissGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+            set dialogState to my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
-                set dialogWindow to my matchingGoToPositionDialog(theProcess)
+                set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
                 if dialogWindow is "UNREADABLE" then return "UNREADABLE"
-                if dialogWindow is missing value then return "CLOSED"
+                if dialogWindow is missing value then return my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
                 set cancelPressed to false
                 using terms from application "System Events"
                     tell theProcess
@@ -2128,7 +2310,7 @@ extension AccessibilityChannel {
                     end tell
                 end using terms from
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess)
+                set dialogState to my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is not "OPEN" then return dialogState
             end repeat
@@ -2138,7 +2320,9 @@ extension AccessibilityChannel {
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
                 try
-                    set dialogCleanupState to my dismissGoToPositionDialog(it)
+                    set preLeafWindowIdentifiers to my preLeafGoToPositionWindowIdentifiers("\(preLeafWindowSnapshotPath)")
+                    if preLeafWindowIdentifiers is "UNREADABLE" then return "DIALOG_UNREADABLE"
+                    set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafWindowIdentifiers)
                     if dialogCleanupState is not "CLOSED" then return "DIALOG_" & dialogCleanupState
                     repeat 3 times
                         set menuFocusState to my menuEscapeFocusState(it)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -906,9 +906,9 @@ extension AccessibilityChannel {
         }
         if case let .failed(classification) = dialogResult,
            classification.requiresFallbackSuppression {
-            // A dead child after LEAF_ARMED/RETURN_ARMED leaves the UI boundary indeterminate, so
-            // another position actuator remains unsafe. That safety rule is not evidence that a
-            // Return was sent: only a normal script result can claim a position submission.
+            // A normal global-input result or a dead child after a durable UI/input boundary leaves
+            // the target indeterminate, so another position actuator remains unsafe. The boundary
+            // does not prove a Return was sent: only a normal script result can claim a submission.
             let dialogState = classification.cleanupObservedClosed ? "closed" : "unobserved"
             var extras = baseExtras.merging([
                 "operation": "transport.goto_position",
@@ -918,9 +918,26 @@ extension AccessibilityChannel {
                 "safe_to_retry": false,
                 "fallback_unsafe": true,
             ]) { _, new in new }
+            if classification.globalInputMayHaveOccurred {
+                extras["dialog_input_attempted"] = true
+                if let inputBoundary = classification.globalInputBoundary {
+                    extras["dialog_input_boundary"] = inputBoundary.rawValue
+                }
+                extras["dialog_input_target"] = "unknown"
+                // The marker is written before the global event. A child can die immediately
+                // afterwards, so this is deliberately conservative rather than a claim that the
+                // observed Go To Position window consumed the input.
+                extras["write_attempted"] = true
+            }
             if classification.dialogSubmissionWasObserved {
                 extras["dialog_submission_attempted"] = true
                 extras["write_attempted"] = true
+            } else if classification.dialogSubmissionMayHaveOccurred {
+                extras["dialog_submission_indeterminate"] = true
+            } else if classification.globalInputMayHaveOccurred {
+                // The completed script proved it did not advance to RETURN_ARMED, but an earlier
+                // global key may already have changed whichever target owned focus.
+                extras["dialog_submission_attempted"] = false
             } else {
                 extras["dialog_submission_indeterminate"] = true
             }
@@ -1377,8 +1394,9 @@ extension AccessibilityChannel {
                     return "DIALOG_ACTUATION_ISSUED: dialog did not become ready"
                 end if
             end tell
-            -- Everything in this block is provably before Return. A normal script result from
-            -- here must therefore remain a non-submission failure, never State B-after-nothing.
+            -- Everything in this block is before Return, but System Events keyboard input is
+            -- global. Once an input boundary is durably armed, a normal result must report that
+            -- it may have reached an unknown target rather than advertising a clean retry.
             set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogFocusState is not "FOCUSED" then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
@@ -1392,18 +1410,29 @@ extension AccessibilityChannel {
                 return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogFocusState & ")"
             end if
             try
+                if not my recordDialogIssuance("SELECT_ALL_ARMED", "\(ledgerPath)") then
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    if cleanupState is not "CLOSED" then
+                        return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: could not persist Cmd+A issuance"
+                end if
                 keystroke "a" using command down
                 delay 0.1
             on error errMsg
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
                 set cleanupState to my dismissOpenMenu(logicProcess, true)
                 if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (" & errMsg & ")"
+                return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: Cmd+A may have been sent (" & errMsg & ")"
             end try
 
             -- Cmd+A is global too. Re-check the same observed window immediately before typing
@@ -1412,54 +1441,65 @@ extension AccessibilityChannel {
             if dialogTypingFocusState is not "FOCUSED" then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
                 set cleanupState to my dismissOpenMenu(logicProcess, true)
                 if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogTypingFocusState & ")"
+                return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: observed Go To Position dialog was not focused before typing (" & dialogTypingFocusState & ")"
             end if
             try
+                if not my recordDialogIssuance("POSITION_INPUT_ARMED", "\(ledgerPath)") then
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    if cleanupState is not "CLOSED" then
+                        return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: could not persist position input issuance"
+                end if
                 keystroke "\(position)"
                 delay 0.1
             on error errMsg
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
                 set cleanupState to my dismissOpenMenu(logicProcess, true)
                 if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (" & errMsg & ")"
+                return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: position text may have been sent (" & errMsg & ")"
             end try
 
-            -- This durable marker is the position-write boundary. It is written before Return so
-            -- a timeout or nonzero child exit after this point is conservatively reported as a
-            -- possibly-issued submission rather than releasing another actuator.
+            -- POSITION_INPUT_ARMED above is the text-write boundary. This separate marker is the
+            -- Return submission boundary, so a timeout or nonzero child exit after either point is
+            -- conservatively reported rather than releasing another actuator.
             set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogReturnFocusState is not "FOCUSED" then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
                 set cleanupState to my dismissOpenMenu(logicProcess, true)
                 if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before Return (" & dialogReturnFocusState & ")"
+                return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: observed Go To Position dialog was not focused before Return (" & dialogReturnFocusState & ")"
             end if
             if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
                 set cleanupState to my dismissOpenMenu(logicProcess, true)
                 if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: could not persist Return issuance"
+                return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: could not persist Return issuance"
             end if
             try
                 keystroke return
@@ -1499,6 +1539,8 @@ extension AccessibilityChannel {
     enum DialogIssuanceStage: String, Equatable {
         case notIssued = "NOT_ISSUED"
         case leafArmed = "LEAF_ARMED"
+        case selectAllArmed = "SELECT_ALL_ARMED"
+        case positionInputArmed = "POSITION_INPUT_ARMED"
         case returnArmed = "RETURN_ARMED"
         case unknown
     }
@@ -1542,6 +1584,7 @@ extension AccessibilityChannel {
             case dialogNotReady
             case dialogActuationIssued(cleanupObservedClosed: Bool)
             case dialogSubmissionNotIssued(cleanupObservedClosed: Bool)
+            case dialogInputIssued(issuance: DialogIssuanceStage, cleanupObservedClosed: Bool)
             case dialogSubmissionIssued(cleanupObservedClosed: Bool)
             case executionFailed(issuance: DialogIssuanceStage, cleanupObservedClosed: Bool)
             case malformedPayload
@@ -1570,6 +1613,8 @@ extension AccessibilityChannel {
                 return "dialog_actuation_issued_cleanup_closed_\(closed)"
             case let .failure(.dialogSubmissionNotIssued(closed)):
                 return "dialog_submission_not_issued_cleanup_closed_\(closed)"
+            case let .failure(.dialogInputIssued(issuance, closed)):
+                return "dialog_input_issued_\(issuance.rawValue)_cleanup_closed_\(closed)"
             case let .failure(.dialogSubmissionIssued(closed)):
                 return "dialog_submission_issued_cleanup_closed_\(closed)"
             case let .failure(.executionFailed(issuance, closed)):
@@ -1579,13 +1624,16 @@ extension AccessibilityChannel {
             }
         }
 
-        /// A second position actuator is unsafe after a normal Return or a dead child that crossed
-        /// either durable UI boundary. LEAF_ARMED is a safety boundary only: it does not prove a
-        /// dialog actuation or position submission occurred.
+        /// A second position actuator is unsafe after a normal global input or a dead child that
+        /// crossed any durable UI/input boundary. LEAF_ARMED is a safety boundary only: it does
+        /// not prove a dialog actuation, global input, or position submission occurred.
         var requiresFallbackSuppression: Bool {
             switch self {
-            case .failure(.dialogSubmissionIssued),
+            case .failure(.dialogInputIssued),
+                 .failure(.dialogSubmissionIssued),
                  .failure(.executionFailed(issuance: .leafArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .positionInputArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
                 return true
@@ -1603,9 +1651,56 @@ extension AccessibilityChannel {
             return false
         }
 
+        /// True once the script reported a global key may have been issued, or a dead child
+        /// crossed the corresponding durable marker. This protects the receipt from claiming
+        /// `write_attempted:false` after Cmd+A, text entry, or Return could have reached another
+        /// focused target.
+        var globalInputMayHaveOccurred: Bool {
+            switch self {
+            case .failure(.dialogInputIssued),
+                 .failure(.dialogSubmissionIssued),
+                 .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .positionInputArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)):
+                return true
+            default:
+                return false
+            }
+        }
+
+        /// The last durable global-input boundary for receipt diagnostics. A normal script result
+        /// reports the exact stage; an execution failure reports the last marker safely persisted
+        /// before the child exited.
+        var globalInputBoundary: DialogIssuanceStage? {
+            switch self {
+            case let .failure(.dialogInputIssued(issuance, _)):
+                return issuance
+            case .failure(.dialogSubmissionIssued):
+                return .returnArmed
+            case let .failure(.executionFailed(issuance, _)) where issuance == .selectAllArmed
+                || issuance == .positionInputArmed || issuance == .returnArmed:
+                return issuance
+            default:
+                return nil
+            }
+        }
+
+        /// A normal input result before Return proves no submission was attempted. A dead child
+        /// after RETURN_ARMED, or with no readable ledger, cannot make that same claim.
+        var dialogSubmissionMayHaveOccurred: Bool {
+            switch self {
+            case .failure(.dialogSubmissionIssued),
+                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
+                return true
+            default:
+                return false
+            }
+        }
+
         /// A later position route is unsafe when a non-submission path cannot prove the menu/dialog UI is gone.
-        /// A clean, normal leaf/input failure may fall through because the script proved no Return
-        /// was sent *and* observed the relevant UI closed.
+        /// A clean, normal leaf or pre-input focus failure may fall through because the script
+        /// proved no global input or Return was sent and observed the relevant UI closed.
         var requiresUnsafeUIRefusal: Bool {
             switch self {
             case .failure(.menuCouldNotBeClosed),
@@ -1626,7 +1721,10 @@ extension AccessibilityChannel {
             case .failure(.dialogNotReady),
                  .failure(.dialogActuationIssued),
                  .failure(.dialogSubmissionNotIssued),
+                 .failure(.dialogInputIssued),
                  .failure(.dialogSubmissionIssued),
+                 .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .positionInputArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
                 return true
@@ -1639,6 +1737,7 @@ extension AccessibilityChannel {
             switch self {
             case let .failure(.dialogActuationIssued(cleanupObservedClosed)),
                  let .failure(.dialogSubmissionNotIssued(cleanupObservedClosed)),
+                 let .failure(.dialogInputIssued(issuance: _, cleanupObservedClosed: cleanupObservedClosed)),
                  let .failure(.dialogSubmissionIssued(cleanupObservedClosed)),
                  let .failure(.executionFailed(issuance: _, cleanupObservedClosed)):
                 return cleanupObservedClosed
@@ -1705,6 +1804,16 @@ extension AccessibilityChannel {
             ))
         case let value where value.hasPrefix("DIALOG_SUBMISSION_NOT_ISSUED"):
             return .failure(.dialogSubmissionNotIssued(
+                cleanupObservedClosed: !value.contains("cleanup was not observed")
+            ))
+        case let value where value.hasPrefix("DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED"):
+            return .failure(.dialogInputIssued(
+                issuance: .selectAllArmed,
+                cleanupObservedClosed: !value.contains("cleanup was not observed")
+            ))
+        case let value where value.hasPrefix("DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED"):
+            return .failure(.dialogInputIssued(
+                issuance: .positionInputArmed,
                 cleanupObservedClosed: !value.contains("cleanup was not observed")
             ))
         case let value where value.hasPrefix("DIALOG_SUBMISSION_ISSUED"):

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1174,29 +1174,15 @@ extension AccessibilityChannel {
             end try
         end recordDialogIssuance
 
-        -- The timeout reconciler runs in a fresh osascript process. Persist the exact pre-leaf
-        -- window identities before the leaf click so that process can exclude any dialog this run
-        -- did not open. An unavailable snapshot is intentionally not a clean empty snapshot.
-        on goToPositionWindowIdentifiers(preLeafWindows)
-            set windowIdentifiers to {}
-            try
-                repeat with preLeafWindow in preLeafWindows
-                    set end of windowIdentifiers to (id of contents of preLeafWindow as text)
-                end repeat
-                return windowIdentifiers
-            on error
-                return "UNREADABLE"
-            end try
-        end goToPositionWindowIdentifiers
-
-        on recordPreLeafGoToPositionWindowSnapshot(windowIdentifiers, snapshotPath)
+        -- The timeout reconciler runs in a fresh osascript process. Persist only the readable
+        -- count of exact Go To Position dialogs immediately before the leaf click. Window IDs are
+        -- not readable in Logic Pro, and names/geometry are neither stable identities nor safe
+        -- serialized data. An unavailable snapshot is intentionally not a clean empty snapshot.
+        on recordPreLeafGoToPositionWindowSnapshot(matchingGoToPositionDialogCount, snapshotPath)
             if snapshotPath is "" then return true
             set temporarySnapshotPath to ""
             try
-                set snapshotText to "READY"
-                repeat with windowIdentifier in windowIdentifiers
-                    set snapshotText to snapshotText & linefeed & (contents of windowIdentifier as text)
-                end repeat
+                set snapshotText to "READY" & linefeed & (matchingGoToPositionDialogCount as text)
                 set temporarySnapshotPath to do shell script "/usr/bin/mktemp " & quoted form of (snapshotPath & ".tmp.XXXXXX")
                 do shell script "/usr/bin/printf %s " & quoted form of snapshotText & " > " & quoted form of temporarySnapshotPath & " && /bin/mv -f " & quoted form of temporarySnapshotPath & " " & quoted form of snapshotPath
                 return true
@@ -1227,53 +1213,82 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
-        -- Capture every pre-leaf window by element identity. A track or plug-in editor can be
-        -- titled "Go To Position", so title/subrole/modality alone cannot say that a window belongs
-        -- to this request. The input target must be a matching window that appeared after this
-        -- run's resolved leaf click.
-        on goToPositionWindowSnapshot(theProcess)
+        -- Count only windows that satisfy the measured input-target predicate. All properties used
+        -- here are readable from Logic Pro; errors are intentionally fail-closed. This numeric
+        -- observation is stable when a window moves and cannot embed a project/window title.
+        on goToPositionDialogCount(theProcess)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        return every window
+                        set matchingWindowCount to 0
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set dialogSubrole to subrole of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then set matchingWindowCount to matchingWindowCount + 1
+                                end if
+                            end if
+                        end repeat
+                        return matchingWindowCount
                     on error
                         return "UNREADABLE"
                     end try
                 end tell
             end using terms from
-        end goToPositionWindowSnapshot
+        end goToPositionDialogCount
 
-        on windowWasPresentBefore(dialogWindow, preLeafWindows)
-            repeat with preLeafWindow in preLeafWindows
-                try
-                    if contents of preLeafWindow is dialogWindow then return true
-                end try
-            end repeat
+        -- This count-based relation replaces unreadable per-window IDs. Equality or a decrease
+        -- means no matching dialog has appeared since the pre-leaf observation; only an increase
+        -- can establish a new matching dialog.
+        on windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
+            if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionDialogCount is less than or equal to preLeafGoToPositionDialogCount then return true
             return false
         end windowWasPresentBefore
 
-        -- Find only an operable, modal Go To Position window that this leaf could have opened.
-        -- Pre-existing same-titled windows are skipped before reading their subrole or AXModal, so
-        -- an unrelated plug-in editor with an unreadable modality cannot block this request.
-        on matchingGoToPositionDialog(theProcess, preLeafWindows)
-            if preLeafWindows is "UNREADABLE" then return "UNREADABLE"
+        -- Keep this in-process count only to preserve the terminal outcome for a newly opened
+        -- window that is not an operable Go To Position dialog. It is never serialized or treated
+        -- as an identity: a count increase merely refuses input rather than naming a target.
+        on goToPositionWindowCount(theProcess)
             using terms from application "System Events"
                 tell theProcess
                     try
+                        return count of every window
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionWindowCount
+
+        -- Find only an operable, modal Go To Position window that this leaf could have opened.
+        -- A target requires exactly one post-leaf match beyond the readable pre-leaf count; any
+        -- pre-existing matching dialog or non-unique increase withholds global typing.
+        on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
+            if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        set matchingDialogWindows to {}
                         repeat with dialogWindow in every window
-                            set candidateWindow to contents of dialogWindow
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then
-                                    set dialogSubrole to subrole of dialogWindow
-                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
-                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                        if dialogIsModal is true then return candidateWindow
-                                    end if
+                                set dialogSubrole to subrole of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then set end of matchingDialogWindows to contents of dialogWindow
                                 end if
                             end if
                         end repeat
-                        return missing value
+                        set currentGoToPositionDialogCount to count of matchingDialogWindows
+                        set wasPresentBefore to my windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
+                        if wasPresentBefore is "UNREADABLE" then return "UNREADABLE"
+                        if wasPresentBefore then return missing value
+                        if currentGoToPositionDialogCount is not (preLeafGoToPositionDialogCount + 1) then return missing value
+                        return item 1 of matchingDialogWindows
                     on error
                         return "UNREADABLE"
                     end try
@@ -1284,23 +1299,12 @@ extension AccessibilityChannel {
         -- The three exact titles and measured modal class are an input-target predicate, not an
         -- absence predicate. A newly opened localized or otherwise unfamiliar window may be this
         -- run's dialog, but must never receive global typing.
-        on newWindowAppearedSince(theProcess, preLeafWindows)
-            if preLeafWindows is "UNREADABLE" then return "UNREADABLE"
-            using terms from application "System Events"
-                tell theProcess
-                    try
-                        repeat with dialogWindow in every window
-                            set candidateWindow to contents of dialogWindow
-                            if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then
-                                return "APPEARED"
-                            end if
-                        end repeat
-                        return "ABSENT"
-                    on error
-                        return "UNREADABLE"
-                    end try
-                end tell
-            end using terms from
+        on newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
+            if preLeafGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
+            set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)
+            if currentGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionWindowCount is greater than preLeafGoToPositionWindowCount then return "APPEARED"
+            return "ABSENT"
         end newWindowAppearedSince
 
         -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
@@ -1487,19 +1491,22 @@ extension AccessibilityChannel {
                     end if
                     return "MENU_DISABLED"
                 end if
-                -- The window identity snapshot, not its title, is the first half of this run's
-                -- absence → leaf → appearance transition. A pre-existing plug-in editor may use
-                -- the same title (and even AXDialog), but can never become this run's input target.
+                -- A readable count of the exact dialog predicate is the first half of this run's
+                -- absence → leaf → appearance transition. It records no user-controlled title or
+                -- geometry. A pre-existing matching dialog is never an input target for this run.
                 set observedGoToPositionDialog to missing value
-                set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)
-                if preLeafGoToPositionWindows is "UNREADABLE" then
+                set preLeafGoToPositionDialogCount to my goToPositionDialogCount(logicProcess)
+                if preLeafGoToPositionDialogCount is "UNREADABLE" then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot was unreadable before leaf click"
                 end if
-                set preLeafGoToPositionWindowIdentifiers to my goToPositionWindowIdentifiers(preLeafGoToPositionWindows)
-                if preLeafGoToPositionWindowIdentifiers is "UNREADABLE" then
-                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window identities were unreadable before leaf click"
+                if preLeafGoToPositionDialogCount is greater than 0 then
+                    return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click"
                 end if
-                if not my recordPreLeafGoToPositionWindowSnapshot(preLeafGoToPositionWindowIdentifiers, "\(snapshotPath)") then
+                set preLeafGoToPositionWindowCount to my goToPositionWindowCount(logicProcess)
+                if preLeafGoToPositionWindowCount is "UNREADABLE" then
+                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window count was unreadable before leaf click"
+                end if
+                if not my recordPreLeafGoToPositionWindowSnapshot(preLeafGoToPositionDialogCount, "\(snapshotPath)") then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot could not be persisted before leaf click"
                 end if
                 try
@@ -1539,7 +1546,7 @@ extension AccessibilityChannel {
                 set observedGoToPositionDialog to missing value
                 repeat 30 times
                     delay 0.1
-                    set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionWindows)
+                    set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionDialogCount)
                     if observedGoToPositionDialog is "UNREADABLE" then
                         set dialogAppearanceUnreadable to true
                         exit repeat
@@ -1548,7 +1555,7 @@ extension AccessibilityChannel {
                         set dialogReady to true
                         exit repeat
                     end if
-                    set newWindowState to my newWindowAppearedSince(logicProcess, preLeafGoToPositionWindows)
+                    set newWindowState to my newWindowAppearedSince(logicProcess, preLeafGoToPositionWindowCount)
                     if newWindowState is "UNREADABLE" then
                         set dialogAppearanceUnreadable to true
                         exit repeat
@@ -1755,11 +1762,19 @@ extension AccessibilityChannel {
                 ?? .unknown
         }
 
-        /// `READY` is written atomically by the child immediately before the leaf click. Anything
-        /// else — including a killed child or a partial write — withholds reconciliation action.
+        /// `READY` plus one canonical decimal count is written atomically by the child immediately
+        /// before the leaf click. Anything else — including a killed child, a partial write, or an
+        /// ambiguous count — withholds reconciliation action.
         var preLeafWindowSnapshotPath: String? {
-            guard let text = try? String(contentsOf: preLeafWindowSnapshotURL, encoding: .utf8),
-                  text.split(separator: "\n", omittingEmptySubsequences: false).first == "READY"
+            guard let text = try? String(contentsOf: preLeafWindowSnapshotURL, encoding: .utf8) else {
+                return nil
+            }
+            let snapshotItems = text.split(separator: "\n", omittingEmptySubsequences: false)
+            guard snapshotItems.count == 2,
+                  snapshotItems[0] == "READY",
+                  let matchingDialogCount = Int(snapshotItems[1]),
+                  matchingDialogCount >= 0,
+                  String(matchingDialogCount) == snapshotItems[1]
             else { return nil }
             return preLeafWindowSnapshotURL.path
         }
@@ -2131,62 +2146,91 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
-        -- The timeout process must not infer ownership from a title. The child persisted these IDs
-        -- immediately before its leaf click; failure to read that snapshot is unsafe, not empty.
-        on preLeafGoToPositionWindowIdentifiers(snapshotPath)
+        -- The timeout process must not infer ownership from a title. The child persisted one
+        -- canonical, readable count immediately before its leaf click; failure to read exactly
+        -- that two-line format is unsafe, not empty.
+        on preLeafGoToPositionDialogCount(snapshotPath)
             try
                 set snapshotText to do shell script "/bin/cat " & (quoted form of snapshotPath)
                 set originalTextItemDelimiters to AppleScript's text item delimiters
                 set AppleScript's text item delimiters to linefeed
                 set snapshotItems to text items of snapshotText
                 set AppleScript's text item delimiters to originalTextItemDelimiters
-                if (count of snapshotItems) is 0 then return "UNREADABLE"
+                if (count of snapshotItems) is not 2 then return "UNREADABLE"
                 if item 1 of snapshotItems is not "READY" then return "UNREADABLE"
-                set windowIdentifiers to {}
-                if (count of snapshotItems) is greater than 1 then
-                    repeat with snapshotItem from 2 to (count of snapshotItems)
-                        set windowIdentifier to item snapshotItem of snapshotItems
-                        if windowIdentifier is not "" then
-                            set end of windowIdentifiers to windowIdentifier
-                        end if
-                    end repeat
-                end if
-                return windowIdentifiers
+                set matchingDialogCountText to item 2 of snapshotItems
+                if matchingDialogCountText is "" then return "UNREADABLE"
+                if matchingDialogCountText is not "0" and character 1 of matchingDialogCountText is "0" then return "UNREADABLE"
+                repeat with countCharacter in characters of matchingDialogCountText
+                    set countCharacterText to contents of countCharacter
+                    if countCharacterText is not in "0123456789" then return "UNREADABLE"
+                end repeat
+                set matchingDialogCount to matchingDialogCountText as integer
+                if matchingDialogCount is less than 0 then return "UNREADABLE"
+                return matchingDialogCount
             on error
                 try
                     set AppleScript's text item delimiters to originalTextItemDelimiters
                 end try
                 return "UNREADABLE"
             end try
-        end preLeafGoToPositionWindowIdentifiers
+        end preLeafGoToPositionDialogCount
 
-        on windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers)
-            repeat with preLeafWindowIdentifier in preLeafWindowIdentifiers
-                if contents of preLeafWindowIdentifier is windowIdentifier then return true
-            end repeat
+        on windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
+            if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionDialogCount is less than or equal to preLeafGoToPositionDialogCount then return true
             return false
         end windowWasPresentBefore
 
-        -- Reconciliation can only act on a measured dialog that was absent from this run's durable
-        -- pre-leaf snapshot. A same-titled modal from before the click is reported, never cancelled.
-        on matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+        on goToPositionDialogCount(theProcess)
             using terms from application "System Events"
                 tell theProcess
                     try
+                        set matchingWindowCount to 0
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                set windowIdentifier to id of dialogWindow as text
-                                if not my windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers) then
-                                    set dialogSubrole to subrole of dialogWindow
-                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
-                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                        if dialogIsModal is true then return contents of dialogWindow
-                                    end if
+                                set dialogSubrole to subrole of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then set matchingWindowCount to matchingWindowCount + 1
                                 end if
                             end if
                         end repeat
-                        return missing value
+                        return matchingWindowCount
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionDialogCount
+
+        -- Reconciliation may act only when the pre-leaf count was zero and exactly one matching
+        -- dialog exists now. A nonzero pre-leaf count is reported without scanning for a target.
+        on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
+            if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if preLeafGoToPositionDialogCount is greater than 0 then return missing value
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        set matchingDialogWindows to {}
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set dialogSubrole to subrole of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then set end of matchingDialogWindows to contents of dialogWindow
+                                end if
+                            end if
+                        end repeat
+                        set currentGoToPositionDialogCount to count of matchingDialogWindows
+                        set wasPresentBefore to my windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
+                        if wasPresentBefore is "UNREADABLE" then return "UNREADABLE"
+                        if wasPresentBefore then return missing value
+                        if currentGoToPositionDialogCount is not (preLeafGoToPositionDialogCount + 1) then return missing value
+                        return item 1 of matchingDialogWindows
                     on error
                         return "UNREADABLE"
                     end try
@@ -2194,38 +2238,15 @@ extension AccessibilityChannel {
             end using terms from
         end matchingGoToPositionDialog
 
-        on preexistingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
-            using terms from application "System Events"
-                tell theProcess
-                    try
-                        repeat with dialogWindow in every window
-                            set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                set windowIdentifier to id of dialogWindow as text
-                                if my windowWasPresentBefore(windowIdentifier, preLeafWindowIdentifiers) then
-                                    set dialogSubrole to subrole of dialogWindow
-                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
-                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                        if dialogIsModal is true then return contents of dialogWindow
-                                    end if
-                                end if
-                            end if
-                        end repeat
-                        return missing value
-                    on error
-                        return "UNREADABLE"
-                    end try
-                end tell
-            end using terms from
-        end preexistingGoToPositionDialog
-
-        on goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
-            set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+        on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
+            if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if preLeafGoToPositionDialogCount is greater than 0 then return "PREEXISTING"
+            set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
             if dialogWindow is "UNREADABLE" then return "UNREADABLE"
             if dialogWindow is not missing value then return "OPEN"
-            set preexistingDialogWindow to my preexistingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
-            if preexistingDialogWindow is "UNREADABLE" then return "UNREADABLE"
-            if preexistingDialogWindow is not missing value then return "PREEXISTING"
+            set currentGoToPositionDialogCount to my goToPositionDialogCount(theProcess)
+            if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionDialogCount is greater than preLeafGoToPositionDialogCount then return "UNIDENTIFIED"
             return "CLOSED"
         end goToPositionDialogState
 
@@ -2278,14 +2299,14 @@ extension AccessibilityChannel {
             end using terms from
         end menuEscapeFocusState
 
-        on dismissGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
-            set dialogState to my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
+        on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
+            set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
-                set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)
+                set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
                 if dialogWindow is "UNREADABLE" then return "UNREADABLE"
-                if dialogWindow is missing value then return my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
+                if dialogWindow is missing value then return my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
                 set cancelPressed to false
                 using terms from application "System Events"
                     tell theProcess
@@ -2310,7 +2331,7 @@ extension AccessibilityChannel {
                     end tell
                 end using terms from
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess, preLeafWindowIdentifiers)
+                set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is not "OPEN" then return dialogState
             end repeat
@@ -2320,9 +2341,9 @@ extension AccessibilityChannel {
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
                 try
-                    set preLeafWindowIdentifiers to my preLeafGoToPositionWindowIdentifiers("\(preLeafWindowSnapshotPath)")
-                    if preLeafWindowIdentifiers is "UNREADABLE" then return "DIALOG_UNREADABLE"
-                    set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafWindowIdentifiers)
+                    set preLeafGoToPositionDialogCount to my preLeafGoToPositionDialogCount("\(preLeafWindowSnapshotPath)")
+                    if preLeafGoToPositionDialogCount is "UNREADABLE" then return "DIALOG_UNREADABLE"
+                    set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount)
                     if dialogCleanupState is not "CLOSED" then return "DIALOG_" & dialogCleanupState
                     repeat 3 times
                         set menuFocusState to my menuEscapeFocusState(it)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1216,9 +1216,10 @@ extension AccessibilityChannel {
         end knownGoToPositionDialogSubrole
 
         -- These are the measured, operable titles, not an absence policy. Locale expansion is
-        -- tracked in #519; until then an unrecognised title must be withheld as unidentified.
+        -- tracked in #519; the reviewed JA title is covered here, while all other unrecognised
+        -- titles must still be withheld as unidentified.
         on knownGoToPositionDialogTitle(dialogTitle)
-            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
+            if dialogTitle is "위치로 이동" or dialogTitle is "位置の移動" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
             return false
         end knownGoToPositionDialogTitle
 
@@ -1273,6 +1274,38 @@ extension AccessibilityChannel {
             end using terms from
         end goToPositionWindowCount
 
+        -- A count cannot preserve window identity: one old window can disappear while an
+        -- unidentified dialog appears and leave the total unchanged. Keep the in-process pre-leaf
+        -- references only long enough to prove that every old window survived this run. They are
+        -- never serialized or used to name a dialog across the timeout process boundary.
+        on preLeafGoToPositionWindowsState(theProcess, preLeafGoToPositionWindows)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with preLeafWindow in preLeafGoToPositionWindows
+                            if not (exists (contents of preLeafWindow)) then return "CHANGED"
+                        end repeat
+                        return "UNCHANGED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end preLeafGoToPositionWindowsState
+
+        -- `CLOSED` is an observed lifecycle result, not a coincidental total-window equality. The
+        -- known dialog reference must have disappeared before this handler is called; this checks
+        -- that every pre-leaf reference remains and that no replacement/unknown window is left.
+        on observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
+            set preLeafWindowsState to my preLeafGoToPositionWindowsState(theProcess, preLeafGoToPositionWindows)
+            if preLeafWindowsState is "UNREADABLE" then return "UNREADABLE"
+            if preLeafWindowsState is not "UNCHANGED" then return "UNIDENTIFIED"
+            set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)
+            if currentGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return "UNIDENTIFIED"
+            return "CLOSED"
+        end observedGoToPositionDialogClosure
+
         -- Find only an operable, modal Go To Position window that this leaf could have opened.
         -- A target requires exactly one post-leaf match beyond the readable pre-leaf count; any
         -- pre-existing matching dialog or non-unique increase withholds global typing.
@@ -1305,7 +1338,7 @@ extension AccessibilityChannel {
             end using terms from
         end matchingGoToPositionDialog
 
-        -- The three exact titles and measured modal class are an input-target predicate, not an
+        -- The reviewed exact titles and measured modal class are an input-target predicate, not an
         -- absence predicate. A newly opened localized or otherwise unfamiliar window may be this
         -- run's dialog, but must never receive global typing.
         on newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
@@ -1319,23 +1352,17 @@ extension AccessibilityChannel {
 
         -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
         -- about whether a titled modal is still blocking the arrange area. `CLOSED` is reserved
-        -- for a readable total-window observation returning to this run's pre-leaf baseline. A
+        -- for the observed disappearance of the target plus preserved pre-leaf references. A
         -- missing reference, title drift, or failed read is not evidence of absence.
-        on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+        on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
             if dialogWindow is missing value then
-                set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
-                if newWindowState is "ABSENT" then return "CLOSED"
-                if newWindowState is "APPEARED" or newWindowState is "UNIDENTIFIED" then return "UNIDENTIFIED"
-                return "UNREADABLE"
+                return my observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
             end if
             using terms from application "System Events"
                 tell theProcess
                     try
                         if not (exists dialogWindow) then
-                            set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
-                            if newWindowState is "ABSENT" then return "CLOSED"
-                            if newWindowState is "APPEARED" or newWindowState is "UNIDENTIFIED" then return "UNIDENTIFIED"
-                            return "UNREADABLE"
+                            return my observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                         end if
                         set dialogTitle to name of dialogWindow
                         if not my knownGoToPositionDialogTitle(dialogTitle) then return "UNIDENTIFIED"
@@ -1389,11 +1416,11 @@ extension AccessibilityChannel {
         -- fallback while this exact dialog is observed open, and every attempt
         -- must be followed by a new exact-dialog observation before it counts
         -- as cleanup.
-        on pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+        on pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+                        set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                         if dialogState is not "OPEN" then return dialogState
                         if exists button "Cancel" of dialogWindow then
                             click button "Cancel" of dialogWindow
@@ -1415,17 +1442,17 @@ extension AccessibilityChannel {
             end using terms from
         end pressGoToPositionDialogCancel
 
-        on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
-            set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+        on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
+            set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
-                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if cancelOutcome is "NO_BUTTON" or cancelOutcome is "UNREADABLE" then
                     -- The Cancel click may have landed even though AX reported failure. Re-observe
                     -- this exact dialog before choosing Escape as a second actuator; unreadable is
                     -- not permission to send a key into an unknown focus target.
-                    set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+                    set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogState is "CLOSED" then return "CLOSED"
                     if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                     if dialogState is not "OPEN" then return dialogState
@@ -1436,7 +1463,7 @@ extension AccessibilityChannel {
                     end using terms from
                 end if
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+                set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                 if dialogState is not "OPEN" then return dialogState
@@ -1521,7 +1548,16 @@ extension AccessibilityChannel {
                 if preLeafGoToPositionDialogCount is greater than 0 then
                     return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click"
                 end if
-                set preLeafGoToPositionWindowCount to my goToPositionWindowCount(logicProcess)
+                -- Preserve concrete pre-leaf references in this process as well as the serialized
+                -- count for timeout reconciliation. The references make a same-count replacement
+                -- detectable after Return; a count by itself cannot do that.
+                set preLeafGoToPositionWindows to {}
+                try
+                    set preLeafGoToPositionWindows to every window as list
+                    set preLeafGoToPositionWindowCount to count of preLeafGoToPositionWindows
+                on error
+                    set preLeafGoToPositionWindowCount to "UNREADABLE"
+                end try
                 if preLeafGoToPositionWindowCount is "UNREADABLE" then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window count was unreadable before leaf click"
                 end if
@@ -1546,7 +1582,7 @@ extension AccessibilityChannel {
                         click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                     end if
                 on error errMsg
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1587,7 +1623,7 @@ extension AccessibilityChannel {
                 if not dialogReady then
                     if dialogAppearanceUnidentified then return "DIALOG_UNIDENTIFIED_NEW_WINDOW"
                     if dialogAppearanceUnreadable then return "DIALOG_APPEARANCE_UNREADABLE"
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1603,7 +1639,7 @@ extension AccessibilityChannel {
             -- it may have reached an unknown target rather than advertising a clean retry.
             try
                 if not my recordDialogIssuance("SELECT_ALL_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1618,7 +1654,7 @@ extension AccessibilityChannel {
                 -- frontmost while this run was preparing the receipt.
                 set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1631,7 +1667,7 @@ extension AccessibilityChannel {
                 keystroke "a" using command down
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1644,7 +1680,7 @@ extension AccessibilityChannel {
 
             try
                 if not my recordDialogIssuance("POSITION_INPUT_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1658,7 +1694,7 @@ extension AccessibilityChannel {
                 -- global position text, not merely after the preceding Cmd+A.
                 set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogTypingFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1671,7 +1707,7 @@ extension AccessibilityChannel {
                 keystroke "\(position)"
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1686,7 +1722,7 @@ extension AccessibilityChannel {
             -- Return submission boundary, so a timeout or nonzero child exit after either point is
             -- conservatively reported rather than releasing another actuator.
             if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1700,7 +1736,7 @@ extension AccessibilityChannel {
             -- owner after its durable marker is written and immediately before submission.
             set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogReturnFocusState is not "FOCUSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1714,7 +1750,7 @@ extension AccessibilityChannel {
                 keystroke return
                 delay 0.2
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1726,9 +1762,9 @@ extension AccessibilityChannel {
             end try
             -- A normal Return reply is not proof Logic consumed it. Observe this exact modal before
             -- returning OK; if it survived, clean it only after recording the submission boundary.
-            set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+            set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogPostReturnState is not "CLOSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1963,6 +1999,11 @@ extension AccessibilityChannel {
         /// A clean, normal leaf or pre-input focus failure may fall through because the script
         /// proved no global input or Return was sent and observed the relevant UI closed.
         var requiresUnsafeUIRefusal: Bool {
+            // The early menu outcomes occur before this run read either dialog count. A menu read
+            // that failed to resolve its leaf says nothing about whether a Go To Position modal is
+            // open, so it cannot release a global-keystroke route. Keep this as an observation
+            // property rather than making each router branch guess which sentinel happened.
+            if !performedDialogSafetyObservation { return true }
             switch self {
             case .failure(.menuCouldNotBeClosed),
                  .failure(.dialogPreexisting),
@@ -1976,6 +2017,20 @@ extension AccessibilityChannel {
                 return true
             default:
                 return false
+            }
+        }
+
+        /// Whether this result is downstream of the run's dialog-safety observation. `false`
+        /// means the route did not read the pre-leaf dialog/window state, not that it observed no
+        /// dialog. Callers must retain the failure rather than treating it as a clean fallback.
+        private var performedDialogSafetyObservation: Bool {
+            switch self {
+            case .failure(.menuNotFound),
+                 .failure(.menuStateUnreadable),
+                 .failure(.menuDisabled):
+                return false
+            default:
+                return true
             }
         }
 
@@ -2160,25 +2215,10 @@ extension AccessibilityChannel {
 
     private enum StrayGoToPositionUIOutcome: Equatable { case closed, openOrUnknown }
 
-    /// Reconcile the exact Go To Position modal before considering menu state. A menu-bar read does
-    /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise another route
-    /// while the dialog remains on screen.
-    private static func observeAndClearStrayGoToPositionUI(
-        preLeafWindowSnapshotPath: String,
-        executeScript: @escaping @Sendable (String, TimeInterval) async -> ChannelResult
-    ) async -> StrayGoToPositionUIOutcome {
-        let target = LogicProTarget.appleScriptTarget()
-        let script = """
-        on knownGoToPositionDialogSubrole(dialogSubrole)
-            if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return true
-            return false
-        end knownGoToPositionDialogSubrole
-
-        on knownGoToPositionDialogTitle(dialogTitle)
-            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
-            return false
-        end knownGoToPositionDialogTitle
-
+    /// Kept as one generated fragment so the timeout reconciler and its no-System-Events parser
+    /// regression test execute exactly the same `do shell script` boundary behavior.
+    static func preLeafGoToPositionWindowSnapshotParserAppleScript() -> String {
+        """
         -- The timeout process must not infer ownership from a title. The child persisted readable
         -- known-dialog and total-window counts immediately before its leaf click; failure to read
         -- exactly that three-line format is unsafe, not empty.
@@ -2186,7 +2226,10 @@ extension AccessibilityChannel {
             try
                 set snapshotText to do shell script "/bin/cat " & (quoted form of snapshotPath)
                 set originalTextItemDelimiters to AppleScript's text item delimiters
-                set AppleScript's text item delimiters to linefeed
+                -- `do shell script` returns command output with LF normalized to CR. The writer
+                -- intentionally persists LF, so parse the returned representation rather than
+                -- pretending the file's byte delimiter survived this API boundary unchanged.
+                set AppleScript's text item delimiters to return
                 set snapshotItems to text items of snapshotText
                 set AppleScript's text item delimiters to originalTextItemDelimiters
                 if (count of snapshotItems) is not 3 then return "UNREADABLE"
@@ -2217,6 +2260,29 @@ extension AccessibilityChannel {
                 return "UNREADABLE"
             end try
         end preLeafGoToPositionWindowSnapshot
+        """
+    }
+
+    /// Reconcile the exact Go To Position modal before considering menu state. A menu-bar read does
+    /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise another route
+    /// while the dialog remains on screen.
+    private static func observeAndClearStrayGoToPositionUI(
+        preLeafWindowSnapshotPath: String,
+        executeScript: @escaping @Sendable (String, TimeInterval) async -> ChannelResult
+    ) async -> StrayGoToPositionUIOutcome {
+        let target = LogicProTarget.appleScriptTarget()
+        let script = """
+        on knownGoToPositionDialogSubrole(dialogSubrole)
+            if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return true
+            return false
+        end knownGoToPositionDialogSubrole
+
+        on knownGoToPositionDialogTitle(dialogTitle)
+            if dialogTitle is "위치로 이동" or dialogTitle is "位置の移動" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
+            return false
+        end knownGoToPositionDialogTitle
+
+        \(preLeafGoToPositionWindowSnapshotParserAppleScript())
 
         on windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
             if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
@@ -2305,7 +2371,10 @@ extension AccessibilityChannel {
             set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)
             if currentGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
             if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return "UNIDENTIFIED"
-            return "CLOSED"
+            -- A fresh process has counts but not the pre-leaf AX references. Equal counts cannot
+            -- distinguish a closed target from an unidentified replacement paired with a different
+            -- disappearing window, so do not manufacture a CLOSED observation or release menu Escape.
+            return "UNIDENTIFIED"
         end goToPositionDialogState
 
         -- System Events keystrokes are global. Re-check frontmost after proving the exact modal

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -2216,20 +2216,21 @@ extension AccessibilityChannel {
     private enum StrayGoToPositionUIOutcome: Equatable { case closed, openOrUnknown }
 
     /// Kept as one generated fragment so the timeout reconciler and its no-System-Events parser
-    /// regression test execute exactly the same `do shell script` boundary behavior.
+    /// regression test execute exactly the same parent-owned snapshot boundary behavior.
     static func preLeafGoToPositionWindowSnapshotParserAppleScript() -> String {
         """
+        use framework "Foundation"
+
         -- The timeout process must not infer ownership from a title. The child persisted readable
         -- known-dialog and total-window counts immediately before its leaf click; failure to read
         -- exactly that three-line format is unsafe, not empty.
         on preLeafGoToPositionWindowSnapshot(snapshotPath)
             try
-                set snapshotText to do shell script "/bin/cat " & (quoted form of snapshotPath)
+                set snapshotText to (current application's NSString's stringWithContentsOfFile:snapshotPath encoding:(current application's NSUTF8StringEncoding) |error|:(missing value)) as text
                 set originalTextItemDelimiters to AppleScript's text item delimiters
-                -- `do shell script` returns command output with LF normalized to CR. The writer
-                -- intentionally persists LF, so parse the returned representation rather than
-                -- pretending the file's byte delimiter survived this API boundary unchanged.
-                set AppleScript's text item delimiters to return
+                -- Foundation preserves the writer's LF delimiters, so parse the persisted
+                -- representation rather than assuming an AppleScript conversion to CR.
+                set AppleScript's text item delimiters to linefeed
                 set snapshotItems to text items of snapshotText
                 set AppleScript's text item delimiters to originalTextItemDelimiters
                 if (count of snapshotItems) is not 3 then return "UNREADABLE"

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import AppKit
+import Darwin
 import Foundation
 
 /// Transport surface: play/stop/record, tempo, cycle range, playhead goto, zoom, and control-bar checkboxes (metronome/count-in).
@@ -777,9 +778,7 @@ extension AccessibilityChannel {
         activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
         sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) },
         executeDialogScript: (@Sendable (String) async -> ChannelResult)? = nil,
-        reconcileAfterDialogExecutionFailure: @escaping @Sendable () async -> Bool = {
-            await observeAndClearStrayGoToPositionUI() == .closed
-        }
+        reconcileAfterDialogExecutionFailure: (@Sendable () async -> Bool)? = nil
     ) async -> ChannelResult {
         var requestedPosition: String? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
@@ -843,6 +842,28 @@ extension AccessibilityChannel {
         // cannot show that a successful run had to bring Logic forward first.
         baseExtras["frontmost_preparation"] = preparation.rawValue
 
+        // An absence/appearance transition can identify this run's modal only while another server
+        // process is not performing the same protocol. This advisory lock is released by the OS if
+        // its owner exits; a contender refuses before any leaf click rather than sharing a dialog.
+        // `executeDialogScript` is the unit-test-only protocol seam. Production callers use the
+        // runtime executor and therefore always take the cross-process ownership lock.
+        let dialogExecutionLock = executeDialogScript == nil
+            ? GoToPositionDialogExecutionLock.acquire()
+            : nil
+        guard executeDialogScript != nil || dialogExecutionLock != nil else {
+            return .error(HonestContract.encodeStateC(
+                error: .mutatingOperationInProgress,
+                hint: "Another Go To Position request is resolving Logic's modal dialog; retry after it completes.",
+                extras: baseExtras.merging([
+                    "operation": "transport.goto_position",
+                    "method": "dialog",
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]) { _, new in new }
+            ))
+        }
+        defer { dialogExecutionLock?.release() }
+
         // The AX runtime owns the script seam. Calling `AppleScriptChannel` here would make a
         // custom runtime only partially injectable and could run a real Logic dialog in a unit
         // test. Production retains this route's measured eight-second budget; a custom runtime
@@ -855,10 +876,25 @@ extension AccessibilityChannel {
                 await runtime.executeAppleScriptWithTimeout(script, 8.0)
             }
         }
+        // Reconciliation is part of the same injected runtime as dialog execution. Otherwise a
+        // fake runtime that omits this optional test seam can launch live osascript while cleaning
+        // up a deliberately failed fixture.
+        let dialogFailureReconciler: @Sendable () async -> Bool
+        if let reconcileAfterDialogExecutionFailure {
+            dialogFailureReconciler = reconcileAfterDialogExecutionFailure
+        } else {
+            dialogFailureReconciler = {
+                await observeAndClearStrayGoToPositionUI(
+                    executeScript: { script, timeout in
+                        await runtime.executeAppleScriptWithTimeout(script, timeout)
+                    }
+                ) == .closed
+            }
+        }
         let dialogResult = await gotoPositionViaDialog(
             position: requestedPosition,
             executeScript: dialogScriptExecutor,
-            reconcileAfterExecutionFailure: reconcileAfterDialogExecutionFailure
+            reconcileAfterExecutionFailure: dialogFailureReconciler
         )
         if case let .driven(payload) = dialogResult {
             // The dialog rung builds its own envelope, so without this the same operation reports
@@ -869,22 +905,25 @@ extension AccessibilityChannel {
             ))
         }
         if case let .failed(classification) = dialogResult,
-           classification.hasPotentialDialogSubmission {
-            // Return was sent normally, or the child died after its parent-owned issuance ledger
-            // recorded a dialog boundary. In either case a second position actuator is unsafe. The
-            // dead-child path deliberately records `write_attempted:true`: the parent cannot turn a
-            // missing process-local return value into a claim that no submission happened.
+           classification.requiresFallbackSuppression {
+            // A dead child after LEAF_ARMED/RETURN_ARMED leaves the UI boundary indeterminate, so
+            // another position actuator remains unsafe. That safety rule is not evidence that a
+            // Return was sent: only a normal script result can claim a position submission.
             let dialogState = classification.cleanupObservedClosed ? "closed" : "unobserved"
-            let extras = baseExtras.merging([
+            var extras = baseExtras.merging([
                 "operation": "transport.goto_position",
                 "method": "dialog",
                 "dialog_actuation_attempted": classification.dialogActuationMayHaveOccurred,
-                "dialog_submission_attempted": true,
                 "dialog_cleanup": dialogState,
-                "write_attempted": true,
                 "safe_to_retry": false,
                 "fallback_unsafe": true,
             ]) { _, new in new }
+            if classification.dialogSubmissionWasObserved {
+                extras["dialog_submission_attempted"] = true
+                extras["write_attempted"] = true
+            } else {
+                extras["dialog_submission_indeterminate"] = true
+            }
             return .success(HonestContract.encodeStateB(
                 reason: .readbackUnavailable,
                 extras: extras
@@ -922,18 +961,15 @@ extension AccessibilityChannel {
         }
 
         // Logic Pro 12.3 exposes the `bar` control as a relative increment, not an absolute musical
-        // bar number: setting AXValue to 37 advances one bar from both bar 1 and bar 3.  There is no
-        // measured conversion from the requested position to that control, so do not turn an unknown
-        // relative movement into a second position actuator by guessing a scale or issuing a write.
-        // A pre-write State C lets the router try its independently position-capable later channels.
+        // bar number. This route neither resolved nor wrote a position slider, so do not label this
+        // failure as a slider write. A non-terminal State C lets independently position-capable
+        // later channels run.
         return .error(HonestContract.encodeStateC(
-            error: .axWriteFailed,
-            hint: "The Control Bar bar slider is a relative increment, not an absolute position writer; no slider position write was issued.",
+            error: .notSupported,
+            hint: "The Go To Position dialog did not submit a position, and no alternative position route was taken.",
             extras: baseExtras.merging([
                 "operation": "transport.goto_position",
-                "via": "slider",
-                "slider_position_write_supported": false,
-                "slider_value_semantics": "relative_increment_not_absolute_position",
+                "position_route": "unavailable",
                 "unobserved_position_components": ["bar", "beat", "subdivision", "tick"],
                 "unexpressed_position_components": ["bar", "beat", "subdivision", "tick"],
                 "write_attempted": false,
@@ -957,6 +993,34 @@ extension AccessibilityChannel {
               let text = String(data: merged, encoding: .utf8)
         else { return payload }
         return text
+    }
+
+    /// Cross-process ownership for the absence → leaf → appearance transition. The advisory POSIX
+    /// lock cannot be re-entered by a second MCP server process and the kernel releases it if the
+    /// owner exits, so a dead server cannot leave a stale dialog-ownership claim behind.
+    private final class GoToPositionDialogExecutionLock {
+        private let fileDescriptor: Int32
+
+        private init(fileDescriptor: Int32) {
+            self.fileDescriptor = fileDescriptor
+        }
+
+        static func acquire() -> GoToPositionDialogExecutionLock? {
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("logic-pro-mcp-goto-position-dialog.lock").path
+            let descriptor = open(path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+            guard descriptor >= 0 else { return nil }
+            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+                close(descriptor)
+                return nil
+            }
+            return GoToPositionDialogExecutionLock(fileDescriptor: descriptor)
+        }
+
+        func release() {
+            flock(fileDescriptor, LOCK_UN)
+            close(fileDescriptor)
+        }
     }
 
     /// The script is internal so the menu-validation regression tests can assert the
@@ -1043,27 +1107,60 @@ extension AccessibilityChannel {
             return ""
         end menuCleanupActuationContext
 
-        -- The Go To Position floating dialog has its own lifecycle; a menu-bar
-        -- observation says nothing about whether this modal is still blocking
-        -- the arrange area.  Keep unreadable distinct from closed, just as the
-        -- #529 menu cleanup does.
-        on goToPositionDialogState(theProcess)
+        -- Find only the modal Go To Position window. Title alone is not a dialog
+        -- identity: an ordinary same-titled window must not satisfy this run's
+        -- dialog poll.
+        on matchingGoToPositionDialog(theProcess)
             using terms from application "System Events"
                 tell theProcess
                     try
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" then return "OPEN"
-                            if dialogTitle is "Go To Position" then return "OPEN"
-                            if dialogTitle is "Go to Position" then return "OPEN"
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set dialogSubrole to subrole of dialogWindow
+                                if dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return contents of dialogWindow
+                            end if
                         end repeat
-                        return "CLOSED"
+                        return missing value
                     on error
                         return "UNREADABLE"
                     end try
                 end tell
             end using terms from
+        end matchingGoToPositionDialog
+
+        -- The Go To Position floating dialog has its own lifecycle; a menu-bar
+        -- observation says nothing about whether this modal is still blocking
+        -- the arrange area. Keep unreadable distinct from closed, just as the
+        -- #529 menu cleanup does.
+        on goToPositionDialogState(theProcess)
+            set dialogWindow to my matchingGoToPositionDialog(theProcess)
+            if dialogWindow is "UNREADABLE" then return "UNREADABLE"
+            if dialogWindow is missing value then return "CLOSED"
+            return "OPEN"
         end goToPositionDialogState
+
+        -- System Events exposes keystroke only globally, not as an action on a
+        -- window/text element. Bind the exact AX window discovered after this
+        -- run's leaf click and refuse unless it remains the focused modal at the
+        -- instant before each global key sequence.
+        on observedGoToPositionDialogFocusState(theProcess, dialogWindow)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        if not (exists dialogWindow) then return "MISSING"
+                        set dialogTitle to name of dialogWindow
+                        set dialogSubrole to subrole of dialogWindow
+                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
+                        if dialogSubrole is not "AXDialog" and dialogSubrole is not "AXSystemDialog" then return "MISSING"
+                        if focused of dialogWindow then return "FOCUSED"
+                        return "NOT_FOCUSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end observedGoToPositionDialogFocusState
 
         -- Prefer this modal's localized Cancel button.  Escape is only a
         -- fallback while this exact dialog is observed open, and every attempt
@@ -1179,24 +1276,34 @@ extension AccessibilityChannel {
                     end if
                 on error
                     -- An unreadable AXEnabled must not authorise the pick.
-                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    set cleanupState to my dismissOpenMenu(logicProcess, false)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_STATE_UNREADABLE"
                 end try
                 if not menuItemEnabled then
-                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    set cleanupState to my dismissOpenMenu(logicProcess, false)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
                     return "MENU_DISABLED"
                 end if
+                -- A same-titled dialog that was already present belongs to neither this leaf
+                -- actuation nor this request. Do not cancel or type into it; absence immediately
+                -- before the leaf is the first half of this run's dialog-appearance transition.
+                set preLeafGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)
+                if preLeafGoToPositionDialog is "UNREADABLE" then
+                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position dialog state was unreadable before leaf click"
+                end if
+                if preLeafGoToPositionDialog is not missing value then
+                    return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click"
+                end if
                 try
                     -- Persist before AXPress: if the child dies after the click, Swift still knows
                     -- that the dialog route may have become active and must not choose another route.
                     if not my recordDialogIssuance("LEAF_ARMED", "\(ledgerPath)") then
-                        set cleanupState to my dismissOpenMenu(logicProcess, true)
+                        set cleanupState to my dismissOpenMenu(logicProcess, false)
                         if cleanupState is not "CLOSED" then
                             return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
                         end if
@@ -1220,14 +1327,20 @@ extension AccessibilityChannel {
                     end if
                     return "DIALOG_ACTUATION_ISSUED: " & errMsg
                 end try
-                -- Wait up to 3s for the dialog window to appear before typing,
-                -- otherwise keystrokes would go to the arrange area and click
-                -- Cmd+A there — silently "Select All Regions".
+                -- Wait up to 3s for a new exact modal dialog to appear before typing. The
+                -- pre-leaf absence plus this observed element prevents a stale/concurrent
+                -- same-titled window from being accepted as this request's dialog.
                 set dialogReady to false
+                set dialogAppearanceUnreadable to false
+                set observedGoToPositionDialog to missing value
                 repeat 30 times
                     delay 0.1
-                    set dialogOpenState to my goToPositionDialogState(logicProcess)
-                    if dialogOpenState is "OPEN" then
+                    set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)
+                    if observedGoToPositionDialog is "UNREADABLE" then
+                        set dialogAppearanceUnreadable to true
+                        exit repeat
+                    end if
+                    if observedGoToPositionDialog is not missing value then
                         set dialogReady to true
                         exit repeat
                     end if
@@ -1241,15 +1354,54 @@ extension AccessibilityChannel {
                     if cleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
+                    if dialogAppearanceUnreadable then return "DIALOG_ACTUATION_ISSUED: dialog appearance became unreadable"
                     return "DIALOG_ACTUATION_ISSUED: dialog did not become ready"
                 end if
             end tell
             -- Everything in this block is provably before Return. A normal script result from
             -- here must therefore remain a non-submission failure, never State B-after-nothing.
+            set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
+            if dialogFocusState is not "FOCUSED" then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogFocusState & ")"
+            end if
             try
-                delay 0.1
                 keystroke "a" using command down
                 delay 0.1
+            on error errMsg
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (" & errMsg & ")"
+            end try
+
+            -- Cmd+A is global too. Re-check the same observed window immediately before typing
+            -- the requested position; System Events has no element-targeted keystroke API.
+            set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
+            if dialogTypingFocusState is not "FOCUSED" then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogTypingFocusState & ")"
+            end if
+            try
                 keystroke "\(position)"
                 delay 0.1
             on error errMsg
@@ -1267,6 +1419,18 @@ extension AccessibilityChannel {
             -- This durable marker is the position-write boundary. It is written before Return so
             -- a timeout or nonzero child exit after this point is conservatively reported as a
             -- possibly-issued submission rather than releasing another actuator.
+            set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
+            if dialogReturnFocusState is not "FOCUSED" then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before Return (" & dialogReturnFocusState & ")"
+            end if
             if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
@@ -1354,6 +1518,8 @@ extension AccessibilityChannel {
             case menuDisabled
             case menuPickFailed
             case menuCouldNotBeClosed(writeAttempted: Bool)
+            case dialogPreexisting
+            case dialogPreexistenceUnreadable
             case dialogNotReady
             case dialogActuationIssued(cleanupObservedClosed: Bool)
             case dialogSubmissionNotIssued(cleanupObservedClosed: Bool)
@@ -1378,6 +1544,8 @@ extension AccessibilityChannel {
             case .failure(.menuPickFailed): return "menu_pick_failed"
             case let .failure(.menuCouldNotBeClosed(writeAttempted)):
                 return "menu_could_not_be_closed_write_attempted_\(writeAttempted)"
+            case .failure(.dialogPreexisting): return "dialog_preexisting"
+            case .failure(.dialogPreexistenceUnreadable): return "dialog_preexistence_unreadable"
             case .failure(.dialogNotReady): return "dialog_not_ready"
             case let .failure(.dialogActuationIssued(closed)):
                 return "dialog_actuation_issued_cleanup_closed_\(closed)"
@@ -1392,10 +1560,10 @@ extension AccessibilityChannel {
             }
         }
 
-        /// Any normal path that explicitly reached Return, plus a dead child that persisted a
-        /// pre-leaf/Return checkpoint. A leaf checkpoint is intentionally conservative after a
-        /// process death: the parent cannot prove the child did not advance to Return before dying.
-        var hasPotentialDialogSubmission: Bool {
+        /// A second position actuator is unsafe after a normal Return or a dead child that crossed
+        /// either durable UI boundary. LEAF_ARMED is a safety boundary only: it does not prove a
+        /// dialog actuation or position submission occurred.
+        var requiresFallbackSuppression: Bool {
             switch self {
             case .failure(.dialogSubmissionIssued),
                  .failure(.executionFailed(issuance: .leafArmed, cleanupObservedClosed: _)),
@@ -1407,12 +1575,23 @@ extension AccessibilityChannel {
             }
         }
 
+        /// The script itself reported that Return was sent or may have been sent. A parent-owned
+        /// ledger is intentionally not included: a child can die immediately after writing it.
+        var dialogSubmissionWasObserved: Bool {
+            if case .failure(.dialogSubmissionIssued) = self {
+                return true
+            }
+            return false
+        }
+
         /// A later position route is unsafe when a non-submission path cannot prove the menu/dialog UI is gone.
         /// A clean, normal leaf/input failure may fall through because the script proved no Return
         /// was sent *and* observed the relevant UI closed.
         var requiresUnsafeUIRefusal: Bool {
             switch self {
             case .failure(.menuCouldNotBeClosed),
+                 .failure(.dialogPreexisting),
+                 .failure(.dialogPreexistenceUnreadable),
                  .failure(.dialogActuationIssued(cleanupObservedClosed: false)),
                  .failure(.dialogSubmissionNotIssued(cleanupObservedClosed: false)),
                  .failure(.dialogNotReady),
@@ -1429,7 +1608,6 @@ extension AccessibilityChannel {
                  .failure(.dialogActuationIssued),
                  .failure(.dialogSubmissionNotIssued),
                  .failure(.dialogSubmissionIssued),
-                 .failure(.executionFailed(issuance: .leafArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
                 return true
@@ -1483,6 +1661,10 @@ extension AccessibilityChannel {
             return .failure(.menuStateUnreadable)
         case "MENU_DISABLED":
             return .failure(.menuDisabled)
+        case let value where value.hasPrefix("DIALOG_PREEXISTING"):
+            return .failure(.dialogPreexisting)
+        case let value where value.hasPrefix("DIALOG_PREEXISTENCE_UNREADABLE"):
+            return .failure(.dialogPreexistenceUnreadable)
         case let value where value.hasPrefix("MENU_PICK_FAILED"):
             if value.hasPrefix("MENU_PICK_FAILED: menu state was not observed closed at entry")
                 || value.hasPrefix("MENU_PICK_FAILED: menu cleanup was not observed") {
@@ -1580,7 +1762,9 @@ extension AccessibilityChannel {
     /// Reconcile the exact Go To Position modal before considering menu state. A menu-bar read does
     /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise another route
     /// while the dialog remains on screen.
-    private static func observeAndClearStrayGoToPositionUI() async -> StrayGoToPositionUIOutcome {
+    private static func observeAndClearStrayGoToPositionUI(
+        executeScript: @escaping @Sendable (String, TimeInterval) async -> ChannelResult
+    ) async -> StrayGoToPositionUIOutcome {
         let target = LogicProTarget.appleScriptTarget()
         let script = """
         on goToPositionDialogState(theProcess)
@@ -1658,7 +1842,7 @@ extension AccessibilityChannel {
             end tell
         end tell
         """
-        guard case let .success(payload) = await AppleScriptChannel.executeAppleScript(script, timeout: 4.0),
+        guard case let .success(payload) = await executeScript(script, 4.0),
               let data = payload.data(using: .utf8),
               let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
               (obj["result"] as? String) == "CLOSED"

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -779,28 +779,52 @@ extension AccessibilityChannel {
         sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) },
         executeDialogScript: @escaping @Sendable (String) async -> ChannelResult = { script in
             await AppleScriptChannel.executeAppleScript(script, timeout: 8.0)
+        },
+        reconcileAfterDialogExecutionFailure: @escaping @Sendable () async -> Bool = {
+            await observeAndClearStrayGoToPositionUI() == .closed
         }
     ) async -> ChannelResult {
         var targetBar: Int? = nil
+        var targetBeat: Int? = nil
+        var requestedPosition: String? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
             targetBar = b
+            targetBeat = 1
+            requestedPosition = "\(b).1.1.1"
         } else if let pos = params["position"] {
             if pos.contains(":") {
                 return .error("AX gotoPosition cannot handle timecode (use MCU mmc_locate)")
             }
-            let parts = pos.split(separator: ".")
-            if let first = parts.first, let b = Int(first) {
-                targetBar = b
+            let parts = pos.split(separator: ".", omittingEmptySubsequences: false)
+            guard parts.count == 4,
+                  let b = Int(parts[0]), (1...9999).contains(b),
+                  let beat = Int(parts[1]), (1...16).contains(beat),
+                  let subdivision = Int(parts[2]), (1...16).contains(subdivision),
+                  let tick = Int(parts[3]), (1...999).contains(tick)
+            else {
+                return .error(HonestContract.encodeStateC(
+                    error: .invalidParams,
+                    hint: "goto_position requires 'bar' (Int 1..9999) or 'position' (B.B.S.S)"
+                ))
             }
+            targetBar = b
+            targetBeat = beat
+            // Keep the caller's complete request. The slider can only express a prefix of it, but
+            // must never silently replace beat/subdivision/tick with its own defaults.
+            requestedPosition = "\(b).\(beat).\(subdivision).\(tick)"
         }
-        guard let bar = targetBar, (1...9999).contains(bar) else {
+        guard let bar = targetBar,
+              let beat = targetBeat,
+              let requestedPosition,
+              (1...9999).contains(bar)
+        else {
             return .error(HonestContract.encodeStateC(
                 error: .invalidParams,
                 hint: "goto_position requires 'bar' (Int 1..9999) or 'position' (B.B.S.S)"
             ))
         }
 
-        var baseExtras: [String: Any] = ["requested": "\(bar).1.1.1"]
+        var baseExtras: [String: Any] = ["requested": requestedPosition]
 
         // Refuse before touching anything: a non-ready result means nothing has been actuated, so
         // the caller can retry without wondering whether the playhead already moved.
@@ -826,7 +850,9 @@ extension AccessibilityChannel {
         baseExtras["frontmost_preparation"] = preparation.rawValue
 
         let dialogResult = await gotoPositionViaDialog(
-            bar: bar, executeScript: executeDialogScript
+            position: requestedPosition,
+            executeScript: executeDialogScript,
+            reconcileAfterExecutionFailure: reconcileAfterDialogExecutionFailure
         )
         if case let .driven(payload) = dialogResult {
             // The dialog rung builds its own envelope, so without this the same operation reports
@@ -837,65 +863,51 @@ extension AccessibilityChannel {
             ))
         }
         if case let .failed(classification) = dialogResult,
-           classification.isUnsafeToActuateAgain {
-            // `dismissOpenMenu` could not prove that the menu closed. A slider write from this
-            // state can operate on the still-open menu, so this is terminal rather than fallback.
-            // This branch runs before the dialog input is typed and submitted. Opening the menu
-            // chain is UI navigation, not a `transport.goto_position` write, so this remains a
-            // State C refusal with `write_attempted:false`. Retain that the navigation click did
-            // happen separately for diagnosis.
+           classification.hasPotentialDialogSubmission {
+            // Return was sent normally, or the child died after its parent-owned issuance ledger
+            // recorded a dialog boundary. In either case a second position actuator is unsafe. The
+            // dead-child path deliberately records `write_attempted:true`: the parent cannot turn a
+            // missing process-local return value into a claim that no submission happened.
+            let dialogState = classification.cleanupObservedClosed ? "closed" : "unobserved"
+            let extras = baseExtras.merging([
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "dialog_actuation_attempted": classification.dialogActuationMayHaveOccurred,
+                "dialog_submission_attempted": true,
+                "dialog_cleanup": dialogState,
+                "write_attempted": true,
+                "safe_to_retry": false,
+                "fallback_unsafe": true,
+            ]) { _, new in new }
+            return .success(HonestContract.encodeStateB(
+                reason: .readbackUnavailable,
+                extras: extras
+            ))
+        }
+        if case let .failed(classification) = dialogResult,
+           classification.requiresUnsafeUIRefusal {
+            // The normal script proved no Return was sent, but could not prove that the menu or
+            // dialog closed. Do not let an unknown focus target receive a slider write.
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
-                hint: "The Go To Position menu could not be closed; the slider fallback was not attempted.",
+                hint: "The Go To Position menu or dialog was not observed closed; the slider fallback was not attempted.",
                 extras: baseExtras.merging([
                     "operation": "transport.goto_position",
                     "method": "dialog",
                     "menu_state": "could_not_be_closed",
                     "menu_actuation_attempted": classification.menuActuationAttemptedBeforeUnsafeRefusal,
+                    "dialog_actuation_attempted": classification.dialogActuationMayHaveOccurred,
+                    // Stated on this path too, and stated as false. The refusal above is about
+                    // cleanup, not about submission: a caller reading only `dialog_actuation_
+                    // attempted` cannot tell "we opened the dialog and never typed into it" from
+                    // "we typed and cannot confirm". A field that appears on one refusal and is
+                    // absent on the neighbouring one is not a contract.
+                    "dialog_submission_attempted": false,
+                    "dialog_cleanup": classification.cleanupObservedClosed ? "closed" : "unobserved",
                     "write_attempted": false,
                     "safe_to_retry": false,
-                    // #530: even though ax_write_failed is normally non-terminal, a still-open
-                    // menu makes every weaker transport channel unsafe to invoke.
                     "fallback_unsafe": true,
                 ]) { _, new in new }
-            ))
-        }
-        if case let .failed(classification) = dialogResult,
-           classification.hasIssuedGoToPositionActuator {
-            // A leaf menu click, dialog input, or Return may take effect even when the AX / AppleScript
-            // invocation says it failed.  Once one of those has been issued, the slider is a *second*
-            // goto-position actuator, not a fallback-safe retry.  This deliberately keys off issuance,
-            // never the return code, following the Delete-key path's write-attempt boundary.
-            let submissionIssued = classification.hasIssuedDialogSubmission
-            let dialogState = classification.dialogCleanupObservedClosed ? "closed" : "unobserved"
-            let extras = baseExtras.merging([
-                "operation": "transport.goto_position",
-                "method": "dialog",
-                "dialog_actuation_attempted": true,
-                "dialog_submission_attempted": submissionIssued,
-                "dialog_cleanup": dialogState,
-                // Opening the dialog is navigation, while a submitted Return may have moved the
-                // playhead. Keep that distinction explicit rather than using a false AX result to
-                // say no position write was attempted.
-                "write_attempted": submissionIssued,
-                "safe_to_retry": false,
-                "fallback_unsafe": true,
-            ]) { _, new in new }
-            if submissionIssued {
-                // Return was issued, so a position write may have landed. The result is uncertain
-                // rather than a known hard failure, but the slider remains unsafe as a second actuator.
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackUnavailable,
-                    extras: extras
-                ))
-            }
-            // The issued leaf only navigates to the dialog. With no submission, no position write was
-            // attempted, so this remains the known State C navigation failure.
-            return .error(HonestContract.encodeStateC(
-                error: .axWriteFailed,
-                hint: "The Go To Position menu item was issued but reported an error; "
-                    + "the slider fallback was not attempted.",
-                extras: extras
             ))
         }
 
@@ -925,10 +937,21 @@ extension AccessibilityChannel {
         }
 
         func sliderExtras(observedBar: Int?, observedBeat: Int? = nil) -> [String: Any] {
-            baseExtras.merging([
+            let unobservedComponents = observedBeat == nil
+                ? ["beat", "subdivision", "tick"]
+                : ["subdivision", "tick"]
+            return baseExtras.merging([
                 "observed": observedBar.map { observedPosition(bar: $0, beat: observedBeat) } ?? NSNull(),
                 "via": "slider",
                 "write_attempted": true,
+                // The control-bar exposes only bar and, on some builds, beat. State A requires an
+                // independently observed complete request, so this route advertises the missing
+                // components instead of certifying the prefix as the requested position.
+                "unobserved_position_components": unobservedComponents,
+                // These fields are carried forward verbatim in `requested`, but the control-bar
+                // sliders have no actuator for them. Keep that loss of expression explicit rather
+                // than silently substituting `.1.1` or implying the prefix was the full request.
+                "unexpressed_position_components": unobservedComponents,
             ]) { _, new in new }
         }
 
@@ -958,7 +981,7 @@ extension AccessibilityChannel {
         var initialBeat: Int?
         if let beatSlider {
             _ = AXHelpers.setAttribute(
-                beatSlider, kAXValueAttribute, NSNumber(value: 1), runtime: runtime.ax
+                beatSlider, kAXValueAttribute, NSNumber(value: beat), runtime: runtime.ax
             )
             switch sliderValue(beatSlider) {
             case .failure, .success(nil):
@@ -969,7 +992,7 @@ extension AccessibilityChannel {
             case let .success(value?):
                 initialBeat = value
             }
-            guard initialBeat == 1 else {
+            guard initialBeat == beat else {
                 return .success(HonestContract.encodeStateB(
                     reason: .readbackMismatch,
                     extras: sliderExtras(observedBar: initialBar, observedBeat: initialBeat)
@@ -1008,14 +1031,18 @@ extension AccessibilityChannel {
             case let .success(value?):
                 finalBeat = value
             }
-            guard finalBeat == 1 else {
+            guard finalBeat == beat else {
                 return .success(HonestContract.encodeStateB(
                     reason: .readbackMismatch,
                     extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
                 ))
             }
         }
-        return .success(HonestContract.encodeStateA(
+        // A bar-only or bar+beat AX read cannot independently verify subdivision and tick. Keep
+        // this State B even when every exposed slider agrees; TransportDispatcher performs the
+        // authoritative full transport-state comparison before emitting State A.
+        return .success(HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
             extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
         ))
     }
@@ -1041,10 +1068,21 @@ extension AccessibilityChannel {
     /// The script is internal so the menu-validation regression tests can assert the
     /// exact generated AppleScript ordering without invoking Logic Pro.
     static func gotoPositionViaDialogAppleScript(bar: Int) -> String {
+        gotoPositionViaDialogAppleScript(position: "\(bar).1.1.1")
+    }
+
+    /// The optional ledger is owned by the Swift parent, not by `osascript`. The child advances it
+    /// immediately *before* each irreversible UI boundary so a timeout cannot erase the fact that
+    /// the child may already have issued it.
+    static func gotoPositionViaDialogAppleScript(
+        position: String,
+        issuanceLedgerPath: String? = nil
+    ) -> String {
         // Poll for the dialog's presence instead of relying on a fixed delay.
         // Without this guard, a slow machine (>500ms to render the dialog) would
         // send Cmd+A to the arrange area, selecting all regions unexpectedly.
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
+        let ledgerPath = issuanceLedgerPath ?? ""
         return """
         -- A selected menu-bar item is the AX observation that one of Logic's
         -- menus is currently open. Return UNREADABLE rather than treating a
@@ -1067,12 +1105,11 @@ extension AccessibilityChannel {
         -- Never claim that Escape cleaned up a menu until AXSelected says so.
         -- Three attempts are enough to cover a menu/submenu chain without
         -- turning a failed close into an unbounded retry.
-        -- `knownOpen` says whether THIS run has already clicked a menu open. It changes what an
-        -- unreadable first read means. At entry nothing has been opened, so UNREADABLE is an absent
-        -- observation and returning it lets the run proceed — refusing there sent 5 of 8 fresh
-        -- processes to the slider route. After this run clicked, a menu IS open: an unreadable read
-        -- is not permission to skip the Escape, because skipping it can end the run with the menu
-        -- still up.
+        -- `knownOpen` says whether THIS run has already clicked a menu open. Before that boundary,
+        -- UNREADABLE returns without Escape because unknown focus might be an unrelated dialog/edit;
+        -- the caller must refuse rather than treating the missing read as clean. After this run
+        -- clicked, an unreadable read is not permission to skip Escape, because this run may leave
+        -- its own menu chain up.
         on dismissOpenMenu(theProcess, knownOpen)
             set menuState to my menuOpenState(theProcess)
             if menuState is "CLOSED" then return "CLOSED"
@@ -1090,6 +1127,19 @@ extension AccessibilityChannel {
             end repeat
             return "OPEN"
         end dismissOpenMenu
+
+        -- The parent creates this file before launching osascript and reads it after the child
+        -- exits or is killed. `do shell script` completes the file write before the next AX/key
+        -- actuation, so the marker survives the child process that could otherwise lose its state.
+        on recordDialogIssuance(stage, ledgerPath)
+            if ledgerPath is "" then return true
+            try
+                do shell script "/usr/bin/printf %s " & quoted form of stage & " > " & quoted form of ledgerPath
+                return true
+            on error
+                return false
+            end try
+        end recordDialogIssuance
 
         -- Appending this context lets the Swift receipt distinguish an unsafe
         -- entry cleanup (no operation actuation) from an unsafe cleanup after a
@@ -1203,20 +1253,14 @@ extension AccessibilityChannel {
         tell application "System Events"
             set logicProcess to \(logicProAppleScript.systemEventsProcessTarget)
             tell logicProcess
-                -- A timed-out predecessor can leave a menu open. Clear and
-                -- observe that state before this run performs any menu read or
-                -- actuation, so a later fallback never inherits an open menu.
+                -- A timed-out predecessor or user action can leave a menu open. An unreadable
+                -- entry read is not evidence that the menu is absent, so it must not release a
+                -- later slider actuation. `knownOpen:false` deliberately withholds Escape when
+                -- focus is unknown.
                 set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)
-                if entryMenuCleanup is "OPEN" or entryMenuCleanup is "OPEN_UNREADABLE" then
-                    return "MENU_PICK_FAILED: a menu was open at entry and would not close (" & entryMenuCleanup & ")"
+                if entryMenuCleanup is not "CLOSED" then
+                    return "MENU_PICK_FAILED: menu state was not observed closed at entry (" & entryMenuCleanup & ")"
                 end if
-                -- UNREADABLE is NOT a refusal here. Nothing has been opened by this
-                -- run yet, so an unreadable menu bar is an absent observation, not
-                -- evidence that something is open — and on a cold System Events
-                -- connection the first read frequently is unreadable. Refusing on it
-                -- sent 5 of 8 fresh processes to the slider route, measured. After
-                -- this run opens a menu the same value IS a refusal, because then
-                -- there is something known to be open.
                 set menuActuationAttempted to false
                 -- This marks the write boundary for actuator selection.  The
                 -- leaf may succeed even if AX reports an error, so any result
@@ -1237,14 +1281,18 @@ extension AccessibilityChannel {
                         set selectedSubmenuItem to menu item "Go To" of menu 1 of selectedMenuBarItem
                         set mi to menu item "Position…" of menu 1 of selectedSubmenuItem
                     else
-                        set cleanupState to my dismissOpenMenu(logicProcess, true)
+                        -- No menu has been opened by this run. If the read is unreadable,
+                        -- `knownOpen:false` must not send Escape into an unrelated focus target.
+                        set cleanupState to my dismissOpenMenu(logicProcess, false)
                         if cleanupState is not "CLOSED" then
                             return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                         end if
                         return "MENU_NOT_FOUND"
                     end if
                 on error errMsg
-                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    -- Locale discovery is read-only; do not claim an unknown menu belongs to
+                    -- this run and do not authorise Escape from an unreadable AX observation.
+                    set cleanupState to my dismissOpenMenu(logicProcess, false)
                     if cleanupState is not "CLOSED" then
                         return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
@@ -1297,6 +1345,15 @@ extension AccessibilityChannel {
                     return "MENU_DISABLED"
                 end if
                 try
+                    -- Persist before AXPress: if the child dies after the click, Swift still knows
+                    -- that the dialog route may have become active and must not choose the slider.
+                    if not my recordDialogIssuance("LEAF_ARMED", "\(ledgerPath)") then
+                        set cleanupState to my dismissOpenMenu(logicProcess, true)
+                        if cleanupState is not "CLOSED" then
+                            return "MENU_PICK_FAILED: menu cleanup was not observed (" & cleanupState & ")"
+                        end if
+                        return "MENU_PICK_FAILED: could not persist dialog issuance before leaf click"
+                    end if
                     set dialogActuationIssued to true
                     click mi
                 on error errMsg
@@ -1334,31 +1391,109 @@ extension AccessibilityChannel {
                     return "DIALOG_ACTUATION_ISSUED: dialog did not become ready"
                 end if
             end tell
+            -- Everything in this block is provably before Return. A normal script result from
+            -- here must therefore remain a non-submission failure, never State B-after-nothing.
             try
                 delay 0.1
                 keystroke "a" using command down
                 delay 0.1
-                keystroke "\(bar)"
+                keystroke "\(position)"
                 delay 0.1
+            on error errMsg
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (" & errMsg & ")"
+            end try
+
+            -- This durable marker is the position-write boundary. It is written before Return so
+            -- a timeout or nonzero child exit after this point is conservatively reported as a
+            -- possibly-issued submission rather than releasing another actuator.
+            if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_NOT_ISSUED: could not persist Return issuance"
+            end if
+            try
                 keystroke return
                 delay 0.2
             on error errMsg
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                 if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_FAILED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
-                return "DIALOG_SUBMISSION_FAILED: dialog input or Return failed after the dialog opened (" & errMsg & ")"
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_ISSUED: Return may have been sent (" & errMsg & ")"
             end try
+            -- A normal Return reply is not proof Logic consumed it. Observe this exact modal before
+            -- returning OK; if it survived, clean it only after recording the submission boundary.
+            set dialogPostReturnState to my goToPositionDialogState(logicProcess)
+            if dialogPostReturnState is not "CLOSED" then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_SUBMISSION_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_SUBMISSION_ISSUED: dialog was not observed closed after Return"
+            end if
         end tell
         return "OK"
         """
     }
 
-    /// The successful AppleScript channel payload is a JSON object containing the
-    /// script's return value in `result`. Only an exact `OK` means this route
-    /// reached the dialog and submitted it. Only failures before the position
-    /// menu leaf is issued may fall through to the slider route.  AX return
-    /// codes do not prove whether that leaf (or later dialog input) took effect.
+    /// State persisted by the parent-owned issuance ledger. `unknown` is deliberately unsafe: a
+    /// missing/corrupt ledger after a dead child is not evidence that the child failed before Return.
+    enum DialogIssuanceStage: String, Equatable {
+        case notIssued = "NOT_ISSUED"
+        case leafArmed = "LEAF_ARMED"
+        case returnArmed = "RETURN_ARMED"
+        case unknown
+    }
+
+    private struct DialogIssuanceLedger {
+        let url: URL
+
+        static func create() -> DialogIssuanceLedger? {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("logic-pro-mcp-goto-position-\(UUID().uuidString)")
+            guard FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data(DialogIssuanceStage.notIssued.rawValue.utf8)
+            ) else { return nil }
+            return DialogIssuanceLedger(url: url)
+        }
+
+        var stage: DialogIssuanceStage {
+            guard let text = try? String(contentsOf: url, encoding: .utf8) else { return .unknown }
+            return DialogIssuanceStage(rawValue: text.trimmingCharacters(in: .whitespacesAndNewlines))
+                ?? .unknown
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// The successful AppleScript channel payload is a JSON object containing the script's return
+    /// value in `result`. Normal script replies distinguish failures before Return from a Return that
+    /// may have landed; execution failures use the parent-owned durable ledger instead.
     enum GotoPositionDialogResultClassification: Equatable {
         enum Failure: Equatable {
             case menuNotFound
@@ -1368,51 +1503,68 @@ extension AccessibilityChannel {
             case menuCouldNotBeClosed(writeAttempted: Bool)
             case dialogNotReady
             case dialogActuationIssued(cleanupObservedClosed: Bool)
+            case dialogSubmissionNotIssued(cleanupObservedClosed: Bool)
             case dialogSubmissionIssued(cleanupObservedClosed: Bool)
+            case executionFailed(issuance: DialogIssuanceStage, cleanupObservedClosed: Bool)
             case malformedPayload
             case unexpectedResult
-            case executionFailed
         }
 
         case driven
         case failure(Failure)
 
-        var isUnsafeToActuateAgain: Bool {
-            if case .failure(.menuCouldNotBeClosed) = self {
-                return true
-            }
-            return false
-        }
-
-        /// A menu leaf click opens the Go To Position dialog, and keyboard input / Return can
-        /// commit it.  Their status returns are not a licence to choose the slider as another
-        /// position actuator.  `dialogNotReady` is included because the generated script can only
-        /// produce it after it has issued the leaf click.
-        var hasIssuedGoToPositionActuator: Bool {
+        /// Any normal path that explicitly reached Return, plus a dead child that persisted a
+        /// pre-leaf/Return checkpoint. A leaf checkpoint is intentionally conservative after a
+        /// process death: the parent cannot prove the child did not advance to Return before dying.
+        var hasPotentialDialogSubmission: Bool {
             switch self {
-            case .failure(.dialogNotReady),
-                 .failure(.dialogActuationIssued),
-                 .failure(.dialogSubmissionIssued):
+            case .failure(.dialogSubmissionIssued),
+                 .failure(.executionFailed(issuance: .leafArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
                 return true
             default:
                 return false
             }
         }
 
-        var hasIssuedDialogSubmission: Bool {
-            if case .failure(.dialogSubmissionIssued) = self {
+        /// A slider is unsafe when a non-submission path cannot prove the menu/dialog UI is gone.
+        /// A clean, normal leaf/input failure may fall through because the script proved no Return
+        /// was sent *and* observed the relevant UI closed.
+        var requiresUnsafeUIRefusal: Bool {
+            switch self {
+            case .failure(.menuCouldNotBeClosed),
+                 .failure(.dialogActuationIssued(cleanupObservedClosed: false)),
+                 .failure(.dialogSubmissionNotIssued(cleanupObservedClosed: false)),
+                 .failure(.dialogNotReady),
+                 .failure(.executionFailed(issuance: .notIssued, cleanupObservedClosed: false)):
                 return true
+            default:
+                return false
             }
-            return false
         }
 
-        /// Closed is an observed result from the dialog-specific cleanup, never an inference from
-        /// a setter or an Escape return.  A leaf error / not-ready outcome has no closed-dialog
-        /// proof, so the receipt keeps that absence visible.
-        var dialogCleanupObservedClosed: Bool {
+        var dialogActuationMayHaveOccurred: Bool {
+            switch self {
+            case .failure(.dialogNotReady),
+                 .failure(.dialogActuationIssued),
+                 .failure(.dialogSubmissionNotIssued),
+                 .failure(.dialogSubmissionIssued),
+                 .failure(.executionFailed(issuance: .leafArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
+                return true
+            default:
+                return false
+            }
+        }
+
+        var cleanupObservedClosed: Bool {
             switch self {
             case let .failure(.dialogActuationIssued(cleanupObservedClosed)),
-                 let .failure(.dialogSubmissionIssued(cleanupObservedClosed)):
+                 let .failure(.dialogSubmissionNotIssued(cleanupObservedClosed)),
+                 let .failure(.dialogSubmissionIssued(cleanupObservedClosed)),
+                 let .failure(.executionFailed(issuance: _, cleanupObservedClosed)):
                 return cleanupObservedClosed
             default:
                 return false
@@ -1453,7 +1605,7 @@ extension AccessibilityChannel {
         case "MENU_DISABLED":
             return .failure(.menuDisabled)
         case let value where value.hasPrefix("MENU_PICK_FAILED"):
-            if value.hasPrefix("MENU_PICK_FAILED: a menu was open at entry and would not close")
+            if value.hasPrefix("MENU_PICK_FAILED: menu state was not observed closed at entry")
                 || value.hasPrefix("MENU_PICK_FAILED: menu cleanup was not observed") {
                 return .failure(.menuCouldNotBeClosed(
                     writeAttempted: value.hasPrefix(
@@ -1466,11 +1618,18 @@ extension AccessibilityChannel {
             return .failure(.dialogNotReady)
         case let value where value.hasPrefix("DIALOG_ACTUATION_ISSUED"):
             return .failure(.dialogActuationIssued(
-                cleanupObservedClosed: !value.contains("dialog cleanup was not observed")
+                // A closed dialog is insufficient if a menu cleanup remained unreadable. Both
+                // surfaces must be observed closed before this known pre-Return path can fall
+                // through to the slider.
+                cleanupObservedClosed: !value.contains("cleanup was not observed")
             ))
-        case let value where value.hasPrefix("DIALOG_SUBMISSION_FAILED"):
+        case let value where value.hasPrefix("DIALOG_SUBMISSION_NOT_ISSUED"):
+            return .failure(.dialogSubmissionNotIssued(
+                cleanupObservedClosed: !value.contains("cleanup was not observed")
+            ))
+        case let value where value.hasPrefix("DIALOG_SUBMISSION_ISSUED"):
             return .failure(.dialogSubmissionIssued(
-                cleanupObservedClosed: !value.contains("dialog cleanup was not observed")
+                cleanupObservedClosed: !value.contains("cleanup was not observed")
             ))
         default:
             return .failure(.unexpectedResult)
@@ -1483,10 +1642,16 @@ extension AccessibilityChannel {
     }
 
     private static func gotoPositionViaDialog(
-        bar: Int,
-        executeScript: @escaping @Sendable (String) async -> ChannelResult
+        position: String,
+        executeScript: @escaping @Sendable (String) async -> ChannelResult,
+        reconcileAfterExecutionFailure: @escaping @Sendable () async -> Bool
     ) async -> GotoPositionDialogRouteResult {
-        let script = gotoPositionViaDialogAppleScript(bar: bar)
+        let ledger = DialogIssuanceLedger.create()
+        defer { ledger?.remove() }
+        let script = gotoPositionViaDialogAppleScript(
+            position: position,
+            issuanceLedgerPath: ledger?.url.path
+        )
         let result = await executeScript(script)
         switch result {
         case .success(let output):
@@ -1506,46 +1671,98 @@ extension AccessibilityChannel {
                 return .driven(HonestContract.encodeStateB(
                     reason: .readbackUnavailable,
                     extras: [
-                        "requested": "\(bar).1.1.1",
-                        "via": "dialog"
+                        "requested": position,
+                        "via": "dialog",
+                        // `OK` is emitted only after the script independently observed the exact
+                        // Go To Position dialog closed following Return.
+                        "dialog_cleanup": "closed",
+                        "dialog_submission_attempted": true,
+                        "write_attempted": true,
                     ]
                 ))
             case .failure:
                 return .failed(classification)
             }
         case .error:
-            // The script died — timeout, TCC refusal, anything. It clicks menus open, so its death
-            // leaves the menu state UNKNOWN, and unknown is not safe: the slider would actuate into
-            // whatever is on screen. Try once to observe and clear any open menu; only a state
-            // observed CLOSED lets the fallback proceed.
-            // If Logic is not running at all, no menu of its can be open, and the script's death
-            // says nothing about menu state. Only when the app IS there does an unobservable menu
-            // become a reason to withhold the fallback.
-            guard ProcessUtils.logicProPID() != nil else {
-                return .failed(.failure(.executionFailed))
-            }
-            switch await observeAndClearStrayMenu() {
-            case .closed:
-                return .failed(.failure(.executionFailed))
-            case .openOrUnknown:
-                return .failed(.failure(.menuCouldNotBeClosed(writeAttempted: false)))
-            }
+            // Do this even when PID discovery fails. The durable checkpoint records whether the
+            // child may have crossed a UI boundary, and a failed reconciliation is never evidence
+            // that a dead child left no modal/menu behind.
+            let issuance = ledger?.stage ?? .unknown
+            let cleanupObservedClosed = await reconcileAfterExecutionFailure()
+            return .failed(.failure(.executionFailed(
+                issuance: issuance,
+                cleanupObservedClosed: cleanupObservedClosed
+            )))
         }
     }
 
+    private enum StrayGoToPositionUIOutcome: Equatable { case closed, openOrUnknown }
 
-    private enum StrayMenuOutcome { case closed, openOrUnknown }
-
-    /// Independent of the script that just died: ask System Events whether any menu bar item is
-    /// selected, send Escape if so, and observe again. Anything other than an observed CLOSED —
-    /// including an unreadable menu bar — is `openOrUnknown`, because a failed reading is not
-    /// evidence that nothing is open.
-    private static func observeAndClearStrayMenu() async -> StrayMenuOutcome {
+    /// Reconcile the exact Go To Position modal before considering menu state. A menu-bar read does
+    /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise the slider
+    /// while the dialog remains on screen.
+    private static func observeAndClearStrayGoToPositionUI() async -> StrayGoToPositionUIOutcome {
         let target = LogicProTarget.appleScriptTarget()
         let script = """
+        on goToPositionDialogState(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return "OPEN"
+                        end repeat
+                        return "CLOSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionDialogState
+
+        on dismissGoToPositionDialog(theProcess)
+            set dialogState to my goToPositionDialogState(theProcess)
+            if dialogState is "CLOSED" then return "CLOSED"
+            if dialogState is not "OPEN" then return dialogState
+            repeat 3 times
+                set cancelPressed to false
+                using terms from application "System Events"
+                    tell theProcess
+                        try
+                            repeat with dialogWindow in every window
+                                set dialogTitle to name of dialogWindow
+                                if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                    if exists button "Cancel" of dialogWindow then
+                                        click button "Cancel" of dialogWindow
+                                        set cancelPressed to true
+                                        exit repeat
+                                    end if
+                                    if exists button "취소" of dialogWindow then
+                                        click button "취소" of dialogWindow
+                                        set cancelPressed to true
+                                        exit repeat
+                                    end if
+                                end if
+                            end repeat
+                        on error
+                        end try
+                        -- Escape is permitted only because this exact dialog was observed OPEN above.
+                        if not cancelPressed then key code 53
+                    end tell
+                end using terms from
+                delay 0.1
+                set dialogState to my goToPositionDialogState(theProcess)
+                if dialogState is "CLOSED" then return "CLOSED"
+                if dialogState is not "OPEN" then return dialogState
+            end repeat
+            return "OPEN"
+        end dismissGoToPositionDialog
+
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
                 try
+                    set dialogCleanupState to my dismissGoToPositionDialog(it)
+                    if dialogCleanupState is not "CLOSED" then return "DIALOG_" & dialogCleanupState
                     repeat 3 times
                         set anyOpen to false
                         repeat with menuBarItem in every menu bar item of menu bar 1

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -913,6 +913,7 @@ extension AccessibilityChannel {
             var extras = baseExtras.merging([
                 "operation": "transport.goto_position",
                 "method": "dialog",
+                "dialog_route_outcome": classification.diagnosticLabel,
                 "dialog_actuation_attempted": classification.dialogActuationMayHaveOccurred,
                 "dialog_cleanup": dialogState,
                 "safe_to_retry": false,
@@ -956,6 +957,7 @@ extension AccessibilityChannel {
                 extras: baseExtras.merging([
                     "operation": "transport.goto_position",
                     "method": "dialog",
+                    "dialog_route_outcome": classification.diagnosticLabel,
                     "menu_state": "could_not_be_closed",
                     "menu_actuation_attempted": classification.menuActuationAttemptedBeforeUnsafeRefusal,
                     "dialog_actuation_attempted": classification.dialogActuationMayHaveOccurred,
@@ -1091,6 +1093,12 @@ extension AccessibilityChannel {
             if menuState is "UNREADABLE" and not knownOpen then return "UNREADABLE"
             if menuState is not "OPEN" and menuState is not "UNREADABLE" then return menuState
             repeat 3 times
+                try
+                    set logicIsFrontmost to frontmost of theProcess
+                on error
+                    return "UNREADABLE"
+                end try
+                if logicIsFrontmost is not true then return "NOT_FRONTMOST"
                 using terms from application "System Events"
                     tell theProcess to key code 53
                 end using terms from
@@ -1104,12 +1112,14 @@ extension AccessibilityChannel {
         end dismissOpenMenu
 
         -- The parent creates this file before launching osascript and reads it after the child
-        -- exits or is killed. `do shell script` completes the file write before the next AX/key
-        -- actuation, so the marker survives the child process that could otherwise lose its state.
+        -- exits or is killed. Write a sibling temporary file and atomically rename it over the
+        -- ledger: killing the child during a marker update must leave the prior conservative
+        -- marker intact, never truncate the ledger to an empty/unknown value.
         on recordDialogIssuance(stage, ledgerPath)
             if ledgerPath is "" then return true
             try
-                do shell script "/usr/bin/printf %s " & quoted form of stage & " > " & quoted form of ledgerPath
+                set temporaryLedgerPath to do shell script "/usr/bin/mktemp " & quoted form of (ledgerPath & ".tmp.XXXXXX")
+                do shell script "/usr/bin/printf %s " & quoted form of stage & " > " & quoted form of temporaryLedgerPath & " && /bin/mv -f " & quoted form of temporaryLedgerPath & " " & quoted form of ledgerPath
                 return true
             on error
                 return false
@@ -1124,9 +1134,17 @@ extension AccessibilityChannel {
             return ""
         end menuCleanupActuationContext
 
-        -- Find only the modal Go To Position window. Title alone is not a dialog
-        -- identity: an ordinary same-titled window must not satisfy this run's
-        -- dialog poll.
+        -- Logic 12.3 measures Go To Position as AXFloatingWindow with AXModal=true.
+        -- These measured subroles remain the KNOWN, operable set. Exact-title windows outside
+        -- that set are deliberately handled by goToPositionDialogState as possibly blocking;
+        -- this matcher must not turn an unfamiliar future subrole into an input target.
+        on knownGoToPositionDialogSubrole(dialogSubrole)
+            if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return true
+            return false
+        end knownGoToPositionDialogSubrole
+
+        -- Find only an operable, modal Go To Position window. Title alone is not a dialog
+        -- identity: an ordinary same-titled window must not satisfy this run's input poll.
         on matchingGoToPositionDialog(theProcess)
             using terms from application "System Events"
                 tell theProcess
@@ -1134,14 +1152,11 @@ extension AccessibilityChannel {
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                -- Measured on Logic 12.3: this window's subrole is
-                                -- AXFloatingWindow, not AXDialog. Gating on the guessed subrole
-                                -- made every drive refuse with "dialog did not become ready"
-                                -- while the dialog was open on screen. Ownership comes from the
-                                -- appearance transition around the leaf click; the subrole only
-                                -- excludes an ordinary document window sharing the title.
                                 set dialogSubrole to subrole of dialogWindow
-                                if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return contents of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then return contents of dialogWindow
+                                end if
                             end if
                         end repeat
                         return missing value
@@ -1152,44 +1167,56 @@ extension AccessibilityChannel {
             end using terms from
         end matchingGoToPositionDialog
 
-        -- The Go To Position floating dialog has its own lifecycle; a menu-bar
-        -- observation says nothing about whether this modal is still blocking
-        -- the arrange area. Keep unreadable distinct from closed, just as the
-        -- #529 menu cleanup does.
+        -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
+        -- about whether a titled modal is still blocking the arrange area. `AXModal` answers
+        -- whether the measured known class is modal; subrole only classifies that class. An exact
+        -- title with an unknown subrole must remain non-CLOSED, so a future Logic build cannot
+        -- release another route while its modal is still present.
         on goToPositionDialogState(theProcess)
-            set dialogWindow to my matchingGoToPositionDialog(theProcess)
-            if dialogWindow is "UNREADABLE" then return "UNREADABLE"
-            if dialogWindow is missing value then return "CLOSED"
-            return "OPEN"
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        repeat with dialogWindow in every window
+                            set dialogTitle to name of dialogWindow
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set dialogSubrole to subrole of dialogWindow
+                                if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "OPEN_UNKNOWN_SUBROLE"
+                                try
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                on error
+                                    return "OPEN_UNREADABLE"
+                                end try
+                                if dialogIsModal is true then return "OPEN"
+                                return "OPEN_UNVERIFIED_MODALITY"
+                            end if
+                        end repeat
+                        return "CLOSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
         end goToPositionDialogState
 
         -- System Events exposes keystroke only globally, not as an action on a
-        -- window/text element. Bind the exact AX window discovered after this
-        -- run's leaf click and refuse unless it remains the focused modal at the
-        -- instant before each global key sequence.
+        -- window/text element. Re-read the global application owner and the exact
+        -- process-local AXFocusedWindow together immediately before each key sequence.
         on observedGoToPositionDialogFocusState(theProcess, dialogWindow)
             using terms from application "System Events"
                 tell theProcess
                     try
+                        set logicIsFrontmost to frontmost
+                        if logicIsFrontmost is not true then return "NOT_FRONTMOST"
                         if not (exists dialogWindow) then return "MISSING"
                         set dialogTitle to name of dialogWindow
                         set dialogSubrole to subrole of dialogWindow
                         if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
-                        -- Same measured set as the discovery matcher. Fixing only that one left
-                        -- this check rejecting the window discovery had just accepted, so the
-                        -- route still closed the dialog and submitted nothing.
-                        if dialogSubrole is not "AXFloatingWindow" and dialogSubrole is not "AXDialog" and dialogSubrole is not "AXSystemDialog" then return "MISSING"
-                        -- Measured on Logic 12.3: this dialog reports AXFocused false and AXMain
-                        -- false while it is the window receiving keystrokes. The signal that is
-                        -- true there is the PROCESS's AXFocusedWindow, which names this dialog.
-                        -- Checking the window's own AXFocused refused every drive on a dialog that
-                        -- was plainly taking input.
-                        if (exists attribute "AXFocusedWindow") then
-                            set processFocusedWindow to value of attribute "AXFocusedWindow"
-                            if processFocusedWindow is dialogWindow then return "FOCUSED"
-                            if (name of processFocusedWindow as text) is dialogTitle then return "FOCUSED"
-                        end if
-                        if focused of dialogWindow then return "FOCUSED"
+                        if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "MISSING"
+                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                        if dialogIsModal is not true then return "NOT_MODAL"
+                        if not (exists attribute "AXFocusedWindow") then return "UNREADABLE"
+                        set processFocusedWindow to value of attribute "AXFocusedWindow"
+                        if processFocusedWindow is dialogWindow then return "FOCUSED"
                         return "NOT_FOCUSED"
                     on error
                         return "UNREADABLE"
@@ -1246,6 +1273,12 @@ extension AccessibilityChannel {
                     if dialogState is "CLOSED" then return "CLOSED"
                     if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                     if dialogState is not "OPEN" then return dialogState
+                    set cleanupDialogWindow to my matchingGoToPositionDialog(theProcess)
+                    if cleanupDialogWindow is "UNREADABLE" or cleanupDialogWindow is missing value then
+                        return "OPEN_UNREADABLE"
+                    end if
+                    set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, cleanupDialogWindow)
+                    if cleanupDialogFocusState is not "FOCUSED" then return cleanupDialogFocusState
                     using terms from application "System Events"
                         tell theProcess to key code 53
                     end using terms from
@@ -1325,15 +1358,17 @@ extension AccessibilityChannel {
                     end if
                     return "MENU_DISABLED"
                 end if
-                -- A same-titled dialog that was already present belongs to neither this leaf
-                -- actuation nor this request. Do not cancel or type into it; absence immediately
-                -- before the leaf is the first half of this run's dialog-appearance transition.
-                set preLeafGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)
-                if preLeafGoToPositionDialog is "UNREADABLE" then
+                -- A same-titled window that was already present belongs to neither this leaf
+                -- actuation nor this request. This includes an unknown future subrole: do not
+                -- dismiss it as absent simply because it is outside the measured input class.
+                -- Absence immediately before the leaf is the first half of this run's dialog-
+                -- appearance transition.
+                set preLeafGoToPositionDialogState to my goToPositionDialogState(logicProcess)
+                if preLeafGoToPositionDialogState is "UNREADABLE" then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position dialog state was unreadable before leaf click"
                 end if
-                if preLeafGoToPositionDialog is not missing value then
-                    return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click"
+                if preLeafGoToPositionDialogState is not "CLOSED" then
+                    return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click (" & preLeafGoToPositionDialogState & ")"
                 end if
                 try
                     -- Persist before AXPress: if the child dies after the click, Swift still knows
@@ -1397,18 +1432,6 @@ extension AccessibilityChannel {
             -- Everything in this block is before Return, but System Events keyboard input is
             -- global. Once an input boundary is durably armed, a normal result must report that
             -- it may have reached an unknown target rather than advertising a clean retry.
-            set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
-            if dialogFocusState is not "FOCUSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
-                if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
-                end if
-                set cleanupState to my dismissOpenMenu(logicProcess, true)
-                if cleanupState is not "CLOSED" then
-                    return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
-                end if
-                return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogFocusState & ")"
-            end if
             try
                 if not my recordDialogIssuance("SELECT_ALL_ARMED", "\(ledgerPath)") then
                     set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
@@ -1420,6 +1443,21 @@ extension AccessibilityChannel {
                         return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
                     end if
                     return "DIALOG_SUBMISSION_NOT_ISSUED: could not persist Cmd+A issuance"
+                end if
+                -- The durable marker precedes the irreversible key. Re-read global application
+                -- focus after that file operation so Cmd+A cannot land in an app that became
+                -- frontmost while this run was preparing the receipt.
+                set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
+                if dialogFocusState is not "FOCUSED" then
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    if cleanupState is not "CLOSED" then
+                        return "DIALOG_SUBMISSION_NOT_ISSUED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (" & dialogFocusState & ")"
                 end if
                 keystroke "a" using command down
                 delay 0.1
@@ -1435,20 +1473,6 @@ extension AccessibilityChannel {
                 return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: Cmd+A may have been sent (" & errMsg & ")"
             end try
 
-            -- Cmd+A is global too. Re-check the same observed window immediately before typing
-            -- the requested position; System Events has no element-targeted keystroke API.
-            set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
-            if dialogTypingFocusState is not "FOCUSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
-                if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
-                end if
-                set cleanupState to my dismissOpenMenu(logicProcess, true)
-                if cleanupState is not "CLOSED" then
-                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
-                end if
-                return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: observed Go To Position dialog was not focused before typing (" & dialogTypingFocusState & ")"
-            end if
             try
                 if not my recordDialogIssuance("POSITION_INPUT_ARMED", "\(ledgerPath)") then
                     set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
@@ -1460,6 +1484,20 @@ extension AccessibilityChannel {
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                     end if
                     return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: could not persist position input issuance"
+                end if
+                -- Re-read focus after persisting this input marker and immediately before the
+                -- global position text, not merely after the preceding Cmd+A.
+                set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
+                if dialogTypingFocusState is not "FOCUSED" then
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    if dialogCleanupState is not "CLOSED" then
+                        return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                    end if
+                    set cleanupState to my dismissOpenMenu(logicProcess, true)
+                    if cleanupState is not "CLOSED" then
+                        return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: menu cleanup was not observed (" & cleanupState & ")"
+                    end if
+                    return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: observed Go To Position dialog was not focused before typing (" & dialogTypingFocusState & ")"
                 end if
                 keystroke "\(position)"
                 delay 0.1
@@ -1478,6 +1516,19 @@ extension AccessibilityChannel {
             -- POSITION_INPUT_ARMED above is the text-write boundary. This separate marker is the
             -- Return submission boundary, so a timeout or nonzero child exit after either point is
             -- conservatively reported rather than releasing another actuator.
+            if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                if dialogCleanupState is not "CLOSED" then
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
+                end if
+                set cleanupState to my dismissOpenMenu(logicProcess, true)
+                if cleanupState is not "CLOSED" then
+                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
+                end if
+                return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: could not persist Return issuance"
+            end if
+            -- Return is global too. The focused Logic dialog must still be the global keyboard
+            -- owner after its durable marker is written and immediately before submission.
             set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogReturnFocusState is not "FOCUSED" then
                 set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
@@ -1489,17 +1540,6 @@ extension AccessibilityChannel {
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
                 end if
                 return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: observed Go To Position dialog was not focused before Return (" & dialogReturnFocusState & ")"
-            end if
-            if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
-                if dialogCleanupState is not "CLOSED" then
-                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
-                end if
-                set cleanupState to my dismissOpenMenu(logicProcess, true)
-                if cleanupState is not "CLOSED" then
-                    return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: menu cleanup was not observed (" & cleanupState & ")"
-                end if
-                return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: could not persist Return issuance"
             end if
             try
                 keystroke return
@@ -1661,7 +1701,8 @@ extension AccessibilityChannel {
                  .failure(.dialogSubmissionIssued),
                  .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .positionInputArmed, cleanupObservedClosed: _)),
-                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)):
+                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
+                 .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
                 return true
             default:
                 return false
@@ -1678,7 +1719,7 @@ extension AccessibilityChannel {
             case .failure(.dialogSubmissionIssued):
                 return .returnArmed
             case let .failure(.executionFailed(issuance, _)) where issuance == .selectAllArmed
-                || issuance == .positionInputArmed || issuance == .returnArmed:
+                || issuance == .positionInputArmed || issuance == .returnArmed || issuance == .unknown:
                 return issuance
             default:
                 return nil
@@ -1937,8 +1978,15 @@ extension AccessibilityChannel {
                             end repeat
                         on error
                         end try
-                        -- Escape is permitted only because this exact dialog was observed OPEN above.
-                        if not cancelPressed then key code 53
+                        -- Escape is permitted only because this exact dialog was observed OPEN
+                        -- above and Logic still owns the global keyboard at this instant.
+                        if not cancelPressed then
+                            if frontmost then
+                                key code 53
+                            else
+                                return "NOT_FRONTMOST"
+                            end if
+                        end if
                     end tell
                 end using terms from
                 delay 0.1
@@ -1960,6 +2008,7 @@ extension AccessibilityChannel {
                             if selected of menuBarItem then set anyOpen to true
                         end repeat
                         if not anyOpen then return "CLOSED"
+                        if not frontmost then return "NOT_FRONTMOST"
                         key code 53
                         delay 0.1
                     end repeat

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -868,26 +868,34 @@ extension AccessibilityChannel {
             // never the return code, following the Delete-key path's write-attempt boundary.
             let submissionIssued = classification.hasIssuedDialogSubmission
             let dialogState = classification.dialogCleanupObservedClosed ? "closed" : "unobserved"
+            let extras = baseExtras.merging([
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "dialog_actuation_attempted": true,
+                "dialog_submission_attempted": submissionIssued,
+                "dialog_cleanup": dialogState,
+                // Opening the dialog is navigation, while a submitted Return may have moved the
+                // playhead. Keep that distinction explicit rather than using a false AX result to
+                // say no position write was attempted.
+                "write_attempted": submissionIssued,
+                "safe_to_retry": false,
+                "fallback_unsafe": true,
+            ]) { _, new in new }
+            if submissionIssued {
+                // Return was issued, so a position write may have landed. The result is uncertain
+                // rather than a known hard failure, but the slider remains unsafe as a second actuator.
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackUnavailable,
+                    extras: extras
+                ))
+            }
+            // The issued leaf only navigates to the dialog. With no submission, no position write was
+            // attempted, so this remains the known State C navigation failure.
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
-                hint: submissionIssued
-                    ? "Go To Position dialog input or submission was issued but did not complete; "
-                        + "the slider fallback was not attempted."
-                    : "The Go To Position menu item was issued but reported an error; "
-                        + "the slider fallback was not attempted.",
-                extras: baseExtras.merging([
-                    "operation": "transport.goto_position",
-                    "method": "dialog",
-                    "dialog_actuation_attempted": true,
-                    "dialog_submission_attempted": submissionIssued,
-                    "dialog_cleanup": dialogState,
-                    // Opening the dialog is navigation, while a submitted Return may have moved the
-                    // playhead.  Keep that distinction explicit rather than using a false AX result to
-                    // say no position write was attempted.
-                    "write_attempted": submissionIssued,
-                    "safe_to_retry": false,
-                    "fallback_unsafe": true,
-                ]) { _, new in new }
+                hint: "The Go To Position menu item was issued but reported an error; "
+                    + "the slider fallback was not attempted.",
+                extras: extras
             ))
         }
 
@@ -1171,6 +1179,13 @@ extension AccessibilityChannel {
             repeat 3 times
                 set cancelOutcome to my pressGoToPositionDialogCancel(theProcess)
                 if cancelOutcome is "NO_BUTTON" or cancelOutcome is "UNREADABLE" then
+                    -- The Cancel click may have landed even though AX reported failure. Re-observe
+                    -- this exact dialog before choosing Escape as a second actuator; unreadable is
+                    -- not permission to send a key into an unknown focus target.
+                    set dialogState to my goToPositionDialogState(theProcess)
+                    if dialogState is "CLOSED" then return "CLOSED"
+                    if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
+                    if dialogState is not "OPEN" then return dialogState
                     using terms from application "System Events"
                         tell theProcess to key code 53
                     end using terms from

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -712,11 +712,10 @@ extension AccessibilityChannel {
 
     // MARK: - Control-bar playhead position helper
 
-    /// Set the playhead to a specific bar. Two paths:
-    /// 1) `탐색 → 이동 → 위치…` dialog (precise, auto-extends project, requires
-    ///    at least one region in arrange — menu item is disabled on empty project)
-    /// 2) Control-bar 마디 slider (clamps to project length; silently stops at
-    ///    end when requested bar exceeds length)
+    /// Set the playhead to a specific bar through Logic's `탐색 → 이동 → 위치…`
+    /// dialog. The Control Bar's `bar` slider is deliberately not used as a
+    /// fallback: in Logic 12.3 its AX value is a relative increment rather than
+    /// an absolute musical bar number.
     /// Accepts `{"bar": Int}` or `{"position": "B.B.S.S"}`.
     /// #109: set the arrange horizontal zoom to `level` (1...10) by writing the
     /// Horizontal-Zoom AXSlider (range 0...1, level 1 = fully out, 10 = fully
@@ -784,12 +783,14 @@ extension AccessibilityChannel {
             await observeAndClearStrayGoToPositionUI() == .closed
         }
     ) async -> ChannelResult {
-        var targetBar: Int? = nil
-        var targetBeat: Int? = nil
         var requestedPosition: String? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
-            targetBar = b
-            targetBeat = 1
+            guard (1...9999).contains(b) else {
+                return .error(HonestContract.encodeStateC(
+                    error: .invalidParams,
+                    hint: "goto_position requires 'bar' (Int 1..9999) or 'position' (B.B.S.S)"
+                ))
+            }
             requestedPosition = "\(b).1.1.1"
         } else if let pos = params["position"] {
             if pos.contains(":") {
@@ -807,16 +808,11 @@ extension AccessibilityChannel {
                     hint: "goto_position requires 'bar' (Int 1..9999) or 'position' (B.B.S.S)"
                 ))
             }
-            targetBar = b
-            targetBeat = beat
-            // Keep the caller's complete request. The slider can only express a prefix of it, but
-            // must never silently replace beat/subdivision/tick with its own defaults.
+            // Keep the caller's complete request. The dialog must never silently replace its
+            // beat/subdivision/tick components with defaults.
             requestedPosition = "\(b).\(beat).\(subdivision).\(tick)"
         }
-        guard let bar = targetBar,
-              let beat = targetBeat,
-              let requestedPosition,
-              (1...9999).contains(bar)
+        guard let requestedPosition
         else {
             return .error(HonestContract.encodeStateC(
                 error: .invalidParams,
@@ -838,7 +834,7 @@ extension AccessibilityChannel {
                     + "to the wrong bar, so nothing was touched. Bring Logic Pro to the front and retry.",
                 extras: baseExtras.merging([
                     "operation": "transport.goto_position",
-                    "method": "ax_bar_slider",
+                    "method": "ax_goto_position_dialog",
                     "frontmost_preparation": preparation.rawValue,
                     "write_attempted": false,
                     "safe_to_retry": true,
@@ -887,10 +883,10 @@ extension AccessibilityChannel {
         if case let .failed(classification) = dialogResult,
            classification.requiresUnsafeUIRefusal {
             // The normal script proved no Return was sent, but could not prove that the menu or
-            // dialog closed. Do not let an unknown focus target receive a slider write.
+            // dialog closed. Do not let an unknown focus target receive any later position write.
             return .error(HonestContract.encodeStateC(
                 error: .axWriteFailed,
-                hint: "The Go To Position menu or dialog was not observed closed; the slider fallback was not attempted.",
+                hint: "The Go To Position menu or dialog was not observed closed; no later position route was attempted.",
                 extras: baseExtras.merging([
                     "operation": "transport.goto_position",
                     "method": "dialog",
@@ -911,147 +907,35 @@ extension AccessibilityChannel {
             ))
         }
 
-        guard let slider = AXLogicProElements.findControlBarBarSlider(runtime: runtime) else {
-            return .error(HonestContract.encodeStateC(
-                error: .elementNotFound,
-                hint: "Neither goto-position dialog nor 마디 slider available",
-                extras: baseExtras
-            ))
+        if case let .failed(classification) = dialogResult {
+            baseExtras["dialog_route_outcome"] = classification.diagnosticLabel
         }
 
-        // AX setters cannot establish either outcome: Logic has returned both failure after an
-        // effective write and success after no change.  The issued write is recorded below, then
-        // every subsequent action is authorised by a status-preserving observation instead.
-        func sliderValue(_ element: AXUIElement) -> Result<Int?, AXHelpers.AXStatusError> {
-            let value: Result<NSNumber?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
-                element, kAXValueAttribute as String, runtime: runtime.ax
-            )
-            return value.map { $0?.intValue }
-        }
-
-        func observedPosition(bar: Int, beat: Int?) -> String {
-            // These are slider readings, not a transport-state parse.  Do not append beat/subbeat/tick
-            // components that no AX reader supplied.
-            guard let beat else { return "\(bar)" }
-            return "\(bar).\(beat)"
-        }
-
-        func sliderExtras(observedBar: Int?, observedBeat: Int? = nil) -> [String: Any] {
-            let unobservedComponents = observedBeat == nil
-                ? ["beat", "subdivision", "tick"]
-                : ["subdivision", "tick"]
-            return baseExtras.merging([
-                "observed": observedBar.map { observedPosition(bar: $0, beat: observedBeat) } ?? NSNull(),
+        // Logic Pro 12.3 exposes the `bar` control as a relative increment, not an absolute musical
+        // bar number: setting AXValue to 37 advances one bar from both bar 1 and bar 3.  There is no
+        // measured conversion from the requested position to that control, so do not turn an unknown
+        // relative movement into a second position actuator by guessing a scale or issuing a write.
+        // A pre-write State C lets the router try its independently position-capable later channels.
+        return .error(HonestContract.encodeStateC(
+            error: .axWriteFailed,
+            hint: "The Control Bar bar slider is a relative increment, not an absolute position writer; no slider position write was issued.",
+            extras: baseExtras.merging([
+                "operation": "transport.goto_position",
                 "via": "slider",
-                "write_attempted": true,
-                // The control-bar exposes only bar and, on some builds, beat. State A requires an
-                // independently observed complete request, so this route advertises the missing
-                // components instead of certifying the prefix as the requested position.
-                "unobserved_position_components": unobservedComponents,
-                // These fields are carried forward verbatim in `requested`, but the control-bar
-                // sliders have no actuator for them. Keep that loss of expression explicit rather
-                // than silently substituting `.1.1` or implying the prefix was the full request.
-                "unexpressed_position_components": unobservedComponents,
+                "slider_position_write_supported": false,
+                "slider_value_semantics": "relative_increment_not_absolute_position",
+                "unobserved_position_components": ["bar", "beat", "subdivision", "tick"],
+                "unexpressed_position_components": ["bar", "beat", "subdivision", "tick"],
+                "write_attempted": false,
+                "safe_to_retry": true,
             ]) { _, new in new }
-        }
-
-        _ = AXHelpers.setAttribute(
-            slider, kAXValueAttribute, NSNumber(value: bar), runtime: runtime.ax
-        )
-        let initialBar: Int?
-        switch sliderValue(slider) {
-        case .failure, .success(nil):
-            // The bar write was issued.  A failed read is not evidence that it was refused, so this
-            // must be uncertain State B rather than State C; neither beat nor Confirm is authorised.
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackUnavailable,
-                extras: sliderExtras(observedBar: nil)
-            ))
-        case let .success(value?):
-            initialBar = value
-        }
-        guard initialBar == bar else {
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackMismatch,
-                extras: sliderExtras(observedBar: initialBar)
-            ))
-        }
-
-        let beatSlider = AXLogicProElements.findControlBarBeatSlider(runtime: runtime)
-        var initialBeat: Int?
-        if let beatSlider {
-            _ = AXHelpers.setAttribute(
-                beatSlider, kAXValueAttribute, NSNumber(value: beat), runtime: runtime.ax
-            )
-            switch sliderValue(beatSlider) {
-            case .failure, .success(nil):
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackUnavailable,
-                    extras: sliderExtras(observedBar: initialBar)
-                ))
-            case let .success(value?):
-                initialBeat = value
-            }
-            guard initialBeat == beat else {
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackMismatch,
-                    extras: sliderExtras(observedBar: initialBar, observedBeat: initialBeat)
-                ))
-            }
-        }
-
-        // Confirm is also an AX actuation whose return code is not a trustworthy outcome.  Read the
-        // actual sliders again afterwards, and certify only the components those reads vended.
-        _ = AXHelpers.performAction(slider, kAXConfirmAction, runtime: runtime.ax)
-        let finalBar: Int?
-        switch sliderValue(slider) {
-        case .failure, .success(nil):
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackUnavailable,
-                extras: sliderExtras(observedBar: initialBar, observedBeat: initialBeat)
-            ))
-        case let .success(value?):
-            finalBar = value
-        }
-        guard finalBar == bar else {
-            return .success(HonestContract.encodeStateB(
-                reason: .readbackMismatch,
-                extras: sliderExtras(observedBar: finalBar)
-            ))
-        }
-
-        var finalBeat: Int?
-        if let beatSlider {
-            switch sliderValue(beatSlider) {
-            case .failure, .success(nil):
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackUnavailable,
-                    extras: sliderExtras(observedBar: finalBar)
-                ))
-            case let .success(value?):
-                finalBeat = value
-            }
-            guard finalBeat == beat else {
-                return .success(HonestContract.encodeStateB(
-                    reason: .readbackMismatch,
-                    extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
-                ))
-            }
-        }
-        // A bar-only or bar+beat AX read cannot independently verify subdivision and tick. Keep
-        // this State B even when every exposed slider agrees; TransportDispatcher performs the
-        // authoritative full transport-state comparison before emitting State A.
-        return .success(HonestContract.encodeStateB(
-            reason: .readbackUnavailable,
-            extras: sliderExtras(observedBar: finalBar, observedBeat: finalBeat)
         ))
     }
 
     /// Move the playhead to `bar` via Logic Pro 12's `탐색 → 이동 → 위치…`
     /// (Navigate → Go To → Position) dialog. Reliable because the dialog auto-
     /// extends project length; however the menu item is disabled when no
-    /// regions exist yet, in which case this returns an error and callers
-    /// should try the slider fallback.
+    /// regions exist yet, in which case the caller may use another position-capable channel.
     /// Adds one field to an already-encoded JSON envelope, leaving it untouched if it cannot be
     /// parsed — a receipt is never worth corrupting to annotate.
     private static func mergingJSONField(_ payload: String, key: String, value: String) -> String {
@@ -1105,7 +989,7 @@ extension AccessibilityChannel {
         -- Never claim that Escape cleaned up a menu until AXSelected says so.
         -- Three attempts are enough to cover a menu/submenu chain without
         -- turning a failed close into an unbounded retry.
-        -- `knownOpen` says whether THIS run has already clicked a menu open. Before that boundary,
+        -- `knownOpen` says whether THIS run has issued its resolved leaf. Before that boundary,
         -- UNREADABLE returns without Escape because unknown focus might be an unrelated dialog/edit;
         -- the caller must refuse rather than treating the missing read as clean. After this run
         -- clicked, an unreadable read is not permission to skip Escape, because this run may leave
@@ -1148,23 +1032,6 @@ extension AccessibilityChannel {
             if menuActuationAttempted then return " after menu actuation"
             return ""
         end menuCleanupActuationContext
-
-        -- AXPress can return before Logic has opened the clicked item's own menu.
-        -- AXSelected belongs to that exact item, so an unrelated open menu cannot
-        -- authorise the next click.
-        on menuItemOpenedAfterClick(theMenuItem)
-            repeat 3 times
-                using terms from application "System Events"
-                    try
-                        if selected of theMenuItem then return "OPEN"
-                    on error
-                        return "UNREADABLE"
-                    end try
-                end using terms from
-                delay 0.1
-            end repeat
-            return "CLOSED"
-        end menuItemOpenedAfterClick
 
         -- The Go To Position floating dialog has its own lifecycle; a menu-bar
         -- observation says nothing about whether this modal is still blocking
@@ -1255,16 +1122,16 @@ extension AccessibilityChannel {
             tell logicProcess
                 -- A timed-out predecessor or user action can leave a menu open. An unreadable
                 -- entry read is not evidence that the menu is absent, so it must not release a
-                -- later slider actuation. `knownOpen:false` deliberately withholds Escape when
+                -- later position actuation. `knownOpen:false` deliberately withholds Escape when
                 -- focus is unknown.
                 set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)
                 if entryMenuCleanup is not "CLOSED" then
                     return "MENU_PICK_FAILED: menu state was not observed closed at entry (" & entryMenuCleanup & ")"
                 end if
                 set menuActuationAttempted to false
-                -- This marks the write boundary for actuator selection.  The
+                -- This records whether the resolved leaf actuation was issued. The
                 -- leaf may succeed even if AX reports an error, so any result
-                -- after it becomes true must not release the slider route.
+                -- after it becomes true must not release another position route.
                 set dialogActuationIssued to false
                 delay 0.2
 
@@ -1273,13 +1140,9 @@ extension AccessibilityChannel {
                 -- Korean attempt into a second English menu actuation.
                 try
                     if exists menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1 then
-                        set selectedMenuBarItem to menu bar item "탐색" of menu bar 1
-                        set selectedSubmenuItem to menu item "이동" of menu 1 of selectedMenuBarItem
-                        set mi to menu item "위치…" of menu 1 of selectedSubmenuItem
+                        set selectedLocaleChain to "KOREAN"
                     else if exists menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1 then
-                        set selectedMenuBarItem to menu bar item "Navigate" of menu bar 1
-                        set selectedSubmenuItem to menu item "Go To" of menu 1 of selectedMenuBarItem
-                        set mi to menu item "Position…" of menu 1 of selectedSubmenuItem
+                        set selectedLocaleChain to "ENGLISH"
                     else
                         -- No menu has been opened by this run. If the read is unreadable,
                         -- `knownOpen:false` must not send Escape into an unrelated focus target.
@@ -1299,36 +1162,11 @@ extension AccessibilityChannel {
                     return "MENU_NOT_FOUND: " & errMsg
                 end try
                 try
-                    -- Opening the selected chain refreshes AXEnabled. This is
-                    -- the only menu-bar chain that can be clicked in this run.
-                    set menuActuationAttempted to true
-                    click selectedMenuBarItem
-                    set menuBarOpenState to my menuItemOpenedAfterClick(selectedMenuBarItem)
-                    if menuBarOpenState is not "OPEN" then
-                        set cleanupState to my dismissOpenMenu(logicProcess, true)
-                        if cleanupState is not "CLOSED" then
-                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
-                        end if
-                        return "MENU_PICK_FAILED: selected menu bar item did not open (" & menuBarOpenState & ")"
+                    if selectedLocaleChain is "KOREAN" then
+                        set menuItemEnabled to enabled of menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
+                    else
+                        set menuItemEnabled to enabled of menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                     end if
-                    click selectedSubmenuItem
-                    set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)
-                    if submenuOpenState is not "OPEN" then
-                        set cleanupState to my dismissOpenMenu(logicProcess, true)
-                        if cleanupState is not "CLOSED" then
-                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
-                        end if
-                        return "MENU_PICK_FAILED: selected submenu item did not open (" & submenuOpenState & ")"
-                    end if
-                on error errMsg
-                    set cleanupState to my dismissOpenMenu(logicProcess, true)
-                    if cleanupState is not "CLOSED" then
-                        return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
-                    end if
-                    return "MENU_NOT_FOUND: " & errMsg
-                end try
-                try
-                    set menuItemEnabled to enabled of mi
                 on error
                     -- An unreadable AXEnabled must not authorise the pick.
                     set cleanupState to my dismissOpenMenu(logicProcess, true)
@@ -1346,7 +1184,7 @@ extension AccessibilityChannel {
                 end if
                 try
                     -- Persist before AXPress: if the child dies after the click, Swift still knows
-                    -- that the dialog route may have become active and must not choose the slider.
+                    -- that the dialog route may have become active and must not choose another route.
                     if not my recordDialogIssuance("LEAF_ARMED", "\(ledgerPath)") then
                         set cleanupState to my dismissOpenMenu(logicProcess, true)
                         if cleanupState is not "CLOSED" then
@@ -1354,8 +1192,13 @@ extension AccessibilityChannel {
                         end if
                         return "MENU_PICK_FAILED: could not persist dialog issuance before leaf click"
                     end if
+                    set menuActuationAttempted to true
                     set dialogActuationIssued to true
-                    click mi
+                    if selectedLocaleChain is "KOREAN" then
+                        click menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
+                    else
+                        click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
+                    end if
                 on error errMsg
                     set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
                     if dialogCleanupState is not "CLOSED" then
@@ -1513,6 +1356,32 @@ extension AccessibilityChannel {
         case driven
         case failure(Failure)
 
+        /// Why the dialog route ended, as a fixed structural token. Without this a caller that
+        /// reaches the non-dialog route cannot tell whether the dialog route was tried and
+        /// abandoned or never reachable.
+        var diagnosticLabel: String {
+            switch self {
+            case .driven: return "driven"
+            case .failure(.menuNotFound): return "menu_not_found"
+            case .failure(.menuStateUnreadable): return "menu_state_unreadable"
+            case .failure(.menuDisabled): return "menu_disabled"
+            case .failure(.menuPickFailed): return "menu_pick_failed"
+            case let .failure(.menuCouldNotBeClosed(writeAttempted)):
+                return "menu_could_not_be_closed_write_attempted_\(writeAttempted)"
+            case .failure(.dialogNotReady): return "dialog_not_ready"
+            case let .failure(.dialogActuationIssued(closed)):
+                return "dialog_actuation_issued_cleanup_closed_\(closed)"
+            case let .failure(.dialogSubmissionNotIssued(closed)):
+                return "dialog_submission_not_issued_cleanup_closed_\(closed)"
+            case let .failure(.dialogSubmissionIssued(closed)):
+                return "dialog_submission_issued_cleanup_closed_\(closed)"
+            case let .failure(.executionFailed(issuance, closed)):
+                return "execution_failed_issuance_\(issuance.rawValue)_cleanup_closed_\(closed)"
+            case .failure(.malformedPayload): return "malformed_payload"
+            case .failure(.unexpectedResult): return "unexpected_result"
+            }
+        }
+
         /// Any normal path that explicitly reached Return, plus a dead child that persisted a
         /// pre-leaf/Return checkpoint. A leaf checkpoint is intentionally conservative after a
         /// process death: the parent cannot prove the child did not advance to Return before dying.
@@ -1528,7 +1397,7 @@ extension AccessibilityChannel {
             }
         }
 
-        /// A slider is unsafe when a non-submission path cannot prove the menu/dialog UI is gone.
+        /// A later position route is unsafe when a non-submission path cannot prove the menu/dialog UI is gone.
         /// A clean, normal leaf/input failure may fall through because the script proved no Return
         /// was sent *and* observed the relevant UI closed.
         var requiresUnsafeUIRefusal: Bool {
@@ -1620,7 +1489,7 @@ extension AccessibilityChannel {
             return .failure(.dialogActuationIssued(
                 // A closed dialog is insufficient if a menu cleanup remained unreadable. Both
                 // surfaces must be observed closed before this known pre-Return path can fall
-                // through to the slider.
+                // through to a later position route.
                 cleanupObservedClosed: !value.contains("cleanup was not observed")
             ))
         case let value where value.hasPrefix("DIALOG_SUBMISSION_NOT_ISSUED"):
@@ -1699,7 +1568,7 @@ extension AccessibilityChannel {
     private enum StrayGoToPositionUIOutcome: Equatable { case closed, openOrUnknown }
 
     /// Reconcile the exact Go To Position modal before considering menu state. A menu-bar read does
-    /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise the slider
+    /// not describe a modal dialog, so a post-timeout `CLOSED` menu must never authorise another route
     /// while the dialog remains on screen.
     private static func observeAndClearStrayGoToPositionUI() async -> StrayGoToPositionUIOutcome {
         let target = LogicProTarget.appleScriptTarget()

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -778,7 +778,8 @@ extension AccessibilityChannel {
         activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
         sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) },
         executeDialogScript: (@Sendable (String) async -> ChannelResult)? = nil,
-        reconcileAfterDialogExecutionFailure: (@Sendable () async -> Bool)? = nil
+        reconcileAfterDialogExecutionFailure: (@Sendable () async -> Bool)? = nil,
+        createDialogIssuanceLedger: @escaping @Sendable () -> DialogIssuanceLedger? = DialogIssuanceLedger.create
     ) async -> ChannelResult {
         var requestedPosition: String? = nil
         if let barStr = params["bar"], let b = Int(barStr) {
@@ -894,7 +895,8 @@ extension AccessibilityChannel {
         let dialogResult = await gotoPositionViaDialog(
             position: requestedPosition,
             executeScript: dialogScriptExecutor,
-            reconcileAfterExecutionFailure: dialogFailureReconciler
+            reconcileAfterExecutionFailure: dialogFailureReconciler,
+            createIssuanceLedger: createDialogIssuanceLedger
         )
         if case let .driven(payload) = dialogResult {
             // The dialog rung builds its own envelope, so without this the same operation reports
@@ -919,7 +921,8 @@ extension AccessibilityChannel {
                 "safe_to_retry": false,
                 "fallback_unsafe": true,
             ]) { _, new in new }
-            if classification.globalInputMayHaveOccurred {
+            switch classification.globalInputEvidence {
+            case .attempted:
                 extras["dialog_input_attempted"] = true
                 if let inputBoundary = classification.globalInputBoundary {
                     extras["dialog_input_boundary"] = inputBoundary.rawValue
@@ -929,17 +932,31 @@ extension AccessibilityChannel {
                 // afterwards, so this is deliberately conservative rather than a claim that the
                 // observed Go To Position window consumed the input.
                 extras["write_attempted"] = true
+            case .indeterminate:
+                // A durable marker is written before a global key, not after it. A dead child
+                // can leave that marker without ever reaching the key (including when no child
+                // spawned), so preserve the uncertainty instead of calling it an attempt.
+                extras["dialog_input_indeterminate"] = true
+                if let inputBoundary = classification.globalInputBoundary {
+                    extras["dialog_input_boundary"] = inputBoundary.rawValue
+                }
+                extras["dialog_input_target"] = "unknown"
+                extras["write_attempted_indeterminate"] = true
+            case .notAttempted:
+                break
             }
-            if classification.dialogSubmissionWasObserved {
+            switch classification.dialogSubmissionEvidence {
+            case .attempted:
                 extras["dialog_submission_attempted"] = true
                 extras["write_attempted"] = true
-            } else if classification.dialogSubmissionMayHaveOccurred {
+            case .indeterminate:
                 extras["dialog_submission_indeterminate"] = true
-            } else if classification.globalInputMayHaveOccurred {
+            case .notAttempted where classification.globalInputEvidence
+                != GotoPositionDialogResultClassification.DialogInputEvidence.notAttempted:
                 // The completed script proved it did not advance to RETURN_ARMED, but an earlier
                 // global key may already have changed whichever target owned focus.
                 extras["dialog_submission_attempted"] = false
-            } else {
+            case .notAttempted:
                 extras["dialog_submission_indeterminate"] = true
             }
             return .success(HonestContract.encodeStateB(
@@ -1079,6 +1096,28 @@ extension AccessibilityChannel {
             end using terms from
         end menuOpenState
 
+        -- Check the global owner on both sides of the menu observation immediately before
+        -- Escape. System Events cannot make those reads atomic with the global key, but this
+        -- bracket rejects a handoff that happens while resolving the menu and leaves only the
+        -- irreducible interval after the final read.
+        on menuEscapeFocusState(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        set logicWasFrontmost to frontmost
+                        if logicWasFrontmost is not true then return "NOT_FRONTMOST"
+                        set menuState to my menuOpenState(theProcess)
+                        if menuState is not "OPEN" then return menuState
+                        set logicIsStillFrontmost to frontmost
+                        if logicIsStillFrontmost is not true then return "NOT_FRONTMOST"
+                        return "FOCUSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end menuEscapeFocusState
+
         -- Never claim that Escape cleaned up a menu until AXSelected says so.
         -- Three attempts are enough to cover a menu/submenu chain without
         -- turning a failed close into an unbounded retry.
@@ -1093,12 +1132,8 @@ extension AccessibilityChannel {
             if menuState is "UNREADABLE" and not knownOpen then return "UNREADABLE"
             if menuState is not "OPEN" and menuState is not "UNREADABLE" then return menuState
             repeat 3 times
-                try
-                    set logicIsFrontmost to frontmost of theProcess
-                on error
-                    return "UNREADABLE"
-                end try
-                if logicIsFrontmost is not true then return "NOT_FRONTMOST"
+                set menuFocusState to my menuEscapeFocusState(theProcess)
+                if menuFocusState is not "FOCUSED" then return menuFocusState
                 using terms from application "System Events"
                     tell theProcess to key code 53
                 end using terms from
@@ -1117,11 +1152,17 @@ extension AccessibilityChannel {
         -- marker intact, never truncate the ledger to an empty/unknown value.
         on recordDialogIssuance(stage, ledgerPath)
             if ledgerPath is "" then return true
+            set temporaryLedgerPath to ""
             try
                 set temporaryLedgerPath to do shell script "/usr/bin/mktemp " & quoted form of (ledgerPath & ".tmp.XXXXXX")
                 do shell script "/usr/bin/printf %s " & quoted form of stage & " > " & quoted form of temporaryLedgerPath & " && /bin/mv -f " & quoted form of temporaryLedgerPath & " " & quoted form of ledgerPath
                 return true
             on error
+                if temporaryLedgerPath is not "" then
+                    try
+                        do shell script "/bin/rm -f " & quoted form of temporaryLedgerPath
+                    end try
+                end if
                 return false
             end try
         end recordDialogIssuance
@@ -1143,19 +1184,49 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
-        -- Find only an operable, modal Go To Position window. Title alone is not a dialog
-        -- identity: an ordinary same-titled window must not satisfy this run's input poll.
-        on matchingGoToPositionDialog(theProcess)
+        -- Capture every pre-leaf window by element identity. A track or plug-in editor can be
+        -- titled "Go To Position", so title/subrole/modality alone cannot say that a window belongs
+        -- to this request. The input target must be a matching window that appeared after this
+        -- run's resolved leaf click.
+        on goToPositionWindowSnapshot(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        return every window
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionWindowSnapshot
+
+        on windowWasPresentBefore(dialogWindow, preLeafWindows)
+            repeat with preLeafWindow in preLeafWindows
+                try
+                    if contents of preLeafWindow is dialogWindow then return true
+                end try
+            end repeat
+            return false
+        end windowWasPresentBefore
+
+        -- Find only an operable, modal Go To Position window that this leaf could have opened.
+        -- Pre-existing same-titled windows are skipped before reading their subrole or AXModal, so
+        -- an unrelated plug-in editor with an unreadable modality cannot block this request.
+        on matchingGoToPositionDialog(theProcess, preLeafWindows)
+            if preLeafWindows is "UNREADABLE" then return "UNREADABLE"
             using terms from application "System Events"
                 tell theProcess
                     try
                         repeat with dialogWindow in every window
+                            set candidateWindow to contents of dialogWindow
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                set dialogSubrole to subrole of dialogWindow
-                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
-                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                    if dialogIsModal is true then return contents of dialogWindow
+                                if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then
+                                    set dialogSubrole to subrole of dialogWindow
+                                    if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                        if dialogIsModal is true then return candidateWindow
+                                    end if
                                 end if
                             end if
                         end repeat
@@ -1169,28 +1240,26 @@ extension AccessibilityChannel {
 
         -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
         -- about whether a titled modal is still blocking the arrange area. `AXModal` answers
-        -- whether the measured known class is modal; subrole only classifies that class. An exact
-        -- title with an unknown subrole must remain non-CLOSED, so a future Logic build cannot
-        -- release another route while its modal is still present.
-        on goToPositionDialogState(theProcess)
+        -- whether the measured known class is modal; subrole only classifies that class. This
+        -- state is intentionally about the exact element newly observed for this run, never a
+        -- title-only scan that can confuse an unrelated same-titled plug-in window for our dialog.
+        on goToPositionDialogState(theProcess, dialogWindow)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        repeat with dialogWindow in every window
-                            set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                set dialogSubrole to subrole of dialogWindow
-                                if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "OPEN_UNKNOWN_SUBROLE"
-                                try
-                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
-                                on error
-                                    return "OPEN_UNREADABLE"
-                                end try
-                                if dialogIsModal is true then return "OPEN"
-                                return "OPEN_UNVERIFIED_MODALITY"
-                            end if
-                        end repeat
-                        return "CLOSED"
+                        if dialogWindow is missing value then return "CLOSED"
+                        if not (exists dialogWindow) then return "CLOSED"
+                        set dialogTitle to name of dialogWindow
+                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "CLOSED"
+                        set dialogSubrole to subrole of dialogWindow
+                        if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "OPEN_UNKNOWN_SUBROLE"
+                        try
+                            set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                        on error
+                            return "OPEN_UNREADABLE"
+                        end try
+                        if dialogIsModal is true then return "OPEN"
+                        return "OPEN_UNVERIFIED_MODALITY"
                     on error
                         return "UNREADABLE"
                     end try
@@ -1199,14 +1268,15 @@ extension AccessibilityChannel {
         end goToPositionDialogState
 
         -- System Events exposes keystroke only globally, not as an action on a
-        -- window/text element. Re-read the global application owner and the exact
-        -- process-local AXFocusedWindow together immediately before each key sequence.
+        -- window/text element. Bracket the exact process-local AXFocusedWindow read with global
+        -- frontmost checks immediately before each key sequence. The second read catches a
+        -- handoff during element resolution; only the unavoidable interval after it remains.
         on observedGoToPositionDialogFocusState(theProcess, dialogWindow)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        set logicIsFrontmost to frontmost
-                        if logicIsFrontmost is not true then return "NOT_FRONTMOST"
+                        set logicWasFrontmost to frontmost
+                        if logicWasFrontmost is not true then return "NOT_FRONTMOST"
                         if not (exists dialogWindow) then return "MISSING"
                         set dialogTitle to name of dialogWindow
                         set dialogSubrole to subrole of dialogWindow
@@ -1216,8 +1286,10 @@ extension AccessibilityChannel {
                         if dialogIsModal is not true then return "NOT_MODAL"
                         if not (exists attribute "AXFocusedWindow") then return "UNREADABLE"
                         set processFocusedWindow to value of attribute "AXFocusedWindow"
-                        if processFocusedWindow is dialogWindow then return "FOCUSED"
-                        return "NOT_FOCUSED"
+                        if processFocusedWindow is not dialogWindow then return "NOT_FOCUSED"
+                        set logicIsStillFrontmost to frontmost
+                        if logicIsStillFrontmost is not true then return "NOT_FRONTMOST"
+                        return "FOCUSED"
                     on error
                         return "UNREADABLE"
                     end try
@@ -1229,28 +1301,24 @@ extension AccessibilityChannel {
         -- fallback while this exact dialog is observed open, and every attempt
         -- must be followed by a new exact-dialog observation before it counts
         -- as cleanup.
-        on pressGoToPositionDialogCancel(theProcess)
+        on pressGoToPositionDialogCancel(theProcess, dialogWindow)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        repeat with dialogWindow in every window
-                            set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                if exists button "Cancel" of dialogWindow then
-                                    click button "Cancel" of dialogWindow
-                                    return "PRESSED"
-                                end if
-                                if exists button "취소" of dialogWindow then
-                                    click button "취소" of dialogWindow
-                                    return "PRESSED"
-                                end if
-                                if exists button "キャンセル" of dialogWindow then
-                                    click button "キャンセル" of dialogWindow
-                                    return "PRESSED"
-                                end if
-                                return "NO_BUTTON"
-                            end if
-                        end repeat
+                        set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
+                        if dialogState is not "OPEN" then return dialogState
+                        if exists button "Cancel" of dialogWindow then
+                            click button "Cancel" of dialogWindow
+                            return "PRESSED"
+                        end if
+                        if exists button "취소" of dialogWindow then
+                            click button "취소" of dialogWindow
+                            return "PRESSED"
+                        end if
+                        if exists button "キャンセル" of dialogWindow then
+                            click button "キャンセル" of dialogWindow
+                            return "PRESSED"
+                        end if
                         return "NO_BUTTON"
                     on error
                         return "UNREADABLE"
@@ -1259,32 +1327,28 @@ extension AccessibilityChannel {
             end using terms from
         end pressGoToPositionDialogCancel
 
-        on dismissOpenGoToPositionDialog(theProcess)
-            set dialogState to my goToPositionDialogState(theProcess)
+        on dismissOpenGoToPositionDialog(theProcess, dialogWindow)
+            set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
-                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess)
+                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess, dialogWindow)
                 if cancelOutcome is "NO_BUTTON" or cancelOutcome is "UNREADABLE" then
                     -- The Cancel click may have landed even though AX reported failure. Re-observe
                     -- this exact dialog before choosing Escape as a second actuator; unreadable is
                     -- not permission to send a key into an unknown focus target.
-                    set dialogState to my goToPositionDialogState(theProcess)
+                    set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
                     if dialogState is "CLOSED" then return "CLOSED"
                     if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                     if dialogState is not "OPEN" then return dialogState
-                    set cleanupDialogWindow to my matchingGoToPositionDialog(theProcess)
-                    if cleanupDialogWindow is "UNREADABLE" or cleanupDialogWindow is missing value then
-                        return "OPEN_UNREADABLE"
-                    end if
-                    set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, cleanupDialogWindow)
+                    set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, dialogWindow)
                     if cleanupDialogFocusState is not "FOCUSED" then return cleanupDialogFocusState
                     using terms from application "System Events"
                         tell theProcess to key code 53
                     end using terms from
                 end if
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess)
+                set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                 if dialogState is not "OPEN" then return dialogState
@@ -1358,17 +1422,13 @@ extension AccessibilityChannel {
                     end if
                     return "MENU_DISABLED"
                 end if
-                -- A same-titled window that was already present belongs to neither this leaf
-                -- actuation nor this request. This includes an unknown future subrole: do not
-                -- dismiss it as absent simply because it is outside the measured input class.
-                -- Absence immediately before the leaf is the first half of this run's dialog-
-                -- appearance transition.
-                set preLeafGoToPositionDialogState to my goToPositionDialogState(logicProcess)
-                if preLeafGoToPositionDialogState is "UNREADABLE" then
-                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position dialog state was unreadable before leaf click"
-                end if
-                if preLeafGoToPositionDialogState is not "CLOSED" then
-                    return "DIALOG_PREEXISTING: Go To Position dialog was already present before leaf click (" & preLeafGoToPositionDialogState & ")"
+                -- The window identity snapshot, not its title, is the first half of this run's
+                -- absence → leaf → appearance transition. A pre-existing plug-in editor may use
+                -- the same title (and even AXDialog), but can never become this run's input target.
+                set observedGoToPositionDialog to missing value
+                set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)
+                if preLeafGoToPositionWindows is "UNREADABLE" then
+                    return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot was unreadable before leaf click"
                 end if
                 try
                     -- Persist before AXPress: if the child dies after the click, Swift still knows
@@ -1388,7 +1448,7 @@ extension AccessibilityChannel {
                         click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                     end if
                 on error errMsg
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1406,7 +1466,7 @@ extension AccessibilityChannel {
                 set observedGoToPositionDialog to missing value
                 repeat 30 times
                     delay 0.1
-                    set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)
+                    set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionWindows)
                     if observedGoToPositionDialog is "UNREADABLE" then
                         set dialogAppearanceUnreadable to true
                         exit repeat
@@ -1417,7 +1477,7 @@ extension AccessibilityChannel {
                     end if
                 end repeat
                 if not dialogReady then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1434,7 +1494,7 @@ extension AccessibilityChannel {
             -- it may have reached an unknown target rather than advertising a clean retry.
             try
                 if not my recordDialogIssuance("SELECT_ALL_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1449,7 +1509,7 @@ extension AccessibilityChannel {
                 -- frontmost while this run was preparing the receipt.
                 set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1462,7 +1522,7 @@ extension AccessibilityChannel {
                 keystroke "a" using command down
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1475,7 +1535,7 @@ extension AccessibilityChannel {
 
             try
                 if not my recordDialogIssuance("POSITION_INPUT_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1489,7 +1549,7 @@ extension AccessibilityChannel {
                 -- global position text, not merely after the preceding Cmd+A.
                 set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogTypingFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1502,7 +1562,7 @@ extension AccessibilityChannel {
                 keystroke "\(position)"
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1517,7 +1577,7 @@ extension AccessibilityChannel {
             -- Return submission boundary, so a timeout or nonzero child exit after either point is
             -- conservatively reported rather than releasing another actuator.
             if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1531,7 +1591,7 @@ extension AccessibilityChannel {
             -- owner after its durable marker is written and immediately before submission.
             set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogReturnFocusState is not "FOCUSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1545,7 +1605,7 @@ extension AccessibilityChannel {
                 keystroke return
                 delay 0.2
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1557,9 +1617,9 @@ extension AccessibilityChannel {
             end try
             -- A normal Return reply is not proof Logic consumed it. Observe this exact modal before
             -- returning OK; if it survived, clean it only after recording the submission boundary.
-            set dialogPostReturnState to my goToPositionDialogState(logicProcess)
+            set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog)
             if dialogPostReturnState is not "CLOSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1576,7 +1636,7 @@ extension AccessibilityChannel {
 
     /// State persisted by the parent-owned issuance ledger. `unknown` is deliberately unsafe: a
     /// missing/corrupt ledger after a dead child is not evidence that the child failed before Return.
-    enum DialogIssuanceStage: String, Equatable {
+    enum DialogIssuanceStage: String, Equatable, Sendable {
         case notIssued = "NOT_ISSUED"
         case leafArmed = "LEAF_ARMED"
         case selectAllArmed = "SELECT_ALL_ARMED"
@@ -1585,7 +1645,7 @@ extension AccessibilityChannel {
         case unknown
     }
 
-    private struct DialogIssuanceLedger {
+    struct DialogIssuanceLedger: Sendable {
         let url: URL
 
         static func create() -> DialogIssuanceLedger? {
@@ -1605,6 +1665,19 @@ extension AccessibilityChannel {
         }
 
         func remove() {
+            // The child may be killed after `mktemp` and before it can rename or clean its sibling.
+            // This run's UUID makes the prefix exclusive, so the parent can safely collect those
+            // orphaned staging files as well as the canonical ledger.
+            let directory = url.deletingLastPathComponent()
+            let temporaryPrefix = url.lastPathComponent + ".tmp."
+            if let siblings = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ) {
+                for sibling in siblings where sibling.lastPathComponent.hasPrefix(temporaryPrefix) {
+                    try? FileManager.default.removeItem(at: sibling)
+                }
+            }
             try? FileManager.default.removeItem(at: url)
         }
     }
@@ -1613,6 +1686,12 @@ extension AccessibilityChannel {
     /// value in `result`. Normal script replies distinguish failures before Return from a Return that
     /// may have landed; execution failures use the parent-owned durable ledger instead.
     enum GotoPositionDialogResultClassification: Equatable {
+        enum DialogInputEvidence: Equatable {
+            case notAttempted
+            case attempted
+            case indeterminate
+        }
+
         enum Failure: Equatable {
             case menuNotFound
             case menuStateUnreadable
@@ -1682,30 +1761,22 @@ extension AccessibilityChannel {
             }
         }
 
-        /// The script itself reported that Return was sent or may have been sent. A parent-owned
-        /// ledger is intentionally not included: a child can die immediately after writing it.
-        var dialogSubmissionWasObserved: Bool {
-            if case .failure(.dialogSubmissionIssued) = self {
-                return true
-            }
-            return false
-        }
-
-        /// True once the script reported a global key may have been issued, or a dead child
-        /// crossed the corresponding durable marker. This protects the receipt from claiming
-        /// `write_attempted:false` after Cmd+A, text entry, or Return could have reached another
-        /// focused target.
-        var globalInputMayHaveOccurred: Bool {
+        /// A normal script reply reached its key actuation statement. A durable ledger marker is
+        /// earlier than that statement, so a dead child leaves the input outcome indeterminate —
+        /// including the `unknown` case where ledger creation or reading failed before a spawn
+        /// failure proves whether a child ever existed.
+        var globalInputEvidence: DialogInputEvidence {
             switch self {
             case .failure(.dialogInputIssued),
-                 .failure(.dialogSubmissionIssued),
-                 .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
+                 .failure(.dialogSubmissionIssued):
+                return .attempted
+            case .failure(.executionFailed(issuance: .selectAllArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .positionInputArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
-                return true
+                return .indeterminate
             default:
-                return false
+                return .notAttempted
             }
         }
 
@@ -1726,16 +1797,18 @@ extension AccessibilityChannel {
             }
         }
 
-        /// A normal input result before Return proves no submission was attempted. A dead child
-        /// after RETURN_ARMED, or with no readable ledger, cannot make that same claim.
-        var dialogSubmissionMayHaveOccurred: Bool {
+        /// A normal script reply reached Return's actuation statement. A parent-owned marker is
+        /// deliberately weaker: it precedes Return and therefore represents uncertainty, not an
+        /// asserted submission attempt.
+        var dialogSubmissionEvidence: DialogInputEvidence {
             switch self {
-            case .failure(.dialogSubmissionIssued),
-                 .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
+            case .failure(.dialogSubmissionIssued):
+                return .attempted
+            case .failure(.executionFailed(issuance: .returnArmed, cleanupObservedClosed: _)),
                  .failure(.executionFailed(issuance: .unknown, cleanupObservedClosed: _)):
-                return true
+                return .indeterminate
             default:
-                return false
+                return .notAttempted
             }
         }
 
@@ -1874,9 +1947,10 @@ extension AccessibilityChannel {
     private static func gotoPositionViaDialog(
         position: String,
         executeScript: @escaping @Sendable (String) async -> ChannelResult,
-        reconcileAfterExecutionFailure: @escaping @Sendable () async -> Bool
+        reconcileAfterExecutionFailure: @escaping @Sendable () async -> Bool,
+        createIssuanceLedger: @escaping @Sendable () -> DialogIssuanceLedger?
     ) async -> GotoPositionDialogRouteResult {
-        let ledger = DialogIssuanceLedger.create()
+        let ledger = createIssuanceLedger()
         defer { ledger?.remove() }
         let script = gotoPositionViaDialogAppleScript(
             position: position,
@@ -1936,56 +2010,120 @@ extension AccessibilityChannel {
     ) async -> StrayGoToPositionUIOutcome {
         let target = LogicProTarget.appleScriptTarget()
         let script = """
-        on goToPositionDialogState(theProcess)
+        on knownGoToPositionDialogSubrole(dialogSubrole)
+            if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return true
+            return false
+        end knownGoToPositionDialogSubrole
+
+        -- Reconciliation has no live AX element from the killed child, so it can only match the
+        -- measured modal class. It must never turn a same-titled normal/editor window into a
+        -- cleanup target merely because its title collides with the dialog.
+        on matchingGoToPositionDialog(theProcess)
             using terms from application "System Events"
                 tell theProcess
                     try
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return "OPEN"
+                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                set dialogSubrole to subrole of dialogWindow
+                                if my knownGoToPositionDialogSubrole(dialogSubrole) then
+                                    set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                                    if dialogIsModal is true then return contents of dialogWindow
+                                end if
+                            end if
                         end repeat
-                        return "CLOSED"
+                        return missing value
                     on error
                         return "UNREADABLE"
                     end try
                 end tell
             end using terms from
+        end matchingGoToPositionDialog
+
+        on goToPositionDialogState(theProcess)
+            set dialogWindow to my matchingGoToPositionDialog(theProcess)
+            if dialogWindow is "UNREADABLE" then return "UNREADABLE"
+            if dialogWindow is missing value then return "CLOSED"
+            return "OPEN"
         end goToPositionDialogState
+
+        -- System Events keystrokes are global. Re-check frontmost after proving the exact modal
+        -- is Logic's AXFocusedWindow so a handoff during AX resolution cannot authorise Escape.
+        on observedGoToPositionDialogFocusState(theProcess, dialogWindow)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        set logicWasFrontmost to frontmost
+                        if logicWasFrontmost is not true then return "NOT_FRONTMOST"
+                        if not (exists dialogWindow) then return "MISSING"
+                        set dialogTitle to name of dialogWindow
+                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
+                        set dialogSubrole to subrole of dialogWindow
+                        if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "MISSING"
+                        set dialogIsModal to value of attribute "AXModal" of dialogWindow
+                        if dialogIsModal is not true then return "NOT_MODAL"
+                        if not (exists attribute "AXFocusedWindow") then return "UNREADABLE"
+                        set processFocusedWindow to value of attribute "AXFocusedWindow"
+                        if processFocusedWindow is not dialogWindow then return "NOT_FOCUSED"
+                        set logicIsStillFrontmost to frontmost
+                        if logicIsStillFrontmost is not true then return "NOT_FRONTMOST"
+                        return "FOCUSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end observedGoToPositionDialogFocusState
+
+        on menuEscapeFocusState(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        set logicWasFrontmost to frontmost
+                        if logicWasFrontmost is not true then return "NOT_FRONTMOST"
+                        set anyOpen to false
+                        repeat with menuBarItem in every menu bar item of menu bar 1
+                            if selected of menuBarItem then set anyOpen to true
+                        end repeat
+                        if not anyOpen then return "CLOSED"
+                        set logicIsStillFrontmost to frontmost
+                        if logicIsStillFrontmost is not true then return "NOT_FRONTMOST"
+                        return "FOCUSED"
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end menuEscapeFocusState
 
         on dismissGoToPositionDialog(theProcess)
             set dialogState to my goToPositionDialogState(theProcess)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
+                set dialogWindow to my matchingGoToPositionDialog(theProcess)
+                if dialogWindow is "UNREADABLE" then return "UNREADABLE"
+                if dialogWindow is missing value then return "CLOSED"
                 set cancelPressed to false
                 using terms from application "System Events"
                     tell theProcess
                         try
-                            repeat with dialogWindow in every window
-                                set dialogTitle to name of dialogWindow
-                                if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
-                                    if exists button "Cancel" of dialogWindow then
-                                        click button "Cancel" of dialogWindow
-                                        set cancelPressed to true
-                                        exit repeat
-                                    end if
-                                    if exists button "취소" of dialogWindow then
-                                        click button "취소" of dialogWindow
-                                        set cancelPressed to true
-                                        exit repeat
-                                    end if
-                                end if
-                            end repeat
+                            if exists button "Cancel" of dialogWindow then
+                                click button "Cancel" of dialogWindow
+                                set cancelPressed to true
+                            else if exists button "취소" of dialogWindow then
+                                click button "취소" of dialogWindow
+                                set cancelPressed to true
+                            else if exists button "キャンセル" of dialogWindow then
+                                click button "キャンセル" of dialogWindow
+                                set cancelPressed to true
+                            end if
                         on error
                         end try
-                        -- Escape is permitted only because this exact dialog was observed OPEN
-                        -- above and Logic still owns the global keyboard at this instant.
                         if not cancelPressed then
-                            if frontmost then
-                                key code 53
-                            else
-                                return "NOT_FRONTMOST"
-                            end if
+                            set cleanupFocusState to my observedGoToPositionDialogFocusState(theProcess, dialogWindow)
+                            if cleanupFocusState is not "FOCUSED" then return cleanupFocusState
+                            key code 53
                         end if
                     end tell
                 end using terms from
@@ -2003,12 +2141,9 @@ extension AccessibilityChannel {
                     set dialogCleanupState to my dismissGoToPositionDialog(it)
                     if dialogCleanupState is not "CLOSED" then return "DIALOG_" & dialogCleanupState
                     repeat 3 times
-                        set anyOpen to false
-                        repeat with menuBarItem in every menu bar item of menu bar 1
-                            if selected of menuBarItem then set anyOpen to true
-                        end repeat
-                        if not anyOpen then return "CLOSED"
-                        if not frontmost then return "NOT_FRONTMOST"
+                        set menuFocusState to my menuEscapeFocusState(it)
+                        if menuFocusState is "CLOSED" then return "CLOSED"
+                        if menuFocusState is not "FOCUSED" then return menuFocusState
                         key code 53
                         delay 0.1
                     end repeat

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1117,8 +1117,14 @@ extension AccessibilityChannel {
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
                             if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                                -- Measured on Logic 12.3: this window's subrole is
+                                -- AXFloatingWindow, not AXDialog. Gating on the guessed subrole
+                                -- made every drive refuse with "dialog did not become ready"
+                                -- while the dialog was open on screen. Ownership comes from the
+                                -- appearance transition around the leaf click; the subrole only
+                                -- excludes an ordinary document window sharing the title.
                                 set dialogSubrole to subrole of dialogWindow
-                                if dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return contents of dialogWindow
+                                if dialogSubrole is "AXFloatingWindow" or dialogSubrole is "AXDialog" or dialogSubrole is "AXSystemDialog" then return contents of dialogWindow
                             end if
                         end repeat
                         return missing value

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1174,15 +1174,17 @@ extension AccessibilityChannel {
             end try
         end recordDialogIssuance
 
-        -- The timeout reconciler runs in a fresh osascript process. Persist only the readable
-        -- count of exact Go To Position dialogs immediately before the leaf click. Window IDs are
-        -- not readable in Logic Pro, and names/geometry are neither stable identities nor safe
-        -- serialized data. An unavailable snapshot is intentionally not a clean empty snapshot.
-        on recordPreLeafGoToPositionWindowSnapshot(matchingGoToPositionDialogCount, snapshotPath)
+        -- The timeout reconciler runs in a fresh osascript process. Persist readable known-dialog
+        -- and total-window counts immediately before the leaf click. Window IDs are not readable
+        -- in Logic Pro, and names/geometry are neither stable identities nor safe serialized data.
+        -- An unavailable snapshot is intentionally not a clean empty snapshot.
+        -- The total window count is independent evidence for the title whitelist: a window whose
+        -- localized title we do not yet know must not disappear into a zero known-dialog count.
+        on recordPreLeafGoToPositionWindowSnapshot(matchingGoToPositionDialogCount, totalWindowCount, snapshotPath)
             if snapshotPath is "" then return true
             set temporarySnapshotPath to ""
             try
-                set snapshotText to "READY" & linefeed & (matchingGoToPositionDialogCount as text)
+                set snapshotText to "READY" & linefeed & (matchingGoToPositionDialogCount as text) & linefeed & (totalWindowCount as text)
                 set temporarySnapshotPath to do shell script "/usr/bin/mktemp " & quoted form of (snapshotPath & ".tmp.XXXXXX")
                 do shell script "/usr/bin/printf %s " & quoted form of snapshotText & " > " & quoted form of temporarySnapshotPath & " && /bin/mv -f " & quoted form of temporarySnapshotPath & " " & quoted form of snapshotPath
                 return true
@@ -1213,6 +1215,13 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
+        -- These are the measured, operable titles, not an absence policy. Locale expansion is
+        -- tracked in #519; until then an unrecognised title must be withheld as unidentified.
+        on knownGoToPositionDialogTitle(dialogTitle)
+            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
+            return false
+        end knownGoToPositionDialogTitle
+
         -- Count only windows that satisfy the measured input-target predicate. All properties used
         -- here are readable from Logic Pro; errors are intentionally fail-closed. This numeric
         -- observation is stable when a window moves and cannot embed a project/window title.
@@ -1223,7 +1232,7 @@ extension AccessibilityChannel {
                         set matchingWindowCount to 0
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                            if my knownGoToPositionDialogTitle(dialogTitle) then
                                 set dialogSubrole to subrole of dialogWindow
                                 if my knownGoToPositionDialogSubrole(dialogSubrole) then
                                     set dialogIsModal to value of attribute "AXModal" of dialogWindow
@@ -1275,7 +1284,7 @@ extension AccessibilityChannel {
                         set matchingDialogWindows to {}
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                            if my knownGoToPositionDialogTitle(dialogTitle) then
                                 set dialogSubrole to subrole of dialogWindow
                                 if my knownGoToPositionDialogSubrole(dialogSubrole) then
                                     set dialogIsModal to value of attribute "AXModal" of dialogWindow
@@ -1304,22 +1313,32 @@ extension AccessibilityChannel {
             set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)
             if currentGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
             if currentGoToPositionWindowCount is greater than preLeafGoToPositionWindowCount then return "APPEARED"
-            return "ABSENT"
+            if currentGoToPositionWindowCount is preLeafGoToPositionWindowCount then return "ABSENT"
+            return "UNIDENTIFIED"
         end newWindowAppearedSince
 
         -- The Go To Position dialog has its own lifecycle; a menu-bar observation says nothing
-        -- about whether a titled modal is still blocking the arrange area. `AXModal` answers
-        -- whether the measured known class is modal; subrole only classifies that class. This
-        -- state is intentionally about the exact element newly observed for this run, never a
-        -- title-only scan that can confuse an unrelated same-titled plug-in window for our dialog.
-        on goToPositionDialogState(theProcess, dialogWindow)
+        -- about whether a titled modal is still blocking the arrange area. `CLOSED` is reserved
+        -- for a readable total-window observation returning to this run's pre-leaf baseline. A
+        -- missing reference, title drift, or failed read is not evidence of absence.
+        on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+            if dialogWindow is missing value then
+                set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
+                if newWindowState is "ABSENT" then return "CLOSED"
+                if newWindowState is "APPEARED" or newWindowState is "UNIDENTIFIED" then return "UNIDENTIFIED"
+                return "UNREADABLE"
+            end if
             using terms from application "System Events"
                 tell theProcess
                     try
-                        if dialogWindow is missing value then return "CLOSED"
-                        if not (exists dialogWindow) then return "CLOSED"
+                        if not (exists dialogWindow) then
+                            set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)
+                            if newWindowState is "ABSENT" then return "CLOSED"
+                            if newWindowState is "APPEARED" or newWindowState is "UNIDENTIFIED" then return "UNIDENTIFIED"
+                            return "UNREADABLE"
+                        end if
                         set dialogTitle to name of dialogWindow
-                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "CLOSED"
+                        if not my knownGoToPositionDialogTitle(dialogTitle) then return "UNIDENTIFIED"
                         set dialogSubrole to subrole of dialogWindow
                         if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "OPEN_UNKNOWN_SUBROLE"
                         try
@@ -1349,7 +1368,7 @@ extension AccessibilityChannel {
                         if not (exists dialogWindow) then return "MISSING"
                         set dialogTitle to name of dialogWindow
                         set dialogSubrole to subrole of dialogWindow
-                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
+                        if not my knownGoToPositionDialogTitle(dialogTitle) then return "MISSING"
                         if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "MISSING"
                         set dialogIsModal to value of attribute "AXModal" of dialogWindow
                         if dialogIsModal is not true then return "NOT_MODAL"
@@ -1370,11 +1389,11 @@ extension AccessibilityChannel {
         -- fallback while this exact dialog is observed open, and every attempt
         -- must be followed by a new exact-dialog observation before it counts
         -- as cleanup.
-        on pressGoToPositionDialogCancel(theProcess, dialogWindow)
+        on pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
             using terms from application "System Events"
                 tell theProcess
                     try
-                        set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
+                        set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
                         if dialogState is not "OPEN" then return dialogState
                         if exists button "Cancel" of dialogWindow then
                             click button "Cancel" of dialogWindow
@@ -1396,17 +1415,17 @@ extension AccessibilityChannel {
             end using terms from
         end pressGoToPositionDialogCancel
 
-        on dismissOpenGoToPositionDialog(theProcess, dialogWindow)
-            set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
+        on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
+            set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
-                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess, dialogWindow)
+                set cancelOutcome to my pressGoToPositionDialogCancel(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
                 if cancelOutcome is "NO_BUTTON" or cancelOutcome is "UNREADABLE" then
                     -- The Cancel click may have landed even though AX reported failure. Re-observe
                     -- this exact dialog before choosing Escape as a second actuator; unreadable is
                     -- not permission to send a key into an unknown focus target.
-                    set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
+                    set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
                     if dialogState is "CLOSED" then return "CLOSED"
                     if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                     if dialogState is not "OPEN" then return dialogState
@@ -1417,7 +1436,7 @@ extension AccessibilityChannel {
                     end using terms from
                 end if
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess, dialogWindow)
+                set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is "UNREADABLE" then return "OPEN_UNREADABLE"
                 if dialogState is not "OPEN" then return dialogState
@@ -1506,7 +1525,7 @@ extension AccessibilityChannel {
                 if preLeafGoToPositionWindowCount is "UNREADABLE" then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window count was unreadable before leaf click"
                 end if
-                if not my recordPreLeafGoToPositionWindowSnapshot(preLeafGoToPositionDialogCount, "\(snapshotPath)") then
+                if not my recordPreLeafGoToPositionWindowSnapshot(preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount, "\(snapshotPath)") then
                     return "DIALOG_PREEXISTENCE_UNREADABLE: Go To Position window snapshot could not be persisted before leaf click"
                 end if
                 try
@@ -1527,7 +1546,7 @@ extension AccessibilityChannel {
                         click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
                     end if
                 on error errMsg
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1560,14 +1579,15 @@ extension AccessibilityChannel {
                         set dialogAppearanceUnreadable to true
                         exit repeat
                     end if
-                    if newWindowState is "APPEARED" then
+                    if newWindowState is "APPEARED" or newWindowState is "UNIDENTIFIED" then
                         set dialogAppearanceUnidentified to true
                         exit repeat
                     end if
                 end repeat
                 if not dialogReady then
                     if dialogAppearanceUnidentified then return "DIALOG_UNIDENTIFIED_NEW_WINDOW"
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    if dialogAppearanceUnreadable then return "DIALOG_APPEARANCE_UNREADABLE"
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1575,7 +1595,6 @@ extension AccessibilityChannel {
                     if cleanupState is not "CLOSED" then
                         return "DIALOG_ACTUATION_ISSUED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
                     end if
-                    if dialogAppearanceUnreadable then return "DIALOG_ACTUATION_ISSUED: dialog appearance became unreadable"
                     return "DIALOG_ACTUATION_ISSUED: dialog did not become ready"
                 end if
             end tell
@@ -1584,7 +1603,7 @@ extension AccessibilityChannel {
             -- it may have reached an unknown target rather than advertising a clean retry.
             try
                 if not my recordDialogIssuance("SELECT_ALL_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1599,7 +1618,7 @@ extension AccessibilityChannel {
                 -- frontmost while this run was preparing the receipt.
                 set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_SUBMISSION_NOT_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1612,7 +1631,7 @@ extension AccessibilityChannel {
                 keystroke "a" using command down
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1625,7 +1644,7 @@ extension AccessibilityChannel {
 
             try
                 if not my recordDialogIssuance("POSITION_INPUT_ARMED", "\(ledgerPath)") then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1639,7 +1658,7 @@ extension AccessibilityChannel {
                 -- global position text, not merely after the preceding Cmd+A.
                 set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
                 if dialogTypingFocusState is not "FOCUSED" then
-                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                    set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then
                         return "DIALOG_INPUT_ISSUED: SELECT_ALL_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                     end if
@@ -1652,7 +1671,7 @@ extension AccessibilityChannel {
                 keystroke "\(position)"
                 delay 0.1
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1667,7 +1686,7 @@ extension AccessibilityChannel {
             -- Return submission boundary, so a timeout or nonzero child exit after either point is
             -- conservatively reported rather than releasing another actuator.
             if not my recordDialogIssuance("RETURN_ARMED", "\(ledgerPath)") then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1681,7 +1700,7 @@ extension AccessibilityChannel {
             -- owner after its durable marker is written and immediately before submission.
             set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)
             if dialogReturnFocusState is not "FOCUSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1695,7 +1714,7 @@ extension AccessibilityChannel {
                 keystroke return
                 delay 0.2
             on error errMsg
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1707,9 +1726,9 @@ extension AccessibilityChannel {
             end try
             -- A normal Return reply is not proof Logic consumed it. Observe this exact modal before
             -- returning OK; if it survived, clean it only after recording the submission boundary.
-            set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog)
-            if dialogPostReturnState is not "CLOSED" then
-                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog)
+            set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
+                if dialogPostReturnState is not "CLOSED" then
+                set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)
                 if dialogCleanupState is not "CLOSED" then
                     return "DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (" & dialogCleanupState & ")"
                 end if
@@ -1762,19 +1781,22 @@ extension AccessibilityChannel {
                 ?? .unknown
         }
 
-        /// `READY` plus one canonical decimal count is written atomically by the child immediately
-        /// before the leaf click. Anything else — including a killed child, a partial write, or an
-        /// ambiguous count — withholds reconciliation action.
+        /// `READY` plus canonical known-dialog and total-window counts is written atomically by the
+        /// child immediately before the leaf click. Anything else — including a killed child, a
+        /// partial write, or an ambiguous count — withholds reconciliation action.
         var preLeafWindowSnapshotPath: String? {
             guard let text = try? String(contentsOf: preLeafWindowSnapshotURL, encoding: .utf8) else {
                 return nil
             }
             let snapshotItems = text.split(separator: "\n", omittingEmptySubsequences: false)
-            guard snapshotItems.count == 2,
+            guard snapshotItems.count == 3,
                   snapshotItems[0] == "READY",
                   let matchingDialogCount = Int(snapshotItems[1]),
+                  let totalWindowCount = Int(snapshotItems[2]),
                   matchingDialogCount >= 0,
-                  String(matchingDialogCount) == snapshotItems[1]
+                  totalWindowCount >= matchingDialogCount,
+                  String(matchingDialogCount) == snapshotItems[1],
+                  String(totalWindowCount) == snapshotItems[2]
             else { return nil }
             return preLeafWindowSnapshotURL.path
         }
@@ -1823,6 +1845,7 @@ extension AccessibilityChannel {
             case dialogPreexistenceUnreadable
             case dialogNotReady
             case dialogUnidentifiedNewWindow
+            case dialogAppearanceUnreadable
             case dialogActuationIssued(cleanupObservedClosed: Bool)
             case dialogSubmissionNotIssued(cleanupObservedClosed: Bool)
             case dialogInputIssued(issuance: DialogIssuanceStage, cleanupObservedClosed: Bool)
@@ -1851,6 +1874,7 @@ extension AccessibilityChannel {
             case .failure(.dialogPreexistenceUnreadable): return "dialog_preexistence_unreadable"
             case .failure(.dialogNotReady): return "dialog_not_ready"
             case .failure(.dialogUnidentifiedNewWindow): return "dialog_unidentified_new_window"
+            case .failure(.dialogAppearanceUnreadable): return "dialog_appearance_unreadable"
             case let .failure(.dialogActuationIssued(closed)):
                 return "dialog_actuation_issued_cleanup_closed_\(closed)"
             case let .failure(.dialogSubmissionNotIssued(closed)):
@@ -1944,6 +1968,7 @@ extension AccessibilityChannel {
                  .failure(.dialogPreexisting),
                  .failure(.dialogPreexistenceUnreadable),
                  .failure(.dialogUnidentifiedNewWindow),
+                 .failure(.dialogAppearanceUnreadable),
                  .failure(.dialogActuationIssued(cleanupObservedClosed: false)),
                  .failure(.dialogSubmissionNotIssued(cleanupObservedClosed: false)),
                  .failure(.dialogNotReady),
@@ -1958,6 +1983,7 @@ extension AccessibilityChannel {
             switch self {
             case .failure(.dialogNotReady),
                  .failure(.dialogUnidentifiedNewWindow),
+                 .failure(.dialogAppearanceUnreadable),
                  .failure(.dialogActuationIssued),
                  .failure(.dialogSubmissionNotIssued),
                  .failure(.dialogInputIssued),
@@ -2034,8 +2060,10 @@ extension AccessibilityChannel {
             return .failure(.menuPickFailed)
         case "DIALOG_NOT_READY":
             return .failure(.dialogNotReady)
-        case "DIALOG_UNIDENTIFIED_NEW_WINDOW":
+        case let value where value.hasPrefix("DIALOG_UNIDENTIFIED_NEW_WINDOW"):
             return .failure(.dialogUnidentifiedNewWindow)
+        case let value where value.hasPrefix("DIALOG_APPEARANCE_UNREADABLE"):
+            return .failure(.dialogAppearanceUnreadable)
         case let value where value.hasPrefix("DIALOG_ACTUATION_ISSUED"):
             return .failure(.dialogActuationIssued(
                 // A closed dialog is insufficient if a menu cleanup remained unreadable. Both
@@ -2146,35 +2174,49 @@ extension AccessibilityChannel {
             return false
         end knownGoToPositionDialogSubrole
 
-        -- The timeout process must not infer ownership from a title. The child persisted one
-        -- canonical, readable count immediately before its leaf click; failure to read exactly
-        -- that two-line format is unsafe, not empty.
-        on preLeafGoToPositionDialogCount(snapshotPath)
+        on knownGoToPositionDialogTitle(dialogTitle)
+            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then return true
+            return false
+        end knownGoToPositionDialogTitle
+
+        -- The timeout process must not infer ownership from a title. The child persisted readable
+        -- known-dialog and total-window counts immediately before its leaf click; failure to read
+        -- exactly that three-line format is unsafe, not empty.
+        on preLeafGoToPositionWindowSnapshot(snapshotPath)
             try
                 set snapshotText to do shell script "/bin/cat " & (quoted form of snapshotPath)
                 set originalTextItemDelimiters to AppleScript's text item delimiters
                 set AppleScript's text item delimiters to linefeed
                 set snapshotItems to text items of snapshotText
                 set AppleScript's text item delimiters to originalTextItemDelimiters
-                if (count of snapshotItems) is not 2 then return "UNREADABLE"
+                if (count of snapshotItems) is not 3 then return "UNREADABLE"
                 if item 1 of snapshotItems is not "READY" then return "UNREADABLE"
                 set matchingDialogCountText to item 2 of snapshotItems
+                set totalWindowCountText to item 3 of snapshotItems
                 if matchingDialogCountText is "" then return "UNREADABLE"
+                if totalWindowCountText is "" then return "UNREADABLE"
                 if matchingDialogCountText is not "0" and character 1 of matchingDialogCountText is "0" then return "UNREADABLE"
+                if totalWindowCountText is not "0" and character 1 of totalWindowCountText is "0" then return "UNREADABLE"
                 repeat with countCharacter in characters of matchingDialogCountText
                     set countCharacterText to contents of countCharacter
                     if countCharacterText is not in "0123456789" then return "UNREADABLE"
                 end repeat
+                repeat with countCharacter in characters of totalWindowCountText
+                    set countCharacterText to contents of countCharacter
+                    if countCharacterText is not in "0123456789" then return "UNREADABLE"
+                end repeat
                 set matchingDialogCount to matchingDialogCountText as integer
+                set totalWindowCount to totalWindowCountText as integer
                 if matchingDialogCount is less than 0 then return "UNREADABLE"
-                return matchingDialogCount
+                if totalWindowCount is less than matchingDialogCount then return "UNREADABLE"
+                return {matchingDialogCount, totalWindowCount}
             on error
                 try
                     set AppleScript's text item delimiters to originalTextItemDelimiters
                 end try
                 return "UNREADABLE"
             end try
-        end preLeafGoToPositionDialogCount
+        end preLeafGoToPositionWindowSnapshot
 
         on windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)
             if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
@@ -2190,7 +2232,7 @@ extension AccessibilityChannel {
                         set matchingWindowCount to 0
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                            if my knownGoToPositionDialogTitle(dialogTitle) then
                                 set dialogSubrole to subrole of dialogWindow
                                 if my knownGoToPositionDialogSubrole(dialogSubrole) then
                                     set dialogIsModal to value of attribute "AXModal" of dialogWindow
@@ -2206,6 +2248,18 @@ extension AccessibilityChannel {
             end using terms from
         end goToPositionDialogCount
 
+        on goToPositionWindowCount(theProcess)
+            using terms from application "System Events"
+                tell theProcess
+                    try
+                        return count of every window
+                    on error
+                        return "UNREADABLE"
+                    end try
+                end tell
+            end using terms from
+        end goToPositionWindowCount
+
         -- Reconciliation may act only when the pre-leaf count was zero and exactly one matching
         -- dialog exists now. A nonzero pre-leaf count is reported without scanning for a target.
         on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
@@ -2217,7 +2271,7 @@ extension AccessibilityChannel {
                         set matchingDialogWindows to {}
                         repeat with dialogWindow in every window
                             set dialogTitle to name of dialogWindow
-                            if dialogTitle is "위치로 이동" or dialogTitle is "Go To Position" or dialogTitle is "Go to Position" then
+                            if my knownGoToPositionDialogTitle(dialogTitle) then
                                 set dialogSubrole to subrole of dialogWindow
                                 if my knownGoToPositionDialogSubrole(dialogSubrole) then
                                     set dialogIsModal to value of attribute "AXModal" of dialogWindow
@@ -2238,8 +2292,9 @@ extension AccessibilityChannel {
             end using terms from
         end matchingGoToPositionDialog
 
-        on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
+        on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
             if preLeafGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
+            if preLeafGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
             if preLeafGoToPositionDialogCount is greater than 0 then return "PREEXISTING"
             set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
             if dialogWindow is "UNREADABLE" then return "UNREADABLE"
@@ -2247,6 +2302,9 @@ extension AccessibilityChannel {
             set currentGoToPositionDialogCount to my goToPositionDialogCount(theProcess)
             if currentGoToPositionDialogCount is "UNREADABLE" then return "UNREADABLE"
             if currentGoToPositionDialogCount is greater than preLeafGoToPositionDialogCount then return "UNIDENTIFIED"
+            set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)
+            if currentGoToPositionWindowCount is "UNREADABLE" then return "UNREADABLE"
+            if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return "UNIDENTIFIED"
             return "CLOSED"
         end goToPositionDialogState
 
@@ -2260,7 +2318,7 @@ extension AccessibilityChannel {
                         if logicWasFrontmost is not true then return "NOT_FRONTMOST"
                         if not (exists dialogWindow) then return "MISSING"
                         set dialogTitle to name of dialogWindow
-                        if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
+                        if not my knownGoToPositionDialogTitle(dialogTitle) then return "MISSING"
                         set dialogSubrole to subrole of dialogWindow
                         if not my knownGoToPositionDialogSubrole(dialogSubrole) then return "MISSING"
                         set dialogIsModal to value of attribute "AXModal" of dialogWindow
@@ -2299,14 +2357,14 @@ extension AccessibilityChannel {
             end using terms from
         end menuEscapeFocusState
 
-        on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
-            set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
+        on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
+            set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
             if dialogState is "CLOSED" then return "CLOSED"
             if dialogState is not "OPEN" then return dialogState
             repeat 3 times
                 set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)
                 if dialogWindow is "UNREADABLE" then return "UNREADABLE"
-                if dialogWindow is missing value then return my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
+                if dialogWindow is missing value then return my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
                 set cancelPressed to false
                 using terms from application "System Events"
                     tell theProcess
@@ -2331,7 +2389,7 @@ extension AccessibilityChannel {
                     end tell
                 end using terms from
                 delay 0.1
-                set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)
+                set dialogState to my goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
                 if dialogState is "CLOSED" then return "CLOSED"
                 if dialogState is not "OPEN" then return dialogState
             end repeat
@@ -2341,9 +2399,11 @@ extension AccessibilityChannel {
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
                 try
-                    set preLeafGoToPositionDialogCount to my preLeafGoToPositionDialogCount("\(preLeafWindowSnapshotPath)")
-                    if preLeafGoToPositionDialogCount is "UNREADABLE" then return "DIALOG_UNREADABLE"
-                    set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount)
+                    set preLeafWindowSnapshot to my preLeafGoToPositionWindowSnapshot("\(preLeafWindowSnapshotPath)")
+                    if preLeafWindowSnapshot is "UNREADABLE" then return "DIALOG_UNREADABLE"
+                    set preLeafGoToPositionDialogCount to item 1 of preLeafWindowSnapshot
+                    set preLeafGoToPositionWindowCount to item 2 of preLeafWindowSnapshot
+                    set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then return "DIALOG_" & dialogCleanupState
                     repeat 3 times
                         set menuFocusState to my menuEscapeFocusState(it)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -1158,7 +1158,20 @@ extension AccessibilityChannel {
                         set dialogTitle to name of dialogWindow
                         set dialogSubrole to subrole of dialogWindow
                         if dialogTitle is not "위치로 이동" and dialogTitle is not "Go To Position" and dialogTitle is not "Go to Position" then return "MISSING"
-                        if dialogSubrole is not "AXDialog" and dialogSubrole is not "AXSystemDialog" then return "MISSING"
+                        -- Same measured set as the discovery matcher. Fixing only that one left
+                        -- this check rejecting the window discovery had just accepted, so the
+                        -- route still closed the dialog and submitted nothing.
+                        if dialogSubrole is not "AXFloatingWindow" and dialogSubrole is not "AXDialog" and dialogSubrole is not "AXSystemDialog" then return "MISSING"
+                        -- Measured on Logic 12.3: this dialog reports AXFocused false and AXMain
+                        -- false while it is the window receiving keystrokes. The signal that is
+                        -- true there is the PROCESS's AXFocusedWindow, which names this dialog.
+                        -- Checking the window's own AXFocused refused every drive on a dialog that
+                        -- was plainly taking input.
+                        if (exists attribute "AXFocusedWindow") then
+                            set processFocusedWindow to value of attribute "AXFocusedWindow"
+                            if processFocusedWindow is dialogWindow then return "FOCUSED"
+                            if (name of processFocusedWindow as text) is dialogTitle then return "FOCUSED"
+                        end if
                         if focused of dialogWindow then return "FOCUSED"
                         return "NOT_FOCUSED"
                     on error

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -294,6 +294,13 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 // `verified:false` — it never confirmed the playhead landed.
                 let position = "\(bar).1.1.1"
                 let traceID = await startTraceIfEnabled(command: command)
+                let beforeTransport = await TransportDispatcher.liveTransportState(router: router, cache: cache)
+                if let unchanged = TransportDispatcher.gotoPositionUnchangedResult(
+                    requestedPosition: position,
+                    beforeTransport: beforeTransport
+                ) {
+                    return await finalizeTrace(unchanged, traceID: traceID)
+                }
                 let result = await withWriteBoundaryArmed(traceID) {
                     await router.route(
                         operation: "transport.goto_position",
@@ -303,6 +310,7 @@ struct MIDIDispatcher: OperationTraceDispatching {
                 let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                     result,
                     requestedPosition: position,
+                    beforeTransport: beforeTransport,
                     router: router,
                     cache: cache
                 )

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -35,15 +35,24 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
+            let requestedPosition = "\(bar).1.1.1"
+            let beforeTransport = await TransportDispatcher.liveTransportState(router: router, cache: cache)
+            if let unchanged = TransportDispatcher.gotoPositionUnchangedResult(
+                requestedPosition: requestedPosition,
+                beforeTransport: beforeTransport
+            ) {
+                return await finalizeTrace(unchanged, traceID: traceID)
+            }
             let result = await withWriteBoundaryArmed(traceID) {
                 await router.route(
                     operation: "transport.goto_position",
-                    params: ["position": "\(bar).1.1.1"]
+                    params: ["position": requestedPosition]
                 )
             }
             let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                 result,
-                requestedPosition: "\(bar).1.1.1",
+                requestedPosition: requestedPosition,
+                beforeTransport: beforeTransport,
                 router: router,
                 cache: cache
             )
@@ -61,6 +70,13 @@ struct NavigateDispatcher: OperationTraceDispatching {
             let markers = await cache.getMarkers()
             func routeMarkerTarget(_ target: MarkerState) async -> CallTool.Result {
                 let traceID = await startTraceIfEnabled(command: command)
+                let beforeTransport = await TransportDispatcher.liveTransportState(router: router, cache: cache)
+                if let unchanged = TransportDispatcher.gotoPositionUnchangedResult(
+                    requestedPosition: target.position,
+                    beforeTransport: beforeTransport
+                ) {
+                    return await finalizeTrace(unchanged, traceID: traceID)
+                }
                 var result = await withWriteBoundaryArmed(traceID) {
                     await router.route(
                         operation: "transport.goto_position",
@@ -78,6 +94,7 @@ struct NavigateDispatcher: OperationTraceDispatching {
                 let finalized = await TransportDispatcher.finalizeGotoPositionResult(
                     result,
                     requestedPosition: target.position,
+                    beforeTransport: beforeTransport,
                     router: router,
                     cache: cache
                 )

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -177,17 +177,11 @@ struct TransportDispatcher: OperationTraceDispatching {
                     )
                 }
                 let traceID = await startTraceIfEnabled(command: command)
-                let result = await withWriteBoundaryArmed(traceID) {
-                    await router.route(
-                        operation: "transport.goto_position",
-                        params: ["position": "\(bar).1.1.1"]
-                    )
-                }
-                let finalized = await finalizeGotoPositionResult(
-                    result,
+                let finalized = await handleGotoPosition(
                     requestedPosition: "\(bar).1.1.1",
                     router: router,
-                    cache: cache
+                    cache: cache,
+                    traceID: traceID
                 )
                 return await finalizeTrace(finalized, traceID: traceID)
             }
@@ -201,17 +195,11 @@ struct TransportDispatcher: OperationTraceDispatching {
                 )
             }
             let traceID = await startTraceIfEnabled(command: command)
-            let result = await withWriteBoundaryArmed(traceID) {
-                await router.route(
-                    operation: "transport.goto_position",
-                    params: ["position": time]
-                )
-            }
-            let finalized = await finalizeGotoPositionResult(
-                result,
+            let finalized = await handleGotoPosition(
                 requestedPosition: time,
                 router: router,
-                cache: cache
+                cache: cache,
+                traceID: traceID
             )
             return await finalizeTrace(finalized, traceID: traceID)
 
@@ -525,16 +513,102 @@ struct TransportDispatcher: OperationTraceDispatching {
         return false
     }
 
+    /// A Go To Position receipt has two distinct truthful success shapes:
+    ///
+    /// * a no-op, where a complete pre-write AX read already matched the request and no global
+    ///   dialog/input path was entered; or
+    /// * an observed movement, where complete pre- and post-write AX reads differ and the latter
+    ///   lands on the request.
+    ///
+    /// A post-write match alone is never enough: it can predate this request.
+    private static func handleGotoPosition(
+        requestedPosition: String,
+        router: ChannelRouter,
+        cache: StateCache,
+        traceID: TraceID?
+    ) async -> CallTool.Result {
+        let beforeTransport = await liveTransportState(router: router, cache: cache)
+        if let unchanged = gotoPositionUnchangedResult(
+            requestedPosition: requestedPosition,
+            beforeTransport: beforeTransport
+        ) { return unchanged }
+
+        // A failed or partial pre-read is not evidence of absence. It only removes the option to
+        // certify a later matching read as this call's effect; the requested operation still runs.
+        let result = await withWriteBoundaryArmed(traceID) {
+            await router.route(
+                operation: "transport.goto_position",
+                params: ["position": requestedPosition]
+            )
+        }
+        return await finalizeGotoPositionResult(
+            result,
+            requestedPosition: requestedPosition,
+            beforeTransport: beforeTransport,
+            router: router,
+            cache: cache
+        )
+    }
+
+    static func gotoPositionUnchangedResult(
+        requestedPosition: String,
+        beforeTransport: TransportState?
+    ) -> CallTool.Result? {
+        guard let beforePosition = completeObservedMusicalPosition(
+            from: beforeTransport,
+            matching: requestedPosition
+        ) else { return nil }
+
+        // This is deliberately an idempotent State A, not a claimed write effect. The complete AX
+        // pre-read established that the requested state already held, so callers avoid opening a
+        // global-input dialog and see the no-write boundary explicitly.
+        return toolTextResult(HonestContract.encodeStateA(extras: [
+            "operation": "transport.goto_position",
+            "requested": requestedPosition,
+            "observed": beforePosition.value,
+            "observed_position_components": beforePosition.observedComponents.map(\.rawValue),
+            "unobserved_position_components": [],
+            "verification_source": "transport_state",
+            "write_attempted": false,
+            "unchanged": true,
+        ]))
+    }
+
+    static func completeObservedMusicalPosition(
+        from transport: TransportState?,
+        matching requestedPosition: String
+    ) -> TransportPositionReadback? {
+        guard !requestedPosition.contains(":"),
+              let readback = transport?.positionReadback,
+              Set(readback.observedComponents) == Set(TransportPositionComponent.allCases),
+              readback.value == requestedPosition
+        else { return nil }
+        return readback
+    }
+
+    static func completeObservedMusicalPosition(
+        _ transport: TransportState?
+    ) -> TransportPositionReadback? {
+        guard let readback = transport?.positionReadback,
+              Set(readback.observedComponents) == Set(TransportPositionComponent.allCases)
+        else { return nil }
+        return readback
+    }
+
     static func finalizeGotoPositionResult(
         _ result: ChannelResult,
         requestedPosition: String,
+        beforeTransport: TransportState?,
         router: ChannelRouter,
         cache: StateCache
     ) async -> CallTool.Result {
         guard result.isSuccess else {
             return toolTextResult(result)
         }
-        guard channelResultIsUnverified(result) else {
+        // No route-level State A is sufficient by itself for a seek. A future channel may observe
+        // its own actuator, but its receipt can still coincide with a playhead that was already at
+        // the requested position; this common finalizer owns the cross-route effect requirement.
+        guard channelResultIsUnverified(result) || channelResultIsVerified(result) else {
             return toolTextResult(result)
         }
         guard let observedTransport = await liveTransportState(router: router, cache: cache) else {
@@ -561,18 +635,19 @@ struct TransportDispatcher: OperationTraceDispatching {
             extras["observed"] = positionReadback.value
             extras["observed_time_position"] = observedTransport.timePosition
         }
+        if let beforePositionReadback = beforeTransport?.positionReadback {
+            extras["observed_before"] = beforePositionReadback.value
+            extras["observed_before_position_components"] = beforePositionReadback.observedComponents.map(\.rawValue)
+        }
 
         // A matching playhead cannot independently verify this request when the dialog channel
         // says its global input target or write boundary was indeterminate. The position remains
         // useful readback evidence, but it is not proof that this call performed the write.
-        let verificationWithheld: String? =
+        let channelVerificationWithheld: String? =
             (extras["dialog_input_target"] as? String) == "unknown" ? "dialog_input_target" :
             (extras["fallback_unsafe"] as? Bool) == true ? "fallback_unsafe" :
             (extras["write_attempted_indeterminate"] as? Bool) == true
                 ? "write_attempted_indeterminate" : nil
-        if let verificationWithheld {
-            extras["verification_withheld"] = verificationWithheld
-        }
 
         let requestedMusicalComponents: [TransportPositionComponent] = requestedPosition.contains(":")
             ? []
@@ -586,26 +661,35 @@ struct TransportDispatcher: OperationTraceDispatching {
             extras["unobserved_position_components"] = unobservedMusicalComponents.map(\.rawValue)
         }
 
-        // A matching display string is insufficient: it may be the model default or a position
-        // synthesized from the Bar/Beat sliders. State A requires every component named by the
-        // request to have been read back from AX.
-        //
-        // Value equality is individually covered by the existing mismatch tests: a request for
-        // `9.1.1.1` with a full readback of `8.1.1.1` must not reach State A. The component-set
-        // conjunct has no individual coverage yet. Its separating input is representable
-        // (`"9.1.1.1"` paired with only `.bar`/`.beat` observations), but the current extractor
-        // does not emit that shape. Keep both checks: the component set stops a readback that
-        // never happened (the model's `"1.1.1.1"` default), while value equality rejects a
-        // genuinely different complete readback.
+        let beforePosition = completeObservedMusicalPosition(beforeTransport)
+        let afterPosition = completeObservedMusicalPosition(observedTransport)
+        let observedEffect: Bool
         if !requestedPosition.contains(":"),
-           verificationWithheld == nil,
-           unobservedMusicalComponents.isEmpty,
-           observedTransport.positionReadback?.value == requestedPosition {
+           let beforePosition,
+           let afterPosition,
+           beforePosition.value != requestedPosition,
+           afterPosition.value == requestedPosition {
+            observedEffect = true
+        } else {
+            observedEffect = false
+        }
+        let verificationWithheld = channelVerificationWithheld
+            ?? (afterPosition?.value == requestedPosition && !observedEffect
+                ? "observed_effect_unavailable" : nil)
+        if let verificationWithheld {
+            extras["verification_withheld"] = verificationWithheld
+        }
+
+        // A matching post-write value is a landing observation, not evidence that this invocation
+        // moved the playhead. State A needs a complete AX reading on each side of the write boundary
+        // and the observed transition must end at the requested value.
+        if verificationWithheld == nil, observedEffect {
             return toolTextResult(HonestContract.encodeStateA(extras: extras))
         }
 
         let reason: HonestContract.UncertainReason =
-            requestedPosition.contains(":") || !unobservedMusicalComponents.isEmpty
+            verificationWithheld != nil || requestedPosition.contains(":")
+                || !unobservedMusicalComponents.isEmpty || beforePosition == nil
                 ? .readbackUnavailable
                 : .readbackMismatch
         return toolTextResult(
@@ -653,7 +737,7 @@ struct TransportDispatcher: OperationTraceDispatching {
         )
     }
 
-    private static func liveTransportState(
+    static func liveTransportState(
         router: ChannelRouter,
         cache: StateCache
     ) async -> TransportState? {

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -557,12 +557,39 @@ struct TransportDispatcher: OperationTraceDispatching {
         extras["observed"] = observedTransport.position
         extras["observed_time_position"] = observedTransport.timePosition
 
-        if !requestedPosition.contains(":"), observedTransport.position == requestedPosition {
+        let requestedMusicalComponents: [TransportPositionComponent] = requestedPosition.contains(":")
+            ? []
+            : TransportPositionComponent.allCases
+        let observedMusicalComponents = observedTransport.positionReadback?.observedComponents ?? []
+        let unobservedMusicalComponents = requestedMusicalComponents.filter {
+            !observedMusicalComponents.contains($0)
+        }
+        if !requestedPosition.contains(":") {
+            extras["observed_position_components"] = observedMusicalComponents.map(\.rawValue)
+            extras["unobserved_position_components"] = unobservedMusicalComponents.map(\.rawValue)
+        }
+
+        // A matching display string is insufficient: it may be the model default or a position
+        // synthesized from the Bar/Beat sliders. State A requires every component named by the
+        // request to have been read back from AX.
+        //
+        // The two conjuncts are redundant for every input reachable today, so NEITHER is
+        // individually mutation-detectable — removing one leaves the other covering the same
+        // cases. That is deliberate rather than accidental, and each covers a different way the
+        // other could be weakened: the component set stops a readback that never happened (the
+        // model's `"1.1.1.1"` default), and the readback value stops a partial read being
+        // compared as if it were whole. Do not delete either on the grounds that tests still
+        // pass without it.
+        if !requestedPosition.contains(":"),
+           unobservedMusicalComponents.isEmpty,
+           observedTransport.positionReadback?.value == requestedPosition {
             return toolTextResult(HonestContract.encodeStateA(extras: extras))
         }
 
         let reason: HonestContract.UncertainReason =
-            requestedPosition.contains(":") ? .readbackUnavailable : .readbackMismatch
+            requestedPosition.contains(":") || !unobservedMusicalComponents.isEmpty
+                ? .readbackUnavailable
+                : .readbackMismatch
         return toolTextResult(
             HonestContract.encodeStateB(reason: reason, extras: extras),
             isError: true

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -573,13 +573,13 @@ struct TransportDispatcher: OperationTraceDispatching {
         // synthesized from the Bar/Beat sliders. State A requires every component named by the
         // request to have been read back from AX.
         //
-        // The two conjuncts are redundant for every input reachable today, so NEITHER is
-        // individually mutation-detectable — removing one leaves the other covering the same
-        // cases. That is deliberate rather than accidental, and each covers a different way the
-        // other could be weakened: the component set stops a readback that never happened (the
-        // model's `"1.1.1.1"` default), and the readback value stops a partial read being
-        // compared as if it were whole. Do not delete either on the grounds that tests still
-        // pass without it.
+        // Value equality is individually covered by the existing mismatch tests: a request for
+        // `9.1.1.1` with a full readback of `8.1.1.1` must not reach State A. The component-set
+        // conjunct has no individual coverage yet. Its separating input is representable
+        // (`"9.1.1.1"` paired with only `.bar`/`.beat` observations), but the current extractor
+        // does not emit that shape. Keep both checks: the component set stops a readback that
+        // never happened (the model's `"1.1.1.1"` default), while value equality rejects a
+        // genuinely different complete readback.
         if !requestedPosition.contains(":"),
            unobservedMusicalComponents.isEmpty,
            observedTransport.positionReadback?.value == requestedPosition {

--- a/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TransportDispatcher.swift
@@ -554,8 +554,25 @@ struct TransportDispatcher: OperationTraceDispatching {
         extras.removeValue(forKey: "note")
         extras["verification_source"] = "transport_state"
         extras["requested"] = requestedPosition
-        extras["observed"] = observedTransport.position
-        extras["observed_time_position"] = observedTransport.timePosition
+        // `position` and `timePosition` have display defaults. Only a position readback may name
+        // an observed landing in this receipt; otherwise `observed` would falsely report the
+        // model's `1.1.1.1` default as an AX read.
+        if let positionReadback = observedTransport.positionReadback {
+            extras["observed"] = positionReadback.value
+            extras["observed_time_position"] = observedTransport.timePosition
+        }
+
+        // A matching playhead cannot independently verify this request when the dialog channel
+        // says its global input target or write boundary was indeterminate. The position remains
+        // useful readback evidence, but it is not proof that this call performed the write.
+        let verificationWithheld: String? =
+            (extras["dialog_input_target"] as? String) == "unknown" ? "dialog_input_target" :
+            (extras["fallback_unsafe"] as? Bool) == true ? "fallback_unsafe" :
+            (extras["write_attempted_indeterminate"] as? Bool) == true
+                ? "write_attempted_indeterminate" : nil
+        if let verificationWithheld {
+            extras["verification_withheld"] = verificationWithheld
+        }
 
         let requestedMusicalComponents: [TransportPositionComponent] = requestedPosition.contains(":")
             ? []
@@ -581,6 +598,7 @@ struct TransportDispatcher: OperationTraceDispatching {
         // never happened (the model's `"1.1.1.1"` default), while value equality rejects a
         // genuinely different complete readback.
         if !requestedPosition.contains(":"),
+           verificationWithheld == nil,
            unobservedMusicalComponents.isEmpty,
            observedTransport.positionReadback?.value == requestedPosition {
             return toolTextResult(HonestContract.encodeStateA(extras: extras))

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+/// A musical-position component whose value was actually read from Logic's AX tree.
+///
+/// `TransportState.position` remains a display value for compatibility, but it is not by itself
+/// evidence that every part of a four-component musical position was observable.  In particular,
+/// Logic's Control Bar can expose only bar and beat sliders.
+enum TransportPositionComponent: String, Sendable, Codable, CaseIterable {
+    case bar
+    case beat
+    case subdivision
+    case tick
+}
+
+/// The raw position text assembled from observed AX controls and the components it contains.
+/// A missing value means the state reader did not observe a position at all; callers must not
+/// promote `TransportState`'s defaults into a readback.
+struct TransportPositionReadback: Sendable, Codable, Equatable {
+    var value: String
+    var observedComponents: [TransportPositionComponent]
+}
+
 /// Transport state from Logic Pro.
 struct TransportState: Sendable, Codable {
     var isPlaying: Bool = false
@@ -8,7 +28,12 @@ struct TransportState: Sendable, Codable {
     var isCycleEnabled: Bool = false
     var isMetronomeEnabled: Bool = false
     var tempo: Double = 120.0
-    var position: String = "1.1.1.1"  // Bar.Beat.Division.Tick
+    /// A display value only. Its legacy default is not an AX observation; consult
+    /// `positionReadback` before treating it as evidence of a landed position.
+    var position: String = "1.1.1.1"
+    /// Which components of `position` came from an AX read. Optional preserves decoding of
+    /// historical state payloads, whose `position` string had no observation provenance.
+    var positionReadback: TransportPositionReadback? = nil
     var timePosition: String = "00:00:00.000"
     var sampleRate: Int = 44100
     var lastUpdated: Date = .distantPast

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -34,6 +34,7 @@ struct TransportState: Sendable, Codable {
     /// Which components of `position` came from an AX read. Optional preserves decoding of
     /// historical state payloads, whose `position` string had no observation provenance.
     var positionReadback: TransportPositionReadback? = nil
+    /// A display value only. It has no independent readback provenance in the transport model.
     var timePosition: String = "00:00:00.000"
     var sampleRate: Int = 44100
     var lastUpdated: Date = .distantPast

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -561,6 +561,12 @@ struct AXLocalePolicyTests {
         #expect(AXLocalePolicy.beatSliderLabel.matches("beat", mode: .exactStrict))
         #expect(AXLocalePolicy.beatSliderLabel.matches("비트", mode: .exactStrict))
         #expect(!AXLocalePolicy.beatSliderLabel.matches("bar", mode: .exactStrict))
+
+        // Mutation this rejects: change this exact group label to generic `position` (or add that
+        // token as a variant), which would make an unrelated AXGroup eligible as the owner.
+        #expect(AXLocalePolicy.playheadPositionGroupLabel.matches("Playhead Position", mode: .exactStrict))
+        #expect(AXLocalePolicy.playheadPositionGroupLabel.matches("재생헤드 위치", mode: .exactStrict))
+        #expect(!AXLocalePolicy.playheadPositionGroupLabel.matches("Position", mode: .exactStrict))
     }
 
     /// The metronome is the one Japanese transport label that is a compound word.

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -228,13 +228,14 @@ struct AXLocalePolicyTests {
     // MARK: - Go-to-Position dialog dismissal (.contains mode)
 
     /// The stale Go-to-Position dialog dismissal matches the window title with
-    /// `.contains`. Pin that the live-verified real titles ("Go to Position",
-    /// "위치로 이동") match even when wrapped in a window title, and that an
+    /// `.contains`. Pin that the reviewed exact titles ("Go to Position",
+    /// "위치로 이동", "位置の移動") match even when wrapped in a window title, and that an
     /// unrelated window is rejected.
     @Test("go-to-position dialog title matches in contains mode")
     func goToPositionContainsMode() {
         #expect(AXLocalePolicy.goToPositionDialogTitle.matches("Go to Position", mode: .contains))
         #expect(AXLocalePolicy.goToPositionDialogTitle.matches("위치로 이동", mode: .contains))
+        #expect(AXLocalePolicy.goToPositionDialogTitle.matches("位置の移動", mode: .contains))
         // Windowed title containing the phrase still matches.
         #expect(AXLocalePolicy.goToPositionDialogTitle.matches("Untitled — 위치로 이동", mode: .contains))
         #expect(AXLocalePolicy.goToPositionDialogTitle.matches("go to position", mode: .contains))

--- a/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
@@ -216,6 +216,9 @@ import Testing
 }
 
 @Test func testAXLogicProElementsControlBarCheckboxesAndLocatorSliders() {
+    // Mutations this rejects: restore the historical four-level Control Bar slider scan, or replace
+    // `playheadPositionGroupLabel` with the generic `playheadPositionFieldLabel`. The live Logic
+    // 12.3 components can be deeper than that cutoff, and a generic Position group is not their owner.
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(320)
     let window = builder.element(321)
@@ -224,12 +227,34 @@ import Testing
     let cycleDescription = builder.element(324)
     let barSlider = builder.element(325)
     let beatSlider = builder.element(326)
+    let positionOuter = builder.element(327)
+    let positionMiddle = builder.element(328)
+    let positionInner = builder.element(329)
+    let playheadPosition = builder.element(330)
+    let positionComponents = builder.element(331)
+    let unrelatedPosition = builder.element(332)
+    let unrelatedBar = builder.element(333)
+    let unrelatedBeat = builder.element(334)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
     builder.setChildren(window, [controlBar])
     builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
     builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
-    builder.setChildren(controlBar, [recordTitle, cycleDescription, barSlider, beatSlider])
+    builder.setChildren(controlBar, [recordTitle, cycleDescription, unrelatedPosition, positionOuter])
+    builder.setAttribute(unrelatedPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(unrelatedPosition, kAXDescriptionAttribute as String, "Position")
+    builder.setChildren(unrelatedPosition, [unrelatedBar, unrelatedBeat])
+    builder.setAttribute(unrelatedBar, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(unrelatedBar, kAXDescriptionAttribute as String, "Bar")
+    builder.setAttribute(unrelatedBeat, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(unrelatedBeat, kAXDescriptionAttribute as String, "Beat")
+    builder.setChildren(positionOuter, [positionMiddle])
+    builder.setChildren(positionMiddle, [positionInner])
+    builder.setChildren(positionInner, [playheadPosition])
+    builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
+    builder.setChildren(playheadPosition, [positionComponents])
+    builder.setChildren(positionComponents, [barSlider, beatSlider])
 
     builder.setAttribute(recordTitle, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     builder.setAttribute(recordTitle, kAXTitleAttribute as String, "Record")

--- a/Tests/LogicProMCPTests/CommercialReadinessTests.swift
+++ b/Tests/LogicProMCPTests/CommercialReadinessTests.swift
@@ -75,8 +75,14 @@ private let toolText = sharedToolText
 
     #expect(!(result.isError!))
     let ops = await ax.executedOps
-    #expect(ops.first?.0 == "transport.goto_position")
-    #expect(ops.first?.1["position"] == "7.1.1.1")
+    // The independent transport-state pre-read establishes the playhead baseline
+    // for observed-effect verification. This test guarantees that cache-resolved
+    // marker navigation still issues exactly one position write, and that its
+    // complete payload is the named marker's cached position rather than a
+    // default or a value re-read from a different source.
+    let gotoPositionOps = ops.filter { $0.0 == "transport.goto_position" }
+    #expect(gotoPositionOps.count == 1)
+    #expect(gotoPositionOps.first?.1 == ["position": "7.1.1.1"])
 }
 
 @Test func testNavigateDispatcherGotoMarkerByIndexUsesCachedPosition() async {
@@ -101,8 +107,14 @@ private let toolText = sharedToolText
 
     #expect(!(result.isError!))
     let ops = await ax.executedOps
-    #expect(ops.first?.0 == "transport.goto_position")
-    #expect(ops.first?.1["position"] == "9.1.1.1")
+    // The independent transport-state pre-read establishes the playhead baseline
+    // for observed-effect verification. This test guarantees that cache-resolved
+    // marker navigation still issues exactly one position write, and that its
+    // complete payload is marker #2's cached position rather than a default or
+    // a value re-read from a different source.
+    let gotoPositionOps = ops.filter { $0.0 == "transport.goto_position" }
+    #expect(gotoPositionOps.count == 1)
+    #expect(gotoPositionOps.first?.1 == ["position": "9.1.1.1"])
 }
 
 @Test func testNavigateDispatcherGotoMarkerColdCacheReturnsElementNotFound() async {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -537,7 +537,11 @@ private func liveTransportJSON(
     #expect(gotoOps.isEmpty)
     let axOps = await ax.executedOps
     expectExecutedOps(axOps, equals: [
+        // Every seek establishes an independent live baseline before routing
+        // its complete requested position to the position-capable AX channel.
+        ("transport.get_state", [:]),
         ("transport.goto_position", ["position": "9.1.1.1"]),
+        ("transport.get_state", [:]),
         ("transport.goto_position", ["position": "00:00:10:12"]),
         ("transport.set_cycle_range", ["start": "4.1.1.1", "end": "12.1.1.1"]),
     ])
@@ -662,21 +666,25 @@ private func liveTransportJSON(
 
 @Test func testTransportDispatcherGotoPositionReturnsErrorWhenTransportReadbackDoesNotMatch() async throws {
     let router = ChannelRouter()
+    let mismatchedPosition = TransportState(
+        position: "8.1.1.1",
+        positionReadback: TransportPositionReadback(
+            value: "8.1.1.1",
+            observedComponents: TransportPositionComponent.allCases
+        ),
+        timePosition: "00:00:08.000",
+        lastUpdated: Date()
+    )
     let ax = SequencedTransportReadbackChannel(
         gotoPositionResult: .success(HonestContract.encodeStateB(
             reason: .readbackUnavailable,
             extras: ["via": "dialog"]
         )),
         transportStates: [
-            TransportState(
-                position: "8.1.1.1",
-                positionReadback: TransportPositionReadback(
-                    value: "8.1.1.1",
-                    observedComponents: TransportPositionComponent.allCases
-                ),
-                timePosition: "00:00:08.000",
-                lastUpdated: Date()
-            )
+            // The first read is the pre-write baseline; the second is the
+            // post-write observation that proves the request still mismatched.
+            mismatchedPosition,
+            mismatchedPosition,
         ]
     )
     await router.register(ax)
@@ -3206,11 +3214,14 @@ private actor SelectiveFailChannel: Channel {
     let axOps = await ax.executedOps
     #expect(mcuOps.isEmpty)
     expectExecutedOps(axOps, equals: [
+        ("transport.get_state", [:]),
         ("transport.goto_position", ["position": "12.1.1.1"]),
         // v3.1.10: both index- and name-based goto_marker
         // now resolve from cache and route via transport.goto_position
         // using the marker's `position` string (chorus at 17.1.1.1).
+        ("transport.get_state", [:]),
         ("transport.goto_position", ["position": "17.1.1.1"]),
+        ("transport.get_state", [:]),
         ("transport.goto_position", ["position": "17.1.1.1"]),
         ("nav.open_marker_list", [:]),
         ("nav.get_markers", [:]),
@@ -3643,7 +3654,10 @@ private actor SelectiveFailChannel: Channel {
 
     #expect(!result.isError!)
     let ops = await ax.executedOps
-    expectExecutedOps(ops, equals: [("transport.goto_position", ["position": "17.1.1.1"])])
+    expectExecutedOps(ops, equals: [
+        ("transport.get_state", [:]),
+        ("transport.goto_position", ["position": "17.1.1.1"]),
+    ])
 }
 
 @Test func testNavigateDispatcherGotoBarRejectsOutOfRange() async {

--- a/Tests/LogicProMCPTests/DispatcherTests.swift
+++ b/Tests/LogicProMCPTests/DispatcherTests.swift
@@ -670,6 +670,10 @@ private func liveTransportJSON(
         transportStates: [
             TransportState(
                 position: "8.1.1.1",
+                positionReadback: TransportPositionReadback(
+                    value: "8.1.1.1",
+                    observedComponents: TransportPositionComponent.allCases
+                ),
                 timePosition: "00:00:08.000",
                 lastUpdated: Date()
             )
@@ -3239,6 +3243,10 @@ private actor SelectiveFailChannel: Channel {
         transportStates: [
             TransportState(
                 position: "17.1.1.1",
+                positionReadback: TransportPositionReadback(
+                    value: "17.1.1.1",
+                    observedComponents: TransportPositionComponent.allCases
+                ),
                 timePosition: "00:00:17.000",
                 lastUpdated: Date()
             )

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -376,6 +376,17 @@ struct HCGlobalInvariantTests {
             #expect(!isError, "\(routeCase.command) failed before route assertion: \(sharedToolText(result))")
             let firstDestination = try #require(routeCase.destinations.first)
             let executedOps = await channels[firstDestination]?.executedOps ?? []
+            if routeCase.command == "mmc_locate", let bar = routeCase.params["bar"]?.intValue {
+                // Bar-based MMC locate shares goto_position's observed-effect
+                // contract: it reads a live baseline, then performs exactly one
+                // primary seek carrying the complete requested position.
+                #expect(executedOps.count == 2, "mmc_locate bar must read a baseline then seek once")
+                #expect(executedOps.first?.0 == "transport.get_state")
+                #expect(executedOps.first?.1 == [:])
+                #expect(executedOps.last?.0 == routeCase.operation)
+                #expect(executedOps.last?.1 == ["position": "\(bar).1.1.1"])
+                continue
+            }
             #expect(executedOps.count == 1, "\(routeCase.command) should execute exactly one primary route")
             #expect(executedOps.first?.0 == routeCase.operation)
         }

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -252,6 +252,139 @@ struct Issue105GotoNoteTests {
         #expect(readableBarOnly.observedComponents == [.bar])
     }
 
+    @Test("an unknown-target write is never promoted to verified by a matching playhead")
+    func unknownInputTargetCannotBeVerifiedByACoincidentPlayhead() async throws {
+        // The channel is honest when a global key may have gone elsewhere: State B with
+        // `dialog_input_target: "unknown"` and `fallback_unsafe: true`. Finalize must not treat that
+        // as "the write landed, now read it back" — if the playhead ALREADY showed the requested
+        // position, a matching read proves nothing about this call.
+        //
+        // Concrete state: playhead already at 5.1.1.1, request 5.1.1.1, Cmd+A went to another
+        // application, child killed at the budget.
+        let unknownTargetEnvelope = HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "requested": "5.1.1.1",
+                "dialog_input_target": "unknown",
+                "dialog_input_attempted": true,
+                "write_attempted": true,
+                "fallback_unsafe": true,
+                "safe_to_retry": false,
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: .success(unknownTargetEnvelope),
+            readbackPosition: "5.1.1.1"
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+        let envelope = try #require(obj(result))
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["verification_withheld"] as? String) == "dialog_input_target")
+        #expect(try #require(envelope["observed"] as? String) == "5.1.1.1")
+    }
+
+    // Locks the `fallback_unsafe` arm: a coincidentally matching playhead is not proof this call performed the write.
+    @Test("an unsafe fallback write is never promoted to verified by a matching playhead")
+    func fallbackUnsafeCannotBeVerifiedByACoincidentPlayhead() async throws {
+        let fallbackUnsafeEnvelope = HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "requested": "5.1.1.1",
+                "dialog_input_attempted": true,
+                "write_attempted": true,
+                "fallback_unsafe": true,
+                "safe_to_retry": false,
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: .success(fallbackUnsafeEnvelope),
+            readbackPosition: "5.1.1.1"
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+        let envelope = try #require(obj(result))
+        let observedState: String = envelope["state"] as? String ?? "nil"
+        #expect(observedState != "A")
+    }
+
+    // Locks the `write_attempted_indeterminate` arm: a coincidentally matching playhead is not proof this call performed the write.
+    @Test("an indeterminate write boundary is never promoted to verified by a matching playhead")
+    func indeterminateWriteBoundaryCannotBeVerifiedByACoincidentPlayhead() async throws {
+        let indeterminateWriteBoundaryEnvelope = HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "requested": "5.1.1.1",
+                "dialog_input_attempted": true,
+                "write_attempted": true,
+                "write_attempted_indeterminate": true,
+                "safe_to_retry": false,
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: .success(indeterminateWriteBoundaryEnvelope),
+            readbackPosition: "5.1.1.1"
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+        let envelope = try #require(obj(result))
+        let observedState: String = envelope["state"] as? String ?? "nil"
+        #expect(observedState != "A")
+    }
+
+    @Test("a matching playhead still verifies an otherwise ordinary dialog envelope")
+    func establishedInputTargetCanBeVerifiedByAMatchingPlayhead() async throws {
+        let establishedTargetEnvelope = HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "requested": "5.1.1.1",
+                "dialog_input_attempted": true,
+                "write_attempted": true,
+                "safe_to_retry": false,
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: .success(establishedTargetEnvelope),
+            readbackPosition: "5.1.1.1"
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(try #require(envelope["state"] as? String) == "A")
+        #expect(try #require(envelope["verified"] as? Bool))
+        #expect(envelope["verification_withheld"] == nil)
+    }
+
     @Test("the TransportState display default is never a goto_position observation")
     func unreadablePositionDefaultCannotReachStateA() async throws {
         // Source mutation: restore finalizeGotoPositionResult's old display-string equality check.
@@ -281,7 +414,8 @@ struct Issue105GotoNoteTests {
         #expect(!(try #require(envelope["verified"] as? Bool)))
         #expect(try #require(envelope["state"] as? String) == "B")
         #expect(try #require(envelope["reason"] as? String) == "readback_unavailable")
-        #expect(try #require(envelope["observed"] as? String) == "1.1.1.1")
+        #expect(envelope["observed"] == nil)
+        #expect(envelope["observed_time_position"] == nil)
         let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
         #expect(unobserved == ["bar", "beat", "subdivision", "tick"])
     }

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -11,46 +11,69 @@ import Testing
 /// verdict. Also locks the faithful verified-vs-mismatch behavior.
 @Suite("Issue105 goto note + verification")
 struct Issue105GotoNoteTests {
+    private static func transportState(_ position: String) -> TransportState {
+        // Encode a real TransportState with the SAME .iso8601 strategy the dispatcher decodes
+        // with. A hand-written fractional-seconds (".000Z") date fails strict .iso8601 decoding
+        // on the CI Foundation and would turn a readable fixture into a fake failed read.
+        var state = TransportState()
+        state.position = position
+        state.positionReadback = TransportPositionReadback(
+            value: position,
+            observedComponents: TransportPositionComponent.allCases
+        )
+        state.lastUpdated = Date(timeIntervalSince1970: 0)
+        return state
+    }
+
+    private static func encodedTransportState(_ position: String) -> ChannelResult {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return .success(String(decoding: (try? encoder.encode(transportState(position))) ?? Data(), as: UTF8.self))
+    }
+
     private actor StubTransportChannel: Channel {
         nonisolated let id: ChannelID = .accessibility
         let gotoResult: ChannelResult
         let readbackPosition: String
         let readbackResult: ChannelResult?
+        let readbackPositions: [String]?
+        let readbackResults: [ChannelResult]?
+        private var readbackIndex = 0
+        private var gotoExecutions = 0
         init(
             gotoResult: ChannelResult,
             readbackPosition: String,
-            readbackResult: ChannelResult? = nil
+            readbackResult: ChannelResult? = nil,
+            readbackPositions: [String]? = nil,
+            readbackResults: [ChannelResult]? = nil
         ) {
             self.gotoResult = gotoResult
             self.readbackPosition = readbackPosition
             self.readbackResult = readbackResult
+            self.readbackPositions = readbackPositions
+            self.readbackResults = readbackResults
         }
         func start() async throws {}
         func stop() async {}
         func healthCheck() async -> ChannelHealth { .healthy(detail: "stub") }
         func execute(operation: String, params: [String: String]) async -> ChannelResult {
             switch operation {
-            case "transport.goto_position": return gotoResult
+            case "transport.goto_position":
+                gotoExecutions += 1
+                return gotoResult
             case "transport.get_state":
+                let index = min(readbackIndex, max(0, (readbackResults?.count ?? readbackPositions?.count ?? 1) - 1))
+                readbackIndex += 1
+                if let readbackResults { return readbackResults[index] }
                 if let readbackResult { return readbackResult }
-                // Encode a real TransportState with the SAME .iso8601 strategy
-                // the dispatcher decodes with. A hand-written date carrying
-                // fractional seconds (".000Z") fails strict .iso8601 decoding on
-                // the CI Foundation, which made `liveTransportState` return nil
-                // and the verdict fall back to the un-stripped State B.
-                var state = TransportState()
-                state.position = readbackPosition
-                state.positionReadback = TransportPositionReadback(
-                    value: readbackPosition,
-                    observedComponents: TransportPositionComponent.allCases
+                return Issue105GotoNoteTests.encodedTransportState(
+                    readbackPositions?[index] ?? readbackPosition
                 )
-                state.lastUpdated = Date(timeIntervalSince1970: 0)
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                return .success(String(decoding: (try? encoder.encode(state)) ?? Data(), as: UTF8.self))
             default: return .error("unexpected: \(operation)")
             }
         }
+
+        func gotoExecutionCount() -> Int { gotoExecutions }
     }
 
     private func text(_ r: CallTool.Result) -> String {
@@ -75,7 +98,11 @@ struct Issue105GotoNoteTests {
     @Test("verified goto_position drops the contradictory readback note")
     func verifiedHasNoStaleNote() async throws {
         let router = ChannelRouter()
-        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 1), readbackPosition: "1.1.1.1"))
+        await router.register(StubTransportChannel(
+            gotoResult: notedDialogStateB(bar: 1),
+            readbackPosition: "1.1.1.1",
+            readbackPositions: ["2.1.1.1", "1.1.1.1"]
+        ))
         let result = await TransportDispatcher.handle(
             command: "goto_position", params: ["bar": .int(1)], router: router, cache: StateCache()
         )
@@ -92,7 +119,11 @@ struct Issue105GotoNoteTests {
     @Test("goto_bar shares the same verified, note-free contract")
     func gotoBarNoteFree() async throws {
         let router = ChannelRouter()
-        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 17), readbackPosition: "17.1.1.1"))
+        await router.register(StubTransportChannel(
+            gotoResult: notedDialogStateB(bar: 17),
+            readbackPosition: "17.1.1.1",
+            readbackPositions: ["1.1.1.1", "17.1.1.1"]
+        ))
         let result = await NavigateDispatcher.handle(
             command: "goto_bar", params: ["bar": .int(17)], router: router, cache: StateCache()
         )
@@ -107,7 +138,11 @@ struct Issue105GotoNoteTests {
     func mismatchFailsClosed() async throws {
         let router = ChannelRouter()
         // Requested bar 1 but the playhead landed at 1.2.1.1 (the #105 symptom).
-        await router.register(StubTransportChannel(gotoResult: notedDialogStateB(bar: 1), readbackPosition: "1.2.1.1"))
+        await router.register(StubTransportChannel(
+            gotoResult: notedDialogStateB(bar: 1),
+            readbackPosition: "1.2.1.1",
+            readbackPositions: ["2.1.1.1", "1.2.1.1"]
+        ))
         let result = await TransportDispatcher.handle(
             command: "goto_position", params: ["bar": .int(1)], router: router, cache: StateCache()
         )
@@ -259,8 +294,9 @@ struct Issue105GotoNoteTests {
         // as "the write landed, now read it back" — if the playhead ALREADY showed the requested
         // position, a matching read proves nothing about this call.
         //
-        // Concrete state: playhead already at 5.1.1.1, request 5.1.1.1, Cmd+A went to another
-        // application, child killed at the budget.
+        // Concrete state: the read changed from 4.1.1.1 to 5.1.1.1, but Cmd+A may have gone to
+        // another application before the child was killed. That transition is still insufficient
+        // while the channel says the global input target was unknown.
         let unknownTargetEnvelope = HonestContract.encodeStateB(
             reason: .readbackUnavailable,
             extras: [
@@ -277,7 +313,8 @@ struct Issue105GotoNoteTests {
         let router = ChannelRouter()
         await router.register(StubTransportChannel(
             gotoResult: .success(unknownTargetEnvelope),
-            readbackPosition: "5.1.1.1"
+            readbackPosition: "5.1.1.1",
+            readbackPositions: ["4.1.1.1", "5.1.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",
@@ -314,7 +351,8 @@ struct Issue105GotoNoteTests {
         let router = ChannelRouter()
         await router.register(StubTransportChannel(
             gotoResult: .success(fallbackUnsafeEnvelope),
-            readbackPosition: "5.1.1.1"
+            readbackPosition: "5.1.1.1",
+            readbackPositions: ["4.1.1.1", "5.1.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",
@@ -328,7 +366,8 @@ struct Issue105GotoNoteTests {
         #expect(try #require(envelope["verification_withheld"] as? String) == "fallback_unsafe")
     }
 
-    // Locks the `write_attempted_indeterminate` arm: a coincidentally matching playhead is not proof this call performed the write.
+    // Locks the `write_attempted_indeterminate` arm: even a measured pre/post transition is not
+    // proof this call performed the write when the durable boundary itself was indeterminate.
     @Test("an indeterminate write boundary is never promoted to verified by a matching playhead")
     func indeterminateWriteBoundaryCannotBeVerifiedByACoincidentPlayhead() async throws {
         let indeterminateWriteBoundaryEnvelope = HonestContract.encodeStateB(
@@ -346,7 +385,8 @@ struct Issue105GotoNoteTests {
         let router = ChannelRouter()
         await router.register(StubTransportChannel(
             gotoResult: .success(indeterminateWriteBoundaryEnvelope),
-            readbackPosition: "5.1.1.1"
+            readbackPosition: "5.1.1.1",
+            readbackPositions: ["4.1.1.1", "5.1.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",
@@ -356,10 +396,13 @@ struct Issue105GotoNoteTests {
         )
         let envelope = try #require(obj(result))
         #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["verification_withheld"] as? String)
+            == "write_attempted_indeterminate")
     }
 
-    @Test("a matching playhead still verifies an otherwise ordinary dialog envelope")
-    func establishedInputTargetCanBeVerifiedByAMatchingPlayhead() async throws {
+    @Test("a complete pre/post playhead transition verifies an ordinary dialog envelope")
+    func establishedInputTargetCanBeVerifiedByAnObservedPlayheadTransition() async throws {
         let establishedTargetEnvelope = HonestContract.encodeStateB(
             reason: .readbackUnavailable,
             extras: [
@@ -374,7 +417,8 @@ struct Issue105GotoNoteTests {
         let router = ChannelRouter()
         await router.register(StubTransportChannel(
             gotoResult: .success(establishedTargetEnvelope),
-            readbackPosition: "5.1.1.1"
+            readbackPosition: "5.1.1.1",
+            readbackPositions: ["4.1.1.1", "5.1.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",
@@ -387,6 +431,109 @@ struct Issue105GotoNoteTests {
         #expect(try #require(envelope["state"] as? String) == "A")
         #expect(try #require(envelope["verified"] as? Bool))
         #expect(envelope["verification_withheld"] == nil)
+        #expect(try #require(envelope["observed_before"] as? String) == "4.1.1.1")
+    }
+
+    @Test("a coincident complete pre/post reading is not a write-effect verification")
+    func coincidentPreAndPostReadbacksCannotVerifyWriteEffect() async throws {
+        // Exercise the finalization property below the explicit dispatcher no-op.  A caller may
+        // reach finalization after issuing a write even when both authoritative readings happen to
+        // equal the request; that coincidence does not establish that this call moved anything.
+        let ordinaryDialogEnvelope = HonestContract.encodeStateA(
+            extras: [
+                "operation": "transport.goto_position",
+                "requested": "5.1.1.1",
+                "write_attempted": true,
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: .success(ordinaryDialogEnvelope),
+            readbackPosition: "5.1.1.1"
+        ))
+
+        let result = await TransportDispatcher.finalizeGotoPositionResult(
+            .success(ordinaryDialogEnvelope),
+            requestedPosition: "5.1.1.1",
+            beforeTransport: Self.transportState("5.1.1.1"),
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["verification_withheld"] as? String)
+            == "observed_effect_unavailable")
+    }
+
+    @Test("a matching post-read without a readable pre-write read never reaches State A")
+    func missingPreWriteReadbackWithholdsEffectVerification() async throws {
+        // Mutation this rejects: restore State A's old post-read equality condition. The post read
+        // reaches 5.1.1.1, but the pre-write transport read failed, so the matching value could
+        // have predated this invocation. The fixture's two distinct state replies prove the
+        // pre-read did not silently become an answer of absence.
+        let establishedTargetEnvelope = HonestContract.encodeStateB(
+            reason: .readbackUnavailable,
+            extras: [
+                "operation": "transport.goto_position",
+                "method": "dialog",
+                "requested": "5.1.1.1",
+                "dialog_input_attempted": true,
+                "write_attempted": true,
+                "safe_to_retry": false,
+            ]
+        )
+        let channel = StubTransportChannel(
+            gotoResult: .success(establishedTargetEnvelope),
+            readbackPosition: "",
+            readbackResults: [
+                .error("pre-write transport read failed"),
+                Self.encodedTransportState("5.1.1.1"),
+            ]
+        )
+        let router = ChannelRouter()
+        await router.register(channel)
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["verification_withheld"] as? String)
+            == "observed_effect_unavailable")
+        #expect(try #require(envelope["observed"] as? String) == "5.1.1.1")
+        #expect(await channel.gotoExecutionCount() == 1, "the failed pre-read must not retire the operation")
+    }
+
+    @Test("an already-observed requested position is an explicit no-write result")
+    func alreadyAtRequestedPositionReturnsUnchangedWithoutOpeningTheDialog() async throws {
+        // Mutation this rejects: remove the complete pre-read no-op branch. A post-read matching
+        // the target after a dialog write would be coincidental; the honest shape is instead an
+        // explicit observed no-op with no route execution.
+        let channel = StubTransportChannel(
+            gotoResult: .error("the dialog route must not run for an observed no-op"),
+            readbackPosition: "5.1.1.1"
+        )
+        let router = ChannelRouter()
+        await router.register(channel)
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("5.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(try #require(envelope["state"] as? String) == "A")
+        #expect(try #require(envelope["verified"] as? Bool))
+        #expect(try #require(envelope["unchanged"] as? Bool))
+        #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+        #expect(await channel.gotoExecutionCount() == 0, "the no-op branch must not open the dialog")
     }
 
     @Test("the TransportState display default is never a goto_position observation")

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -185,53 +185,71 @@ struct Issue105GotoNoteTests {
 
     @Test("unreadable six-level bar and beat sliders do not become observed zeroes")
     func unreadablePositionSlidersDoNotInventObservedComponents() throws {
-        // Source mutation: restore `extractSliderValue(slider, runtime: runtime) ?? 0` for either
-        // component. The missing Bar value and unparseable Beat value would then fabricate `0.0`
-        // and falsely mark both components observed.
-        let builder = FakeAXRuntimeBuilder()
-        let app = builder.element(1060)
-        let window = builder.element(1061)
-        let controlBar = builder.element(1062)
-        let positionOuter = builder.element(1063)
-        let positionMiddle = builder.element(1064)
-        let positionInner = builder.element(1065)
-        let playheadPosition = builder.element(1066)
-        let positionComponents = builder.element(1067)
-        let barSlider = builder.element(1068)
-        let beatSlider = builder.element(1069)
-        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
-        builder.setChildren(window, [controlBar])
-        builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
-        builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
-        builder.setChildren(controlBar, [positionOuter])
-        builder.setChildren(positionOuter, [positionMiddle])
-        builder.setChildren(positionMiddle, [positionInner])
-        builder.setChildren(positionInner, [playheadPosition])
-        builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
-        builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
-        builder.setChildren(playheadPosition, [positionComponents])
-        builder.setChildren(positionComponents, [barSlider, beatSlider])
-        builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
-        builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
-        builder.setAttribute(beatSlider, kAXRoleAttribute as String, kAXSliderRole as String)
-        builder.setAttribute(beatSlider, kAXDescriptionAttribute as String, "Beat")
-        builder.setAttribute(beatSlider, kAXValueAttribute as String, "not-a-number")
+        // Mutations this rejects, independently:
+        // - restore `barValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)`: a missing
+        //   Bar paired with a readable Beat would fabricate `0.3`.
+        // - restore `beatValue = Int(extractSliderValue(slider, runtime: runtime) ?? 0)`: a
+        //   readable Bar paired with an invalid Beat would fabricate `37.0`.
+        func positionReadback(barValue: Any?, beatValue: Any?) throws -> TransportPositionReadback? {
+            let builder = FakeAXRuntimeBuilder()
+            let app = builder.element(1060)
+            let window = builder.element(1061)
+            let controlBar = builder.element(1062)
+            let positionOuter = builder.element(1063)
+            let positionMiddle = builder.element(1064)
+            let positionInner = builder.element(1065)
+            let playheadPosition = builder.element(1066)
+            let positionComponents = builder.element(1067)
+            let barSlider = builder.element(1068)
+            let beatSlider = builder.element(1069)
+            builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+            builder.setChildren(window, [controlBar])
+            builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+            builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+            builder.setChildren(controlBar, [positionOuter])
+            builder.setChildren(positionOuter, [positionMiddle])
+            builder.setChildren(positionMiddle, [positionInner])
+            builder.setChildren(positionInner, [playheadPosition])
+            builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+            builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
+            builder.setChildren(playheadPosition, [positionComponents])
+            builder.setChildren(positionComponents, [barSlider, beatSlider])
+            builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+            builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
+            builder.setAttribute(beatSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+            builder.setAttribute(beatSlider, kAXDescriptionAttribute as String, "Beat")
+            if let barValue {
+                builder.setAttribute(barSlider, kAXValueAttribute as String, barValue)
+            }
+            if let beatValue {
+                builder.setAttribute(beatSlider, kAXValueAttribute as String, beatValue)
+            }
 
-        let extracted = AccessibilityChannel.defaultGetTransportState(
-            runtime: builder.makeLogicRuntime(appElement: app)
-        )
-        let payload: String
-        if case let .success(value) = extracted {
-            payload = value
-        } else {
-            Issue.record("expected transport state extraction to encode successfully")
-            return
+            let extracted = AccessibilityChannel.defaultGetTransportState(
+                runtime: builder.makeLogicRuntime(appElement: app)
+            )
+            let payload: String
+            if case let .success(value) = extracted {
+                payload = value
+            } else {
+                Issue.record("expected transport state extraction to encode successfully")
+                return nil
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try decoder.decode(
+                TransportState.self,
+                from: try #require(payload.data(using: .utf8))
+            ).positionReadback
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let state = try decoder.decode(TransportState.self, from: try #require(payload.data(using: .utf8)))
 
-        #expect(state.positionReadback == nil)
+        #expect(try positionReadback(barValue: nil, beatValue: NSNumber(value: 3)) == nil)
+        let unreadableBeatReadback = try positionReadback(
+            barValue: NSNumber(value: 37), beatValue: "not-a-number"
+        )
+        let readableBarOnly = try #require(unreadableBeatReadback)
+        #expect(readableBarOnly.value == "37")
+        #expect(readableBarOnly.observedComponents == [.bar])
     }
 
     @Test("the TransportState display default is never a goto_position observation")

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Foundation
 import MCP
 import Testing
@@ -14,9 +15,15 @@ struct Issue105GotoNoteTests {
         nonisolated let id: ChannelID = .accessibility
         let gotoResult: ChannelResult
         let readbackPosition: String
-        init(gotoResult: ChannelResult, readbackPosition: String) {
+        let readbackResult: ChannelResult?
+        init(
+            gotoResult: ChannelResult,
+            readbackPosition: String,
+            readbackResult: ChannelResult? = nil
+        ) {
             self.gotoResult = gotoResult
             self.readbackPosition = readbackPosition
+            self.readbackResult = readbackResult
         }
         func start() async throws {}
         func stop() async {}
@@ -25,6 +32,7 @@ struct Issue105GotoNoteTests {
             switch operation {
             case "transport.goto_position": return gotoResult
             case "transport.get_state":
+                if let readbackResult { return readbackResult }
                 // Encode a real TransportState with the SAME .iso8601 strategy
                 // the dispatcher decodes with. A hand-written date carrying
                 // fractional seconds (".000Z") fails strict .iso8601 decoding on
@@ -32,6 +40,10 @@ struct Issue105GotoNoteTests {
                 // and the verdict fall back to the un-stripped State B.
                 var state = TransportState()
                 state.position = readbackPosition
+                state.positionReadback = TransportPositionReadback(
+                    value: readbackPosition,
+                    observedComponents: TransportPositionComponent.allCases
+                )
                 state.lastUpdated = Date(timeIntervalSince1970: 0)
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .iso8601
@@ -104,5 +116,92 @@ struct Issue105GotoNoteTests {
         #expect(o["observed"] as? String == "1.2.1.1")
         let resultIsError = result.isError ?? false
         #expect(resultIsError)
+    }
+
+    @Test("an unreadable suffix from real AX extraction cannot verify a four-component request")
+    func partialAXPositionReadbackCannotReachStateA() async throws {
+        // Source mutation: restore the bar/beat synthesizer `"\(barValue).\(beatValue).1.1"`,
+        // or compare `TransportState.position` without its observed components in
+        // finalizeGotoPositionResult. Either turns this partial AX readback into false State A.
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1050)
+        let window = builder.element(1051)
+        let controlBar = builder.element(1052)
+        let playheadPosition = builder.element(1053)
+        let barSlider = builder.element(1054)
+        let beatSlider = builder.element(1055)
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setChildren(window, [controlBar])
+        builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+        builder.setChildren(controlBar, [playheadPosition])
+        builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
+        builder.setChildren(playheadPosition, [barSlider, beatSlider])
+        builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+        builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
+        builder.setAttribute(barSlider, kAXValueAttribute as String, NSNumber(value: 37))
+        builder.setAttribute(beatSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+        builder.setAttribute(beatSlider, kAXDescriptionAttribute as String, "Beat")
+        builder.setAttribute(beatSlider, kAXValueAttribute as String, NSNumber(value: 3))
+        let runtime = builder.makeLogicRuntime(appElement: app)
+        let extracted = AccessibilityChannel.defaultGetTransportState(runtime: runtime)
+
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: notedDialogStateB(bar: 37),
+            readbackPosition: "37.3.1.1",
+            readbackResult: extracted
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("37.3.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["reason"] as? String) == "readback_unavailable")
+        #expect(try #require(envelope["observed"] as? String) == "37.3")
+        let observed = try #require(envelope["observed_position_components"] as? [String])
+        let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
+        #expect(observed == ["bar", "beat"])
+        #expect(unobserved == ["subdivision", "tick"])
+    }
+
+    @Test("the TransportState display default is never a goto_position observation")
+    func unreadablePositionDefaultCannotReachStateA() async throws {
+        // Source mutation: restore finalizeGotoPositionResult's old display-string equality check.
+        // The legacy `"1.1.1.1"` display default without any readable AX position control must
+        // never certify State A.
+        var unreadableState = TransportState()
+        unreadableState.lastUpdated = Date(timeIntervalSince1970: 0)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let unreadableResult = ChannelResult.success(
+            String(decoding: try encoder.encode(unreadableState), as: UTF8.self)
+        )
+        let router = ChannelRouter()
+        await router.register(StubTransportChannel(
+            gotoResult: notedDialogStateB(bar: 1),
+            readbackPosition: "",
+            readbackResult: unreadableResult
+        ))
+        let result = await TransportDispatcher.handle(
+            command: "goto_position",
+            params: ["position": .string("1.1.1.1")],
+            router: router,
+            cache: StateCache()
+        )
+
+        let envelope = try #require(obj(result))
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["reason"] as? String) == "readback_unavailable")
+        #expect(try #require(envelope["observed"] as? String) == "1.1.1.1")
+        let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
+        #expect(unobserved == ["bar", "beat", "subdivision", "tick"])
     }
 }

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -120,24 +120,36 @@ struct Issue105GotoNoteTests {
 
     @Test("an unreadable suffix from real AX extraction cannot verify a four-component request")
     func partialAXPositionReadbackCannotReachStateA() async throws {
-        // Source mutation: restore the bar/beat synthesizer `"\(barValue).\(beatValue).1.1"`,
-        // or compare `TransportState.position` without its observed components in
-        // finalizeGotoPositionResult. Either turns this partial AX readback into false State A.
+        // Source mutations: restore the historical four-level slider scan, restore the bar/beat
+        // synthesizer `"\(barValue).\(beatValue).1.1"`, or compare `TransportState.position`
+        // without its observed components in finalizeGotoPositionResult. The first misses the
+        // measured Logic 12.3 topology; either latter mutation turns this partial AX readback into
+        // false State A.
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1050)
         let window = builder.element(1051)
         let controlBar = builder.element(1052)
-        let playheadPosition = builder.element(1053)
-        let barSlider = builder.element(1054)
-        let beatSlider = builder.element(1055)
+        let positionOuter = builder.element(1053)
+        let positionMiddle = builder.element(1054)
+        let positionInner = builder.element(1055)
+        let playheadPosition = builder.element(1056)
+        let positionComponents = builder.element(1057)
+        let barSlider = builder.element(1058)
+        let beatSlider = builder.element(1059)
         builder.setAttribute(app, kAXMainWindowAttribute as String, window)
         builder.setChildren(window, [controlBar])
         builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
         builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
-        builder.setChildren(controlBar, [playheadPosition])
+        // This is the measured six-level Control Bar topology from the Logic 12.3 locator
+        // fixture: Control Bar → outer → middle → inner → Playhead Position → components → slider.
+        builder.setChildren(controlBar, [positionOuter])
+        builder.setChildren(positionOuter, [positionMiddle])
+        builder.setChildren(positionMiddle, [positionInner])
+        builder.setChildren(positionInner, [playheadPosition])
         builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
         builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
-        builder.setChildren(playheadPosition, [barSlider, beatSlider])
+        builder.setChildren(playheadPosition, [positionComponents])
+        builder.setChildren(positionComponents, [barSlider, beatSlider])
         builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
         builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
         builder.setAttribute(barSlider, kAXValueAttribute as String, NSNumber(value: 37))
@@ -169,6 +181,57 @@ struct Issue105GotoNoteTests {
         let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
         #expect(observed == ["bar", "beat"])
         #expect(unobserved == ["subdivision", "tick"])
+    }
+
+    @Test("unreadable six-level bar and beat sliders do not become observed zeroes")
+    func unreadablePositionSlidersDoNotInventObservedComponents() throws {
+        // Source mutation: restore `extractSliderValue(slider, runtime: runtime) ?? 0` for either
+        // component. The missing Bar value and unparseable Beat value would then fabricate `0.0`
+        // and falsely mark both components observed.
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1060)
+        let window = builder.element(1061)
+        let controlBar = builder.element(1062)
+        let positionOuter = builder.element(1063)
+        let positionMiddle = builder.element(1064)
+        let positionInner = builder.element(1065)
+        let playheadPosition = builder.element(1066)
+        let positionComponents = builder.element(1067)
+        let barSlider = builder.element(1068)
+        let beatSlider = builder.element(1069)
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setChildren(window, [controlBar])
+        builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
+        builder.setChildren(controlBar, [positionOuter])
+        builder.setChildren(positionOuter, [positionMiddle])
+        builder.setChildren(positionMiddle, [positionInner])
+        builder.setChildren(positionInner, [playheadPosition])
+        builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
+        builder.setChildren(playheadPosition, [positionComponents])
+        builder.setChildren(positionComponents, [barSlider, beatSlider])
+        builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+        builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
+        builder.setAttribute(beatSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+        builder.setAttribute(beatSlider, kAXDescriptionAttribute as String, "Beat")
+        builder.setAttribute(beatSlider, kAXValueAttribute as String, "not-a-number")
+
+        let extracted = AccessibilityChannel.defaultGetTransportState(
+            runtime: builder.makeLogicRuntime(appElement: app)
+        )
+        let payload: String
+        if case let .success(value) = extracted {
+            payload = value
+        } else {
+            Issue.record("expected transport state extraction to encode successfully")
+            return
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let state = try decoder.decode(TransportState.self, from: try #require(payload.data(using: .utf8)))
+
+        #expect(state.positionReadback == nil)
     }
 
     @Test("the TransportState display default is never a goto_position observation")

--- a/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
+++ b/Tests/LogicProMCPTests/Issue105GotoNoteTests.swift
@@ -292,16 +292,20 @@ struct Issue105GotoNoteTests {
         #expect(try #require(envelope["observed"] as? String) == "5.1.1.1")
     }
 
-    // Locks the `fallback_unsafe` arm: a coincidentally matching playhead is not proof this call performed the write.
-    @Test("an unsafe fallback write is never promoted to verified by a matching playhead")
-    func fallbackUnsafeCannotBeVerifiedByACoincidentPlayhead() async throws {
+    // A post-Return title/reference loss is not an observed dialog closure. The channel carries
+    // `fallback_unsafe`, and a matching playhead may predate this request, so finalization must
+    // preserve State B rather than falsely certifying State A.
+    @Test("an unidentified post-Return dialog is never verified by a coincident playhead")
+    func postReturnUnidentifiedDialogCannotBeVerifiedByACoincidentPlayhead() async throws {
         let fallbackUnsafeEnvelope = HonestContract.encodeStateB(
             reason: .readbackUnavailable,
             extras: [
                 "operation": "transport.goto_position",
                 "method": "dialog",
                 "requested": "5.1.1.1",
-                "dialog_input_attempted": true,
+                "dialog_route_outcome": "dialog_submission_issued_cleanup_closed_false",
+                "dialog_cleanup": "unobserved",
+                "dialog_submission_attempted": true,
                 "write_attempted": true,
                 "fallback_unsafe": true,
                 "safe_to_retry": false,
@@ -319,8 +323,9 @@ struct Issue105GotoNoteTests {
             cache: StateCache()
         )
         let envelope = try #require(obj(result))
-        let observedState: String = envelope["state"] as? String ?? "nil"
-        #expect(observedState != "A")
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!(try #require(envelope["verified"] as? Bool)))
+        #expect(try #require(envelope["verification_withheld"] as? String) == "fallback_unsafe")
     }
 
     // Locks the `write_attempted_indeterminate` arm: a coincidentally matching playhead is not proof this call performed the write.
@@ -350,8 +355,7 @@ struct Issue105GotoNoteTests {
             cache: StateCache()
         )
         let envelope = try #require(obj(result))
-        let observedState: String = envelope["state"] as? String ?? "nil"
-        #expect(observedState != "A")
+        #expect(try #require(envelope["state"] as? String) == "B")
     }
 
     @Test("a matching playhead still verifies an otherwise ordinary dialog envelope")

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -29,6 +29,10 @@ struct Issue108Tests {
                 // Foundation, making liveTransportState return nil.
                 var state = TransportState()
                 state.position = readbackPosition
+                state.positionReadback = TransportPositionReadback(
+                    value: readbackPosition,
+                    observedComponents: TransportPositionComponent.allCases
+                )
                 state.lastUpdated = Date(timeIntervalSince1970: 0)
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .iso8601

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -13,8 +13,9 @@ struct Issue108Tests {
 
     private actor StubTransportChannel: Channel {
         nonisolated let id: ChannelID = .accessibility
-        let readbackPosition: String
-        init(readbackPosition: String) { self.readbackPosition = readbackPosition }
+        let readbackPositions: [String]
+        private var readbackIndex = 0
+        init(readbackPositions: [String]) { self.readbackPositions = readbackPositions }
         func start() async throws {}
         func stop() async {}
         func healthCheck() async -> ChannelHealth { .healthy(detail: "stub") }
@@ -27,10 +28,12 @@ struct Issue108Tests {
                 // the dispatcher decodes with — a hand-written fractional-seconds
                 // date (".000Z") fails strict .iso8601 decoding on the CI
                 // Foundation, making liveTransportState return nil.
+                let index = min(readbackIndex, readbackPositions.count - 1)
+                readbackIndex += 1
                 var state = TransportState()
-                state.position = readbackPosition
+                state.position = readbackPositions[index]
                 state.positionReadback = TransportPositionReadback(
-                    value: readbackPosition,
+                    value: readbackPositions[index],
                     observedComponents: TransportPositionComponent.allCases
                 )
                 state.lastUpdated = Date(timeIntervalSince1970: 0)
@@ -52,7 +55,9 @@ struct Issue108Tests {
     @Test("mmc_locate(bar) verifies the playhead via transport-state read-back")
     func mmcLocateVerifies() async throws {
         let router = ChannelRouter()
-        await router.register(StubTransportChannel(readbackPosition: "5.1.1.1"))
+        // State A needs a measured change across the write boundary, not merely a matching
+        // post-read that may have predated this locate request.
+        await router.register(StubTransportChannel(readbackPositions: ["1.1.1.1", "5.1.1.1"]))
         let result = await MIDIDispatcher.handle(
             command: "mmc_locate", params: ["bar": .int(5)], router: router, cache: StateCache()
         )
@@ -67,7 +72,7 @@ struct Issue108Tests {
     @Test("mmc_locate(bar) fails closed when the playhead does not land")
     func mmcLocateMismatchFailsClosed() async throws {
         let router = ChannelRouter()
-        await router.register(StubTransportChannel(readbackPosition: "9.1.1.1"))
+        await router.register(StubTransportChannel(readbackPositions: ["1.1.1.1", "9.1.1.1"]))
         let result = await MIDIDispatcher.handle(
             command: "mmc_locate", params: ["bar": .int(5)], router: router, cache: StateCache()
         )

--- a/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
@@ -26,10 +26,11 @@ struct Issue136GotoDriftHonestTests {
     private actor StubTransportChannel: Channel {
         nonisolated let id: ChannelID = .accessibility
         let gotoResult: ChannelResult
-        let readbackPosition: String
-        init(gotoResult: ChannelResult, readbackPosition: String) {
+        let readbackPositions: [String]
+        private var readbackIndex = 0
+        init(gotoResult: ChannelResult, readbackPositions: [String]) {
             self.gotoResult = gotoResult
-            self.readbackPosition = readbackPosition
+            self.readbackPositions = readbackPositions
         }
         func start() async throws {}
         func stop() async {}
@@ -38,10 +39,12 @@ struct Issue136GotoDriftHonestTests {
             switch operation {
             case "transport.goto_position": return gotoResult
             case "transport.get_state":
+                let index = min(readbackIndex, readbackPositions.count - 1)
+                readbackIndex += 1
                 var state = TransportState()
-                state.position = readbackPosition
+                state.position = readbackPositions[index]
                 state.positionReadback = TransportPositionReadback(
-                    value: readbackPosition,
+                    value: readbackPositions[index],
                     observedComponents: TransportPositionComponent.allCases
                 )
                 state.lastUpdated = Date(timeIntervalSince1970: 0)
@@ -81,7 +84,7 @@ struct Issue136GotoDriftHonestTests {
         // #136 symptom: the write "succeeded" but the readback disagrees.
         await router.register(StubTransportChannel(
             gotoResult: dispatchAckStateB(requested: "9.1.1.1"),
-            readbackPosition: "9.2.1.1"
+            readbackPositions: ["1.1.1.1", "9.2.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",
@@ -129,12 +132,12 @@ struct Issue136GotoDriftHonestTests {
         #expect(!text(result).contains("not read back"))
     }
 
-    @Test("control case: exact readback match is the only path to verified:true")
+    @Test("control case: an exact landing after a distinct pre-read is verified:true")
     func exactMatchIsVerifiedTrue() async throws {
         let router = ChannelRouter()
         await router.register(StubTransportChannel(
             gotoResult: dispatchAckStateB(requested: "9.1.1.1"),
-            readbackPosition: "9.1.1.1"
+            readbackPositions: ["1.1.1.1", "9.1.1.1"]
         ))
         let result = await TransportDispatcher.handle(
             command: "goto_position",

--- a/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue136GotoDriftHonestTests.swift
@@ -40,6 +40,10 @@ struct Issue136GotoDriftHonestTests {
             case "transport.get_state":
                 var state = TransportState()
                 state.position = readbackPosition
+                state.positionReadback = TransportPositionReadback(
+                    value: readbackPosition,
+                    observedComponents: TransportPositionComponent.allCases
+                )
                 state.lastUpdated = Date(timeIntervalSince1970: 0)
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .iso8601

--- a/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
+++ b/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
@@ -129,15 +129,20 @@ struct Issue440TransportFrontmostTests {
         )
 
         // The AX tree is empty, so this fails further along — but NOT at the gate, and without
-        // having activated anything. A gate that refused here would block every legitimate call.
+        // having activated anything. The early menu failure cannot observe whether a dialog is
+        // present, so the current contract refuses later position routes rather than falling
+        // through to a global-input fallback. A gate that refused here would block every
+        // legitimate call before this terminal safety decision was reached.
         let obj = try #require(envelope(result))
-        // The route gets past the gate and fails further along without resolving or writing an
-        // alternative position route. Source mutation: restore `via:"slider"` / `ax_write_failed`
-        // in that receipt; this exact-route assertion must fail.
+        // This proves both facts the test owns: the gate admitted the dialog route, and its
+        // post-gate menu failure stayed terminal with no position write.
         #expect(try #require(obj["frontmost_preparation"] as? String) == "already_frontmost")
         #expect(try #require(obj["state"] as? String) == "C")
-        #expect(try #require(obj["error"] as? String) == "not_supported")
-        #expect(try #require(obj["position_route"] as? String) == "unavailable")
+        #expect(try #require(obj["error"] as? String) == "ax_write_failed")
+        #expect(try #require(obj["dialog_route_outcome"] as? String) == "menu_not_found")
+        #expect(try #require(obj["fallback_unsafe"] as? Bool))
+        #expect(!(try #require(obj["safe_to_retry"] as? Bool)))
+        #expect(obj["position_route"] == nil)
         let writeAttempted = try #require(obj["write_attempted"] as? Bool)
         #expect(!writeAttempted)
         #expect(obj["via"] == nil)

--- a/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
+++ b/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
@@ -16,7 +16,9 @@ import Testing
 struct Issue440TransportFrontmostTests {
     /// A runtime whose AX tree is irrelevant: every test here must refuse or proceed before any AX
     /// element is looked up, so reaching the tree at all is itself the failure.
-    private func unusableAXRuntime() -> AXLogicProElements.Runtime {
+    private func unusableAXRuntime(
+        dialogScriptExecutions: Counter? = nil
+    ) -> AXLogicProElements.Runtime {
         return AXLogicProElements.Runtime(
             logicProPID: { 4242 },
             ax: AXHelpers.Runtime(
@@ -26,7 +28,17 @@ struct Issue440TransportFrontmostTests {
                 children: { _ in [] },
                 performAction: { _, _ in false },
                 childCount: { _ in 0 }
-            )
+            ),
+            // Stubbed deliberately. Omitting it defaults to the real `AppleScriptChannel`, so this
+            // test drove the actual Logic Pro on any machine where Logic was running, and its
+            // result depended on whether the dialog route happened to work there. It passed only
+            // while that route was broken.
+            executeAppleScript: { _ in
+                dialogScriptExecutions?.bump()
+                // A normal pre-actuation dialog refusal proves the route can safely reach its
+                // documented slider refusal without opening a real Logic dialog.
+                return .success(#"{"result":"MENU_NOT_FOUND: fixture"}"#)
+            }
         )
     }
 
@@ -103,10 +115,15 @@ struct Issue440TransportFrontmostTests {
     @Test("a frontmost Logic is not refused — the gate lets real work through")
     func frontmostProceedsPastTheGate() async throws {
         let activations = Counter()
+        let frontmostReadings = Counter()
+        let dialogScriptExecutions = Counter()
+        // Mutation this rejects: replace `isFrontmost: isFrontmost` in
+        // `gotoPositionViaBarSlider`'s FrontmostGate call with a non-injected false answer. The
+        // route then refuses before this runtime's dialog seam and these assertions fail.
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "1"],
-            runtime: unusableAXRuntime(),
-            isFrontmost: { true },
+            runtime: unusableAXRuntime(dialogScriptExecutions: dialogScriptExecutions),
+            isFrontmost: { frontmostReadings.bump(); return true },
             activateLogic: { activations.bump(); return true },
             sleepMicros: { _ in }
         )
@@ -114,9 +131,20 @@ struct Issue440TransportFrontmostTests {
         // The AX tree is empty, so this fails further along — but NOT at the gate, and without
         // having activated anything. A gate that refused here would block every legitimate call.
         let obj = try #require(envelope(result))
+        // The route gets past the gate and fails further along, at the Control Bar slider, which
+        // reports that it cannot express a position rather than issuing a write.
         #expect(try #require(obj["frontmost_preparation"] as? String) == "already_frontmost")
-        #expect(obj["write_attempted"] == nil)
+        #expect(try #require(obj["state"] as? String) == "C")
+        #expect(try #require(obj["error"] as? String) == "ax_write_failed")
+        #expect(try #require(obj["via"] as? String) == "slider")
+        let sliderPositionWriteSupported = try #require(obj["slider_position_write_supported"] as? Bool)
+        let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+        #expect(!sliderPositionWriteSupported)
+        #expect(!writeAttempted)
+        #expect(result.message.contains(#""write_attempted":false"#))
         #expect(activations.value == 0)
+        #expect(frontmostReadings.value == FrontmostGate.requiredObservations)
+        #expect(dialogScriptExecutions.value == 1)
     }
 }
 

--- a/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
+++ b/Tests/LogicProMCPTests/Issue440TransportFrontmostTests.swift
@@ -131,16 +131,16 @@ struct Issue440TransportFrontmostTests {
         // The AX tree is empty, so this fails further along — but NOT at the gate, and without
         // having activated anything. A gate that refused here would block every legitimate call.
         let obj = try #require(envelope(result))
-        // The route gets past the gate and fails further along, at the Control Bar slider, which
-        // reports that it cannot express a position rather than issuing a write.
+        // The route gets past the gate and fails further along without resolving or writing an
+        // alternative position route. Source mutation: restore `via:"slider"` / `ax_write_failed`
+        // in that receipt; this exact-route assertion must fail.
         #expect(try #require(obj["frontmost_preparation"] as? String) == "already_frontmost")
         #expect(try #require(obj["state"] as? String) == "C")
-        #expect(try #require(obj["error"] as? String) == "ax_write_failed")
-        #expect(try #require(obj["via"] as? String) == "slider")
-        let sliderPositionWriteSupported = try #require(obj["slider_position_write_supported"] as? Bool)
+        #expect(try #require(obj["error"] as? String) == "not_supported")
+        #expect(try #require(obj["position_route"] as? String) == "unavailable")
         let writeAttempted = try #require(obj["write_attempted"] as? Bool)
-        #expect(!sliderPositionWriteSupported)
         #expect(!writeAttempted)
+        #expect(obj["via"] == nil)
         #expect(result.message.contains(#""write_attempted":false"#))
         #expect(activations.value == 0)
         #expect(frontmostReadings.value == FrontmostGate.requiredObservations)

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -1729,12 +1729,12 @@ func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
     #expect(!script.contains("AXIdentifier"))
 }
 
-@Test("the timeout parser accepts the LF snapshot after do shell script normalizes it to CR")
-func timeoutSnapshotParserUsesTheShellReturnedDelimiter() throws {
-    // Mutation this rejects: change the production parser's `text item delimiters to return` back
-    // to `linefeed`. The writer persists LF, but `do shell script` returns that output as CR; the
-    // probe executes that same boundary without touching System Events and would produce one item
-    // rather than the required three.
+@Test("the timeout parser accepts the LF snapshot through Foundation")
+func timeoutSnapshotParserUsesFoundationPreservedDelimiter() throws {
+    // Mutation this rejects: change the production parser's `text item delimiters to linefeed`
+    // back to `return`. Foundation preserves the writer's LF, so the probe executes that same
+    // boundary without touching System Events and would produce one item rather than the
+    // required three.
     let directory = FileManager.default.temporaryDirectory
         .appendingPathComponent("logic-pro-mcp-snapshot-parser-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -1755,8 +1755,8 @@ func timeoutSnapshotParserUsesTheShellReturnedDelimiter() throws {
     #expect(probeResult.exitCode == 0)
     #expect(probeResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "0, 1")
     #expect(writer.contains("set snapshotText to \"READY\" & linefeed"))
-    #expect(parser.contains("set AppleScript's text item delimiters to return"))
-    #expect(!parser.contains("set AppleScript's text item delimiters to linefeed"))
+    #expect(parser.contains("set AppleScript's text item delimiters to linefeed"))
+    #expect(!parser.contains("set AppleScript's text item delimiters to return"))
 }
 
 @Test("the write script emits the unidentified-window refusal, and emits it before any dismissal")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -134,6 +134,37 @@ private func issue529Envelope(_ result: ChannelResult) -> [String: Any]? {
     return envelope
 }
 
+private func issue529PreexistingDialogRuntime(
+    reconciliationCalls: Issue529Counter
+) -> (builder: FakeAXRuntimeBuilder, runtime: AXLogicProElements.Runtime, cancel: AXUIElement) {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(52_901)
+    let projectWindow = builder.element(52_902)
+    let dialogWindow = builder.element(52_903)
+    let cancel = builder.element(52_904)
+
+    builder.setAttribute(app, kAXMainWindowAttribute as String, projectWindow)
+    builder.setAttribute(app, kAXWindowsAttribute as String, [projectWindow, dialogWindow])
+    builder.setAttribute(projectWindow, kAXModalAttribute as String, false)
+    builder.setAttribute(dialogWindow, kAXTitleAttribute as String, "Go To Position")
+    builder.setAttribute(dialogWindow, kAXSubroleAttribute as String, kAXFloatingWindowSubrole as String)
+    builder.setAttribute(dialogWindow, kAXModalAttribute as String, true)
+    builder.setAttribute(cancel, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(cancel, kAXTitleAttribute as String, "Cancel")
+    builder.setChildren(dialogWindow, [cancel])
+
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        setAttributeHandler: nil,
+        performActionHandler: nil,
+        executeAppleScript: { _ in
+            reconciliationCalls.bump()
+            return .success(#"{"result":"CLOSED"}"#)
+        }
+    )
+    return (builder, runtime, cancel)
+}
+
 @Suite("Issue #529 — Go To Position menu validation")
 struct Issue529MenuValidationTests {
     @Test("locale is decided by non-actuating reads before one resolved leaf is issued")
@@ -417,6 +448,60 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
+    @Test("an unidentified new window is terminal and cannot release another position route")
+    func unidentifiedNewWindowDoesNotProduceRouterContinuableResult() async throws {
+        // Mutation this rejects: restore the old `dialog did not become ready` result for an
+        // unmatched post-leaf window, or remove this classification from the unsafe-UI refusal.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        #expect(script.contains("on newWindowAppearedSince(theProcess, preLeafWindows)"))
+        #expect(script.contains("return \"DIALOG_UNIDENTIFIED_NEW_WINDOW\""))
+
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_UNIDENTIFIED_NEW_WINDOW"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String)
+            == "dialog_unidentified_new_window")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(!(try #require(envelope["safe_to_retry"] as? Bool)))
+        #expect(HonestContract.isFallbackUnsafeStateC(result.message))
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("an absent new window retains the clean pre-input State C")
+    func noNewWindowStillProducesExistingCleanStateC() async throws {
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: dialog did not become ready"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["error"] as? String) == "not_supported")
+        #expect(try #require(envelope["safe_to_retry"] as? Bool))
+        #expect(envelope["fallback_unsafe"] == nil)
+        #expect(sliderWrites.value == 0)
+    }
+
     @Test("a clean leaf-only failure does not invent an AX slider route")
     func cleanLeafActuationFailureDoesNotInventSliderRoute() async throws {
         // Source mutation: restore `via:"slider"` or `error:.axWriteFailed` in the no-route
@@ -539,11 +624,11 @@ struct Issue529MenuValidationTests {
         #expect(!FileManager.default.fileExists(atPath: temporaryPath))
     }
 
-    @Test("default dead-child reconciliation stays on the injected runtime seam")
-    func defaultDeadChildReconciliationUsesInjectedRuntime() async throws {
-        // Source mutation: call `AppleScriptChannel.executeAppleScript` directly from
-        // `observeAndClearStrayGoToPositionUI`. This fake runtime would see no reconciliation
-        // script, proving the default failure path escaped the test/runtime seam.
+    @Test("a timeout without a pre-leaf snapshot does not run reconciliation")
+    func unavailablePreLeafSnapshotDoesNotRunDefaultReconciliation() async throws {
+        // Mutation this rejects: remove the `preLeafWindowSnapshotPath` guard in the default
+        // reconciler. A killed child with no durable ownership snapshot must not run a cleanup
+        // script whose Cancel branch could target another run's matching dialog.
         let sliderWrites = Issue529Counter()
         let reconciliationCalls = Issue529Counter()
         let runtime = issue529SliderRuntime(
@@ -566,9 +651,37 @@ struct Issue529MenuValidationTests {
         #expect(!result.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "C")
         #expect(try #require(envelope["dialog_route_outcome"] as? String)
-            == "execution_failed_issuance_NOT_ISSUED_cleanup_closed_true")
-        #expect(reconciliationCalls.value == 1)
+            == "execution_failed_issuance_NOT_ISSUED_cleanup_closed_false")
+        #expect(reconciliationCalls.value == 0)
         #expect(sliderWrites.value == 0)
+    }
+
+    @Test("the default reconciler never cancels a pre-existing dialog after LEAF_ARMED")
+    func defaultReconcilerLeavesPreexistingDialogUntouchedAfterLeafTimeout() async throws {
+        // Mutation this rejects: pass the ledger path through without requiring its READY
+        // pre-leaf snapshot. The default reconciliation script would then be launched after this
+        // LEAF_ARMED timeout and could press Cancel on the fixture's already-open dialog.
+        let reconciliationCalls = Issue529Counter()
+        let fixture = issue529PreexistingDialogRuntime(reconciliationCalls: reconciliationCalls)
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: fixture.runtime,
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { script in
+                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
+                try! "LEAF_ARMED".write(toFile: ledgerPath, atomically: true, encoding: .utf8)
+                return .error("osascript timed out after leaf click")
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(reconciliationCalls.value == 0)
+        #expect(fixture.builder.actionCalls.isEmpty)
     }
 
     @Test("an existing dialog or focus loss refuses before a position submission")
@@ -1101,9 +1214,10 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
 
 @Test("dead-child reconciliation targets the measured dialog before menu state")
 func aDeadScriptReconcilesDialogBeforeMenuState() throws {
-    // Mutations this rejects: restore the PID bypass, match a dialog by title alone, remove the
-    // final frontmost read after AXFocusedWindow, or send menu Escape after a single frontmost
-    // read. Each would either skip cleanup or let Escape reach a different focused modal/app.
+    // Mutations this rejects: restore the PID bypass, drop the durable pre-leaf identity filter,
+    // remove the final frontmost read after AXFocusedWindow, or send menu Escape after a single
+    // frontmost read. Each would either cancel another run's dialog or let Escape reach a
+    // different focused modal/app.
     let source = try String(
         contentsOfFile: #filePath.replacingOccurrences(
             of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
@@ -1115,8 +1229,16 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let helperEnd = try #require(source.range(of: "// MARK: - Control-bar checkbox helpers"))
     let helper = String(source[helperStart.lowerBound..<helperEnd.lowerBound])
     let measuredSubrole = try issue529Position(of: "on knownGoToPositionDialogSubrole(dialogSubrole)", in: helper)
-    let dialogObservation = try issue529Position(of: "on matchingGoToPositionDialog(theProcess)", in: helper)
-    let dialogCleanup = try issue529Position(of: "set dialogCleanupState to my dismissGoToPositionDialog(it)", in: helper)
+    let dialogObservation = try issue529Position(
+        of: "on matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)", in: helper
+    )
+    let snapshotRead = try issue529Position(
+        of: "on preLeafGoToPositionWindowIdentifiers(snapshotPath)", in: helper
+    )
+    let dialogCleanup = try issue529Position(
+        of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafWindowIdentifiers)",
+        in: helper
+    )
     let focusedWindowRead = try issue529Position(
         of: "set processFocusedWindow to value of attribute \"AXFocusedWindow\"", in: helper
     )
@@ -1125,7 +1247,8 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let menuCleanupTail = String(helper[menuFocus...])
     let menuEscape = try issue529Position(of: "key code 53", in: menuCleanupTail)
 
-    #expect(measuredSubrole < dialogObservation)
+    #expect(measuredSubrole < snapshotRead)
+    #expect(snapshotRead < dialogObservation)
     #expect(dialogObservation < dialogCleanup)
     #expect(focusedWindowRead < finalFrontmostRead)
     #expect(dialogCleanup < menuFocus)
@@ -1134,4 +1257,37 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     #expect(helper.contains("if processFocusedWindow is not dialogWindow then return \"NOT_FOCUSED\""))
     #expect(!helper.contains("if frontmost then"))
     #expect(!helper.contains("ProcessUtils.logicProPID"))
+}
+
+@Test("the write script emits the unidentified-window refusal, and emits it before any dismissal")
+func writeScriptRefusesAnUnidentifiedNewWindowBeforeDismissingAnything() throws {
+    // The whole unidentified-new-window refusal rests on this one AppleScript return. Every Swift-side
+    // test downstream of it starts from a reply string, so deleting this line leaves the parser, the
+    // classifier and the envelope tests all green while the defect returns: a window this run opened but
+    // could not name would again be reported CLOSED, the result would be router-continuable, and CGEvent
+    // would type the position into the live dialog.
+    //
+    // Order is part of the contract, not decoration. The refusal must come BEFORE
+    // `dismissOpenGoToPositionDialog`, or the script would cancel the window it just declined to identify
+    // — which is the same wrong-target cancellation the reconciler was fixed to avoid.
+    let source = try String(
+        contentsOfFile: #filePath.replacingOccurrences(
+            of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
+            with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift"
+        ),
+        encoding: .utf8
+    )
+    // Scope to the not-ready block. An earlier dismissal exists in the leaf-click `on error` handler,
+    // which is a different case and legitimately dismisses first.
+    let scriptStart = try #require(source.range(of: "                if not dialogReady then"))
+    let scriptEnd = try #require(source.range(of: "    struct DialogIssuanceLedger"))
+    let script = String(source[scriptStart.lowerBound..<scriptEnd.lowerBound])
+
+    let unidentifiedRefusal = try issue529Position(
+        of: "if dialogAppearanceUnidentified then return \"DIALOG_UNIDENTIFIED_NEW_WINDOW\"", in: script
+    )
+    let dialogDismissal = try issue529Position(
+        of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(", in: script
+    )
+    #expect(unidentifiedRefusal < dialogDismissal)
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -37,6 +37,14 @@ private final class Issue529Counter: @unchecked Sendable {
     }
 }
 
+private final class Issue529StringBox: @unchecked Sendable {
+    private(set) var value: String?
+
+    func set(_ value: String) {
+        self.value = value
+    }
+}
+
 private actor Issue529DialogLockGate {
     private var started = false
     private var startWaiter: CheckedContinuation<Void, Never>?
@@ -463,18 +471,19 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["state"] as? String) == "B")
         let writeAttempted = envelope["write_attempted"] as? Bool
         let submissionAttempted = envelope["dialog_submission_attempted"] as? Bool
-        #expect(writeAttempted == nil)
-        #expect(submissionAttempted == nil)
+        #expect(writeAttempted.map { $0 ? "true" : "false" } == nil)
+        #expect(submissionAttempted.map { $0 ? "true" : "false" } == nil)
         #expect(try #require(envelope["dialog_submission_indeterminate"] as? Bool))
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("a dead child with a corrupt dialog ledger reports possible global input")
-    func deadChildWithUnknownLedgerDoesNotOmitGlobalInputReceipt() async throws {
-        // Mutation this rejects: remove `.executionFailed(issuance: .unknown, ...)` from
-        // `globalInputMayHaveOccurred`. A corrupt/truncated ledger cannot prove that Cmd+A or
-        // position text was not sent, so its receipt must not claim `write_attempted:false`.
+    @Test("a spawn failure without a ledger reports global input as indeterminate")
+    func spawnFailureWithoutLedgerDoesNotOverclaimAGlobalInputAttempt() async throws {
+        // Mutation this rejects: return `.attempted` rather than `.indeterminate` for
+        // `.executionFailed(issuance: .unknown, ...)`. With ledger creation intentionally failed,
+        // this fixture's `spawnFailed` result proves no child or key event existed; uncertainty
+        // still suppresses fallback, but must not be serialized as an asserted attempt.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -482,16 +491,9 @@ struct Issue529MenuValidationTests {
             isFrontmost: { true },
             activateLogic: { true },
             sleepMicros: { _ in },
-            executeDialogScript: { script in
-                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
-                try! "truncated-before-replacement".write(
-                    toFile: ledgerPath,
-                    atomically: false,
-                    encoding: .utf8
-                )
-                return .error("osascript was killed while updating the issuance ledger")
-            },
-            reconcileAfterDialogExecutionFailure: { true }
+            executeDialogScript: { _ in .error("osascript spawnFailed") },
+            reconcileAfterDialogExecutionFailure: { true },
+            createDialogIssuanceLedger: { nil }
         )
 
         let envelope = try #require(issue529Envelope(result))
@@ -499,13 +501,42 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["state"] as? String) == "B")
         #expect(try #require(envelope["dialog_route_outcome"] as? String)
             == "execution_failed_issuance_unknown_cleanup_closed_true")
-        #expect(try #require(envelope["dialog_input_attempted"] as? Bool))
+        #expect(try #require(envelope["dialog_input_indeterminate"] as? Bool))
         #expect(try #require(envelope["dialog_input_boundary"] as? String) == "unknown")
         #expect(try #require(envelope["dialog_input_target"] as? String) == "unknown")
-        #expect(try #require(envelope["write_attempted"] as? Bool))
+        #expect(try #require(envelope["write_attempted_indeterminate"] as? Bool))
+        #expect(envelope["dialog_input_attempted"] == nil)
+        #expect(envelope["write_attempted"] == nil)
         #expect(try #require(envelope["dialog_submission_indeterminate"] as? Bool))
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(sliderWrites.value == 0)
+    }
+
+    @Test("parent ledger cleanup removes an orphaned randomized staging file")
+    func parentLedgerCleanupRemovesOrphanedTemporaryFile() async throws {
+        // Mutation this rejects: remove the sibling-prefix cleanup from
+        // `DialogIssuanceLedger.remove()`. This fixture leaves a `.tmp.*` file behind exactly as a
+        // killed child can after `mktemp`; the parent must remove it before returning.
+        let orphanedTemporaryPath = Issue529StringBox()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: Issue529Counter()),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { script in
+                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
+                let temporaryPath = ledgerPath + ".tmp.orphaned-test"
+                try! Data("orphaned".utf8).write(to: URL(fileURLWithPath: temporaryPath))
+                orphanedTemporaryPath.set(temporaryPath)
+                return .error("osascript terminated after mktemp")
+            },
+            reconcileAfterDialogExecutionFailure: { true }
+        )
+
+        _ = result
+        let temporaryPath = try #require(orphanedTemporaryPath.value)
+        #expect(!FileManager.default.fileExists(atPath: temporaryPath))
     }
 
     @Test("default dead-child reconciliation stays on the injected runtime seam")
@@ -789,7 +820,8 @@ struct Issue529MenuValidationTests {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let returnKey = try issue529Position(of: "keystroke return", in: script)
         let postReturnObservation = try issue529Position(
-            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess)", in: script
+            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog)",
+            in: script
         )
         let ok = try issue529Position(of: "return \"OK\"", in: script)
 
@@ -800,9 +832,9 @@ struct Issue529MenuValidationTests {
     @Test("durable issuance checkpoints precede the leaf and Return actuators")
     func durableIssuanceCheckpointsPrecedeActuators() throws {
         // Mutations this rejects: move either persistent checkpoint after its corresponding click
-        // or key event, or restore a direct `printf > ledgerPath` replacement. The former recreates
-        // a no-record timeout window; the latter can truncate the prior conservative marker before
-        // the replacement becomes durable.
+        // or key event, restore a direct `printf > ledgerPath` replacement, or omit cleanup after
+        // a post-`mktemp` failure. The former recreates a no-record timeout window; the latter two
+        // can respectively truncate the prior marker or leak a randomized staging file.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(
             position: "529.4.1.1",
             issuanceLedgerPath: "/private/tmp/issue529-ledger"
@@ -828,11 +860,17 @@ struct Issue529MenuValidationTests {
         let temporaryLedger = try issue529Position(of: "set temporaryLedgerPath to do shell script", in: ledgerHandler)
         let stagedWrite = try issue529Position(of: "quoted form of temporaryLedgerPath", in: ledgerHandler)
         let atomicRename = try issue529Position(of: "&& /bin/mv -f", in: ledgerHandler)
+        let cleanupGuard = try issue529Position(
+            of: "if temporaryLedgerPath is not \"\" then", in: ledgerHandler
+        )
+        let temporaryCleanup = try issue529Position(of: "/bin/rm -f", in: ledgerHandler)
 
         #expect(leafCheckpoint < leafClick)
         #expect(returnCheckpoint < returnKey)
         #expect(temporaryLedger < stagedWrite)
         #expect(stagedWrite < atomicRename)
+        #expect(atomicRename < cleanupGuard)
+        #expect(cleanupGuard < temporaryCleanup)
         #expect(ledgerHandler.contains("ledgerPath & \".tmp.XXXXXX\""))
     }
 
@@ -897,20 +935,20 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }
 
-@Test("the Go To Position dialog is newly observed and focus-bound before global typing")
-func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
-    // Mutations this rejects: remove AXFloatingWindow or AXModal from the known input class,
-    // collapse OPEN_UNKNOWN_SUBROLE to CLOSED, remove the global `frontmost` recheck, restore a
-    // title/AXFocused fallback for AXFocusedWindow identity, or move any global key before its
-    // post-marker focus guard. Any one either rejects the measured dialog or lets a stale,
-    // non-modal, or newly frontmost application receive this request's input.
+@Test("the newly opened Go To Position dialog is bracket-focus-bound before global typing")
+func gotoPositionDialogRequiresNewIdentityAndBracketedFocusedBinding() throws {
+    // Mutations this rejects: remove AXFloatingWindow or AXModal from the known input class;
+    // delete the pre-leaf identity snapshot or its new-window predicate; remove the second
+    // frontmost read after AXFocusedWindow; restore a title/AXFocused fallback; or move a global
+    // key before its post-marker focus guard. Any one can select a same-titled plug-in window or
+    // let a handoff during AX resolution authorise input for another application.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
-    let preLeafObservation = try issue529Position(
-        of: "set preLeafGoToPositionDialogState to my goToPositionDialogState(logicProcess)",
+    let preLeafSnapshot = try issue529Position(
+        of: "set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)",
         in: script
     )
-    let preLeafAbsenceGuard = try issue529Position(
-        of: "if preLeafGoToPositionDialogState is not \"CLOSED\" then",
+    let preLeafSnapshotGuard = try issue529Position(
+        of: "if preLeafGoToPositionWindows is \"UNREADABLE\" then",
         in: script
     )
     let leafClick = try issue529Position(
@@ -918,7 +956,7 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
         in: script
     )
     let observedDialog = try issue529Position(
-        of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)",
+        of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionWindows)",
         in: script
     )
     let selectAllLedger = try issue529Position(
@@ -954,16 +992,19 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
         of: "end observedGoToPositionDialogFocusState", in: script
     )
     let focusHandler = String(script[focusHandlerStart..<focusHandlerEnd])
-    let globalFocusRead = try issue529Position(of: "set logicIsFrontmost to frontmost", in: focusHandler)
+    let firstFrontmostRead = try issue529Position(of: "set logicWasFrontmost to frontmost", in: focusHandler)
     let focusedWindowRead = try issue529Position(
         of: "set processFocusedWindow to value of attribute \"AXFocusedWindow\"", in: focusHandler
     )
-    let dialogStateHandlerStart = try issue529Position(of: "on goToPositionDialogState(theProcess)", in: script)
+    let finalFrontmostRead = try issue529Position(
+        of: "set logicIsStillFrontmost to frontmost", in: focusHandler
+    )
+    let dialogStateHandlerStart = try issue529Position(of: "on goToPositionDialogState(theProcess, dialogWindow)", in: script)
     let dialogStateHandlerEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
     let dialogStateHandler = String(script[dialogStateHandlerStart..<dialogStateHandlerEnd])
 
-    #expect(preLeafObservation < preLeafAbsenceGuard)
-    #expect(preLeafAbsenceGuard < leafClick)
+    #expect(preLeafSnapshot < preLeafSnapshotGuard)
+    #expect(preLeafSnapshotGuard < leafClick)
     #expect(leafClick < observedDialog)
     #expect(observedDialog < selectAllLedger)
     #expect(selectAllLedger < focusGuard)
@@ -975,10 +1016,12 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
     #expect(positionInput < returnLedger)
     #expect(returnLedger < returnFocusGuard)
     #expect(returnFocusGuard < returnKey)
-    #expect(globalFocusRead < focusedWindowRead)
-    #expect(focusHandler.contains("if logicIsFrontmost is not true then return \"NOT_FRONTMOST\""))
+    #expect(firstFrontmostRead < focusedWindowRead)
+    #expect(focusedWindowRead < finalFrontmostRead)
+    #expect(focusHandler.contains("if logicWasFrontmost is not true then return \"NOT_FRONTMOST\""))
+    #expect(focusHandler.contains("if logicIsStillFrontmost is not true then return \"NOT_FRONTMOST\""))
     #expect(focusHandler.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
-    #expect(focusHandler.contains("if processFocusedWindow is dialogWindow then return \"FOCUSED\""))
+    #expect(focusHandler.contains("if processFocusedWindow is not dialogWindow then return \"NOT_FOCUSED\""))
     #expect(!focusHandler.contains("name of processFocusedWindow"))
     #expect(!focusHandler.contains("if focused of dialogWindow"))
     #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogSubrole(dialogSubrole) then return \"OPEN_UNKNOWN_SUBROLE\""))
@@ -986,14 +1029,41 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
     #expect(dialogStateHandler.contains("return \"OPEN_UNVERIFIED_MODALITY\""))
 }
 
+@Test("a pre-existing same-titled window cannot become this run's dialog target")
+func gotoPositionDialogIgnoresSameTitledPreLeafWindows() throws {
+    // Mutation this rejects: delete `windowWasPresentBefore` from the dialog matcher. Without that
+    // identity predicate, a track-named plug-in editor can satisfy a title-based Go To Position
+    // poll despite existing before this run's only leaf click.
+    let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+    let snapshot = try issue529Position(
+        of: "set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)", in: script
+    )
+    let leaf = try issue529Position(
+        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        in: script
+    )
+    let matcherStart = try issue529Position(
+        of: "on matchingGoToPositionDialog(theProcess, preLeafWindows)", in: script
+    )
+    let matcherEnd = try issue529Position(of: "end matchingGoToPositionDialog", in: script)
+    let matcher = String(script[matcherStart..<matcherEnd])
+    let priorWindowGuard = try issue529Position(
+        of: "if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then", in: matcher
+    )
+    let subroleRead = try issue529Position(of: "set dialogSubrole to subrole of dialogWindow", in: matcher)
+
+    #expect(snapshot < leaf)
+    #expect(priorWindowGuard < subroleRead)
+}
+
 @Test("an unreadable Cancel result re-observes the dialog before Escape")
 func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // Mutation this rejects: move `key code 53` directly after an `UNREADABLE` Cancel result,
-    // bypassing either the fresh `goToPositionDialogState` observation or the immediate
-    // frontmost-plus-AXFocusedWindow guard for the exact dialog.
+    // bypassing either the fresh exact-dialog state observation or the bracketed
+    // frontmost-plus-AXFocusedWindow guard for that exact dialog.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
     let handlerStart = try issue529Position(
-        of: "on dismissOpenGoToPositionDialog(theProcess)", in: script
+        of: "on dismissOpenGoToPositionDialog(theProcess, dialogWindow)", in: script
     )
     let handlerEnd = try issue529Position(of: "end dismissOpenGoToPositionDialog", in: script)
     let handler = String(script[handlerStart..<handlerEnd])
@@ -1005,7 +1075,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // `.first { before < $0 && $0 < escape }` form, none is selected using the ordering asserted
     // below, so moving Escape before a guard makes the test fail.
     let reobservation = try issue529Position(
-        of: "set dialogState to my goToPositionDialogState(theProcess)", in: unreadableBranch
+        of: "set dialogState to my goToPositionDialogState(theProcess, dialogWindow)", in: unreadableBranch
     )
     let closedGuard = try issue529Position(
         of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: unreadableBranch
@@ -1016,11 +1086,8 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     let stillOpenGuard = try issue529Position(
         of: "if dialogState is not \"OPEN\" then return dialogState", in: unreadableBranch
     )
-    let cleanupDialogBinding = try issue529Position(
-        of: "set cleanupDialogWindow to my matchingGoToPositionDialog(theProcess)", in: unreadableBranch
-    )
     let cleanupFocusGuard = try issue529Position(
-        of: "set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, cleanupDialogWindow)",
+        of: "set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, dialogWindow)",
         in: unreadableBranch
     )
     let escape = try issue529Position(of: "key code 53", in: unreadableBranch)
@@ -1028,15 +1095,15 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     #expect(reobservation < closedGuard)
     #expect(closedGuard < unreadableGuard)
     #expect(unreadableGuard < stillOpenGuard)
-    #expect(stillOpenGuard < cleanupDialogBinding)
-    #expect(cleanupDialogBinding < cleanupFocusGuard)
+    #expect(stillOpenGuard < cleanupFocusGuard)
     #expect(cleanupFocusGuard < escape)
 }
 
-@Test("dead-child reconciliation observes the named dialog before menu state")
+@Test("dead-child reconciliation targets the measured dialog before menu state")
 func aDeadScriptReconcilesDialogBeforeMenuState() throws {
-    // Mutations this rejects: restore the PID bypass (which skips cleanup), or reduce the recovery
-    // helper to menu-only observation. Either source relationship below fails.
+    // Mutations this rejects: restore the PID bypass, match a dialog by title alone, remove the
+    // final frontmost read after AXFocusedWindow, or send menu Escape after a single frontmost
+    // read. Each would either skip cleanup or let Escape reach a different focused modal/app.
     let source = try String(
         contentsOfFile: #filePath.replacingOccurrences(
             of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
@@ -1047,11 +1114,24 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let helperStart = try #require(source.range(of: "private static func observeAndClearStrayGoToPositionUI("))
     let helperEnd = try #require(source.range(of: "// MARK: - Control-bar checkbox helpers"))
     let helper = String(source[helperStart.lowerBound..<helperEnd.lowerBound])
-    let dialogObservation = try issue529Position(of: "on goToPositionDialogState(theProcess)", in: helper)
+    let measuredSubrole = try issue529Position(of: "on knownGoToPositionDialogSubrole(dialogSubrole)", in: helper)
+    let dialogObservation = try issue529Position(of: "on matchingGoToPositionDialog(theProcess)", in: helper)
     let dialogCleanup = try issue529Position(of: "set dialogCleanupState to my dismissGoToPositionDialog(it)", in: helper)
-    let menuLoop = try issue529Position(of: "repeat with menuBarItem in every menu bar item", in: helper)
+    let focusedWindowRead = try issue529Position(
+        of: "set processFocusedWindow to value of attribute \"AXFocusedWindow\"", in: helper
+    )
+    let finalFrontmostRead = try issue529Position(of: "set logicIsStillFrontmost to frontmost", in: helper)
+    let menuFocus = try issue529Position(of: "set menuFocusState to my menuEscapeFocusState(it)", in: helper)
+    let menuCleanupTail = String(helper[menuFocus...])
+    let menuEscape = try issue529Position(of: "key code 53", in: menuCleanupTail)
 
+    #expect(measuredSubrole < dialogObservation)
     #expect(dialogObservation < dialogCleanup)
-    #expect(dialogCleanup < menuLoop)
+    #expect(focusedWindowRead < finalFrontmostRead)
+    #expect(dialogCleanup < menuFocus)
+    #expect(menuCleanupTail.startIndex < menuEscape)
+    #expect(helper.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
+    #expect(helper.contains("if processFocusedWindow is not dialogWindow then return \"NOT_FOCUSED\""))
+    #expect(!helper.contains("if frontmost then"))
     #expect(!helper.contains("ProcessUtils.logicProPID"))
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -362,6 +362,60 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
+    @Test("an issued leaf AX failure stays State C and never selects the slider")
+    func issuedLeafActuationFailureDoesNotSelectSlider() async throws {
+        // Mutation this rejects: remove `.dialogActuationIssued` from
+        // `hasIssuedGoToPositionActuator`, letting this result fall through to the slider.
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: AXPress reported failure"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["state"] as? String) == "C")
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        let submissionAttempted = try #require(envelope["dialog_submission_attempted"] as? Bool)
+        let fallbackUnsafe = try #require(envelope["fallback_unsafe"] as? Bool)
+        #expect(!writeAttempted)
+        #expect(!submissionAttempted)
+        #expect(fallbackUnsafe)
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("an issued dialog submission is State B and never selects the slider")
+    func issuedSubmissionFailureIsUnverifiableStateB() async throws {
+        // Mutation this rejects: encode the submission-issued branch with `encodeStateC` again.
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_SUBMISSION_FAILED: dialog cleanup was not observed (OPEN_UNREADABLE)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        let submissionAttempted = try #require(envelope["dialog_submission_attempted"] as? Bool)
+        let fallbackUnsafe = try #require(envelope["fallback_unsafe"] as? Bool)
+        #expect(writeAttempted)
+        #expect(submissionAttempted)
+        #expect(fallbackUnsafe)
+        #expect(sliderWrites.value == 0)
+    }
+
     @Test("a menu-not-found dialog result still falls through to the slider")
     func menuNotFoundStillFallsThroughToSlider() async throws {
         let sliderWrites = Issue529Counter()
@@ -378,6 +432,28 @@ struct Issue529MenuValidationTests {
 
         let envelope = try #require(issue529Envelope(result))
         #expect(try #require(envelope["via"] as? String) == "slider")
+        #expect(sliderWrites.value > 0)
+    }
+
+    @Test("State A slider evidence includes only position components read back")
+    func stateASliderEvidenceOmitsUnreadPositionComponents() async throws {
+        // Mutation this rejects: make `observedPosition` append `.1.1.1` when no beat slider
+        // was read back, which would certify position components with no observation.
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in .success(#"{"result":"MENU_NOT_FOUND"}"#) }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["state"] as? String) == "A")
+        let observed = try #require(envelope["observed"] as? String)
+        #expect(observed == "529")
+        #expect(!observed.contains("."))
         #expect(sliderWrites.value > 0)
     }
 
@@ -429,6 +505,45 @@ func dismissalContextDecidesWhetherAnUnreadableReadSkipsEscape() throws {
 
     // And the handler must only take the skip when knownOpen is false.
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
+}
+
+@Test("an unreadable Cancel result re-observes the dialog before Escape")
+func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
+    // Mutation this rejects: move `key code 53` directly after an `UNREADABLE` Cancel result,
+    // bypassing the fresh `goToPositionDialogState` observation.
+    let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+    let handlerStart = try issue529Position(
+        of: "on dismissOpenGoToPositionDialog(theProcess)", in: script
+    )
+    let handlerEnd = try issue529Position(of: "end dismissOpenGoToPositionDialog", in: script)
+    let handler = String(script[handlerStart..<handlerEnd])
+    let cancelOutcome = try issue529Position(
+        of: "set cancelOutcome to my pressGoToPositionDialogCancel(theProcess)", in: handler
+    )
+    let escape = try issue529Position(of: "key code 53", in: handler)
+    let reobservation = try #require(
+        issue529Positions(
+            of: "set dialogState to my goToPositionDialogState(theProcess)", in: handler
+        ).first { cancelOutcome < $0 && $0 < escape }
+    )
+    let closedGuard = try #require(
+        issue529Positions(of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: handler)
+            .first { reobservation < $0 && $0 < escape }
+    )
+    let unreadableGuard = try #require(
+        issue529Positions(of: "if dialogState is \"UNREADABLE\" then return \"OPEN_UNREADABLE\"", in: handler)
+            .first { reobservation < $0 && $0 < escape }
+    )
+    let stillOpenGuard = try #require(
+        issue529Positions(of: "if dialogState is not \"OPEN\" then return dialogState", in: handler)
+            .first { reobservation < $0 && $0 < escape }
+    )
+
+    #expect(cancelOutcome < reobservation)
+    #expect(reobservation < closedGuard)
+    #expect(closedGuard < unreadableGuard)
+    #expect(unreadableGuard < stillOpenGuard)
+    #expect(stillOpenGuard < escape)
 }
 
 /// A dead script (timeout, TCC refusal, anything) leaves the menu state UNKNOWN, and this script

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -37,9 +37,41 @@ private final class Issue529Counter: @unchecked Sendable {
     }
 }
 
+private actor Issue529DialogLockGate {
+    private var started = false
+    private var startWaiter: CheckedContinuation<Void, Never>?
+    private var releaseRequested = false
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func entered() {
+        started = true
+        startWaiter?.resume()
+        startWaiter = nil
+    }
+
+    func waitUntilEntered() async {
+        guard !started else { return }
+        await withCheckedContinuation { startWaiter = $0 }
+    }
+
+    func waitForRelease() async {
+        guard !releaseRequested else { return }
+        await withCheckedContinuation { releaseWaiter = $0 }
+    }
+
+    func release() {
+        releaseRequested = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+}
+
 private func issue529SliderRuntime(
     sliderWrites: Issue529Counter,
-    includeBeatSlider: Bool = false
+    includeBeatSlider: Bool = false,
+    executeAppleScript: @escaping @Sendable (String) async -> ChannelResult = { _ in
+        .success(#"{"result":"MENU_NOT_FOUND"}"#)
+    }
 ) -> AXLogicProElements.Runtime {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(5290)
@@ -75,7 +107,8 @@ private func issue529SliderRuntime(
             builder.setAttribute(element, attribute, value)
             return true
         },
-        performActionHandler: { _, _ in true }
+        performActionHandler: { _, _ in true },
+        executeAppleScript: executeAppleScript
     )
 }
 
@@ -269,7 +302,7 @@ struct Issue529MenuValidationTests {
             of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
             in: script
         )
-        let leafErrorHandlerEnd = try issue529Position(of: "-- Wait up to 3s for the dialog window", in: script)
+        let leafErrorHandlerEnd = try issue529Position(of: "-- Wait up to 3s for a new exact modal dialog", in: script)
         let leafErrorHandler = String(script[leafClick..<leafErrorHandlerEnd])
         let cleanupAfterMenuItemClick = try issue529Position(
             of: "set cleanupState to my dismissOpenMenu(logicProcess, true)", in: leafErrorHandler
@@ -375,10 +408,10 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("a clean leaf-only failure does not turn the relative slider into a position write")
-    func cleanLeafActuationFailureDoesNotWriteRelativeSlider() async throws {
-        // Mutation this rejects: restore the AXValue write to the `bar` slider. Its measured value
-        // is a one-bar relative increment, so a clean dialog failure must leave it untouched.
+    @Test("a clean leaf-only failure does not invent an AX slider route")
+    func cleanLeafActuationFailureDoesNotInventSliderRoute() async throws {
+        // Source mutation: restore `via:"slider"` or `error:.axWriteFailed` in the no-route
+        // receipt. The dialog failure did not resolve or write a slider, so this must fail.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -394,20 +427,21 @@ struct Issue529MenuValidationTests {
         let envelope = try #require(issue529Envelope(result))
         #expect(!result.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "C")
-        #expect(try #require(envelope["via"] as? String) == "slider")
+        #expect(try #require(envelope["error"] as? String) == "not_supported")
+        #expect(try #require(envelope["position_route"] as? String) == "unavailable")
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
-        let positionWriteSupported = try #require(envelope["slider_position_write_supported"] as? Bool)
         #expect(!writeAttempted)
-        #expect(!positionWriteSupported)
+        #expect(envelope["via"] == nil)
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("a dead child after the durable leaf checkpoint is State B and cannot select the slider")
-    func deadChildAfterLeafCheckpointDoesNotReleaseSlider() async throws {
+    @Test("a dead child after the durable leaf checkpoint is indeterminate and cannot select the slider")
+    func deadChildAfterLeafCheckpointDoesNotClaimSubmissionOrReleaseSlider() async throws {
         // Mutations this rejects:
         // 1. Remove the parent-owned `LEAF_ARMED` ledger checkpoint or ignore it in the `.error`
         //    branch — this clean-reconciliation fixture falls through to the slider.
-        // 2. Report `write_attempted:false` for the durable checkpoint — the receipt assertion fails.
+        // 2. Source mutation: set `dialog_submission_attempted:true` / `write_attempted:true`
+        //    for LEAF_ARMED. The marker precedes the leaf click, so it cannot prove submission.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -426,9 +460,129 @@ struct Issue529MenuValidationTests {
         let envelope = try #require(issue529Envelope(result))
         #expect(result.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "B")
-        #expect(try #require(envelope["write_attempted"] as? Bool))
-        #expect(try #require(envelope["dialog_submission_attempted"] as? Bool))
+        let writeAttempted = envelope["write_attempted"] as? Bool
+        let submissionAttempted = envelope["dialog_submission_attempted"] as? Bool
+        #expect(writeAttempted == nil)
+        #expect(submissionAttempted == nil)
+        #expect(try #require(envelope["dialog_submission_indeterminate"] as? Bool))
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(sliderWrites.value == 0)
+    }
+
+    @Test("default dead-child reconciliation stays on the injected runtime seam")
+    func defaultDeadChildReconciliationUsesInjectedRuntime() async throws {
+        // Source mutation: call `AppleScriptChannel.executeAppleScript` directly from
+        // `observeAndClearStrayGoToPositionUI`. This fake runtime would see no reconciliation
+        // script, proving the default failure path escaped the test/runtime seam.
+        let sliderWrites = Issue529Counter()
+        let reconciliationCalls = Issue529Counter()
+        let runtime = issue529SliderRuntime(
+            sliderWrites: sliderWrites,
+            executeAppleScript: { _ in
+                reconciliationCalls.bump()
+                return .success(#"{"result":"CLOSED"}"#)
+            }
+        )
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: runtime,
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in .error("osascript timed out before any ledger boundary") }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String)
+            == "execution_failed_issuance_NOT_ISSUED_cleanup_closed_true")
+        #expect(reconciliationCalls.value == 1)
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("an existing dialog or focus loss refuses before a position submission")
+    func preexistingDialogAndFocusLossDoNotSubmitPosition() async throws {
+        // Source mutations: classify DIALOG_PREEXISTING as a clean fallback, or classify
+        // DIALOG_SUBMISSION_NOT_ISSUED as issued. Either lets another run's dialog receive a
+        // position write or falsely reports that this focus-loss fixture submitted one.
+        let preexisting = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: Issue529Counter()),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_PREEXISTING: fixture dialog belongs to another request"}"#)
+            }
+        )
+        let preexistingEnvelope = try #require(issue529Envelope(preexisting))
+        #expect(!preexisting.isSuccess)
+        #expect(try #require(preexistingEnvelope["state"] as? String) == "C")
+        #expect(try #require(preexistingEnvelope["fallback_unsafe"] as? Bool))
+        let preexistingWrite = try #require(preexistingEnvelope["write_attempted"] as? Bool)
+        #expect(!preexistingWrite)
+
+        let focusLoss = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: Issue529Counter()),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (NOT_FOCUSED)"}"#)
+            }
+        )
+        let focusLossEnvelope = try #require(issue529Envelope(focusLoss))
+        #expect(!focusLoss.isSuccess)
+        #expect(try #require(focusLossEnvelope["state"] as? String) == "C")
+        let focusLossWrite = try #require(focusLossEnvelope["write_attempted"] as? Bool)
+        #expect(!focusLossWrite)
+        #expect(focusLossEnvelope["dialog_submission_attempted"] == nil)
+    }
+
+    @Test("a concurrent Go To Position request is refused before its leaf protocol begins")
+    func concurrentDialogRequestCannotShareTheObservedModal() async throws {
+        // Source mutation: remove GoToPositionDialogExecutionLock acquisition, or take it after
+        // executing the dialog script. The contender then reaches its injected script instead of
+        // refusing before any menu leaf can be issued.
+        let gate = Issue529DialogLockGate()
+        let firstScriptCalls = Issue529Counter()
+        let contenderScriptCalls = Issue529Counter()
+        let firstRuntime = issue529SliderRuntime(
+            sliderWrites: Issue529Counter(),
+            executeAppleScript: { _ in
+                firstScriptCalls.bump()
+                await gate.entered()
+                await gate.waitForRelease()
+                return .success(#"{"result":"MENU_NOT_FOUND"}"#)
+            }
+        )
+        let contenderRuntime = issue529SliderRuntime(
+            sliderWrites: Issue529Counter(),
+            executeAppleScript: { _ in
+                contenderScriptCalls.bump()
+                return .success(#"{"result":"MENU_NOT_FOUND"}"#)
+            }
+        )
+
+        async let first = AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"], runtime: firstRuntime,
+            isFrontmost: { true }, activateLogic: { true }, sleepMicros: { _ in }
+        )
+        await gate.waitUntilEntered()
+        let contender = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "530"], runtime: contenderRuntime,
+            isFrontmost: { true }, activateLogic: { true }, sleepMicros: { _ in }
+        )
+        await gate.release()
+        _ = await first
+
+        let contenderEnvelope = try #require(issue529Envelope(contender))
+        #expect(!contender.isSuccess)
+        #expect(try #require(contenderEnvelope["error"] as? String) == "mutating_operation_in_progress")
+        #expect(firstScriptCalls.value == 1)
+        #expect(contenderScriptCalls.value == 0)
     }
 
     @Test("only the post-Return branch is submission-issued")
@@ -465,7 +619,7 @@ struct Issue529MenuValidationTests {
         let preReturnEnvelope = try #require(issue529Envelope(preReturn))
         #expect(!preReturn.isSuccess)
         #expect(try #require(preReturnEnvelope["state"] as? String) == "C")
-        #expect(try #require(preReturnEnvelope["via"] as? String) == "slider")
+        #expect(try #require(preReturnEnvelope["position_route"] as? String) == "unavailable")
         let preReturnWriteAttempted = try #require(preReturnEnvelope["write_attempted"] as? Bool)
         #expect(!preReturnWriteAttempted)
         #expect(preReturnSliderWrites.value == 0)
@@ -514,7 +668,8 @@ struct Issue529MenuValidationTests {
         let envelope = try #require(issue529Envelope(result))
         #expect(!result.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "C")
-        #expect(try #require(envelope["via"] as? String) == "slider")
+        #expect(try #require(envelope["error"] as? String) == "not_supported")
+        #expect(try #require(envelope["position_route"] as? String) == "unavailable")
         #expect(try #require(envelope["dialog_route_outcome"] as? String) == "menu_not_found")
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
         #expect(!writeAttempted)
@@ -546,7 +701,7 @@ struct Issue529MenuValidationTests {
         #expect(unexpressed == ["bar", "beat", "subdivision", "tick"])
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
         #expect(!writeAttempted)
-        #expect(try #require(envelope["slider_value_semantics"] as? String) == "relative_increment_not_absolute_position")
+        #expect(try #require(envelope["position_route"] as? String) == "unavailable")
         #expect(sliderWrites.value == 0)
     }
 
@@ -631,13 +786,15 @@ struct Issue529MenuValidationTests {
 /// than sending it into unknown focus. Locale discovery itself owns no menu actuation.
 @Test("locale discovery stays unowned until the resolved leaf issuance boundary")
 func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
-    // Mutation this rejects: change either locale-resolution cleanup call back to
-    // `dismissOpenMenu(logicProcess, true)`, which authorises Escape after an unreadable read.
+    // Source mutations: change any of the AXEnabled-read, disabled-entry, or LEAF_ARMED-write
+    // failure cleanups to `dismissOpenMenu(logicProcess, true)`. Each is before this run's leaf,
+    // so UNREADABLE must withhold Escape from unrelated focus.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
 
-    // Entry plus the two locale-resolution exits are unowned reads.
+    // Entry, locale discovery, enabled/disabled handling, and a failed durable checkpoint are all
+    // unowned until the resolved leaf is actually issued.
     #expect(script.contains("my dismissOpenMenu(logicProcess, false)"))
-    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 3)
+    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 6)
 
     let leafCheckpoint = try issue529Position(
         of: "recordDialogIssuance(\"LEAF_ARMED\"",
@@ -648,11 +805,63 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
         in: script
     )
     #expect(leafCheckpoint < resolvedLeaf)
+    let preLeaf = String(script[..<resolvedLeaf])
+    #expect(!preLeaf.contains("my dismissOpenMenu(logicProcess, true)"))
     #expect(!script.contains("click selectedMenuBarItem"))
     #expect(!script.contains("click selectedSubmenuItem"))
 
     // The handler itself only skips Escape when no menu has been established as this run's.
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
+}
+
+@Test("the Go To Position dialog is a new focused AXDialog bound before global typing")
+func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
+    // Source mutations: remove the pre-leaf absence check, accept title without AXSubrole, or
+    // move either Cmd+A/position keystroke before the observed-dialog focus guard. Any one lets a
+    // stale/concurrent dialog or another frontmost app receive this request's input.
+    let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
+    let preLeafObservation = try issue529Position(
+        of: "set preLeafGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)",
+        in: script
+    )
+    let preLeafAbsenceGuard = try issue529Position(
+        of: "if preLeafGoToPositionDialog is not missing value then",
+        in: script
+    )
+    let leafClick = try issue529Position(
+        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        in: script
+    )
+    let observedDialog = try issue529Position(
+        of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)",
+        in: script
+    )
+    let focusGuard = try issue529Position(
+        of: "set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)",
+        in: script
+    )
+    let focusRefusal = try issue529Position(
+        of: "observed Go To Position dialog was not focused before typing",
+        in: script
+    )
+    let selectAll = try issue529Position(of: "keystroke \"a\" using command down", in: script)
+    let typingFocusGuard = try issue529Position(
+        of: "set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)",
+        in: script
+    )
+    let positionInput = try issue529Position(of: "keystroke \"529.4.7.123\"", in: script)
+
+    #expect(preLeafObservation < preLeafAbsenceGuard)
+    #expect(preLeafAbsenceGuard < leafClick)
+    #expect(leafClick < observedDialog)
+    #expect(observedDialog < focusGuard)
+    #expect(focusGuard < focusRefusal)
+    #expect(focusRefusal < selectAll)
+    #expect(selectAll < positionInput)
+    #expect(selectAll < typingFocusGuard)
+    #expect(typingFocusGuard < positionInput)
+    #expect(script.contains("set dialogSubrole to subrole of dialogWindow"))
+    #expect(script.contains("if focused of dialogWindow then return \"FOCUSED\""))
 }
 
 @Test("an unreadable Cancel result re-observes the dialog before Escape")
@@ -703,7 +912,7 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
         ),
         encoding: .utf8
     )
-    let helperStart = try #require(source.range(of: "private static func observeAndClearStrayGoToPositionUI()"))
+    let helperStart = try #require(source.range(of: "private static func observeAndClearStrayGoToPositionUI("))
     let helperEnd = try #require(source.range(of: "// MARK: - Control-bar checkbox helpers"))
     let helper = String(source[helperStart.lowerBound..<helperEnd.lowerBound])
     let dialogObservation = try issue529Position(of: "on goToPositionDialogState(theProcess)", in: helper)

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -585,44 +585,74 @@ struct Issue529MenuValidationTests {
         #expect(contenderScriptCalls.value == 0)
     }
 
-    @Test("only the post-Return branch is submission-issued")
-    func preReturnFailuresFallThroughWhilePostReturnFailuresAreStateB() async throws {
-        // Mutations this rejects:
-        // 1. Move `keystroke return` into the pre-Return error scope or delete it — the generated
-        //    script ordering assertions fail.
-        // 2. Classify `DIALOG_SUBMISSION_NOT_ISSUED` as issued — the pre-Return receipt stops
-        //    disclosing that no position write was sent.
+    @Test("global-input and Return boundaries suppress a clean retry")
+    func inputAndReturnIssuanceAreReportedAsUnsafe() async throws {
+        // Source mutations: remove either SELECT_ALL_ARMED/POSITION_INPUT_ARMED checkpoint, or
+        // classify DIALOG_INPUT_ISSUED as a clean non-submission failure. The first leaves a
+        // timeout gap; the second returns State C with `write_attempted:false` after global input.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let inputFailure = try issue529Position(
-            of: "return \"DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return",
+        let selectAllLedger = try issue529Position(
+            of: "recordDialogIssuance(\"SELECT_ALL_ARMED\"",
             in: script
         )
+        let selectAll = try issue529Position(of: "keystroke \"a\" using command down", in: script)
+        let positionInputLedger = try issue529Position(
+            of: "recordDialogIssuance(\"POSITION_INPUT_ARMED\"",
+            in: script
+        )
+        let positionInput = try issue529Position(of: "keystroke \"529.1.1.1\"", in: script)
         let returnLedger = try issue529Position(
             of: "recordDialogIssuance(\"RETURN_ARMED\"",
             in: script
         )
         let returnKey = try issue529Position(of: "keystroke return", in: script)
-        #expect(inputFailure < returnLedger)
+        #expect(selectAllLedger < selectAll)
+        #expect(selectAll < positionInputLedger)
+        #expect(positionInputLedger < positionInput)
+        #expect(positionInput < returnLedger)
         #expect(returnLedger < returnKey)
 
-        let preReturnSliderWrites = Issue529Counter()
-        let preReturn = await AccessibilityChannel.gotoPositionViaBarSlider(
+        let preInputSliderWrites = Issue529Counter()
+        let preInput = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
-            runtime: issue529SliderRuntime(sliderWrites: preReturnSliderWrites),
+            runtime: issue529SliderRuntime(sliderWrites: preInputSliderWrites),
             isFrontmost: { true },
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (AX error)"}"#)
+                .success(#"{"result":"DIALOG_SUBMISSION_NOT_ISSUED: observed Go To Position dialog was not focused before typing (NOT_FOCUSED)"}"#)
             }
         )
-        let preReturnEnvelope = try #require(issue529Envelope(preReturn))
-        #expect(!preReturn.isSuccess)
-        #expect(try #require(preReturnEnvelope["state"] as? String) == "C")
-        #expect(try #require(preReturnEnvelope["position_route"] as? String) == "unavailable")
-        let preReturnWriteAttempted = try #require(preReturnEnvelope["write_attempted"] as? Bool)
-        #expect(!preReturnWriteAttempted)
-        #expect(preReturnSliderWrites.value == 0)
+        let preInputEnvelope = try #require(issue529Envelope(preInput))
+        #expect(!preInput.isSuccess)
+        #expect(try #require(preInputEnvelope["state"] as? String) == "C")
+        #expect(try #require(preInputEnvelope["position_route"] as? String) == "unavailable")
+        let preInputWriteAttempted = try #require(preInputEnvelope["write_attempted"] as? Bool)
+        #expect(!preInputWriteAttempted)
+        #expect(preInputSliderWrites.value == 0)
+
+        let inputSliderWrites = Issue529Counter()
+        let input = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: inputSliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_INPUT_ISSUED: POSITION_INPUT_ARMED: position text may have been sent (AX error)"}"#)
+            }
+        )
+        let inputEnvelope = try #require(issue529Envelope(input))
+        #expect(input.isSuccess)
+        #expect(try #require(inputEnvelope["state"] as? String) == "B")
+        #expect(try #require(inputEnvelope["dialog_input_attempted"] as? Bool))
+        #expect(try #require(inputEnvelope["dialog_input_boundary"] as? String) == "POSITION_INPUT_ARMED")
+        #expect(try #require(inputEnvelope["dialog_input_target"] as? String) == "unknown")
+        #expect(try #require(inputEnvelope["write_attempted"] as? Bool))
+        #expect(!(try #require(inputEnvelope["safe_to_retry"] as? Bool)))
+        #expect(try #require(inputEnvelope["fallback_unsafe"] as? Bool))
+        #expect(!(try #require(inputEnvelope["dialog_submission_attempted"] as? Bool)))
+        #expect(inputSliderWrites.value == 0)
 
         let postReturnSliderWrites = Issue529Counter()
         let postReturn = await AccessibilityChannel.gotoPositionViaBarSlider(
@@ -793,7 +823,6 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
 
     // Entry, locale discovery, enabled/disabled handling, and a failed durable checkpoint are all
     // unowned until the resolved leaf is actually issued.
-    #expect(script.contains("my dismissOpenMenu(logicProcess, false)"))
     #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 6)
 
     let leafCheckpoint = try issue529Position(
@@ -814,10 +843,11 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }
 
-@Test("the Go To Position dialog is a new focused AXDialog bound before global typing")
+@Test("the Go To Position dialog is newly observed and focus-bound before global typing")
 func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
-    // Source mutations: remove the pre-leaf absence check, accept title without AXSubrole, or
-    // move either Cmd+A/position keystroke before the observed-dialog focus guard. Any one lets a
+    // Source mutations: remove AXFloatingWindow from either the discovery or focus-validation
+    // subrole set, remove the pre-leaf absence check, or move either Cmd+A/position keystroke
+    // before the observed-dialog focus guard. Any one rejects the measured dialog or lets a
     // stale/concurrent dialog or another frontmost app receive this request's input.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
     let preLeafObservation = try issue529Position(
@@ -857,11 +887,17 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
     #expect(observedDialog < focusGuard)
     #expect(focusGuard < focusRefusal)
     #expect(focusRefusal < selectAll)
-    #expect(selectAll < positionInput)
     #expect(selectAll < typingFocusGuard)
     #expect(typingFocusGuard < positionInput)
     #expect(script.contains("set dialogSubrole to subrole of dialogWindow"))
-    #expect(script.contains("if focused of dialogWindow then return \"FOCUSED\""))
+    #expect(script.contains(
+        "if dialogSubrole is \"AXFloatingWindow\" or dialogSubrole is \"AXDialog\" or dialogSubrole is \"AXSystemDialog\" then return contents of dialogWindow"
+    ))
+    #expect(script.contains(
+        "if dialogSubrole is not \"AXFloatingWindow\" and dialogSubrole is not \"AXDialog\" and dialogSubrole is not \"AXSystemDialog\" then return \"MISSING\""
+    ))
+    #expect(script.contains("set processFocusedWindow to value of attribute \"AXFocusedWindow\""))
+    #expect(script.contains("if processFocusedWindow is dialogWindow then return \"FOCUSED\""))
 }
 
 @Test("an unreadable Cancel result re-observes the dialog before Escape")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -21,6 +21,14 @@ private func issue529Positions(of fragment: String, in script: String) -> [Strin
     return positions
 }
 
+private func issue529LedgerPath(from script: String, stage: String) throws -> String {
+    let prefix = "recordDialogIssuance(\"\(stage)\", \""
+    let start = try #require(script.range(of: prefix))
+    let tail = script[start.upperBound...]
+    let end = try #require(tail.firstIndex(of: "\""))
+    return String(tail[..<end])
+}
+
 private final class Issue529Counter: @unchecked Sendable {
     private(set) var value = 0
 
@@ -29,26 +37,35 @@ private final class Issue529Counter: @unchecked Sendable {
     }
 }
 
-private func issue529SliderRuntime(sliderWrites: Issue529Counter) -> AXLogicProElements.Runtime {
+private func issue529SliderRuntime(
+    sliderWrites: Issue529Counter,
+    includeBeatSlider: Bool = false
+) -> AXLogicProElements.Runtime {
     let builder = FakeAXRuntimeBuilder()
     let app = builder.element(5290)
     let window = builder.element(5291)
     let controlBar = builder.element(5292)
     let barSlider = builder.element(5293)
+    let beatSlider = builder.element(5294)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
     builder.setChildren(window, [controlBar])
     builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
     builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
-    builder.setChildren(controlBar, [barSlider])
+    builder.setChildren(controlBar, includeBeatSlider ? [barSlider, beatSlider] : [barSlider])
     builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
     builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
     builder.setAttribute(barSlider, kAXValueAttribute as String, NSNumber(value: 1))
+    if includeBeatSlider {
+        builder.setAttribute(beatSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+        builder.setAttribute(beatSlider, kAXDescriptionAttribute as String, "Beat")
+        builder.setAttribute(beatSlider, kAXValueAttribute as String, NSNumber(value: 1))
+    }
 
     return builder.makeLogicRuntime(
         appElement: app,
         setAttributeHandler: { element, attribute, value in
-            if element == barSlider, attribute == kAXValueAttribute as String {
+            if (element == barSlider || element == beatSlider), attribute == kAXValueAttribute as String {
                 sliderWrites.bump()
             }
             builder.setAttribute(element, attribute, value)
@@ -179,48 +196,40 @@ struct Issue529MenuValidationTests {
         #expect(entryCleanup < menuBarOpen)
     }
 
-    /// Measured, not reasoned: refusing at entry on any non-CLOSED value sent 5 of 8 fresh server
-    /// processes to the slider route, because the first menu-bar read on a cold System Events
-    /// connection is frequently unreadable. Nothing has been opened at that point, so an unreadable
-    /// menu bar is an absent observation rather than evidence of an open menu. `OPEN_UNREADABLE`
-    /// is distinct: this run observed OPEN, sent Escape, and then could not observe closure.
-    @Test("entry permits a fresh unreadable menu bar")
-    func entryCleanupDoesNotRefuseOnAnUnreadableMenuBar() throws {
+    @Test("entry refuses an unreadable menu bar before any transport actuation")
+    func entryCleanupRefusesAnUnreadableMenuBar() throws {
+        // Mutation this rejects: restore the `OPEN || OPEN_UNREADABLE` guard, which treats an
+        // unreadable entry read as safe enough to start the menu/slider route.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let entryGuard = try issue529Position(
-            of: "if entryMenuCleanup is \"OPEN\" or entryMenuCleanup is \"OPEN_UNREADABLE\" then",
+            of: "if entryMenuCleanup is not \"CLOSED\" then",
             in: script
         )
         let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
 
         #expect(entryGuard < localeDecision)
-        #expect(!script.contains("if entryMenuCleanup is not \"CLOSED\" then"))
-        #expect(!script.contains("if entryMenuCleanup is \"OPEN\" then"))
-        // Post-actuation refusals still require a confirmed close, so the asymmetry is asserted
-        // rather than assumed.
-        #expect(script.contains("if cleanupState is not \"CLOSED\" then"))
+        #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
     }
 
-    /// Script fixture: `menuOpenState` returns OPEN, Escape is posted, and the next read is
-    /// UNREADABLE. The distinct `OPEN_UNREADABLE` outcome must be terminal at entry; changing the
-    /// entry guard back to `entryMenuCleanup is "OPEN"` makes this test fail.
-    @Test("OPEN then Escape then UNREADABLE refuses at entry")
+    /// Script fixture: the entry menu read is unreadable. Because this run has not opened a menu,
+    /// it must refuse without manufacturing an Escape into an unknown focus target.
+    @Test("unreadable entry state refuses without Escape")
     func entryCleanupRefusesUnreadableAfterObservedOpen() async throws {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let escape = try issue529Position(of: "key code 53", in: script)
-        let unreadableAfterEscape = try issue529Position(
-            of: "if menuState is \"UNREADABLE\" then return \"OPEN_UNREADABLE\"",
-            in: script
+        let dismissalStart = try issue529Position(of: "on dismissOpenMenu(theProcess, knownOpen)", in: script)
+        let dismissalEnd = try issue529Position(of: "end dismissOpenMenu", in: script)
+        let dismissal = String(script[dismissalStart..<dismissalEnd])
+        let unreadableGuard = try issue529Position(
+            of: "if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\"",
+            in: dismissal
         )
+        let escape = try issue529Position(of: "key code 53", in: dismissal)
         let entryGuard = try issue529Position(
-            of: "if entryMenuCleanup is \"OPEN\" or entryMenuCleanup is \"OPEN_UNREADABLE\" then",
+            of: "if entryMenuCleanup is not \"CLOSED\" then",
             in: script
         )
-        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
 
-        #expect(escape < unreadableAfterEscape)
-        #expect(unreadableAfterEscape < entryGuard)
-        #expect(entryGuard < localeDecision)
+        #expect(unreadableGuard < escape)
 
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
@@ -230,7 +239,7 @@ struct Issue529MenuValidationTests {
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"MENU_PICK_FAILED: a menu was open at entry and would not close (OPEN_UNREADABLE)"}"#)
+                .success(#"{"result":"MENU_PICK_FAILED: menu state was not observed closed at entry (UNREADABLE)"}"#)
             }
         )
 
@@ -248,7 +257,7 @@ struct Issue529MenuValidationTests {
             in: script
         )
         let entryRefusal = try issue529Position(
-            of: "return \"MENU_PICK_FAILED: a menu was open at entry",
+            of: "return \"MENU_PICK_FAILED: menu state was not observed closed at entry",
             in: script
         )
         let cleanupRefusalReturns = issue529Positions(of: "return \"", in: script).filter { position in
@@ -268,7 +277,7 @@ struct Issue529MenuValidationTests {
         var previousRefusalReturn = entryRefusal
         for refusalReturn in cleanupRefusalReturns {
             let cleanupBetweenRefusals = issue529Positions(
-                of: "set cleanupState to my dismissOpenMenu(logicProcess, true)",
+                of: "set cleanupState to my dismissOpenMenu(logicProcess,",
                 in: script
             ).contains { previousRefusalReturn < $0 && $0 < refusalReturn }
             #expect(cleanupBetweenRefusals)
@@ -282,18 +291,18 @@ struct Issue529MenuValidationTests {
         let attempted = try issue529Position(of: "set menuActuationAttempted to true", in: script)
         let menuBarClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
         let menuItemClick = try issue529Position(of: "click mi", in: script)
-        let cleanupAfterMenuItemClick = try #require(
-            issue529Positions(of: "set cleanupState to my dismissOpenMenu(logicProcess, true)", in: script)
-                .last
+        let leafErrorHandlerEnd = try issue529Position(of: "-- Wait up to 3s for the dialog window", in: script)
+        let leafErrorHandler = String(script[menuItemClick..<leafErrorHandlerEnd])
+        let cleanupAfterMenuItemClick = try issue529Position(
+            of: "set cleanupState to my dismissOpenMenu(logicProcess, true)", in: leafErrorHandler
         )
-        let refusalContextAfterMenuItemClick = try #require(
-            issue529Positions(of: "my menuCleanupActuationContext(menuActuationAttempted)", in: script)
-                .last
+        let refusalContextAfterMenuItemClick = try issue529Position(
+            of: "my menuCleanupActuationContext(menuActuationAttempted)", in: leafErrorHandler
         )
 
         #expect(attempted < menuBarClick)
         #expect(menuBarClick < menuItemClick)
-        #expect(menuItemClick < cleanupAfterMenuItemClick)
+        #expect(menuItemClick < leafErrorHandlerEnd)
         #expect(cleanupAfterMenuItemClick < refusalContextAfterMenuItemClick)
     }
 
@@ -333,7 +342,7 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["state"] as? String) == "C")
         #expect(try #require(envelope["menu_state"] as? String) == "could_not_be_closed")
         let hint = try #require(envelope["hint"] as? String)
-        #expect(hint.contains("could not be closed"))
+        #expect(hint.contains("not observed closed"))
         #expect(!(try #require(envelope["write_attempted"] as? Bool)))
         #expect(!(try #require(envelope["menu_actuation_attempted"] as? Bool)))
         #expect(HonestContract.isFallbackUnsafeStateC(result.message))
@@ -362,10 +371,10 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("an issued leaf AX failure stays State C and never selects the slider")
-    func issuedLeafActuationFailureDoesNotSelectSlider() async throws {
-        // Mutation this rejects: remove `.dialogActuationIssued` from
-        // `hasIssuedGoToPositionActuator`, letting this result fall through to the slider.
+    @Test("an issued leaf AX failure with unobserved cleanup stays State C and never selects the slider")
+    func issuedLeafActuationFailureWithUnobservedCleanupDoesNotSelectSlider() async throws {
+        // Mutation this rejects: treat a leaf failure with no cleanup observation as a clean
+        // navigation-only failure, letting this result fall through to the slider.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -374,7 +383,7 @@ struct Issue529MenuValidationTests {
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: AXPress reported failure"}"#)
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (OPEN_UNREADABLE)"}"#)
             }
         )
 
@@ -389,9 +398,10 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("an issued dialog submission is State B and never selects the slider")
-    func issuedSubmissionFailureIsUnverifiableStateB() async throws {
-        // Mutation this rejects: encode the submission-issued branch with `encodeStateC` again.
+    @Test("a clean leaf-only failure permits the slider fallback")
+    func cleanLeafActuationFailureAllowsSliderFallback() async throws {
+        // Mutation this rejects: make every `.dialogActuationIssued` result block the slider,
+        // even after the script observed dialog/menu cleanup and proved it never reached Return.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -400,12 +410,93 @@ struct Issue529MenuValidationTests {
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_SUBMISSION_FAILED: dialog cleanup was not observed (OPEN_UNREADABLE)"}"#)
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: AXPress reported failure after observed cleanup"}"#)
             }
         )
 
         let envelope = try #require(issue529Envelope(result))
+        #expect(try #require(envelope["via"] as? String) == "slider")
+        #expect(sliderWrites.value > 0)
+    }
+
+    @Test("a dead child after the durable leaf checkpoint is State B and cannot select the slider")
+    func deadChildAfterLeafCheckpointDoesNotReleaseSlider() async throws {
+        // Mutations this rejects:
+        // 1. Remove the parent-owned `LEAF_ARMED` ledger checkpoint or ignore it in the `.error`
+        //    branch — this clean-reconciliation fixture falls through to the slider.
+        // 2. Report `write_attempted:false` for the durable checkpoint — the receipt assertion fails.
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { script in
+                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
+                try! "LEAF_ARMED".write(toFile: ledgerPath, atomically: true, encoding: .utf8)
+                return .error("osascript timed out after leaf click")
+            },
+            reconcileAfterDialogExecutionFailure: { true }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
         #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["write_attempted"] as? Bool))
+        #expect(try #require(envelope["dialog_submission_attempted"] as? Bool))
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("only the post-Return branch is submission-issued")
+    func preReturnFailuresFallThroughWhilePostReturnFailuresAreStateB() async throws {
+        // Mutations this rejects:
+        // 1. Move `keystroke return` into the pre-Return error scope or delete it — the generated
+        //    script ordering assertions fail.
+        // 2. Classify `DIALOG_SUBMISSION_NOT_ISSUED` as issued — the pre-Return run stops using the
+        //    slider and fails the first behavioral assertion.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let inputFailure = try issue529Position(
+            of: "return \"DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return",
+            in: script
+        )
+        let returnLedger = try issue529Position(
+            of: "recordDialogIssuance(\"RETURN_ARMED\"",
+            in: script
+        )
+        let returnKey = try issue529Position(of: "keystroke return", in: script)
+        #expect(inputFailure < returnLedger)
+        #expect(returnLedger < returnKey)
+
+        let preReturnSliderWrites = Issue529Counter()
+        let preReturn = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: preReturnSliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return (AX error)"}"#)
+            }
+        )
+        let preReturnEnvelope = try #require(issue529Envelope(preReturn))
+        #expect(try #require(preReturnEnvelope["via"] as? String) == "slider")
+        #expect(preReturnSliderWrites.value > 0)
+
+        let postReturnSliderWrites = Issue529Counter()
+        let postReturn = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: postReturnSliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_SUBMISSION_ISSUED: Return may have been sent (AX error)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(postReturn))
+        #expect(postReturn.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "B")
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
         let submissionAttempted = try #require(envelope["dialog_submission_attempted"] as? Bool)
@@ -413,7 +504,7 @@ struct Issue529MenuValidationTests {
         #expect(writeAttempted)
         #expect(submissionAttempted)
         #expect(fallbackUnsafe)
-        #expect(sliderWrites.value == 0)
+        #expect(postReturnSliderWrites.value == 0)
     }
 
     @Test("a menu-not-found dialog result still falls through to the slider")
@@ -435,14 +526,16 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value > 0)
     }
 
-    @Test("State A slider evidence includes only position components read back")
-    func stateASliderEvidenceOmitsUnreadPositionComponents() async throws {
-        // Mutation this rejects: make `observedPosition` append `.1.1.1` when no beat slider
-        // was read back, which would certify position components with no observation.
+    @Test("partial slider evidence for an explicit beat remains State B")
+    func partialSliderEvidenceDoesNotCertifyTheRequestedPosition() async throws {
+        // Mutations this rejects:
+        // 1. Return `encodeStateA` after bar/beat read-back — the State-B assertion fails.
+        // 2. Reset `targetBeat` to 1 or rebuild `requested` as `.1.1.1` — the exact request and
+        //    observed bar/beat assertions fail.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
-            params: ["bar": "529"],
-            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            params: ["position": "529.4.1.1"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites, includeBeatSlider: true),
             isFrontmost: { true },
             activateLogic: { true },
             sleepMicros: { _ in },
@@ -450,11 +543,59 @@ struct Issue529MenuValidationTests {
         )
 
         let envelope = try #require(issue529Envelope(result))
-        #expect(try #require(envelope["state"] as? String) == "A")
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["requested"] as? String) == "529.4.1.1")
         let observed = try #require(envelope["observed"] as? String)
-        #expect(observed == "529")
-        #expect(!observed.contains("."))
+        #expect(observed == "529.4")
+        let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
+        #expect(unobserved == ["subdivision", "tick"])
+        let unexpressed = try #require(envelope["unexpressed_position_components"] as? [String])
+        #expect(unexpressed == ["subdivision", "tick"])
         #expect(sliderWrites.value > 0)
+    }
+
+    @Test("the dialog receives the complete requested musical position")
+    func dialogTypesTheFullRequestedPosition() throws {
+        // Mutation this rejects: replace the dialog input with the bar number or reconstruct it as
+        // `.1.1.1`, silently discarding the request's beat/subdivision/tick components.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
+        #expect(script.contains("keystroke \"529.4.7.123\""))
+    }
+
+    @Test("successful dialog submission observes modal closure before OK")
+    func successfulDialogSubmissionObservesClosureBeforeOK() throws {
+        // Mutation this rejects: return `OK` immediately after `keystroke return`, without reading
+        // `goToPositionDialogState` and handling a dialog Logic ignored.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let returnKey = try issue529Position(of: "keystroke return", in: script)
+        let postReturnObservation = try issue529Position(
+            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess)", in: script
+        )
+        let ok = try issue529Position(of: "return \"OK\"", in: script)
+
+        #expect(returnKey < postReturnObservation)
+        #expect(postReturnObservation < ok)
+    }
+
+    @Test("durable issuance checkpoints precede the leaf and Return actuators")
+    func durableIssuanceCheckpointsPrecedeActuators() throws {
+        // Mutation this rejects: move either persistent checkpoint after its corresponding click or
+        // key event, recreating the timeout window in which osascript dies with no durable record.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(
+            position: "529.4.1.1",
+            issuanceLedgerPath: "/private/tmp/issue529-ledger"
+        )
+        let leafCheckpoint = try issue529Position(
+            of: "recordDialogIssuance(\"LEAF_ARMED\"", in: script
+        )
+        let leafClick = try issue529Position(of: "click mi", in: script)
+        let returnCheckpoint = try issue529Position(
+            of: "recordDialogIssuance(\"RETURN_ARMED\"", in: script
+        )
+        let returnKey = try issue529Position(of: "keystroke return", in: script)
+
+        #expect(leafCheckpoint < leafClick)
+        #expect(returnCheckpoint < returnKey)
     }
 
     @Test("JSON-wrapped disabled and not-ready sentinels still refuse the dialog route")
@@ -487,23 +628,25 @@ struct Issue529MenuValidationTests {
     }
 }
 
-/// The entry cleanup and the post-click cleanups must not treat an unreadable menu bar the same way.
-/// Before this run clicks anything, UNREADABLE is an absent observation and the run proceeds —
-/// refusing there sent 5 of 8 fresh server processes to the slider route. After this run has clicked
-/// a menu open, an unreadable read is NOT permission to skip the Escape: skipping it can end the run
-/// with the menu still up, which is the state this branch exists to prevent.
-@Test("an unreadable read skips Escape only before this run opened anything")
-func dismissalContextDecidesWhetherAnUnreadableReadSkipsEscape() throws {
+/// Before this run opens its selected chain, an unreadable menu read must withhold Escape rather
+/// than sending it into unknown focus. Once the run has clicked that chain, cleanup can use Escape.
+@Test("unowned cleanup never marks a menu known-open before the selected chain click")
+func dismissalContextKeepsLocaleReadsUnownedUntilMenuActuation() throws {
+    // Mutation this rejects: change either locale-resolution cleanup call back to
+    // `dismissOpenMenu(logicProcess, true)`, which authorises Escape after an unreadable read.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
 
-    // Entry: the one call that may skip.
+    // Entry plus the two locale-resolution exits are unowned reads.
     #expect(script.contains("my dismissOpenMenu(logicProcess, false)"))
-    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 1)
+    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 3)
 
-    // Every other call knows a menu was opened by this run.
-    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, true)", in: script).count > 1)
+    let selectedChainClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
+    let firstKnownOpenCleanup = try #require(
+        issue529Positions(of: "my dismissOpenMenu(logicProcess, true)", in: script).first
+    )
+    #expect(selectedChainClick < firstKnownOpenCleanup)
 
-    // And the handler must only take the skip when knownOpen is false.
+    // The handler itself only skips Escape when no menu has been established as this run's.
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }
 
@@ -517,41 +660,37 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     )
     let handlerEnd = try issue529Position(of: "end dismissOpenGoToPositionDialog", in: script)
     let handler = String(script[handlerStart..<handlerEnd])
-    let cancelOutcome = try issue529Position(
-        of: "set cancelOutcome to my pressGoToPositionDialogCancel(theProcess)", in: handler
+    let unreadableBranchStart = try issue529Position(
+        of: "if cancelOutcome is \"NO_BUTTON\" or cancelOutcome is \"UNREADABLE\" then", in: handler
     )
-    let escape = try issue529Position(of: "key code 53", in: handler)
-    let reobservation = try #require(
-        issue529Positions(
-            of: "set dialogState to my goToPositionDialogState(theProcess)", in: handler
-        ).first { cancelOutcome < $0 && $0 < escape }
+    let unreadableBranch = String(handler[unreadableBranchStart...])
+    // Every operand is the first occurrence in the same fixed branch slice. Unlike the former
+    // `.first { before < $0 && $0 < escape }` form, none is selected using the ordering asserted
+    // below, so moving Escape before a guard makes the test fail.
+    let reobservation = try issue529Position(
+        of: "set dialogState to my goToPositionDialogState(theProcess)", in: unreadableBranch
     )
-    let closedGuard = try #require(
-        issue529Positions(of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: handler)
-            .first { reobservation < $0 && $0 < escape }
+    let closedGuard = try issue529Position(
+        of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: unreadableBranch
     )
-    let unreadableGuard = try #require(
-        issue529Positions(of: "if dialogState is \"UNREADABLE\" then return \"OPEN_UNREADABLE\"", in: handler)
-            .first { reobservation < $0 && $0 < escape }
+    let unreadableGuard = try issue529Position(
+        of: "if dialogState is \"UNREADABLE\" then return \"OPEN_UNREADABLE\"", in: unreadableBranch
     )
-    let stillOpenGuard = try #require(
-        issue529Positions(of: "if dialogState is not \"OPEN\" then return dialogState", in: handler)
-            .first { reobservation < $0 && $0 < escape }
+    let stillOpenGuard = try issue529Position(
+        of: "if dialogState is not \"OPEN\" then return dialogState", in: unreadableBranch
     )
+    let escape = try issue529Position(of: "key code 53", in: unreadableBranch)
 
-    #expect(cancelOutcome < reobservation)
     #expect(reobservation < closedGuard)
     #expect(closedGuard < unreadableGuard)
     #expect(unreadableGuard < stillOpenGuard)
     #expect(stillOpenGuard < escape)
 }
 
-/// A dead script (timeout, TCC refusal, anything) leaves the menu state UNKNOWN, and this script
-/// clicks menus open. Unknown is not safe: the slider would actuate into whatever is on screen.
-/// Only a menu state observed CLOSED after the death may authorise the fallback.
-@Test("a dead script does not authorise the slider until the menu is observed closed")
-func aDeadScriptMustNotAuthoriseTheSliderOnAnUnknownMenuState() throws {
-    // Mutation that must fail this test: return `.executionFailed` directly on `.error` again.
+@Test("dead-child reconciliation observes the named dialog before menu state")
+func aDeadScriptReconcilesDialogBeforeMenuState() throws {
+    // Mutations this rejects: restore the PID bypass (which skips cleanup), or reduce the recovery
+    // helper to menu-only observation. Either source relationship below fails.
     let source = try String(
         contentsOfFile: #filePath.replacingOccurrences(
             of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
@@ -559,18 +698,14 @@ func aDeadScriptMustNotAuthoriseTheSliderOnAnUnknownMenuState() throws {
         ),
         encoding: .utf8
     )
-    let errorBranch = try #require(source.range(of: "case .error:"))
-    let tail = String(source[errorBranch.upperBound...].prefix(1200))
+    let helperStart = try #require(source.range(of: "private static func observeAndClearStrayGoToPositionUI()"))
+    let helperEnd = try #require(source.range(of: "// MARK: - Control-bar checkbox helpers"))
+    let helper = String(source[helperStart.lowerBound..<helperEnd.lowerBound])
+    let dialogObservation = try issue529Position(of: "on goToPositionDialogState(theProcess)", in: helper)
+    let dialogCleanup = try issue529Position(of: "set dialogCleanupState to my dismissGoToPositionDialog(it)", in: helper)
+    let menuLoop = try issue529Position(of: "repeat with menuBarItem in every menu bar item", in: helper)
 
-    // The death path must consult an observation before classifying.
-    #expect(tail.contains("observeAndClearStrayMenu"))
-    // And an unobserved / open state must be the unsafe classification, not the fallback-safe one.
-    let unsafeAt = try #require(tail.range(of: "menuCouldNotBeClosed"))
-    let safeAt = try #require(tail.range(of: "executionFailed"))
-    #expect(safeAt.lowerBound < unsafeAt.lowerBound)
-    #expect(tail.contains("case .closed:"))
-    #expect(tail.contains("case .openOrUnknown:"))
-    // An app that is not running has no menu of its own open, so its absence must NOT be read as
-    // an unknown menu state — that is what made a Logic-less CI environment refuse the fallback.
-    #expect(tail.contains("ProcessUtils.logicProPID() != nil"))
+    #expect(dialogObservation < dialogCleanup)
+    #expect(dialogCleanup < menuLoop)
+    #expect(!helper.contains("ProcessUtils.logicProPID"))
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -453,7 +453,7 @@ struct Issue529MenuValidationTests {
         // Mutation this rejects: restore the old `dialog did not become ready` result for an
         // unmatched post-leaf window, or remove this classification from the unsafe-UI refusal.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        #expect(script.contains("on newWindowAppearedSince(theProcess, preLeafWindows)"))
+        #expect(script.contains("on newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)"))
         #expect(script.contains("return \"DIALOG_UNIDENTIFIED_NEW_WINDOW\""))
 
         let sliderWrites = Issue529Counter()
@@ -1048,20 +1048,25 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
 }
 
-@Test("the newly opened Go To Position dialog is bracket-focus-bound before global typing")
-func gotoPositionDialogRequiresNewIdentityAndBracketedFocusedBinding() throws {
+@Test("the newly opened Go To Position dialog is count-bound and bracket-focus-bound before global typing")
+func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
     // Mutations this rejects: remove AXFloatingWindow or AXModal from the known input class;
-    // delete the pre-leaf identity snapshot or its new-window predicate; remove the second
+    // delete the pre-leaf readable count snapshot or its new-window predicate; remove the second
     // frontmost read after AXFocusedWindow; restore a title/AXFocused fallback; or move a global
     // key before its post-marker focus guard. Any one can select a same-titled plug-in window or
     // let a handoff during AX resolution authorise input for another application.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
-    let preLeafSnapshot = try issue529Position(
-        of: "set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)",
-        in: script
-    )
-    let preLeafSnapshotGuard = try issue529Position(
-        of: "if preLeafGoToPositionWindows is \"UNREADABLE\" then",
+    let preLeafSnapshot = try #require(
+        script.range(
+            of: "set preLeafGoToPositionDialogCount to my goToPositionDialogCount(logicProcess)",
+            options: .backwards
+        )
+    ).lowerBound
+    let preLeafSnapshotGuard = try #require(
+        script.range(of: "if preLeafGoToPositionDialogCount is \"UNREADABLE\" then", options: .backwards)
+    ).lowerBound
+    let preexistingDialogGuard = try issue529Position(
+        of: "if preLeafGoToPositionDialogCount is greater than 0 then",
         in: script
     )
     let leafClick = try issue529Position(
@@ -1069,7 +1074,7 @@ func gotoPositionDialogRequiresNewIdentityAndBracketedFocusedBinding() throws {
         in: script
     )
     let observedDialog = try issue529Position(
-        of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionWindows)",
+        of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess, preLeafGoToPositionDialogCount)",
         in: script
     )
     let selectAllLedger = try issue529Position(
@@ -1117,7 +1122,8 @@ func gotoPositionDialogRequiresNewIdentityAndBracketedFocusedBinding() throws {
     let dialogStateHandler = String(script[dialogStateHandlerStart..<dialogStateHandlerEnd])
 
     #expect(preLeafSnapshot < preLeafSnapshotGuard)
-    #expect(preLeafSnapshotGuard < leafClick)
+    #expect(preLeafSnapshotGuard < preexistingDialogGuard)
+    #expect(preexistingDialogGuard < leafClick)
     #expect(leafClick < observedDialog)
     #expect(observedDialog < selectAllLedger)
     #expect(selectAllLedger < focusGuard)
@@ -1142,31 +1148,38 @@ func gotoPositionDialogRequiresNewIdentityAndBracketedFocusedBinding() throws {
     #expect(dialogStateHandler.contains("return \"OPEN_UNVERIFIED_MODALITY\""))
 }
 
-@Test("a pre-existing same-titled window cannot become this run's dialog target")
-func gotoPositionDialogIgnoresSameTitledPreLeafWindows() throws {
-    // Mutation this rejects: delete `windowWasPresentBefore` from the dialog matcher. Without that
-    // identity predicate, a track-named plug-in editor can satisfy a title-based Go To Position
-    // poll despite existing before this run's only leaf click.
+@Test("a pre-existing matching dialog refuses before this run's leaf click")
+func gotoPositionDialogRefusesPreexistingMatchingDialogBeforeLeaf() throws {
+    // Mutation this rejects: remove the readable count guard. Without it, an already-open matching
+    // dialog could be used as the target of this run's global keystrokes.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
     let snapshot = try issue529Position(
-        of: "set preLeafGoToPositionWindows to my goToPositionWindowSnapshot(logicProcess)", in: script
+        of: "set preLeafGoToPositionDialogCount to my goToPositionDialogCount(logicProcess)", in: script
+    )
+    let preexistingGuard = try issue529Position(
+        of: "if preLeafGoToPositionDialogCount is greater than 0 then", in: script
     )
     let leaf = try issue529Position(
         of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
         in: script
     )
     let matcherStart = try issue529Position(
-        of: "on matchingGoToPositionDialog(theProcess, preLeafWindows)", in: script
+        of: "on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: script
     )
     let matcherEnd = try issue529Position(of: "end matchingGoToPositionDialog", in: script)
     let matcher = String(script[matcherStart..<matcherEnd])
-    let priorWindowGuard = try issue529Position(
-        of: "if not my windowWasPresentBefore(candidateWindow, preLeafWindows) then", in: matcher
+    let countBasedPriorWindowGuard = try issue529Position(
+        of: "set wasPresentBefore to my windowWasPresentBefore(currentGoToPositionDialogCount, preLeafGoToPositionDialogCount)",
+        in: matcher
     )
-    let subroleRead = try issue529Position(of: "set dialogSubrole to subrole of dialogWindow", in: matcher)
+    let exactNewCountGuard = try issue529Position(
+        of: "if currentGoToPositionDialogCount is not (preLeafGoToPositionDialogCount + 1) then return missing value",
+        in: matcher
+    )
 
-    #expect(snapshot < leaf)
-    #expect(priorWindowGuard < subroleRead)
+    #expect(snapshot < preexistingGuard)
+    #expect(preexistingGuard < leaf)
+    #expect(countBasedPriorWindowGuard < exactNewCountGuard)
 }
 
 @Test("an unreadable Cancel result re-observes the dialog before Escape")
@@ -1214,7 +1227,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
 
 @Test("dead-child reconciliation targets the measured dialog before menu state")
 func aDeadScriptReconcilesDialogBeforeMenuState() throws {
-    // Mutations this rejects: restore the PID bypass, drop the durable pre-leaf identity filter,
+    // Mutations this rejects: restore the PID bypass, drop the durable pre-leaf count filter,
     // remove the final frontmost read after AXFocusedWindow, or send menu Escape after a single
     // frontmost read. Each would either cancel another run's dialog or let Escape reach a
     // different focused modal/app.
@@ -1230,15 +1243,36 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let helper = String(source[helperStart.lowerBound..<helperEnd.lowerBound])
     let measuredSubrole = try issue529Position(of: "on knownGoToPositionDialogSubrole(dialogSubrole)", in: helper)
     let dialogObservation = try issue529Position(
-        of: "on matchingGoToPositionDialog(theProcess, preLeafWindowIdentifiers)", in: helper
+        of: "on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: helper
     )
     let snapshotRead = try issue529Position(
-        of: "on preLeafGoToPositionWindowIdentifiers(snapshotPath)", in: helper
+        of: "on preLeafGoToPositionDialogCount(snapshotPath)", in: helper
     )
     let dialogCleanup = try issue529Position(
-        of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafWindowIdentifiers)",
+        of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount)",
         in: helper
     )
+    let dialogStateStart = try issue529Position(
+        of: "on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)", in: helper
+    )
+    let dialogStateEnd = try issue529Position(of: "end goToPositionDialogState", in: helper)
+    let dialogState = String(helper[dialogStateStart..<dialogStateEnd])
+    let preexistingCountRefusal = try issue529Position(
+        of: "if preLeafGoToPositionDialogCount is greater than 0 then return \"PREEXISTING\"", in: dialogState
+    )
+    let targetMatch = try issue529Position(
+        of: "set dialogWindow to my matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)",
+        in: dialogState
+    )
+    let dismissHandlerStart = try issue529Position(
+        of: "on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: helper
+    )
+    let dismissHandlerEnd = try issue529Position(of: "end dismissGoToPositionDialog", in: helper)
+    let dismissHandler = String(helper[dismissHandlerStart..<dismissHandlerEnd])
+    let nonOpenRefusal = try issue529Position(
+        of: "if dialogState is not \"OPEN\" then return dialogState", in: dismissHandler
+    )
+    let cancelAttempt = try issue529Position(of: "if exists button \"Cancel\" of dialogWindow then", in: dismissHandler)
     let focusedWindowRead = try issue529Position(
         of: "set processFocusedWindow to value of attribute \"AXFocusedWindow\"", in: helper
     )
@@ -1250,6 +1284,8 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     #expect(measuredSubrole < snapshotRead)
     #expect(snapshotRead < dialogObservation)
     #expect(dialogObservation < dialogCleanup)
+    #expect(preexistingCountRefusal < targetMatch)
+    #expect(nonOpenRefusal < cancelAttempt)
     #expect(focusedWindowRead < finalFrontmostRead)
     #expect(dialogCleanup < menuFocus)
     #expect(menuCleanupTail.startIndex < menuEscape)
@@ -1257,6 +1293,38 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     #expect(helper.contains("if processFocusedWindow is not dialogWindow then return \"NOT_FOCUSED\""))
     #expect(!helper.contains("if frontmost then"))
     #expect(!helper.contains("ProcessUtils.logicProPID"))
+}
+
+@Test("the pre-leaf snapshot accepts only a readiness marker and a canonical decimal count")
+func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
+    // Mutation this rejects: weaken the count-format guard so a stale/truncated snapshot or a
+    // title-shaped delimiter payload can reach timeout reconciliation as if it named this run.
+    let ledger = try #require(AccessibilityChannel.DialogIssuanceLedger.create())
+    defer { ledger.remove() }
+
+    let snapshotURL = ledger.preLeafWindowSnapshotURL
+    #expect(ledger.preLeafWindowSnapshotPath == nil)
+
+    try "READY\n0".write(to: snapshotURL, atomically: true, encoding: .utf8)
+    #expect(ledger.preLeafWindowSnapshotPath == snapshotURL.path)
+
+    for malformedSnapshot in [
+        "READY",
+        "READY\n",
+        "READY\n01",
+        "READY\n-1",
+        "READY\n1|title=forged",
+        "READY\n1\nextra",
+        "UNAVAILABLE",
+    ] {
+        try malformedSnapshot.write(to: snapshotURL, atomically: true, encoding: .utf8)
+        #expect(ledger.preLeafWindowSnapshotPath == nil)
+    }
+
+    let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+    #expect(script.contains("set snapshotText to \"READY\" & linefeed & (matchingGoToPositionDialogCount as text)"))
+    #expect(!script.contains("id of contents of preLeafWindow"))
+    #expect(!script.contains("AXIdentifier"))
 }
 
 @Test("the write script emits the unidentified-window refusal, and emits it before any dismissal")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -45,6 +45,46 @@ private final class Issue529StringBox: @unchecked Sendable {
     }
 }
 
+/// Bridges the real AX Go To Position route into ChannelRouter while retaining the script-result
+/// seam. This lets the adversarial fixtures prove both that their script response was consumed and
+/// that the router did not release CGEvent's `/` + position + Return sequence.
+private actor Issue529DialogFixtureChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private let scriptResult: String
+    private let scriptExecutions: Issue529Counter
+    private let sliderWrites: Issue529Counter
+
+    init(
+        scriptResult: String,
+        scriptExecutions: Issue529Counter,
+        sliderWrites: Issue529Counter
+    ) {
+        self.scriptResult = scriptResult
+        self.scriptExecutions = scriptExecutions
+        self.sliderWrites = sliderWrites
+    }
+
+    func start() async throws {}
+    func stop() async {}
+    func healthCheck() async -> ChannelHealth { .healthy(detail: "dialog fixture") }
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        let scriptResult = scriptResult
+        let scriptExecutions = scriptExecutions
+        return await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: params,
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                scriptExecutions.bump()
+                return .success(#"{"result":"\#(scriptResult)"}"#)
+            }
+        )
+    }
+}
+
 private actor Issue529DialogLockGate {
     private var started = false
     private var startWaiter: CheckedContinuation<Void, Never>?
@@ -420,6 +460,73 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
+    @Test("a leaf click that may have opened an unidentified dialog never releases CGEvent")
+    func leafActuationFailureAfterOpeningDialogDoesNotRouteToCGEvent() async throws {
+        // Mutation this rejects: remove the `dialogActuationIssued(cleanupObservedClosed: false)`
+        // unsafe-UI classification. The fixture is the leaf's AX error after the total-window
+        // observation saw a new, unidentifiable dialog. Its reply must remain terminal: reaching
+        // CGEvent would post `/`, the position text, and Return into that still-open dialog.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
+        let leafFailureBlock = String(script[leafClick...])
+        let leafError = try issue529Position(of: "on error errMsg", in: leafFailureBlock)
+        let cleanup = try issue529Position(
+            of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)",
+            in: leafFailureBlock
+        )
+        let cleanupRefusal = try issue529Position(
+            of: "if dialogCleanupState is not \"CLOSED\" then", in: leafFailureBlock
+        )
+        let dialogStateStart = try issue529Position(
+            of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)",
+            in: script
+        )
+        let dialogStateEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
+        let dialogState = String(script[dialogStateStart..<dialogStateEnd])
+        #expect(leafError < cleanup)
+        #expect(cleanup < cleanupRefusal)
+        #expect(dialogState.contains("if dialogWindow is missing value then"))
+        #expect(dialogState.contains("if newWindowState is \"APPEARED\" or newWindowState is \"UNIDENTIFIED\" then return \"UNIDENTIFIED\""))
+
+        let scriptExecutions = Issue529Counter()
+        let sliderWrites = Issue529Counter()
+        let accessibility = Issue529DialogFixtureChannel(
+            scriptResult: "DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (UNIDENTIFIED)",
+            scriptExecutions: scriptExecutions,
+            sliderWrites: sliderWrites
+        )
+        let cgEventRecorder = CGEventRecorder()
+        let cgEvent = CGEventChannel(runtime: .init(
+            isLogicProRunning: { true },
+            logicProPID: { 529 },
+            postKeyEvent: { keyCode, flags, pid in
+                cgEventRecorder.post(keyCode: keyCode, flags: flags, pid: pid)
+            },
+            sleepMicros: { _ in }
+        ))
+        let router = ChannelRouter()
+        await router.register(accessibility)
+        await router.register(cgEvent)
+
+        let result = await router.route(
+            operation: "transport.goto_position",
+            params: ["position": "529.1.1.1"]
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String)
+            == "dialog_actuation_issued_cleanup_closed_false")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(scriptExecutions.value == 1, "fixture seam must deliver the leaf-error reply")
+        #expect(sliderWrites.value == 0)
+        #expect(cgEventRecorder.snapshot().isEmpty, "CGEvent must not receive the fallback sequence")
+    }
+
     @Test("an issued leaf AX failure with unobserved cleanup stays State C and never selects the slider")
     func issuedLeafActuationFailureWithUnobservedCleanupDoesNotSelectSlider() async throws {
         // Mutation this rejects: classify OPEN_UNKNOWN_SUBROLE cleanup as CLOSED (or otherwise
@@ -448,24 +555,38 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("an unidentified new window is terminal and cannot release another position route")
+    @Test("an unrecognised localized dialog title is terminal and cannot release another position route")
     func unidentifiedNewWindowDoesNotProduceRouterContinuableResult() async throws {
-        // Mutation this rejects: restore the old `dialog did not become ready` result for an
-        // unmatched post-leaf window, or remove this classification from the unsafe-UI refusal.
+        // Mutation this rejects: treat an unmatched title as “not present”, restore the old `dialog
+        // did not become ready` result, or remove this classification from the unsafe-UI refusal.
+        // #519 still owns locale support; this fixture pins the narrower promise that a title we
+        // cannot match is honestly reported as unidentified rather than absent.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         #expect(script.contains("on newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)"))
         #expect(script.contains("return \"DIALOG_UNIDENTIFIED_NEW_WINDOW\""))
 
         let sliderWrites = Issue529Counter()
-        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
-            params: ["bar": "529"],
-            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
-            isFrontmost: { true },
-            activateLogic: { true },
-            sleepMicros: { _ in },
-            executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_UNIDENTIFIED_NEW_WINDOW"}"#)
-            }
+        let scriptExecutions = Issue529Counter()
+        let accessibility = Issue529DialogFixtureChannel(
+            scriptResult: "DIALOG_UNIDENTIFIED_NEW_WINDOW: localized title not in the measured whitelist",
+            scriptExecutions: scriptExecutions,
+            sliderWrites: sliderWrites
+        )
+        let cgEventRecorder = CGEventRecorder()
+        let cgEvent = CGEventChannel(runtime: .init(
+            isLogicProRunning: { true },
+            logicProPID: { 529 },
+            postKeyEvent: { keyCode, flags, pid in
+                cgEventRecorder.post(keyCode: keyCode, flags: flags, pid: pid)
+            },
+            sleepMicros: { _ in }
+        ))
+        let router = ChannelRouter()
+        await router.register(accessibility)
+        await router.register(cgEvent)
+        let result = await router.route(
+            operation: "transport.goto_position",
+            params: ["position": "529.1.1.1"]
         )
 
         let envelope = try #require(issue529Envelope(result))
@@ -476,7 +597,87 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(!(try #require(envelope["safe_to_retry"] as? Bool)))
         #expect(HonestContract.isFallbackUnsafeStateC(result.message))
+        #expect(scriptExecutions.value == 1, "fixture seam must deliver the unrecognised-title reply")
         #expect(sliderWrites.value == 0)
+        #expect(cgEventRecorder.snapshot().isEmpty, "CGEvent must not receive the localized-dialog fallback")
+    }
+
+    @Test("an unreadable post-leaf total-window count is terminal rather than clean actuation")
+    func unreadableDialogAppearanceDoesNotReleaseAnotherPositionRoute() async throws {
+        // Mutation this rejects: restore the old DIALOG_ACTUATION_ISSUED “appearance became
+        // unreadable” reply, which the classifier treated as cleanup observed closed. A failed
+        // count did not answer whether the leaf opened a dialog, so no later route may type.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let unreadableRefusal = try issue529Position(
+            of: "if dialogAppearanceUnreadable then return \"DIALOG_APPEARANCE_UNREADABLE\"",
+            in: script
+        )
+        let cleanup = try #require(
+            issue529Positions(of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(", in: script)
+                .first(where: { unreadableRefusal < $0 })
+        )
+        #expect(unreadableRefusal < cleanup)
+
+        let sliderWrites = Issue529Counter()
+        let scriptExecutions = Issue529Counter()
+        let accessibility = Issue529DialogFixtureChannel(
+            scriptResult: "DIALOG_APPEARANCE_UNREADABLE",
+            scriptExecutions: scriptExecutions,
+            sliderWrites: sliderWrites
+        )
+        let cgEventRecorder = CGEventRecorder()
+        let cgEvent = CGEventChannel(runtime: .init(
+            isLogicProRunning: { true },
+            logicProPID: { 529 },
+            postKeyEvent: { keyCode, flags, pid in
+                cgEventRecorder.post(keyCode: keyCode, flags: flags, pid: pid)
+            },
+            sleepMicros: { _ in }
+        ))
+        let router = ChannelRouter()
+        await router.register(accessibility)
+        await router.register(cgEvent)
+        let result = await router.route(
+            operation: "transport.goto_position",
+            params: ["position": "529.1.1.1"]
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String) == "dialog_appearance_unreadable")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(scriptExecutions.value == 1, "fixture seam must deliver the unreadable-count reply")
+        #expect(sliderWrites.value == 0)
+        #expect(cgEventRecorder.snapshot().isEmpty, "CGEvent must not receive the unreadable-count fallback")
+    }
+
+    @Test("an unidentified post-Return dialog never emits the ordinary dialog State B")
+    func postReturnUnidentifiedDialogCarriesUnsafeVerificationProvenance() async throws {
+        // Mutation this rejects: let goToPositionDialogState return CLOSED for a missing reference,
+        // `exists false`, or an unrecognised title. The post-Return cleanup reply then lacks the
+        // unsafe marker and a coincident playhead can falsely certify State A downstream.
+        let scriptExecutions = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["position": "5.1.1.1"],
+            runtime: issue529SliderRuntime(sliderWrites: Issue529Counter()),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { _ in
+                scriptExecutions.bump()
+                return .success(#"{"result":"DIALOG_SUBMISSION_ISSUED: dialog cleanup was not observed (UNIDENTIFIED)"}"#)
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String)
+            == "dialog_submission_issued_cleanup_closed_false")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(try #require(envelope["dialog_submission_attempted"] as? Bool))
+        #expect(scriptExecutions.value == 1, "fixture seam must deliver the post-Return reply")
     }
 
     @Test("an absent new window retains the clean pre-input State C")
@@ -504,9 +705,13 @@ struct Issue529MenuValidationTests {
 
     @Test("a clean leaf-only failure does not invent an AX slider route")
     func cleanLeafActuationFailureDoesNotInventSliderRoute() async throws {
-        // Source mutation: restore `via:"slider"` or `error:.axWriteFailed` in the no-route
-        // receipt. The dialog failure did not resolve or write a slider, so this must fail.
+        // This requirement remains correct, but its fixture is deliberately narrow: “after
+        // observed cleanup” means the post-leaf total-window check proved no new window remained.
+        // If the click opened any window, the write script now returns unobserved cleanup instead
+        // and the terminal test above applies. Source mutation: restore `via:"slider"` or
+        // `error:.axWriteFailed` in the no-route receipt.
         let sliderWrites = Issue529Counter()
+        let scriptExecutions = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
             runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
@@ -514,7 +719,8 @@ struct Issue529MenuValidationTests {
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: AXPress reported failure after observed cleanup"}"#)
+                scriptExecutions.bump()
+                return .success(#"{"result":"DIALOG_ACTUATION_ISSUED: AXPress reported failure after observed cleanup"}"#)
             }
         )
 
@@ -526,6 +732,7 @@ struct Issue529MenuValidationTests {
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
         #expect(!writeAttempted)
         #expect(envelope["via"] == nil)
+        #expect(scriptExecutions.value == 1, "fixture seam must deliver the observed-cleanup reply")
         #expect(sliderWrites.value == 0)
     }
 
@@ -682,6 +889,69 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(reconciliationCalls.value == 0)
         #expect(fixture.builder.actionCalls.isEmpty)
+    }
+
+    @Test("timeout reconciliation refuses an unrecognised modal before menu Escape")
+    func timeoutReconcilerChecksTotalWindowCountBeforeReportingClosed() async throws {
+        // Mutation this rejects: remove the total-window count below the title whitelist. With
+        // READY\n0\n1 and a newly opened modal whose title is not measured, the old reconciler
+        // returned CLOSED and sent menu Escape. The fixture returns DIALOG_UNIDENTIFIED to prove
+        // the reconciliation seam ran; the captured script pins the count-and-return ordering.
+        let reconciliationCalls = Issue529Counter()
+        let reconciliationScript = Issue529StringBox()
+        let runtime = issue529SliderRuntime(
+            sliderWrites: Issue529Counter(),
+            executeAppleScript: { script in
+                reconciliationCalls.bump()
+                reconciliationScript.set(script)
+                return .success(#"{"result":"DIALOG_UNIDENTIFIED"}"#)
+            }
+        )
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: runtime,
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { script in
+                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
+                try! "LEAF_ARMED".write(toFile: ledgerPath, atomically: true, encoding: .utf8)
+                let snapshotPath = URL(fileURLWithPath: ledgerPath)
+                    .appendingPathExtension("preleaf-windows").path
+                try! "READY\n0\n1".write(toFile: snapshotPath, atomically: true, encoding: .utf8)
+                return .error("osascript timed out after leaf click")
+            }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        let script = try #require(reconciliationScript.value)
+        let dialogStateStart = try issue529Position(
+            of: "on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)",
+            in: script
+        )
+        let dialogStateEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
+        let dialogState = String(script[dialogStateStart..<dialogStateEnd])
+        let totalWindowCount = try issue529Position(
+            of: "set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)", in: dialogState
+        )
+        let unidentified = try issue529Position(
+            of: "if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return \"UNIDENTIFIED\"",
+            in: dialogState
+        )
+        let closed = try issue529Position(of: "return \"CLOSED\"", in: dialogState)
+        let dialogCleanup = try issue529Position(
+            of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)",
+            in: script
+        )
+        let menuFocus = try issue529Position(of: "set menuFocusState to my menuEscapeFocusState(it)", in: script)
+
+        #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(reconciliationCalls.value == 1, "fixture seam must execute the timeout reconciler")
+        #expect(totalWindowCount < unidentified)
+        #expect(unidentified < closed)
+        #expect(dialogCleanup < menuFocus)
     }
 
     @Test("an existing dialog or focus loss refuses before a position submission")
@@ -933,13 +1203,17 @@ struct Issue529MenuValidationTests {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let returnKey = try issue529Position(of: "keystroke return", in: script)
         let postReturnObservation = try issue529Position(
-            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog)",
+            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)",
             in: script
+        )
+        let postReturnClosedGate = try issue529Position(
+            of: "if dialogPostReturnState is not \"CLOSED\" then", in: script
         )
         let ok = try issue529Position(of: "return \"OK\"", in: script)
 
         #expect(returnKey < postReturnObservation)
-        #expect(postReturnObservation < ok)
+        #expect(postReturnObservation < postReturnClosedGate)
+        #expect(postReturnClosedGate < ok)
     }
 
     @Test("durable issuance checkpoints precede the leaf and Return actuators")
@@ -1117,7 +1391,9 @@ func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
     let finalFrontmostRead = try issue529Position(
         of: "set logicIsStillFrontmost to frontmost", in: focusHandler
     )
-    let dialogStateHandlerStart = try issue529Position(of: "on goToPositionDialogState(theProcess, dialogWindow)", in: script)
+    let dialogStateHandlerStart = try issue529Position(
+        of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: script
+    )
     let dialogStateHandlerEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
     let dialogStateHandler = String(script[dialogStateHandlerStart..<dialogStateHandlerEnd])
 
@@ -1144,6 +1420,8 @@ func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
     #expect(!focusHandler.contains("name of processFocusedWindow"))
     #expect(!focusHandler.contains("if focused of dialogWindow"))
     #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogSubrole(dialogSubrole) then return \"OPEN_UNKNOWN_SUBROLE\""))
+    #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogTitle(dialogTitle) then return \"UNIDENTIFIED\""))
+    #expect(dialogStateHandler.contains("set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)"))
     #expect(dialogStateHandler.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
     #expect(dialogStateHandler.contains("return \"OPEN_UNVERIFIED_MODALITY\""))
 }
@@ -1189,7 +1467,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // frontmost-plus-AXFocusedWindow guard for that exact dialog.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
     let handlerStart = try issue529Position(
-        of: "on dismissOpenGoToPositionDialog(theProcess, dialogWindow)", in: script
+        of: "on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: script
     )
     let handlerEnd = try issue529Position(of: "end dismissOpenGoToPositionDialog", in: script)
     let handler = String(script[handlerStart..<handlerEnd])
@@ -1201,7 +1479,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // `.first { before < $0 && $0 < escape }` form, none is selected using the ordering asserted
     // below, so moving Escape before a guard makes the test fail.
     let reobservation = try issue529Position(
-        of: "set dialogState to my goToPositionDialogState(theProcess, dialogWindow)", in: unreadableBranch
+        of: "set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: unreadableBranch
     )
     let closedGuard = try issue529Position(
         of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: unreadableBranch
@@ -1246,14 +1524,14 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
         of: "on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: helper
     )
     let snapshotRead = try issue529Position(
-        of: "on preLeafGoToPositionDialogCount(snapshotPath)", in: helper
+        of: "on preLeafGoToPositionWindowSnapshot(snapshotPath)", in: helper
     )
     let dialogCleanup = try issue529Position(
-        of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount)",
+        of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)",
         in: helper
     )
     let dialogStateStart = try issue529Position(
-        of: "on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount)", in: helper
+        of: "on goToPositionDialogState(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)", in: helper
     )
     let dialogStateEnd = try issue529Position(of: "end goToPositionDialogState", in: helper)
     let dialogState = String(helper[dialogStateStart..<dialogStateEnd])
@@ -1265,7 +1543,7 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
         in: dialogState
     )
     let dismissHandlerStart = try issue529Position(
-        of: "on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: helper
+        of: "on dismissGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)", in: helper
     )
     let dismissHandlerEnd = try issue529Position(of: "end dismissGoToPositionDialog", in: helper)
     let dismissHandler = String(helper[dismissHandlerStart..<dismissHandlerEnd])
@@ -1295,7 +1573,7 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     #expect(!helper.contains("ProcessUtils.logicProPID"))
 }
 
-@Test("the pre-leaf snapshot accepts only a readiness marker and a canonical decimal count")
+@Test("the pre-leaf snapshot accepts only a readiness marker and canonical dialog/window counts")
 func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
     // Mutation this rejects: weaken the count-format guard so a stale/truncated snapshot or a
     // title-shaped delimiter payload can reach timeout reconciliation as if it named this run.
@@ -1305,7 +1583,7 @@ func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
     let snapshotURL = ledger.preLeafWindowSnapshotURL
     #expect(ledger.preLeafWindowSnapshotPath == nil)
 
-    try "READY\n0".write(to: snapshotURL, atomically: true, encoding: .utf8)
+    try "READY\n0\n1".write(to: snapshotURL, atomically: true, encoding: .utf8)
     #expect(ledger.preLeafWindowSnapshotPath == snapshotURL.path)
 
     for malformedSnapshot in [
@@ -1315,6 +1593,11 @@ func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
         "READY\n-1",
         "READY\n1|title=forged",
         "READY\n1\nextra",
+        "READY\n0\n",
+        "READY\n01\n1",
+        "READY\n0\n01",
+        "READY\n1\n0",
+        "READY\n0\n1\nextra",
         "UNAVAILABLE",
     ] {
         try malformedSnapshot.write(to: snapshotURL, atomically: true, encoding: .utf8)
@@ -1322,7 +1605,7 @@ func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
     }
 
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-    #expect(script.contains("set snapshotText to \"READY\" & linefeed & (matchingGoToPositionDialogCount as text)"))
+    #expect(script.contains("set snapshotText to \"READY\" & linefeed & (matchingGoToPositionDialogCount as text) & linefeed & (totalWindowCount as text)"))
     #expect(!script.contains("id of contents of preLeafWindow"))
     #expect(!script.contains("AXIdentifier"))
 }
@@ -1357,5 +1640,45 @@ func writeScriptRefusesAnUnidentifiedNewWindowBeforeDismissingAnything() throws 
     let dialogDismissal = try issue529Position(
         of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(", in: script
     )
+    #expect(unidentifiedRefusal < dialogDismissal)
+}
+
+@Test("the write script records APPEARED before relying on the unidentified-window refusal")
+func writeScriptMarksAnAppearedUnidentifiedWindow() throws {
+    // The Swift classifier can only protect the result that AppleScript emits. Deleting this
+    // assignment leaves `dialogAppearanceUnidentified` false, bypasses the terminal return below,
+    // and turns a newly opened unknown-title window into a clean actuation failure. Keep the
+    // APPEARED observation, assignment, terminal return, and no-dismissal order load-bearing.
+    let source = try String(
+        contentsOfFile: #filePath.replacingOccurrences(
+            of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
+            with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift"
+        ),
+        encoding: .utf8
+    )
+    let pollStart = try #require(source.range(of: "                repeat 30 times"))
+    let scriptEnd = try #require(source.range(of: "    struct DialogIssuanceLedger"))
+    let script = String(source[pollStart.lowerBound..<scriptEnd.lowerBound])
+    let totalWindowObservation = try issue529Position(
+        of: "set newWindowState to my newWindowAppearedSince(logicProcess, preLeafGoToPositionWindowCount)",
+        in: script
+    )
+    let appearedGuard = try issue529Position(
+        of: "if newWindowState is \"APPEARED\" or newWindowState is \"UNIDENTIFIED\" then",
+        in: script
+    )
+    let appearedAssignment = try issue529Position(
+        of: "set dialogAppearanceUnidentified to true", in: script
+    )
+    let unidentifiedRefusal = try issue529Position(
+        of: "if dialogAppearanceUnidentified then return \"DIALOG_UNIDENTIFIED_NEW_WINDOW\"", in: script
+    )
+    let dialogDismissal = try issue529Position(
+        of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(", in: script
+    )
+
+    #expect(totalWindowObservation < appearedGuard)
+    #expect(appearedGuard < appearedAssignment)
+    #expect(appearedAssignment < unidentifiedRefusal)
     #expect(unidentifiedRefusal < dialogDismissal)
 }

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -47,12 +47,16 @@ private func issue529SliderRuntime(
     let controlBar = builder.element(5292)
     let barSlider = builder.element(5293)
     let beatSlider = builder.element(5294)
+    let playheadPosition = builder.element(5295)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, window)
     builder.setChildren(window, [controlBar])
     builder.setAttribute(controlBar, kAXRoleAttribute as String, kAXGroupRole as String)
     builder.setAttribute(controlBar, kAXDescriptionAttribute as String, "Control Bar")
-    builder.setChildren(controlBar, includeBeatSlider ? [barSlider, beatSlider] : [barSlider])
+    builder.setChildren(controlBar, [playheadPosition])
+    builder.setAttribute(playheadPosition, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(playheadPosition, kAXDescriptionAttribute as String, "Playhead Position")
+    builder.setChildren(playheadPosition, includeBeatSlider ? [barSlider, beatSlider] : [barSlider])
     builder.setAttribute(barSlider, kAXRoleAttribute as String, kAXSliderRole as String)
     builder.setAttribute(barSlider, kAXDescriptionAttribute as String, "Bar")
     builder.setAttribute(barSlider, kAXValueAttribute as String, NSNumber(value: 1))
@@ -91,8 +95,11 @@ private func issue529Envelope(_ result: ChannelResult) -> [String: Any]? {
 
 @Suite("Issue #529 — Go To Position menu validation")
 struct Issue529MenuValidationTests {
-    @Test("locale is decided by non-actuating reads before one selected chain opens")
-    func localeIsDecidedBeforeSingleMenuChainOpens() throws {
+    @Test("locale is decided by non-actuating reads before one resolved leaf is issued")
+    func localeIsDecidedBeforeSingleResolvedLeafIsIssued() throws {
+        // Mutation this rejects: restore either intermediate menu-bar/submenu click, or replace
+        // either full leaf path with an object selected by a prior click. Both let a menu-bar click
+        // block the script before the Go To Position dialog can open.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let koreanDecision = try issue529Position(
             of: "if exists menu item \"위치…\"",
@@ -102,86 +109,55 @@ struct Issue529MenuValidationTests {
             of: "else if exists menu item \"Position…\"",
             in: script
         )
-        let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
-        let menuBarOpened = try issue529Position(
-            of: "set menuBarOpenState to my menuItemOpenedAfterClick(selectedMenuBarItem)",
+        let enabledRead = try issue529Position(
+            of: "set menuItemEnabled to enabled of menu item \"위치…\"",
             in: script
         )
-        let submenuOpen = try issue529Position(of: "click selectedSubmenuItem", in: script)
-        let submenuOpened = try issue529Position(
-            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
+        let koreanLeaf = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
             in: script
         )
-        let enabledRead = try issue529Position(of: "enabled of mi", in: script)
+        let englishLeaf = try issue529Position(
+            of: "click menu item \"Position…\" of menu 1 of menu item \"Go To\" of menu 1 of menu bar item \"Navigate\" of menu bar 1",
+            in: script
+        )
 
         #expect(koreanDecision < englishDecision)
-        #expect(englishDecision < menuBarOpen)
-        #expect(menuBarOpen < menuBarOpened)
-        #expect(menuBarOpened < submenuOpen)
-        #expect(menuBarOpen < submenuOpen)
-        #expect(submenuOpen < submenuOpened)
-        #expect(submenuOpened < enabledRead)
-        #expect(submenuOpen < enabledRead)
+        #expect(englishDecision < enabledRead)
+        #expect(enabledRead < koreanLeaf)
+        #expect(koreanLeaf < englishLeaf)
         #expect(!script.contains("click menu bar item"))
-        #expect(issue529Positions(of: "click selectedMenuBarItem", in: script).count == 1)
-        #expect(issue529Positions(of: "click selectedSubmenuItem", in: script).count == 1)
+        #expect(!script.contains("selectedMenuBarItem"))
+        #expect(!script.contains("selectedSubmenuItem"))
+        #expect(!script.contains("menuItemOpenedAfterClick"))
     }
 
-    @Test("the leaf click requires the selected submenu's own open observation")
-    func leafClickRequiresSelectedSubmenuToOpen() throws {
+    @Test("the dialog-ready poll remains the authority after the resolved leaf click")
+    func resolvedLeafClickIsFollowedByDialogReadyPoll() throws {
+        // Mutation this rejects: remove the bounded exact-dialog poll, or put dialog input before
+        // it. The leaf can issue successfully while Logic has not rendered the modal yet.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let submenuClick = try issue529Position(of: "click selectedSubmenuItem", in: script)
-        let submenuOpened = try issue529Position(
-            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
             in: script
         )
-        let submenuNotOpen = try issue529Position(
-            of: "if submenuOpenState is not \"OPEN\" then",
+        let readyPoll = try issue529Position(
+            of: "repeat 30 times",
             in: script
         )
-        let submenuRefusal = try issue529Position(
-            of: "return \"MENU_PICK_FAILED: selected submenu item did not open (\"",
+        let input = try issue529Position(
+            of: "keystroke \"529.1.1.1\"",
             in: script
         )
-        let leafClick = try issue529Position(of: "click mi", in: script)
 
-        #expect(submenuClick < submenuOpened)
-        #expect(submenuOpened < submenuNotOpen)
-        #expect(submenuNotOpen < submenuRefusal)
-        #expect(submenuRefusal < leafClick)
-    }
-
-    @Test("an unrelated open menu cannot satisfy the submenu observation")
-    func submenuObservationIsBoundToTheClickedItem() throws {
-        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let observationStart = try issue529Position(
-            of: "on menuItemOpenedAfterClick(theMenuItem)",
-            in: script
-        )
-        let observationEnd = try issue529Position(of: "end menuItemOpenedAfterClick", in: script)
-        let observation = String(script[observationStart..<observationEnd])
-        _ = try #require(
-            observation.range(of: "if selected of theMenuItem then return \"OPEN\"")
-        )
-
-        #expect(!observation.contains("menuOpenState("))
-        #expect(!observation.contains("theProcess"))
-    }
-
-    @Test("the healthy submenu path still clicks the leaf")
-    func healthySubmenuPathStillClicksLeaf() throws {
-        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let submenuOpened = try issue529Position(
-            of: "set submenuOpenState to my menuItemOpenedAfterClick(selectedSubmenuItem)",
-            in: script
-        )
-        let leafClick = try issue529Position(of: "click mi", in: script)
-
-        #expect(submenuOpened < leafClick)
+        #expect(leafClick < readyPoll)
+        #expect(readyPoll < input)
     }
 
     @Test("entry cleanup runs before locale discovery or menu actuation")
     func entryTimeCleanupPrecedesMenuWork() throws {
+        // Mutation this rejects: move entry cleanup below either locale resolution or the resolved
+        // leaf click, allowing a stale menu to leak into this request's only menu actuation.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let entryCleanup = try issue529Position(
             of: "set entryMenuCleanup to my dismissOpenMenu(logicProcess, false)",
@@ -189,11 +165,14 @@ struct Issue529MenuValidationTests {
         )
         let firstOperationalDelay = try issue529Position(of: "delay 0.2", in: script)
         let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
-        let menuBarOpen = try issue529Position(of: "click selectedMenuBarItem", in: script)
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
 
         #expect(entryCleanup < firstOperationalDelay)
         #expect(entryCleanup < localeDecision)
-        #expect(entryCleanup < menuBarOpen)
+        #expect(entryCleanup < leafClick)
     }
 
     @Test("entry refuses an unreadable menu bar before any transport actuation")
@@ -224,11 +203,6 @@ struct Issue529MenuValidationTests {
             in: dismissal
         )
         let escape = try issue529Position(of: "key code 53", in: dismissal)
-        let entryGuard = try issue529Position(
-            of: "if entryMenuCleanup is not \"CLOSED\" then",
-            in: script
-        )
-
         #expect(unreadableGuard < escape)
 
         let sliderWrites = Issue529Counter()
@@ -285,14 +259,18 @@ struct Issue529MenuValidationTests {
         }
     }
 
-    @Test("cleanup after click mi is marked as an attempted menu write")
-    func menuItemClickMarksSubsequentCleanupAsAttempted() throws {
+    @Test("cleanup after the resolved leaf is marked as an attempted menu write")
+    func resolvedLeafClickMarksSubsequentCleanupAsAttempted() throws {
+        // Mutation this rejects: move the attempt marker after the leaf or remove it, which makes
+        // a leaf-error cleanup claim the menu was never actuated.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let attempted = try issue529Position(of: "set menuActuationAttempted to true", in: script)
-        let menuBarClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
-        let menuItemClick = try issue529Position(of: "click mi", in: script)
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
         let leafErrorHandlerEnd = try issue529Position(of: "-- Wait up to 3s for the dialog window", in: script)
-        let leafErrorHandler = String(script[menuItemClick..<leafErrorHandlerEnd])
+        let leafErrorHandler = String(script[leafClick..<leafErrorHandlerEnd])
         let cleanupAfterMenuItemClick = try issue529Position(
             of: "set cleanupState to my dismissOpenMenu(logicProcess, true)", in: leafErrorHandler
         )
@@ -300,9 +278,8 @@ struct Issue529MenuValidationTests {
             of: "my menuCleanupActuationContext(menuActuationAttempted)", in: leafErrorHandler
         )
 
-        #expect(attempted < menuBarClick)
-        #expect(menuBarClick < menuItemClick)
-        #expect(menuItemClick < leafErrorHandlerEnd)
+        #expect(attempted < leafClick)
+        #expect(leafClick < leafErrorHandlerEnd)
         #expect(cleanupAfterMenuItemClick < refusalContextAfterMenuItemClick)
     }
 
@@ -398,10 +375,10 @@ struct Issue529MenuValidationTests {
         #expect(sliderWrites.value == 0)
     }
 
-    @Test("a clean leaf-only failure permits the slider fallback")
-    func cleanLeafActuationFailureAllowsSliderFallback() async throws {
-        // Mutation this rejects: make every `.dialogActuationIssued` result block the slider,
-        // even after the script observed dialog/menu cleanup and proved it never reached Return.
+    @Test("a clean leaf-only failure does not turn the relative slider into a position write")
+    func cleanLeafActuationFailureDoesNotWriteRelativeSlider() async throws {
+        // Mutation this rejects: restore the AXValue write to the `bar` slider. Its measured value
+        // is a one-bar relative increment, so a clean dialog failure must leave it untouched.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -415,8 +392,14 @@ struct Issue529MenuValidationTests {
         )
 
         let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
         #expect(try #require(envelope["via"] as? String) == "slider")
-        #expect(sliderWrites.value > 0)
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        let positionWriteSupported = try #require(envelope["slider_position_write_supported"] as? Bool)
+        #expect(!writeAttempted)
+        #expect(!positionWriteSupported)
+        #expect(sliderWrites.value == 0)
     }
 
     @Test("a dead child after the durable leaf checkpoint is State B and cannot select the slider")
@@ -453,8 +436,8 @@ struct Issue529MenuValidationTests {
         // Mutations this rejects:
         // 1. Move `keystroke return` into the pre-Return error scope or delete it — the generated
         //    script ordering assertions fail.
-        // 2. Classify `DIALOG_SUBMISSION_NOT_ISSUED` as issued — the pre-Return run stops using the
-        //    slider and fails the first behavioral assertion.
+        // 2. Classify `DIALOG_SUBMISSION_NOT_ISSUED` as issued — the pre-Return receipt stops
+        //    disclosing that no position write was sent.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let inputFailure = try issue529Position(
             of: "return \"DIALOG_SUBMISSION_NOT_ISSUED: dialog input failed before Return",
@@ -480,8 +463,12 @@ struct Issue529MenuValidationTests {
             }
         )
         let preReturnEnvelope = try #require(issue529Envelope(preReturn))
+        #expect(!preReturn.isSuccess)
+        #expect(try #require(preReturnEnvelope["state"] as? String) == "C")
         #expect(try #require(preReturnEnvelope["via"] as? String) == "slider")
-        #expect(preReturnSliderWrites.value > 0)
+        let preReturnWriteAttempted = try #require(preReturnEnvelope["write_attempted"] as? Bool)
+        #expect(!preReturnWriteAttempted)
+        #expect(preReturnSliderWrites.value == 0)
 
         let postReturnSliderWrites = Issue529Counter()
         let postReturn = await AccessibilityChannel.gotoPositionViaBarSlider(
@@ -507,8 +494,11 @@ struct Issue529MenuValidationTests {
         #expect(postReturnSliderWrites.value == 0)
     }
 
-    @Test("a menu-not-found dialog result still falls through to the slider")
-    func menuNotFoundStillFallsThroughToSlider() async throws {
+    @Test("a menu-not-found dialog result does not issue the relative slider")
+    func menuNotFoundDoesNotIssueRelativeSlider() async throws {
+        // Mutation this rejects: restore the old slider AXValue write after `MENU_NOT_FOUND`, which
+        // moves the playhead by one bar instead of expressing the requested absolute position, or
+        // drop `dialog_route_outcome` and hide why the dialog did not drive.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -522,16 +512,20 @@ struct Issue529MenuValidationTests {
         )
 
         let envelope = try #require(issue529Envelope(result))
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
         #expect(try #require(envelope["via"] as? String) == "slider")
-        #expect(sliderWrites.value > 0)
+        #expect(try #require(envelope["dialog_route_outcome"] as? String) == "menu_not_found")
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        #expect(!writeAttempted)
+        #expect(sliderWrites.value == 0)
     }
 
-    @Test("partial slider evidence for an explicit beat remains State B")
-    func partialSliderEvidenceDoesNotCertifyTheRequestedPosition() async throws {
-        // Mutations this rejects:
-        // 1. Return `encodeStateA` after bar/beat read-back — the State-B assertion fails.
-        // 2. Reset `targetBeat` to 1 or rebuild `requested` as `.1.1.1` — the exact request and
-        //    observed bar/beat assertions fail.
+    @Test("a reachable bar and beat slider still cannot express an absolute position")
+    func relativeSliderDoesNotCertifyOrIssueTheRequestedPosition() async throws {
+        // Mutation this rejects: set `kAXValueAttribute` on either Playhead Position component.
+        // The measured bar control increments relatively; no guessed mapping may turn it into an
+        // absolute-position write, even when the `beat` slider is reachable.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["position": "529.4.1.1"],
@@ -543,15 +537,17 @@ struct Issue529MenuValidationTests {
         )
 
         let envelope = try #require(issue529Envelope(result))
-        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(!result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "C")
         #expect(try #require(envelope["requested"] as? String) == "529.4.1.1")
-        let observed = try #require(envelope["observed"] as? String)
-        #expect(observed == "529.4")
         let unobserved = try #require(envelope["unobserved_position_components"] as? [String])
-        #expect(unobserved == ["subdivision", "tick"])
+        #expect(unobserved == ["bar", "beat", "subdivision", "tick"])
         let unexpressed = try #require(envelope["unexpressed_position_components"] as? [String])
-        #expect(unexpressed == ["subdivision", "tick"])
-        #expect(sliderWrites.value > 0)
+        #expect(unexpressed == ["bar", "beat", "subdivision", "tick"])
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        #expect(!writeAttempted)
+        #expect(try #require(envelope["slider_value_semantics"] as? String) == "relative_increment_not_absolute_position")
+        #expect(sliderWrites.value == 0)
     }
 
     @Test("the dialog receives the complete requested musical position")
@@ -588,7 +584,10 @@ struct Issue529MenuValidationTests {
         let leafCheckpoint = try issue529Position(
             of: "recordDialogIssuance(\"LEAF_ARMED\"", in: script
         )
-        let leafClick = try issue529Position(of: "click mi", in: script)
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
         let returnCheckpoint = try issue529Position(
             of: "recordDialogIssuance(\"RETURN_ARMED\"", in: script
         )
@@ -628,10 +627,10 @@ struct Issue529MenuValidationTests {
     }
 }
 
-/// Before this run opens its selected chain, an unreadable menu read must withhold Escape rather
-/// than sending it into unknown focus. Once the run has clicked that chain, cleanup can use Escape.
-@Test("unowned cleanup never marks a menu known-open before the selected chain click")
-func dismissalContextKeepsLocaleReadsUnownedUntilMenuActuation() throws {
+/// Before this run issues its resolved leaf, an unreadable menu read must withhold Escape rather
+/// than sending it into unknown focus. Locale discovery itself owns no menu actuation.
+@Test("locale discovery stays unowned until the resolved leaf issuance boundary")
+func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
     // Mutation this rejects: change either locale-resolution cleanup call back to
     // `dismissOpenMenu(logicProcess, true)`, which authorises Escape after an unreadable read.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
@@ -640,11 +639,17 @@ func dismissalContextKeepsLocaleReadsUnownedUntilMenuActuation() throws {
     #expect(script.contains("my dismissOpenMenu(logicProcess, false)"))
     #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 3)
 
-    let selectedChainClick = try issue529Position(of: "click selectedMenuBarItem", in: script)
-    let firstKnownOpenCleanup = try #require(
-        issue529Positions(of: "my dismissOpenMenu(logicProcess, true)", in: script).first
+    let leafCheckpoint = try issue529Position(
+        of: "recordDialogIssuance(\"LEAF_ARMED\"",
+        in: script
     )
-    #expect(selectedChainClick < firstKnownOpenCleanup)
+    let resolvedLeaf = try issue529Position(
+        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        in: script
+    )
+    #expect(leafCheckpoint < resolvedLeaf)
+    #expect(!script.contains("click selectedMenuBarItem"))
+    #expect(!script.contains("click selectedSubmenuItem"))
 
     // The handler itself only skips Escape when no menu has been established as this run's.
     #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -244,6 +244,28 @@ struct Issue529MenuValidationTests {
         #expect(!script.contains("menuItemOpenedAfterClick"))
     }
 
+    @Test("the reviewed Japanese Go To Position title is an exact operable dialog title")
+    func japaneseGoToPositionTitleIsCoveredInBothDialogObservers() throws {
+        // Mutation this rejects: remove `dialogTitle is "位置の移動"` from either title predicate.
+        // This issue covers the exact JA modal title plus its existing キャンセル dismissal path;
+        // it does not claim Japanese Navigate-menu routing or a general locale policy (#519).
+        let writeScript = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let source = try String(
+            contentsOfFile: #filePath.replacingOccurrences(
+                of: "Tests/LogicProMCPTests/Issue529MenuValidationTests.swift",
+                with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift"
+            ),
+            encoding: .utf8
+        )
+        let titlePredicateOccurrences = issue529Positions(
+            of: "dialogTitle is \"位置の移動\"", in: source
+        )
+
+        #expect(writeScript.contains("dialogTitle is \"位置の移動\""))
+        #expect(writeScript.contains("button \"キャンセル\""))
+        #expect(titlePredicateOccurrences.count == 2, "write and timeout observers must agree on the exact JA title")
+    }
+
     @Test("the dialog-ready poll remains the authority after the resolved leaf click")
     func resolvedLeafClickIsFollowedByDialogReadyPoll() throws {
         // Mutation this rejects: remove the bounded exact-dialog poll, or put dialog input before
@@ -474,14 +496,14 @@ struct Issue529MenuValidationTests {
         let leafFailureBlock = String(script[leafClick...])
         let leafError = try issue529Position(of: "on error errMsg", in: leafFailureBlock)
         let cleanup = try issue529Position(
-            of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)",
+            of: "set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)",
             in: leafFailureBlock
         )
         let cleanupRefusal = try issue529Position(
             of: "if dialogCleanupState is not \"CLOSED\" then", in: leafFailureBlock
         )
         let dialogStateStart = try issue529Position(
-            of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)",
+            of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)",
             in: script
         )
         let dialogStateEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
@@ -489,7 +511,7 @@ struct Issue529MenuValidationTests {
         #expect(leafError < cleanup)
         #expect(cleanup < cleanupRefusal)
         #expect(dialogState.contains("if dialogWindow is missing value then"))
-        #expect(dialogState.contains("if newWindowState is \"APPEARED\" or newWindowState is \"UNIDENTIFIED\" then return \"UNIDENTIFIED\""))
+        #expect(dialogState.contains("return my observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)"))
 
         let scriptExecutions = Issue529Counter()
         let sliderWrites = Issue529Counter()
@@ -600,6 +622,53 @@ struct Issue529MenuValidationTests {
         #expect(scriptExecutions.value == 1, "fixture seam must deliver the unrecognised-title reply")
         #expect(sliderWrites.value == 0)
         #expect(cgEventRecorder.snapshot().isEmpty, "CGEvent must not receive the localized-dialog fallback")
+    }
+
+    @Test("a menu result that never observed dialogs cannot release CGEvent")
+    func uninspectedDialogPreflightFailuresDoNotRouteToCGEvent() async throws {
+        // Mutation this rejects: change `if !performedDialogSafetyObservation { return true }`
+        // to return false. Each script reply exits before either pre-leaf dialog/window count, so
+        // it cannot answer that no modal is open. The recorder would otherwise receive `/`, digits,
+        // and Return globally. Running all three proves every classifier seam reaches this gate.
+        for (scriptResult, diagnostic) in [
+            ("MENU_NOT_FOUND", "menu_not_found"),
+            ("MENU_DISABLED", "menu_disabled"),
+            ("MENU_STATE_UNREADABLE", "menu_state_unreadable"),
+        ] {
+            let scriptExecutions = Issue529Counter()
+            let sliderWrites = Issue529Counter()
+            let accessibility = Issue529DialogFixtureChannel(
+                scriptResult: scriptResult,
+                scriptExecutions: scriptExecutions,
+                sliderWrites: sliderWrites
+            )
+            let cgEventRecorder = CGEventRecorder()
+            let cgEvent = CGEventChannel(runtime: .init(
+                isLogicProRunning: { true },
+                logicProPID: { 529 },
+                postKeyEvent: { keyCode, flags, pid in
+                    cgEventRecorder.post(keyCode: keyCode, flags: flags, pid: pid)
+                },
+                sleepMicros: { _ in }
+            ))
+            let router = ChannelRouter()
+            await router.register(accessibility)
+            await router.register(cgEvent)
+            let result = await router.route(
+                operation: "transport.goto_position",
+                params: ["position": "5.1.1.1"]
+            )
+
+            let envelope = try #require(issue529Envelope(result))
+            #expect(!result.isSuccess, "\(scriptResult) must remain terminal")
+            #expect(try #require(envelope["state"] as? String) == "C")
+            #expect(try #require(envelope["dialog_route_outcome"] as? String) == diagnostic)
+            #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+            #expect(!(try #require(envelope["write_attempted"] as? Bool)))
+            #expect(scriptExecutions.value == 1, "fixture seam must deliver \(scriptResult)")
+            #expect(sliderWrites.value == 0)
+            #expect(cgEventRecorder.snapshot().isEmpty, "\(scriptResult) must not release CGEvent")
+        }
     }
 
     @Test("an unreadable post-leaf total-window count is terminal rather than clean actuation")
@@ -891,12 +960,12 @@ struct Issue529MenuValidationTests {
         #expect(fixture.builder.actionCalls.isEmpty)
     }
 
-    @Test("timeout reconciliation refuses an unrecognised modal before menu Escape")
-    func timeoutReconcilerChecksTotalWindowCountBeforeReportingClosed() async throws {
-        // Mutation this rejects: remove the total-window count below the title whitelist. With
-        // READY\n0\n1 and a newly opened modal whose title is not measured, the old reconciler
-        // returned CLOSED and sent menu Escape. The fixture returns DIALOG_UNIDENTIFIED to prove
-        // the reconciliation seam ran; the captured script pins the count-and-return ordering.
+    @Test("timeout reconciliation refuses an unrecognised modal rather than reporting closed")
+    func timeoutReconcilerChecksTotalWindowCountBeforeWithholdingClosure() async throws {
+        // Mutation this rejects: return CLOSED after the equal-count branch. A timeout process has
+        // only serialized counts, not the in-process pre-leaf AX references, so equal totals cannot
+        // distinguish a vanished target from a replacement paired with a different disappearance.
+        // The fixture returns DIALOG_UNIDENTIFIED to prove the reconciliation seam ran.
         let reconciliationCalls = Issue529Counter()
         let reconciliationScript = Issue529StringBox()
         let runtime = issue529SliderRuntime(
@@ -938,7 +1007,6 @@ struct Issue529MenuValidationTests {
             of: "if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return \"UNIDENTIFIED\"",
             in: dialogState
         )
-        let closed = try issue529Position(of: "return \"CLOSED\"", in: dialogState)
         let dialogCleanup = try issue529Position(
             of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)",
             in: script
@@ -950,7 +1018,7 @@ struct Issue529MenuValidationTests {
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(reconciliationCalls.value == 1, "fixture seam must execute the timeout reconciler")
         #expect(totalWindowCount < unidentified)
-        #expect(unidentified < closed)
+        #expect(!dialogState.contains("return \"CLOSED\""))
         #expect(dialogCleanup < menuFocus)
     }
 
@@ -1131,11 +1199,10 @@ struct Issue529MenuValidationTests {
         #expect(postReturnSliderWrites.value == 0)
     }
 
-    @Test("a menu-not-found dialog result does not issue the relative slider")
+    @Test("a menu-not-found result with no dialog observation is terminal and does not issue the slider")
     func menuNotFoundDoesNotIssueRelativeSlider() async throws {
-        // Mutation this rejects: restore the old slider AXValue write after `MENU_NOT_FOUND`, which
-        // moves the playhead by one bar instead of expressing the requested absolute position, or
-        // drop `dialog_route_outcome` and hide why the dialog did not drive.
+        // Mutation this rejects: treat MENU_NOT_FOUND as a clean fallback. It occurs before a
+        // dialog count, so it must be terminal even though no position write was attempted.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -1151,9 +1218,9 @@ struct Issue529MenuValidationTests {
         let envelope = try #require(issue529Envelope(result))
         #expect(!result.isSuccess)
         #expect(try #require(envelope["state"] as? String) == "C")
-        #expect(try #require(envelope["error"] as? String) == "not_supported")
-        #expect(try #require(envelope["position_route"] as? String) == "unavailable")
+        #expect(try #require(envelope["error"] as? String) == "ax_write_failed")
         #expect(try #require(envelope["dialog_route_outcome"] as? String) == "menu_not_found")
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
         #expect(!writeAttempted)
         #expect(sliderWrites.value == 0)
@@ -1171,7 +1238,9 @@ struct Issue529MenuValidationTests {
             isFrontmost: { true },
             activateLogic: { true },
             sleepMicros: { _ in },
-            executeDialogScript: { _ in .success(#"{"result":"MENU_NOT_FOUND"}"#) }
+            executeDialogScript: { _ in
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: dialog did not become ready"}"#)
+            }
         )
 
         let envelope = try #require(issue529Envelope(result))
@@ -1203,7 +1272,7 @@ struct Issue529MenuValidationTests {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let returnKey = try issue529Position(of: "keystroke return", in: script)
         let postReturnObservation = try issue529Position(
-            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindowCount)",
+            of: "set dialogPostReturnState to my goToPositionDialogState(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)",
             in: script
         )
         let postReturnClosedGate = try issue529Position(
@@ -1214,6 +1283,57 @@ struct Issue529MenuValidationTests {
         #expect(returnKey < postReturnObservation)
         #expect(postReturnObservation < postReturnClosedGate)
         #expect(postReturnClosedGate < ok)
+    }
+
+    @Test("post-Return closure preserves every pre-leaf window rather than trusting an equal count")
+    func postReturnClosureRequiresStablePreLeafWindowReferences() throws {
+        // Mutation this rejects: remove `if preLeafWindowsState is not "UNCHANGED" then return
+        // "UNIDENTIFIED"`. In the separating state, the original dialog reference is absent, an
+        // old unrelated window also disappeared, and an unnamed Go To Position modal remains. The
+        // totals happen to match, but the missing pre-leaf reference proves that equality is not
+        // an observed closure of this run's dialog.
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        let preLeafSnapshot = try issue529Position(
+            of: "set preLeafGoToPositionWindows to every window as list", in: script
+        )
+        let leafClick = try issue529Position(
+            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            in: script
+        )
+        let stateStart = try issue529Position(
+            of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)",
+            in: script
+        )
+        let stateEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
+        let state = String(script[stateStart..<stateEnd])
+        let closureStart = try issue529Position(
+            of: "on observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)",
+            in: script
+        )
+        let closureEnd = try issue529Position(of: "end observedGoToPositionDialogClosure", in: script)
+        let closure = String(script[closureStart..<closureEnd])
+        let referenceRead = try issue529Position(
+            of: "set preLeafWindowsState to my preLeafGoToPositionWindowsState(theProcess, preLeafGoToPositionWindows)",
+            in: closure
+        )
+        let preservedGuard = try issue529Position(
+            of: "if preLeafWindowsState is not \"UNCHANGED\" then return \"UNIDENTIFIED\"", in: closure
+        )
+        let currentCount = try issue529Position(
+            of: "set currentGoToPositionWindowCount to my goToPositionWindowCount(theProcess)", in: closure
+        )
+        let countGuard = try issue529Position(
+            of: "if currentGoToPositionWindowCount is not preLeafGoToPositionWindowCount then return \"UNIDENTIFIED\"", in: closure
+        )
+        let closed = try issue529Position(of: "return \"CLOSED\"", in: closure)
+
+        #expect(preLeafSnapshot < leafClick)
+        #expect(state.contains("if not (exists dialogWindow) then"))
+        #expect(state.contains("return my observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)"))
+        #expect(referenceRead < preservedGuard)
+        #expect(preservedGuard < currentCount)
+        #expect(currentCount < countGuard)
+        #expect(countGuard < closed)
     }
 
     @Test("durable issuance checkpoints precede the leaf and Return actuators")
@@ -1392,7 +1512,7 @@ func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
         of: "set logicIsStillFrontmost to frontmost", in: focusHandler
     )
     let dialogStateHandlerStart = try issue529Position(
-        of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: script
+        of: "on goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)", in: script
     )
     let dialogStateHandlerEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
     let dialogStateHandler = String(script[dialogStateHandlerStart..<dialogStateHandlerEnd])
@@ -1421,7 +1541,7 @@ func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
     #expect(!focusHandler.contains("if focused of dialogWindow"))
     #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogSubrole(dialogSubrole) then return \"OPEN_UNKNOWN_SUBROLE\""))
     #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogTitle(dialogTitle) then return \"UNIDENTIFIED\""))
-    #expect(dialogStateHandler.contains("set newWindowState to my newWindowAppearedSince(theProcess, preLeafGoToPositionWindowCount)"))
+    #expect(dialogStateHandler.contains("return my observedGoToPositionDialogClosure(theProcess, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)"))
     #expect(dialogStateHandler.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
     #expect(dialogStateHandler.contains("return \"OPEN_UNVERIFIED_MODALITY\""))
 }
@@ -1467,7 +1587,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // frontmost-plus-AXFocusedWindow guard for that exact dialog.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
     let handlerStart = try issue529Position(
-        of: "on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: script
+        of: "on dismissOpenGoToPositionDialog(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)", in: script
     )
     let handlerEnd = try issue529Position(of: "end dismissOpenGoToPositionDialog", in: script)
     let handler = String(script[handlerStart..<handlerEnd])
@@ -1479,7 +1599,7 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // `.first { before < $0 && $0 < escape }` form, none is selected using the ordering asserted
     // below, so moving Escape before a guard makes the test fail.
     let reobservation = try issue529Position(
-        of: "set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindowCount)", in: unreadableBranch
+        of: "set dialogState to my goToPositionDialogState(theProcess, dialogWindow, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)", in: unreadableBranch
     )
     let closedGuard = try issue529Position(
         of: "if dialogState is \"CLOSED\" then return \"CLOSED\"", in: unreadableBranch
@@ -1523,9 +1643,7 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let dialogObservation = try issue529Position(
         of: "on matchingGoToPositionDialog(theProcess, preLeafGoToPositionDialogCount)", in: helper
     )
-    let snapshotRead = try issue529Position(
-        of: "on preLeafGoToPositionWindowSnapshot(snapshotPath)", in: helper
-    )
+    let snapshotParser = AccessibilityChannel.preLeafGoToPositionWindowSnapshotParserAppleScript()
     let dialogCleanup = try issue529Position(
         of: "set dialogCleanupState to my dismissGoToPositionDialog(it, preLeafGoToPositionDialogCount, preLeafGoToPositionWindowCount)",
         in: helper
@@ -1559,8 +1677,9 @@ func aDeadScriptReconcilesDialogBeforeMenuState() throws {
     let menuCleanupTail = String(helper[menuFocus...])
     let menuEscape = try issue529Position(of: "key code 53", in: menuCleanupTail)
 
-    #expect(measuredSubrole < snapshotRead)
-    #expect(snapshotRead < dialogObservation)
+    #expect(helper.contains("\\(preLeafGoToPositionWindowSnapshotParserAppleScript())"))
+    #expect(snapshotParser.contains("on preLeafGoToPositionWindowSnapshot(snapshotPath)"))
+    #expect(measuredSubrole < dialogObservation)
     #expect(dialogObservation < dialogCleanup)
     #expect(preexistingCountRefusal < targetMatch)
     #expect(nonOpenRefusal < cancelAttempt)
@@ -1608,6 +1727,36 @@ func preLeafGoToPositionSnapshotIsUnambiguousAndNonInjectable() throws {
     #expect(script.contains("set snapshotText to \"READY\" & linefeed & (matchingGoToPositionDialogCount as text) & linefeed & (totalWindowCount as text)"))
     #expect(!script.contains("id of contents of preLeafWindow"))
     #expect(!script.contains("AXIdentifier"))
+}
+
+@Test("the timeout parser accepts the LF snapshot after do shell script normalizes it to CR")
+func timeoutSnapshotParserUsesTheShellReturnedDelimiter() throws {
+    // Mutation this rejects: change the production parser's `text item delimiters to return` back
+    // to `linefeed`. The writer persists LF, but `do shell script` returns that output as CR; the
+    // probe executes that same boundary without touching System Events and would produce one item
+    // rather than the required three.
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("logic-pro-mcp-snapshot-parser-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let snapshotURL = directory.appendingPathComponent("preleaf-windows")
+    try "READY\n0\n1".write(to: snapshotURL, atomically: true, encoding: .utf8)
+
+    let parser = AccessibilityChannel.preLeafGoToPositionWindowSnapshotParserAppleScript()
+    let parserProbe = parser + "\nreturn preLeafGoToPositionWindowSnapshot(\"\(snapshotURL.path)\")"
+    let probeResult = try runProcess(
+        executable: "/usr/bin/osascript",
+        arguments: ["-e", parserProbe],
+        currentDirectoryURL: directory
+    )
+
+    let writer = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+
+    #expect(probeResult.exitCode == 0)
+    #expect(probeResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "0, 1")
+    #expect(writer.contains("set snapshotText to \"READY\" & linefeed"))
+    #expect(parser.contains("set AppleScript's text item delimiters to return"))
+    #expect(!parser.contains("set AppleScript's text item delimiters to linefeed"))
 }
 
 @Test("the write script emits the unidentified-window refusal, and emits it before any dismissal")

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -383,8 +383,9 @@ struct Issue529MenuValidationTests {
 
     @Test("an issued leaf AX failure with unobserved cleanup stays State C and never selects the slider")
     func issuedLeafActuationFailureWithUnobservedCleanupDoesNotSelectSlider() async throws {
-        // Mutation this rejects: treat a leaf failure with no cleanup observation as a clean
-        // navigation-only failure, letting this result fall through to the slider.
+        // Mutation this rejects: classify OPEN_UNKNOWN_SUBROLE cleanup as CLOSED (or otherwise
+        // treat this leaf failure as clean navigation), letting an unrecognised titled modal fall
+        // through to the slider while it remains open.
         let sliderWrites = Issue529Counter()
         let result = await AccessibilityChannel.gotoPositionViaBarSlider(
             params: ["bar": "529"],
@@ -393,7 +394,7 @@ struct Issue529MenuValidationTests {
             activateLogic: { true },
             sleepMicros: { _ in },
             executeDialogScript: { _ in
-                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (OPEN_UNREADABLE)"}"#)
+                .success(#"{"result":"DIALOG_ACTUATION_ISSUED: dialog cleanup was not observed (OPEN_UNKNOWN_SUBROLE)"}"#)
             }
         )
 
@@ -464,6 +465,44 @@ struct Issue529MenuValidationTests {
         let submissionAttempted = envelope["dialog_submission_attempted"] as? Bool
         #expect(writeAttempted == nil)
         #expect(submissionAttempted == nil)
+        #expect(try #require(envelope["dialog_submission_indeterminate"] as? Bool))
+        #expect(try #require(envelope["fallback_unsafe"] as? Bool))
+        #expect(sliderWrites.value == 0)
+    }
+
+    @Test("a dead child with a corrupt dialog ledger reports possible global input")
+    func deadChildWithUnknownLedgerDoesNotOmitGlobalInputReceipt() async throws {
+        // Mutation this rejects: remove `.executionFailed(issuance: .unknown, ...)` from
+        // `globalInputMayHaveOccurred`. A corrupt/truncated ledger cannot prove that Cmd+A or
+        // position text was not sent, so its receipt must not claim `write_attempted:false`.
+        let sliderWrites = Issue529Counter()
+        let result = await AccessibilityChannel.gotoPositionViaBarSlider(
+            params: ["bar": "529"],
+            runtime: issue529SliderRuntime(sliderWrites: sliderWrites),
+            isFrontmost: { true },
+            activateLogic: { true },
+            sleepMicros: { _ in },
+            executeDialogScript: { script in
+                let ledgerPath = try! issue529LedgerPath(from: script, stage: "LEAF_ARMED")
+                try! "truncated-before-replacement".write(
+                    toFile: ledgerPath,
+                    atomically: false,
+                    encoding: .utf8
+                )
+                return .error("osascript was killed while updating the issuance ledger")
+            },
+            reconcileAfterDialogExecutionFailure: { true }
+        )
+
+        let envelope = try #require(issue529Envelope(result))
+        #expect(result.isSuccess)
+        #expect(try #require(envelope["state"] as? String) == "B")
+        #expect(try #require(envelope["dialog_route_outcome"] as? String)
+            == "execution_failed_issuance_unknown_cleanup_closed_true")
+        #expect(try #require(envelope["dialog_input_attempted"] as? Bool))
+        #expect(try #require(envelope["dialog_input_boundary"] as? String) == "unknown")
+        #expect(try #require(envelope["dialog_input_target"] as? String) == "unknown")
+        #expect(try #require(envelope["write_attempted"] as? Bool))
         #expect(try #require(envelope["dialog_submission_indeterminate"] as? Bool))
         #expect(try #require(envelope["fallback_unsafe"] as? Bool))
         #expect(sliderWrites.value == 0)
@@ -760,8 +799,10 @@ struct Issue529MenuValidationTests {
 
     @Test("durable issuance checkpoints precede the leaf and Return actuators")
     func durableIssuanceCheckpointsPrecedeActuators() throws {
-        // Mutation this rejects: move either persistent checkpoint after its corresponding click or
-        // key event, recreating the timeout window in which osascript dies with no durable record.
+        // Mutations this rejects: move either persistent checkpoint after its corresponding click
+        // or key event, or restore a direct `printf > ledgerPath` replacement. The former recreates
+        // a no-record timeout window; the latter can truncate the prior conservative marker before
+        // the replacement becomes durable.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(
             position: "529.4.1.1",
             issuanceLedgerPath: "/private/tmp/issue529-ledger"
@@ -777,9 +818,22 @@ struct Issue529MenuValidationTests {
             of: "recordDialogIssuance(\"RETURN_ARMED\"", in: script
         )
         let returnKey = try issue529Position(of: "keystroke return", in: script)
+        let ledgerHandlerStart = try issue529Position(
+            of: "on recordDialogIssuance(stage, ledgerPath)", in: script
+        )
+        let ledgerHandlerEnd = try issue529Position(
+            of: "end recordDialogIssuance", in: script
+        )
+        let ledgerHandler = String(script[ledgerHandlerStart..<ledgerHandlerEnd])
+        let temporaryLedger = try issue529Position(of: "set temporaryLedgerPath to do shell script", in: ledgerHandler)
+        let stagedWrite = try issue529Position(of: "quoted form of temporaryLedgerPath", in: ledgerHandler)
+        let atomicRename = try issue529Position(of: "&& /bin/mv -f", in: ledgerHandler)
 
         #expect(leafCheckpoint < leafClick)
         #expect(returnCheckpoint < returnKey)
+        #expect(temporaryLedger < stagedWrite)
+        #expect(stagedWrite < atomicRename)
+        #expect(ledgerHandler.contains("ledgerPath & \".tmp.XXXXXX\""))
     }
 
     @Test("JSON-wrapped disabled and not-ready sentinels still refuse the dialog route")
@@ -845,17 +899,18 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
 
 @Test("the Go To Position dialog is newly observed and focus-bound before global typing")
 func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
-    // Source mutations: remove AXFloatingWindow from either the discovery or focus-validation
-    // subrole set, remove the pre-leaf absence check, or move either Cmd+A/position keystroke
-    // before the observed-dialog focus guard. Any one rejects the measured dialog or lets a
-    // stale/concurrent dialog or another frontmost app receive this request's input.
+    // Mutations this rejects: remove AXFloatingWindow or AXModal from the known input class,
+    // collapse OPEN_UNKNOWN_SUBROLE to CLOSED, remove the global `frontmost` recheck, restore a
+    // title/AXFocused fallback for AXFocusedWindow identity, or move any global key before its
+    // post-marker focus guard. Any one either rejects the measured dialog or lets a stale,
+    // non-modal, or newly frontmost application receive this request's input.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(position: "529.4.7.123")
     let preLeafObservation = try issue529Position(
-        of: "set preLeafGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)",
+        of: "set preLeafGoToPositionDialogState to my goToPositionDialogState(logicProcess)",
         in: script
     )
     let preLeafAbsenceGuard = try issue529Position(
-        of: "if preLeafGoToPositionDialog is not missing value then",
+        of: "if preLeafGoToPositionDialogState is not \"CLOSED\" then",
         in: script
     )
     let leafClick = try issue529Position(
@@ -866,6 +921,9 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
         of: "set observedGoToPositionDialog to my matchingGoToPositionDialog(logicProcess)",
         in: script
     )
+    let selectAllLedger = try issue529Position(
+        of: "recordDialogIssuance(\"SELECT_ALL_ARMED\"", in: script
+    )
     let focusGuard = try issue529Position(
         of: "set dialogFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)",
         in: script
@@ -875,35 +933,64 @@ func gotoPositionDialogRequiresAppearanceTransitionAndFocusedBinding() throws {
         in: script
     )
     let selectAll = try issue529Position(of: "keystroke \"a\" using command down", in: script)
+    let positionInputLedger = try issue529Position(
+        of: "recordDialogIssuance(\"POSITION_INPUT_ARMED\"", in: script
+    )
     let typingFocusGuard = try issue529Position(
         of: "set dialogTypingFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)",
         in: script
     )
     let positionInput = try issue529Position(of: "keystroke \"529.4.7.123\"", in: script)
+    let returnLedger = try issue529Position(of: "recordDialogIssuance(\"RETURN_ARMED\"", in: script)
+    let returnFocusGuard = try issue529Position(
+        of: "set dialogReturnFocusState to my observedGoToPositionDialogFocusState(logicProcess, observedGoToPositionDialog)",
+        in: script
+    )
+    let returnKey = try issue529Position(of: "keystroke return", in: script)
+    let focusHandlerStart = try issue529Position(
+        of: "on observedGoToPositionDialogFocusState(theProcess, dialogWindow)", in: script
+    )
+    let focusHandlerEnd = try issue529Position(
+        of: "end observedGoToPositionDialogFocusState", in: script
+    )
+    let focusHandler = String(script[focusHandlerStart..<focusHandlerEnd])
+    let globalFocusRead = try issue529Position(of: "set logicIsFrontmost to frontmost", in: focusHandler)
+    let focusedWindowRead = try issue529Position(
+        of: "set processFocusedWindow to value of attribute \"AXFocusedWindow\"", in: focusHandler
+    )
+    let dialogStateHandlerStart = try issue529Position(of: "on goToPositionDialogState(theProcess)", in: script)
+    let dialogStateHandlerEnd = try issue529Position(of: "end goToPositionDialogState", in: script)
+    let dialogStateHandler = String(script[dialogStateHandlerStart..<dialogStateHandlerEnd])
 
     #expect(preLeafObservation < preLeafAbsenceGuard)
     #expect(preLeafAbsenceGuard < leafClick)
     #expect(leafClick < observedDialog)
-    #expect(observedDialog < focusGuard)
+    #expect(observedDialog < selectAllLedger)
+    #expect(selectAllLedger < focusGuard)
     #expect(focusGuard < focusRefusal)
     #expect(focusRefusal < selectAll)
-    #expect(selectAll < typingFocusGuard)
+    #expect(selectAll < positionInputLedger)
+    #expect(positionInputLedger < typingFocusGuard)
     #expect(typingFocusGuard < positionInput)
-    #expect(script.contains("set dialogSubrole to subrole of dialogWindow"))
-    #expect(script.contains(
-        "if dialogSubrole is \"AXFloatingWindow\" or dialogSubrole is \"AXDialog\" or dialogSubrole is \"AXSystemDialog\" then return contents of dialogWindow"
-    ))
-    #expect(script.contains(
-        "if dialogSubrole is not \"AXFloatingWindow\" and dialogSubrole is not \"AXDialog\" and dialogSubrole is not \"AXSystemDialog\" then return \"MISSING\""
-    ))
-    #expect(script.contains("set processFocusedWindow to value of attribute \"AXFocusedWindow\""))
-    #expect(script.contains("if processFocusedWindow is dialogWindow then return \"FOCUSED\""))
+    #expect(positionInput < returnLedger)
+    #expect(returnLedger < returnFocusGuard)
+    #expect(returnFocusGuard < returnKey)
+    #expect(globalFocusRead < focusedWindowRead)
+    #expect(focusHandler.contains("if logicIsFrontmost is not true then return \"NOT_FRONTMOST\""))
+    #expect(focusHandler.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
+    #expect(focusHandler.contains("if processFocusedWindow is dialogWindow then return \"FOCUSED\""))
+    #expect(!focusHandler.contains("name of processFocusedWindow"))
+    #expect(!focusHandler.contains("if focused of dialogWindow"))
+    #expect(dialogStateHandler.contains("if not my knownGoToPositionDialogSubrole(dialogSubrole) then return \"OPEN_UNKNOWN_SUBROLE\""))
+    #expect(dialogStateHandler.contains("set dialogIsModal to value of attribute \"AXModal\" of dialogWindow"))
+    #expect(dialogStateHandler.contains("return \"OPEN_UNVERIFIED_MODALITY\""))
 }
 
 @Test("an unreadable Cancel result re-observes the dialog before Escape")
 func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     // Mutation this rejects: move `key code 53` directly after an `UNREADABLE` Cancel result,
-    // bypassing the fresh `goToPositionDialogState` observation.
+    // bypassing either the fresh `goToPositionDialogState` observation or the immediate
+    // frontmost-plus-AXFocusedWindow guard for the exact dialog.
     let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
     let handlerStart = try issue529Position(
         of: "on dismissOpenGoToPositionDialog(theProcess)", in: script
@@ -929,12 +1016,21 @@ func unreadableCancelDoesNotAuthoriseEscapeWithoutDialogObservation() throws {
     let stillOpenGuard = try issue529Position(
         of: "if dialogState is not \"OPEN\" then return dialogState", in: unreadableBranch
     )
+    let cleanupDialogBinding = try issue529Position(
+        of: "set cleanupDialogWindow to my matchingGoToPositionDialog(theProcess)", in: unreadableBranch
+    )
+    let cleanupFocusGuard = try issue529Position(
+        of: "set cleanupDialogFocusState to my observedGoToPositionDialogFocusState(theProcess, cleanupDialogWindow)",
+        in: unreadableBranch
+    )
     let escape = try issue529Position(of: "key code 53", in: unreadableBranch)
 
     #expect(reobservation < closedGuard)
     #expect(closedGuard < unreadableGuard)
     #expect(unreadableGuard < stillOpenGuard)
-    #expect(stillOpenGuard < escape)
+    #expect(stillOpenGuard < cleanupDialogBinding)
+    #expect(cleanupDialogBinding < cleanupFocusGuard)
+    #expect(cleanupFocusGuard < escape)
 }
 
 @Test("dead-child reconciliation observes the named dialog before menu state")


### PR DESCRIPTION
Closes #534.

`transport.goto_position` did not work, and when it appeared to, it was verifying against components nobody had read.

## It never completed a single dialog drive

Timed directly under `osascript` on Logic Pro 12.3:

| step | elapsed |
|---|---|
| `click menu bar item "Navigate"` | **never returns** (killed at 120 s) |
| `click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate"` | **0.23 s**, dialog opens, no menu left open |

A System Events click on a menu-bar item does not return while the menu it opened is on screen, so the two-step "click the menu bar item, observe that it opened, then click into it" sequence can never complete. Every request died on the 8-second budget and fell through to the slider — which moves the playhead one bar per call rather than to the requested position.

The single leaf-path click is restored. With one actuation there is no next click for a return code to select, and its effect is observed by the poll that waits for the dialog window.

## State A was fabricated from a prefix or a default

`TransportState.position` defaults to `"1.1.1.1"`, and the extractor synthesized subdivision and tick as `.1.1` from the Bar and Beat sliders. A request could verify against a suffix nobody had observed; with no readable position control at all, the default alone verified `1.1.1.1`.

The extractor now records which components it actually read, and State A requires every component the request names to be among them. **The consequence is user-visible: on this surface `goto_position` no longer returns State A**, because Logic exposes only Bar and Beat. It returns State B naming `subdivision` and `tick` as unobserved. The operation works; it cannot be verified to four components, and now says so.

This is also why my own live check could not catch it — the instrument I used as independent ground truth is the same pair of sliders, so it can never see the suffix.

## Other review findings, all fixed

A dead script lost its issuance state, so a timeout after the leaf click released the slider as a second actuator — issuance is recorded through a parent-owned durable ledger written before each boundary. One `try` covered everything from the pre-Return delay to the post-Return delay, so a failure before anything was sent reported `dialog_submission_attempted: true`. A nominal `OK` never observed that the dialog had closed, and timeout cleanup looked only for stray menus. Three pre-leaf branches authorised Escape into UI this run had not opened. The dialog poll accepted any window with a matching title, so a stale or another process's dialog satisfied it.

The bar slider's `AXValue` is not a bar number — writing 37 moved the playhead 1→2, and 3→4. It is a relative increment, so that write is removed rather than scaled by guesswork.

**A test that drove the real Logic.** `Issue440TransportFrontmostTests` never stubbed `executeAppleScript`, so its result depended on the machine — it passed only while the dialog route was broken. Stubbing it exposed the real hole: the dialog executor called the script channel directly instead of through the runtime, so an injected seam was ignored. The runtime now carries a timeout-aware script seam.

**A guessed AX constant.** The ownership check assumed the Go To Position window has subrole `AXDialog`. Measured, it is `AXFloatingWindow` — so every drive refused with "dialog did not become ready" while the dialog was open, and the whole unit suite passed throughout because the fixtures shared the guess.

## Live on Logic 12.3

| check | result |
|---|---|
| precondition | playhead parked at 1.1.1.1 |
| `37.3.1.1` | Logic's own Playhead Position sliders read bar 37, beat 3 |
| envelope | State B, `unobserved_position_components: [subdivision, tick]` |
| request echoed unrewritten | `37.3.1.1` |
| dialog left open | none |
| region-bound visual assertion on the transport readout | changed |

Ship gate: 3524 tests, live evidence bound to HEAD with a screen recording.