### PR TITLE
chore: keep the live-evidence harnesses in the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,16 @@ jobs:
   # does no work and exists so that one required name transitively requires every real gate. It must
   # run with `if: always()` and inspect results explicitly — a job skipped because a dependency
   # failed reports as skipped, and GitHub does not treat a skipped required check as a failure.
+  # The single required status check on `main`, and deliberately the only one.
+  #
+  # This job runs no build of its own — it is the aggregator. `if: always()` makes it run even when a
+  # dependency failed, and it then refuses unless every gate succeeded. Requiring it is therefore
+  # equivalent to requiring `compile` and `test`, with two advantages: renaming or adding a gate does not
+  # need the branch ruleset edited in lockstep, and a job that legitimately does not run on some event
+  # cannot leave a required check pending forever and wedge the merge button.
+  #
+  # If you are here because "only `build` is required" looked like a hole: it is not. Add new gates to
+  # `needs` and assert their result below; do not add them to the ruleset.
   build:
     runs-on: ubuntu-latest
     needs: [compile, test]

--- a/Scripts/livekit/README.md
+++ b/Scripts/livekit/README.md
@@ -1,0 +1,70 @@
+# livekit — live evidence against the running Logic Pro
+
+A green unit suite says the code does what its fixtures say. Only a run against the real application says
+it does what the user needs. On 2026-08-14 three changes here passed every unit test and the ship gate
+while being dead or wrong live: `transport.goto_position` refused every call because a window property it
+serialized cannot be read on Logic's windows, the modal reconciler stopped recognising the sheet it exists
+to press, and a marker delete could not verify a deletion that had happened. Nothing but a live run found
+any of them.
+
+This directory is the instrument for those runs. It lives in the repo rather than a scratch directory
+because the previous copy was deleted by a `/tmp` sweep mid-investigation.
+
+## Running one
+
+```sh
+LPM_EVIDENCE_ROOT=/abs/path/outside/every/worktree \
+  python3 Scripts/livekit/live_538_modal_reconcile.py <worktree> <full-40-char-head-sha>
+```
+
+Requires Logic Pro running, a release binary at `<worktree>/.build/release/LogicProMCP`, and a terminal
+with Accessibility + Automation permission. `Scripts/livekit/evidence.py` refuses to start if any of that
+is missing rather than producing a document that looks like evidence.
+
+`~/.claude/scripts/lpm-ship.sh` reads the document this writes and refuses to push without it. The evidence
+root must be outside every worktree of the repository: evidence living inside the tree can be rewritten by
+the thing it is judging.
+
+## What `evidence.py` will not let you record
+
+Each of these exists because that exact false evidence was produced without it.
+
+| refused | why |
+|---|---|
+| an unsettled capture | a screenshot taken mid-redraw shows a state nobody was in; `shot()` waits for two identical frames |
+| a capture straddling displays | on a multi-monitor desk a window can span screens; the image then matches nothing the user saw |
+| a region-less visual assertion | a whole-window diff changes when the clock ticks and proves nothing specific |
+| a check with no named mutation | a check nobody has watched fail is decoration, not evidence |
+| a cached read presented as live | `provenance()` records the source and age and marks it unusable |
+
+Two hardware facts are baked in because guessing them cost hours: a window capture is in backing PIXELS
+(3840x2100 for a 1920x1050 window), so regions given in window points are scaled; and `screencapture -v`
+only finalises its file when its own `-V` timer elapses — SIGINT, SIGTERM, closing stdin and a
+process-group SIGINT all leave NO file at all.
+
+## Writing a new harness
+
+Copy the closest existing one. Then:
+
+- **Derive regions from the element, not from a guess.** `live_523_marker_delete.py` asks the witness node
+  where it is. An earlier version guessed the top of the window; the node is near the bottom, so the
+  assertion compared two identical wrong crops and read as "nothing changed" on a run that plainly worked.
+- **Read the independent witness through a path the product does not use.** The 523 harness reads Logic's
+  marker count through System Events. A check that reads what the product reads is a mirror, not a witness.
+- **Bound every precondition loop and fail loudly.** A reduction loop with no attempt cap ran against a
+  refusal it could never satisfy until it was killed. A precondition that cannot converge must say so.
+- **Follow the product's own contract in preconditions.** `track.delete` refuses an ambiguous
+  `expected_name` and its hint says to rename by index first. The harness ignored that twice — once with a
+  name, once by guessing `target_ref` would help — and both times the answer was already in the envelope.
+- **Record the operation, not the setup.** Start the recording after the precondition.
+
+## `check_review_integrity.sh`
+
+Blind reviews arrive as text over a transport that has been observed to interleave two of its own streams
+into one output. Run this over a review before treating it as a verdict. Exit codes are distinct because
+"damaged" and "cannot be checked" are different answers: `0` intact, `1` damage detected, `2` integrity
+undetermined — and undetermined is not a pass.
+
+The envelope and the contents fail separately. "These are all the findings" belongs to the envelope and
+dies with it. An individual finding carrying file:line and a reproduction path verifies against the repo on
+its own terms and survives the transport that damaged it.

--- a/Scripts/livekit/check_review_integrity.sh
+++ b/Scripts/livekit/check_review_integrity.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Verify a blind-review output was not damaged in transit.
+#
+# On 2026-08-16 a review arrived with two of its own output streams interleaved. Its first 506 lines were
+# unrecoverable; the remaining 270 were intact and held 14 findings including a BLOCKER. Two lessons are
+# built in here:
+#
+#   * The ENVELOPE and the CONTENTS fail separately. "These are all the findings" is a property of the
+#     envelope and dies with it. An individual finding carrying file:line citations and a reproduction
+#     path verifies against the repo on its own terms and survives.
+#   * It was caught only because the corruption fell mid-word. At a paragraph boundary the result is
+#     grammatical, complete-looking, and silently missing a finding.
+#
+# Exit codes are distinct because "damaged" and "cannot be checked" are different answers:
+#   0  intact
+#   1  damage detected — discard the verdict; individual findings may still be verified on their own
+#   2  integrity CANNOT be determined — the check did not run, which is not the same as passing
+#
+# Usage: check_review_integrity.sh <review-output-file>
+set -uo pipefail
+F="${1:?usage: check_review_integrity.sh <review-output>}"
+DAMAGED=0
+fail() { echo "-> REVIEW INTEGRITY FAIL: $1"; DAMAGED=1; }
+undetermined() { echo "-> REVIEW INTEGRITY UNDETERMINED: $1"; exit 2; }
+
+[ -s "$F" ] || undetermined "empty output — nothing to check"
+
+# --- ordinals: the primary count, because they survive a lost tail ---------------------------------
+# Each finding heading carries `[k/N]`. A missing middle finding shows as a gap (1,2,4) and a lost tail
+# still leaves N known, so "I have 9 of 14" is countable. A single trailing FINDINGS line cannot do that.
+ORDINALS=$(grep -oE '^(#{2,3}|\*\*) *\[[0-9]+/[0-9]+\]' "$F" | grep -oE '[0-9]+/[0-9]+' || true)
+# Reviewers write findings as `### MAJOR — …` or `**MAJOR — …**`; both count. Missing the second
+# spelling made this checker report 0 headings on a perfectly good review — a false alarm is as useless
+# as a missed one.
+HEADINGS=$(grep -cE '^(#{2,3} *(\[[0-9]+/[0-9]+\] *)?|\*\*)(BLOCKER|MAJOR|MINOR)' "$F")
+
+if [ -n "$ORDINALS" ]; then
+    TOTAL=$(printf '%s\n' "$ORDINALS" | cut -d/ -f2 | sort -u)
+    [ "$(printf '%s\n' "$TOTAL" | wc -l | tr -d ' ')" = "1" ] \
+        || fail "findings disagree about the total ($(echo $TOTAL | tr '\n' ' ')) — two outputs were spliced"
+    SEEN=$(printf '%s\n' "$ORDINALS" | cut -d/ -f1 | sort -n | uniq | tr '\n' ' ')
+    COUNT=$(printf '%s\n' "$ORDINALS" | cut -d/ -f1 | sort -nu | wc -l | tr -d ' ')
+    [ "$COUNT" = "$(echo $TOTAL | head -1)" ] \
+        || fail "have findings [$SEEN] of $TOTAL — $(( $(echo $TOTAL|head -1) - COUNT )) missing"
+else
+    DECLARED=$(grep -oE '^FINDINGS: *[0-9]+' "$F" | tail -1 | grep -oE '[0-9]+' || true)
+    [ -n "$DECLARED" ] || undetermined "no [k/N] ordinals and no 'FINDINGS: N' line — a dropped finding cannot be detected"
+    [ "$DECLARED" = "$HEADINGS" ] || fail "declared $DECLARED findings, found $HEADINGS headings"
+fi
+
+VERDICTS=$(grep -cE '^`?VERDICT: (MERGE|DO NOT MERGE)' "$F")
+[ "$VERDICTS" = "1" ] || fail "expected exactly one VERDICT line, found $VERDICTS"
+
+# --- splice markers: what interleaving leaves that prose never does --------------------------------
+# Measured on the real pair, same minute and flags: corrupted 12 mid-line '###' and 142/488 odd-backtick
+# lines; its clean sibling 0 and 0.
+MIDHASH=$(grep -cE '.+###' "$F")
+[ "$MIDHASH" -eq 0 ] || fail "$MIDHASH line(s) carry '###' inside the line — a heading was spliced into other text"
+ODD=$(awk '{n=gsub(/`/,"`"); if (n%2==1) c++} END {print c+0}' "$F")
+[ "$ODD" -eq 0 ] || fail "$ODD line(s) have an unbalanced code span — text was cut mid-token"
+
+[ "$DAMAGED" -eq 0 ] || {
+    echo
+    echo "The VERDICT is discarded. Individual findings that carry file:line and a reproduction path may"
+    echo "still be verified against the repo — damage to the envelope does not refute its contents."
+    exit 1
+}
+echo "review integrity ok — $HEADINGS findings, one verdict, no splice markers"

--- a/Scripts/livekit/check_review_integrity.sh
+++ b/Scripts/livekit/check_review_integrity.sh
@@ -21,9 +21,36 @@ set -uo pipefail
 F="${1:?usage: check_review_integrity.sh <review-output>}"
 DAMAGED=0
 fail() { echo "-> REVIEW INTEGRITY FAIL: $1"; DAMAGED=1; }
-undetermined() { echo "-> REVIEW INTEGRITY UNDETERMINED: $1"; exit 2; }
+# "cannot be checked" only stands when nothing else already answered the question. A spliced file usually
+# loses its count line as well, and exiting 2 there would report an open question about a file whose damage
+# has already been seen.
+undetermined() {
+    echo "-> REVIEW INTEGRITY UNDETERMINED: $1"
+    [ "$DAMAGED" -eq 0 ] || return 0
+    exit 2
+}
 
 [ -s "$F" ] || undetermined "empty output — nothing to check"
+
+# --- splice markers first: what interleaving leaves that prose never does ---------------------------
+# These run BEFORE the count checks on purpose. A spliced file often loses its count line too, and
+# reporting "integrity undetermined" for a file whose damage is visible understates what is known.
+# Observed damage outranks an unanswerable question.
+MIDHASH=$(grep -cE '.+###' "$F")
+[ "$MIDHASH" -eq 0 ] || fail "$MIDHASH line(s) carry '###' inside the line — a heading was spliced into other text"
+# Fenced blocks are skipped, fence lines included: a fence is three backticks, so it is ALWAYS odd, and
+# code legitimately contains unpaired backticks. Without this every review carrying a reproduction command
+# was called damaged — and this check's failure path is "discard the verdict", the same decision that
+# nearly threw away thirteen findings including a blocker. A false alarm here costs as much as a miss.
+#
+# Known blind spot, stated rather than papered over: interleaving that falls entirely inside a fenced
+# block is invisible to this signal. The mid-line `###` check and the ordinal sequence cover that case.
+ODD=$(awk '
+  /^[[:space:]]*```/ { infence = !infence; next }
+  !infence           { n = gsub(/`/, "`"); if (n % 2 == 1) c++ }
+  END                { print c+0 }
+' "$F")
+[ "$ODD" -eq 0 ] || fail "$ODD line(s) have an unbalanced code span — text was cut mid-token"
 
 # --- ordinals: the primary count, because they survive a lost tail ---------------------------------
 # Each finding heading carries `[k/N]`. A missing middle finding shows as a gap (1,2,4) and a lost tail
@@ -54,10 +81,6 @@ VERDICTS=$(grep -cE '^`?VERDICT: (MERGE|DO NOT MERGE)' "$F")
 # --- splice markers: what interleaving leaves that prose never does --------------------------------
 # Measured on the real pair, same minute and flags: corrupted 12 mid-line '###' and 142/488 odd-backtick
 # lines; its clean sibling 0 and 0.
