### PR TITLE
feat(#549): make the sheet scan name the node it gave up on

### DIFF
--- a/Scripts/livekit/live_549_receipt_names_the_node.py
+++ b/Scripts/livekit/live_549_receipt_names_the_node.py
@@ -129,7 +129,14 @@ ev.check("549/no-blocker-left-behind",
 # observed string always states how many receipts actually carried a reason.
 with_reason = [(op, b) for op, b in receipts
                if isinstance(b, dict) and b.get("reconciled_modal_unreadable_reason")]
-named = [(op, b) for op, b in with_reason if isinstance(b.get("reconciled_modal_unreadable_node"), dict)]
+# `unrecorded` is the marker for "a failure arrived with no node", so counting it as "named" would let
+# the check pass on exactly the receipts it exists to catch.
+def names_a_node(body):
+    node = body.get("reconciled_modal_unreadable_node")
+    return isinstance(node, dict) and node.get("site") != "unrecorded"
+
+
+named = [(op, b) for op, b in with_reason if names_a_node(b)]
 exercised = len(with_reason) > 0
 
 ev.check("549/an-unreadable-reason-always-names-its-node",

--- a/Scripts/livekit/live_549_receipt_names_the_node.py
+++ b/Scripts/livekit/live_549_receipt_names_the_node.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Live proof for #549's observability change: when the sheet scan gives up, the receipt says where.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_549_receipt_names_the_node.py <worktree> <full-40-char-head-sha>
+
+This harness deliberately does NOT assert that `track.create` reaches State A. That is #549's open
+defect, it does not reproduce on demand, and this change does not fix it. Asserting it here would make a
+green run look like a repair. What this change claims is narrower and is what is checked:
+
+  1. adding the field did not break create or delete
+  2. any receipt that reports an unreadable sheet-scan reason also names the node
+  3. the named node carries no user-authored content
+
+Check 2 is a universal claim over the receipts this run actually collects. If the intermittent failure
+does not occur, it is vacuously true — so the run records HOW MANY receipts carried a reason, and the
+document states that count rather than letting a green tick imply the path was exercised. A check that
+was never exercised is reported as never exercised.
+
+Instrument conditions: every value asserted comes from the operation's own envelope; the sheet count is
+read through System Events, which the product does not use. No sampling and no time budget affects any
+assertion.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+rec = None
+
+OPERATIONS = 4  # create/delete pairs; more attempts, more chances the intermittent failure appears
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def sheet_count():
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'get count of every sheet of (first window whose name ends with "Tracks")')
+
+
+def tracks():
+    d.tool("logic_tracks", "select", {"index": 0})
+    return d.resource("logic://tracks").get("data", []) or []
+
+
+win = E.logic_window()
+if not win:
+    ev.check("549/precondition-logic-window", False, "Logic's Tracks window is on screen",
+             "no window found", "closed the Tracks window; this check went red")
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+
+before = tracks()
+ev.note("precondition", {"tracks": len(before), "sheets": sheet_count()})
+
+rec = ev.record_screen(seconds=110)
+pre = ev.shot("before-operations", settle_region=RAIL)
+
+receipts = []
+created = 0
+deleted = 0
+for i in range(OPERATIONS):
+    n_before = len(tracks())
+    body = d.tool("logic_tracks", "create_instrument")
+    time.sleep(1.6)
+    receipts.append(("create", body))
+    if len(tracks()) == n_before + 1:
+        created += 1
+
+    t = tracks()
+    if len(t) > 2:
+        target = t[-1]
+        unique = f"ZZ549obs {i}"
+        d.tool("logic_tracks", "rename", {"index": target["id"], "name": unique})
+        time.sleep(0.8)
+        n_before = len(tracks())
+        body = d.tool("logic_tracks", "delete", {"index": target["id"], "expected_name": unique})
+        time.sleep(1.4)
+        receipts.append(("delete", body))
+        if len(tracks()) == n_before - 1:
+            deleted += 1
+
+# The operations above are balanced — each create is matched by a delete — so the header rail ends up
+# pixel-identical to how it started and a "did the rail change" assertion is false against a run that
+# plainly worked. Leave one extra track standing for the visual comparison, then remove it.
+d.tool("logic_tracks", "create_instrument")
+time.sleep(1.6)
+post = ev.shot("after-operations", settle_region=RAIL)
+
+# ---- 1. the field did not break the operations ----
+ev.check("549/operations-still-work",
+         created == OPERATIONS and deleted >= 1,
+         "every create still adds a track and delete still removes one",
+         f"creates_landed={created}/{OPERATIONS} deletes_landed={deleted}",
+         "threaded the new detail through a code path that also carried a return value, and the "
+         "operation stopped performing its write")
+
+ev.check("549/no-blocker-left-behind",
+         sheet_count() == "0",
+         "System Events, a path the product does not use, reports no sheet remains",
+         f"sheets_after={sheet_count()!r}",
+         "left a sheet up; this independent read said 1 with Logic waiting on a human")
+
+# ---- 2. every receipt that reports an unreadable reason names the node ----
+#
+# Universal over the receipts collected. Vacuous if the intermittent failure did not appear, so the
+# observed string always states how many receipts actually carried a reason.
+with_reason = [(op, b) for op, b in receipts
+               if isinstance(b, dict) and b.get("reconciled_modal_unreadable_reason")]
+named = [(op, b) for op, b in with_reason if isinstance(b.get("reconciled_modal_unreadable_node"), dict)]
+exercised = len(with_reason) > 0
+
+ev.check("549/an-unreadable-reason-always-names-its-node",
+         len(named) == len(with_reason),
+         "no receipt reports an unreadable sheet scan without saying which node it gave up on",
+         f"receipts={len(receipts)} with_reason={len(with_reason)} named={len(named)} "
+         f"exercised={exercised}"
+         + ("" if exercised else "  <- the intermittent failure did not occur; this run does not "
+                                 "exercise the field, and says so"),
+         "dropped the else-branch that marks a missing detail as unrecorded; a receipt reported a "
+         "sheet-scan failure with no node and the omission was indistinguishable from 'no node'")
+
+# ---- 3. the node names structure only ----
+sentinel_sources = [t.get("name") for t in tracks() if t.get("name")]
+leaked = []
+for op, b in named:
+    blob = json.dumps(b.get("reconciled_modal_unreadable_node"), ensure_ascii=False)
+    for name in sentinel_sources:
+        if name and name in blob:
+            leaked.append((op, name))
+
+ev.check("549/the-node-carries-no-user-content",
+         not leaked,
+         "the node names roles and ordinal indices only — no track name reaches the receipt",
+         f"named_receipts={len(named)} candidate_strings={len(sentinel_sources)} leaked={leaked}",
+         "published the node's AXDescription as its role; a live track name appeared in the receipt "
+         "and the check caught it")
+
+ev.visual("549/the-track-rail-changes",
+          pre["file"], post["file"], RAIL, expect_change=True,
+          why="one extra track is standing at this point, so the header rail must differ")
+
+# remove the extra track left standing for the visual
+t = tracks()
+if len(t) > len(before):
+    last = t[-1]
+    d.tool("logic_tracks", "rename", {"index": last["id"], "name": "ZZ549obs visual"})
+    time.sleep(0.8)
+    d.tool("logic_tracks", "delete", {"index": last["id"], "expected_name": "ZZ549obs visual"})
+    time.sleep(1.4)
+
+after = tracks()
+ev.restored("549/track-count-returned-to-start", len(after) == len(before),
+            f"before={len(before)} after={len(after)}")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -2004,12 +2004,21 @@ extension AccessibilityChannel {
         // carrying a node from a sheet scan in an earlier poll. That is the "names the wrong node
         // confidently" outcome this field exists to prevent, and it would be believed precisely because
         // the field looks specific.
-        if let sheetScanFailureDetail {
-            extras["reconciled_modal_unreadable_node"] = sheetScanFailureDetail.envelopeValue
-        } else if unreadableReason?.originatesInSheetScan == true {
-            extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
-        } else {
-            extras.removeValue(forKey: "reconciled_modal_unreadable_node")
+        // The node moves with the reason it describes — both are written here, or neither is touched.
+        //
+        // The first version of this fix removed the key whenever THIS merge carried no detail, which was
+        // wrong in the same shape it was fixing. The reason above is only written when this merge has
+        // one, so a merge with no reason leaves the previous merge's reason standing; deleting its node
+        // there strands a reason whose node was known and discarded. Scoping both to the same condition
+        // keeps the pair consistent whichever merge last supplied it.
+        if let unreadableReason {
+            if let sheetScanFailureDetail {
+                extras["reconciled_modal_unreadable_node"] = sheetScanFailureDetail.envelopeValue
+            } else if unreadableReason.originatesInSheetScan {
+                extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
+            } else {
+                extras.removeValue(forKey: "reconciled_modal_unreadable_node")
+            }
         }
     }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -70,6 +70,21 @@ extension AccessibilityChannel {
             }
         }
 
+        /// Whether this failure came from the sheet scan and therefore SHOULD be accompanied by a
+        /// `ModalSheetScanFailureDetail` naming the node it gave up on. The other cases arise before or
+        /// beside that scan and have no node to name, so their missing detail is correct rather than a
+        /// gap. `mergeReconcileExtras` uses this to tell those two situations apart instead of letting
+        /// both look identical in the receipt.
+        var originatesInSheetScan: Bool {
+            switch self {
+            case .windowSheetReadFailed, .descendantTraversalDepthCap:
+                return true
+            case .mainWindowReadFailed, .axWindowsReadFailed, .topLevelWindowModalReadFailed,
+                 .appRootUnavailable, .axWindowsPayloadUninterpretable, .strayMenuReadFailed:
+                return false
+            }
+        }
+
         var envelopeExtras: [String: Any] {
             var extras: [String: Any] = [
                 "reconciled_modal_unreadable_reason": wireReason
@@ -79,6 +94,112 @@ extension AccessibilityChannel {
                 extras["reconciled_modal_unreadable_ax_status_name"] = symbolicName
             }
             return extras
+        }
+    }
+
+    /// #549: structural facts about the exact node where the sheet scan gave
+    /// up, captured beside a `.windowSheetReadFailed` /
+    /// `.descendantTraversalDepthCap` `ModalReadFailure` so a receipt can
+    /// name WHICH node and WHICH scan, not only a status code. This is kept
+    /// as a companion value rather than folded into `ModalReadFailure`
+    /// itself so every existing `ModalReadFailure` equality check (dozens,
+    /// across #538's fixtures) keeps comparing exactly the same two cases it
+    /// always has — this type only ever ADDS a receipt field, it never
+    /// changes what `unreadableReason` compares equal to.
+    ///
+    /// HARD CONSTRAINT: every field here is a structural fact (a role, an
+    /// ordinal child index, which scan was running) — never a window title,
+    /// `AXDescription`, `AXValue`, or any other string a user authored. A
+    /// value built from this type must remain safe to paste into a bug
+    /// report or ship in a log.
+    struct ModalSheetScanFailureDetail: Sendable, Equatable {
+        /// Which of the sheet scan's three entry points was running when the
+        /// read failed. The direct scan of the main window and the scan over
+        /// every OTHER window each get their own label; a failure reached
+        /// through either one's recursive descent (below the window's direct
+        /// children) is reported as `recursiveDescendantWalk` regardless of
+        /// which window started it, because at that depth the failure is
+        /// genuinely inside the generic descendant walk, not the top-level
+        /// per-window dispatch.
+        enum Site: String, Sendable, Equatable {
+            case mainWindowFirstSheetLookup = "main_window_first_sheet_lookup"
+            case anyWindowSheetLookup = "any_window_sheet_lookup"
+            case recursiveDescendantWalk = "recursive_descendant_walk"
+        }
+
+        /// Which read on the failing node did not answer. `depthCapped` is
+        /// not an AX attribute read at all — the traversal gave up before
+        /// attempting one — but it names the same "which scan step gave up"
+        /// question the other two answer.
+        enum Attribute: String, Sendable, Equatable {
+            case children = "AXChildren"
+            case role = "AXRole"
+            case depthCapped = "depth_cap"
+        }
+
+        /// One step of the root-to-node ordinal path: the index of the taken
+        /// child within its parent's `AXChildren`, and the parent's own role
+        /// (`nil` only for the window root itself, whose role this scan
+        /// never independently reads).
+        struct PathStep: Sendable, Equatable {
+            let parentRole: String?
+            let childIndex: Int
+        }
+
+        let site: Site
+        let attribute: Attribute
+        /// The failing node's own role, when it was already known before the
+        /// read that failed. An `AXChildren` failure always has this — a
+        /// node only reaches that read after its own role was confirmed
+        /// non-sheet by the caller that descended into it. `nil` when the
+        /// failing read WAS the role lookup itself.
+        let subjectRole: String?
+        /// Root-to-node ordinal path, one entry per level of descent from
+        /// the window root down to (but not including) the failing node.
+        let path: [PathStep]
+        /// Whether the failing node's own identity — had this exact read
+        /// succeeded — could still have changed the scan's verdict. `true`
+        /// only for an `AXChildren`/depth-cap failure on a node whose role
+        /// was already confirmed non-sheet: THAT node is provably not the
+        /// missing sheet, so the read that failed could only have ruled out
+        /// content beneath it, never revealed the sheet itself. `false` for
+        /// an `AXRole` failure, where the node's identity is unknown and
+        /// could have been the sheet. This deliberately does not claim
+        /// knowledge of an `AXChildren` failure's unexamined descendants —
+        /// only that the reported node itself was not load-bearing.
+        let wouldHaveBeenAbsent: Bool
+
+        /// Emitted when the sheet scan reported a failure but no detail reached the receipt. It marks a
+        /// hole in this feature's own coverage rather than a fact about Logic, and it is deliberately
+        /// shaped like the real value so a reader scanning for the field finds something instead of
+        /// nothing.
+        /// Computed rather than a stored `static let`: a `[String: Any]` is not `Sendable`, so storing it
+        /// globally is a concurrency error under this toolchain.
+        static var unrecordedEnvelopeValue: [String: Any] {
+            [
+                "site": "unrecorded",
+                "note": "the sheet scan reported a failure but no node detail reached this receipt; "
+                    + "a set-site for the failure reason is missing its companion detail"
+            ]
+        }
+
+        var envelopeValue: [String: Any] {
+            var value: [String: Any] = [
+                "site": site.rawValue,
+                "attribute": attribute.rawValue,
+                "path": path.map { step -> [String: Any] in
+                    var entry: [String: Any] = ["child_index": step.childIndex]
+                    if let parentRole = step.parentRole {
+                        entry["parent_role"] = parentRole
+                    }
+                    return entry
+                },
+                "would_have_been_absent": wouldHaveBeenAbsent,
+            ]
+            if let subjectRole {
+                value["subject_role"] = subjectRole
+            }
+            return value
         }
     }
 
@@ -112,6 +233,13 @@ extension AccessibilityChannel {
         /// source could not establish its answer. This is diagnostic provenance,
         /// not a separate classifier state.
         let unreadableReason: ModalReadFailure?
+        /// #549: present only alongside a `.windowSheetReadFailed` /
+        /// `.descendantTraversalDepthCap` `unreadableReason` that originated
+        /// from the sheet scan itself — names the exact node and scan that
+        /// gave up. `nil` for every other `unreadableReason` case (an
+        /// unreadable `AXWindows`/`AXMenuBar`/app-root read has no sheet-tree
+        /// node to name).
+        let sheetScanFailureDetail: ModalSheetScanFailureDetail?
 
         /// `kind == .none` names the positive modal facts that were found; it
         /// does not by itself certify that every source was readable. A
@@ -140,7 +268,8 @@ extension AccessibilityChannel {
             witnessSummary: ModalReconcileWitnessSummary? = nil,
             refusal: AlertAcknowledgeRefusal? = nil,
             actionFailure: AXHelpers.AXActionError? = nil,
-            unreadableReason: ModalReadFailure? = nil
+            unreadableReason: ModalReadFailure? = nil,
+            sheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
         ) {
             self.kind = kind
             self.decision = decision
@@ -151,6 +280,7 @@ extension AccessibilityChannel {
             self.refusal = refusal
             self.actionFailure = actionFailure
             self.unreadableReason = unreadableReason
+            self.sheetScanFailureDetail = sheetScanFailureDetail
         }
 
         static let none = ModalReconcileOutcome(kind: .none, decision: .noAction, performed: false)
@@ -290,7 +420,8 @@ extension AccessibilityChannel {
             kind: kind,
             decision: decision,
             performed: false,
-            unreadableReason: read.unreadableReason
+            unreadableReason: read.unreadableReason,
+            sheetScanFailureDetail: read.sheetScanFailureDetail
         )
     }
 
@@ -313,7 +444,8 @@ extension AccessibilityChannel {
             kind: kind,
             decision: decision,
             performed: false,
-            unreadableReason: read.unreadableReason
+            unreadableReason: read.unreadableReason,
+            sheetScanFailureDetail: read.sheetScanFailureDetail
         )
     }
 
@@ -373,7 +505,8 @@ extension AccessibilityChannel {
                 kind: kind,
                 decision: decision,
                 performed: false,
-                unreadableReason: read.unreadableReason
+                unreadableReason: read.unreadableReason,
+                sheetScanFailureDetail: read.sheetScanFailureDetail
             )
         }
 
@@ -400,7 +533,8 @@ extension AccessibilityChannel {
             witnessSummary: result.witnessSummary,
             refusal: result.refusal,
             actionFailure: result.actionFailure,
-            unreadableReason: read.unreadableReason
+            unreadableReason: read.unreadableReason,
+            sheetScanFailureDetail: read.sheetScanFailureDetail
         )
     }
 
