### PR TITLE
chore: ignore the per-developer MCP client configuration [HOLD — owner decision]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/media/reddit-dudddee-*
 # Python bytecode cache
 __pycache__/
 *.pyc
+
+# Per-developer MCP client configuration. Not part of the server.
+.mcp.json


### PR DESCRIPTION
**Held pending the repository owner.** Narrowed from three files to one after checking each individually
instead of treating them as one category. The original three-file version was wrong.

**`.mcp.json` — ignored here (this PR).** One developer's MCP client wiring. It does not describe the
server this repository builds and has no reason to reach a contributor's clone.

**`.commitlore-policy.json` — deliberately NOT ignored.** Its own tool documents it as a shared file:

> The setting lives in `.commitlore-policy.json` at the repository root … **The file is committed with
> the repository: turning it on applies to everyone who clones it.** — `commitlore auto --help`

Ignoring it would be a mistake. The open question is the opposite one: the local copy carries
`unattended: true`, which authorises an agent host to prepare, verify and stage records with nobody in
the loop. Committing that binds every contributor, so it is a policy decision rather than a hygiene one
and is not bundled in here.

**`HANDOFF.md` — not ignored here either.** It is a maintainer's working file. A shared ignore list is
not the place for one person's notes; `.git/info/exclude` holds it locally without putting a private
filename in front of every contributor. Already done locally, nothing to merge.

---

The release does not depend on any of this. `Scripts/release-stable.sh` refuses a dirty worktree, and
moving the untracked files outside the repository for the duration of the tag clears it and leaves no
trace in the repository. Verified: dry-run passes every precondition, and `pre-push` exits 0 with the
policy file absent (tested with both empty stdin and a real tag ref).