-MIDHASH=$(grep -cE '.+###' "$F")
-[ "$MIDHASH" -eq 0 ] || fail "$MIDHASH line(s) carry '###' inside the line — a heading was spliced into other text"
-ODD=$(awk '{n=gsub(/`/,"`"); if (n%2==1) c++} END {print c+0}' "$F")
-[ "$ODD" -eq 0 ] || fail "$ODD line(s) have an unbalanced code span — text was cut mid-token"
 
 [ "$DAMAGED" -eq 0 ] || {
     echo

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -1,0 +1,533 @@
+"""Live-evidence recorder for driving Logic Pro through a built LogicProMCP binary.
+
+A unit test says the code does what its fixtures say. Only a run against the real application says it
+does what the user needs. This module is the instrument for that run, and it is deliberately hostile to
+its own operator: every affordance here exists because a specific class of false evidence was produced
+without it.
+
+What it refuses to let you record:
+
+- **An unsettled capture.** A screenshot taken while Logic is still redrawing shows a state nobody was
+  ever in. `shot()` takes frames until two consecutive ones are byte-identical, and marks the record
+  `settled: false` if they never converge.
+- **A capture straddling two displays.** On a multi-monitor desk a window can span screens and the
+  resulting image is not what the user sees. Every capture records which display it fell wholly within.
+- **A whole-window diff as a visual assertion.** A full-window comparison changes when the clock ticks.
+  `visual()` requires an explicit region and states what it expected to happen there.
+- **A check that cannot fail.** `check()` requires you to name the mutation you applied to the product
+  that flipped it. A check nobody has seen fail is not evidence.
+- **A cached read presented as live.** `provenance()` records the source and age of any value that did
+  not come from a fresh read, and marks it unusable as live evidence.
+
+The ship gate (`~/.claude/scripts/lpm-ship.sh` -> `lpm-live-gate.sh`) reads the document this writes and
+refuses the push if any of the above is violated. The gate is the enforcement; this module is what makes
+compliance the easy path.
+
+Usage:
+
+    import evidence as E
+    E.REPO = "/path/to/worktree"
+    E.BIN  = f"{E.REPO}/.build/release/LogicProMCP"
+
+    ev = E.Evidence(HEAD_SHA_40_CHARS, os.environ["LPM_EVIDENCE_ROOT"])
+    rec = ev.record_screen()             # start a screen recording of the whole run
+    d   = E.Driver()                     # MCP stdio client against the built binary
+
+    before = ev.shot("before", settle_region=REGION)
+    body   = d.tool("logic_tracks", "delete", {"index": 3})
+    after  = ev.shot("after", settle_region=REGION)
+
+    ev.check("523/the-count-drops-by-one", observed == before_n - 1,
+             "Logic's own count readout drops by exactly one",
+             f"before={before_n} after={observed}",
+             "reverted the post-write inventory guard; this check went green on a delete that never happened")
+    ev.visual("523/the-readout-changes", before["file"], after["file"], REGION,
+              expect_change=True, why="one marker was deleted")
+    ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1))
+
+`LPM_EVIDENCE_ROOT` must be an absolute path OUTSIDE every worktree of the repository; the gate refuses
+otherwise, because evidence living inside the tree can be rewritten by the thing it is judging.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+
+# Set by the harness before use.
+REPO = ""
+BIN = ""
+
+_SETTLE_TRIES = 8
+_SETTLE_GAP = 0.35
+
+
+# ---------------------------------------------------------------------------
+# Window geometry
+# ---------------------------------------------------------------------------
+
+def logic_window(title_contains="Tracks"):
+    """The on-screen bounds of a Logic window, via CoreGraphics rather than AX.
+
+    Deliberately not an AX read: the harness must be able to see the window even when the AX tree is
+    exactly what is under test. Returns None when no matching window is on screen.
+    """
+    try:
+        import Quartz
+    except ImportError:
+        return None
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID)
+    for w in wins or []:
+        if w.get("kCGWindowOwnerName") != "Logic Pro":
+            continue
+        name = w.get("kCGWindowName") or ""
+        if title_contains and title_contains not in name:
+            continue
+        b = w["kCGWindowBounds"]
+        return {"id": w["kCGWindowNumber"], "title": name,
+                "x": int(b["X"]), "y": int(b["Y"]),
+                "w": int(b["Width"]), "h": int(b["Height"])}
+    return None
+
+
+def _displays():
+    try:
+        import Quartz
+    except ImportError:
+        return []
+    err, ids, _ = Quartz.CGGetActiveDisplayList(16, None, None)
+    if err:
+        return []
+    out = []
+    for i, did in enumerate(ids):
+        r = Quartz.CGDisplayBounds(did)
+        out.append({"display": i,
+                    "bounds": [int(r.origin.x), int(r.origin.y),
+                               int(r.size.width), int(r.size.height)]})
+    return out
+
+
+def _display_containing(win):
+    """Which display wholly contains this window, if any.
+
+    A window spanning two screens produces a capture that matches nothing the user saw, so the answer
+    `wholly_within: False` is recorded rather than silently accepted.
+    """
+    for d in _displays():
+        x, y, w, h = d["bounds"]
+        if win["x"] >= x and win["y"] >= y and \
+           win["x"] + win["w"] <= x + w and win["y"] + win["h"] <= y + h:
+            return {**d, "wholly_within": True}
+    ds = _displays()
+    return {**(ds[0] if ds else {"display": -1, "bounds": []}), "wholly_within": False}
+
+
+# ---------------------------------------------------------------------------
+# MCP stdio driver
+# ---------------------------------------------------------------------------
+
+class Driver:
+    """A minimal MCP stdio client against the built binary.
+
+    Speaks to the same artifact the gate hashes, so the evidence and the shipped code cannot diverge.
+    """
+
+    def __init__(self, binary=None, timeout=180):
+        self.binary = binary or BIN
+        self.timeout = timeout
+        self._id = 0
+        self.proc = subprocess.Popen(
+            [self.binary], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, text=True, bufsize=1)
+        self._send("initialize", {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "clientInfo": {"name": "livekit", "version": "1"}})
+        self._notify("notifications/initialized")
+
+    def _write(self, obj):
+        self.proc.stdin.write(json.dumps(obj) + "\n")
+        self.proc.stdin.flush()
+
+    def _read(self):
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            line = self.proc.stdout.readline()
+            if not line:
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                return json.loads(line)
+            except ValueError:
+                continue
+        return None
+
+    def _notify(self, method, params=None):
+        self._write({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def _send(self, method, params=None):
+        self._id += 1
+        self._write({"jsonrpc": "2.0", "id": self._id, "method": method, "params": params or {}})
+        return self._read()
+
+    def tool(self, name, command, params=None):
+        """Call a tool and return its parsed body.
+
+        Arguments nest under `params`, matching the wire shape the server actually accepts.
+        """
+        args = {"command": command}
+        if params is not None:
+            args["params"] = params
+        raw = self._send("tools/call", {"name": name, "arguments": args})
+        return _body(raw)
+
+    def resource(self, uri):
+        raw = self._send("resources/read", {"uri": uri})
+        try:
+            return json.loads(raw["result"]["contents"][0]["text"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            return {}
+
+    def get(self, uri, key, default=None):
+        return self.resource(uri).get(key, default)
+
+    def close(self):
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=5)
+        except Exception:
+            try:
+                self.proc.kill()
+            except Exception:
+                pass
+
+
+def _body(raw):
+    if not raw or "result" not in raw:
+        return {"_transport_error": raw}
+    res = raw["result"]
+    if res.get("structuredContent") is not None:
+        return res["structuredContent"]
+    text = "".join(c.get("text", "") for c in res.get("content", []))
+    try:
+        return json.loads(text)
+    except ValueError:
+        return {"_text": text}
+
+
+# ---------------------------------------------------------------------------
+# Evidence document
+# ---------------------------------------------------------------------------
+
+class Evidence:
+    """Accumulates records and writes `<root>/<head>/evidence.json`.
+
+    `head` must be the FULL 40-character SHA. The gate looks the directory up by that exact name, and a
+    short SHA fails it with a message that reads like missing evidence rather than a misfiled path.
+    """
+
+    def __init__(self, head, root, name=None):
+        if not re.fullmatch(r"[0-9a-f]{40}", head or ""):
+            # Not fatal: exploratory runs use a label. The gate will simply not find it, which is correct.
+            pass
+        self.head = head
+        self.dir = os.path.join(root, head)
+        os.makedirs(self.dir, exist_ok=True)
+        self.name = name or os.path.basename(REPO or "livekit")
+        self.records = []
+        self._window_points = None
+
+    # -- observations -------------------------------------------------------
+
+    def note(self, tag, payload):
+        """Record a reading that is context rather than a claim."""
+        self.records.append({"kind": "observation", "tag": tag, "payload": payload})
+
+    def check(self, tag, passed, expected, observed, mutation):
+        """Assert something about the run.
+
+        `mutation` names the change to the PRODUCT that was seen to flip this check. A check whose
+        mutation is unknown is recorded with `mutation_flips: false` and the gate refuses the run — a
+        check nobody has watched fail is decoration.
+        """
+        self.records.append({
+            "kind": "check", "tag": tag, "passed": bool(passed),
+            "expected": expected, "observed": observed,
+            "mutation": mutation or None, "mutation_flips": bool(mutation),
+        })
+        return bool(passed)
+
+    def provenance(self, tag, source, cache_age_sec, usable):
+        """Record where a value came from when it did not come from a fresh read."""
+        self.records.append({
+            "kind": "provenance", "tag": tag, "source": source,
+            "cache_age_sec": cache_age_sec,
+            "usable_as_live_evidence": bool(usable),
+        })
+
+    def restored(self, tag, restored, detail=""):
+        """Record that state the run mutated was put back."""
+        self.records.append({
+            "kind": "restoration", "tag": tag,
+            "restored": bool(restored), "detail": detail,
+        })
+
+    # -- capture ------------------------------------------------------------
+
+    def shot(self, tag, settle_region=None, window_title="Tracks"):
+        """Capture the Logic window, waiting until the pixels stop moving.
+
+        `settle_region` is an (x, y, w, h) rectangle in window coordinates. Settling is judged on that
+        region alone: Logic repaints level meters and clocks continuously, so a whole-window settle
+        never converges and would silently record `settled: false` on a perfectly good run.
+        """
+        path = os.path.join(self.dir, f"{tag.replace('/', '_')}.png")
+        win = logic_window(window_title)
+        if not win:
+            self.records.append({"kind": "capture", "tag": tag, "file": path,
+                                 "window": None, "display": {"wholly_within": False},
+                                 "hash": None, "frames": 0, "settled": False,
+                                 "why": "no Logic window on screen"})
+            return {"file": path, "settled": False}
+
+        prev, frames, settled = None, 0, False
+        for _ in range(_SETTLE_TRIES):
+            _capture_window(win["id"], path)
+            frames += 1
+            h = _region_hash(path, settle_region, (win["w"], win["h"]))
+            if prev is not None and h == prev:
+                settled = True
+                break
+            prev = h
+            time.sleep(_SETTLE_GAP)
+
+        self._window_points = (win["w"], win["h"])
+        self.records.append({
+            "kind": "capture", "tag": tag, "file": path, "window": win,
+            "display": _display_containing(win),
+            "hash": _file_hash(path), "region_hash": prev,
+            "frames": frames, "settled": settled,
+        })
+        return {"file": path, "settled": settled, "window": win, "region_hash": prev}
+
+    def visual(self, tag, before_file, after_file, region, expect_change, why,
+               window_points=None):
+        """Compare one named region across two captures and state what was expected there.
+
+        A region is mandatory. A full-window diff answers "did anything at all change", which is true
+        whenever the transport clock advances, and proves nothing about the feature.
+        """
+        wp = window_points or self._window_points
+        b = _region_hash(before_file, region, wp)
+        a = _region_hash(after_file, region, wp)
+        readable = b is not None and a is not None
+        changed = readable and b != a
+        # An unreadable comparison is not a passing one, whichever way the expectation points.
+        passed = readable and (changed == bool(expect_change))
+        self.records.append({
+            "kind": "visual", "tag": tag, "region": list(region) if region else None,
+            "before": before_file, "after": after_file,
+            "expected": ("region changes" if expect_change else "region does not change") + f" — {why}",
+            "observed": f"before {(b or '?')[:16]} after {(a or '?')[:16]} changed={changed}",
+            "passed": passed,
+        })
+        return passed
+
+    # -- recording ----------------------------------------------------------
+
+    def record_screen(self, seconds=90):
+        """Start a screen recording covering the whole run.
+
+        `seconds` is a hard duration, not a maximum, and `stop_recording` waits it out. That is not a
+        convenience choice: `screencapture -v` only finalises its file when its own `-V` timer elapses.
+        Measured on macOS 15 — SIGINT, SIGTERM, closing stdin, and a process-group SIGINT all leave NO
+        file at all. Pick a duration a little longer than the run rather than a generous one, since the
+        wait is real.
+
+        The file name never begins with a dot: `screencapture` rejects dotfiles while still exiting 0,
+        which produces a silent absence rather than an error.
+        """
+        path = os.path.join(self.dir, "run.mov")
+        proc = subprocess.Popen(
+            ["/usr/sbin/screencapture", "-v", "-V", str(seconds), path],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(1.5)
+        return {"proc": proc, "file": path, "seconds": seconds}
+
+    def stop_recording(self, handle, settle=1.0):
+        """Wait for the recording to finalise, then record what actually landed on disk."""
+        if not handle:
+            return
+        time.sleep(settle)
+        try:
+            handle["proc"].wait(timeout=handle.get("seconds", 90) + 30)
+        except Exception:
+            try:
+                handle["proc"].kill()
+            except Exception:
+                pass
+        time.sleep(1.0)
+        self.recording(handle["file"])
+
+    def recording(self, path):
+        exists = os.path.isfile(path)
+        self.records.append({
+            "kind": "recording", "file": path, "exists": exists,
+            "bytes": os.path.getsize(path) if exists else 0,
+        })
+
+    # -- output -------------------------------------------------------------
+
+    def write(self):
+        built_from, dirty = _worktree_head(REPO)
+        if dirty:
+            # A binary built from a dirty tree does not correspond to the commit it claims. Say so in
+            # the document rather than letting the SHA imply a correspondence that does not hold.
+            self.records.append({
+                "kind": "provenance", "tag": "artifact/worktree-was-dirty",
+                "source": "git status --porcelain", "cache_age_sec": None,
+                "usable_as_live_evidence": False,
+            })
+        doc = {
+            "name": self.name,
+            "head": self.head,
+            "artifact": {
+                "path": BIN,
+                "sha256": _file_hash(BIN),
+                "built_from": built_from,
+                "worktree_clean": not dirty,
+            },
+            "records": self.records,
+        }
+        out = os.path.join(self.dir, "evidence.json")
+        with open(out, "w") as fh:
+            json.dump(doc, fh, indent=1)
+        return self._summary(out)
+
+    def _summary(self, out):
+        recs = self.records
+        checks = [r for r in recs if r["kind"] == "check"]
+        caps = [r for r in recs if r["kind"] == "capture"]
+        vis = [r for r in recs if r["kind"] == "visual"]
+        return {
+            "file": out,
+            "checks": len(checks),
+            "passed": sum(1 for c in checks if c["passed"]),
+            "mutation_backed": sum(1 for c in checks if c["mutation_flips"]),
+            "captures_unsettled": sum(1 for c in caps if not c["settled"]),
+            "captures_straddling_displays":
+                sum(1 for c in caps if not c.get("display", {}).get("wholly_within")),
+            "restorations_failed":
+                sum(1 for r in recs if r["kind"] == "restoration" and not r["restored"]),
+            "cached_reads_used_as_live":
+                sum(1 for r in recs if r["kind"] == "provenance" and not r["usable_as_live_evidence"]),
+            "visual_assertions": len(vis),
+            "visual_failed": sum(1 for v in vis if not v["passed"]),
+            "recordings": sum(1 for r in recs if r["kind"] == "recording"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _capture_window(window_id, path):
+    subprocess.run(["/usr/sbin/screencapture", "-x", "-o", "-l", str(window_id), path],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+
+
+def _file_hash(path):
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def _region_hash(png, region, window_points=None):
+    """Hash one rectangle of a PNG.
+
+    `region` is in WINDOW POINTS, the same units `logic_window()` reports. The capture is in backing
+    PIXELS — measured 3840x2100 for a 1920x1050 window on this hardware — so the rectangle is scaled by
+    the ratio the image itself reveals. Without that scaling the crop lands somewhere else entirely and
+    the assertion compares two identical wrong regions, which reads as "nothing changed" on a run where
+    the feature plainly worked.
+
+    Returns None rather than falling back to a whole-file hash: an unusable comparison must be visible
+    as unusable, not disguised as a difference.
+    """
+    if not os.path.isfile(png):
+        return None
+    try:
+        from Quartz import (CGImageSourceCreateWithURL, CGImageSourceCreateImageAtIndex,
+                            CGImageCreateWithImageInRect, CGRectMake, CGDataProviderCopyData,
+                            CGImageGetDataProvider, CGImageGetWidth, CGImageGetHeight)
+        from Foundation import NSURL
+        url = NSURL.fileURLWithPath_(png)
+        src = CGImageSourceCreateWithURL(url, None)
+        if src is None:
+            return None
+        img = CGImageSourceCreateImageAtIndex(src, 0, None)
+        if img is None:
+            return None
+        if not region:
+            data = CGDataProviderCopyData(CGImageGetDataProvider(img))
+            return hashlib.sha256(bytes(data)).hexdigest()
+        pw, ph = CGImageGetWidth(img), CGImageGetHeight(img)
+        sx = sy = 1.0
+        if window_points:
+            wpts, hpts = window_points
+            if wpts:
+                sx = pw / float(wpts)
+            if hpts:
+                sy = ph / float(hpts)
+        x, y, w, h = region
+        sub = CGImageCreateWithImageInRect(
+            img, CGRectMake(x * sx, y * sy, w * sx, h * sy))
+        if sub is None:
+            return None
+        data = CGDataProviderCopyData(CGImageGetDataProvider(sub))
+        return hashlib.sha256(bytes(data)).hexdigest()
+    except Exception:
+        return None
+
+
+def have_tools():
+    """Everything the recorder needs, checked before a run rather than mid-run."""
+    missing = []
+    if not shutil.which("screencapture") and not os.path.exists("/usr/sbin/screencapture"):
+        missing.append("screencapture")
+    try:
+        import Quartz  # noqa: F401
+    except ImportError:
+        missing.append("pyobjc (Quartz)")
+    if BIN and not os.access(BIN, os.X_OK):
+        missing.append(f"built binary at {BIN}")
+    return missing
+
+
+def _worktree_head(repo):
+    """(HEAD sha, dirty) for the worktree the binary was built in.
+
+    `dirty` counts tracked-file modifications under Sources/ and Tests/ only: an untracked scratch file
+    does not change what was compiled, but an edited source does, and a binary built from an edited tree
+    is not evidence about the commit it is filed under.
+    """
+    if not repo:
+        return None, False
+    try:
+        head = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
+                              capture_output=True, text=True, check=False).stdout.strip()
+        st = subprocess.run(["git", "-C", repo, "status", "--porcelain", "--", "Sources", "Tests"],
+                            capture_output=True, text=True, check=False).stdout.strip()
+        return (head or None), bool(st)
+    except Exception:
+        return None, False

--- a/Scripts/livekit/fixtures/review-fenced-clean.md
+++ b/Scripts/livekit/fixtures/review-fenced-clean.md
@@ -1,0 +1,8 @@
+### [1/2] MAJOR — the guard accepts a stale count
+**Where:** `Foo.swift:120`
+Reproduction:
+```bash
+swift test --filter StaleCountTests
+```
+### [2/2] MINOR — comment overstates the lock
+VERDICT: MERGE

--- a/Scripts/livekit/fixtures/review-interleaved-damaged.txt
+++ b/Scripts/livekit/fixtures/review-interleaved-damaged.txt
@@ -1,0 +1,776 @@
+I'll review the modal-observation diff against the Honest Contract rules, starting with the worktree, the branch diff, and the tests that claim State A.The review is scoped to Honest Contract observation, not a generic style pass. Next I’ll load CommitLore, the branch diff, and the modal/sheet files those findings have to stand on.The worktree HEAD is not `1cdc65fc`, and `main...HEAD` is empty. I’ll pin the actual branch tip and recover the modal-observation commits from there.The first git commands ran in the livekit workspace, not the 538 worktree. I’ll rerun them from `/Users/isaac/projects/logic-pro-mcp-wt-538`.The mergeable delta is `origin/main...HEAD` (34 files). I’ll map State A, absence conclusions, and the gone/`blocker_set_clear` pairing in those files first.I’ll split the six Honest Contract questions across parallel reviewers and read the reconcile and AX files at the same time.The reviewers are on the six questions. I’m reading the reconcile path, State A gates, and the gone/`blocker_set_clear` pairing next.I'llI'll inspect inspect the 538 modal/sheet the  diff538 and modal trace button resolve/sheet/press Honest/ Contract paths andreport plus blocker map/ every State A emission againstretry classification. its write and independent read-back.I'll review the mergeable modal/sheet delta and the core AX files for fabricated fields and false "I'll reviewno blocking window" conclusions. the 538 pairing, dead-assertion rules, and the CI forbid script from the listed files only.The modal-reconcile and honesty helpers look like the main risk surface. I’ll read those next, plus the issue-538 tests.Next I’ll read the production pairing and scan the listed tests for `#expect` forms that cannot fail.Core reconcile and button-press paths look large; I'll read those files in slices and follow each resolve → press → report hop.Focusing next on the 538 modal files and every `encodeStateA` / settled / `gone` path in that delta.The pairing lives in the later reconcile/witness functions; I’ll read those next and finish the remaining `#expect` sites.Next I’ll inspect how Project and Tracks promote modal observations into State A/B envelopes.The executor looks bound to captured elements; next I’ll check callers that rematch titles and how unreadable scans feed retry/blocker decisions.The 538 State A sites are in Project and Tracks; next I’ll read those functions end-to-end against their read-back gates.I'll read the witness tests and the rest of the gone/`blocker_set_clear` path in production.The reconciler itself never claims State A. Next I’ll read the project and track callers that still do, and how they treat a gone sheet.Create/delete State A gates look complete-scan based; I’ll verify that against tests and whether a pre-write fact can still slip through.Checking one create/delete interaction and whether `observeModalAfterMutation` can report `.none` on a single post-rebuild read.## Dead `#expect`s (rules 1–2)
+
+In the scoped 538/453/dialog/status files I did **not** find a top-level `#expect(==/!=)` whose operand is `Bool`/`Bool?`, and I did **not** find `(dict[…] as? String ?? "nil") != "A"`.
+
+Those files use the live spellings: `#expect(x)` / `#expect(!x)`, `try #require` then a bare expect, and String/enum/Int `==`. Absence is usually forced to fail (`try #require(envelope["state"] as? String)`, or `?? "ABSENT"` then `== "mandatory_new_track"`## at 2. Fabricated / inferred [Issue538ModalWitnessTests.swift: fields (number1980, count, name, id])
+
+###(file BLOCK:///Users/isaac/projectsER — `observed_track/logic-pro-mcp-_namewt:-538/Tests/LogicProMCPTests/ "Untitled"` on State AIssue538ModalWitnessTests.swift)).
+**Where:** [`
+
+`TestsAXValue/LogicProMCPTests/Extractors.swift:583AccessibilityChannelTests.swift` has **no** 538 gone-584 /`](/Users `blocker_set_clear/isaac/projects/logic` / reconcile-pro-mcp-wt-witness-538/Sources/Logic assertionsPro.
+
+##MCP--- Question
+
+/ ##Accessibility1/ —AX StateValue A emittersExtractors.swift) returns and pre-write observations CI scanner `("Untitled",
+
+Modal vs commit false)` when no reconcile never 9c18637f emits title State/ Adescription/text. `project
+
+`Scripts/ci--field value is read.new` neverforbid-dead-expect.sh. [`Accessibility emits State A. The only` didChannel+Tracks.swift:139 538 modal move4-1397/sheet paths that can toward emit`] A **(/typesUsers**,/ notisaac only/projects/logic-pro- are track `== true` shapesmcp-wt-538/ create and trackSources/LogicProMCP/. After delete.
+
+--- stripping stringsChannels/AccessibilityChannel+Tracks
+
+### Non/closures it.swift) copies-emitters (sound still flags literals ` (`observedTrack.name`==)
+
+** true``, `AccessibilityChannel.perform` / `reconc onto the State A extras!=.
+
+ile** falseAfterHowMutation`,` ` /?? true `reconcilePreflight`**/false`, populated:** Best
+- `effort== . `somefind(``/AllDescendants` /), then aUsers/isaac/projects/ `getTitle **logic-pro-mcp-` / `getDescription`second** pass onwt-538/Sources/ (failuresLogicProMCP/Channels/ top-level `#expectAccessibilityChannel+ModalReconcile flatten to nil` operands:.swift).: Missing1359 `as? Bool`, a name`, fully parent `: is replaced1398 with the literalhesized comparison, a bare`, `:1420 `"Untitled" local/``, `:1448`. `liveIdentityBacked`
+
+- Chainfunc` is dropped: `reconc` `Bool`;ile` → `perform name, same(. the envelope has no flag.
+
+ declaredclickCreate |** .OnconfirmDelete | .acknowledge Bool member on bothAlert | .escapeMenu)` State A/B:** sides Yes
+,- — State Write and: labelled bound-tuple AX `Presstest or A,Case.expected` loops.
+
+ Escape
+- Independent as read-back: bound**Holes the if the header-element poll type’s (`. pass name was readgone` only.
+
+**REPRODUCTION PATH:** still on leaves `-**25202` of Create- (no **track fixture: rail current hits inthat** element) **plus count the** increases scoped ` bycomplete files,Modal butRead theIs scriptClear` → `witness one `Summary.blocker will not failAXLayoutItem` withSetClear`
+- CI on them `performed` is hardcoded no `AX):
+
+| Hole | `false`. `.Title`/`AX Why it cannotDescription`/`AXTextFieldgone` is never treated fail | What as causation` name or as. Assert State “no A `observed_track_ it blockername !=.” would "
+ miss-Untitled |
+"`| Pair (ing---| is---| implemented---|
+| `#expect((dict["state"]or require here as? String ?? "nil, not at a live") != "A")`-identity flag). Today State | Oper A. Tests: the testands are `String`. `Issue538 Missing key → `"ModalWitnessTests` `:nil" != "A"` at [`Issue538TrackCreation1614 is trueObservationTests.swift:121-.–163 |189 Envelope1`]`, omitted(/ ` `:Users240/isaac/projects/state` /9–2485`.logic-pro-mcp- never reached
+
+**`observeProjectCreation State A. |
+| `#Outcomewt`-**538
+/Tests/LogicProMCPTests/Issueexpect(dict["state"]`/Users/isaac/538TrackCreationObservationTests.swift as? String != "Aprojects/logic-pro-) only pins")` | `mcp-wt-538/nil != "A"` is type, true. Same absenceSources/LogicProMCP so/Channels/AccessibilityChannel+ `"-pass without `??`.ProjectUntitled |.swift"` Same ships:.286 |
+| `#expect(outcome.performed == as–489 observed`
+
+- Chain.
+
+---
+
+### BLOCKER outcome.actionAttempted)` — `mandatory_track_: `createEmptyProjectFrom | BothQualifiedcreated` is not a created `Bool`State` / `createEmpty-track read- members, **ProjectFromChooser` → `back
+**Where:** [`different**observeProjectCreationOutcome`
+-Accessibility Writes: File names →Channel+Project.swift:170- ` >175matching New_ /bool_member_equality` does Choose, then at, not fire; most one bound neither side350 Create
+- Success is a bare local-351,427. path is | always Causal-432, State463`](/Users/isaac `performed` restored from ` B (`:/projects/logic-proactionAttempted`. |
+|471`,-mcp-wt-538 `#expect(summary.blocker/Sources/LogicProMCP `:483`). Window/Set titleChannelsClear !=/ nilAccessibility)`Channel |+Project `.swiftBool?).
+
+` `!= nil` is a + track**How populated:**
+ Bool? operand extras1. `mandatory; scanner are not certifiedTrackSheetGone = only special.
+- “ (witness-cases `as? BoolSheet gone” forSummary.blockerSet` / bareClear == true)` — ** `mandatory_ locals / samenot** `observedGone`.track_created` is ** member. | `
+only2blocker**_ `.witness `Summaryobserved?.TrackCountblocker =Set AXLogicset_clear` droppedProElements.allTrackHeaders(Clear == true` (` from theruntime:).count` —:350– the flattening receipt. |
+
+351`), never enumerator ([ `observedSo: **literal`AXLogicGone`. GoneProElements+Tracks.swift: without ` `== true` is covered184-202blocker_set_clear`; the documented`](/Users/isaac/ keeps polling or coalesce endsprojects B/-logicthen--inepro- (`:352mcp-wt-538/quality hole is not;Sources/LogicProMCP–378 “`).types
+ not- `mandatory/Accessibility/AXLogicPro shapes” is only partialTrackCreationWasObserved` stillElements+Tracks.swift)), not.**
+
+St requires `observed `allTrackHeadersReadale comment (notTrackCount > 0``.
+3. `mandatory a dead assert (`:170TrackCreationWasObserved(sheet–175): [Gone, count > 0)`AX`).Logic —
+
+ anyPro---Elements positive
+
+Dialog###Filter EmitterTests .swift1: —377 track]( header count, not create Statefile:///Users/isaac/ a + A
+
+**Siteprojects/logic-pro-1 delta vs a:** `AccessibilityChannel+mcp-wt-538Tracks.swift:1400 pre-write rail/Tests/LogicProMCP.
+
+**`  
+`createTests/AXLogicProElementsOn State A/TrackViaMenu` (`DialogFilterTests.swift) still:1245`)B:** Always State B (`project → menu says `#expect(!(bool)) ``.new is`),AX but dead the. field The script is a boolean project and Press` (`:177 fact. A9c18637f say2 the opposite; leftover rail (`) → `reconcprevious document stillileAfterMutation` (`: `#expect(!dialogPresent( v1291`,…))` at :ended `witnessAttempts: 1379 is live by `mainWindow()` /`) → `verifyTrackCreation.
+
+---
+
+## Pairing ``all (`:1329:Track goneHeaders`) vs →()` ` `), or aencodeStateA` (`blocker_set_clear`:1400`)
+
+** false vs State A
+
+**NoWrite:** Track- `blocker. “menu press._set_clear` ( Optional leftoverThis sheet is gone” doesQ/3), sets not require `blocker_setpost-menu Create ( `mandatory_track_createdpreflight never_clear` before State A: true` without observing * / clicks settled Create: / success `:.**126 They5 are`). different facts. Call
+
+**Required read-ers that certify thethis* create.
+
+back for world use**REPRODUCTION PATH:** After A:**
+1. a **complete Status Choose/** clean-preserving **Create, keep read, not `. an old arrangepre-write** railgone`.
+
+Evidence rail (`beforeTracks !=:
+
+1. Identity with ≥1 ` nil`; unreadable `.AX-LayoutgoneItem`` is only in `- `252AXWindows02`` on and the makebefore cannot flatten `blocker_ to 0 — tested **captured** element ([AccessibilityChannel+ModalReconcile.swift `:43–:965118`)](file:///Users/set_clear == true`. Envelope must not set
+2. `currentTracksisaac/projects/logic- `mandatory_track_created.count > beforeTracks.countpro-mcp-wt-: true` unless a` (`:137538/Sources/LogicPro status6MCP–/-preserving138Channels read/ ofAccessibility theChannel *new8+Modal`)
+Reconc3ile..swift)– One* window shows a post1047 `observeModalAfterMutation`-create increment with). Comment. Pair at : `kind == .none &&:955 modalObservationIsComplete && arrange `blocker–961 says itWindow was ._set_clear == true does **not** answerfound` (`:1379` with `all “is no–138TrackHeaders()5 blocker == present []`,.”` `:
+ (1512flatten.2–1524`)) must `pollBoundSheetWitness`
+
+Does stay `false` ( **already), **not** require:breaks on `.gone`** Create ` but leftover and returns headersblocker (: must not flip_set_clear`,1073 it ` `.). No scantrue`.
+
+---
+
+### MAJOR — `gone`, two clean polls.
+new,3_ type.track_ `performdialog()`_ thenauto_confirmed: true` match, or a write always calls is press-bound track `completeModalReadIsClear-attempt, not a identity. `` and `withBlocker verified close
+**Where:**observedCreatedTrack` is extras [`AccessibilityChannel+ModalReconcSetClear` (` only (`:139clickCreate`ile.swift:16654–1399`).-1667`](/Users
+
+**Gone :134/isaac/projects/logic-pro-mcp-wt vs `blocker_set_9–1353-538/Sources/Logic, `confirmDeleteclear` beforePro settled`MCP/ :/138AChannels8:**/ AAccessibilityChannel+ModalReconcile.swift–1392 does not use `.);gone`. Sett, `acknowledgeAlert` : setled is a **single1416–141 from `kind** complete `.9, `escapeMenu` == .mandatoryNewTrack &&none` scan. Delete :1439–1442 actionAttempted` ([’s two-poll).
+4. `observe`Tracks.swift: absenceModalAfterMutation` (:1356,141 settle is **272–9,168not** applied (`0284:152)- never1681 attaches,1745`]7–1534` vs a witness(/Users/isaac/projects create `:. Track/logic-pro-mcp1386–1400`). create/delete State-wt-538/Sources
+
+---
+
+#### A uses **/LogicProMCP/Channels MAJOR — create Athat** read/AccessibilityChannel+Tracks.swift on a single + `deletion)). `actionModalObservationIsSettledClean post-write absence
+
+Attempted` is true evenMeasured rule` (`kind == .none when `AX: absence must settle &&Press. Delete` modalObservation fails ([Is`CompleteModal && arrangeWindow encodesWasRead`) at that as ` [AccessibilitydeletionCleanObservationStreakIsReconcile.swift:1493-1498,136Channel+Tracks.swift:1376Settled`](/Users/isaac/9]` (`projects/logic-pro-(file:///Users/isaac>=mcp-wt-538//projects/logic-proSources/LogicProMCP/ 2`, `:-mcp-wt-538Channels/AccessibilityChannel+Modal153/Sources/LogicProMCPReconcile.swift)). `performed1–1534`, test `:/`190Channels is2/ always–Accessibility `Channelfalse+`.Tracks
+
+.swift**)–On State A/1910`). Create callsB:** Yes.138 `deletionModalObservationIsSett Create State5 and :ledClean` once and1697 returns A immediately.
+
+ A keeps the *action*–1716After extras (`verification —ReconcileOutcome` is the Create, Logic rebuild **not** `observedGone post-menu dialog outcomes UI.` / action, not the Bound sheet-witness ` `- laterblocker settle252Set02 observeClear)`.` at
+ is5 `..gone ``;project.new` sets [`Tracks.swift:129 a replacement sheet `mandatoryTrackSheetGone`8-1310, can from **`blocker135SetClear == true` only be missing from## 2-1364. Press `** ([Accessibility vs read1,139AXChildren` for one completeChannel+Project.swift:350 vs report
+
+**No0-1400-looking scan](file:///Users/ identity`](/Users/isaac/. That is enoughisaac/projects/logic- rematch on the 538 for createprojects/logic-pro-pro-mcp-wt- press path.** Resolve,mcp A538 press-/.
+
+wt,Sources**- and/RE538PRODUCTIONLogic the/ PATHPro actionMCP** label/ ( sharefailChannels/AccessibilityChannelSources/LogicProMCP/ing test, same shape one captured `AXChannels/AccessibilityChannel+Tracks+Project.swift)–351). `observed as `createDoesNotUIElement`. Ord.swift). Delete State A canGone` is never read.inalCert reify-StatefindAWhileMandatory carry TheSheetRemains` +, first-enabled fallback, the same flag.
+
+ name is a lie window-index lookup, and `goneIdentityPlusDepthCap**REPRODUCTION PATH:** New press-by-title are:IsNotBlockerSetClear not on it is “ Track sheet, ``):
+
+1. Fake this path.
+
+complete scanAXPress` on arrange clear,” then**Resolve + ( Create  `same returnsmandatory1 snapshotTrack header failure as + (` post the-Creation252Was02Observed(sheetGoneObserved classifier`/`-menu mandatory:count)** — New Track sheet +-25204`), sheet> `/ Create/Cancel0)` (:170–Users later disappears for ( another reason, rail/isaac/projects/logic175Cancel disabled,). :428
+–2.-pro-mcp-wt count increases, Menu431).
+
+`-538/Sources/Logic later observe is pressperformed attaches` is hardcoded `falseProMCP/Channels/Accessibility `.none`+Channel+ModalReconcile.swift` on every sheetcomplete:/alert →657/ State-menu A action714 with`
+
+ `-new_track the sheet (do not add the Sheet/ header yet).
+3._dialog_auto_confirmed (:window1359–: true`.
+
+ buttons come Create press: invalidate bound sheet (`---
+
+### MAJOR — ` from `findAllDescendants1365, :139-8252–02140`1 on `(..., role: AXobserved_trackButton, maxDepth: AXRole`), add the, :1420_index` is the Swift6)`, new header, **do–1424, rail then `button :1448–1452 not** attach a replacement ordinalLabel` =,). on ` Tests not thatAX that an sameTitle only AX` assert identifier else `
+! `**AXperformedWhereDescription`:** cannot`. [`
+AX-Value see turn.
+4. First Create = first `AXLocaleExtractors.swift:276 a gonePolicy.createButton` exact match `verifyTrackCreation`] (`Create` / `생성(/Users/isaac/projects` observe (→settled/` / `作成`).
+no sleep/logic-pro-mcp- Delete = firstsuccess promotion-wt-538/Sources before attempt Label.
+
+---
+
+## Findings/LogicProMCP/Accessibility 0) sees countSet exact **or** `
+
+### MAJOR —/AXValueExtractors.swifthasPrefix(" `.gone` from `-252) `id: index`;Delete+ [`02 ")Tracks1`.swift and`. can: complete
+ fire145 `. with-none Those no` complete elements → blocker are today’s stored7-1458 on `Modal code-set scan
+
+`bound,1395`]SignalRead` (` returns A atcreateButton` /(/SheetUsersWitness/Observationisaac`/ /projects ` `:1400`.
+5 `deleteButton` / `/logic-pro-mcpboundTopLevelAlertalert. On the **next-wt-538/SourcesWitnessObservation` / `boundTarget`).** modal read/LogicProMCP/ChannelsStrayMenuWitnessObservation` Comments/AccessibilityChannel+Tracks.swift, attach a replacement return `.gone` on). at `
+
+**How `AXSheet` `-25202` and stop335 populated- “.:**347New ` `poll Track`headersBound and”.*`. `
+ breaksenumerated4246()`.. ** No `AX-426Expect:**.Identifier` / stable` state the not The id point: do A ( is read.
+
+**On State only production pairing not re-resolve through anreplacement is ** A:** Yes, ordinal window/sheet path.
+
+ as `observed_track_ meansafter** those helpers**Press** — sameindex`.
+
+**REPRODUCTION blocker, inside PATH file:** ` Two148 set not settled). `perform()`.
+
+Tests5-header **- that159 stopActual:** A rail after6 at`
+
+ the helper- already returned after create; assert step 4.
+
+:
+
+- [Issue `clickNewTrackCreateButton theThis is not “`538Modal /WitnessTests `confirm.swift:DeleteTracks field is not presentedgone ⇒53](Sheet`: as a host settled.” Itfile `guard:///Users/isaac/ id is “one completeprojects/logic-pro- let captured. Fail none ⇒mcp-wt-538/` → if a header’s settled AX `performActionResult(captured,” identifierTests which is,/ `" violates AXLogic thePressPro same)`. pairingMCP MissingTests element/Issue538ModalWitnessTestsTrack.swift) `#expect(observed the witness ⇒-UUID == .gone, … summary no attempt"` and extras)`
+- : was still claim, no AppleScript,108–114 poll built to protect `observed no title rematch.
+ (`:247 present_track_index == - Alert:→gone, no7–24811` as `top scan
+-`).
+
+---
+
+#### MAJORLevelDialogRead` is identity :2395 — create A from identity.
+
+ a run--- count again that
+
+ this,### then ` MAJORCF — `observed_track `.gone`_type` is inferred,Equal write` did on not cause
+
+A ( including from the dialog and is only `afterreplacement the on fabricated the single.count test name titled
+ button** +Where:** [` does > a before.count` plusAX one clean title ** equalityseparate** `readValueExtractors.swift:613; press modal (`:137ModalSignals` — good is still-652)
+6-– :1402560`). Menu `classifiedButton.element`.`](/ `2 CountUsers alertAX/ `.Pressisaacgone`/`
+ success-projects is/ : trusted260/title driftlogic-pro-mcp- (`:1783 ⇒ refuse5 menu `.gone`
+
+**wt-538/Sources/–1785`)RE (`PRODUCTIONtargetChanged PATH`.**LogicProMCP/Accessibility/ even though AX In / `buttonCountChanged`),AXValueExtractors.swift). return codes lie a test ( not a different. Noor a new click Last resort is identity is bound caller of `pollBoundSheet `.unknown`. The. The to the pressWitness` only old `click combined string.
+
+**REPRODUCTION PATH A): includes button — ` captured header  sheetextract already1;Track`Name /(... first).-nameenabled path created is documented`, so `" `, published after snapshot** as removed (`AXUntitled"` participates
+
+1. Rail1518-.
+
+**On State A:**1538`).
+- Escape alreadyRole` → `. Yes (`observed_ contains ` is thetrack_type`, `track onlyExisting` Apple (Scriptlayout infailure(AX_type_verification_sourceStatusError(raw: AX item) and `Already Created this executor: "observed_header"` (`159` (sameError.invalidUIElement.rawValue))`; replacement rail9). `-
+
+AX**161SheetRE0PRODUCTION``), PATH still and:** on it New the, ** host. ` is key- header with no type tokensnot** `AXpollBoundcode 53, not a and no readableLayoutItem` yet —SheetWitness` returns `[ button.
+
+**Report name → State `enumerate.gone]` and**
+
+TrackHeaderRows` then never calls `completeModal A `observed_track- EnReadIsClear`. If returns only layout itemsvelopes get_type: that "unknown"` labeled: ` `reconciled_action`AXLogic `ProElements+Tracks summary / `new isobserved.swift_ treated_:track asheader_364 settled`.dialog–/_ Or376Stateauto a`). name
+ that2 happens._confirmed` from `attempt A, the replacement `create to contain `"audio"`/` sheet isedReconcileActionLabel`TrackViaMenu`;" still (`164 pre-writeinstrument live."` with no type read2-1644 `perform chrome`, `165 count()` today.
+
+---
+
+### MAJOR —1-166 = 1.
+ would set `modal7`). They3. Menu `_reconciliation_witness.poll `blocker_set do **not** reperformAction` returns `true-`s_read and`clear **= /does ` notfalse`;**observations the observation` mutate are a title local poll API would not the rail.
+
+---
+
+### or re tall.
+4. After the-find aies
+**Where:** MAJOR — `project press (or.new` treats ` button. `createButton [`ModalReconcile.swift on the firstblocker_set_Title` / `deletePrimary:192-234 post-write header read),clear` as “sheet goneTitle` never leave`](/Users/isaac/ set `Already Created`’” and ignores `Modals role to `AXprojects/logic-pro- identity `.gone`
+
+[Signals`.
+- Tests lockAccessibilityLayoutmcpItemChannel-`.+wt
+5-.538/SourcesProject “ Nocaptured.swift/:LogicPro350MCP]/(file:///Users/isaac/ sheet.Channels/AccessibilityChannel+Modal Create/projects/logic-pro- CompleteDelete only”: `/Reconcilemcp-wt-538/.swift). ` `.none`.
+pollCount =Sources/LogicProMCP/Users/isaac/projects/6. **Expect:** Blogic-pro-mcp-Channels/AccessibilityChannel+Project labels.count`;/C (thiswt-538/Tests/ `observations` is a histogram.swift)– write created351,LogicProMCPTests/Issue of `" nothing).538ModalWitnessTests.swift: :428–431.
+
+Fixtures **Actual:** A,present"|"1614 `makeProjectNewPerformedCreate `-goneWithobserved163"|"5Track_un`,Fixturedeltareadable `:`_*167 (:" 1`.`,
+
+ possibly**On State A3225-169 naming the pre/B:** Merg1–32416`, `1781-existing track.
+
+ed whenever)-179 always4 do`; `/**Users/isaac/projects/ **both** `-REPRODUCTION PATH B — leftover a witness exists ([`Tracks25202` on the bound mandatory sheet (logic-pro-mcp-wt-538/Tests/ sheet **and** empty `.swift:1357writeLogicProMCPTests/Issue,142AXSheets`. They is Create538TrackCreationObservationTests.swift, not the menu)** cannot tell the0`](/Users/isaac:192-291`;/ two
+
+ `/1 factsprojectsUsers. apart/ Start/.
+
+logic withisaac**- the/REproPRODUCTIONprojects PATH/logic (fail-pro-mcp-mcp-wt-538 mandatory Newing test to-wt-538/Tests/Sources/LogicProMCP Track sheet already up/LogicProMCPTests/ write).** Same/Channels/AccessibilityChannel+ (Cancel disabled),Issue453AlertAcknowledgeBindingTests as `makeTracks.swift), [`Project.swift N tracks, no.swift:273-299ProjectNewPerformedCreateWithTrack:230-231`.
+
+### menu-Fixture`,,361 MINOR — timeout reportcreated track- but **do not** inject.
+2. `create drops362`](/ `-25202` ( theUsersTrackbound press/Viaisaac andMenu/ publishes`:projects pre/flight doeslogic **-pro-mcp- `not** click Create (`: a later observeAXRole` stays `"wt-538/Sources/1265`).LogicProMCP/Channels/-AXSheet"`). After SnapshotonlyAccessibility remChannelatch
+
++`Projectcreate.swift)). Create, ` =TrackViaMenu` presses Not N.
+3. Menu pressAXSheets=[] via Logic returns success` and window children stay (sheet `reconcileAfterMutation`’s `[trackHeaders]` and records (sheet poll may ` count neverdialog make.
+
+ in_ it `**confirmationRE a_PRODUCTION noattempt PATH-edop` from).
+4AXChildren`).  
+:** ` that pass. `reconcileAfterMutation (`128Expectedwitness` presses the **pre6Attempts: 1` create if-existing** Create (`-1308 path ([ pairing is real:1318–133`). Success`6Tracks.swift:1291: do keeps-`).129
+55`].(/ Count N not set `mandatory_ those extras (`+1, sheet gone,Users/isaac/projects/1390-140track_created` / do one complete `.logic-pro-mcp-0nonewt not``).- → Exhaust treat538 Aion the/.
+ ** sheetSources6over/. ** as gone whileLogicProMCP/Channels/writes** extras identity is `.AccessibilityExpectChannel:**+ notTracks A.swift for)) from `observe thepresent`.  
+Actual: ` → `polls: ModalAfterMutation` (`137 **completeModalReadIsClear ==01-`137 even if Logicmenu** create rebuilt many true` → `mandatory (or B5 times. DoTrackSheetGone =:`, `1415- not treat `polls leftover1424`), whose true` → with` as an AX- `-sheetaction a CreateAttempt header).ed, **`Actual ` is:**mandatory A_ always with falsetrack ` (`_createdread integer269menu_clicked` +-284.
+
+---
+
+### MINOR `reconciled_action`).
+
+** — request: click_create`.
+
+REPRODUCTION PATH**
+
+1 / clock=true` (test at :The count increase. Fixture: mandatory222 / was empty not true New Track sheet with before Create-string stand3–223 a real `Create; it was true0 would-ins on` element independently A; still/ of passB the menu extras). ** create
+
+ runsInverse: keep; bound `-25202` (
+| Field | Poprequested** menu write Create press is`.ulated as. Pre accepted; sheet | Agone`) but make ** the follow-up scan incomplete/B? | Sitestays up-existing sheet (depth-cap tree** (or |
+|---|---|---|---| is the cause.
+
+Un like : count never increases).
+| `requested_readable-before is already
+2. First2410).delta` | Constant blocked ( pass `gone `test `:1`43 /`). `- A1: **Identity`successfulPlus ` |Depthreconc ACapiledIs_Notaction=BlockerSetClear` (:** underclick_create`, `dialog and-count is2482_confirmation_attempted= B | [`Tracks.swift not.
+
+---
+
+###) already lockstrue`.
+3. Four:1344 `observeModalAfterMutation` Emitter 2 — track `blocker_,1582 polls see delete State A
+
+**Siteset_clear=false``](/Users/isaac/ `.mandatoryNewTrack` and:** `AccessibilityChannel+ on **reconcprojects/logic-pro- do not pressTracks.swift:1731`mcp-wt-538/.
+4. Terminalile**. `  
+`defaultDeleteTrack` mergeSources/LogicProMCP/ sets (`Channelsobserve:/Project153AccessibilityCreation7ChannelOutcome+`)`Tracks → has menu `AX `reconciled_action`.swift) |
+| `observation **no**Press` → observe to `"none"` and om-first,_elapsed_ms` / equivalent:its `new_track_ at `observation_budget_ms lastdialog_auto_confirmed`. most one action per kind
+5. Envelope` | `attempt * delay attempt with `blocker (`:1641–165 can` | BSetClear !=5`) → `encode show `dialog | [`Project true` isStateA` (`:173_confirmation_attempted:.swift:464,486 State B (`mandatory true` + `reconc1`)
+
+**Write:** Trackiled`]_ >_(/track DeleteactionUsers_ Track:/. "createisaacnone Optional_/ confirm"`unprojects afterconfirmed/`,logic--delete / a real Createpro-mcp-wt- :352–370 press.
+
+That is not leftover538 Create.
+
+/**SourcesRequired/ readLogic-Pro) press-Xback for A:**
+1MCP/Channels/AccessibilityChannel/ — good —report-Y, but it+Project.swift) |
+| but nothing. Readable is press-on `window_title` | asserts ` `beforeCount` and-captured-element / `get `currentCount` (unobservedGone && report-fromreadable ≠-a-laterTitle(...) ?? ""` | !blockerSetClear` on  B that- enveloperem0 | [`; tests `:1987atch.
+
+### MINORProject.swift:462`](/`,.
+
+ `:---234
+
+1### MAJOR — — first `Delete`)
+2. `currentUsers/isaac/projects/ ` / goneCount < beforeCount` vs first Create inlogic-pro-mcp--clean the **pre a leaky descendantwt-538/Sources/ fixture couples-menu walk
+
+`findLogicProMCP/Channels/ `.** snapshot (`:AllDescendants` uses best1694–1696gone` and `blocker-AccessibilityChanneleffort+ `getProjectChildren.swift`)`)
+3. **Two |
+| `observed_window_set_clear=true / consecutive** polls where_ ``
+
+titles `getobserve`[RoleIssue` | (`538 `ModalAXgetHelpersWitnessAttribute.swiftTests(:.swiftAX77:-16284ModalAfterMutation` (Windows) ?? []` then`, `491-5167the`), which flatten](file:///Users/ titles | observe, **not** the B | [`Project.swift: a failed child post-action reconcileisaac/projects/logic- walk202-209) is settledpro-mcp-wt- to `[]`. Classification,225`] clean (`538/Tests/LogicPro still:(/169Users/isaac/projectsMCPTests/Issue538Modal sets/logic-pro-mcpWitnessTests.swift)–7–1716`, `unreadableReason: nil `:`-163150 (`1wt7141- and–538 :150/1685Sources8–/LogicProMCP/Channels`). `.`)
+4. Sett1692:
+
+```swift
+/AccessibilityChannel+Project.swiftfirst` +led = `kind#expect(witness `hasPrefix("Delete ")) — failed AX == .none && complete &&.observedGone, …` (`679-682`)Windows → `[]` current)
+#expect(try # can bind “ as if zeroCount != nil` (`:require(witness.blockerSetDelete Tracks Only” ( windows |
+| `selection`1512–1524`).or any earlierClear))
+```
+
+` | Hard Post `Delete …makeBoundSheetFixture` `:-coded `"action witnessEmpty Project"` / `"gone cannot`)direct` la while"` (:under | extras a B sheet | just [`Project.swift:222 only2805–280 seen on `,356 say `confirm_delete`.arrangeWindow` (`:1697, :2821`](/ Press8–1703–2827) bothUsers/isaac/projects/ and the`).
+
+**Gonelogic-pro-mcp- in-memory vs `blocker_set_ invalidates the captured role **and** returnswt-538/Sources/ `cleardelete`:** A `AXLogicProMCP/Channels/Button` are the same does not use `.goneAccessibilityChannel+Project.swift)Sheets=[]`.  
+
+ element |
+`.**|; SettRE `led thePRODUCTION issheet ** PATH anamed_.**kind repeated Production**: ` action issummary the primary` | `String(des complete blockercribing: outcome.kind)`.
+
+**REPRODUCTION PATH**.withBlock-set scan. Delete | B | [`
+
+1erSetClear(summary.-to-zero + auto. Delete-confirm sheet:Project.swift:395`]observedGone)` instead of `-Create stays B ( button(/Users/isaac/projectscompleteModalcountRead returnsIsClear`. order `/logic-pro-mcp to These 1;Delete Tracks Only`,-wt-538/Sources two tests still pass. comments `: then `Delete Tracks and Content/LogicProMCP/Channels The`.159/1
+Accessibility testsChannel2– that159+.4 would `Project.swiftdefaultDeleteTrack` →) |
+| `dialog fail`). are Auxiliary :-_present` |177host sheet cannot `reconcileAfterMutation(isDelete8 (`!clear be skipped into `kindContext: true)`.
+3 != .none \|\` with replacement A| !complete` | State. Assert the + main-window drift (test `:818 pressed id), :1557 B only | [`–823`).
+
+ is the first prefix /Tracks.swift:1434-**Pre-write match,143 observation : →5161 not1`] the ((/ LabelreplacementUsersSet primary/isaac/projects/ A?** A decrement cannot; extraslogic-pro-mcp- alert predate the still/ `menu), and :248wt-538/Sources/ snapshot.2 (depth capreconciled_action=LogicProMCP/Channels/ Already). `:confirm_delete`.
+
+NoAccessibilityChannel+Tracks.swift)-clean — unreadable scan1647` remaining  modal alone reported / `:170538 ordinal is not enough (` as dialog / window8` /deletion present- menuState ( honestyAindexfailGate only /-Truth firstclosedTable-`,enabled but `: /187 press4-by-title not assert `!performed` —–1899 executor a modal **hard`). Concurrent.
+
+---
+
+## read) |
+
+Internal ( extracoded false 5. Partial / un delete after snapshot is** — sonot usuallyreadable scan as blocker or wire they stay the usual) fabric green.
+
+--- TO retry-stop
+
+### Incomplete childrenations that feed
+
+### MAJOR — create StateCTOU, A walk classify not does does: a not ** `  usenotseen538 gone gone** invent a sheet
+
+`find orSheet theDescendantLookup` (`UnknownBlockerSignals` sets/sett action-witness scan975 `sheetPresent: true`led hole.
+
+
+
+[Issue-1027`): failed with empty description ([**Sound**538TrackCreationObservationTests.swift role on`ModalReconcile.swift for the 538:185](file a child is “ pairing rule and:///Users/isaac/projects for “alreadynot a candidate/logic-pro-mcp:586-609`](/Users/isaac/projects/logic-pro-”; siblings gone /-wt-538/Testsmcp keep/ scanningLogic- already;Prowt clean ifMCP- / nothing538Tests already is// empty foundSources/LogicProMCP/Issue538TrackCreationObservationTestsChannels/AccessibilityChannel+Modal rail.swift)–.”186 andReconcile.swift)); unread :286–, the first
+
+---
+
+### Adjacent failure is `.287 reach `AXDescription` → State A in listedunreadable` / `.incomplete `verified `""` ([`, not `.found`. files (not 538 gone` + ``:/settled gates `readstate == "A661)
+
+| Site | Chain"` afterRemainingModalSignals` (`-662 | Write | Read `observe640-648-`]Modal`)(/backAfter turnsUsers |Mutation a/ Pre`isaac- +/writeprojects count observation,/logic-pro- failed host scan with can bemcp-wt-538/ not after `. A? |
+|------|--------|--------Sources/LogicProMCP/gone`.
+
+ no positive hit intoChannels|-----------/| `.noneAccessibility`Channel ++Modal`createConfirmationUsesBoundCreate----------------------------------|
+| `AccessibilityReconcile.swift)); unread Cancel `unreadableReason`,Button` never injectChannel+Tracks.swift:s enabled `- →25202`. After not `unknownSheet`.71` | `default Create it only clears
+
+Locked by `/ `true` ([`:686 `AXSheets` (:-688`](/SelectTrack` → `verifyUsers/isaac/projects/247Userslogic–-Track/248proSelectionisaac-`/ |mcp `-projects/selectwtlogic-TrackVia538-/AXpro`-Tests/ |mcp- `, :257AXSelected == true` onwt-538/Sources/LogicProMCPTests/Issue–261 index | **LogicProMCP/Channels/538ModalWitnessTests.swift:Yes,464-485). StateAccessibilityChannel+Modal idempotent.** Already A is a laterReconcile.swift)); `blocking` (kind-selected passes `kind ==DialogTarget` `. .none && complete` poll with `role =none`, `modal no baseline (`:.
+
+122**REPRODUCTION PATH.** observed_observationSub=roleincomplete ?? AX`,Dialog zero3–1224 After the bound`, Create presses`). press) ` |
+ and,title|` ` invalidate `114 the… captured sheet (`+Tracks5--25202`) **.swift:159` | `/`owningWindow` `115and** attachdefaultSetTrackToggle` |?? ""` a replacement New none | checkbox ([`AX1`.
+
+` Track ` already `desired` | **LogicProElements.swift:292seenUnknownBlockerSignals`AXSheet` on the-297 same host,Yes, by design** (`action: "no- (`584-609`](/Users/isaac/`) sets withop"`). |
+| `projects/logic-pro- count `sheetPresent: true`…+Tracks.swift:246 alreadymcp increased **-` (withoutwt |**- same an538/Sources/LogicProMCP/, `AX afterSheet laddersame shapeAccessibility/AXLogicProElements | toggle`. It as `createDoesNotCert.swift)).
+
+`track is only used for rungs |ifyStateAWhileMandatorySheet_count_before` / post-write `topLevelDialogRead ==Remains` :377 value . ==blocking` (` `track_). Ifcount_after` / ` desired | Halt623 aobserved_delta` on the barrier-624`), i caller used `witness 538 create can A.e. a window. **/beforeobserved anydeleteGone rung paths use` ( `allor `TrackblockerHeadersReadSet`Clear and` that copied from it** if an `NSNull) already answered to certify unreadable first read later` State A when, unread this would go reads desired — those `AXModal == true`. (`:315–317` green while counts That is a real modal, not a failed sheet search.
+
+### Unreadable ` → `: a sheet are not fabricated.
+
+AXModal` on a host246 remains`),. attribut Current production---
+
+## 3 does **not** become a observeing `r. “No blocking window” blocker
+
+`topLevelDialog-ung fromRead.nameloop failed`` / (` should malformed that stay768 / never- State partial ran reads. |
+
+
+`| `783`): `AX B (`kind…+Tracks.swift:108kind == .none` isModal` nil == mandatory_new_track0` | `defaultRename`) the classifier — pin / malformed / anyTrack` | none | name failure default ( when every already matches **both** `stateincluding `-25205` / flag is | **Yes, by design != `-25212`) → `. false ([`ModalReconciliation** (`viaunreadable(.topLevelWindow.swift:110 "A"`: "no-op"` and `witnessModalReadFailed)`,-113`](/Users/.observedGone == true). |
+| `…+ then &&isaac `Tracks blocker/_un.swiftprojectsreadable:/Modal107logicSignals1-`pro` →- classifymcp-wt-set_clear != true` | same, after `.none`. Tests on the **538/Sources/LogicPro set: `146action** receiptMCP/Accessibility/ModalRe/menu8-149,conciliation.swift)). That is | AX3`.
+
+If set or not only the later **not** by observe `.
+
+AX---Modal
+
+ ==### true MAJOR type | name itself a clean desk` and ** == requested: ` — honestysubrole** is un | Only after `:modalObservationIs tests doreadable (not definitiveComplete not absence107 lock`)9 the is →` `. pairing ` noun
+
+-readableTheseop missReason == nil`blocking` → `unknown; not cannot ([`ModalReconcile.swiftSheet` (`820 a :120-122-824`). That fail if gone is538 treated issue as world,409 is “confirmed modal. |
+| `…+-clean, because, unnamed kind,” not “-411`] they neverProject.swift:656`,unreadable AXModal.”(/Users/isaac/projects read `blocker `:664` | `save/logic-pro-mcp
+
+`modalAsViaAXDialog_set_clear`MainWindow ==-wt-538/Sources / `observedGone`:
+
+` | set/ path .- +LogicunPro [readableMCPIssue`/538 (`ChannelsMenu460Witness-461`) skips/AccessibilityChannel+ModalReconcHonestyTests.swift:22 Save | `File alertsManager.fileExists` |ile].swift(file)).:/// CreateUsers/delete//menus entirelyisaac/projects/logic- State A AND **Yes.** and returns incompletepro-mcp-wt- No pre-write `.538/Tests/LogicPro absence. Existing `completeModalMCPTests/Issue538Menunone`. Fail- fileReadIsClear` requireclosed, not anWitness + SaveHonesty `Tests.swift)– `.AXPress` success (23, invented sheet.
+
+none` **### :canand36 lie `.**,)un complete : →readable ([ A`52. does — |
+ not only become `!`Tracks.swift:1379performed|` ` /… `+actionProjectAttempt.swift State C; it **-:7531385` | `opened`
+- [Issue538,1522-1524BounceDialogViaMenu` |ModaldoesWitness**Tests become.swift “:164must click” on track`](/Users7](file:///Users create
+
+Witness AppleScript menu |/ sameisaac/projects/logic/isaac/projects/logic polls only script sees-pro-mcp-wt-pro-mcp-wt stop on `. “Bounce”-538/Sources/Logic-538/Tests/Logicgone` (`1073/“바ProMCP/Channels/AccessibilityProMCPTests/Issue538운`,ChannelModal `스+Witness125”TracksTests |0.swift.swift **);)–Yes164 [`ModalReconcile.swift:`). `.un.**8, Dialog : already170 open8– satisfies the1481-148readable` retries1709 —2`](/Users/isaac poll. Labels are hardcoded inside replacement sheet/ ENprojects//KOlogic.- |
+
+Savepro the witness, only `!performed`
+-as /-mcp-wt-538 budget (`- [Issue453AlertAcknowledge bounce are sheet/Sources/LogicProMCP1048BindingTests.swift:291]--adjacent1051`)./Channels/AccessibilityChannel+(file:///Users/isaac `project causalityModalReconcile.swift)).
+
+/projects/logic-pro-###.new holes BLOCKmcp`,ER continues- not — whilewt the Successful- 538538 gone empty //Tests/LogicProMCP/`blocker_set_clear shallow children `!modalObservationTests/Issue453AlertAcknowledge`IsComplete gate` (`325 treatedBindingTests.swift)–292.
+
+---
+
+### Gone as absence (absence-333`) — acknowledged alert gated and only exits did, no `observed ` on `blocker_set_ not settle)
+**SitesunknownSheetclear` before settled/Gone` / `blocker_:**
+` on the lastset_clear`
+
+**REA
+
+| Path |- [`findSheetDescendant attempt (`380PRODUCTION PATH.** Menu fixture UsesLookup- already`] `.407(/gone`).`Users Create/ as Stateisaac settled C// requiresprojects a/logic-pro closesA? | Requires **-mcpcomplete**- cleanwt-538 the classified `blocker_set_clear observation/Sources/LogicProMCP item and can` ( and no count/Channels/AccessibilityChannel+or equivalent complete add aModalReconcile.swift) `: increase (`1434 modal scan floating)? |
+|------|----------------------------986-1027-1446`).|------------------------------------------------`
+
+### — MAJOR `children — replacement (same--------------|
+| Re as : unreadable createResult` **concile `performed` |1560 settlesuccess). No Assert ` is advertised (`[]`performed**` `observed as a dialog always false) | Witness → noGone && blocker the user always sheet → `.absent`. must click
+
+```SetClear == false`. Today records a
+- [`complete1434:1441 nothing **separate** `completeModalReadIsClear`](/:/Users/ does onModalReadIsClear` |
+Users/isaac/projects/isaac/projects/logic- the honesty| `project.new` extraslogic-pro-mcp-pro-mcp-wt- file.
+
+ | No | `mandatorywt-538/Sources/538/Sources/LogicProTrackLogicMCP---ProSheet/
+
+GoneMCPChannels###`// MINChannels **AccessibilityORonly/Channel — `isDefinitiveAbsence+Tracks.swift
+        letAccessibilityChannel+ModalReconcile` is on the** if `blockerSet.swift) `:1473 blockingOrUnreadable = last right type; duplicateClear == true` (`:Modal.kind != .none-1482` +350`) |
+| Delete || !lastModal.modal — **one** snapshot merge note on A | No |ObservationIsComplete
+        merged.
+ `symbolicName`
+
+`is Two complete["- Createdialog settle_present"] =DefinitiveAbsence` is `.none` observes: ** on `AXHelpers blockingOrUnreadable
+       ; if blockingOrUnreadable {
+one** `observe.AXStatusError` ([            notModal `. mergedAfter["goneMutationwaiting`` |
+_ perfor |AX_ CreateuserHelpers A"].swift |: = No276 true |]
+1s slot One            return .success(Honest ([`Tracks.swift:136 complete `.none`;(file:///Users/isaac/projects/logic-proContract.encodeStateB(
+```4-1388 **not** the-mcp-wt-538
+
+`kind == Create`](/ witnessUsers’s/isaac//Sources/LogicProMCP .none` + `un `blocker_set_clearprojects/logic-pro-/Accessibility/AXHelpers.swiftreadableReason != nil` still`, and **mcp-wt-538/)– sets `dialognot** settledSources/LogicProMCP/_present`278 acrossChannels/AccessibilityChannel+Tracks and `waiting_for_):.swift twouser)). only abs`. `- `252merge05Reconc`ences / |
+
+ `-The25212`. ` Delete needsileExtras` correctlyinvalidUIElement` is ** 538 pairing is two ([not** absence with held forholds `reconc;` itTracks is.swift `:153 reconcile receipts,iled_modal_kind`isTransientDuringRebuild` (:1-1534 `project.new`, and delete and writes `reconc285–288,169 A. Create7-1716iled_modal_observation=) and separately A is the gap `axStatusIsBoundElementincomplete` (`1668`](/Users/isaac/: it neverGone` (:965- promotesprojects–167/9671).logic`),- sopro the- envelopemcp-wt-538/ `.gone` to A
+
+Modal contradicts itself:Sources/LogicProMCP/, but it will reconcileChannels/AccessibilityChannel+Tracks incomplete promote **duplicates observation a **single** complete** that predicate **and** “dialog.swift)).
+- Post none to as present, wait for-Create witness A while `axStatusIsDefinit: ` the user.”
+
+The a replacement sheet caniveAbsence` (:944 witnessAttempts4×: 1`, still appear–946) instead of `.error1 `s.isdelayDef loop: does init retry0ive`Absence; ([ after budget`Tracks.swift:129`. AX1-1295`](/ it stops andWindows **does notUsers/isaac/projects/ lies** use itlogic-pro-mcp- for about `- *why252*.05
+
+` (unsupportedwt-538/Sources/LogicProMCP/Channels/ → `**REPRODUCTION PATH** (AccessibilityChannel+Tracks.swift))failing test shapeaxWindowsReadFailed`, then immediate `complete already :877–880);Modal used at `ReadIsnoClearValue` ([`ModalReconcile.swift:1349` is empty `Issue538ModalWitnessTests` ~ (:-1353`](/875–876lineUsers/isaac/projects/logic-pro-mcp- 400)
+
+). Using the propertywt1-.538 Arrange window/ presentSources/; `AXSheetsLogicProMCP/Channels/ = on AXWindows would beAccessibilityChannel+ModalReconcile.swift the - wrong)).252 **
+
+call05Failed site`;**, ` notAXChildren` or children the wrong a descendant (`-25200`/` type.
+
+`symbolicName` role is-25204`/`- is on the same `-25200`25202` on the struct/`-25204`; host) stay un no `AXSheet (:readable. **Success`; no `294–314AXModal == of) and includes `invalidUI true` window.
+2. an empty childElement` and ` ` listcannotcreate duringCompleteTrack rebuildVia`. does EnvelopeMenu` after a successful extras use `symbolic not.**
+
+** TrackName`, not `diagnosticLabelREPRODUCTION PATH:** After Create-` (:77–79menu click (, host `AXChildren`). Test commentcount may returns `. stay at flat [Issuesuccess([])` for one).
+3538.Modal EachWitnessTests.swift: poll while the `observeModalAfterMutation`1198](file:/// New Track sheet is still being is `.none` + `Users/isaac/projects/ rebuiltlogicwindow-_;prosheet_ other- windowsreadmcp `_-failed` (wt-538/Tests/or `descendantAXModal == false`; menuLogicProMCPTests/Issue_ bar unselected538ModalWitnessTests.swift)–traversal_depth_cap`).. `completeModalReadIs1201 records the
+4. After four origin/main mergeClear == true polls, expect (` **` /cannotnot** `dialog create State AComplete` vs snake_case_present` / ` if the railwaiting ` already_diagnostic incrementedforLabel_`).user That`. expect Today. Same both is a ** are `true`, shape aslive String** `state= the depth-cap pairing compareB`, `reason=retry: test ([_exhausted`, `reconciled missing `symbolic`Issue538ModalWitnessTests_modal_kind`Name` → `.swift:2471-248 absent, `reconciled_nil == "5`](/Users/isaacmodal_observation=incomplete`.cannotComplete"` fails/
+
+.
+
+Deleteprojects** (`/RE173logicPRODUCTION8- PATHpro (-duplicatemcp-wt-538-1760`) does/Tests/LogicProMCP drift **not** set `waitingTests/Issue538ModalWitness).** Change only_for_user`; it `AXStatusTests.swift)), but is onlyError.isDefinitiveAbsence with retry a` to include `invalid-exhausted State **successful emptyUIElement`. Modal B.
+
+### Failed search is** tree not a found sheet sheet instead of a cap walk /
+
+Sheet `..
+
+ `---modal
+
+Main###Window` keep using the private BLOCKER — `dialogPresentfound` only when` / `window copy → testsHostsBlockingModal` can `AXRole == AXSheet` (` stay green while922 answer marker-923`, `100 “no dialog/other channels4-1005” from a partial walk treat `-25202` as`). AX
+**Where emptyWindows. Or the:** [`AXLogic/` reverseProAX:ElementsSheets change.swift`: failures177-218 are un only the private copyreadable or fall`](/Users/isaac/; `AXHelpers` testsprojects through./ Testslogic-pro- stay green.
+
+:` `488mcp-wt-538/-524Sources/LogicProMCP/modalMainWindow` already maps ``, `930Accessibility/AXLogicProElementsisDefinitiveAbsence`.swift).
+
+|-950`. → `.absent` (: Input |524
+
+ Conclusion–###525 |
+ Gone| without---| `---|blocker
+_|set_). Adding Direct `-25202` thereclear` does not certify `AXChildren would treat` a `- rebuilding clean or stop main window as “25205`/`-252 observation
+
+Bound `-25202` isno main window12` | `false` `.gone` and **.” Pinends (no sheet on with `AX that witness this window) |
+MainWindow` →** (`948- `-|967252 Direct02 children readable`, and sheet a`, `1041 sheet still on `AXWindows` nested under `-1047`, `107AXGroup` | ` (same3`). ` intentfalse` — **no descentblocker_ as :191** (`caseset_clear` is a3). .success: continue`) |
+ separate complete scan (`
+
+---
+
+### MINOR| Top134 — `#-level New Track **9-1353expect(kind != .informational`,windowAlert `**)`147 (` isAX3 liveModal- but ==148 weak true
+
+`,[ not `AXLogicProElementsDialogFilterTests.swift:AXDialog`/`AXSystem3`). `project.new`901](file:///UsersDialog`, no `AXSheet advances/isaac/projects/logic` child) | `false-pro-mcp-wt `mandatoryTrack-`538 — SheetGone` only when `538’/Tests/LogicProMCPblockerSetClear == true`Tests/AXLogicProElementss `topLevelDialog (`350-351DialogFilterTests.swift) —Read` *does`). Tests: replacement enum `!=`,* alert not see Bool this/. ([menu Pass gone`esModal forReconc `.ilenone.swift`,: `.unknownSheet`, `.blocking`, + unclear788-811`](/ etc. A setUsers/isaac/projects/ classifier that drops (`1496-155 the unreadable twologic-pro-mcp-7`, `156-button dialog towt-538/Sources/0-1611`); `.none` stillLogicProMCP/Channels/ Create/ passes. AssertAccessibilityChannel+ModalReconcile theDelete gone +.swift)) |
+| Child exact clear kind role ( `- (`252161054`-/`1631`, `1675-1692and `!action-25212` | skip candidate`).
+
+AfterAttempted`, already (search the first Create ** :902,).
+
+---
+
+**Notattempt**, `project a blocker:**.new` latches and `perform OK) |
+| Child role other only observes (`312()` does failure | `-323 runtrue` (fail-closed`). Gone + a) unclear complete |
+ scan| after AX every issuedWindows fail/malformed ( Create/Deletereplacement | New ` Tracktrue`, (/ackfail-closed) |
+
+Used or unreadable complete/Escape. State as scan) will A for tracks requires not press again “no modal a later complete `kind →” before synthetic keys == .none`, terminal ([`Tracks.swift:914 `mandatory_track_create-916 not`](/_ `.Usersungone/confirmed`.isaac` The/ State holes B are. ( That is fail-1) observationprojects/logic-pro- APIs emitmcp-wt-538/closed anti-double `.gone` alone-create, not a falseSources/LogicProMCP/, (2) `projectChannels/AccessibilityChannel+Tracks.new` aliases.swift clear)).
+
+**REPRODUCTION→“ PATH:** Windowgone,” (3) several `AXModal == tests false cannot A`, see. ` a ObservationAX stillSheets runs == to -252 budget.
+
+05###`, New `AXStatusError` split (HEAD pairing regression; Track `AXSheet, (4) the `` under one CI script still missesorigin/main` not `AXGroup` (the readable the documented String deep-sheet here)
+
+|-absence form fixture at Mapping and some Bool [`Issue538ModalWitnessTests-typed | `-25202.swift:607` invalid-UI646Element | `- `==`.`](/Users/isaac/25204` cannotprojects/logic-pro-Complete | `-25205`mcp-wt-538/ / `-25212` |
+Tests/LogicProMCPTests|---|---|---|---|
+/Issue538ModalWitnessTests| `AXHelpers.swift)). `dialog.isDefinitiveAbsence` `276-278Present()` | no | == false` while `read noModal |Signals yesAnd |
+Alert| LocalTarget` is `axStatusIsDefinit `.mandatoryNewTrackiveAbsence` `944-946`. Second fixture: sole window is` | no | no | yes (duplicate) |
+| `isTransient modalDuringRebuild` `285- New Track (288` | **not AXyes** | yes | no |
+Dialog|, Bound no witness AX `SheetaxStatusIsBoundElementGone` child) → ` `965-967` |dialogPresent() == **`.gone`** | `. false`.unreadable` | n
+
+---
+
+### MAJOR —/a (not `kind used) |
+| Host == .none` from failed reads sheet ` (cleanchildrenResult` ` only if the982-985` | `. caller ignores `unreadableReason`)
+Theseunreadable` (retry) | `.unreadable` **do** | `.absent` |
+
+Modal produce `. reconcile does **not** callnone`; `isTransientDuringRebuild`. they set Marker delete ` stillunreadable doesReason (``Accessibility so State A shouldChannel+MarkerDelete.swift: not fire.517`). Wid They **areening `isDefinitive** “no blocking windowAbsence` to include `-25202` would make a host” if anyone class `-25202` look like “ifies `readModalSignals()` aloneno sheet” (false ([` cleanModal). NarrowReconcile.swift:418-ing `isTransientDuringRebuild` would421`](/ change marker-delete settle, not the Users/isaac/projects/538 witnesslogic-pro-mcp-. Onwt-538/Sources/ this tree theLogicProMCP/Channels/ two `isDefinitiveAbsence` copies stillAccessibilityChannel+ModalReconcile match; bound.swift `.gone) drops` is the local reason — production mutate and intentional (` pathsIssue use `And538ModalWitnessTests.swiftAlertTarget`).
+
+| Site:37-56 | Trigger`). `. | Result |
+|git` in---|---|---|
+| [` this worktree was not readable,ModalReconcile.swift so a post:-merge460 **-461`](/delta vsUsers/isaac/projects/ `origin/main`**logic-pro-mcp- is unverified.wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | `AXMainWindow` / arrange `.unreadable` | `unreadableModalSignals` → flags all false → `.none` **and skips other hosts** |
+| [`ModalReconcile.swift:531-537`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | arrange `.unreadable` mapped to `.malformedAttribute` | same short-circuit |
+| [`ModalReconcile.swift:750-754`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | AXWindows success `.absent` / `.malformed` | unreadable, not empty |
+| [`ModalReconcile.swift:757-758,877-880`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | AXWindows failure except `noValue` (incl. `-25205`) | unreadable |
+| [`ModalReconcile.swift:773-783`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | AXModal success `nil` / type mismatch / **any** AXModal failure including `-25205`/`-25212` | unreadable (not false) |
+| [`ModalReconcile.swift:980-985,997-1001,1016-1027`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | children fail (not `-25205`/`-25212`); role fail while walking; depth cap `:980` | unreadable / incomplete → `.none` + reason |
+| [`ModalReconcile.swift:651-652,1198-1199`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | stray-menu children / `AXSelected` fail | `.none` + `strayMenuReadFailed` |
+| [`ModalReconcile.swift:514-515`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift) | no app root | `.none` + `appRootUnavailable` |
+
+**REPRODUCTION PATH:** Already pinned in [`Issue538ModalWitnessTests`](/Users/isaac/projects/logic-pro-mcp-wt-538/Tests/LogicProMCPTests/Issue538ModalWitnessTests.swift) (`depthCapIsFailClosed`, `malformedChildrenAreFailClosed`, `indeterminateAXModalFailsClosed`, `unreadableStrayMenuFailsClosed`, `axWindowsUnsupportedIsNotNoOtherHosts`). Mutation: `classify(readModalSignals()) == .none` without checking `modalObservationIsComplete`.
+
+---
+
+### MAJOR — AXWindows `noValue` (`-25212`) is “no windows / no blocker”
+**Where:** [`ModalReconcile.swift:755-756,875-876`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift).
+
+Contract treats `-25212` as ANSWER. Here it is **empty search space**: `topLevelDialogRead → .none`, `anyWindowSheetLookup → .absent`. If a sheet host still exists and AXWindows says `noValue`, that is a clean desk.
+
+**REPRODUCTION PATH:** `AXMainWindow` found with an `AXSheet` child; app `AXWindows` returns `-25212`. Main-window sheet scan still sees the sheet. Invert: **no** `AXMainWindow`, `AXWindows == -25212`, sheet only reachable via windows list → `.none` + complete.
+
+---
+
+### MAJOR — `project.new` treats `.informationalAlert` / `.strayMenu` as non-blocking
+**Where:** [`Project.swift:421-422`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift) `case .none, .informationalAlert, .strayMenu: break` then certifies the arrange window.
+
+**REPRODUCTION PATH:** After Create, complete read is `.informationalAlert` (one-button AXDialog). Observer still emits `created_project_window_observed` State B. Not `kind == .none`, but it settles the write while a blocker is present.
+
+---
+
+### MINOR / correctly fail-closed (not “no blocker”)
+- **AXSheets `-25205`:** never absence; always fall through to descendants ([`ModalReconcile.swift:909-934`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)). Tests: `structuralAbsenceStatusesRemainClean`, `uninformativeAXSheetsOutcomesReachDescendantSheet`.
+- **AXSheets role fail while searching:** `continue`, then descendants (`:924-927`) — search, not verdict.
+- **AXModal fail:** unreadable, not false (`:778-783`).
+- **Sheet AXModal:** unused for classify; bound **alert** witness uses AXModal (`:1112-1128`); bound **sheet** uses AXRole (`:1038-1051`).
+- **`-25202` on captured element:** `.gone` only ([`ModalReconcile.swift:965-967,1041-1047`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)). Other statuses stay `.unreadable`. Not a blocker-set answer.
+- **`isDialogWindow` / `isBlockingDialogWindow`:** failed/missing subrole → not a dialog ([`AXLogicProElements.swift:430-448`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift)) — used for arrange filtering / `dialogPresent` first hop, not 538’s AXModal scan.
+- **`blockingDialogTarget()`** `AXWindows ?? []` ([`:252-257`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift)) → `nil` (“no target”). 538 classify uses `topLevelDialogRead`, not this.
+- **`strayMenu`:** menu-bar / children `-25205`/`-25212` → `.none` ([`ModalReconcile.swift:1179-1205`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)) — ANSWER of no menu.
+- **`classify` New Track walk:** `readModalSignals(from:)` + `findAllDescendants(..., maxDepth: 6)` via flattening `getChildren` ([`:670-672`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)). Missed buttons → `unknownSheet` / description-only mandatory, **not** `.none` (`sheetPresent: true`).
+- **`seenUnknownBlockerSignals`:** fabricates a sheet so classify is `.unknownSheet`, not `.none`.
+
+There is no function named `classifyNewTrack`. Classification is `ModalReconciliation.classify` + `readModalSignals(from:)`.
+
+---
+
+### Pairing: gone ∧ `blocker_set_clear` before settled?
+
+**Gone alone cannot settle.** `performed` is hard-`false` ([`ModalReconcile.swift:1365,1401,1424,1451`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)). Tests reject gone-as-performed ([`Issue538ModalWitnessTests.swift:1614-1733`](/Users/isaac/projects/logic-pro-mcp-wt-538/Tests/LogicProMCPTests/Issue538ModalWitnessTests.swift)). Gone + incomplete scan ⇒ `blocker_set_clear == false` ([`:2471-2485`](/Users/isaac/projects/logic-pro-mcp-wt-538/Tests/LogicProMCPTests/Issue538ModalWitnessTests.swift)).
+
+**They are not AND-ed for settlement.**
+- Witness: `blocker_set_clear` is a **separate** `completeModalReadIsClear` write, always attached after the bound poll ([`ModalReconcile.swift:1349-1353,1388-1392,1416-1419,1439-1442`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift)).
+- `project.new` sets `mandatoryTrackSheetGone` from **`blockerSetClear == true` only** — `observedGone` is not required ([`Project.swift:350-351`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift)).
+- Create/delete State A ignore the bound gone witness and use a later `kind == .none && complete` observe ([`Tracks.swift:1370-1388,1641-1716`](/Users/isaac/projects/logic-pro-mcp-wt-538/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift)).
+
+**REPRODUCTION PATH (clear without gone):** After Create, bound `AXRole` stays `-25204` (unreadable, not gone); host `AXChildren` is a successful empty list (or the sheet is missed). Envelope: `observations.unreadable_sheet_-25204 ≥ 1`, `gone` absent, `blocker_set_clear: true` → `project.new` treats the sheet as gone. Inverse (gone without clear) is already tested and does **not** settle.The create path can certify State A from a single clean absence. I’m confirming that against the name extractor and the settle loop before I write the verdict.Reviewed `origin/main...HEAD` at `1cdc65fc` (local `main` is stale; the mergeable 538 delta is 34 files). The origin/main merge left `isDefinitiveAbsence` / `symbolicName` on `AXStatusError` and did not move them onto `AXActionError`. `-25202` on a **captured** element is `.gone` again; every other status stays `.unreadable`. That pairing is implemented on the reconcile *receipt*. It is **not** what certifies State A on track create.
+
+## Evidence
+
+**Who can emit State A**
+
+The reconciler never does. `perform()` hard-codes `performed: false` after Create / Delete / ack / Escape (`AccessibilityChannel+ModalReconcile.swift:1359–1452`). `project.new` ends in State B (`AccessibilityChannel+Project.swift:471, 483`).
+
+The only 538 modal paths that emit A:
+
+| Path | Site | Gate |
+|---|---|---|
+| `createTrackViaMenu` → `verifyTrackCreation` | `AccessibilityChannel+Tracks.swift:1400` | count increased **and one** `kind == .none && complete` observe |
+| `defaultDeleteTrack` | `AccessibilityChannel+Tracks.swift:1731` | count decreased **and two** consecutive clean observes |
+
+Delete uses `deletionCleanObservationStreakIsSettled` (`>= 2`, `:1531–1534`). Create calls `deletionModalObservationIsSettledClean` once and returns immediately (`:1379–1400`). It does not read `observedGone` or the action-witness `blocker_set_clear`.
+
+**Gone vs `blocker_set_clear`**
+
+`boundSheetWitnessObservation` maps only `-25202` on the captured element to `.gone` (`:965–1051`). `pollBoundSheetWitness` **stops on `.gone`** (`:1073`). `perform()` then always runs a separate `completeModalReadIsClear` and writes `blocker_set_clear` (`:1349–1353` and the other three actions). `project.new` treats the sheet as gone only when `blockerSetClear == true` (`Project.swift:350–351`), never from `observedGone`. Delete State A uses two complete `.none` observes, not `.gone`.
+
+So: gone-alone cannot set `performed` or delete-A. Create-A never looks at gone — it looks at **one** complete `.none`. That is the hole.
+
+**Merge**
+
+`AXStatusError.isDefinitiveAbsence` is only `-25205` / `-25212` (`AXHelpers.swift:276–278`). `isTransientDuringRebuild` still includes `-25202` (`:285–288`) and is used by marker-delete, not by the 538 bound witness. Modal reconcile duplicates the absence predicate locally (`:944–946`) instead of calling the property.
+
+---
+
+## Findings
+
+### BLOCKER — Create State A from a single unsettled absence
+`AccessibilityChannel+Tracks.swift:1379–1400`
+
+Absence must settle. Delete already requires two clean polls. Create certifies A on the first `observeModalAfterMutation` that is `.none` + complete, with no sleep before attempt 0. After Create, Logic rebuilds: the bound sheet is `-25202` (`.gone`), `AXChildren` can be a successful `[]` for one poll, and a replacement New Track sheet can appear on the next read. That one empty snapshot is enough for A.
+
+This is not “gone ⇒ A”. It is “one complete none ⇒ A”, which is the same pairing the depth-cap test exists to protect (`Issue538ModalWitnessTests.swift:2477–2485`).
+
+**REPRODUCTION PATH**
+
+1. Fake arrange + 1 `AXLayoutItem` + post-menu mandatory New Track sheet (Create / Cancel, Cancel disabled).
+2. Menu press attaches the sheet. Do not add the new header yet.
+3. Create press: bound sheet `AXRole` → `-25202`; add the new header; do **not** attach a replacement on that turn.
+4. `verifyTrackCreation` attempt 0 (no sleep) sees count+1 and complete `.none` → today’s code returns A at `:1400`.
+5. On the next modal read, attach a replacement `AXSheet` “New Track”.
+6. Expect: not A. Actual: A already returned.
+
+Same shape with host `childrenResult == .success([])` for one poll instead of a missing replacement (`ModalReconcile.swift:986–1027`).
+
+---
+
+### MAJOR — Create State A from a count this write did not cause
+`AccessibilityChannel+Tracks.swift:1376–1400`, `AXLogicProElements+Tracks.swift:364–376`
+
+A is only `after.count > before.count` plus that one clean modal. Unreadable-before is blocked. A **successful under-count** is not.
+
+`enumerateTrackHeaderRows` returns only `AXLayoutItem` children once any exist. A pre-existing header that is still an `AXGroup` is invisible to the snapshot, then appears as a +1 after the menu.
+
+**REPRODUCTION PATH**
+
+1. Rail: `Existing` (`AXLayoutItem`) + `Already Created` (`AXGroup`).
+2. `createTrackViaMenu`. Pre-write count = 1.
+3. Menu `AXPress` returns true and does not mutate the rail.
+4. First post-write read: set `Already Created` role to `AXLayoutItem`. No sheet. Complete `.none`.
+5. Expect: not A. Actual: A, `observed_delta: 1`.
+
+Second fixture: leftover mandatory New Track already up. Preflight does not click Create (`:1265`). Menu press may no-op. `reconcileAfterMutation` clicks the **pre-existing** Create. Count +1, one clean none → A for the menu op.
+
+---
+
+### MAJOR — `observed_track_name: "Untitled"` was not read
+`AXValueExtractors.swift:583–584` → `Tracks.swift:1396`
+
+`extractTrackName` returns `("Untitled", false)` when title / description / text field are unread. `liveIdentityBacked` is dropped. State A extras publish the literal as if the header named itself.
+
+**REPRODUCTION PATH**
+
+Create-track fixture: rail grows by one `AXLayoutItem` with no `AXTitle` / `AXDescription` / name field. Assert State A does not carry `observed_track_name == "Untitled"` (or require a live-identity flag). Today `Issue538TrackCreationObservationTests.swift:121–189` only pins type.
+
+`observed_track_index` is the Swift `enumerated()` ordinal (`:1457–1458`), not an AX identifier. Same extras blob.
+
+---
+
+### MAJOR — `new_track_dialog_auto_confirmed: true` is a press attempt
+`ModalReconcile.swift:1493–1498, 1665–1667`; `Tracks.swift:1356, 1390–1400`
+
+`actionAttempted` is true when `AXPress` **fails**. `performed` stays false. Create State A still merges the *action* extras (`verificationReconcileOutcome` is the post-menu reconcile, not the later observe).
+
+**REPRODUCTION PATH**
+
+New Track sheet. Create `AXPress` returns `-25202`. Sheet later closes for another reason. Count increases. Later observe is `.none`+complete. Envelope: State A + `new_track_dialog_auto_confirmed: true`.
+
+---
+
+### MAJOR — `dialogPresent` can answer “no blocking window” from a failed or partial walk
+`AXLogicProElements.swift:177–218`
+
+538 taught the reconciler that `AXModal` answers blocking (`ModalReconcile.swift:768–824`). `dialogPresent` still does not read `AXModal`. It is: flattening `isBlockingDialogWindow` (subrole `AXDialog`/`AXSystemDialog`) **or** a **direct** `AXSheet` child.
+
+| Input | `dialogPresent` |
+|---|---|
+| Child role / AXWindows failure (not `-25205`/`-25212`) | `true` (fail-closed) |
+| Direct children `-25205`/`-25212` | `false` |
+| Sheet nested under `AXGroup` (no descent) | `false` |
+| Top-level New Track **window** (`AXModal == true`, not Dialog/SystemDialog, no AXSheet child) | `false` |
+| Subrole unreadable via `getAttribute` → nil, no direct sheet | `false` |
+
+Used as the no-modal gate before synthetic keys (`Tracks.swift:914–916`) and by dispatchers. Reconciler `topLevelDialogRead` **does** see the modal New Track window.
+
+**REPRODUCTION PATH**
+
+1. Window `AXModal == false`, `AXSheets == -25205`, New Track `AXSheet` under one `AXGroup` (fixture at `Issue538ModalWitnessTests.swift:607–646`). `dialogPresent() == false` while `readModalSignalsAndAlertTarget` is `.mandatoryNewTrack`.
+2. Sole window is modal New Track (not AXDialog, no AXSheet child) → `dialogPresent() == false`.
+
+---
+
+### MAJOR — “no blocking window” sites (reconciler)
+
+These produce `kind == .none`. State A is supposed to also require `modalObservationIsComplete`. They are clean-desk answers if that flag is ignored (`readModalSignals()` drops it, `:418–421`; production mutate paths use `AndAlertTarget`).
+
+| Site | What becomes “none” |
+|---|---|
+| `ModalReconcile.swift:460–461, 531–537` | Unreadable main/arrange window → `unreadableModalSignals`, **skips other hosts** |
+| `:750–754` | AXWindows success `.absent` / `.malformed` → unreadable (not empty) |
+| `:757–758, 877–880` | AXWindows failure except `noValue`, including `-25205` → unreadable |
+| `:755–756, 875–876` | AXWindows `-25212` → empty search space (ANSWER, but empty) |
+| `:773–783` | AXModal nil / type mismatch / any failure including `-25205`/`-25212` → unreadable, **not** false |
+| `:980–1027` | Children fail (not `-25205`/`-25212`); role fail while walking; depth cap → unreadable/incomplete |
+| `:986` | Children **success `[]`** → `.absent` (see BLOCKER) |
+| `:651–652, 1179–1205` | Stray-menu fail → `.none` + reason; `-25205`/`-25212` on menu bar → no menu |
+| `Project.swift:421–422` | `.informationalAlert` / `.strayMenu` treated as non-blocking for the arrange-window witness |
+
+AXSheets `-25205` correctly falls through to descendants (`:909–934`). `-25202` on a **search** node stays unreadable, not gone.
+
+**REPRODUCTION PATH (AXWindows `noValue` as empty world):** no `AXMainWindow`, app `AXWindows == -25212`, sheet only reachable via the windows list → `.none` + complete.
+
+---
+
+### MAJOR — unreadable create settle is advertised as a dialog
+`Tracks.swift:1434–1441`
+
+```1434:1441:Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+        let blockingOrUnreadable = lastModal.kind != .none || !lastModal.modalObservationIsComplete
+        merged["dialog_present"] = blockingOrUnreadable
+        if blockingOrUnreadable {
+            merged["waiting_for_user"] = true
+            return .success(HonestContract.encodeStateB(
+```
+
+`kind == .none` + `unreadableReason != nil` still sets `dialog_present` and `waiting_for_user`. `mergeReconcileExtras` honestly writes `reconciled_modal_observation=incomplete` (`:1668–1671`). The envelope contradicts itself and stops the create as “wait for the user.”
+
+**REPRODUCTION PATH**
+
+Arrange present; `AXSheets = -25205`; a descendant role is `-25200`; no sheet; no `AXModal == true` window. After a successful Track-menu click, four observe polls stay `.none` + `window_sheet_read_failed`. Expect not `dialog_present` / `waiting_for_user`. Actual: both true, State B `retry_exhausted`.
+
+Create also calls `reconcileAfterMutation` **once** (`:1291–1295`, `witnessAttempts: 1`) then only observes. A New Track sheet that appears after that one shot, or a top-level modal whose **subrole** fails (`:820–824` → `.blocking` → `unknownSheet`), never gets a Create retry. That wedges; it does not emit A.
+
+---
+
+### Q4 — button pressed vs button reported
+
+**No identity rematch on the 538 press path.** Create / Delete press the captured element (`:1489–1515`). Alert re-reads, requires `CFEqual` + same title, then still presses `classifiedButton.element` (`:1548–1596`). No ordinal window lookup, no `click button 1`.
+
+**MINOR** — `findAllDescendants` + `.first` + `hasPrefix("Delete ")` (`:670–682`) can bind “Delete Tracks Only” ahead of “Delete Tracks and Content”. Pressed element == stored element; the wire label is still `confirm_delete`.
+
+**MINOR** — exhausted create overwrites extras from `observeModalAfterMutation` (`:1415–1424`), so a real Create press can ship as `dialog_confirmation_attempted: true` + `reconciled_action: "none"`.
+
+---
+
+### Q2 — other fields (not read from Logic)
+
+| Field | What it actually is | On A/B? |
+|---|---|---|
+| `mandatory_track_created` | `blockerSetClear` **and** flattening `allTrackHeaders().count > 0` (`Project.swift:170–175, 427–432`) — not a +1 on the new window | State B only |
+| `modal_reconciliation_witness.polls` / `observations` | Local poll histogram (`ModalReconcile.swift:192–234`) | A/B when a witness exists |
+| `requested_delta` | Constant `1` / `-1` | A and B |
+| `observed_window_titles` | `AXWindows ?? []` then titles (`Project.swift:202–209`) | B |
+
+`track_count_before` / `after` / `observed_delta` on create/delete use `allTrackHeadersRead` and `NSNull` when unread. Those counts are not invented.
+
+---
+
+### Q6 — tests that cannot fail
+
+In the 538/453/dialog/status files I did **not** find a top-level `#expect(==/!=)` with a `Bool`/`Bool?` operand, and I did **not** find `(dict["state"] as? String ?? "nil") != "A"`. Those files use `#expect(x)` / `#expect(!x)`, `try #require` then a bare expect, and String/enum/Int `==`.
+
+`Scripts/ci-forbid-dead-expect.sh` (9c18637f) still will not catch:
+
+- `#expect((dict["state"] as? String ?? "nil") != "A")` — missing key passes
+- `#expect(dict["state"] as? String != "A")` — `nil != "A"` passes
+- `#expect(outcome.performed == outcome.actionAttempted)` — two different Bool members
+
+Stale comment at `AXLogicProElementsDialogFilterTests.swift:377` still says `#expect(!(bool))` is dead. It is not; `:379` is live.
+
+Honesty tests that only assert `!performed` (`Issue538MenuWitnessHonestyTests.swift:22–23`; `Issue538ModalWitnessTests.swift:1647–1648`) cannot see a gone→settled regression because `performed` is hardcoded false. The pairing is locked by `:1557`, `:1611`, `:1778`, `:2482` — not by those honesty tests.
+
+---
+
+## Pairing verdict (the question you asked to verify)
+
+| Path | Gone alone settles? | `blocker_set_clear` (or equivalent complete scan) required? |
+|---|---|---|
+| Reconcile `performed` | No (always false) | Separate `completeModalReadIsClear` always recorded |
+| `project.new` extras | No | **Only** `blockerSetClear == true` (ignores `observedGone`) |
+| Delete A | No | Two complete `.none` observes |
+| Create A | No | **One** complete `.none` — **not** settled, **not** AND-ed with gone |
+
+`-25202` on the captured element is `.gone`. That is correct and tested (`Issue538ModalWitnessTests.swift:37–56, 2562, 2605`). It is **not** AND-ed with `blocker_set_clear` before create State A, because create State A never looks at either witness field.
+
+---
+
+VERDICT: DO NOT MERGE

--- a/Scripts/livekit/fixtures/review-missing-middle-finding.md
+++ b/Scripts/livekit/fixtures/review-missing-middle-finding.md
@@ -1,0 +1,3 @@
+### [1/3] BLOCKER — a
+### [3/3] MAJOR — c
+VERDICT: MERGE

--- a/Scripts/livekit/fixtures/review-uncheckable.md
+++ b/Scripts/livekit/fixtures/review-uncheckable.md
@@ -1,0 +1,2 @@
+### MAJOR — no count declared anywhere
+VERDICT: MERGE

--- a/Scripts/livekit/live_523_marker_delete.py
+++ b/Scripts/livekit/live_523_marker_delete.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Live proof for navigate.delete_marker (#523) against the running Logic Pro.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_523_marker_delete.py <worktree> <full-40-char-head-sha>
+
+The thing under test is not "did a marker disappear" — it is whether the receipt is entitled to say so.
+
+`AXRows`, `AXChildren` and `AXSelectedRows` are three properties of one `AXTable`. When Logic rebuilds that
+table after a delete they can all omit the same row for the same reason, so their agreement is not
+corroboration and a bound row no longer matching the selection is satisfied by the rebuild rather than by
+the deletion. A State A built on those alone was reachable with no marker deleted at all.
+
+The independent witness is Logic's own count: an `AXStaticText` described "Number of Items" in the Marker
+List, reading "2 Markers" / "1 Marker". It is not a projection of the table, so a false State A now needs
+two unrelated surfaces to lie in the same direction at the same moment. This harness checks both halves,
+and reads the witness itself through System Events — a path the product does not use — so the check is not
+a mirror of the thing it is checking.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+
+def logic_item_count():
+    """Logic's own count, read independently of the product."""
+    script = ('tell application "System Events" to tell process "Logic Pro"\n'
+              'set g to (first group of (first window whose name ends with "Marker List") '
+              'whose description is "Marker")\n'
+              'repeat with k in (every UI element of g)\n'
+              'try\n'
+              'if (description of contents of k) is "Number of Items" then return '
+              '(value of contents of k) as text\n'
+              'end try\n'
+              'end repeat\n'
+              'return "ABSENT"\n'
+              'end tell')
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def count_band(win):
+    """The witness element's own rectangle, in window points, measured rather than guessed.
+
+    A region picked by eye is a guess about layout that silently stops being true — this one was
+    guessed at the top of the window and the node is actually near the bottom, so the assertion
+    compared two identical wrong crops and read as "nothing changed" on a run that plainly worked.
+    Ask the element where it is.
+    """
+    script = ('tell application "System Events" to tell process "Logic Pro"\n'
+              'set w to (first window whose name ends with "Marker List")\n'
+              'set wp to position of w\n'
+              'set g to (first group of w whose description is "Marker")\n'
+              'repeat with k in (every UI element of g)\n'
+              'try\n'
+              'if (description of contents of k) is "Number of Items" then\n'
+              'set p to position of contents of k\n'
+              'set sz to size of contents of k\n'
+              'return ((item 1 of p) - (item 1 of wp)) & "," & ((item 2 of p) - (item 2 of wp)) '
+              '& "," & (item 1 of sz) & "," & (item 2 of sz)\n'
+              'end if\n'
+              'end try\n'
+              'end repeat\n'
+              'return "ABSENT"\n'
+              'end tell')
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    parts = (r.stdout or "").strip().replace(", ", ",").split(",")
+    if len(parts) != 4:
+        return None
+    try:
+        x, y, w, h = (int(v) for v in parts)
+    except ValueError:
+        return None
+    # A little margin so anti-aliasing at the edges cannot decide the verdict.
+    return (max(0, x - 4), max(0, y - 4), w + 8, h + 8)
+
+
+def count_of(text):
+    m = re.match(r"\s*(\d+)", text or "")
+    return int(m.group(1)) if m else None
+
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+
+win = E.logic_window("Marker List")
+if not win:
+    ev.check("523/precondition-marker-list-window", False,
+             "Logic's Marker List window is on screen", "no window found",
+             "closed the Marker List; this check went red")
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+# The witness element's own rectangle, so the visual assertion is about the thing the verdict rests on
+# rather than about the window in general.
+COUNT_BAND = count_band(win) or (0, int(win["h"] * 0.90), win["w"], int(win["h"] * 0.10))
+
+# ---- precondition: at least two markers, so a delete leaves something behind ----
+while (count_of(logic_item_count()) or 0) < 2:
+    d.tool("logic_navigate", "create_marker")
+    time.sleep(0.8)
+
+before_text = logic_item_count()
+before_n = count_of(before_text)
+ev.note("precondition", {"item_count_text": before_text})
+
+rec = ev.record_screen(seconds=45)
+pre = ev.shot("before-delete", settle_region=COUNT_BAND, window_title="Marker List")
+
+body = d.tool("logic_navigate", "delete_marker", {"index": 0})
+time.sleep(1.5)
+post = ev.shot("after-delete", settle_region=COUNT_BAND, window_title="Marker List")
+after_text = logic_item_count()
+after_n = count_of(after_text)
+ev.note("response", {"body": body, "item_count_after": after_text})
+
+ev.check("523/logic-own-count-drops-by-exactly-one",
+         before_n is not None and after_n == before_n - 1,
+         "Logic's own Number of Items readout drops by exactly one",
+         f"before={before_text!r} after={after_text!r}",
+         "made AXPick a no-op; this count did not move while the table's projections still claimed the "
+         "row had gone")
+
+ev.check("523/the-delete-is-verified-not-merely-attempted",
+         body.get("state") == "A" and body.get("verified") is True,
+         "the receipt reaches State A because two unrelated surfaces agree",
+         f"state={body.get('state')!r} verified={body.get('verified')!r} "
+         f"reason={body.get('reason')!r}",
+         "required only the table's own projections; State A became reachable with nothing deleted")
+
+ev.check("523/the-count-witness-was-actually-read",
+         body.get("item_count_witness_state") == "readable"
+         and body.get("observed_marker_count_before") is not None
+         and body.get("observed_marker_count_after") is not None,
+         "both count readings are published, not inferred",
+         f"witness={body.get('item_count_witness_state')!r} "
+         f"before={body.get('observed_marker_count_before')!r} "
+         f"after={body.get('observed_marker_count_after')!r}",
+         "let an unparseable witness stand in as zero; State A survived a witness nobody could read")
+
+ev.check("523/the-product-and-an-independent-read-agree",
+         body.get("observed_marker_count_after") == after_n,
+         "the count the product reports matches the one read through System Events",
+         f"product={body.get('observed_marker_count_after')!r} independent={after_n!r}",
+         "reported the expected count instead of the observed one; the two reads diverged")
+
+ev.visual("523/the-count-readout-changes",
+          pre["file"], post["file"], COUNT_BAND, expect_change=True,
+          why=f"the marker count went {before_text!r} to {after_text!r}, so the readout must repaint")
+
+ev.restored("523/markers-remain-for-the-next-run", (after_n or 0) >= 1,
+            f"item_count_after={after_text!r}")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/livekit/live_534_goto_position.py
+++ b/Scripts/livekit/live_534_goto_position.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Live proof for transport.goto_position (#534) against the running Logic Pro.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_534_goto_position.py <worktree> <full-40-char-head-sha>
+
+What this proves, and why each check exists:
+
+- The playhead actually MOVES. Verification for this operation used to be granted by a post-read that
+  merely equalled the request, which is satisfied by a playhead that was already there. The run parks
+  the playhead first and asserts a transition, so a no-op cannot pass.
+- The route under test is the one that ran. A sibling router rung can move the playhead by other means;
+  an envelope that says `via: dialog` while a later rung did the work is not evidence about this route.
+- The receipt does not claim more than it observed. Logic's control bar exposes only bar and beat, so a
+  four-component State A would be synthesised rather than read.
+- The dialog does not outlive the operation. A modal left on screen poisons every later call.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+PARK = "1.1.1.1"
+TARGET = "37.3.1.1"
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+rec = ev.record_screen(seconds=45)
+d = E.Driver()
+
+
+def playhead():
+    """The transport readout, read live rather than from cache."""
+    body = d.tool("logic_transport", "goto_position", {"position": PARK}) if False else None
+    return d.resource("logic://transport")
+
+
+win = E.logic_window()
+if not win:
+    ev.check("534/precondition-logic-window", False,
+             "Logic's Tracks window is on screen", "no window found",
+             "closed the Tracks window; this check went red")
+    d.close()
+    ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1))
+    sys.exit(1)
+
+# The transport LCD sits in the control bar along the top of the arrange window. The region is named so
+# the visual assertion is about the readout, not about "some pixel somewhere changed" — Logic repaints
+# meters continuously and a whole-window diff is always true.
+LCD = (int(win["w"] * 0.42), 0, int(win["w"] * 0.34), int(win["h"] * 0.055))
+
+# ---- precondition: park the playhead so the measured move is unambiguous ----
+park_body = d.tool("logic_transport", "goto_position", {"position": PARK})
+time.sleep(0.8)
+before_state = d.resource("logic://transport")
+ev.note("precondition", {"park_result_state": park_body.get("state"),
+                         "transport_before": before_state})
+
+pre = ev.shot("before-goto", settle_region=LCD)
+
+# ---- the operation under test ----
+body = d.tool("logic_transport", "goto_position", {"position": TARGET})
+time.sleep(0.8)
+post = ev.shot("after-goto", settle_region=LCD)
+ev.note("response", {"body": body})
+
+observed_before = body.get("observed_before")
+observed = body.get("observed")
+
+ev.check("534/the-playhead-actually-moved",
+         bool(observed_before) and bool(observed) and observed_before != observed,
+         "the readout differs before and after, so a transition was observed",
+         f"observed_before={observed_before!r} observed={observed!r}",
+         "restored verification-by-equality; a request equal to the current position then passed")
+
+ev.check("534/the-requested-bar-and-beat-are-reached",
+         str(observed or "").startswith("37.3"),
+         "the playhead lands on bar 37 beat 3",
+         f"requested={body.get('requested')!r} observed={observed!r}",
+         "dropped the beat from the typed position; the readout stayed on 37.1")
+
+ev.check("534/the-request-is-not-silently-rewritten",
+         body.get("requested") == TARGET,
+         f"the envelope echoes {TARGET}",
+         f"requested={body.get('requested')!r}",
+         "rewrote the request to the nearest bar before echoing it")
+
+ev.check("534/the-operation-under-test-actually-ran",
+         body.get("error") is None and body.get("write_attempted") is True,
+         "the envelope is an outcome of goto_position, not a routing refusal",
+         f"state={body.get('state')!r} error={body.get('error')!r} "
+         f"write_attempted={body.get('write_attempted')!r}",
+         "made the menu lookup fail; the run became a refusal with write_attempted false")
+
+ev.check("534/a-partial-readback-is-not-certified-complete",
+         not (body.get("state") == "A" and
+              body.get("observed_position_components") not in (None, [])
+              and len(body.get("observed_position_components") or []) < 4),
+         "State A is withheld while subdivision and tick are unobserved",
+         f"state={body.get('state')!r} components={body.get('observed_position_components')!r}",
+         "let a two-component readback certify State A; a bar/beat-only read was reported verified")
+
+ev.check("534/the-dialog-does-not-outlive-the-operation",
+         body.get("dialog_cleanup") in ("closed", None),
+         "no Go To Position window remains after the route returns",
+         f"dialog_cleanup={body.get('dialog_cleanup')!r}",
+         "skipped the dismissal; the modal stayed up and the next call refused")
+
+ev.visual("534/the-transport-readout-moves-with-the-operation",
+          pre["file"], post["file"], LCD, expect_change=True,
+          why=f"the playhead moved from {PARK} to {TARGET}, so the LCD must repaint")
+
+# ---- restore ----
+restore = d.tool("logic_transport", "goto_position", {"position": PARK})
+time.sleep(0.6)
+after_restore = d.resource("logic://transport")
+ev.restored("534/playhead-parked-again",
+            restore.get("error") is None,
+            f"restore_state={restore.get('state')!r} transport={after_restore.get('position')!r}")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/livekit/live_538_modal_reconcile.py
+++ b/Scripts/livekit/live_538_modal_reconcile.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Live proof for track.delete's modal reconciler (#538) against the running Logic Pro.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_538_modal_reconcile.py <worktree> <full-40-char-head-sha>
+
+Deleting the LAST track makes Logic raise its mandatory "New Track" sheet, whose only exit is Create. That
+sheet is the subject: the branch exists to observe it, press the Create it actually read, and then witness
+the sheet go away. So the run reduces the project to one track on purpose — that is the precondition, not
+the assertion.
+
+Two traps this harness has already been caught by, both encoded here rather than left to the operator:
+
+- `logic://tracks` falls back to names synthesised from the project file when the live AX read is
+  unavailable, and a synthesised name is stale the moment a rename lands. Trusting one handed `track.delete`
+  an identity that no longer existed; the product correctly refused, and the run read as a product failure.
+  The precondition now settles on a reading that agrees with the rename it just performed.
+- Logic replaces the deleted last track with a fresh default one, so the header rail can end up
+  pixel-identical to how it started. The surviving track is renamed to something nothing else would produce
+  so the name band HAS to change when it is replaced.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+WITNESS_NAME = "ZZ538 Witness Fixture"
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+rec = None  # started after the precondition: the recording should show the operation, not the setup
+
+
+def tracks():
+    """A `select` forces a live AX read of the track headers.
+
+    Without it the resource answers with names synthesised from the project file, which are not an
+    observation of anything on screen.
+    """
+    d.tool("logic_tracks", "select", {"index": 0})
+    return d.resource("logic://tracks").get("data", []) or []
+
+
+def sheet_count():
+    """Logic's own answer, via a path the product does not use, so it is not a mirror of the product."""
+    script = ('tell application "System Events" to tell process "Logic Pro" to '
+              'get count of every sheet of (first window whose name ends with "Tracks")')
+    import subprocess
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+win = E.logic_window()
+if not win:
+    ev.check("538/precondition-logic-window", False, "Logic's Tracks window is on screen",
+             "no window found", "closed the Tracks window; this check went red")
+    d.close(); ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+# The track header rail: the name band of the surviving track lives here.
+RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+
+# ---- precondition: exactly one track, distinctively named ----
+#
+# Logic hands several new tracks the SAME default name, and `track.delete` rightly refuses an ambiguous
+# target: "'Deluxe Classic' names more than one live track, so the target cannot be identified." Its hint is
+# the way through — rename by INDEX, which is not blocked by name ambiguity, then delete by the new unique
+# name. Binding by `track_ref` does not help: the refusal is about the live name, not about which reference
+# was supplied.
+#
+# The attempt bound below is the other half: a precondition that cannot converge must say so rather than
+# spin. An earlier version had no bound and ran against an unsatisfiable refusal until it was killed.
+t = tracks()
+attempts = 0
+while len(t) > 1 and attempts < 40:
+    attempts += 1
+    idx = t[-1]["id"]
+    unique = f"ZZ538 Doomed {attempts}"
+    d.tool("logic_tracks", "rename", {"index": idx, "name": unique})
+    time.sleep(0.8)
+    d.tool("logic_tracks", "delete", {"index": idx, "expected_name": unique})
+    time.sleep(1.2)
+    t = tracks()
+
+if len(t) != 1:
+    ev.check("538/precondition-reduced-to-one-track", False,
+             "the project can be reduced to a single track so the mandatory sheet is raised",
+             f"still {len(t)} tracks after {attempts} rounds: {[x.get('name') for x in t]}",
+             "removed the attempt bound; the loop ran against a refusal it could not satisfy until killed")
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+renamed = None
+settle_attempts = []
+if t:
+    renamed = d.tool("logic_tracks", "rename", {"index": t[0]["id"], "name": WITNESS_NAME})
+    for _ in range(6):
+        time.sleep(1.0)
+        t = tracks()
+        settle_attempts.append([x.get("name") for x in t])
+        if t and t[0].get("name") == WITNESS_NAME:
+            break
+
+ev.check("538/precondition-distinctive-track-name",
+         bool(t) and t[0].get("name") == WITNESS_NAME,
+         "the surviving track carries a name nothing else would produce",
+         f"rename={json.dumps(renamed)[:160]} settle_attempts={settle_attempts}",
+         "read the track list once instead of settling on the rename; the stale synthesised name was "
+         "handed to delete and the product refused it as a target identity mismatch")
+
+ev.note("precondition", {"tracks": [x.get("name") for x in t],
+                         "sheets_before": sheet_count()})
+
+rec = ev.record_screen(seconds=45)
+pre = ev.shot("before-last-track-delete", settle_region=RAIL)
+
+# ---- the operation under test ----
+body = d.tool("logic_tracks", "delete",
+              {"index": t[0]["id"], "expected_name": t[0]["name"]}) if t else {}
+time.sleep(2.0)
+post = ev.shot("after-last-track-delete", settle_region=RAIL)
+ev.note("response", {"body": body})
+
+witness = (body.get("modal_reconciliation_witness") or {}) if isinstance(body, dict) else {}
+observations = witness.get("observations") or {}
+polls = witness.get("polls")
+
+ev.check("538/the-sheet-was-classified-not-guessed",
+         body.get("reconciled_modal_kind") == "mandatory_new_track",
+         "the mandatory New Track sheet is recognised for what it is",
+         f"kind={body.get('reconciled_modal_kind')!r} action={body.get('reconciled_action')!r}",
+         "treated a -25205 AXSheets answer as a failure; the sheet was never found and every poll "
+         "reported unknown_sheet")
+
+ev.check("538/the-create-it-read-is-the-one-it-pressed",
+         body.get("reconciled_action") == "click_create",
+         "the reconciler presses the Create control it resolved, not a default button",
+         f"action={body.get('reconciled_action')!r}",
+         "restored the unchecked Return seam; the receipt showed a confirmation with no control read")
+
+ev.check("538/the-sheet-close-is-actually-observed",
+         (observations.get("gone", 0) or 0) > 0,
+         "at least one poll observed the sheet gone",
+         f"polls={polls} observations={observations}",
+         "classified the observer's own -25205 as a failure; all polls answered the same status and "
+         "'gone' never appeared")
+
+unreadable = sum(v for k, v in observations.items() if str(k).endswith(tuple(f"-252{n:02d}" for n in range(0, 15))))
+ev.check("538/the-witness-is-not-blind",
+         polls is not None and unreadable == 0,
+         "not every poll was an unreadable status — a blind witness proves nothing",
+         f"polls={polls} unreadable={unreadable}",
+         "made every sheet read fail; the witness still reported a settled observation")
+
+after_sheets = sheet_count()
+ev.check("538/logic-agrees-the-sheet-is-gone",
+         after_sheets == "0",
+         "System Events, a path the product does not use, reports no sheet remains",
+         f"sheets_after={after_sheets!r}",
+         "left the sheet up by skipping the Create press; this independent read still said 1")
+
+ev.visual("538/the-track-rail-changes",
+          pre["file"], post["file"], RAIL, expect_change=True,
+          why=f"the distinctively named track {WITNESS_NAME!r} was deleted and replaced")
+
+ev.restored("538/project-has-a-track-again", True,
+            f"tracks_after={[x.get('name') for x in tracks()]}")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/livekit/live_544_output_schema.py
+++ b/Scripts/livekit/live_544_output_schema.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Live proof for #544 — a tool that declares an output schema always answers with one.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_544_output_schema.py <worktree> <full-40-char-head-sha>
+
+This one is a protocol fix, so its proof looks different from a UI operation's. What is checked:
+
+- The two commands from the external report (`logic_system.permissions`, `refresh_cache`) return
+  `structuredContent` over a real MCP stdio session against the built binary — that is the thing the
+  reporting client rejected, so it has to be observed on the wire rather than in a unit fixture.
+- A prose ERROR path returns it too, since half the violating sites were failure sentences.
+- `health`, which always complied, still passes its JSON through unwrapped rather than nested under
+  `message` — the fix must not have changed the shape of answers that were already correct.
+- The visual assertion is an ABSENCE one: these are read-only system commands, so the arrange window must
+  NOT change while they run. A region that does change would mean a "read" moved something.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+MUT = ("removed the `?? .object(prose)` fallback in toolTextResult; these commands returned "
+       "structuredContent nil again and a schema-enforcing client rejected the call")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+rec = ev.record_screen(seconds=45)
+d = E.Driver()
+
+win = E.logic_window()
+if not win:
+    ev.check("544/precondition-logic-window", False,
+             "Logic's Tracks window is on screen", "no window found",
+             "closed the Tracks window; this check went red")
+    d.close(); ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+# The track rail: a read-only system command has no business repainting it.
+RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+pre = ev.shot("before-system-reads", settle_region=RAIL)
+
+
+def structured(name, command, params=None):
+    """Call over the wire and report whether structuredContent came back, as the client sees it."""
+    args = {"command": command}
+    if params is not None:
+        args["params"] = params
+    raw = d._send("tools/call", {"name": name, "arguments": args})
+    res = (raw or {}).get("result", {})
+    return res.get("structuredContent"), res
+
+
+perm, _ = structured("logic_system", "permissions")
+ev.check("544/permissions-answers-with-structured-content", perm is not None,
+         "logic_system.permissions returns structuredContent, as its declared outputSchema requires",
+         f"structuredContent={'present' if perm is not None else 'ABSENT'}", MUT)
+
+refresh, _ = structured("logic_system", "refresh_cache")
+ev.check("544/refresh-cache-answers-with-structured-content", refresh is not None,
+         "logic_system.refresh_cache returns structuredContent",
+         f"structuredContent={'present' if refresh is not None else 'ABSENT'}", MUT)
+
+ev.check("544/refresh-cache-says-whether-it-actually-ran",
+         isinstance(refresh, dict) and "refreshed" in refresh,
+         "the receipt distinguishes a refresh that ran from one merely queued",
+         f"refreshed={None if not isinstance(refresh, dict) else refresh.get('refreshed')!r} "
+         f"source={None if not isinstance(refresh, dict) else refresh.get('source')!r}",
+         "reverted refresh_cache to its prose strings; the distinction was recoverable only by "
+         "string-matching the message")
+
+ev.check("544/permissions-carries-the-states-not-only-prose",
+         isinstance(perm, dict) and {"accessibility", "automation_logic_pro",
+                                     "automation_system_events", "post_event"} <= set(perm),
+         "the four TCC states are fields, beside the human summary",
+         f"keys={sorted(perm.keys()) if isinstance(perm, dict) else perm!r}",
+         "reverted permissions to toolTextResult(status.summary); only a message field remained")
+
+# A prose FAILURE path: half the violating sites were failure sentences, not successes.
+err, _ = structured("logic_project", "open", {"path": "/nonexistent-☃.logicx"})
+ev.check("544/a-prose-error-is-structured-too", err is not None,
+         "a failure answered in prose still satisfies the declared schema",
+         f"structuredContent={'present' if err is not None else 'ABSENT'}", MUT)
+
+# Answers that were already JSON must be passed through, not nested under `message`.
+health, _ = structured("logic_system", "health")
+ev.check("544/an-already-valid-answer-is-not-rewrapped",
+         isinstance(health, dict) and "message" not in health and "channels" in health,
+         "health's JSON object is passed through unchanged rather than nested under message",
+         f"keys={sorted(health.keys())[:6] if isinstance(health, dict) else health!r}",
+         "made toolTextResult wrap unconditionally; health's fields disappeared under a message key")
+
+_, perm_res = structured("logic_system", "permissions")
+perm_text = "".join(c.get("text", "") for c in perm_res.get("content", []))
+ev.check("544/the-text-the-oracle-grades-is-unchanged",
+         perm_text.startswith("Accessibility: "),
+         "permissions still emits the exact prose its semantic oracle grades line by line",
+         f"text_prefix={perm_text[:40]!r}",
+         "encoded the new object as the text; the oracle stopped matching and qualification would have "
+         "turned a correct answer RED while every unit test stayed green")
+
+post = ev.shot("after-system-reads", settle_region=RAIL)
+ev.visual("544/read-only-commands-do-not-disturb-the-session",
+          pre["file"], post["file"], RAIL, expect_change=False,
+          why="permissions, refresh_cache and health are reads; the track rail must be untouched")
+
+ev.restored("544/no-session-state-was-mutated", True,
+            "only read-only system commands and one failing project open were issued")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/livekit/test_review_integrity.sh
+++ b/Scripts/livekit/test_review_integrity.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Prove check_review_integrity.sh against its own subject matter.
+#
+# A checker that has never been shown to fail is exactly what it exists to catch. Two of these fixtures are
+# real: `review-interleaved-damaged.txt` is the review that actually arrived with two of its own output
+# streams spliced together, and `review-fenced-clean.md` is the shape that a first version of the checker
+# wrongly called damaged — a fence is three backticks, so it is always odd, and every review carrying a
+# reproduction command tripped it. That false alarm mattered more than most: this check's failure path is
+# "discard the verdict", the same call that nearly threw away thirteen findings including a blocker.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check_review_integrity.sh"
+FIX="$HERE/fixtures"
+FAILED=0
+
+expect() { # <expected-exit> <file> <why>
+    bash "$CHECK" "$2" >/dev/null 2>&1
+    local got=$?
+    if [ "$got" = "$1" ]; then
+        printf 'ok   %-40s %s\n' "$(basename "$2")" "$3"
+    else
+        printf 'FAIL %-40s expected exit %s, got %s — %s\n' "$(basename "$2")" "$1" "$got" "$3"
+        FAILED=1
+    fi
+}
+
+expect 0 "$FIX/review-fenced-clean.md"            "a normal review with a fenced reproduction command is intact"
+expect 1 "$FIX/review-interleaved-damaged.txt"    "the real spliced review is rejected"
+expect 1 "$FIX/review-missing-middle-finding.md"  "a gap in the k/N sequence is a dropped finding"
+expect 2 "$FIX/review-uncheckable.md"             "no ordinals and no count is undetermined, NOT a pass"
+
+[ "$FAILED" -eq 0 ] || { echo; echo "review-integrity checker is not doing its job"; exit 1; }
+echo
+echo "check_review_integrity.sh proven against 4 cases including the real damaged review"


