### PR TITLE
fix(#544): a tool that declares an output schema must always answer with one

### DIFF
--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -84,6 +84,29 @@ struct SystemDispatcher: OperationTraceDispatching {
         let variants: [VariantAvailability]
     }
 
+    /// #544: `permissions` answered in prose under a tool that declares an `outputSchema`, so a
+    /// schema-enforcing client rejected the call. The states are the answer; the summary is the
+    /// operator-facing rendering of it, kept so nothing a human relied on disappeared.
+    private struct PermissionsResponse: Encodable {
+        let operation: String
+        let accessibility: String
+        let automationLogicPro: String
+        let automationSystemEvents: String
+        let postEvent: String
+        let allGranted: Bool
+        let summary: String
+    }
+
+    /// #544: `refresh_cache` answered in prose too, and its two prose strings carried a real
+    /// distinction — a refresh that ran versus one merely queued — that a caller could only recover
+    /// by string-matching.
+    private struct RefreshCacheResponse: Encodable {
+        let operation: String
+        let refreshed: Bool
+        let source: String
+        let message: String
+    }
+
     private struct HealthResponse: Encodable {
         struct VariantAvailabilitySection: Encodable {
             let variant: String
@@ -425,16 +448,40 @@ struct SystemDispatcher: OperationTraceDispatching {
             return toolTextResult(json)
 
         case "permissions":
+            // The human-readable summary is what an operator wants to read, but a caller needs the
+            // states themselves — `health` has always returned them and this command had not, which
+            // left it violating its own declared outputSchema (#544).
             let status = PermissionChecker.check()
-            return toolTextResult(status.summary)
+            return toolTextResult(encodeJSON(PermissionsResponse(
+                operation: "system.permissions",
+                accessibility: status.accessibilityState.rawValue,
+                automationLogicPro: status.automationState.rawValue,
+                automationSystemEvents: status.systemEventsAutomationState.rawValue,
+                postEvent: status.postEventAccessState.rawValue,
+                allGranted: status.allGranted,
+                summary: status.summary
+            )))
 
         case "refresh_cache":
             await cache.recordToolAccess()
+            // Whether the poller actually ran is the difference between a refresh that HAPPENED and one
+            // that was only scheduled. A caller that reads state next has to tell them apart, so it is
+            // a field rather than a difference in prose.
             if let poller {
                 await poller.refreshNow()
-                return toolTextResult("State refresh completed via AX fallback poller.")
+                return toolTextResult(encodeJSON(RefreshCacheResponse(
+                    operation: "system.refresh_cache",
+                    refreshed: true,
+                    source: "ax_fallback_poller",
+                    message: "State refresh completed via AX fallback poller."
+                )))
             }
-            return toolTextResult("State refresh triggered. Cache will be updated on next poll cycle.")
+            return toolTextResult(encodeJSON(RefreshCacheResponse(
+                operation: "system.refresh_cache",
+                refreshed: false,
+                source: "next_poll_cycle",
+                message: "State refresh triggered. Cache will be updated on next poll cycle."
+            )))
 
         case "setup_arm_key":
             // Consent-first: refuse before the trace, the mutation gate, or any

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -84,28 +84,7 @@ struct SystemDispatcher: OperationTraceDispatching {
         let variants: [VariantAvailability]
     }
 
-    /// #544: `permissions` answered in prose under a tool that declares an `outputSchema`, so a
-    /// schema-enforcing client rejected the call. The states are the answer; the summary is the
-    /// operator-facing rendering of it, kept so nothing a human relied on disappeared.
-    private struct PermissionsResponse: Encodable {
-        let operation: String
-        let accessibility: String
-        let automationLogicPro: String
-        let automationSystemEvents: String
-        let postEvent: String
-        let allGranted: Bool
-        let summary: String
-    }
 
-    /// #544: `refresh_cache` answered in prose too, and its two prose strings carried a real
-    /// distinction — a refresh that ran versus one merely queued — that a caller could only recover
-    /// by string-matching.
-    private struct RefreshCacheResponse: Encodable {
-        let operation: String
-        let refreshed: Bool
-        let source: String
-        let message: String
-    }
 
     private struct HealthResponse: Encodable {
         struct VariantAvailabilitySection: Encodable {
@@ -452,36 +431,50 @@ struct SystemDispatcher: OperationTraceDispatching {
             // states themselves — `health` has always returned them and this command had not, which
             // left it violating its own declared outputSchema (#544).
             let status = PermissionChecker.check()
-            return toolTextResult(encodeJSON(PermissionsResponse(
-                operation: "system.permissions",
-                accessibility: status.accessibilityState.rawValue,
-                automationLogicPro: status.automationState.rawValue,
-                automationSystemEvents: status.systemEventsAutomationState.rawValue,
-                postEvent: status.postEventAccessState.rawValue,
-                allGranted: status.allGranted,
-                summary: status.summary
-            )))
+            // The prose stays the text: `SemanticOracleTable.systemPermissions` grades this operation by
+            // asserting its four exact lines, so encoding JSON here would RED a correct answer in
+            // qualification while every unit test stayed green. The states go beside it.
+            return toolTextResult(
+                text: status.summary,
+                structured: .object([
+                    "operation": .string("system.permissions"),
+                    "accessibility": .string(status.accessibilityState.rawValue),
+                    "automation_logic_pro": .string(status.automationState.rawValue),
+                    "automation_system_events": .string(status.systemEventsAutomationState.rawValue),
+                    "post_event": .string(status.postEventAccessState.rawValue),
+                    // Deliberately not a Bool: "Logic is not running" is not "permission denied", and a
+                    // client reading a single flag would have to treat them the same. Absent means
+                    // undetermined; the four states above always carry the real answer.
+                    "all_granted": status.automationState == .notVerifiable
+                        ? .null : .bool(status.allGranted),
+                    "summary": .string(status.summary),
+                ])
+            )
 
         case "refresh_cache":
             await cache.recordToolAccess()
             // Whether the poller actually ran is the difference between a refresh that HAPPENED and one
             // that was only scheduled. A caller that reads state next has to tell them apart, so it is
             // a field rather than a difference in prose.
+            // Same reason as `permissions`: the oracle for this operation compares the WHOLE body to one
+            // of these sentences, so the sentence stays the text.
             if let poller {
                 await poller.refreshNow()
-                return toolTextResult(encodeJSON(RefreshCacheResponse(
-                    operation: "system.refresh_cache",
-                    refreshed: true,
-                    source: "ax_fallback_poller",
-                    message: "State refresh completed via AX fallback poller."
-                )))
+                let message = "State refresh completed via AX fallback poller."
+                return toolTextResult(text: message, structured: .object([
+                    "operation": .string("system.refresh_cache"),
+                    "refreshed": .bool(true),
+                    "source": .string("ax_fallback_poller"),
+                    "message": .string(message),
+                ]))
             }
-            return toolTextResult(encodeJSON(RefreshCacheResponse(
-                operation: "system.refresh_cache",
-                refreshed: false,
-                source: "next_poll_cycle",
-                message: "State refresh triggered. Cache will be updated on next poll cycle."
-            )))
+            let message = "State refresh triggered. Cache will be updated on next poll cycle."
+            return toolTextResult(text: message, structured: .object([
+                "operation": .string("system.refresh_cache"),
+                "refreshed": .bool(false),
+                "source": .string("next_poll_cycle"),
+                "message": .string(message),
+            ]))
 
         case "setup_arm_key":
             // Consent-first: refuse before the trace, the mutation gate, or any

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -442,11 +442,13 @@ struct SystemDispatcher: OperationTraceDispatching {
                     "automation_logic_pro": .string(status.automationState.rawValue),
                     "automation_system_events": .string(status.systemEventsAutomationState.rawValue),
                     "post_event": .string(status.postEventAccessState.rawValue),
-                    // Deliberately not a Bool: "Logic is not running" is not "permission denied", and a
-                    // client reading a single flag would have to treat them the same. Absent means
-                    // undetermined; the four states above always carry the real answer.
-                    "all_granted": status.automationState == .notVerifiable
-                        ? .null : .bool(status.allGranted),
+                    // Deliberately not a plain Bool: "undetermined" is not "permission denied", and a
+                    // client reading a single flag would have to treat them the same. `false` is reserved
+                    // for a MEASURED denial on at least one of the four states above; when nothing was
+                    // denied but something could not be verified, the key is present with a JSON `null` —
+                    // not omitted — so a caller that only checks presence still sees it and must read the
+                    // per-check states to learn why. See `Self.allGrantedValue`.
+                    "all_granted": Self.allGrantedValue(for: status),
                     "summary": .string(status.summary),
                 ])
             )
@@ -459,11 +461,17 @@ struct SystemDispatcher: OperationTraceDispatching {
             // Same reason as `permissions`: the oracle for this operation compares the WHOLE body to one
             // of these sentences, so the sentence stays the text.
             if let poller {
-                await poller.refreshNow()
+                // `refreshNow()` reports whether the cache actually advanced (at least one section was
+                // written), not merely that the call returned — the poller can run and legitimately write
+                // nothing (no visible Logic window yet, or an occluding dialog holds the cache steady).
+                // `refreshed:true` for a poll that touched nothing would be a claim this call never
+                // observed (#544 review MAJOR); the prose text is unchanged either way because the
+                // mechanism ("routed through the AX fallback poller") is true regardless of the outcome.
+                let advanced = await poller.refreshNow()
                 let message = "State refresh completed via AX fallback poller."
                 return toolTextResult(text: message, structured: .object([
                     "operation": .string("system.refresh_cache"),
-                    "refreshed": .bool(true),
+                    "refreshed": .bool(advanced),
                     "source": .string("ax_fallback_poller"),
                     "message": .string(message),
                 ]))
@@ -472,7 +480,10 @@ struct SystemDispatcher: OperationTraceDispatching {
             return toolTextResult(text: message, structured: .object([
                 "operation": .string("system.refresh_cache"),
                 "refreshed": .bool(false),
-                "source": .string("next_poll_cycle"),
+                // Not "next_poll_cycle": no poller is attached, so this call never started — and
+                // never scheduled — a future poll cycle. Naming one it did not start would be a
+                // claim about a mechanism that is not wired up (#544 review MINOR).
+                "source": .string("none"),
                 "message": .string(message),
             ]))
 
@@ -1139,6 +1150,20 @@ struct SystemDispatcher: OperationTraceDispatching {
 
         default:
             return unknownCommandResult(command)
+        }
+    }
+
+    /// Maps the MEASURED tri-state permission aggregate (`PermissionStatus.aggregateState`,
+    /// #544 review MAJOR) to the `all_granted` JSON value the `permissions` command emits:
+    /// `.bool(false)` only when something was ACTIVELY DENIED, `.null` when nothing was denied
+    /// but something is undetermined (never conflated with a denial), `.bool(true)` only when
+    /// every check came back granted. Pure and stateless so the mapping — not just the
+    /// underlying tri-state — can be pinned by a test without driving `handle` against live TCC.
+    static func allGrantedValue(for status: PermissionChecker.PermissionStatus) -> Value {
+        switch status.aggregateState {
+        case .granted: return .bool(true)
+        case .notGranted: return .bool(false)
+        case .notVerifiable: return .null
         }
     }
 

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -136,7 +136,16 @@ actor StatePoller {
 
     // MARK: - Poll loop
 
-    func refreshNow() async {
+    /// Runs one poll cycle and reports whether the cache actually advanced —
+    /// i.e. at least one section was written and `postPoll` fired for it — not
+    /// merely whether this function returned. A poll that finds no visible
+    /// window (below the miss threshold) or that backs off under an occluding
+    /// dialog writes nothing and returns `false`; every caller that needs to
+    /// know "did state move" (not "did I call refreshNow") must read this
+    /// return value rather than assume a completed call means a write landed
+    /// (#544 review).
+    @discardableResult
+    func refreshNow() async -> Bool {
         await pollOnce(axChannel: axChannel, cache: cache)
     }
 
@@ -159,7 +168,20 @@ actor StatePoller {
         Log.info("AX Supplementary Poller loop exited", subsystem: "poller")
     }
 
-    private func pollOnce(axChannel: AccessibilityChannel, cache: StateCache) async {
+    /// Emits `postPoll` iff this cycle touched at least one cache section, and
+    /// reports that as the honest "did the cache advance" signal. A poll that
+    /// returns having written nothing (window not visible below threshold,
+    /// backing off under an occluding dialog) must report `false`, not merely
+    /// "the function returned" (#544 review).
+    @discardableResult
+    private func finishPoll(_ cacheKeys: [ResourceCacheKey]) async -> Bool {
+        guard !cacheKeys.isEmpty else { return false }
+        await postPoll(cacheKeys)
+        return true
+    }
+
+    @discardableResult
+    private func pollOnce(axChannel: AccessibilityChannel, cache: StateCache) async -> Bool {
         var cacheKeys: [ResourceCacheKey] = []
         guard runtime.hasVisibleWindow() else {
             // Be conservative: a single missed window check is often a transient
@@ -177,8 +199,7 @@ actor StatePoller {
                 await cache.updateBlockingDialogButtons(nil)
                 cacheKeys.append(.document)
             }
-            if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
-            return
+            return await finishPoll(cacheKeys)
         }
         consecutiveWindowMisses = 0
         // #432: sample the authoritative blocking-dialog signal once per
@@ -239,8 +260,7 @@ actor StatePoller {
                 // do NOT clear hasDocument. fetchedAt timestamps continue
                 // ageing so `cache_age_sec` keeps growing — clients that
                 // treat freshness as a contract still see staleness.
-                if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
-                return
+                return await finishPoll(cacheKeys)
             }
             consecutivePollMisses += 1
             if consecutivePollMisses >= Self.failureThreshold {
@@ -253,8 +273,7 @@ actor StatePoller {
         }
 
         guard hasDocument else {
-            if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
-            return
+            return await finishPoll(cacheKeys)
         }
 
         let transportReady = await poll(
@@ -288,7 +307,7 @@ actor StatePoller {
                 await cache.markMarkersUnreadable()
             }
         }
-        if !cacheKeys.isEmpty { await postPoll(cacheKeys) }
+        return await finishPoll(cacheKeys)
     }
 
     /// 3 consecutive misses (~9s at the 3s poll interval) before declaring

--- a/Sources/LogicProMCP/Utilities/MCPToolContent.swift
+++ b/Sources/LogicProMCP/Utilities/MCPToolContent.swift
@@ -29,6 +29,27 @@ func toolTextResult(_ result: ChannelResult) -> CallTool.Result {
     toolTextResult(result.message, isError: !result.isSuccess)
 }
 
+/// A receipt whose two halves are deliberately different: the text a caller has always read, and the
+/// structured object the declared `outputSchema` requires.
+///
+/// Reaching for this instead of encoding the object as the text matters more than it looks. Several
+/// operations are graded by `SemanticOracleTable` against the exact prose they emit — permissions is
+/// checked line by line, refresh_cache whole-body — so replacing the text with JSON turns a correct
+/// answer RED in qualification while every unit test stays green, because the oracles run against
+/// fixtures rather than the live handler. Keep the text; add the structure beside it.
+func toolTextResult(
+    text: String,
+    structured: Value,
+    isError: Bool = false
+) -> CallTool.Result {
+    let payload: Value? = structured
+    return CallTool.Result(
+        content: [toolTextContent(text)],
+        structuredContent: payload,
+        isError: isError
+    )
+}
+
 func toolStateCResult(
     _ error: HonestContract.FailureError,
     hint: String? = nil,

--- a/Sources/LogicProMCP/Utilities/MCPToolContent.swift
+++ b/Sources/LogicProMCP/Utilities/MCPToolContent.swift
@@ -6,9 +6,21 @@ func toolTextContent(_ text: String) -> Tool.Content {
 }
 
 func toolTextResult(_ text: String, isError: Bool = false) -> CallTool.Result {
-    CallTool.Result(
+    // Every tool here is registered with an `outputSchema`, and MCP requires a response that declares
+    // one to carry matching `structuredContent`. A handler that hands back prose — a permission
+    // summary, "State refresh completed", a failure sentence — produced `nil` here and so violated the
+    // tool's own contract; a schema-enforcing client rejects the call outright (#544, reported against
+    // v3.13.0 with `logic_system.permissions` and `refresh_cache`).
+    //
+    // Prose is therefore carried as an object rather than dropped. The text in `content` stays
+    // byte-identical, and the structured half says what it actually is instead of claiming a shape it
+    // does not have. This is the floor, not the goal: a command whose answer has real fields should
+    // encode those fields, and the two commands in the report now do.
+    let prose: [String: Value] = ["message": .string(text)]
+    let structured: Value? = structuredContentValue(fromToolText: text) ?? .object(prose)
+    return CallTool.Result(
         content: [toolTextContent(text)],
-        structuredContent: structuredContentValue(fromToolText: text),
+        structuredContent: structured,
         isError: isError
     )
 }

--- a/Sources/LogicProMCP/Utilities/PermissionChecker.swift
+++ b/Sources/LogicProMCP/Utilities/PermissionChecker.swift
@@ -132,7 +132,36 @@ enum PermissionChecker {
         // an Apple Events denial — the exact #188 false-green. The production
         // probe is unconditional (System Events is always running), so a denied
         // target is reported truthfully here rather than advertised as ready.
+        //
+        // This is a plain Bool by design for callers that must fail closed on
+        // anything short of a VERIFIED grant (`--check-permissions` exit code,
+        // `SetupDoctor`'s status clamp): it intentionally collapses "actively
+        // denied" and "could not be verified" into the same `false`, because
+        // both mean "do not proceed". `aggregateState` below is for the caller
+        // that must NOT make that collapse.
         var allGranted: Bool { accessibility && automationLogicPro && automationSystemEvents && postEventAccess }
+
+        // The MEASURED tri-state aggregate across all four checks (#544 review
+        // MAJOR): `.notGranted` only when at least one check was ACTIVELY
+        // DENIED by the OS; `.notVerifiable` when nothing was denied but at
+        // least one check could not run (Logic Pro not launched, an osascript
+        // probe timed out); `.granted` only when every check came back
+        // granted. Unlike `allGranted`, this never reports a denial for a
+        // check that simply never ran — an undetermined check is not evidence
+        // of a refusal, and reporting it as one is indistinguishable from a
+        // real "NOT GRANTED" to a caller reading a single flag.
+        //
+        // Pure and stateless over the four already-computed states (no live
+        // TCC call), so the mapping is directly testable via the
+        // `PermissionStatus(accessibilityState:automationState:...)`
+        // initializer without driving `SystemDispatcher.handle` against the
+        // real permission system.
+        var aggregateState: CheckState {
+            let states = [accessibilityState, automationState, systemEventsAutomationState, postEventAccessState]
+            if states.contains(.notGranted) { return .notGranted }
+            if states.contains(.notVerifiable) { return .notVerifiable }
+            return .granted
+        }
 
         var summary: String {
             var lines: [String] = []

--- a/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
@@ -9,8 +9,18 @@ import MCP
 ///
 /// The reporter found two commands. The property is wider than the two: ANY handler that answers with
 /// something other than a JSON object breaks the contract of whichever tool it belongs to, and ten such
-/// sites existed across four dispatchers. These tests lock the property rather than the two instances,
-/// so the next prose return is caught by the suite instead of by a user.
+/// sites existed across four dispatchers.
+///
+/// What this suite does and does NOT lock, stated exactly, because an earlier version of this comment
+/// claimed the whole property and a review had to point out that it did not:
+///
+/// - LOCKED: the `toolTextResult` floor. Delete it and permissions, refresh_cache, help and
+///   is_running go back to nil `structuredContent`, and the sweep goes red.
+/// - LOCKED: a new tool that builds a `CallTool.Result` without `structuredContent` at all.
+/// - NOT LOCKED: the next handler that answers in prose. The floor wraps it as `{"message": …}`, which
+///   satisfies "structuredContent is not nil", so the sweep stays green. Prose is legal now — it is
+///   schema-conformant and the client no longer refuses it — but a command whose answer has real fields
+///   should still encode them, and nothing here forces that.
 @Suite("Issue #544 — a declared outputSchema is always honoured")
 struct Issue544OutputSchemaContractTests {
 

--- a/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
@@ -114,4 +114,211 @@ struct Issue544OutputSchemaContractTests {
         }
         #expect(permFields["accessibility"] != nil)
     }
+
+    // MARK: - #544 review MAJOR — `all_granted` must not conflate "undetermined"
+    // with "denied". `allGrantedValue(for:)` is the pure mapping the dispatcher's
+    // `permissions` case delegates to; it is tested here directly (data in,
+    // `Value` out) without driving `handle` against live TCC.
+
+    @Test("all_granted is true only when every check is granted")
+    func allGrantedValueIsTrueWhenEveryCheckIsGranted() {
+        let status = PermissionChecker.PermissionStatus(
+            accessibilityState: .granted,
+            automationState: .granted,
+            systemEventsAutomationState: .granted,
+            postEventAccessState: .granted
+        )
+        #expect(SystemDispatcher.allGrantedValue(for: status) == .bool(true))
+    }
+
+    @Test("all_granted is null, not false, when nothing is denied but something is undetermined")
+    func allGrantedValueIsNullNotFalseForUndetermined() {
+        // Exact reproduction from the review: Automation (Logic Pro) granted,
+        // Automation (System Events) not verifiable. Mutation target: change
+        // `Self.allGrantedValue` back to
+        // `status.automationState == .notVerifiable ? .null : .bool(status.allGranted)`
+        // and this goes RED because it evaluates to `.bool(false)`.
+        let status = PermissionChecker.PermissionStatus(
+            accessibilityState: .granted,
+            automationState: .granted,
+            systemEventsAutomationState: .notVerifiable,
+            postEventAccessState: .granted
+        )
+        #expect(SystemDispatcher.allGrantedValue(for: status) == .null)
+    }
+
+    @Test("all_granted is false when something is actually denied, even alongside an undetermined check")
+    func allGrantedValueIsFalseWhenSomethingIsDeniedEvenNextToUndetermined() {
+        // The other direction: a MEASURED denial must still surface as
+        // `.bool(false)`, not soften to `.null` just because a sibling check
+        // is undetermined. Mutation target: make the mapping check
+        // `.notVerifiable` membership before `.notGranted` membership (as
+        // `PermissionStatus.aggregateState` deliberately does NOT) and this
+        // goes RED because it would report `.null` instead of `.bool(false)`.
+        let status = PermissionChecker.PermissionStatus(
+            accessibilityState: .notGranted,
+            automationState: .notVerifiable,
+            systemEventsAutomationState: .granted,
+            postEventAccessState: .granted
+        )
+        #expect(SystemDispatcher.allGrantedValue(for: status) == .bool(false))
+    }
+
+    // MARK: - #544 review MAJOR — `refreshed` must reflect whether the cache
+    // actually advanced, not whether `StatePoller.refreshNow()` merely returned.
+
+    @Test("refresh_cache reports refreshed:false when the attached poller writes nothing")
+    func refreshCacheReportsFalseWhenPollerWritesNothing() async throws {
+        // Exact reproduction from the review: a StatePoller whose
+        // Runtime.hasVisibleWindow reports no window, called once against a
+        // fresh (zero-miss) poller. Production always supplies a poller, so
+        // pre-fix this branch unconditionally claimed `refreshed: true`.
+        let cache = StateCache()
+        let channel = AccessibilityChannel(runtime: .init(
+            isTrusted: { true }, isLogicProRunning: { true }, appRoot: { nil },
+            transportState: { .success("{}") }, toggleTransportButton: { _ in .success("{}") },
+            setTempo: { _ in .success("{}") }, setCycleRange: { _ in .success("{}") },
+            tracks: { .error("no window") }, selectedTrack: { .success("{}") },
+            selectTrack: { _ in .success("{}") }, setTrackToggle: { _, _ in .success("{}") },
+            renameTrack: { _ in .success("{}") }, mixerState: { .success("[]") },
+            channelStrip: { _ in .success("{}") }, setMixerValue: { _, _ in .success("{}") },
+            projectInfo: { .error("no window") }, markers: { .success("[]") }
+        ))
+        let poller = StatePoller(
+            axChannel: channel, cache: cache,
+            runtime: .init(hasVisibleWindow: { false })
+        )
+
+        let result = await SystemDispatcher.handle(
+            command: "refresh_cache", params: [:],
+            router: ChannelRouter(), cache: cache, poller: poller
+        )
+
+        // The graded prose is untouched regardless of the outcome.
+        guard case .text(let text, _, _) = try #require(result.content.first) else {
+            Issue.record("expected text content"); return
+        }
+        #expect(text == "State refresh completed via AX fallback poller.")
+        guard case .object(let fields) = try #require(result.structuredContent) else {
+            Issue.record("expected an object"); return
+        }
+        #expect(fields["refreshed"] == Value.bool(false))
+        #expect(fields["source"] == Value.string("ax_fallback_poller"))
+    }
+
+    @Test("refresh_cache reports refreshed:true when the attached poller writes fresh state")
+    func refreshCacheReportsTrueWhenPollerWritesFreshState() async throws {
+        let cache = StateCache()
+        let channel = AccessibilityChannel(runtime: .init(
+            isTrusted: { true }, isLogicProRunning: { true }, appRoot: { nil },
+            transportState: { .success("{}") }, toggleTransportButton: { _ in .success("{}") },
+            setTempo: { _ in .success("{}") }, setCycleRange: { _ in .success("{}") },
+            tracks: { .success("[]") }, selectedTrack: { .success("{}") },
+            selectTrack: { _ in .success("{}") }, setTrackToggle: { _, _ in .success("{}") },
+            renameTrack: { _ in .success("{}") }, mixerState: { .success("[]") },
+            channelStrip: { _ in .success("{}") }, setMixerValue: { _, _ in .success("{}") },
+            projectInfo: {
+                .success(#"{"name":"Fresh","sampleRate":48000,"bitDepth":24,"tempo":120,"timeSignature":"4/4","trackCount":0,"filePath":null,"lastUpdated":"2026-04-16T00:00:00Z"}"#)
+            },
+            markers: { .success("[]") }
+        ))
+        let poller = StatePoller(
+            axChannel: channel, cache: cache,
+            runtime: .init(hasVisibleWindow: { true })
+        )
+
+        let result = await SystemDispatcher.handle(
+            command: "refresh_cache", params: [:],
+            router: ChannelRouter(), cache: cache, poller: poller
+        )
+
+        guard case .object(let fields) = try #require(result.structuredContent) else {
+            Issue.record("expected an object"); return
+        }
+        #expect(fields["refreshed"] == Value.bool(true))
+        #expect(await cache.getProject().name == "Fresh")
+    }
+
+    @Test("refresh_cache without an attached poller names no mechanism it did not start")
+    func refreshCacheWithoutPollerNamesNoUnstartedCycle() async throws {
+        // #544 review MINOR: `source: "next_poll_cycle"` named a poll cycle
+        // this call never started (no poller is even attached). Mutation
+        // target: revert `source` to `.string("next_poll_cycle")` and this
+        // goes RED.
+        let result = await SystemDispatcher.handle(
+            command: "refresh_cache", params: [:],
+            router: ChannelRouter(), cache: StateCache()
+        )
+        guard case .object(let fields) = try #require(result.structuredContent) else {
+            Issue.record("expected an object"); return
+        }
+        #expect(fields["refreshed"] == Value.bool(false))
+        #expect(fields["source"] == Value.string("none"))
+    }
+
+    // MARK: - #544 review MAJOR — the registry-shape test cannot fail a tool
+    // that ANSWERS with prose. This exercises every command of every
+    // outputSchema-declaring tool through the REAL dispatch path
+    // (`LogicProServer.makeHandlers`, the same route `tools/call` uses) and
+    // asserts `structuredContent != nil` on every response — not just that
+    // the tool's static schema declares an object type.
+
+    /// Commands excluded from the blind sweep, with the reason each one
+    /// cannot be safely invoked with empty params in a unit test — not
+    /// silently skipped. `logic_project.launch` is the only one: unlike
+    /// every other mutating command, it does not route through the
+    /// (unregistered-in-this-harness) `ChannelRouter` and carries no
+    /// confirmation/consent gate, so with empty params it drives
+    /// `ProcessUtils.isLogicProRunning` + a REAL `osascript activate` against
+    /// the host machine's Logic Pro installation if one is present.
+    private static let structuredContentSweepExclusions: [String: Set<String>] = [
+        "logic_project": ["launch"],
+    ]
+
+    @Test("every command of every outputSchema-declaring tool answers with structuredContent")
+    func everyCommandOfEveryOutputSchemaToolAnswersWithStructuredContent() async throws {
+        // PRD-011: contain `export_support_bundle`'s empty-params default
+        // write under a temp root instead of the real
+        // ~/Library/Logs/LogicProMCP so this sweep cannot leave files on the
+        // host machine.
+        let rootKey = "LOGIC_MCP_SUPPORT_BUNDLE_ROOT_OVERRIDE"
+        let previousRoot = getenv(rootKey).map { String(cString: $0) }
+        setenv(rootKey, FileManager.default.temporaryDirectory.path, 1)
+        defer {
+            if let previousRoot { setenv(rootKey, previousRoot, 1) } else { unsetenv(rootKey) }
+        }
+
+        let server = LogicProServer()
+        let handlers = await server.makeHandlers()
+        var invoked = 0
+        var listedExceptions = 0
+
+        for tool in ServerCatalog.tools {
+            guard let toolID = ToolID(rawValue: tool.name) else {
+                Issue.record("\(tool.name) has no matching ToolID"); continue
+            }
+            let commands = OperationRegistry.commands(for: toolID)
+            #expect(!commands.isEmpty, "\(tool.name) has no registered commands to sweep")
+            let exclusions = Self.structuredContentSweepExclusions[tool.name] ?? []
+            for command in commands {
+                if exclusions.contains(command) {
+                    listedExceptions += 1
+                    continue
+                }
+                let result = await handlers.callTool(
+                    CallTool.Parameters(name: tool.name, arguments: ["command": .string(command)])
+                )
+                #expect(
+                    result.structuredContent != nil,
+                    "\(tool.name).\(command) answered without structuredContent"
+                )
+                invoked += 1
+            }
+        }
+
+        // Prove the sweep actually exercised commands rather than iterating
+        // an empty registry view.
+        #expect(invoked > 50)
+        #expect(listedExceptions == 1)
+    }
 }

--- a/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+import MCP
+@testable import LogicProMCP
+
+/// #544, reported externally against v3.13.0: `logic_system.permissions` and `refresh_cache` returned
+/// prose under a tool registered with an `outputSchema`, so `structuredContent` came back nil and a
+/// schema-enforcing client refused the call with `MCP error -32600`.
+///
+/// The reporter found two commands. The property is wider than the two: ANY handler that answers with
+/// something other than a JSON object breaks the contract of whichever tool it belongs to, and ten such
+/// sites existed across four dispatchers. These tests lock the property rather than the two instances,
+/// so the next prose return is caught by the suite instead of by a user.
+@Suite("Issue #544 — a declared outputSchema is always honoured")
+struct Issue544OutputSchemaContractTests {
+
+    @Test("prose that is not a JSON object still yields structured content")
+    func proseStillCarriesStructuredContent() throws {
+        let result = toolTextResult("State refresh completed via AX fallback poller.")
+
+        // Mutation: drop the `?? .object(prose)` fallback in `toolTextResult` and this is nil again.
+        let structured = try #require(result.structuredContent)
+        guard case .object(let fields) = structured else {
+            Issue.record("structuredContent must be an object, got \(structured)")
+            return
+        }
+        #expect(fields["message"] == .string("State refresh completed via AX fallback poller."))
+
+        // The text half must be untouched: a client reading `content[0].text` sees exactly what it saw
+        // before, so the fix cannot have changed what any existing caller reads.
+        guard case .text(let text, _, _) = try #require(result.content.first) else {
+            Issue.record("expected a text content block")
+            return
+        }
+        #expect(text == "State refresh completed via AX fallback poller.")
+    }
+
+    @Test("a JSON object answer is passed through unwrapped, not nested under message")
+    func jsonAnswersAreNotDoubleWrapped() throws {
+        let result = toolTextResult(#"{"operation":"system.health","ok":true}"#)
+        let structured = try #require(result.structuredContent)
+        guard case .object(let fields) = structured else {
+            Issue.record("expected an object")
+            return
+        }
+        #expect(fields["operation"] == .string("system.health"))
+        #expect(fields["message"] == nil)
+    }
+
+    @Test("every tool registered with an outputSchema declares an object schema")
+    func everyRegisteredToolDeclaresAnObjectSchema() throws {
+        // The registration list is the thing that creates the obligation, so the test reads it rather
+        // than restating a list someone has to remember to extend.
+        for tool in ServerCatalog.tools {
+            let schema = try #require(tool.outputSchema, "\(tool.name) must declare an outputSchema")
+            guard case .object(let fields) = schema else {
+                Issue.record("\(tool.name) outputSchema is not an object")
+                continue
+            }
+            #expect(fields["type"] == Value.string("object"))
+        }
+    }
+
+    @Test("an error receipt built from prose is structured too")
+    func errorProseIsStructured() throws {
+        let result = toolTextResult("Failed to open the project.", isError: true)
+        let structured = try #require(result.structuredContent)
+        guard case .object(let fields) = structured else {
+            Issue.record("expected an object")
+            return
+        }
+        #expect(fields["message"] == .string("Failed to open the project."))
+        #expect(try #require(result.isError))
+    }
+}

--- a/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
+++ b/Tests/LogicProMCPTests/Issue544OutputSchemaContractTests.swift
@@ -72,4 +72,46 @@ struct Issue544OutputSchemaContractTests {
         #expect(fields["message"] == .string("Failed to open the project."))
         #expect(try #require(result.isError))
     }
+
+    @Test("the two reported commands keep the exact text their semantic oracle grades")
+    func structuredAnswersDoNotDisturbTheGradedText() async throws {
+        // The first attempt at #544 encoded the new objects AS the text. Every unit test stayed green and
+        // the live gate passed, because `SemanticOracleTable` grades these operations against fixtures
+        // rather than the live handler — so a correct answer would only have turned RED later, in
+        // qualification. The text and the structure are now separate halves on purpose, and this test is
+        // the thing that notices if they are ever merged again.
+        let refresh = await SystemDispatcher.handle(
+            command: "refresh_cache", params: [:],
+            router: ChannelRouter(), cache: StateCache()
+        )
+        guard case .text(let refreshText, _, _) = try #require(refresh.content.first) else {
+            Issue.record("expected text content"); return
+        }
+        #expect(refreshText == "State refresh triggered. Cache will be updated on next poll cycle.")
+        #expect(try #require(SemanticOracleTable.systemRefreshCache.evaluate(
+            responseData: Data(refreshText.utf8), readbackData: Data("{}".utf8)
+        )))
+
+        // ...and the structured half is still there, which is the whole point of the change.
+        guard case .object(let refreshFields) = try #require(refresh.structuredContent) else {
+            Issue.record("expected an object"); return
+        }
+        #expect(refreshFields["refreshed"] == Value.bool(false))
+
+        let perms = await SystemDispatcher.handle(
+            command: "permissions", params: [:],
+            router: ChannelRouter(), cache: StateCache()
+        )
+        guard case .text(let permText, _, _) = try #require(perms.content.first) else {
+            Issue.record("expected text content"); return
+        }
+        #expect(permText.hasPrefix("Accessibility: "))
+        #expect(try #require(SemanticOracleTable.systemPermissions.evaluate(
+            responseData: Data(permText.utf8), readbackData: Data("{}".utf8)
+        )))
+        guard case .object(let permFields) = try #require(perms.structuredContent) else {
+            Issue.record("expected an object"); return
+        }
+        #expect(permFields["accessibility"] != nil)
+    }
 }

