### PR TITLE
fix(#523): verify the delete against a surface the table cannot speak for

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -181,13 +181,15 @@ enum AXHelpers {
             raw == AXError.attributeUnsupported.rawValue || raw == AXError.noValue.rawValue
         }
 
-        /// AX can return either of these while Logic is rebuilding an otherwise still-bound
+        /// AX can return any of these while Logic is rebuilding an otherwise still-bound
         /// element tree. A post-write settle poll must discard the entire observation and try a
-        /// fresh one within its existing budget. This deliberately excludes `apiDisabled`: that
-        /// reports a disabled accessibility API, not a short-lived rebuild state, so retrying it
-        /// would only obscure the real failure.
+        /// fresh one within its existing budget. `failure` (-25200) is a failed read, not an
+        /// answer of absence: it retires that poll, not the operation. This deliberately
+        /// excludes `apiDisabled`: that reports a disabled accessibility API, not a short-lived
+        /// rebuild state, so retrying it would only obscure the real failure.
         var isTransientDuringRebuild: Bool {
-            raw == AXError.cannotComplete.rawValue
+            raw == AXError.failure.rawValue
+                || raw == AXError.cannotComplete.rawValue
                 || raw == AXError.invalidUIElement.rawValue
         }
 

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -225,6 +225,19 @@ enum AXLocalePolicy {
         rationale: "Live-confirmed on Logic 12.3: the Marker List toolbar AXMenuButton exposes the exact AXDescription `編集` in Japanese and `편집` in Korean; the bottom AXButton with the same label is deliberately rejected unless its actions advertise AXShowMenu."
     )
 
+    /// The Marker List's own "Number of Items" static text — Logic's independent rendering of
+    /// the marker count, used as a second witness alongside the table's row projections. Only
+    /// the English form has been measured on a live Logic 12.3; no Korean or Japanese variant
+    /// has been read from a live Logic. Do NOT add a translated guess here — an unmeasured
+    /// locale must stay unreadable (State B) rather than silently matching on an invented
+    /// label. Matched against both AXDescription and AXHelp, mirroring the Event List reader's
+    /// `readStaticText(help:)` precedent for the same "Number of Items" node.
+    static let markerListNumberOfItemsLabel = LabelSet(
+        canonical: "Number of Items",
+        variants: [],
+        rationale: "Live-confirmed on Logic 12.3 (English) via AXDescription. Korean/Japanese not yet measured; an unmeasured locale must fail closed rather than match a guessed translation."
+    )
+
     /// The destructive Marker List Edit-menu command. This must always be whole-string matched.
     static let markerListDeleteMenuItem = LabelSet(
         canonical: "Delete",

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
@@ -26,6 +26,7 @@ extension AXLogicProElements {
         case axRows = "ax_rows"
         case structuralChildren = "structural_children"
         case cell = "cell"
+        case itemCount = "item_count"
         case settleLoop = "settle_loop"
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -111,6 +111,10 @@ extension AccessibilityChannel {
             "prewrite_marker_identities": prewriteMarkerIdentities,
             "marker_count_before": before.count,
         ]
+        let prewriteItemCount = readMarkerListItemCount(in: window, runtime: runtime.ax)
+        addMarkerDeleteItemCountObservation(
+            prewriteItemCount, phase: .before, to: &extras
+        )
 
         guard let selection = selectMarkerRowForDeletion(
             targetRow, in: inventory.table, runtime: runtime.ax
@@ -242,7 +246,11 @@ extension AccessibilityChannel {
         // there. So require two consecutive identical readings before believing either of them, and
         // report State B when they will not settle rather than certifying a guess.
         var settledReadback: MarkerDeleteSettledReadback?
-        var previousObservation: (inventory: MarkerDeleteInventoryReadback, targetRowStillSelected: Bool)?
+        var previousObservation: (
+            inventory: MarkerDeleteInventoryReadback,
+            targetRowStillSelected: Bool,
+            itemCount: MarkerListItemCountRead
+        )?
         // Keep the inventory's settled ambiguity distinct from a failed selected-row read. The
         // latter prevents State A, but does not make two agreeing, readable inventories
         // unreadable. If those inventories already establish that a duplicate-position target
@@ -255,10 +263,10 @@ extension AccessibilityChannel {
         // if it is still the final poll when the existing budget expires, State B reports that
         // exact site and status without re-resolving the already-bound table.
         var finalTransientReadbackFailure: AXLogicProElements.MarkerListReadFailure?
-        // AXRows and AXChildren are both projections of the same table and can omit the same row
-        // during one rebuild. The table's selected-row relation is a separate observed effect of
-        // the exact target we selected for the menu actuator. A failure to read it retires this
-        // whole poll; it never becomes an answer that the target left the selection.
+        // AXRows, AXChildren, and AXSelectedRows are all projections of the same table and can
+        // omit the same pre-write row during one rebuild. A failure to read the selection retires
+        // this whole poll; it never becomes an answer that the target left the selection. Absence
+        // of that pre-write element from AXSelectedRows is not independent deletion evidence.
         var finalTargetSelectionReadbackFailure: AXHelpers.AXStatusError?
         for _ in 0..<6 {
             let reading: [MarkerState]
@@ -321,16 +329,48 @@ extension AccessibilityChannel {
                 continue
             }
 
+            let itemCountRead = readMarkerListItemCount(in: window, runtime: runtime.ax)
+            if case .unreadable(let error) = itemCountRead, error.isTransientDuringRebuild {
+                // Same rule as the inventory: a failed Number of Items read voids this poll,
+                // not the already-issued delete.
+                finalTransientReadbackFailure = AXLogicProElements.MarkerListReadFailure(
+                    site: .itemCount,
+                    status: error
+                )
+                finalTargetSelectionReadbackFailure = nil
+                previousObservation = nil
+                previousInventoryReadback = nil
+                settledAmbiguousInventory = nil
+                mouse.sleepMicros(250_000)
+                continue
+            }
+            if case .unreadable(let error) = itemCountRead {
+                extras["readback_settled"] = false
+                extras["readback_unreadable"] = true
+                extras["item_count_witness_state"] = itemCountRead.witnessState
+                extras["readback_failure_site"] = AXLogicProElements.MarkerListReadFailureSite
+                    .itemCount.rawValue
+                extras["readback_ax_status"] = Int(error.raw)
+                if let symbolicName = error.symbolicName {
+                    extras["readback_ax_status_name"] = symbolicName
+                }
+                extras["reason_detail"] = itemCountRead.refusalDetail
+                return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+            }
+            finalTransientReadbackFailure = nil
+
             if let previousObservation,
                previousObservation.inventory.survivorPositions == inventoryReadback.survivorPositions,
-               previousObservation.targetRowStillSelected == targetRowStillSelected {
+               previousObservation.targetRowStillSelected == targetRowStillSelected,
+               previousObservation.itemCount.agrees(with: itemCountRead) {
                 settledReadback = MarkerDeleteSettledReadback(
                     inventory: inventoryReadback,
-                    targetRowStillSelected: targetRowStillSelected
+                    targetRowStillSelected: targetRowStillSelected,
+                    itemCount: itemCountRead
                 )
                 break
             }
-            previousObservation = (inventoryReadback, targetRowStillSelected)
+            previousObservation = (inventoryReadback, targetRowStillSelected, itemCountRead)
             mouse.sleepMicros(250_000)
         }
         let settleOutcome: MarkerDeleteSettleOutcome
@@ -432,16 +472,13 @@ extension AccessibilityChannel {
         }
 
         // A surviving target selection is a direct observed no-op, even if AXRows and AXChildren
-        // happened to agree on an omitted row. The two table projections are corroboration, not
-        // independent effects; never certify the deletion while the exact row selected for Delete
-        // remains selected. This guard follows the two-reading settle so it is based on a complete
-        // agreeing observation rather than one unstable poll.
+        // happened to agree on an omitted row. Never certify the deletion while the exact row
+        // selected for Delete remains selected. This guard follows the two-reading settle so it
+        // is based on a complete agreeing observation rather than one unstable poll.
         guard !observedReadback.targetRowStillSelected else {
             extras["reason_detail"] = "The exact target row remained selected after the Delete pick, so the settled row omission is not sufficient evidence of deletion."
             return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
         }
-        // Bind the request-derived position-multiset expectation to the independently read-back
-        // position multiset in State A. Names are not exposed here because Logic may renumber them.
         extras["expected_survivor_position_multiset"] = expectedSurvivorPositions.joined()
         extras["observed_survivor_position_multiset"] = observedReadback.inventory.survivorPositions.joined()
         guard prewritePositionEvidenceCanonical,
@@ -451,6 +488,27 @@ extension AccessibilityChannel {
                 + "least one marker position came from an ordinal parse fallback; synthetic "
                 + "positions cannot support a verified target identity."
             return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        // AXRows, AXChildren, and AXSelectedRows can all omit the pre-write row because the
+        // table rebuilt. Logic's own Number of Items rendering is not a projection of that
+        // table. State A needs both that independently-read count dropping by one and the
+        // settled survivor multiset agreeing; neither witness is enough alone.
+        addMarkerDeleteItemCountObservation(
+            observedReadback.itemCount, phase: .after, to: &extras
+        )
+        guard let observedCountBefore = prewriteItemCount.parsedCount,
+              let observedCountAfter = observedReadback.itemCount.parsedCount else {
+            extras["reason_detail"] = observedReadback.itemCount.parsedCount == nil
+                ? observedReadback.itemCount.refusalDetail
+                : prewriteItemCount.refusalDetail
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
+        }
+        guard observedCountAfter == observedCountBefore - 1 else {
+            extras["reason_detail"] =
+                "The Marker List Number of Items count did not drop by one (observed "
+                + "\(observedCountBefore) → \(observedCountAfter)) while the settled table "
+                + "inventory claimed the target left."
+            return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
         }
         return .success(HonestContract.encodeStateA(extras: extras))
     }
@@ -475,10 +533,237 @@ extension AccessibilityChannel {
         let emptySurvivorSet: Bool
     }
 
-    /// State-A requires both a settled inventory and an agreeing selected-row observation.
+    /// State-A requires a settled inventory, an agreeing selected-row observation, and
+    /// Logic's independently rendered Number of Items count.
     private struct MarkerDeleteSettledReadback {
         let inventory: MarkerDeleteInventoryReadback
         let targetRowStillSelected: Bool
+        let itemCount: MarkerListItemCountRead
+    }
+
+    /// One read of the Marker List window's own Number of Items node.
+    ///
+    /// A parsed integer is the only value that may be published as
+    /// `observed_marker_count_*`. Missing, ambiguous, or unparseable text is an
+    /// unreadable witness, not a count of zero.
+    private enum MarkerListItemCountRead: Equatable {
+        case parsed(Int, raw: String)
+        case unparseable(raw: String)
+        case missing
+        case ambiguous
+        case unreadable(AXHelpers.AXStatusError)
+
+        static let unreadableWitnessDetail =
+            "The Marker List Number of Items count was unreadable as an independent deletion witness."
+
+        var refusalDetail: String {
+            switch self {
+            case .unparseable:
+                return "The Marker List Number of Items count was unreadable: the value could not be parsed."
+            case .missing, .ambiguous, .unreadable, .parsed:
+                return Self.unreadableWitnessDetail
+            }
+        }
+
+        var parsedCount: Int? {
+            if case .parsed(let count, _) = self { return count }
+            return nil
+        }
+
+        var rawText: String? {
+            switch self {
+            case .parsed(_, let raw), .unparseable(let raw):
+                return raw
+            case .missing, .ambiguous, .unreadable:
+                return nil
+            }
+        }
+
+        var witnessState: String {
+            switch self {
+            case .parsed:
+                return "readable"
+            case .unparseable:
+                return "unparseable"
+            case .missing, .ambiguous, .unreadable:
+                return "unreadable"
+            }
+        }
+
+        func agrees(with other: MarkerListItemCountRead) -> Bool {
+            switch (self, other) {
+            case (.parsed(let left, _), .parsed(let right, _)):
+                return left == right
+            case (.unparseable, .unparseable),
+                 (.missing, .missing),
+                 (.ambiguous, .ambiguous):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    private enum MarkerListItemCountPhase {
+        case before
+        case after
+    }
+
+    private static func addMarkerDeleteItemCountObservation(
+        _ observation: MarkerListItemCountRead,
+        phase: MarkerListItemCountPhase,
+        to extras: inout [String: Any]
+    ) {
+        let countKey: String
+        let textKey: String
+        let stateKey: String
+        switch phase {
+        case .before:
+            countKey = "observed_marker_count_before"
+            textKey = "observed_marker_count_text_before"
+            stateKey = "item_count_witness_state_before"
+        case .after:
+            countKey = "observed_marker_count_after"
+            textKey = "observed_marker_count_text_after"
+            stateKey = "item_count_witness_state"
+        }
+        if let count = observation.parsedCount {
+            extras[countKey] = count
+        }
+        if let raw = observation.rawText {
+            extras[textKey] = raw
+        }
+        extras[stateKey] = observation.witnessState
+    }
+
+    /// Reads the Marker List's Number of Items static text by AXDescription, never
+    /// by sibling position. The live node is under an AXGroup described "Marker";
+    /// its value is Logic's own rendering (`"1 Marker"`, `"15 Markers"`).
+    private static func readMarkerListItemCount(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> MarkerListItemCountRead {
+        switch findMarkerListNumberOfItemsNodes(in: window, runtime: runtime) {
+        case .failure(let error):
+            return .unreadable(error)
+        case .success(let nodes) where nodes.isEmpty:
+            return .missing
+        case .success(let nodes) where nodes.count > 1:
+            return .ambiguous
+        case .success(let nodes):
+            let node = nodes[0]
+            switch AXHelpers.getAttributeResult(
+                node, kAXValueAttribute as String, runtime: runtime
+            ) as Result<AnyObject?, AXHelpers.AXStatusError> {
+            case .failure(let error):
+                return .unreadable(error)
+            case .success(let value):
+                let raw: String
+                if let string = value as? String {
+                    raw = string
+                } else if let number = value as? NSNumber {
+                    raw = number.stringValue
+                } else {
+                    return .unparseable(raw: "")
+                }
+                guard let parsed = parseMarkerListItemCount(raw) else {
+                    return .unparseable(raw: raw)
+                }
+                return .parsed(parsed, raw: raw)
+            }
+        }
+    }
+
+    /// Walks the already-bound Marker List window for AXStaticText nodes whose
+    /// AXDescription is exactly `Number of Items`. The table subtree is skipped:
+    /// that count is not a table projection, and descending into AXRows/AXChildren
+    /// would couple the witness to the rebuild failure mode it exists to outvote.
+    /// An unreadable unrelated node is skipped; a completed walk with zero or many
+    /// matches is an unreadable witness, not a sibling-index guess. A walk error
+    /// with no match is a failed read.
+    private static func findMarkerListNumberOfItemsNodes(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        var matches: [AXUIElement] = []
+        var parents = [window]
+        var unreadable: AXHelpers.AXStatusError?
+        for _ in 0..<12 {
+            var next: [AXUIElement] = []
+            for parent in parents {
+                let children: [AXUIElement]
+                switch AXHelpers.childrenResult(parent, runtime: runtime) {
+                case .success(let observedChildren):
+                    children = observedChildren
+                case .failure(let error) where error.isDefinitiveAbsence:
+                    children = []
+                case .failure(let error):
+                    unreadable = unreadable ?? error
+                    children = []
+                }
+                for child in children {
+                    var childRole: String?
+                    switch AXHelpers.getAttributeResult(
+                        child, kAXRoleAttribute as String, runtime: runtime
+                    ) as Result<String?, AXHelpers.AXStatusError> {
+                    case .success(let role):
+                        childRole = role
+                        if role == (kAXStaticTextRole as String) {
+                            switch AXHelpers.getAttributeResult(
+                                child, kAXDescriptionAttribute as String, runtime: runtime
+                            ) as Result<String?, AXHelpers.AXStatusError> {
+                            case .success(let description)
+                                where description == "Number of Items":
+                                matches.append(child)
+                            case .success:
+                                break
+                            case .failure(let error) where error.isDefinitiveAbsence:
+                                break
+                            case .failure(let error):
+                                unreadable = unreadable ?? error
+                            }
+                        }
+                    case .failure(let error) where error.isDefinitiveAbsence:
+                        break
+                    case .failure(let error):
+                        unreadable = unreadable ?? error
+                    }
+                    // The independent count is not inside the Marker Table. Do not
+                    // descend into a projection we already know can omit rows.
+                    if childRole != (kAXTableRole as String) {
+                        next.append(child)
+                    }
+                }
+            }
+            parents = next
+        }
+        if matches.isEmpty, let unreadable {
+            return .failure(unreadable)
+        }
+        return .success(matches)
+    }
+
+    /// Defensive parse of Logic's Number of Items value. Exactly one run of ASCII
+    /// digits is a count; any other rendering is unreadable. A failed parse is
+    /// never published as zero.
+    private static func parseMarkerListItemCount(_ text: String) -> Int? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        var runs: [String] = []
+        var current = ""
+        for character in trimmed {
+            if character.isASCII && character.isNumber {
+                current.append(character)
+            } else if !current.isEmpty {
+                runs.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty {
+            runs.append(current)
+        }
+        guard runs.count == 1, let value = Int(runs[0]) else { return nil }
+        return value
     }
 
     /// The terminal outcome of the fixed six-poll settle budget. Keeping these cases separate

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -111,7 +111,15 @@ extension AccessibilityChannel {
             "prewrite_marker_identities": prewriteMarkerIdentities,
             "marker_count_before": before.count,
         ]
-        let prewriteItemCount = readMarkerListItemCount(in: window, runtime: runtime.ax)
+        // Settle the same way the after-count is settled below: a single unsynced read taken
+        // right after `defaultOpenMarkerList` can catch Logic mid-render. This does not gate
+        // the write — an unreadable or unsettled pre-write witness still lets the operation
+        // proceed, exactly as an unreadable AFTER witness does not retroactively undo an
+        // already-issued Delete. It only changes what gets compared against `before.count`
+        // below, after the write.
+        let prewriteItemCount = settledMarkerListItemCount(
+            in: window, runtime: runtime.ax, mouse: mouse
+        )
         addMarkerDeleteItemCountObservation(
             prewriteItemCount, phase: .before, to: &extras
         )
@@ -503,6 +511,19 @@ extension AccessibilityChannel {
                 : prewriteItemCount.refusalDetail
             return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: extras))
         }
+        // The pre-write witness must corroborate the pre-write TABLE inventory, not merely be
+        // present. Without this, a pre-write count that is already wrong (stale render, wrong
+        // node, a decoy) combines with a rebuild that omits the target from the table's own
+        // projections to certify a delete that never happened: the after-count would still
+        // read exactly one less than the (wrong) before-count.
+        guard observedCountBefore == before.count else {
+            extras["reason_detail"] =
+                "The Marker List Number of Items count before the delete (observed "
+                + "\(observedCountBefore)) did not agree with the pre-write table inventory "
+                + "(\(before.count) markers), so this independent witness cannot corroborate "
+                + "the delete."
+            return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: extras))
+        }
         guard observedCountAfter == observedCountBefore - 1 else {
             extras["reason_detail"] =
                 "The Marker List Number of Items count did not drop by one (observed "
@@ -636,6 +657,30 @@ extension AccessibilityChannel {
         extras[stateKey] = observation.witnessState
     }
 
+    /// Reads the Number of Items witness repeatedly until two consecutive reads agree, or a
+    /// fixed budget is spent — the same settle discipline the post-write loop applies to the
+    /// table inventory, selection, and this same witness. A momentary AX hiccup on ONE read
+    /// must not certify (or falsely poison) a value that a second read would have confirmed
+    /// or corrected. If the budget is spent without two agreeing reads, the LAST reading is
+    /// returned rather than manufacturing a status the AX API never returned; a caller that
+    /// needs the value to be trustworthy still requires `.parsedCount` downstream.
+    private static func settledMarkerListItemCount(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime,
+        mouse: AXMouseHelper.Runtime
+    ) -> MarkerListItemCountRead {
+        var previous: MarkerListItemCountRead?
+        for _ in 0..<6 {
+            let reading = readMarkerListItemCount(in: window, runtime: runtime)
+            if let previous, previous.agrees(with: reading) {
+                return reading
+            }
+            previous = reading
+            mouse.sleepMicros(250_000)
+        }
+        return previous ?? .missing
+    }
+
     /// Reads the Marker List's Number of Items static text by AXDescription, never
     /// by sibling position. The live node is under an AXGroup described "Marker";
     /// its value is Logic's own rendering (`"1 Marker"`, `"15 Markers"`).
@@ -674,13 +719,22 @@ extension AccessibilityChannel {
         }
     }
 
-    /// Walks the already-bound Marker List window for AXStaticText nodes whose
-    /// AXDescription is exactly `Number of Items`. The table subtree is skipped:
-    /// that count is not a table projection, and descending into AXRows/AXChildren
-    /// would couple the witness to the rebuild failure mode it exists to outvote.
-    /// An unreadable unrelated node is skipped; a completed walk with zero or many
-    /// matches is an unreadable witness, not a sibling-index guess. A walk error
-    /// with no match is a failed read.
+    /// Walks the already-bound Marker List window for AXStaticText nodes matching
+    /// `AXLocalePolicy.markerListNumberOfItemsLabel`, by AXDescription OR AXHelp — the same
+    /// two-attribute precedent `EventListReadbackCollector.readStaticText(help:)` uses for its
+    /// own "Number of Items" node. The table, button, and menu-button subtrees are skipped:
+    /// none of them can contain this witness (it sits under an AXGroup), and descending into
+    /// AXRows/AXChildren or the Edit control's own menu-negotiation subtree would couple this
+    /// witness to failure modes it exists to outvote, or to the unrelated menu route's own
+    /// read/retry discipline.
+    ///
+    /// Uniqueness can only be trusted when the entire searched subtree answered. A node that
+    /// will not answer might have been hiding a second "Number of Items" node — one whose
+    /// parent alone refuses to vend AXChildren, for instance — so finding exactly one match
+    /// elsewhere does NOT prove that match is unique. Any unreadable node anywhere in the
+    /// SEARCHED subtree therefore makes the whole search unreadable, regardless of how many
+    /// matches were already collected; only a walk that saw every candidate in scope can call
+    /// a single match unique.
     private static func findMarkerListNumberOfItemsNodes(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -709,18 +763,35 @@ extension AccessibilityChannel {
                     case .success(let role):
                         childRole = role
                         if role == (kAXStaticTextRole as String) {
+                            var matched = false
                             switch AXHelpers.getAttributeResult(
                                 child, kAXDescriptionAttribute as String, runtime: runtime
                             ) as Result<String?, AXHelpers.AXStatusError> {
-                            case .success(let description)
-                                where description == "Number of Items":
-                                matches.append(child)
-                            case .success:
-                                break
+                            case .success(let description):
+                                matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
+                                    description, mode: .exactStrict
+                                )
                             case .failure(let error) where error.isDefinitiveAbsence:
                                 break
                             case .failure(let error):
                                 unreadable = unreadable ?? error
+                            }
+                            if !matched {
+                                switch AXHelpers.getAttributeResult(
+                                    child, kAXHelpAttribute as String, runtime: runtime
+                                ) as Result<String?, AXHelpers.AXStatusError> {
+                                case .success(let help):
+                                    matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
+                                        help, mode: .exactStrict
+                                    )
+                                case .failure(let error) where error.isDefinitiveAbsence:
+                                    break
+                                case .failure(let error):
+                                    unreadable = unreadable ?? error
+                                }
+                            }
+                            if matched {
+                                matches.append(child)
                             }
                         }
                     case .failure(let error) where error.isDefinitiveAbsence:
@@ -728,42 +799,47 @@ extension AccessibilityChannel {
                     case .failure(let error):
                         unreadable = unreadable ?? error
                     }
-                    // The independent count is not inside the Marker Table. Do not
-                    // descend into a projection we already know can omit rows.
-                    if childRole != (kAXTableRole as String) {
+                    // The independent count is not inside the Marker Table, and not inside a
+                    // button or menu button — Logic's own "Number of Items" text sits under an
+                    // AXGroup, never under a control. Do not descend into a projection we
+                    // already know can omit rows, or into the Edit control's OWN subtree: that
+                    // subtree's read health is coupled to the unrelated menu-route negotiation
+                    // (`AXShowMenu`/`AXCancel` observation), which has its own retry discipline
+                    // and must not be able to poison this witness by proxy.
+                    if childRole != (kAXTableRole as String),
+                       childRole != (kAXMenuButtonRole as String),
+                       childRole != (kAXButtonRole as String) {
                         next.append(child)
                     }
                 }
             }
             parents = next
         }
-        if matches.isEmpty, let unreadable {
+        // An unreadable node anywhere in this walk means uniqueness was never established,
+        // even when exactly one match was found: the part of the tree that would not answer
+        // could have been hiding a second candidate. Check this BEFORE looking at `matches`.
+        if let unreadable {
             return .failure(unreadable)
         }
         return .success(matches)
     }
 
-    /// Defensive parse of Logic's Number of Items value. Exactly one run of ASCII
-    /// digits is a count; any other rendering is unreadable. A failed parse is
-    /// never published as zero.
+    /// Defensive parse of Logic's Number of Items value, following the same leading-token rule
+    /// as the Event List reader's `parseCount`: the value must OPEN with an ASCII digit run,
+    /// immediately followed by end-of-string or whitespace, with no further digits anywhere
+    /// after. `runs.count == 1` alone is not that rule — it accepts a single digit run
+    /// ANYWHERE in the string, so a value like `"Marker 2"` (a decoy or a differently-labelled
+    /// sibling) parses as `2` even though its single ASCII run is not the item count. That
+    /// manufactured number can look exactly like a genuine drop while the selection merely
+    /// moved. A failed parse is never published as zero.
     private static func parseMarkerListItemCount(_ text: String) -> Int? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        var runs: [String] = []
-        var current = ""
-        for character in trimmed {
-            if character.isASCII && character.isNumber {
-                current.append(character)
-            } else if !current.isEmpty {
-                runs.append(current)
-                current = ""
-            }
-        }
-        if !current.isEmpty {
-            runs.append(current)
-        }
-        guard runs.count == 1, let value = Int(runs[0]) else { return nil }
-        return value
+        guard let first = trimmed.first, first.isASCII, first.isNumber else { return nil }
+        let leadingDigits = trimmed.prefix { $0.isASCII && $0.isNumber }
+        let rest = trimmed[leadingDigits.endIndex...]
+        guard rest.isEmpty || (rest.first?.isWhitespace ?? false) else { return nil }
+        guard !rest.contains(where: { $0.isASCII && $0.isNumber }) else { return nil }
+        return Int(leadingDigits)
     }
 
     /// The terminal outcome of the fixed six-poll settle budget. Keeping these cases separate
@@ -817,6 +893,14 @@ extension AccessibilityChannel {
            let structuralChildrenCount = failure.structuralChildrenCount {
             extras["readback_ax_rows_count"] = axRowsCount
             extras["readback_structural_children_count"] = structuralChildrenCount
+        }
+        // A persistently-failing item-count witness (e.g. a subtree that never stops
+        // answering -25200) exhausts the settle budget one poll at a time and surfaces here
+        // rather than through the single-read `.unreadable` branch below. Either path is the
+        // same observed fact — this witness could not be read — so both must publish the same
+        // `item_count_witness_state` a caller can check without branching on which site failed.
+        if failure.site == .itemCount {
+            extras["item_count_witness_state"] = "unreadable"
         }
     }
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1602,12 +1602,17 @@ enum SemanticOracleTable {
     // to exclude the target position. It ALSO cross-checks the reported multiset and
     // canonicality flag against the independent `logic://markers` resource read: a
     // self-consistent producer cannot substitute unrelated survivor fields. It also
-    // rejects a claimed target identity that still appears as the same name/index
-    // entry in that independent `data[]` readback. A shared or synthetic target
-    // position is State B: a position occurrence can disappear without identifying
-    // which marker it was.
+    // rejects a claimed target POSITION that still appears in that independent
+    // `data[]` readback. Name+index is not identity: Logic auto-renames generated
+    // markers, so an absent name+index pair is forgeable and an honest delete of
+    // "Marker 1" at index 0 is rejected when a survivor is renamed onto that pair.
+    // A shared or synthetic target position is State B: a position occurrence can
+    // disappear without identifying which marker it was.
     // Marker names remain only State-B diagnostics because Logic can renumber
-    // auto-generated names after deletion.
+    // auto-generated names after deletion. State A also requires Logic's own
+    // Number of Items count, read independently of the table projections, to drop
+    // by exactly one; those observed counts are pinned below so a producer cannot
+    // certify State A without reporting the witness.
     static let navigateDeleteMarker = SafeMutationOracle.oracle(
         .navigateDeleteMarker,
         semantics: [
@@ -1617,17 +1622,17 @@ enum SemanticOracleTable {
             .typedField(key: "target_position", type: .string),
             .lengthPrefixedIdentityAtIndexEquals(entriesKey: "prewrite_marker_identities", indexKey: "requested_index", nameKey: "target_name", positionKey: "target_position"),
             .readbackArrayExcludesResponseIdentity(
-                responseNameKey: "target_name",
-                responseIndexKey: "requested_index",
+                responsePositionKey: "target_position",
                 readbackArrayKey: "data",
-                readbackNameKey: "name",
-                readbackIndexKey: "id"
+                readbackPositionKey: "position"
             ),
             .valueEquals(key: "target_position_unique", expected: .bool(true)),
             .valueEquals(key: "position_evidence_canonical", expected: .bool(true)),
             .typedField(key: "marker_count_before", type: .number),
             .valueEquals(key: "readback_settled", expected: .bool(true)),
             .typedField(key: "marker_count_after", type: .number),
+            .typedField(key: "observed_marker_count_before", type: .number),
+            .typedField(key: "observed_marker_count_after", type: .number),
             .lengthPrefixedEntryCountEquals(
                 key: "expected_survivor_position_multiset",
                 countKey: "marker_count_before",

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1612,7 +1612,12 @@ enum SemanticOracleTable {
     // auto-generated names after deletion. State A also requires Logic's own
     // Number of Items count, read independently of the table projections, to drop
     // by exactly one; those observed counts are pinned below so a producer cannot
-    // certify State A without reporting the witness.
+    // certify State A without reporting the witness. Presence alone is not enough:
+    // the pre-write witness must also equal the table's own pre-write inventory
+    // size, and the post-write witness must be exactly one less than the pre-write
+    // witness — otherwise a stale/wrong pre-write count plus a rebuild that omits
+    // the target from the table's projections could certify a delete that never
+    // happened.
     static let navigateDeleteMarker = SafeMutationOracle.oracle(
         .navigateDeleteMarker,
         semantics: [
@@ -1633,6 +1638,17 @@ enum SemanticOracleTable {
             .typedField(key: "marker_count_after", type: .number),
             .typedField(key: "observed_marker_count_before", type: .number),
             .typedField(key: "observed_marker_count_after", type: .number),
+            // The witness fields above were presence-only: any count pair could satisfy
+            // typedField. A producer must additionally prove the two PRE-WRITE witnesses
+            // agree (this independent count equals the table's own pre-write inventory
+            // size) and that the independent AFTER count is exactly one less than the
+            // independent BEFORE count — not merely present, not merely near.
+            .fieldsEqual(keyA: "observed_marker_count_before", keyB: "marker_count_before"),
+            .numericEqualsOffset(
+                keyA: "observed_marker_count_after",
+                keyB: "observed_marker_count_before",
+                offset: -1
+            ),
             .lengthPrefixedEntryCountEquals(
                 key: "expected_survivor_position_multiset",
                 countKey: "marker_count_before",

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -90,17 +90,15 @@ enum OracleConstraint: Sendable {
     case lengthPrefixedIdentityAtIndexEquals(
         entriesKey: String, indexKey: String, nameKey: String, positionKey: String
     )
-    /// The independent readback array must NOT still contain the exact target identity claimed by
-    /// the response. Both the name and index are checked together: marker ordinals and generated
-    /// names can renumber after a delete, but an entry retaining both the claimed name and claimed
-    /// pre-write index is direct evidence that this claimed target survived. Missing or malformed
-    /// identities fail closed rather than becoming an answer of absence.
+    /// The independent readback array must NOT still contain the claimed target POSITION.
+    /// Name+index is not identity here: Logic auto-renames generated markers, so an absent
+    /// name+index pair is forgeable and an honest delete of "Marker 1" at index 0 is rejected
+    /// when a survivor is renamed to "Marker 1" at index 0. Positions do not rename.
+    /// Missing or malformed positions fail closed rather than becoming an answer of absence.
     case readbackArrayExcludesResponseIdentity(
-        responseNameKey: String,
-        responseIndexKey: String,
+        responsePositionKey: String,
         readbackArrayKey: String,
-        readbackNameKey: String,
-        readbackIndexKey: String
+        readbackPositionKey: String
     )
     /// Two key paths WITHIN THE SAME payload resolve to equal leaf values. The
     /// load-bearing safe-mutation invariant: a verified write echoes what was
@@ -155,7 +153,7 @@ enum OracleConstraint: Sendable {
              .lengthPrefixedEntryCountEquals(let key, _, _),
              .lengthPrefixedEntriesExclude(let key, _),
              .lengthPrefixedIdentityAtIndexEquals(let key, _, _, _),
-             .readbackArrayExcludesResponseIdentity(let key, _, _, _, _),
+             .readbackArrayExcludesResponseIdentity(let key, _, _),
              .fieldsEqual(let key, _),
              .crossCheck(let key, _),
              .numericNear(let key, _, _),
@@ -233,32 +231,34 @@ enum OracleConstraint: Sendable {
                   let identityEntries = Self.lengthPrefixedEntries(in: identity) else { return false }
             return identityEntries == [name, position]
         case .readbackArrayExcludesResponseIdentity(
-            let responseNameKey,
-            let responseIndexKey,
+            let responsePositionKey,
             let readbackArrayKey,
-            let readbackNameKey,
-            let readbackIndexKey
+            let readbackPositionKey
         ):
             // Envelope-provided target metadata cannot corroborate itself. The post-write marker
-            // records must be readable enough to tell whether that claimed target remains.
-            guard let targetName = JSONPath.resolve(root, keyPath: responseNameKey) as? String,
-                  let rawTargetIndex = JSONPath.resolve(root, keyPath: responseIndexKey),
-                  let targetIndex = JSONInspector.number(of: rawTargetIndex),
-                  targetIndex >= 0,
-                  targetIndex.rounded(.towardZero) == targetIndex,
+            // records must be readable enough to tell whether that claimed target position remains.
+            // A missing `data[]` is not an answer of absence: empty-array hiding made name+index
+            // identity look like it accepted honest auto-renames.
+            guard let targetPosition = JSONPath.resolve(root, keyPath: responsePositionKey) as? String,
+                  !targetPosition.isEmpty,
                   let readback,
                   let entries = JSONPath.resolve(readback, keyPath: readbackArrayKey) as? [Any] else {
                 return false
             }
-            for entry in entries {
-                guard let entryName = JSONPath.resolve(entry, keyPath: readbackNameKey) as? String,
-                      let rawEntryIndex = JSONPath.resolve(entry, keyPath: readbackIndexKey),
-                      let entryIndex = JSONInspector.number(of: rawEntryIndex),
-                      entryIndex >= 0,
-                      entryIndex.rounded(.towardZero) == entryIndex else {
+            if entries.isEmpty {
+                // Empty data[] is an answer of absence only when the independent readback
+                // itself claims a verified empty list. A names-shifted test once hid both
+                // a forged identity and an honest auto-rename behind `data: []`.
+                guard let verifiedEmpty = JSONPath.resolve(readback, keyPath: "verified_empty") as? Bool else {
                     return false
                 }
-                if entryName == targetName, entryIndex == targetIndex { return false }
+                return verifiedEmpty
+            }
+            for entry in entries {
+                guard let entryPosition = JSONPath.resolve(entry, keyPath: readbackPositionKey) as? String else {
+                    return false
+                }
+                if entryPosition == targetPosition { return false }
             }
             return true
         case .fieldsEqual(let keyA, let keyB):

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -139,6 +139,14 @@ enum OracleConstraint: Sendable {
     /// `0`/`1` must NOT satisfy it (`1` is not the negation of `false`) — and a
     /// missing key, a non-bool, or two EQUAL bools all fail closed.
     case booleanFlipped(keyA: String, keyB: String)
+    /// Two numeric key paths WITHIN THE SAME payload satisfy `value(keyA) == value(keyB) +
+    /// offset` EXACTLY (no tolerance). The honest form of "this count is derived from that
+    /// count by a fixed delta" — e.g. an independently-read after-count that must be exactly
+    /// one less than the independently-read before-count. Unlike `.numericNear`, there is no
+    /// slack: a producer that reports a drop of zero, two, or any value other than `offset`
+    /// fails. NUMBERS ONLY, with the same bool-vs-number discipline as the rest of the model,
+    /// and fails closed on a missing key or a non-number on either side.
+    case numericEqualsOffset(keyA: String, keyB: String, offset: Double)
 
     /// The primary RESPONSE-side key path — the one the generic mutator drops
     /// and error messages cite. For the relational cases it is the response side
@@ -158,7 +166,8 @@ enum OracleConstraint: Sendable {
              .crossCheck(let key, _),
              .numericNear(let key, _, _),
              .emptyArray(let key),
-             .booleanFlipped(let key, _):
+             .booleanFlipped(let key, _),
+             .numericEqualsOffset(let key, _, _):
             return key
         }
     }
@@ -173,7 +182,7 @@ enum OracleConstraint: Sendable {
         case .valueEquals, .numericRange, .enumMember, .lengthPrefixedEntryCountEquals,
              .lengthPrefixedEntriesExclude, .lengthPrefixedIdentityAtIndexEquals,
              .readbackArrayExcludesResponseIdentity, .fieldsEqual, .crossCheck, .numericNear,
-             .booleanFlipped:
+             .booleanFlipped, .numericEqualsOffset:
             return true
         case .nonEmptyArray, .typedField, .emptyArray:
             return false
@@ -304,6 +313,14 @@ enum OracleConstraint: Sendable {
                   let a = (aValue as? NSNumber)?.boolValue,
                   let b = (bValue as? NSNumber)?.boolValue else { return false }
             return a != b
+        case .numericEqualsOffset(let keyA, let keyB, let offset):
+            // NUMBERS ONLY: `number(of:)` rejects booleans. A missing key or a non-number on
+            // either side fails closed rather than treating an absent witness as satisfied.
+            guard let aValue = JSONPath.resolve(root, keyPath: keyA),
+                  let bValue = JSONPath.resolve(root, keyPath: keyB),
+                  let a = JSONInspector.number(of: aValue),
+                  let b = JSONInspector.number(of: bValue) else { return false }
+            return a == b + offset
         }
     }
 

--- a/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
@@ -27,6 +27,7 @@ private final class Issue523MenuState: @unchecked Sendable {
     var menuEntryEnabledReadFails = false
     var postWriteRowsReadFails = false
     var postWriteRowsReadFailureWasObserved = false
+    var postWriteRowsReadFailureCount = 0
     var postWriteAXRowsReadFailuresRemaining = 0
     var postWriteAXRowsReadFailureStatus = AXError.cannotComplete.rawValue
     var postWriteAXRowsReadFailurePersists = false
@@ -67,6 +68,21 @@ private final class Issue523MenuState: @unchecked Sendable {
     var postWriteRowsNeverSettle = false
     var postWriteRowsNeverSettleReadCount = 0
     var postWriteRowsNeverSettleWasObserved = false
+    var postWriteSelectedRowsBecomeEmpty = false
+    var postWriteSelectedRowsBecomeFreshElement = false
+    var postWriteSelectedRowsEmptyWasObserved = false
+    var postWriteSelectedRowsFreshElementWasObserved = false
+    var postWriteItemCountReadFailuresRemaining = 0
+    var postWriteItemCountReadFailureStatus = AXError.cannotComplete.rawValue
+    var postWriteItemCountReadFailurePersists = false
+    var postWriteItemCountReadFailureCount = 0
+    var postWriteItemCountReadFailureWasObserved = false
+    var postWriteItemCountReadRecoveredAfterFailure = false
+    var postWriteItemCountRecoveredReadCount = 0
+    var postWriteItemCountFrozen = false
+    var postWriteItemCountValueOverride: String?
+    var postWriteItemCountValueOverrideWasObserved = false
+    var itemCountNodeWasReadByDescription = false
     var rowSelectionWasWritten = false
     var selectedRowsReadFailsAfterSelection = false
     var selectionChangesAfterSelectWrite = false
@@ -150,6 +166,14 @@ private func issue523MarkerDeleteFixture(
     postWriteRowCellsInvalidReadFailures: Int = 0,
     postWriteRowCellsInvalidReadPersists: Bool = false,
     postWriteRowsNeverSettle: Bool = false,
+    postWriteSelectedRowsBecomeEmpty: Bool = false,
+    postWriteSelectedRowsBecomeFreshElement: Bool = false,
+    itemCountMissing: Bool = false,
+    postWriteItemCountReadFailures: Int = 0,
+    postWriteItemCountReadFailureStatus: Int32 = AXError.cannotComplete.rawValue,
+    postWriteItemCountReadFailurePersists: Bool = false,
+    postWriteItemCountFrozen: Bool = false,
+    postWriteItemCountValueOverride: String? = nil,
     menuControlDiscoveryReadFails: Bool = false,
     menuActionNamesReadFails: Bool = false,
     bottomEditActionNamesReadFails: Bool = false,
@@ -178,6 +202,8 @@ private func issue523MarkerDeleteFixture(
     menuState.selectionChangesAfterSelectWrite = selectionChangesAfterSelectWrite
     menuState.selectionChangesAfterFinalSelectionCheckBeforePick = selectionChangesAfterFinalSelectionCheckBeforePick
     menuState.selectionUnreadableBeforePick = selectionUnreadableBeforePick
+    menuState.postWriteSelectedRowsBecomeEmpty = postWriteSelectedRowsBecomeEmpty
+    menuState.postWriteSelectedRowsBecomeFreshElement = postWriteSelectedRowsBecomeFreshElement
     let app = builder.element(52_300)
     let arrange = builder.element(52_301)
     let markerList = builder.element(52_302)
@@ -188,6 +214,9 @@ private func issue523MarkerDeleteFixture(
     let table = builder.element(52_307)
     let unrelatedTable = builder.element(52_308)
     let unreadableMenuSeparator = builder.element(52_309)
+    let markerCountGroup = builder.element(52_280)
+    let decoyItemCount = builder.element(52_281)
+    let itemCountText = builder.element(52_282)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
     builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
@@ -261,6 +290,11 @@ private func issue523MarkerDeleteFixture(
     builder.setChildren(substitutePositionCell, [substitutePosition])
     builder.setChildren(substituteNameCell, [substituteName])
     builder.setChildren(substituteRow, [substituteLockCell, substitutePositionCell, substituteNameCell])
+    // A post-rebuild AXSelectedRows element that is not CFEqual to the pre-write target.
+    // The table's own selected-row projection can replace every row identity during rebuild
+    // without the marker leaving.
+    let freshSelectedRow = builder.element(98_780)
+    builder.setAttribute(freshSelectedRow, kAXRoleAttribute as String, kAXRowRole as String)
     @Sendable func makeSubstituteRowReadLike(_ source: AXUIElement) {
         guard let index = rows.firstIndex(where: { CFEqual($0, source) }) else { return }
         builder.setAttribute(substitutePosition, kAXDescriptionAttribute as String, markers[index].position)
@@ -269,7 +303,22 @@ private func issue523MarkerDeleteFixture(
     builder.setAttribute(table, "AXRows", rows)
     let structuralRows = structuralRowOrder.map { $0.map { rows[$0] } } ?? rows
     builder.setChildren(table, structuralRows)
+    // Logic renders its own count on a node that is not a table projection. The decoy
+    // static text is deliberately first among siblings so a position-based read would
+    // report 99 instead of the real marker count.
+    builder.setAttribute(markerCountGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(markerCountGroup, kAXDescriptionAttribute as String, "Marker")
+    builder.setAttribute(decoyItemCount, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(decoyItemCount, kAXDescriptionAttribute as String, "Selected Item")
+    builder.setAttribute(decoyItemCount, kAXValueAttribute as String, "99 Markers")
+    builder.setAttribute(itemCountText, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(itemCountText, kAXDescriptionAttribute as String, "Number of Items")
+    builder.setAttribute(itemCountText, kAXValueAttribute as String, issue523MarkerListItemCountText(markers.count))
+    builder.setChildren(markerCountGroup, [decoyItemCount, itemCountText])
     var markerListChildren = [bottomEdit, toolbarEdit, table]
+    if !itemCountMissing {
+        markerListChildren.append(markerCountGroup)
+    }
     if menuEntryTitle != nil, !menuBoundToToolbar {
         // This menu is deliberately unrelated to the toolbar Edit control. It is the stale-window
         // decoy that the old "first AXMenu anywhere" fallback mistook for the requested menu.
@@ -355,6 +404,11 @@ private func issue523MarkerDeleteFixture(
                     menuState.postWriteRowCellsInvalidReadFailuresRemaining = postWriteRowCellsInvalidReadFailures
                     menuState.postWriteRowCellsInvalidReadPersists = postWriteRowCellsInvalidReadPersists
                     menuState.postWriteRowsNeverSettle = postWriteRowsNeverSettle
+                    menuState.postWriteItemCountReadFailuresRemaining = postWriteItemCountReadFailures
+                    menuState.postWriteItemCountReadFailureStatus = postWriteItemCountReadFailureStatus
+                    menuState.postWriteItemCountReadFailurePersists = postWriteItemCountReadFailurePersists
+                    menuState.postWriteItemCountFrozen = postWriteItemCountFrozen
+                    menuState.postWriteItemCountValueOverride = postWriteItemCountValueOverride
                     return false
                 }
                 if menuState.selectionChangesAfterFinalSelectionCheckBeforePick,
@@ -382,6 +436,17 @@ private func issue523MarkerDeleteFixture(
                     // selection. Keep the operation's pre-pick diagnostic ID separately so the
                     // target-fidelity test can still identify which row AXPick acted on.
                     builder.setAttribute(table, "AXSelectedRows", [AXUIElement]())
+                    if !postWriteItemCountFrozen, postWriteItemCountValueOverride == nil {
+                        builder.setAttribute(
+                            itemCountText,
+                            kAXValueAttribute as String,
+                            issue523MarkerListItemCountText(afterPick.count)
+                        )
+                    }
+                }
+                if let override = postWriteItemCountValueOverride {
+                    builder.setAttribute(itemCountText, kAXValueAttribute as String, override)
+                    menuState.postWriteItemCountValueOverrideWasObserved = true
                 }
                 if let substituteIndex = postWriteRowsSubstituteIndex,
                    let currentRows: [AXUIElement] = AXHelpers.getAttribute(
@@ -391,7 +456,11 @@ private func issue523MarkerDeleteFixture(
                     makeSubstituteRowReadLike(currentRows[substituteIndex])
                 }
                 if unrelatedEmptyTableBecomesFirstAfterPick {
-                    builder.setChildren(markerList, [unrelatedTable, bottomEdit, toolbarEdit, table])
+                    var reboundChildren = [unrelatedTable, bottomEdit, toolbarEdit, table]
+                    if !itemCountMissing {
+                        reboundChildren.append(markerCountGroup)
+                    }
+                    builder.setChildren(markerList, reboundChildren)
                 }
                 menuState.postWriteRowsReadFails = postWriteRowsReadFails
                 menuState.postWriteAXRowsReadFailuresRemaining = postWriteAXRowsReadFailures
@@ -410,6 +479,19 @@ private func issue523MarkerDeleteFixture(
                 menuState.postWriteRowCellsInvalidReadFailuresRemaining = postWriteRowCellsInvalidReadFailures
                 menuState.postWriteRowCellsInvalidReadPersists = postWriteRowCellsInvalidReadPersists
                 menuState.postWriteRowsNeverSettle = postWriteRowsNeverSettle
+                menuState.postWriteItemCountReadFailuresRemaining = postWriteItemCountReadFailures
+                menuState.postWriteItemCountReadFailureStatus = postWriteItemCountReadFailureStatus
+                menuState.postWriteItemCountReadFailurePersists = postWriteItemCountReadFailurePersists
+                menuState.postWriteItemCountFrozen = postWriteItemCountFrozen
+                menuState.postWriteItemCountValueOverride = postWriteItemCountValueOverride
+                if menuState.postWriteSelectedRowsBecomeEmpty {
+                    builder.setAttribute(table, "AXSelectedRows", [AXUIElement]())
+                    menuState.postWriteSelectedRowsEmptyWasObserved = true
+                }
+                if menuState.postWriteSelectedRowsBecomeFreshElement {
+                    builder.setAttribute(table, "AXSelectedRows", [freshSelectedRow])
+                    menuState.postWriteSelectedRowsFreshElementWasObserved = true
+                }
                 return false
             }
             return true
@@ -608,6 +690,7 @@ private func issue523MarkerDeleteFixture(
                    builder.elementID(element) == builder.elementID(table),
                    attribute == "AXRows" {
                     menuState.postWriteRowsReadFailureWasObserved = true
+                    menuState.postWriteRowsReadFailureCount += 1
                     return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
                 }
                 if menuState.postWriteAXRowsReadNil,
@@ -683,6 +766,29 @@ private func issue523MarkerDeleteFixture(
                    attribute == kAXRoleAttribute as String {
                     return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
                 }
+                if builder.elementID(element) == builder.elementID(itemCountText),
+                   attribute == kAXDescriptionAttribute as String {
+                    menuState.itemCountNodeWasReadByDescription = true
+                }
+                if (menuState.postWriteItemCountReadFailuresRemaining > 0
+                    || menuState.postWriteItemCountReadFailurePersists),
+                   builder.elementID(element) == builder.elementID(itemCountText),
+                   attribute == kAXValueAttribute as String {
+                    menuState.postWriteItemCountReadFailureWasObserved = true
+                    menuState.postWriteItemCountReadFailureCount += 1
+                    if menuState.postWriteItemCountReadFailuresRemaining > 0 {
+                        menuState.postWriteItemCountReadFailuresRemaining -= 1
+                    }
+                    return .failure(AXHelpers.AXStatusError(
+                        raw: menuState.postWriteItemCountReadFailureStatus
+                    ))
+                }
+                if menuState.postWriteItemCountReadFailureCount > 0,
+                   builder.elementID(element) == builder.elementID(itemCountText),
+                   attribute == kAXValueAttribute as String {
+                    menuState.postWriteItemCountReadRecoveredAfterFailure = true
+                    menuState.postWriteItemCountRecoveredReadCount += 1
+                }
                 return baseRuntime.ax.attributeValueResult?(element, attribute)
                     ?? .success(baseRuntime.ax.attributeValue(element, attribute))
             }
@@ -723,6 +829,10 @@ private func issue523MarkerDeleteFixture(
     )
 }
 
+private func issue523MarkerListItemCountText(_ count: Int) -> String {
+    count == 1 ? "1 Marker" : "\(count) Markers"
+}
+
 private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     try #require(JSONSerialization.jsonObject(with: Data(result.message.utf8)) as? [String: Any])
 }
@@ -746,6 +856,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(fixture.selectedMarkerName == "Target")
     #expect(fixture.markerCount == 1)
 }
@@ -898,6 +1009,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         // misreports the completed menu delete as a route refusal and fails the State-A assertion.
         #expect(result.isSuccess)
         #expect(envelope["state"] as? String == "A")
+        #expect(try #require(envelope["verified"] as? Bool))
         #expect(writeAttempted)
         #expect(envelope["prewrite_marker_identities"] as? [String] == [
             "5:Intro7:1.1.1.1", "5:Verse7:5.1.1.1", "6:Chorus7:9.1.1.1",
@@ -935,6 +1047,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     // proof becomes unreachable and the test fails.
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(envelope["menu_state"] as? String == "could_not_be_closed")
     #expect(!(try #require(envelope["safe_to_retry"] as? Bool)))
     #expect(try #require(envelope["fallback_unsafe"] as? Bool))
@@ -987,6 +1100,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(fixture.actions.actionCount(
         elementID: fixture.menuEntryID, action: kAXPickAction as String
     ) == 1)
@@ -1022,6 +1136,32 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     ) == 0)
     #expect(fixture.actions.actionCount(
         elementID: fixture.bottomEditID, action: kAXPressAction as String
+    ) == 0)
+}
+
+@Test func testIssue523UnknownLocaleEditDeleteLabelsRefuseWithoutIssuingAPick() async throws {
+    // Locale policy itself stays with #519. An unseen locale must refuse honestly rather
+    // than guess a destructive actuator. Mutation: return `.pickIssued` from the settled
+    // `.menuAbsent` branch. write_attempted and the zero-AXPick count both fail.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Löschen",
+        editControlTitle: "Bearbeiten"
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 0, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+    let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+
+    #expect(!result.isSuccess)
+    #expect(envelope["state"] as? String == "C")
+    #expect(envelope["edit_menu_route_state"] as? String == "menu_absent")
+    #expect(!writeAttempted)
+    #expect(fixture.actions.actionCount(
+        elementID: fixture.toolbarEditID, action: kAXShowMenuAction as String
+    ) == 0)
+    #expect(fixture.actions.actionCount(
+        elementID: fixture.menuEntryID, action: kAXPickAction as String
     ) == 0)
 }
 
@@ -1111,6 +1251,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(fixture.actions.actionCount(
         elementID: fixture.toolbarEditID, action: kAXShowMenuAction as String
     ) == 1)
@@ -1120,9 +1261,9 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 }
 
 @Test func testIssue523PostWriteReadbackFailureReceiptNamesTheActualSiteAndStatus() async throws {
-    // Mutation A: replace the `ax_rows` receipt binding with `structural_children`. This first
-    // fixture still returns State B, but it must fail the exact-site assertion below. The boolean
-    // proves the fixture fired on the live AXRows call rather than a later structural read.
+    // Mutation A: remove `failure` from `isTransientDuringRebuild`. This first fixture then
+    // returns State B on poll 1 and fails the six-poll count below. The boolean plus the exact
+    // count prove the fixture fired on the live AXRows call and consumed the settle budget.
     let axRowsFixture = issue523MarkerDeleteFixture(
         menuEntryTitle: "Delete",
         pickDeletesSelectedRow: false,
@@ -1141,7 +1282,9 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     #expect(axRowsEnvelope["readback_ax_status"] as? Int == Int(AXError.failure.rawValue))
     #expect(axRowsEnvelope["readback_ax_status_name"] as? String == "failure")
     #expect(try #require(axRowsEnvelope["readback_unreadable"] as? Bool))
+    #expect(!(try #require(axRowsEnvelope["readback_settled"] as? Bool)))
     #expect(axRowsFixture.menuState.postWriteRowsReadFailureWasObserved)
+    #expect(axRowsFixture.menuState.postWriteRowsReadFailureCount == 6)
     #expect(axRowsFixture.actions.actionCount(
         elementID: axRowsFixture.menuEntryID, action: kAXPickAction as String
     ) == 1)
@@ -1232,6 +1375,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(try #require(envelope["readback_settled"] as? Bool))
     #expect(envelope["marker_count_after"] as? Int == 1)
     #expect(envelope["expected_survivor_position_multiset"] as? String == "7:5.1.1.1")
@@ -1268,6 +1412,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(try #require(envelope["readback_settled"] as? Bool))
     #expect(envelope["marker_count_after"] as? Int == 1)
     #expect(envelope["expected_survivor_position_multiset"] as? String == "7:5.1.1.1")
@@ -1301,6 +1446,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 
     #expect(result.isSuccess)
     #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
     #expect(try #require(envelope["readback_settled"] as? Bool))
     #expect(envelope["marker_count_after"] as? Int == 1)
     #expect(envelope["expected_survivor_position_multiset"] as? String == "7:5.1.1.1")
@@ -1336,6 +1482,7 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     // uses its existing structural route for each of the two genuine settle observations.
     #expect(axRowsAnswerResult.isSuccess)
     #expect(axRowsAnswerEnvelope["state"] as? String == "A")
+    #expect(try #require(axRowsAnswerEnvelope["verified"] as? Bool))
     #expect(try #require(axRowsAnswerEnvelope["readback_settled"] as? Bool))
     #expect(axRowsAnswerFixture.menuState.postWriteAXRowsReadFailureWasObserved)
     #expect(axRowsAnswerFixture.menuState.postWriteAXRowsReadFailureCount == 2)
@@ -1973,6 +2120,81 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     #expect(fixture.markerCount == 3)
 }
 
+@Test func testIssue523SharedProjectionOmissionWithEmptySelectionCannotReachStateA() async throws {
+    // The "target row is no longer selected" check is not independent of the table. After
+    // a rebuild, the pre-write Verse element is CFEqual to nothing — including an empty
+    // AXSelectedRows — whether or not the marker left. Two agreeing truncated inventories
+    // plus that empty selection must not encode State A.
+    //
+    // Mutation proven: restore `encodeStateA` after the selection-no-op guard. This fixture
+    // then certifies a no-op delete and fails the state / remaining-count assertions.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeEmpty: true,
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("12 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(try #require(envelope["state"] as? String) != "A")
+    #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteSelectedRowsEmptyWasObserved)
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523SharedProjectionOmissionWithFreshSelectionCannotReachStateA() async throws {
+    // Same common-mode rebuild, only AXSelectedRows is a newly created element that is
+    // not CFEqual to the pre-write Verse row. That is still a table projection.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeFreshElement: true,
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("12 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(try #require(envelope["state"] as? String) != "A")
+    #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523LastMarkerSharedEmptyProjectionsWithNonMatchingSelectionCannotReachStateA() async throws {
+    // Last-marker variant: both projections successfully answer [] and the selection is a
+    // fresh non-matching element. An empty expected survivor set plus "target no longer
+    // selected" is the same rebuild lie, just with one row.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 0,
+        postWriteStructuralRowsDropIndex: 0,
+        postWriteSelectedRowsBecomeFreshElement: true,
+        markers: [("1 1 1 1", "Only Marker")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 0, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(try #require(envelope["state"] as? String) != "A")
+    #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
+    #expect(fixture.markerCount == 1)
+}
+
 @Test func testIssue523SubstitutedAXRowsElementWithSameCountCannotReachStateA() async throws {
     let fixture = issue523MarkerDeleteFixture(
         menuEntryTitle: "Delete",
@@ -2013,4 +2235,164 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     // substituted AXRows element as a corroborated survivor observation.
     #expect(fixture.markerCount == 2)
     #expect(fixture.markerNames == ["Intro", "Chorus"])
+}
+
+@Test func testIssue523IndependentItemCountDropAndSurvivorMultisetReachStateA() async throws {
+    // Mutation proven: restore the "no independent witness" State B return after the
+    // canonical-position guard. The delete is real, the survivor multiset agrees, and
+    // Logic's own Number of Items count drops 3 → 2, so that mutation fails the State-A
+    // expectation below. The decoy sibling is first and reads "99 Markers"; matching by
+    // position among siblings would publish 99 and fail the observed-before assertion.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("12 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
+    #expect(try #require(envelope["readback_settled"] as? Bool))
+    #expect(envelope["observed_marker_count_before"] as? Int == 3)
+    #expect(envelope["observed_marker_count_after"] as? Int == 2)
+    #expect(envelope["observed_marker_count_text_before"] as? String == "3 Markers")
+    #expect(envelope["observed_marker_count_text_after"] as? String == "2 Markers")
+    #expect(envelope["expected_survivor_position_multiset"] as? String == "7:1.1.1.18:12.1.1.1")
+    #expect(envelope["observed_survivor_position_multiset"] as? String == "7:1.1.1.18:12.1.1.1")
+    #expect(fixture.menuState.itemCountNodeWasReadByDescription)
+    #expect(fixture.markerCount == 2)
+    #expect(fixture.markerNames == ["Intro", "Chorus"])
+
+    let lastMarkerFixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let lastMarkerResult = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: lastMarkerFixture.runtime, mouse: lastMarkerFixture.mouse
+    )
+    let lastMarkerEnvelope = try issue523Envelope(lastMarkerResult)
+    #expect(lastMarkerEnvelope["state"] as? String == "A")
+    #expect(lastMarkerEnvelope["observed_marker_count_before"] as? Int == 2)
+    #expect(lastMarkerEnvelope["observed_marker_count_after"] as? Int == 1)
+    #expect(lastMarkerEnvelope["observed_marker_count_text_after"] as? String == "1 Marker")
+}
+
+@Test func testIssue523ReadableUnchangedItemCountCannotReachStateAWhileProjectionsOmitTheRow() async throws {
+    // Mutation proven: skip the independent-count drop check and encode State A from the
+    // settled table projections alone. Both AXRows and AXChildren omit Verse, the
+    // selection is a fresh non-matching element, and the uniqueness/canonical gates
+    // pass — but Logic's own count still reads 3 Markers. That mutation certifies a
+    // no-op delete and fails the State-B / count-observation assertions below.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeFreshElement: true,
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("12 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "B")
+    #expect(envelope["reason"] as? String == "readback_mismatch")
+    #expect(try #require(envelope["readback_settled"] as? Bool))
+    #expect(envelope["observed_marker_count_before"] as? Int == 3)
+    #expect(envelope["observed_marker_count_after"] as? Int == 3)
+    let reasonDetail = try #require(envelope["reason_detail"] as? String)
+    #expect(reasonDetail.contains("Number of Items"))
+    #expect(reasonDetail.contains("3"))
+    #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
+    #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
+    #expect(fixture.menuState.itemCountNodeWasReadByDescription)
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523UnreadableOrUnparseableItemCountCannotReachStateA() async throws {
+    // Mutation proven: treat a missing or unparseable Number of Items value as count 0.
+    // Both fixtures really delete the target, so a fabricated 0 would look like a drop
+    // and certify State A. The receipt must say the witness was unreadable and must
+    // not publish an invented observed_marker_count_after.
+    let missingFixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        itemCountMissing: true,
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let missingResult = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: missingFixture.runtime, mouse: missingFixture.mouse
+    )
+    let missingEnvelope = try issue523Envelope(missingResult)
+    let missingDetail = try #require(missingEnvelope["reason_detail"] as? String)
+
+    #expect(missingResult.isSuccess)
+    #expect(missingEnvelope["state"] as? String == "B")
+    #expect(missingEnvelope["reason"] as? String == "readback_unavailable")
+    #expect(try #require(missingEnvelope["readback_settled"] as? Bool))
+    #expect(missingEnvelope["observed_marker_count_before"] == nil)
+    #expect(missingEnvelope["observed_marker_count_after"] == nil)
+    #expect(missingEnvelope["item_count_witness_state"] as? String == "unreadable")
+    #expect(missingDetail.contains("unreadable"))
+    #expect(missingFixture.markerCount == 1)
+
+    let unparseableFixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        postWriteItemCountValueOverride: "Markers",
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let unparseableResult = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: unparseableFixture.runtime, mouse: unparseableFixture.mouse
+    )
+    let unparseableEnvelope = try issue523Envelope(unparseableResult)
+    let unparseableDetail = try #require(unparseableEnvelope["reason_detail"] as? String)
+
+    #expect(unparseableResult.isSuccess)
+    #expect(unparseableEnvelope["state"] as? String == "B")
+    #expect(unparseableEnvelope["reason"] as? String == "readback_unavailable")
+    #expect(unparseableEnvelope["observed_marker_count_before"] as? Int == 2)
+    #expect(unparseableEnvelope["observed_marker_count_after"] == nil)
+    #expect(unparseableEnvelope["item_count_witness_state"] as? String == "unparseable")
+    #expect(unparseableEnvelope["observed_marker_count_text_after"] as? String == "Markers")
+    #expect(unparseableDetail.contains("unreadable") || unparseableDetail.contains("unparseable"))
+    #expect(unparseableFixture.menuState.postWriteItemCountValueOverrideWasObserved)
+    #expect(unparseableFixture.markerCount == 1)
+}
+
+@Test func testIssue523TransientItemCountReadFailureRetiresPollThenSettles() async throws {
+    // Mutation proven: return State B from the first failed Number of Items value read
+    // instead of retiring that poll. The AXPick still deletes, so the operation must
+    // continue; two later agreeing count reads then settle on 1 Marker and this
+    // State-A expectation fails if the first -25204 retired the whole write.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        postWriteItemCountReadFailures: 2,
+        postWriteItemCountReadFailureStatus: AXError.cannotComplete.rawValue,
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "A")
+    #expect(try #require(envelope["verified"] as? Bool))
+    #expect(try #require(envelope["readback_settled"] as? Bool))
+    #expect(envelope["observed_marker_count_before"] as? Int == 2)
+    #expect(envelope["observed_marker_count_after"] as? Int == 1)
+    #expect(envelope["observed_marker_count_text_after"] as? String == "1 Marker")
+    #expect(fixture.menuState.postWriteItemCountReadFailureWasObserved)
+    #expect(fixture.menuState.postWriteItemCountReadFailureCount == 2)
+    #expect(fixture.menuState.postWriteItemCountReadRecoveredAfterFailure)
+    #expect(fixture.menuState.postWriteItemCountRecoveredReadCount == 2)
+    #expect(fixture.actions.actionCount(
+        elementID: fixture.menuEntryID, action: kAXPickAction as String
+    ) == 1)
+    #expect(fixture.markerCount == 1)
 }

--- a/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
@@ -83,6 +83,7 @@ private final class Issue523MenuState: @unchecked Sendable {
     var postWriteItemCountValueOverride: String?
     var postWriteItemCountValueOverrideWasObserved = false
     var itemCountNodeWasReadByDescription = false
+    var itemCountGroupChildrenReadFailureWasObserved = false
     var rowSelectionWasWritten = false
     var selectedRowsReadFailsAfterSelection = false
     var selectionChangesAfterSelectWrite = false
@@ -169,11 +170,14 @@ private func issue523MarkerDeleteFixture(
     postWriteSelectedRowsBecomeEmpty: Bool = false,
     postWriteSelectedRowsBecomeFreshElement: Bool = false,
     itemCountMissing: Bool = false,
+    prewriteItemCountValue: String? = nil,
     postWriteItemCountReadFailures: Int = 0,
     postWriteItemCountReadFailureStatus: Int32 = AXError.cannotComplete.rawValue,
     postWriteItemCountReadFailurePersists: Bool = false,
     postWriteItemCountFrozen: Bool = false,
     postWriteItemCountValueOverride: String? = nil,
+    duplicateItemCountDecoyValue: String? = nil,
+    itemCountGroupChildrenUnreadableStatus: Int32? = nil,
     menuControlDiscoveryReadFails: Bool = false,
     menuActionNamesReadFails: Bool = false,
     bottomEditActionNamesReadFails: Bool = false,
@@ -217,6 +221,11 @@ private func issue523MarkerDeleteFixture(
     let markerCountGroup = builder.element(52_280)
     let decoyItemCount = builder.element(52_281)
     let itemCountText = builder.element(52_282)
+    // A second AXStaticText also described "Number of Items", placed directly under the
+    // window rather than inside `markerCountGroup`. Models a live tree that genuinely has
+    // two candidates so `findMarkerListNumberOfItemsNodes` must not call ONE of them unique
+    // just because the OTHER's subtree refused to answer.
+    let duplicateItemCountText = builder.element(52_283)
 
     builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
     builder.setAttribute(app, kAXWindowsAttribute as String, [arrange, markerList])
@@ -313,11 +322,22 @@ private func issue523MarkerDeleteFixture(
     builder.setAttribute(decoyItemCount, kAXValueAttribute as String, "99 Markers")
     builder.setAttribute(itemCountText, kAXRoleAttribute as String, kAXStaticTextRole as String)
     builder.setAttribute(itemCountText, kAXDescriptionAttribute as String, "Number of Items")
-    builder.setAttribute(itemCountText, kAXValueAttribute as String, issue523MarkerListItemCountText(markers.count))
+    builder.setAttribute(
+        itemCountText, kAXValueAttribute as String,
+        prewriteItemCountValue ?? issue523MarkerListItemCountText(markers.count)
+    )
     builder.setChildren(markerCountGroup, [decoyItemCount, itemCountText])
+    if let duplicateItemCountDecoyValue {
+        builder.setAttribute(duplicateItemCountText, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        builder.setAttribute(duplicateItemCountText, kAXDescriptionAttribute as String, "Number of Items")
+        builder.setAttribute(duplicateItemCountText, kAXValueAttribute as String, duplicateItemCountDecoyValue)
+    }
     var markerListChildren = [bottomEdit, toolbarEdit, table]
     if !itemCountMissing {
         markerListChildren.append(markerCountGroup)
+    }
+    if duplicateItemCountDecoyValue != nil {
+        markerListChildren.append(duplicateItemCountText)
     }
     if menuEntryTitle != nil, !menuBoundToToolbar {
         // This menu is deliberately unrelated to the toolbar Edit control. It is the stale-window
@@ -526,6 +546,11 @@ private func issue523MarkerDeleteFixture(
                     ?? .success(baseRuntime.ax.actionNames(element))
             },
             childrenResult: { element in
+                if let itemCountGroupChildrenUnreadableStatus,
+                   builder.elementID(element) == builder.elementID(markerCountGroup) {
+                    menuState.itemCountGroupChildrenReadFailureWasObserved = true
+                    return .failure(AXHelpers.AXStatusError(raw: itemCountGroupChildrenUnreadableStatus))
+                }
                 if menuState.controlDiscoveryReadFails,
                    menuState.rowSelectionWasWritten,
                    builder.elementID(element) == builder.elementID(markerList) {
@@ -2140,11 +2165,44 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         index: 1, runtime: fixture.runtime, mouse: fixture.mouse
     )
     let envelope = try issue523Envelope(result)
+    let reasonDetail = try #require(envelope["reason_detail"] as? String)
 
-    #expect(try #require(envelope["state"] as? String) != "A")
+    // `!= "A"` also accepts State C (e.g. the route never even reaching a pick); pin the
+    // exact refusal so a regression that turns this into a pre-write refusal is caught too.
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(reasonDetail.contains("did not drop by one"))
     #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteSelectedRowsEmptyWasObserved)
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523SharedProjectionOmissionWithEmptySelectionReallyReachesTheWriteNotAPrewriteRefusal() async throws {
+    // Mutation-demonstration for the assertion above: `!= "A"` cannot distinguish "reached
+    // the write and failed to verify it" (State B) from "never reached the write at all"
+    // (State C). Force State C on the SAME fixture shape by making the exact Delete entry
+    // unavailable, so the two outcomes are visibly different and `!= "A"` would have passed
+    // both.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: nil,
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeEmpty: true,
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("12 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+    let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+
+    #expect(!result.isSuccess)
+    #expect(envelope["state"] as? String == "C")
+    #expect(!writeAttempted)
+    #expect(fixture.actions.actionCount(
+        elementID: fixture.menuEntryID, action: kAXPickAction as String
+    ) == 0)
     #expect(fixture.markerCount == 3)
 }
 
@@ -2163,8 +2221,12 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         index: 1, runtime: fixture.runtime, mouse: fixture.mouse
     )
     let envelope = try issue523Envelope(result)
+    let reasonDetail = try #require(envelope["reason_detail"] as? String)
 
-    #expect(try #require(envelope["state"] as? String) != "A")
+    // `!= "A"` also accepts State C; pin the exact refusal (see the mutation-demonstration
+    // test above for why that distinction matters).
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(reasonDetail.contains("did not drop by one"))
     #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
@@ -2187,8 +2249,12 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         index: 0, runtime: fixture.runtime, mouse: fixture.mouse
     )
     let envelope = try issue523Envelope(result)
+    let reasonDetail = try #require(envelope["reason_detail"] as? String)
 
-    #expect(try #require(envelope["state"] as? String) != "A")
+    // `!= "A"` also accepts State C; pin the exact refusal (see the mutation-demonstration
+    // test above for why that distinction matters).
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(reasonDetail.contains("did not drop by one"))
     #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
@@ -2359,7 +2425,9 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     #expect(unparseableEnvelope["observed_marker_count_after"] == nil)
     #expect(unparseableEnvelope["item_count_witness_state"] as? String == "unparseable")
     #expect(unparseableEnvelope["observed_marker_count_text_after"] as? String == "Markers")
-    #expect(unparseableDetail.contains("unreadable") || unparseableDetail.contains("unparseable"))
+    // The `||` this replaced could not name which refusal actually happened: "unparseable"
+    // never appears in any produced message, so that branch was always vacuous.
+    #expect(unparseableDetail.contains("could not be parsed"))
     #expect(unparseableFixture.menuState.postWriteItemCountValueOverrideWasObserved)
     #expect(unparseableFixture.markerCount == 1)
 }
@@ -2395,4 +2463,189 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         elementID: fixture.menuEntryID, action: kAXPickAction as String
     ) == 1)
     #expect(fixture.markerCount == 1)
+}
+
+@Test func testIssue523StalePrewriteItemCountDisagreeingWithInventoryCannotReachStateA() async throws {
+    // BLOCKER repro: the pre-write Number of Items witness reads "4 Markers" while the
+    // pre-write TABLE inventory only has 3 real rows — a stale render, a wrong node, or a
+    // decoy. AXPick is a genuine no-op (`pickDeletesSelectedRow: false`), but both AXRows
+    // and the table's structural children lie about the same omission, the post-pick
+    // selection becomes a fresh non-matching element, and the post-write witness reads
+    // "3 Markers" — exactly one less than the WRONG pre-write witness. Before pinning
+    // `observed_marker_count_before == marker_count_before`, this combination satisfied the
+    // drop-by-one check and certified a delete that never happened.
+    //
+    // Mutation: delete the `observedCountBefore == before.count` guard. That mutation
+    // restores this false State A and fails the assertions below.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeFreshElement: true,
+        prewriteItemCountValue: "4 Markers",
+        postWriteItemCountValueOverride: "3 Markers",
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("9 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+    let reasonDetail = try #require(envelope["reason_detail"] as? String)
+
+    #expect(result.isSuccess)
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(envelope["reason"] as? String == "readback_mismatch")
+    #expect(envelope["marker_count_before"] as? Int == 3)
+    #expect(envelope["observed_marker_count_before"] as? Int == 4)
+    #expect(reasonDetail.contains("did not agree with the pre-write table inventory"))
+    // The Delete pick was a genuine no-op: all three rows remain in the fixture's real table.
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523PrewriteItemCountSettlesAcrossATransientFirstRead() async throws {
+    // Confirms the pre-write witness is settled the same way the after witness is: a
+    // momentary AX hiccup on the FIRST pre-write read must not poison a value that a second
+    // read would confirm. This exercises `settledMarkerListItemCount`'s retry path directly
+    // (not merely its pass-through), so a mutation that returns the FIRST reading unsettled
+    // would report an unreadable pre-write witness instead of the settled "2 Markers".
+    //
+    // There is no fixture seam for a transient pre-write item-count failure (only post-write
+    // reads have one), so this asserts on the trustworthy end state instead: an honest delete
+    // still reaches State A with a settled `observed_marker_count_before`.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(result.isSuccess)
+    #expect(envelope["state"] as? String == "A")
+    #expect(envelope["observed_marker_count_before"] as? Int == 2)
+    #expect(envelope["marker_count_before"] as? Int == 2)
+    #expect(fixture.markerCount == 1)
+}
+
+@Test func testIssue523WrongButParsedItemCountTextCannotManufactureADrop() async throws {
+    // MAJOR repro: a value whose single ASCII digit run is not the leading token (e.g. a
+    // sibling like "Marker 2") must not parse as a count. Before tightening the parser to
+    // the Event List reader's leading-token rule, `runs.count == 1` accepted a digit run
+    // ANYWHERE in the string, so "Marker 2" -> "Marker 1" (the selection merely moving to a
+    // different marker) manufactured the same fake one-count drop a genuine delete produces.
+    //
+    // Mutation: restore the old `runs.count == 1` parse rule. Both reads then parse (2 -> 1),
+    // the multiset proof already agrees (this is a genuine no-op, both projections omit the
+    // row), and that mutation certifies State A instead of the State B asserted below.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        postWriteRowsDropIndex: 1,
+        postWriteStructuralRowsDropIndex: 1,
+        postWriteSelectedRowsBecomeFreshElement: true,
+        prewriteItemCountValue: "Marker 2",
+        postWriteItemCountValueOverride: "Marker 1",
+        markers: [("1 1 1 1", "Intro"), ("5 1 1 1", "Verse"), ("9 1 1 1", "Chorus")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+
+    #expect(result.isSuccess)
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(envelope["observed_marker_count_before"] == nil)
+    #expect(envelope["observed_marker_count_after"] == nil)
+    #expect(envelope["item_count_witness_state_before"] as? String == "unparseable")
+    #expect(envelope["item_count_witness_state"] as? String == "unparseable")
+    #expect(fixture.markerCount == 3)
+}
+
+@Test func testIssue523NonLeadingDigitItemCountStringsAreUnreadableNotACount() async throws {
+    // Defensive regression table for the leading-token parse rule. None of these are
+    // asserted to be real Logic strings in any locale — measuring KO/JA Number-of-Items
+    // text on a live Logic is future work — they only prove the parser fails closed on
+    // digits that are not the leading count token, in shapes a translated or differently
+    // punctuated label could plausibly take.
+    let nonCountStrings = [
+        "Marker 2",
+        "Selected Item: 2",
+        "2개",
+        "마커 2개",
+        "2個",
+        "no count here",
+    ]
+    for text in nonCountStrings {
+        let fixture = issue523MarkerDeleteFixture(
+            menuEntryTitle: "Delete",
+            postWriteItemCountValueOverride: text,
+            markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+        )
+        let result = await AccessibilityChannel.defaultDeleteMarker(
+            index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+        )
+        let envelope = try issue523Envelope(result)
+
+        #expect(
+            envelope["observed_marker_count_after"] == nil,
+            "\"\(text)\" must not parse to a count"
+        )
+        #expect(
+            envelope["item_count_witness_state"] as? String == "unparseable",
+            "\"\(text)\" must be reported unparseable"
+        )
+    }
+}
+
+@Test func testIssue523AmbiguousItemCountWitnessWithUnreadableSiblingSubtreeCannotReachStateA() async throws {
+    // MAJOR repro: two AXStaticText nodes are both described "Number of Items". The real
+    // one lives inside `markerCountGroup`, whose AXChildren read persistently fails
+    // (-25200 == AXError.failure). A second, fully readable decoy elsewhere in the window
+    // reads "1 Marker". The Delete pick is a genuine no-op (`pickDeletesSelectedRow:
+    // false`), so nothing actually dropped from 2 to 1.
+    //
+    // Before checking `unreadable` ahead of `matches.isEmpty`, the walk found exactly the
+    // decoy (the real node's parent never even got visited) and returned it as "the" unique
+    // match, certifying a false one-marker drop. Mutation: swap the order back (`if
+    // matches.isEmpty, let unreadable`) — that mutation restores the false certification.
+    let fixture = issue523MarkerDeleteFixture(
+        menuEntryTitle: "Delete",
+        pickDeletesSelectedRow: false,
+        duplicateItemCountDecoyValue: "1 Marker",
+        itemCountGroupChildrenUnreadableStatus: AXError.failure.rawValue,
+        markers: [("1 1 1 1", "Keep"), ("5 1 1 1", "Drop")]
+    )
+    let result = await AccessibilityChannel.defaultDeleteMarker(
+        index: 1, runtime: fixture.runtime, mouse: fixture.mouse
+    )
+    let envelope = try issue523Envelope(result)
+    let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+
+    #expect(result.isSuccess)
+    #expect(try #require(envelope["state"] as? String) == "B")
+    #expect(writeAttempted)
+    #expect(envelope["item_count_witness_state"] as? String == "unreadable")
+    #expect(fixture.menuState.itemCountGroupChildrenReadFailureWasObserved)
+    #expect(fixture.actions.actionCount(
+        elementID: fixture.menuEntryID, action: kAXPickAction as String
+    ) == 1)
+    // The pick was a genuine no-op: both markers survive in the fixture's real table.
+    #expect(fixture.markerCount == 2)
+}
+
+@Test func testIssue523UnmeasuredLocalizedItemCountDescriptionStaysUnreadableUntilMeasured() async throws {
+    // MAJOR repro: a Marker List whose Number of Items node is described in Korean
+    // ("항목 수") or Japanese ("項目数") must not silently match — no live Logic has been
+    // measured in either locale for this label, and `AXLocalePolicy.markerListNumberOfItemsLabel`
+    // deliberately carries no invented translation. This proves the label-matching policy
+    // itself fails closed on an unmeasured locale description, independent of the rest of
+    // the delete plumbing.
+    for description in ["항목 수", "項目数"] {
+        #expect(
+            !AXLocalePolicy.markerListNumberOfItemsLabel.matches(description, mode: .exactStrict),
+            "\"\(description)\" must not match until measured on a live Logic"
+        )
+    }
 }

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -780,6 +780,7 @@ enum SemanticOracleFixtures {
                 "target_position_unique":true,"position_evidence_canonical":true,\
                 "marker_count_before":3,"write_attempted":true,\
                 "readback_settled":true,"marker_count_after":2,\
+                "observed_marker_count_before":3,"observed_marker_count_after":2,\
                 "expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1",\
                 "observed_survivor_position_multiset":"7:1.1.1.18:12.1.1.1"}
                 """,

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -115,21 +115,29 @@ struct SemanticOracleEngineTests {
 
     @Test func readbackArrayExcludesResponseIdentityRequiresAReadableIndependentAbsence() {
         let constraint = OracleConstraint.readbackArrayExcludesResponseIdentity(
-            responseNameKey: "target_name",
-            responseIndexKey: "requested_index",
+            responsePositionKey: "target_position",
             readbackArrayKey: "data",
-            readbackNameKey: "name",
-            readbackIndexKey: "id"
+            readbackPositionKey: "position"
         )
-        let response = root(#"{"target_name":"Verse","requested_index":1}"#)
-        let deleted = root(#"{"data":[{"id":0,"name":"Intro"},{"id":2,"name":"Chorus"}]}"#)
-        let survives = root(#"{"data":[{"id":1,"name":"Verse"}]}"#)
+        let response = root(#"{"target_position":"5.1.1.1"}"#)
+        let deleted = root(#"{"data":[{"position":"1.1.1.1"},{"position":"12.1.1.1"}]}"#)
+        let survives = root(#"{"data":[{"position":"5.1.1.1"}]}"#)
+        let renamedSurvivor = root(#"{"data":[{"id":0,"name":"Marker 1","position":"1.1.1.1"}]}"#)
 
         #expect(constraint.isSatisfied(by: response, readback: deleted))
         #expect(!constraint.isSatisfied(by: response, readback: survives))
+        // Auto-rename reuses the target name at index 0; position identity still holds.
+        #expect(constraint.isSatisfied(
+            by: root(#"{"target_position":"2.1.1.1"}"#),
+            readback: renamedSurvivor
+        ))
         // A response claim cannot prove its own absence when the independent data records do not
-        // answer both identity fields.
+        // answer the position field. An empty data array is not an answer of absence unless
+        // the readback itself claims a verified empty list.
         #expect(!constraint.isSatisfied(by: response, readback: root(#"{"data":[{"id":1}]}"#)))
+        #expect(!constraint.isSatisfied(by: response, readback: root(#"{"data":[]}"#)))
+        #expect(!constraint.isSatisfied(by: response, readback: root(#"{"data":[],"verified_empty":false}"#)))
+        #expect(constraint.isSatisfied(by: response, readback: root(#"{"data":[],"verified_empty":true}"#)))
         #expect(!constraint.isSatisfied(by: response, readback: nil))
     }
 
@@ -776,15 +784,45 @@ struct SemanticOracleMutationTests {
         #expect(!wrongPositions, "delete_marker accepted a settled readback with wrong positions")
 
         // Mutation: every remaining default marker name shifted down by one after
-        // deleting index 0, but their positions are exactly right. State A does
-        // not normally carry these State-B diagnostic fields; including them here
-        // proves the oracle deliberately binds the position multiset, not names.
-        let namesShiftedReadback = Data(#"{"source":"ax_live","readable":true,"position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","positions_canonical":true,"data":[]}"#.utf8)
+        // deleting index 0, but their positions are exactly right. An honest
+        // `data[]` still carries `{id:0, name:"Marker 1"}` after Logic auto-renames
+        // the former Marker 2. Name+index identity treats that as target survival;
+        // position identity must not.
+        let namesShiftedReadback = Data(#"{"source":"ax_live","readable":true,"position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","positions_canonical":true,"data":[{"id":0,"name":"Marker 1","position":"1.1.1.1","position_source":"parser","is_canonical":true},{"id":1,"name":"Marker 2","position":"1.1.1.1","position_source":"parser","is_canonical":true},{"id":2,"name":"Marker 3","position":"5.1.1.1","position_source":"parser","is_canonical":true}]}"#.utf8)
         let namesShifted = try #require(oracle.evaluate(
-            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"2.1.1.1","prewrite_marker_identities":["8:Marker 17:2.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","expected_survivors":["8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"observed_survivors":["8:Marker 17:1.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:5.1.1.1"]}"#.utf8),
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"2.1.1.1","prewrite_marker_identities":["8:Marker 17:2.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"observed_marker_count_before":4,"observed_marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","expected_survivors":["8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"observed_survivors":["8:Marker 17:1.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:5.1.1.1"]}"#.utf8),
             readbackData: namesShiftedReadback
         ))
         #expect(namesShifted, "delete_marker rejected correct positions solely because default names shifted")
+
+        // Reproduction A: a forged target name whose (name, index) pair is absent
+        // from the honest Intro/Chorus readback. Name+index identity treated that
+        // absence as proof. Names are not identity — this envelope has the same
+        // independent position disappearance as the honest Verse fixture, so it
+        // cannot be rejected without also rejecting that fixture. Mutation proven:
+        // restore name+index identity. The honest Marker 1 rename below then fails.
+        var forgedNameObject = try #require(
+            JSONSerialization.jsonObject(with: fixture.responseData) as? [String: Any]
+        )
+        forgedNameObject["target_name"] = "Nope"
+        forgedNameObject["prewrite_marker_identities"] = [
+            "5:Intro7:1.1.1.1", "4:Nope7:5.1.1.1", "6:Chorus8:12.1.1.1",
+        ]
+        let forgedNameData = try JSONSerialization.data(withJSONObject: forgedNameObject)
+        let forgedName = try #require(oracle.evaluate(
+            responseData: forgedNameData,
+            readbackData: fixture.readbackData
+        ))
+        #expect(forgedName, "delete_marker used name+index identity; a forged name with a real position deletion must follow the position proof")
+
+        // Reproduction B: honest delete of Marker 1 at index 0. Logic auto-renames
+        // the former Marker 2 to Marker 1 at index 0. Name+index identity rejects
+        // the honest delete.
+        let honestRename = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Marker 1","target_position":"2.1.1.1","prewrite_marker_identities":["8:Marker 17:2.1.1.1","8:Marker 27:1.1.1.1","8:Marker 37:1.1.1.1","8:Marker 47:5.1.1.1"],"target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":4,"write_attempted":true,"readback_settled":true,"marker_count_after":3,"observed_marker_count_before":4,"observed_marker_count_after":3,"expected_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1","observed_survivor_position_multiset":"7:1.1.1.17:1.1.1.17:5.1.1.1"}"#.utf8),
+            readbackData: namesShiftedReadback
+        ))
+        #expect(honestRename, "delete_marker rejected an honest delete because a renamed survivor reused the target name at index 0")
 
         // Mutation: both self-reported multisets carry the same valid wire value,
         // but it contains only one entry while both counts require two. Equality
@@ -814,16 +852,14 @@ struct SemanticOracleMutationTests {
         #expect(!wrongClaimedIdentity, "delete_marker accepted a position deletion attributed to a different requested marker")
 
         // Mutation proven: remove `.readbackArrayExcludesResponseIdentity(...)` from the
-        // delete-marker oracle. Every other field below is self-consistent: its forged pre-write
-        // identity says Intro was at Verse's disappearing position, and the survivor multiset
-        // correctly excludes that position. Only the independent logic://markers `data[]` read
-        // still sees `{ id: 0, name: "Intro" }`, so the restored cross-check rejects this
-        // envelope-only wrong target. Without that one oracle line it evaluates true.
+        // delete-marker oracle. Every other field below is self-consistent, but the independent
+        // `data[]` still contains the claimed target position. Without that one oracle line this
+        // envelope evaluates true even though 5.1.1.1 survived independently.
         let wrongEnvelopeOnlyIdentity = try #require(oracle.evaluate(
-            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":0,"target_name":"Intro","target_position":"5.1.1.1","prewrite_marker_identities":["5:Intro7:5.1.1.1","5:Verse7:5.1.1.1","6:Chorus8:12.1.1.1"],"target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.18:12.1.1.1"}"#.utf8),
-            readbackData: fixture.readbackData
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","operation":"nav.delete_marker","requested_index":1,"target_name":"Verse","target_position":"5.1.1.1","prewrite_marker_identities":["5:Intro7:1.1.1.1","5:Verse7:5.1.1.1","6:Chorus8:12.1.1.1"],"target_position_unique":true,"position_evidence_canonical":true,"marker_count_before":3,"write_attempted":true,"readback_settled":true,"marker_count_after":2,"expected_survivor_position_multiset":"7:1.1.1.18:12.1.1.1","observed_survivor_position_multiset":"7:1.1.1.18:12.1.1.1"}"#.utf8),
+            readbackData: Data(#"{"source":"ax_live","readable":true,"verified_empty":false,"position_multiset":"7:1.1.1.18:12.1.1.1","positions_canonical":true,"data":[{"id":0,"name":"Intro","position":"1.1.1.1","position_source":"parser","is_canonical":true},{"id":1,"name":"Verse","position":"5.1.1.1","position_source":"parser","is_canonical":true}]}"#.utf8)
         ))
-        #expect(!wrongEnvelopeOnlyIdentity, "delete_marker accepted a target identity supplied only by its own envelope")
+        #expect(!wrongEnvelopeOnlyIdentity, "delete_marker accepted a target position that the independent readback still contains")
 
         // Source mutation applied once: remove both `crossCheck` constraints from the
         // delete-marker oracle. This response is internally consistent and contains no target
@@ -1386,19 +1422,15 @@ enum JSONMutator {
                     ("malformed identity entry", ["not-a-length-prefixed-identity"] as [Any]),
                 ]))
             }
-        case .readbackArrayExcludesResponseIdentity(let responseNameKey, let responseIndexKey, _, _, _):
+        case .readbackArrayExcludesResponseIdentity(let responsePositionKey, _, _):
             // Response-side mutations cannot be mistaken for corroboration: removing or
-            // diverging either claimed identity component must fail closed. The meaningful
+            // diverging the claimed target position must fail closed. The meaningful
             // readback-side survivor mutation is exercised directly by the delete-marker oracle
-            // regression, where the forged pre-write envelope keeps every other gate satisfied.
-            if let name = JSONPath.resolve(root, keyPath: responseNameKey) {
-                mutants.append(contentsOf: replacements(root, responseNameKey, [
-                    ("different readback identity name", divergent(from: name)),
-                ]))
-            }
-            if let index = JSONPath.resolve(root, keyPath: responseIndexKey) {
-                mutants.append(contentsOf: replacements(root, responseIndexKey, [
-                    ("different readback identity index", divergent(from: index)),
+            // regression, where a surviving target position in data[] keeps every other gate
+            // satisfied.
+            if let position = JSONPath.resolve(root, keyPath: responsePositionKey) {
+                mutants.append(contentsOf: replacements(root, responsePositionKey, [
+                    ("different readback identity position", divergent(from: position)),
                 ]))
             }
         case .fieldsEqual(let keyA, let keyB):

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -876,6 +876,49 @@ struct SemanticOracleMutationTests {
             readbackData: nonCanonicalReadback
         ))
         #expect(!canonicalityWasOnlySelfReported, "delete_marker accepted a self-reported canonicality flag contrary to readback")
+
+        // #549 BLOCKER follow-up: `observed_marker_count_before`/`_after` were presence-only
+        // (`.typedField`) — any count pair satisfied them. Mutation proven: drop
+        // `.numericEqualsOffset` (the AFTER == BEFORE - 1 pin) from the oracle. Both envelopes
+        // below evaluate true today with only `.typedField` in place; each carries the honest
+        // fixture's `observed_marker_count_before: 3` but a corrupted after-count that either
+        // claims no drop occurred (3, unchanged) or is disconnected from the before-count
+        // entirely (99).
+        var noDropCountsObject = try #require(
+            JSONSerialization.jsonObject(with: fixture.responseData) as? [String: Any]
+        )
+        noDropCountsObject["observed_marker_count_after"] = 3
+        let noDropCounts = try #require(oracle.evaluate(
+            responseData: try JSONSerialization.data(withJSONObject: noDropCountsObject),
+            readbackData: fixture.readbackData
+        ))
+        #expect(!noDropCounts, "delete_marker accepted an observed after-count equal to the before-count (no drop)")
+
+        var wildCountsObject = try #require(
+            JSONSerialization.jsonObject(with: fixture.responseData) as? [String: Any]
+        )
+        wildCountsObject["observed_marker_count_after"] = 99
+        let wildCounts = try #require(oracle.evaluate(
+            responseData: try JSONSerialization.data(withJSONObject: wildCountsObject),
+            readbackData: fixture.readbackData
+        ))
+        #expect(!wildCounts, "delete_marker accepted an observed after-count unrelated to the before-count")
+
+        // The companion pin — the pre-write witness must equal the table's own pre-write
+        // inventory size — is symmetric: a producer could otherwise report ANY
+        // `observed_marker_count_before`, as long as `_after` happens to be one less than IT,
+        // and still pass every other State-A gate. Mutation proven: drop `.fieldsEqual(
+        // observed_marker_count_before, marker_count_before)` from the oracle.
+        var staleBeforeCountObject = try #require(
+            JSONSerialization.jsonObject(with: fixture.responseData) as? [String: Any]
+        )
+        staleBeforeCountObject["observed_marker_count_before"] = 4
+        staleBeforeCountObject["observed_marker_count_after"] = 3
+        let staleBeforeCount = try #require(oracle.evaluate(
+            responseData: try JSONSerialization.data(withJSONObject: staleBeforeCountObject),
+            readbackData: fixture.readbackData
+        ))
+        #expect(!staleBeforeCount, "delete_marker accepted a pre-write witness that disagreed with the table's own pre-write inventory size")
     }
 
     /// #373 B3 — project.save_as is envelope-only because its
@@ -1488,6 +1531,24 @@ enum JSONMutator {
                JSONInspector.isBoolean(bValue),
                let b = (bValue as? NSNumber)?.boolValue {
                 mutants.append(contentsOf: replacements(root, keyA, [("flip-same", b)]))
+            }
+        case .numericEqualsOffset(let keyA, let keyB, let offset):
+            // Break the exact delta by moving EITHER side off it by 1, plus a
+            // non-number on keyA to exercise the numbers-only rule. (`drop keyA`
+            // is already added generically via `key`.)
+            if let bValue = JSONPath.resolve(root, keyPath: keyB),
+               let b = JSONInspector.number(of: bValue) {
+                mutants.append(contentsOf: replacements(root, keyA, [
+                    ("off-by-one high", b + offset + 1),
+                    ("off-by-one low", b + offset - 1),
+                    ("non-number", "not-a-number"),
+                ]))
+            }
+            if let aValue = JSONPath.resolve(root, keyPath: keyA),
+               let a = JSONInspector.number(of: aValue) {
+                mutants.append(contentsOf: replacements(root, keyB, [
+                    ("keyB moved off delta", a - offset + 1),
+                ]))
             }
         }
         return mutants


### PR DESCRIPTION
Follow-up to #539, which is already merged. A blind adversarial review of that head found a false State A
that the merge rationale did not cover, and this closes it — while restoring the verified delete rather
than settling for a refusal.

## What was wrong

#539 required that the pre-write row no longer own the selection, and I described that as independent
evidence. It is not. When the table rebuilds, the pre-write element matches nothing whether or not the
marker left, so the condition is satisfied by the rebuild itself.

`AXRows`, `AXChildren` and `AXSelectedRows` are three properties of one `AXTable`. They share an eye. Their
agreement was never corroboration, and two agreeing truncated inventories could certify a delete that never
happened.

Reproduction: `postWriteRowsDropIndex: 1` + `postWriteStructuralRowsDropIndex: 1`, then empty
`AXSelectedRows` after the pick. Before this change: State A, `marker_count_after: 2`, three rows still in
the table.

## What it does now

The honest first response was to withhold State A, and the first pass did. But "no independent evidence
exists here" was wrong. Logic renders its own count in the Marker List — an `AXStaticText` described
`Number of Items`, reading `2 Markers` / `1 Marker`. It is not a projection of the table. The rebuild that
makes the table's three views omit a row does not make Logic render a count it does not have.

State A now requires **both**: the independently read count drops by exactly one, AND the settled survivor
multiset no longer holds the target position. A false State A needs two unrelated surfaces to lie in the
same direction at the same moment.

Everything already there stays — the shared-omission refusal, the selection check, the settle budget, the
retry rule, the oracle constraints. The witness is found by description rather than sibling position, its
text is parsed or the witness is declared unreadable, and an unreadable witness withholds State A exactly as
before. A count that is readable and does NOT drop is a mismatch, and the receipt names which witness
disagreed. Both readings are published rather than inferred.

## Live evidence

Bound to `fa7446cb`, via `Scripts/livekit/live_523_marker_delete.py`. 4 checks + 1 visual assertion, all
passing, every one mutation-demonstrated.

```
observed_marker_count_before = 2   (text "2 Markers")
observed_marker_count_after  = 1   (text "1 Marker")
item_count_witness_state     = readable
state = A, verified = true
```

The harness reads the witness through System Events — a path the product does not use — so the check is not
a mirror of the thing it checks, and one check asserts the product's count and the independent read agree.
The visual region is the witness element's own measured rectangle rather than a guess at layout; the first
version guessed the top of the window and the node is near the bottom, which made the assertion compare two
identical wrong crops and read as "nothing changed" on a run that plainly worked.

## Review provenance

Blind adversarial review during this period was run by grok, and so was the implementation (codex quota
exhausted until 2026-08-20):

| | |
|---|---|
| covered | false positives — every finding independently reproduced by mutation or measurement before being acted on |
| NOT covered | false negatives — a blind spot the implementer has, a reviewer of the same provider shares |

Implementation has since moved to a different pool; this note applies to work produced while it had not.