### PR DESCRIPTION
## Blind-review exemption: NOT exempt

Tooling-only PRs (zero lines of product code) are exempt from a blind verdict. This one is not, and the
carve-out is the reason: **a PR that creates or fixes a check or a gate is exactly the kind that fails
silently when it is wrong.**

Evidence from this PR's own diff that it is in the carve-out:

- `Scripts/livekit/check_review_integrity.sh` — a new check
- `Scripts/livekit/test_review_integrity.sh` + `fixtures/` — a regression suite proving that check
- `.github/workflows/ci.yml` — comment only, no behaviour change (see below)

That classification was earned, not theoretical: review of this branch found the integrity checker calling
**every** review containing a fenced code block "damaged", and its failure path is "discard the verdict" —
the same call that nearly threw away thirteen findings including a blocker earlier today. Two more ordering
defects surfaced while building the regression for that fix.

Tooling only — no product code changes.

## Why this is in the repo

On 2026-08-14 three changes passed the full unit suite **and** the ship gate while being dead or wrong
against the running application:

- `transport.goto_position` refused every call, because the snapshot it wrote serialized `id of window` —
  a property Logic does not expose on its windows, so the read errored on every run and the route
  fail-closed permanently.
- the modal reconciler stopped recognising the New Track sheet it exists to press.
- a marker delete could not verify a deletion that had actually happened.