--- a/Tests/LogicProMCPTests/PermissionCheckerTests.swift
+++ b/Tests/LogicProMCPTests/PermissionCheckerTests.swift
@@ -121,6 +121,80 @@ private final class PermissionRuntimeHarness: @unchecked Sendable {
     #expect(status.summary.contains("NOT VERIFIABLE"))
 }
 
+// MARK: - #544 review MAJOR — `aggregateState` must not conflate "undetermined"
+// with "denied". `PermissionStatus.allGranted` is a plain Bool that
+// intentionally collapses both into `false` for fail-closed callers
+// (`--check-permissions`, `SetupDoctor`); `aggregateState` is the tri-state a
+// caller that must NOT make that collapse (the `system.permissions` JSON
+// field) reads instead. All constructed directly via the existing
+// state-based `PermissionStatus` initializer — no live TCC call, no seam
+// needed, so the mapping is pinned as pure data-in/data-out.
+
+@Test func testAggregateStateIsGrantedOnlyWhenEveryCheckIsGranted() {
+    let status = PermissionChecker.PermissionStatus(
+        accessibilityState: .granted,
+        automationState: .granted,
+        systemEventsAutomationState: .granted,
+        postEventAccessState: .granted
+    )
+    #expect(status.aggregateState == .granted)
+}
+
+@Test func testAggregateStateReportsNotVerifiableWhenNothingIsDeniedButSomethingIsUndetermined() {
+    // Exact reproduction from the #544 adversarial review: Logic Pro
+    // automation is granted, but the SEPARATE System Events automation
+    // target could not be verified (e.g. an osascript timeout). Pre-fix,
+    // `SystemDispatcher` only special-cased `automationState == .notVerifiable`,
+    // so this exact combination fell through to `.bool(status.allGranted)` ==
+    // `.bool(false)` — indistinguishable from a real denial.
+    let status = PermissionChecker.PermissionStatus(
+        accessibilityState: .granted,
+        automationState: .granted,
+        systemEventsAutomationState: .notVerifiable,
+        postEventAccessState: .granted
+    )
+    #expect(status.aggregateState == .notVerifiable)
+}
+
+@Test func testAggregateStateReportsNotVerifiableWhenLogicProAutomationItselfIsUndetermined() {
+    // The ORIGINAL pre-fix special case (Logic Pro not running) must still
+    // resolve to undetermined, not a denial — this direction must not
+    // regress while fixing the MAJOR above.
+    let status = PermissionChecker.PermissionStatus(
+        accessibilityState: .granted,
+        automationState: .notVerifiable,
+        systemEventsAutomationState: .granted,
+        postEventAccessState: .granted
+    )
+    #expect(status.aggregateState == .notVerifiable)
+}
+
+@Test func testAggregateStateReportsNotGrantedWhenAnythingIsMeasuredDenied() {
+    // A REAL denial must still win over "granted" — the fix must not soften
+    // `aggregateState` into optimism. Accessibility denied, everything else
+    // granted.
+    let status = PermissionChecker.PermissionStatus(
+        accessibilityState: .notGranted,
+        automationState: .granted,
+        systemEventsAutomationState: .granted,
+        postEventAccessState: .granted
+    )
+    #expect(status.aggregateState == .notGranted)
+}
+
+@Test func testAggregateStatePrefersDeniedOverUndeterminedWhenBothArePresent() {
+    // A measured denial must win over an undetermined sibling, not average
+    // out to "undetermined" — a real refusal is never softened by an
+    // unrelated check that simply never ran.
+    let status = PermissionChecker.PermissionStatus(
+        accessibilityState: .notGranted,
+        automationState: .notVerifiable,
+        systemEventsAutomationState: .granted,
+        postEventAccessState: .granted
+    )
+    #expect(status.aggregateState == .notGranted)
+}
+
 @Test(processInspectionUnavailableInSandbox)
 func testPermissionCheckerProductionWrapperFunctionsReturnStatuses() {
     // The Bool returns are environment-dependent (real TCC state), so no value

--- a/Tests/LogicProMCPTests/StatePollerOcclusionTests.swift
+++ b/Tests/LogicProMCPTests/StatePollerOcclusionTests.swift
@@ -103,11 +103,18 @@ private func seedCache(_ cache: StateCache) async {
 
     // Single occluded poll is enough to flip the flag — clients should not
     // have to wait for a threshold to learn that data is stale-by-occlusion.
-    await poller.refreshNow()
+    let advanced = await poller.refreshNow()
     #expect(await cache.getAXOccluded())
     // hasDocument intentionally stays true so reads do not 4xx; staleness
     // is signalled via axOccluded + the existing cache_age_sec field.
     #expect(await cache.getHasDocument())
+    // #544 review MAJOR: the occluded early-out preserves the cache and
+    // writes NO `ResourceCacheKey` (project/tracks both failed, and the
+    // occlusion branch appends nothing to `cacheKeys`), so `refreshNow()`
+    // must report `false` here even though `axOccluded` flipped — the
+    // occlusion flag lives outside the versioned cache sections `refreshed`
+    // is answering for.
+    #expect(!advanced)
 }
 
 @Test func testPollerClearsOccludedFlagWhenAXRecovers() async {
@@ -241,14 +248,20 @@ private func seedCache(_ cache: StateCache) async {
         )
     )
 
-    await poller.refreshNow()
-    await poller.refreshNow()
+    let firstMiss = await poller.refreshNow()
+    let secondMiss = await poller.refreshNow()
     #expect(await cache.getHasDocument(),
             "first 2 misses must not clear (existing failureThreshold=3 contract)")
 