@@ -414,6 +548,8 @@ extension AccessibilityChannel {
         let createButton: AXUIElement?
         let deleteButton: AXUIElement?
         let unreadableReason: ModalReadFailure?
+        /// #549: see `ModalReconcileOutcome.sheetScanFailureDetail`.
+        let sheetScanFailureDetail: ModalSheetScanFailureDetail?
 
         /// A content classifier may say `.none` while an independent host scan
         /// remains unreadable. Consumers that need a clean observation must use
@@ -457,14 +593,15 @@ extension AccessibilityChannel {
             switch anyWindowSheetLookup(runtime: runtime) {
             case .found(let sheet):
                 return readModalSignals(from: sheet, runtime: runtime)
-            case .incomplete(let reason), .unreadable(let reason):
+            case .incomplete(let reason, let detail), .unreadable(let reason, let detail):
                 // An unavailable host only retires the clean answer. Keep
                 // reading independent blocker sources: an identified dialog or
                 // menu is still actionable, and the next outer poll may read
                 // this host successfully.
                 return readRemainingModalSignals(
                     runtime: runtime,
-                    sheetScanFailure: reason
+                    sheetScanFailure: reason,
+                    sheetScanFailureDetail: detail
                 )
             case .absent:
                 return readRemainingModalSignals(runtime: runtime, sheetScanFailure: nil)
@@ -473,16 +610,21 @@ extension AccessibilityChannel {
             return unreadableModalSignals(reason: reason)
         case .found(let window):
             let primarySheetScanFailure: ModalReadFailure?
-            switch firstSheetLookup(in: window, maxDepth: 32, runtime: runtime.ax) {
+            let primarySheetScanFailureDetail: ModalSheetScanFailureDetail?
+            switch firstSheetLookup(
+                in: window, maxDepth: 32, runtime: runtime.ax, site: .mainWindowFirstSheetLookup
+            ) {
             case .found(let sheet):
                 // A sheet already proves this is not a clean pass. It outranks
                 // the other blocker kinds, so no action target from another
                 // window is carried into this classification.
                 return readModalSignals(from: sheet, runtime: runtime)
-            case .incomplete(let reason), .unreadable(let reason):
+            case .incomplete(let reason, let detail), .unreadable(let reason, let detail):
                 primarySheetScanFailure = reason
+                primarySheetScanFailureDetail = detail
             case .absent:
                 primarySheetScanFailure = nil
+                primarySheetScanFailureDetail = nil
             }
 
             // `AXMainWindow` identifies the arrange window, not the only
@@ -491,17 +633,22 @@ extension AccessibilityChannel {
             // may withhold CLEAN, but it must not hide a positively identified
             // New Track sheet on another host.
             var sheetScanFailure = primarySheetScanFailure
+            var sheetScanFailureDetail = primarySheetScanFailureDetail
             switch anyWindowSheetLookup(runtime: runtime, excluding: window) {
             case .found(let sheet):
                 return readModalSignals(from: sheet, runtime: runtime)
-            case .incomplete(let reason), .unreadable(let reason):
-                sheetScanFailure = sheetScanFailure ?? reason
+            case .incomplete(let reason, let detail), .unreadable(let reason, let detail):
+                if sheetScanFailure == nil {
+                    sheetScanFailure = reason
+                    sheetScanFailureDetail = detail
+                }
             case .absent:
                 break
             }
             return readRemainingModalSignals(
                 runtime: runtime,
-                sheetScanFailure: sheetScanFailure
+                sheetScanFailure: sheetScanFailure,
+                sheetScanFailureDetail: sheetScanFailureDetail
             )
         }
     }
@@ -557,7 +704,8 @@ extension AccessibilityChannel {
         topLevelAlertPrimaryButton: String = "",
         alertTarget: AXLogicProElements.BlockingDialogTarget? = nil,
         strayMenuTarget: AXUIElement? = nil,
-        unreadableReason: ModalReadFailure? = nil
+        unreadableReason: ModalReadFailure? = nil,
+        sheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
     ) -> ModalSignalRead {
         ModalSignalRead(
             signals: ModalReconciliation.ModalSignals(
@@ -580,7 +728,8 @@ extension AccessibilityChannel {
             sheet: nil,
             createButton: nil,
             deleteButton: nil,
-            unreadableReason: unreadableReason
+            unreadableReason: unreadableReason,
+            sheetScanFailureDetail: sheetScanFailureDetail
         )
     }
 
@@ -588,9 +737,14 @@ extension AccessibilityChannel {
     /// need fail-closed behaviour key on `unreadableReason`, not on inventing
     /// `unknownSheet`.
     private static func unreadableModalSignals(
-        reason: ModalReadFailure? = nil
+        reason: ModalReadFailure? = nil,
+        sheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
     ) -> ModalSignalRead {
-        noSheetModalSignals(strayMenuOpen: false, unreadableReason: reason)
+        noSheetModalSignals(
+            strayMenuOpen: false,
+            unreadableReason: reason,
+            sheetScanFailureDetail: sheetScanFailureDetail
+        )
     }
 
     /// A modal window was observed and could not be classified as a sanctioned
@@ -617,7 +771,8 @@ extension AccessibilityChannel {
             sheet: nil,
             createButton: nil,
             deleteButton: nil,
-            unreadableReason: nil
+            unreadableReason: nil,
+            sheetScanFailureDetail: nil
         )
     }
 
@@ -627,7 +782,8 @@ extension AccessibilityChannel {
     /// poll may make the unavailable window readable again.
     private static func readRemainingModalSignals(
         runtime: AXLogicProElements.Runtime,
-        sheetScanFailure: ModalReadFailure?
+        sheetScanFailure: ModalReadFailure?,
+        sheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
     ) -> ModalSignalRead {
         switch topLevelDialogRead(runtime: runtime) {
         case .unreadable(let reason):
@@ -656,7 +812,8 @@ extension AccessibilityChannel {
                     // of every clean-observation gate.
                     return noSheetModalSignals(
                         strayMenuOpen: false,
-                        unreadableReason: sheetScanFailure
+                        unreadableReason: sheetScanFailure,
+                        sheetScanFailureDetail: sheetScanFailureDetail
                     )
                 }
                 return noSheetModalSignals(strayMenuOpen: false)
@@ -723,7 +880,8 @@ extension AccessibilityChannel {
         sheet: sheet,
         createButton: createButton?.element,
         deleteButton: deleteButton?.element,
-        unreadableReason: nil)
+        unreadableReason: nil,
+        sheetScanFailureDetail: nil)
     }
 
     /// A complete top-level scan can find an auto-acknowledgeable AXDialog, a
@@ -861,8 +1019,12 @@ extension AccessibilityChannel {
     private enum SheetLookup {
         case found(AXUIElement)
         case absent
-        case incomplete(ModalReadFailure)
-        case unreadable(ModalReadFailure)
+        /// #549: `detail` names the exact node/scan/attribute behind `reason`
+        /// when the failure originated in the sheet scan itself (always true
+        /// for every construction site below); `nil` is not currently
+        /// reachable but keeps this additive rather than force-unwrapped.
+        case incomplete(ModalReadFailure, ModalSheetScanFailureDetail?)
+        case unreadable(ModalReadFailure, ModalSheetScanFailureDetail?)
     }
 
     /// Status-preserving sheet lookup used for classification and for a clean
@@ -878,7 +1040,9 @@ extension AccessibilityChannel {
         excluding excludedWindow: AXUIElement? = nil
     ) -> SheetLookup {
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
-            return .unreadable(.appRootUnavailable)
+            // No sheet-tree node was ever reached, so there is nothing for
+            // #549's `ModalSheetScanFailureDetail` to name.
+            return .unreadable(.appRootUnavailable, nil)
         }
         let windows: [AXUIElement]
         switch AXHelpers.getAXUIElementArrayRead(
@@ -890,41 +1054,52 @@ extension AccessibilityChannel {
             // A raw absent/non-array AXWindows result cannot prove no other
             // sheet host exists. Keep its distinct diagnostic cause instead of
             // laundering it into a clean empty list.
-            return .unreadable(.axWindowsPayloadUninterpretable)
+            return .unreadable(.axWindowsPayloadUninterpretable, nil)
         case .failure(let error):
             // `noValue` is not "the app has zero windows" — AX statuses can
             // lie during a rebuild, and a real window (holding a real sheet)
             // can exist behind a transiently unreadable AXWindows call. Every
             // failure, noValue included, must not be laundered into "no other
             // hosts".
-            return .unreadable(.axWindowsReadFailed(error))
+            return .unreadable(.axWindowsReadFailed(error), nil)
         }
         var incompleteReason: ModalReadFailure?
+        var incompleteDetail: ModalSheetScanFailureDetail?
         var unreadableReason: ModalReadFailure?
+        var unreadableDetail: ModalSheetScanFailureDetail?
         for window in windows {
             guard excludedWindow.map({ !CFEqual(window, $0) }) ?? true else { continue }
-            switch firstSheetLookup(in: window, maxDepth: 32, runtime: runtime.ax) {
+            switch firstSheetLookup(
+                in: window, maxDepth: 32, runtime: runtime.ax, site: .anyWindowSheetLookup
+            ) {
             case .found(let sheet):
                 return .found(sheet)
-            case .unreadable(let reason):
+            case .unreadable(let reason, let detail):
                 // This window cannot contribute to a clean scan, but it must
                 // not stop a later window from contributing a real sheet.
                 // Preserve the first unavailable answer for the no-sheet exit.
-                unreadableReason = unreadableReason ?? reason
-            case .incomplete(let reason):
-                incompleteReason = incompleteReason ?? reason
+                if unreadableReason == nil {
+                    unreadableReason = reason
+                    unreadableDetail = detail
+                }
+            case .incomplete(let reason, let detail):
+                if incompleteReason == nil {
+                    incompleteReason = reason
+                    incompleteDetail = detail
+                }
             case .absent:
                 continue
             }
         }
-        if let unreadableReason { return .unreadable(unreadableReason) }
-        return incompleteReason.map(SheetLookup.incomplete) ?? .absent
+        if let unreadableReason { return .unreadable(unreadableReason, unreadableDetail) }
+        return incompleteReason.map { .incomplete($0, incompleteDetail) } ?? .absent
     }
 
     private static func firstSheetLookup(
         in window: AXUIElement,
         maxDepth: Int,
-        runtime: AXHelpers.Runtime
+        runtime: AXHelpers.Runtime,
+        site: ModalSheetScanFailureDetail.Site
     ) -> SheetLookup {
         // Live measurement on Logic shows `AXSheets` is unsupported (-25205,
         // zero elements) both while idle and while the mandatory New Track
@@ -944,6 +1119,10 @@ extension AccessibilityChannel {
                     case .failure, .success:
                         // A failure while searching says this node is not a
                         // candidate. It is not a verdict on the rest of the tree.
+                        // Deliberately not surfaced as a `ModalReadFailure`:
+                        // this non-authoritative cheap-positive check always
+                        // falls through to the authoritative descendant
+                        // traversal below, unchanged from before #549.
                         continue
                     }
                 }
@@ -951,7 +1130,7 @@ extension AccessibilityChannel {
         case .failure, .success(.none):
             break
         }
-        return findSheetDescendantLookup(in: window, maxDepth: maxDepth, runtime: runtime)
+        return findSheetDescendantLookup(in: window, maxDepth: maxDepth, runtime: runtime, site: site)
     }
 
 
@@ -992,59 +1171,125 @@ extension AccessibilityChannel {
     /// before reaching it. An unreadable branch retires only that branch: later
     /// siblings can still positively identify a sheet. If none do, retain the
     /// first failure so a partial tree cannot prove that a sheet is absent.
+    /// - Parameters:
+    ///   - site: which top-level scan is asking. Passed through unchanged at
+    ///     the entry call; every RECURSIVE call below passes
+    ///     `.recursiveDescendantWalk` instead, so a failure at the window's
+    ///     own direct children is attributed to whichever caller invoked this
+    ///     scan, and a failure any deeper is attributed to the generic walk.
+    ///   - ancestorPath: the root-to-`element` ordinal path accumulated so
+    ///     far, for #549's `ModalSheetScanFailureDetail.path`.
+    ///   - elementRole: `element`'s own role, when already known (nil only
+    ///     for the initial window-root call, whose role this scan never
+    ///     independently reads).
     private static func findSheetDescendantLookup(
         in element: AXUIElement,
         maxDepth: Int,
-        runtime: AXHelpers.Runtime
+        runtime: AXHelpers.Runtime,
+        site: ModalSheetScanFailureDetail.Site,
+        ancestorPath: [ModalSheetScanFailureDetail.PathStep] = [],
+        elementRole: String? = nil
     ) -> SheetLookup {
-        guard maxDepth > 0 else { return .incomplete(.descendantTraversalDepthCap) }
+        guard maxDepth > 0 else {
+            return .incomplete(
+                .descendantTraversalDepthCap,
+                ModalSheetScanFailureDetail(
+                    site: site,
+                    attribute: .depthCapped,
+                    subjectRole: elementRole,
+                    path: ancestorPath,
+                    // The node we were about to descend into was already
+                    // confirmed non-sheet by the caller that reached it here;
+                    // only its unexamined descendants remain unknown.
+                    wouldHaveBeenAbsent: true
+                )
+            )
+        }
         switch AXHelpers.childrenResult(element, runtime: runtime) {
         case .failure(let error):
             // A node with no children is an answer: nothing here, keep looking elsewhere.
             guard !axStatusIsDefinitiveAbsence(error) else { return .absent }
-            return .unreadable(.windowSheetReadFailed(error))
+            return .unreadable(
+                .windowSheetReadFailed(error),
+                ModalSheetScanFailureDetail(
+                    site: site,
+                    attribute: .children,
+                    subjectRole: elementRole,
+                    path: ancestorPath,
+                    wouldHaveBeenAbsent: true
+                )
+            )
         case .success(let children):
             var incompleteReason: ModalReadFailure?
+            var incompleteDetail: ModalSheetScanFailureDetail?
             var unreadableReason: ModalReadFailure?
-            var nonSheetChildren: [AXUIElement] = []
+            var unreadableDetail: ModalSheetScanFailureDetail?
+            var nonSheetChildren: [(element: AXUIElement, role: String?, index: Int)] = []
 
             // The measured New Track sheet is a direct child of the arrange
             // window. Give each direct child a chance to identify itself before
             // walking below a readable sibling; several unrelated direct nodes
             // can reject `AXRole` with -25200.
-            for child in children {
+            for (index, child) in children.enumerated() {
                 switch AXHelpers.getAttributeResult(child, kAXRoleAttribute as String, runtime: runtime) as Result<String?, AXHelpers.AXStatusError> {
                 case .failure(let error):
                     // A failed role read makes this child an unreadable
                     // candidate, not a verdict on its siblings. Preserve the
                     // first status for the no-sheet exit, then keep scanning.
-                    unreadableReason = unreadableReason ?? .windowSheetReadFailed(error)
+                    if unreadableReason == nil {
+                        unreadableReason = .windowSheetReadFailed(error)
+                        unreadableDetail = ModalSheetScanFailureDetail(
+                            site: site,
+                            attribute: .role,
+                            // The failing child's own role is exactly what
+                            // this read could not establish.
+                            subjectRole: nil,
+                            path: ancestorPath + [.init(parentRole: elementRole, childIndex: index)],
+                            // Unknown identity: this child might have BEEN
+                            // the sheet, so the verdict cannot be claimed
+                            // absent from this failure alone.
+                            wouldHaveBeenAbsent: false
+                        )
+                    }
                     continue
                 case .success(let role):
                     if role == (kAXSheetRole as String) {
                         return .found(child)
                     }
-                    nonSheetChildren.append(child)
+                    nonSheetChildren.append((child, role, index))
                 }
             }
 
             // Only descend after the direct-child pass did not find a sheet.
-            for child in nonSheetChildren {
-                switch findSheetDescendantLookup(in: child, maxDepth: maxDepth - 1, runtime: runtime) {
+            for (child, role, index) in nonSheetChildren {
+                switch findSheetDescendantLookup(
+                    in: child,
+                    maxDepth: maxDepth - 1,
+                    runtime: runtime,
+                    site: .recursiveDescendantWalk,
+                    ancestorPath: ancestorPath + [.init(parentRole: elementRole, childIndex: index)],
+                    elementRole: role
+                ) {
                 case .found(let sheet):
                     return .found(sheet)
-                case .unreadable(let reason):
+                case .unreadable(let reason, let detail):
                     // This sub-branch was not fully searchable, but another
                     // sibling can still carry the sheet we need to classify.
-                    unreadableReason = unreadableReason ?? reason
-                case .incomplete(let reason):
-                    incompleteReason = incompleteReason ?? reason
+                    if unreadableReason == nil {
+                        unreadableReason = reason
+                        unreadableDetail = detail
+                    }
+                case .incomplete(let reason, let detail):
+                    if incompleteReason == nil {
+                        incompleteReason = reason
+                        incompleteDetail = detail
+                    }
                 case .absent:
                     continue
                 }
             }
-            if let unreadableReason { return .unreadable(unreadableReason) }
-            return incompleteReason.map(SheetLookup.incomplete) ?? .absent
+            if let unreadableReason { return .unreadable(unreadableReason, unreadableDetail) }
+            return incompleteReason.map { .incomplete($0, incompleteDetail) } ?? .absent
         }
     }
 
@@ -1707,7 +1952,8 @@ extension AccessibilityChannel {
         witnessSummary: ModalReconcileWitnessSummary? = nil,
         refusal: AlertAcknowledgeRefusal? = nil,
         actionFailure: AXHelpers.AXActionError? = nil,
-        unreadableReason: ModalReadFailure? = nil
+        unreadableReason: ModalReadFailure? = nil,
+        sheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
     ) {
         guard kind != .none || unreadableReason != nil else { return }
         if kind != .none {
@@ -1746,6 +1992,19 @@ extension AccessibilityChannel {
             for (key, value) in unreadableReason.envelopeExtras {
                 extras[key] = value
             }
+        }
+        // #549: which exact node/scan/attribute the sheet scan gave up on,
+        // ADDITIVE beside the existing status-only fields above.
+        //
+        // The `else if` is the load-bearing half. "The detail is threaded through every site that sets
+        // `unreadableReason`" is a claim about coverage, and coverage claims decay: the next site added
+        // will set the reason and forget the detail, and the field will simply be absent. An absent
+        // field reads as "the scan had no unreadable node" — which is precisely the silence this field
+        // exists to end. So a sheet-scan failure with no detail says so, loudly, instead of vanishing.
+        if let sheetScanFailureDetail {
+            extras["reconciled_modal_unreadable_node"] = sheetScanFailureDetail.envelopeValue
+        } else if unreadableReason?.originatesInSheetScan == true {
+            extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
         }
     }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -148,26 +148,31 @@ extension AccessibilityChannel {
 
         let site: Site
         let attribute: Attribute
-        /// The failing node's own role, when it was already known before the
-        /// read that failed. An `AXChildren` failure always has this — a
-        /// node only reaches that read after its own role was confirmed
-        /// non-sheet by the caller that descended into it. `nil` when the
-        /// failing read WAS the role lookup itself.
+        /// The failing node's own role, when it was already known before the read that failed.
+        ///
+        /// `nil` in two distinct situations, and the receipt cannot tell them apart — say so rather than
+        /// implying otherwise. Either the failing read WAS the role lookup, or the failing node is the
+        /// window root, whose role this scan never reads (`firstSheetLookup` enters the walk with no
+        /// role for it). So an `AXChildren` failure does NOT always carry a role: a failed `AXChildren`
+        /// read on the window itself — an ordinary occurrence while Logic rebuilds — reports `nil` here
+        /// with an empty path.
         let subjectRole: String?
         /// Root-to-node ordinal path, one entry per level of descent from
         /// the window root down to (but not including) the failing node.
         let path: [PathStep]
-        /// Whether the failing node's own identity — had this exact read
-        /// succeeded — could still have changed the scan's verdict. `true`
-        /// only for an `AXChildren`/depth-cap failure on a node whose role
-        /// was already confirmed non-sheet: THAT node is provably not the
-        /// missing sheet, so the read that failed could only have ruled out
-        /// content beneath it, never revealed the sheet itself. `false` for
-        /// an `AXRole` failure, where the node's identity is unknown and
-        /// could have been the sheet. This deliberately does not claim
-        /// knowledge of an `AXChildren` failure's unexamined descendants —
-        /// only that the reported node itself was not load-bearing.
-        let wouldHaveBeenAbsent: Bool
+        // There is deliberately NO "would the scan have answered absent" field. One was specified and
+        // built, and it was wrong: for an `AXChildren` or depth-cap failure it reported `true` — the
+        // failing node is provably not the sheet — while the subtree BELOW that node went entirely
+        // unexamined and may hold it. In the likeliest real case, Logic wedged on a sheet this scan
+        // cannot read, that field would have told an investigator the failed read could not have hidden
+        // it. A confidently wrong pointer is worse than none, and this type exists precisely because
+        // confident wrongness cost three misdiagnoses.
+        //
+        // What is known is already carried, without a counterfactual:
+        //   `subjectRole` present — the node's role was read and is not a sheet
+        //   `subjectRole` nil     — the node was never identified; it could have been the sheet
+        //   either way            — everything below the failing node is unexamined, which is exactly
+        //                           why the verdict was `.unreadable` rather than `.absent`
 
         /// Emitted when the sheet scan reported a failure but no detail reached the receipt. It marks a
         /// hole in this feature's own coverage rather than a fact about Logic, and it is deliberately
@@ -194,7 +199,6 @@ extension AccessibilityChannel {
                     }
                     return entry
                 },
-                "would_have_been_absent": wouldHaveBeenAbsent,
             ]
             if let subjectRole {
                 value["subject_role"] = subjectRole
@@ -1019,10 +1023,11 @@ extension AccessibilityChannel {
     private enum SheetLookup {
         case found(AXUIElement)
         case absent
-        /// #549: `detail` names the exact node/scan/attribute behind `reason`
-        /// when the failure originated in the sheet scan itself (always true
-        /// for every construction site below); `nil` is not currently
-        /// reachable but keeps this additive rather than force-unwrapped.
+        /// #549: `detail` names the exact node/scan/attribute behind `reason` when the failure
+        /// originated in the sheet scan itself. `nil` IS reachable and is the correct value for the
+        /// failures that arise before the walk begins — `appRootUnavailable`,
+        /// `axWindowsPayloadUninterpretable`, `axWindowsReadFailed` — which have no node to name. Do not
+        /// force-unwrap it.
         case incomplete(ModalReadFailure, ModalSheetScanFailureDetail?)
         case unreadable(ModalReadFailure, ModalSheetScanFailureDetail?)
     }
@@ -1197,11 +1202,7 @@ extension AccessibilityChannel {
                     site: site,
                     attribute: .depthCapped,
                     subjectRole: elementRole,
-                    path: ancestorPath,
-                    // The node we were about to descend into was already
-                    // confirmed non-sheet by the caller that reached it here;
-                    // only its unexamined descendants remain unknown.
-                    wouldHaveBeenAbsent: true
+                    path: ancestorPath
                 )
             )
         }
@@ -1215,8 +1216,7 @@ extension AccessibilityChannel {
                     site: site,
                     attribute: .children,
                     subjectRole: elementRole,
-                    path: ancestorPath,
-                    wouldHaveBeenAbsent: true
+                    path: ancestorPath
                 )
             )
         case .success(let children):
@@ -1244,11 +1244,7 @@ extension AccessibilityChannel {
                             // The failing child's own role is exactly what
                             // this read could not establish.
                             subjectRole: nil,
-                            path: ancestorPath + [.init(parentRole: elementRole, childIndex: index)],
-                            // Unknown identity: this child might have BEEN
-                            // the sheet, so the verdict cannot be claimed
-                            // absent from this failure alone.
-                            wouldHaveBeenAbsent: false
+                            path: ancestorPath + [.init(parentRole: elementRole, childIndex: index)]
                         )
                     }
                     continue
@@ -2001,10 +1997,19 @@ extension AccessibilityChannel {
         // will set the reason and forget the detail, and the field will simply be absent. An absent
         // field reads as "the scan had no unreadable node" — which is precisely the silence this field
         // exists to end. So a sheet-scan failure with no detail says so, loudly, instead of vanishing.
+        // The write is TOTAL — every branch either sets the key or removes it. `verifyTrackCreation`
+        // merges twice into one dictionary (`+Tracks.swift`: the post-menu outcome, then `var merged =
+        // extras` and the final poll's outcome). Without the removal, a node recorded by the first merge
+        // survives into a receipt whose reason came from the second: a `stray_menu_read_failed` envelope
+        // carrying a node from a sheet scan in an earlier poll. That is the "names the wrong node
+        // confidently" outcome this field exists to prevent, and it would be believed precisely because
+        // the field looks specific.
         if let sheetScanFailureDetail {
             extras["reconciled_modal_unreadable_node"] = sheetScanFailureDetail.envelopeValue
         } else if unreadableReason?.originatesInSheetScan == true {
             extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
+        } else {
+            extras.removeValue(forKey: "reconciled_modal_unreadable_node")
         }
     }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -227,7 +227,8 @@ extension AccessibilityChannel {
         observedWindowTitles: [String]?,
         observationBudgetMs: Int,
         witnessSummary: ModalReconcileWitnessSummary? = nil,
-        modalUnreadableReason: ModalReadFailure? = nil
+        modalUnreadableReason: ModalReadFailure? = nil,
+        modalSheetScanFailureDetail: ModalSheetScanFailureDetail? = nil
     ) -> String {
         var extras: [String: Any] = [
             "operation": "project.new",
@@ -258,6 +259,13 @@ extension AccessibilityChannel {
             extras["modal_observation"] = "incomplete"
             for (key, value) in modalUnreadableReason.envelopeExtras {
                 extras[key] = value
+            }
+            // See mergeReconcileExtras: a sheet-scan failure carrying no companion detail says so
+            // rather than omitting the field, because an omitted field reads as "no unreadable node".
+            if let modalSheetScanFailureDetail {
+                extras["reconciled_modal_unreadable_node"] = modalSheetScanFailureDetail.envelopeValue
+            } else if modalUnreadableReason.originatesInSheetScan {
+                extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
             }
         }
         return HonestContract.encodeStateB(
@@ -332,6 +340,10 @@ extension AccessibilityChannel {
         var mandatoryTrackCreateActionAttempted = false
         var mandatoryTrackCreateActionFailure: AXHelpers.AXActionError?
         var lastModalUnreadableReason: ModalReadFailure?
+        // #549: mirrors `lastModalUnreadableReason` at every site that sets/
+        // clears it, so the unknown-sheet envelope below can also name the
+        // exact node/scan behind the failure.
+        var lastModalSheetScanFailureDetail: ModalSheetScanFailureDetail?
         let attempts = max(1, observationAttempts)
         for attempt in 0..<attempts {
             try? await Task.sleep(nanoseconds: observationDelayNanoseconds)
@@ -349,12 +361,14 @@ extension AccessibilityChannel {
             if !outcome.modalObservationIsComplete {
                 if let unreadableReason = outcome.unreadableReason {
                     lastModalUnreadableReason = unreadableReason
+                    lastModalSheetScanFailureDetail = outcome.sheetScanFailureDetail
                 }
                 continue
             }
             // Do not carry a transient, already-resolved scan failure into a
             // later complete observation's final envelope.
             lastModalUnreadableReason = nil
+            lastModalSheetScanFailureDetail = nil
 
             switch outcome.kind {
             case .mandatoryNewTrack:
@@ -420,6 +434,7 @@ extension AccessibilityChannel {
                 // still ends in State B below without any unchecked action.
                 if let unreadableReason = outcome.unreadableReason {
                     lastModalUnreadableReason = unreadableReason
+                    lastModalSheetScanFailureDetail = outcome.sheetScanFailureDetail
                 }
                 guard attempt + 1 == attempts else { continue }
                 var extras: [String: Any] = [
@@ -435,6 +450,12 @@ extension AccessibilityChannel {
                     for (key, value) in lastModalUnreadableReason.envelopeExtras {
                         extras[key] = value
                     }
+                }
+                // See mergeReconcileExtras: an omitted field would read as "no unreadable node".
+                if let lastModalSheetScanFailureDetail {
+                    extras["reconciled_modal_unreadable_node"] = lastModalSheetScanFailureDetail.envelopeValue
+                } else if lastModalUnreadableReason?.originatesInSheetScan == true {
+                    extras["reconciled_modal_unreadable_node"] = ModalSheetScanFailureDetail.unrecordedEnvelopeValue
                 }
                 return .error(HonestContract.encodeStateB(
                     reason: .readbackUnavailable,
@@ -481,7 +502,8 @@ extension AccessibilityChannel {
                     witnessSummary: outcome.witnessSummary,
                     refusal: outcome.refusal,
                     actionFailure: outcome.actionFailure,
-                    unreadableReason: outcome.unreadableReason
+                    unreadableReason: outcome.unreadableReason,
+                    sheetScanFailureDetail: outcome.sheetScanFailureDetail
                 )
                 return .error(HonestContract.encodeStateB(
                     reason: .readbackUnavailable,
@@ -554,7 +576,8 @@ extension AccessibilityChannel {
             observedWindowTitles: observedWindowTitles(runtime: runtime),
             observationBudgetMs: attempts * Int(observationDelayNanoseconds / 1_000_000),
             witnessSummary: witnessSummary,
-            modalUnreadableReason: lastModalUnreadableReason
+            modalUnreadableReason: lastModalUnreadableReason,
+            modalSheetScanFailureDetail: lastModalSheetScanFailureDetail
         ))
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -1388,7 +1388,8 @@ extension AccessibilityChannel {
             witnessSummary: reconcileOutcome.witnessSummary,
             refusal: reconcileOutcome.refusal,
             actionFailure: reconcileOutcome.actionFailure,
-            unreadableReason: reconcileOutcome.unreadableReason
+            unreadableReason: reconcileOutcome.unreadableReason,
+            sheetScanFailureDetail: reconcileOutcome.sheetScanFailureDetail
         )
 
         var lastModal = reconcileOutcome
@@ -1476,7 +1477,8 @@ extension AccessibilityChannel {
             witnessSummary: lastModal.witnessSummary,
             refusal: lastModal.refusal,
             actionFailure: lastModal.actionFailure,
-            unreadableReason: lastModal.unreadableReason
+            unreadableReason: lastModal.unreadableReason,
+            sheetScanFailureDetail: lastModal.sheetScanFailureDetail
         )
         // Without a successful pre-write rail read, a later count cannot tell
         // whether the tracks existed before the menu action. The write may have
@@ -1678,6 +1680,9 @@ extension AccessibilityChannel {
         var reconcileActionFailure: AXHelpers.AXActionError?
         var reconcileWitnessSummary: ModalReconcileWitnessSummary?
         var reconcileUnreadableReason: ModalReadFailure?
+        // #549: which exact node/scan the sheet scan gave up on, mirrored
+        // beside `reconcileUnreadableReason` at every site that sets/clears it.
+        var reconcileSheetScanFailureDetail: ModalSheetScanFailureDetail?
         var actionAttemptedModalKinds: Set<String> = []
         var mandatoryNewTrackReconciliationPerformed = false
         var consecutiveCleanModalObservations = 0
@@ -1746,6 +1751,7 @@ extension AccessibilityChannel {
                 if let actionFailure = outcome.actionFailure { reconcileActionFailure = actionFailure }
                 if let unreadableReason = outcome.unreadableReason {
                     reconcileUnreadableReason = unreadableReason
+                    reconcileSheetScanFailureDetail = outcome.sheetScanFailureDetail
                 }
                 // A current unacted *new* blocker must not inherit a witness
                 // from a prior sheet. A repeated observation of the same kind
@@ -1767,11 +1773,13 @@ extension AccessibilityChannel {
                 // so a later instance is eligible for one fresh direct action.
                 actionAttemptedModalKinds.removeAll()
                 reconcileUnreadableReason = nil
+                reconcileSheetScanFailureDetail = nil
             } else if let unreadableReason = outcome.unreadableReason {
                 // An incomplete no-modal answer is neither a blocker nor a
                 // clean pass. Preserve its diagnostic and leave the action
                 // latch intact until a later complete observation settles it.
                 reconcileUnreadableReason = unreadableReason
+                reconcileSheetScanFailureDetail = outcome.sheetScanFailureDetail
             }
             let observedTrackCountDecreased = beforeCount.flatMap { beforeCount in
                 currentCount.map { $0 < beforeCount }
@@ -1808,7 +1816,8 @@ extension AccessibilityChannel {
                     witnessSummary: reconcileWitnessSummary,
                     refusal: reconcileRefusal,
                     actionFailure: reconcileActionFailure,
-                    unreadableReason: reconcileUnreadableReason
+                    unreadableReason: reconcileUnreadableReason,
+                    sheetScanFailureDetail: reconcileSheetScanFailureDetail
                 )
                 return .success(HonestContract.encodeStateA(extras: extras))
             }
@@ -1834,7 +1843,8 @@ extension AccessibilityChannel {
             witnessSummary: reconcileWitnessSummary,
             refusal: reconcileRefusal,
             actionFailure: reconcileActionFailure,
-            unreadableReason: reconcileUnreadableReason
+            unreadableReason: reconcileUnreadableReason,
+            sheetScanFailureDetail: reconcileSheetScanFailureDetail
         )
         return .success(HonestContract.encodeStateB(
             reason: .retryExhausted,

--- a/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
+++ b/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
@@ -58,7 +58,6 @@ struct Issue549ModalScanFailureDetailTests {
         #expect(detail.attribute == .children)
         #expect(detail.subjectRole == (kAXGroupRole as String))
         #expect(detail.path == [.init(parentRole: nil, childIndex: 1)])
-        #expect(detail.wouldHaveBeenAbsent)
     }
 
     @Test("a role-read failure at the window's own top level is attributed to the main-window scan, not the recursive walk")
@@ -96,7 +95,6 @@ struct Issue549ModalScanFailureDetailTests {
         #expect(detail.attribute == .role)
         #expect(detail.subjectRole == nil, "a role failure cannot name a role it never read")
         #expect(detail.path == [.init(parentRole: nil, childIndex: 0)])
-        #expect(!detail.wouldHaveBeenAbsent)
     }
 
     @Test("a role-read failure on another window is attributed to the any-window scan")
@@ -172,7 +170,6 @@ struct Issue549ModalScanFailureDetailTests {
         let detail = try #require(read.sheetScanFailureDetail)
 
         #expect(detail.attribute == .children)
-        #expect(detail.wouldHaveBeenAbsent)
     }
 
     @Test("the counterfactual reports NOT would-have-been-absent when the hidden node's true (unreadable) role is the sheet")
@@ -217,7 +214,6 @@ struct Issue549ModalScanFailureDetailTests {
         #expect(!read.signals.sheetPresent)
         let detail = try #require(read.sheetScanFailureDetail)
         #expect(detail.attribute == .role)
-        #expect(!detail.wouldHaveBeenAbsent)
     }
 
     // MARK: - No user content
@@ -325,6 +321,48 @@ struct Issue549ModalScanFailureDetailTests {
         )
         #expect(extras["reconciled_modal_unreadable_node"] == nil)
         #expect(extras["reconciled_modal_unreadable_reason"] != nil)
+    }
+
+    @Test("a second merge into the same receipt cannot leave the first merge's node behind")
+    func staleNodeDoesNotSurviveASecondMerge() throws {
+        // `verifyTrackCreation` merges twice into one dictionary: the post-menu outcome, then
+        // `var merged = extras` plus the final poll's outcome. The reason is overwritten by the second
+        // merge; if the node were only ever written and never removed, a node from the first merge's
+        // sheet scan would ride along beside a reason from a poll that never touched the sheet tree —
+        // naming the wrong node, confidently, in the one field added to stop exactly that.
+        var extras: [String: Any] = [:]
+        let firstDetail = AccessibilityChannel.ModalSheetScanFailureDetail(
+            site: .mainWindowFirstSheetLookup,
+            attribute: .children,
+            subjectRole: kAXGroupRole as String,
+            path: [.init(parentRole: nil, childIndex: 1)]
+        )
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .none,
+            action: "none",
+            newTrackAutoConfirmed: false,
+            unreadableReason: .windowSheetReadFailed(AXHelpers.AXStatusError(raw: -25200)),
+            sheetScanFailureDetail: firstDetail
+        )
+        let afterFirst = try #require(extras["reconciled_modal_unreadable_node"] as? [String: Any])
+        #expect((afterFirst["subject_role"] as? String) == (kAXGroupRole as String))
+
+        // Second merge: a stray-menu failure, which never involved the sheet scan and carries no node.
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .none,
+            action: "none",
+            newTrackAutoConfirmed: false,
+            unreadableReason: .strayMenuReadFailed,
+            sheetScanFailureDetail: nil
+        )
+        let reason = try #require(extras["reconciled_modal_unreadable_reason"] as? String)
+        #expect(reason == "stray_menu_read_failed")
+        #expect(
+            extras["reconciled_modal_unreadable_node"] == nil,
+            "the earlier sheet-scan node must not survive beside a reason from a different scan"
+        )
     }
 }
 

--- a/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
+++ b/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
@@ -364,6 +364,45 @@ struct Issue549ModalScanFailureDetailTests {
             "the earlier sheet-scan node must not survive beside a reason from a different scan"
         )
     }
+
+    @Test("a merge that carries no reason leaves the previous reason and its node together")
+    func aMergeWithoutAReasonStrandsNeitherHalf() throws {
+        // The counterpart to the stale-node test, and the defect the first version of that fix
+        // introduced. The reason is only written when a merge supplies one, so a merge without one
+        // leaves the earlier reason standing. Removing its node there would report a sheet-scan failure
+        // whose node was known and then discarded — the same "the receipt is missing what was measured"
+        // shape, pointed the other way.
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .none,
+            action: "none",
+            newTrackAutoConfirmed: false,
+            unreadableReason: .windowSheetReadFailed(AXHelpers.AXStatusError(raw: -25200)),
+            sheetScanFailureDetail: AccessibilityChannel.ModalSheetScanFailureDetail(
+                site: .recursiveDescendantWalk,
+                attribute: .children,
+                subjectRole: kAXCellRole as String,
+                path: [.init(parentRole: kAXRowRole as String, childIndex: 0)]
+            )
+        )
+        // A second merge that found a real blocker and has no unreadable reason of its own.
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .mandatoryNewTrack,
+            action: "click_create",
+            newTrackAutoConfirmed: true,
+            unreadableReason: nil,
+            sheetScanFailureDetail: nil
+        )
+        let reason = try #require(extras["reconciled_modal_unreadable_reason"] as? String)
+        #expect(reason == "window_sheet_read_failed")
+        let node = try #require(
+            extras["reconciled_modal_unreadable_node"] as? [String: Any],
+            "the node describing a surviving reason must survive with it"
+        )
+        #expect((node["subject_role"] as? String) == (kAXCellRole as String))
+    }
 }
 
 private final class LockedCounter549: @unchecked Sendable {

--- a/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
+++ b/Tests/LogicProMCPTests/Issue549ModalScanFailureDetailTests.swift
@@ -1,0 +1,348 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #549: `track.create` / `track.delete` intermittently answer State B
+/// `retry_exhausted` with only a status code (`window_sheet_read_failed`,
+/// `-25200`) naming NOTHING about which node or which scan gave up. These
+/// tests prove `AccessibilityChannel.ModalSheetScanFailureDetail` — the
+/// additive receipt field this ticket adds — actually names the failing
+/// node (role + structural path), the scan that was running (site), the
+/// attribute read that failed, and a bounded counterfactual, WITHOUT ever
+/// carrying user-authored content (window titles, `AXDescription`,
+/// `AXValue`).
+@Suite("Issue #549 — sheet-scan failure names the failing node")
+struct Issue549ModalScanFailureDetailTests {
+
+    @Test("a children-read failure at a known ordinal position names the node's role, structural path, site, and status")
+    func childrenReadFailureNamesNodeRoleAndPath() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9001)
+        let window = builder.element(9002)
+        let decoy = builder.element(9003)
+        let targetGroup = builder.element(9004)
+        let childrenReads = LockedCounter549()
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setAttribute(decoy, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        builder.setAttribute(targetGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+        // `decoy` (index 0) is left with no children — a genuine, readable
+        // dead end. `targetGroup` (index 1) is the reported node: its own
+        // role is already known (non-sheet), but its `AXChildren` read fails.
+        builder.setChildren(window, [decoy, targetGroup])
+
+        let cannotComplete = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            childrenResultHandler: { element in
+                guard CFEqual(element, targetGroup) else { return nil }
+                _ = childrenReads.next()
+                return .failure(cannotComplete)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let read = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+
+        #expect(childrenReads.current() > 0, "the targetGroup AXChildren failure seam must fire, or this test proves nothing")
+        #expect(read.unreadableReason == .windowSheetReadFailed(cannotComplete))
+        let detail = try #require(
+            read.sheetScanFailureDetail,
+            "a windowSheetReadFailed originating in the sheet scan must always carry #549's detail"
+        )
+        // Mutation-proved below: see the report for the observed FAIL output
+        // when `subjectRole`/`path` were forced to nil/[].
+        #expect(detail.site == .recursiveDescendantWalk)
+        #expect(detail.attribute == .children)
+        #expect(detail.subjectRole == (kAXGroupRole as String))
+        #expect(detail.path == [.init(parentRole: nil, childIndex: 1)])
+        #expect(detail.wouldHaveBeenAbsent)
+    }
+
+    @Test("a role-read failure at the window's own top level is attributed to the main-window scan, not the recursive walk")
+    func topLevelRoleFailureUsesMainWindowSite() throws {
+        // Same shape as the previous test, but the failure is a ROLE read on
+        // a DIRECT child of the window (depth 0) rather than a CHILDREN read
+        // one level down — this is the one case where `site` must read
+        // `mainWindowFirstSheetLookup`, not `recursiveDescendantWalk`.
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9011)
+        let window = builder.element(9012)
+        let unreadableChild = builder.element(9013)
+        let roleReads = LockedCounter549()
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setChildren(window, [unreadableChild])
+
+        let cannotComplete = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                guard CFEqual(element, unreadableChild), attribute == (kAXRoleAttribute as String) else { return nil }
+                _ = roleReads.next()
+                return .failure(cannotComplete)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let read = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+
+        #expect(roleReads.current() > 0, "the direct-child AXRole failure seam must fire, or this test proves nothing")
+        let detail = try #require(read.sheetScanFailureDetail)
+        #expect(detail.site == .mainWindowFirstSheetLookup)
+        #expect(detail.attribute == .role)
+        #expect(detail.subjectRole == nil, "a role failure cannot name a role it never read")
+        #expect(detail.path == [.init(parentRole: nil, childIndex: 0)])
+        #expect(!detail.wouldHaveBeenAbsent)
+    }
+
+    @Test("a role-read failure on another window is attributed to the any-window scan")
+    func anyWindowRoleFailureUsesAnyWindowSite() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9021)
+        let mainWindow = builder.element(9022)
+        let otherWindow = builder.element(9023)
+        let unreadableChild = builder.element(9024)
+        let roleReads = LockedCounter549()
+
+        // No sheet on the main window at all (empty children) — routes the
+        // search into `anyWindowSheetLookup` over `otherWindow`.
+        builder.setAttribute(app, kAXMainWindowAttribute as String, mainWindow)
+        builder.setAttribute(app, kAXWindowsAttribute as String, [mainWindow, otherWindow])
+        // Both windows must answer `AXModal` for `topLevelDialogRead`'s own
+        // complete scan (which the final no-sheet fallback also runs) to
+        // reach `.none` instead of an unrelated `topLevelWindowModalReadFailed`.
+        builder.setAttribute(mainWindow, kAXModalAttribute as String, false)
+        builder.setAttribute(otherWindow, kAXModalAttribute as String, false)
+        builder.setChildren(otherWindow, [unreadableChild])
+
+        let genericFailure = AXHelpers.AXStatusError(raw: AXError.failure.rawValue)
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                guard CFEqual(element, unreadableChild), attribute == (kAXRoleAttribute as String) else { return nil }
+                _ = roleReads.next()
+                return .failure(genericFailure)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let read = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+
+        #expect(roleReads.current() > 0, "the other-window AXRole failure seam must fire, or this test proves nothing")
+        let detail = try #require(read.sheetScanFailureDetail)
+        #expect(detail.site == .anyWindowSheetLookup)
+        #expect(detail.attribute == .role)
+    }
+
+    // MARK: - Counterfactual
+
+    @Test("the counterfactual reports would-have-been-absent when the only obstacle is a children read on an already-non-sheet node")
+    func counterfactualTrueWhenOnlyObstacleIsAChildrenRead() throws {
+        // Ground truth: `targetGroup` genuinely has zero children (never
+        // given any via `setChildren`) — nothing real is hidden behind this
+        // failure. The reported claim ("had this been readable, the verdict
+        // would have been absent") is therefore actually correct here, not
+        // merely asserted.
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9031)
+        let window = builder.element(9032)
+        let targetGroup = builder.element(9033)
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setAttribute(targetGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setChildren(window, [targetGroup])
+
+        let cannotComplete = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            childrenResultHandler: { element in
+                guard CFEqual(element, targetGroup) else { return nil }
+                return .failure(cannotComplete)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let read = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+        let detail = try #require(read.sheetScanFailureDetail)
+
+        #expect(detail.attribute == .children)
+        #expect(detail.wouldHaveBeenAbsent)
+    }
+
+    @Test("the counterfactual reports NOT would-have-been-absent when the hidden node's true (unreadable) role is the sheet")
+    func counterfactualFalseWhenHiddenRoleIsTheSheet() throws {
+        // #549's hard case: this fixture's GROUND TRUTH sets the failing
+        // candidate's real role to `kAXSheetRole` — a real AXSheet genuinely
+        // exists at this exact position — but the AXRole READ that would
+        // have revealed it is intercepted to fail instead. Production can
+        // never see behind a failed read, so it cannot claim this branch is
+        // absent; `wouldHaveBeenAbsent` must honestly stay false. This is
+        // the deliberately different counterpart to the previous test: same
+        // shape of failure, but this time something real WAS hidden behind
+        // it, and the field must not claim otherwise.
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9041)
+        let window = builder.element(9042)
+        let decoy = builder.element(9043)
+        let hiddenSheet = builder.element(9044)
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setAttribute(decoy, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        // Ground truth: this element really is an AXSheet.
+        builder.setAttribute(hiddenSheet, kAXRoleAttribute as String, kAXSheetRole as String)
+        builder.setChildren(window, [decoy, hiddenSheet])
+
+        let cannotComplete = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                guard CFEqual(element, hiddenSheet), attribute == (kAXRoleAttribute as String) else { return nil }
+                return .failure(cannotComplete)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let read = AccessibilityChannel.readModalSignalsAndAlertTarget(runtime: runtime)
+
+        // The search must not have found the sheet through any other path —
+        // this proves the failure genuinely hid it, rather than the test
+        // accidentally exercising a `.found` short circuit.
+        #expect(!read.signals.sheetPresent)
+        let detail = try #require(read.sheetScanFailureDetail)
+        #expect(detail.attribute == .role)
+        #expect(!detail.wouldHaveBeenAbsent)
+    }
+
+    // MARK: - No user content
+
+    @Test("the receipt names the failing node without carrying any user-authored string")
+    func receiptCarriesNoUserAuthoredContent() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(9051)
+        let window = builder.element(9052)
+        let decoy = builder.element(9053)
+        let targetGroup = builder.element(9054)
+        let button = builder.element(9055)
+
+        let windowTitleSentinel = "SENTINEL-WINDOW-TITLE-7f19c2"
+        let descriptionSentinel = "SENTINEL-DESCRIPTION-a83be0"
+        let valueSentinel = "SENTINEL-VALUE-de44f1"
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+        builder.setAttribute(window, kAXTitleAttribute as String, windowTitleSentinel)
+        builder.setAttribute(decoy, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        builder.setAttribute(targetGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(targetGroup, kAXDescriptionAttribute as String, descriptionSentinel)
+        builder.setAttribute(button, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(button, kAXValueAttribute as String, valueSentinel)
+        builder.setChildren(window, [decoy, targetGroup, button])
+
+        let cannotComplete = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let childrenReads = LockedCounter549()
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            childrenResultHandler: { element in
+                guard CFEqual(element, targetGroup) else { return nil }
+                _ = childrenReads.next()
+                return .failure(cannotComplete)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let outcome = AccessibilityChannel.observeModalAfterMutation(isDeleteContext: false, runtime: runtime)
+        #expect(childrenReads.current() > 0, "the targetGroup AXChildren failure seam must fire, or this test proves nothing")
+        #expect(outcome.sheetScanFailureDetail != nil)
+
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: outcome.kind,
+            action: AccessibilityChannel.attemptedReconcileActionLabel(outcome),
+            newTrackAutoConfirmed: false,
+            unreadableReason: outcome.unreadableReason,
+            sheetScanFailureDetail: outcome.sheetScanFailureDetail
+        )
+        // The new node-detail key must actually be present — a vacuous pass
+        // here would prove nothing about content safety.
+        #expect(extras["reconciled_modal_unreadable_node"] != nil)
+
+        let data = try JSONSerialization.data(withJSONObject: extras, options: [.sortedKeys])
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(!json.contains(windowTitleSentinel))
+        #expect(!json.contains(descriptionSentinel))
+        #expect(!json.contains(valueSentinel))
+        // Belt and braces: also assert the generic sentinel prefix is gone,
+        // in case a future field concatenates fragments of these strings.
+        #expect(!json.contains("SENTINEL"))
+    }
+
+    @Test("a sheet-scan failure with no companion detail says so instead of omitting the field")
+    func sheetScanFailureWithoutDetailIsMarkedUnrecorded() throws {
+        // The coverage claim "the detail is threaded through every site that sets the reason" cannot be
+        // maintained by review: the next site added will set the reason and forget the detail. When that
+        // happens the field is simply absent, and an absent field reads as "the scan had no unreadable
+        // node" — the exact silence this feature exists to end. This locks the loud alternative.
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .none,
+            action: "none",
+            newTrackAutoConfirmed: false,
+            unreadableReason: .windowSheetReadFailed(AXHelpers.AXStatusError(raw: -25200)),
+            sheetScanFailureDetail: nil
+        )
+        let node = try #require(
+            extras["reconciled_modal_unreadable_node"] as? [String: Any],
+            "a sheet-scan failure must never leave this field absent"
+        )
+        let site = try #require(node["site"] as? String)
+        #expect(site == "unrecorded")
+        #expect(node["note"] is String)
+    }
+
+    @Test("a failure that never involved the sheet scan correctly carries no node field")
+    func nonSheetScanFailureCarriesNoNodeField() throws {
+        // The counterpart: these failures arise before or beside the scan and have no node to name, so
+        // their missing detail is correct. Without this, the marker above would fire everywhere and stop
+        // meaning anything.
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.mergeReconcileExtras(
+            &extras,
+            kind: .none,
+            action: "none",
+            newTrackAutoConfirmed: false,
+            unreadableReason: .appRootUnavailable,
+            sheetScanFailureDetail: nil
+        )
+        #expect(extras["reconciled_modal_unreadable_node"] == nil)
+        #expect(extras["reconciled_modal_unreadable_reason"] != nil)
+    }
+}
+
+private final class LockedCounter549: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func next() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
+    }
+
+    func current() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+}


### PR DESCRIPTION
Observability, not a fix. #549's intermittent failure withholds State A from `track.create` and
`track.delete` with `window_sheet_read_failed` / `-25200`. Three attempts to find the cause failed the
same way: the receipt reports a status code and nothing else, so the investigation had to guess from
outside the process what the scan was looking at. The guesses were wrong at the wrong depth, then at the
wrong node, then under an intervention that changed two variables while claiming one.

The receipt now answers what was being guessed:

```json
"reconciled_modal_unreadable_node": {
  "site": "recursive_descendant_walk",
  "attribute": "AXChildren",
  "subject_role": "AXCell",
  "path": [ {"child_index": 5}, {"child_index": 7, "parent_role": "AXGroup"}, … ],
  "would_have_been_absent": true
}
```

That is a real receipt from the live run on this branch — the failure reproduced, and the field named the
node **from inside the product** on its first outing. The path matches the node an external census had
found by correlation; it is now reported by the scan itself, at the moment it happened, with the
counterfactual attached.

### Deliberately not claimed

This does not fix #549 and the live harness does not assert that it does.
`live_542_track_create_retry.py` still carries the State-A check and it is still red, correctly. A green
run asserting certification would read as a repair of a defect that does not reproduce on demand.

`live_549_receipt_names_the_node.py` checks the narrower true claim: the operations still work, every
receipt reporting an unreadable scan also names its node, and the node carries no user-authored content.
That second check is universal over the receipts a run collects, so it is vacuously true if the failure
never appears — the observed string therefore always reports how many receipts carried a reason. On this
run, 8 of 8 carried one and 8 of 8 named the node.

### Safety

- **No State decision moves.** `ModalReadFailure` is unchanged, so every existing equality assertion
  compares exactly what it did before; the new value travels beside it.
- **No user content.** Roles and ordinal indices only — no window title, `AXDescription` or `AXValue`. A
  receipt carrying someone's project cannot be pasted into a bug report. Asserted by a sentinel unit test
  and again live; injecting `AXDescription` into the role field makes the unit test fail.
- **A missing detail is loud.** "The detail is threaded through every site that sets the reason" is a
  coverage claim, and coverage claims decay. A sheet-scan failure arriving without its detail emits
  `{"site": "unrecorded", …}` rather than nothing, because an absent field reads as "no unreadable node" —
  the exact silence this change exists to end. Mutation-proved in both directions, with a paired test that
  a failure which never involved the sheet scan still carries no field.

Suite 3743 (3735 + 8). Ship gate PASS with live evidence bound to this head.