Nothing but a live run found any of them. The harnesses that did find them lived in a scratch directory and
were deleted by a `/tmp` sweep mid-investigation — which is the immediate reason they are here now.

## What is in it

`evidence.py` — the recorder. It is deliberately hostile to its operator: it refuses an unsettled capture,
a capture straddling two displays, a visual assertion with no named region, a check whose flipping mutation
is unnamed, and a cached read offered as a live one. Each refusal exists because that exact false evidence
was produced without it. `~/.claude/scripts/lpm-ship.sh` reads the document it writes and refuses to push
without one.

Two measured hardware facts are encoded so they are not rediscovered: a window capture is in backing PIXELS
(3840x2100 for a 1920x1050 window), so regions expressed in window points are scaled; and
`screencapture -v` finalises its file only when its own `-V` timer elapses — SIGINT, SIGTERM, closing stdin
and a process-group SIGINT all leave **no file at all**.

`live_523_*`, `live_534_*`, `live_538_*`, `live_544_*` — one harness per operation, each documenting what
it proves and why each check exists.

`check_review_integrity.sh` — a different failure. A blind review arrived with two of its own output streams
interleaved into one file. It was caught only because the corruption fell mid-word; at a paragraph boundary
the same event yields a grammatical, complete-looking review silently missing a finding. Exit codes separate
"damaged" (1) from "integrity could not be determined" (2), because a check that did not run is not a pass.

## Notes for whoever writes the next harness

The README carries the traps that cost the most time, each stated as what to do instead — derive regions
from the element rather than guessing at layout; read the independent witness through a path the product
does not use; bound every precondition loop and fail loudly; follow the product's own contract in
preconditions rather than guessing around its refusals; record the operation, not the setup.


---

## Also in this branch: a CI comment, no behaviour change

`.github/workflows/ci.yml` gains a comment block and nothing else. Two people independently read the branch
ruleset, saw one required status check (`build`) against three visible jobs, and concluded a red `test`
could merge behind a green `build`.

It cannot. `build` runs no build — it is the aggregator: `if: always()` so it runs even when a dependency
failed, then refuses unless every gate succeeded. Requiring it is equivalent to requiring `compile` and
`test`, and better, because adding or renaming a gate does not need the ruleset edited in lockstep and a
job that legitimately does not run on some event cannot leave a required check pending and wedge the merge
button.

The design was right and unwritten, which cost a review round and nearly cost the design itself — the
obvious "fix" is to add the other two contexts, which would have introduced the pending-wedge risk this
avoids. The comment now meets that reader in the file they are already looking at.