-    await poller.refreshNow()
+    let thirdMiss = await poller.refreshNow()
     #expect(!(await cache.getHasDocument()),
             "3rd consecutive miss without occlusion must clear, as before")
     #expect(!(await cache.getAXOccluded()),
             "axOccluded must be false when document is genuinely closed")
+    // #544 review MAJOR: the first 2 misses write nothing (no ResourceCacheKey
+    // section changed) and must report `false`; only the 3rd, which actually
+    // flips `hasDocument` to false, may report `true`.
+    #expect(!firstMiss)
+    #expect(!secondMiss)
+    #expect(thirdMiss)
 }

--- a/Tests/LogicProMCPTests/StatePollerTests.swift
+++ b/Tests/LogicProMCPTests/StatePollerTests.swift
@@ -297,11 +297,79 @@ private func makeStatePollerAccessibilityRuntime(
     // Post-hardening: a single missed window check no longer clears state —
     // 3 consecutive misses are required so transient AX glitches don't make
     // resource reads flap "no document open" during normal Logic UI motion.
-    await poller.refreshNow()
-    await poller.refreshNow()
+    let firstMiss = await poller.refreshNow()
+    let secondMiss = await poller.refreshNow()
     #expect(await cache.getHasDocument()) // still trusts cache after 2 misses
-    await poller.refreshNow()
+    let thirdMiss = await poller.refreshNow()
     #expect(!(await cache.getHasDocument())) // 3rd miss clears
+
+    // #544 review MAJOR: `refreshNow()` must report whether the cache
+    // actually advanced, not merely that the call returned. The first two
+    // misses write nothing (below `failureThreshold`) and must report
+    // `false`; only the 3rd call, which actually flips `hasDocument`, may
+    // report `true`.
+    #expect(!firstMiss)
+    #expect(!secondMiss)
+    #expect(thirdMiss)
+}
+
+/// #544 review MAJOR — exact reproduction from the adversarial review: a
+/// `StatePoller` whose `Runtime.hasVisibleWindow` reports no window, called
+/// ONCE with a fresh (zero-miss) poller. Pre-fix, `SystemDispatcher`
+/// unconditionally reported `refreshed: true` for any call that reached this
+/// point because `refreshNow()` returned `Void` — a completed call was
+/// (wrongly) treated as evidence of a write. This pins the poller-level fix:
+/// a single below-threshold miss writes nothing to the cache and must report
+/// `false`.
+@Test func testStatePollerRefreshNowReportsFalseForSingleBelowThresholdMiss() async {
+    final class WindowCheckCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var calls = 0
+        func hit() -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            calls += 1
+            return false
+        }
+    }
+    let counter = WindowCheckCounter()
+    let cache = StateCache()
+    let channel = AccessibilityChannel(
+        runtime: makeStatePollerAccessibilityRuntime(projectInfoResult: .error("unavailable"))
+    )
+    let poller = StatePoller(
+        axChannel: channel,
+        cache: cache,
+        runtime: .init(hasVisibleWindow: { counter.hit() })
+    )
+
+    let advanced = await poller.refreshNow()
+
+    // Prove the fixture seam actually fired before trusting its result.
+    #expect(counter.calls == 1)
+    #expect(!advanced)
+}
+
+/// #544 review MAJOR — the positive case: a poll that actually reads and
+/// caches fresh state must report `true`. Complements the false-path tests
+/// above so the return value is pinned in both directions, not just the one
+/// the report reproduced.
+@Test func testStatePollerRefreshNowReportsTrueWhenItWritesFreshState() async {
+    let cache = StateCache()
+    let channel = AccessibilityChannel(
+        runtime: makeStatePollerAccessibilityRuntime(
+            projectInfoResult: .success(#"{"name":"Fresh","sampleRate":48000,"bitDepth":24,"tempo":120,"timeSignature":"4/4","trackCount":1,"filePath":null,"lastUpdated":"2026-04-16T00:00:00Z"}"#)
+        )
+    )
+    let poller = StatePoller(
+        axChannel: channel,
+        cache: cache,
+        runtime: .init(hasVisibleWindow: { true })
+    )
+
+    let advanced = await poller.refreshNow()
+
+    #expect(advanced)
+    #expect(await cache.getProject().name == "Fresh")
 }
 
 @Test func testStatePollerPopulatesMarkerCache() async {


### PR DESCRIPTION
Closes #544. Reported externally against v3.13.0 by @edgarperatla-create, who traced it to the exact line.

`logic_system.permissions` and `refresh_cache` returned prose under a tool registered with
`genericObjectOutputSchema()`, so `structuredContent` came back nil and a schema-enforcing client refused
the call with `MCP error -32600`.

**The report named two commands; the property covered ten.** The same violation existed in
`SystemDispatcher` (2), `ProjectDispatcher` (4), `TrackDispatcher+RecordSequence` (4) and `EditDispatcher`
(1) — every handler answering with something other than a JSON object breaks the contract of whichever tool
it belongs to. Fixing the two would have left the other eight waiting for the next client strict enough to
notice. So `toolTextResult` carries prose as `{"message": …}` instead of dropping it, and the `content` text
stays byte-identical so nothing an existing caller reads changes.

Compliance is the floor. Both reported commands now encode what they actually know: `permissions` returns
the four TCC states and `all_granted` beside the human summary, and `refresh_cache` distinguishes a refresh
that RAN from one merely queued — a real difference its two prose strings carried, previously recoverable
only by string-matching.

The test reads the tool registration list rather than restating it, so a newly registered tool is covered
without anyone remembering to extend a list.

## Live evidence

Bound to `339f5ec7`, produced by `Scripts/livekit/live_544_output_schema.py` against the release binary over
a real MCP stdio session — the wire is where the reporting client rejected this, so a unit fixture would not
have been the same statement.

```
checks 6/6, every one mutation-demonstrated
captures settled, wholly within one display
visual assertion passed
recording present
```

Three of the checks are worth naming: the two reported commands answer with `structuredContent` where they
returned nil before; a prose ERROR path does too (half the violating sites were failure sentences); and
`health`'s already-valid JSON is passed through **unwrapped** rather than nested under `message` — a fix
that rewrapped correct answers would have broken more than it repaired.

The visual assertion is an absence one: these are read-only system commands, so the track rail must NOT
change while they run.

## Review provenance

Blind adversarial review was run by grok. Implementation was NOT: the first two commits are mine and the
third is a Claude subagent, so the two providers are split for every commit on this branch. An earlier
version of this section claimed otherwise — it was copied from a sibling PR where the overlap was real, and
it was wrong here. The distinction matters because a same-provider review covers false positives but not
false negatives, and saying so when it does not apply cheapens the note where it does.
