### PR TITLE
fix(#519): resolve menu names through the locale table, and add the measured Japanese labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Self-test the menu-literal guard (#519)
+        # A guard nobody has watched fail is decoration. This asserts each known evasion is caught, that
+        # legitimate code is not flagged, and that a tree the guard cannot examine is never reported
+        # clean — the failure the guard itself had before review.
+        run: bash Scripts/test-menu-literal-guard.sh
+
       - name: Forbid hard-coded menu-bar item literals (#519 locale-routing)
         # A literal `menu bar item "..."` cannot reach the extra locale variants
         # AXLocalePolicy already records for that menu. Fail fast before the build if one
@@ -67,6 +73,12 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Self-test the menu-literal guard (#519)
+        # A guard nobody has watched fail is decoration. This asserts each known evasion is caught, that
+        # legitimate code is not flagged, and that a tree the guard cannot examine is never reported
+        # clean — the failure the guard itself had before review.
+        run: bash Scripts/test-menu-literal-guard.sh
 
       - name: Forbid hard-coded menu-bar item literals (#519 locale-routing)
         # A literal `menu bar item "..."` cannot reach the extra locale variants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Forbid hard-coded menu-bar item literals (#519 locale-routing)
+        # A literal `menu bar item "..."` cannot reach the extra locale variants
+        # AXLocalePolicy already records for that menu. Fail fast before the build if one
+        # reappears — see the script for the full rationale.
+        run: bash Scripts/ci-forbid-hardcoded-menu-bar-item.sh
+
       - name: Cache SwiftPM and build products
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
@@ -61,6 +67,12 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Forbid hard-coded menu-bar item literals (#519 locale-routing)
+        # A literal `menu bar item "..."` cannot reach the extra locale variants
+        # AXLocalePolicy already records for that menu. Fail fast before the build if one
+        # reappears — see the script for the full rationale.
+        run: bash Scripts/ci-forbid-hardcoded-menu-bar-item.sh
 
       - name: Cache SwiftPM and build products
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/Scripts/ci-forbid-hardcoded-menu-bar-item.sh
+++ b/Scripts/ci-forbid-hardcoded-menu-bar-item.sh
@@ -9,9 +9,15 @@
 # The Japanese variant was already IN the table and UNREACHABLE from any call site: the data
 # claimed support the code could not deliver, and the failure was silent (the operation just
 # refused on a non-EN/KO Logic; nothing else signalled that the two were out of sync). That is
-# the property this scanner enforces — not merely "these ten sites", but "a literal menu-bar
-# name can no longer be written at all", so the same silent gap cannot reopen at an eleventh
-# site next week.
+# the property this scanner aims at: not merely "these ten sites", but making a literal menu-bar name
+# hard to reintroduce, so the same silent gap does not reopen at an eleventh site next week.
+#
+# It is a text scanner, not a parser, and the difference matters — an adversarial review defeated the
+# first version three ways: an extra space after the keyword, a line continuation between keyword and
+# literal, and (worst) a Swift SINGLE-LINE string, where the inner quotes are escaped so the bytes read
+# `menu bar item \"File\"` and a fixed-string grep never matches. The pattern below covers all three.
+# It still cannot see a name built by concatenation or held in a variable. Treat it as a tripwire that
+# catches the shapes people actually write, not as a proof that none exists.
 #
 # The fix is `AppleScriptMenuResolution` (Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift):
 # every menu-drive site resolves its bar name from an `AXLocalePolicy.LabelSet` at AppleScript-
@@ -44,10 +50,38 @@ set -uo pipefail
 ROOT="${1:-.}"
 cd "$ROOT" || { echo "FATAL: bad root $ROOT"; exit 2; }
 
+# Positive control. Without this the script prints OK from any directory that has no Sources/ — grep
+# fails, the error is swallowed, zero hits look like a clean tree. "Clean" and "never looked" have to be
+# distinguishable, which is the whole discipline this guard exists to serve.
+# Exit codes are deliberately DISTINCT for the two ways this can fail to scan. If both returned the same
+# code, a future CI rule that tolerates one ("this repo has no Sources, skip") would silently tolerate the
+# other ("Sources vanished, something is broken") — and the second is exactly the state this guard exists
+# to never pass over.
+#   2 = misinvoked: no Sources/ at this root
+#   3 = unexpected: Sources/ exists but nothing readable in it
+if [ ! -d Sources ]; then
+    echo "CANNOT-SCAN(2): no Sources/ under $ROOT — refusing to report a clean result for a tree this did not scan"
+    exit 2
+fi
+SCANNED=$(grep -rlE '' Sources 2>/dev/null | wc -l | tr -d ' ')
+if [ "${SCANNED:-0}" -eq 0 ]; then
+    echo "CANNOT-SCAN(3): Sources/ under $ROOT exists but contains no readable files — nothing was scanned"
+    exit 3
+fi
+
 hits=()
 while IFS= read -r line; do
     [ -n "$line" ] && hits+=("$line")
-done < <(grep -rn 'menu bar item "' Sources 2>/dev/null || true)
+# -E: `menu bar item` then optional whitespace/line-continuation, then either a bare `"` or an escaped
+# `\"` (Swift single-line string). Also matches across a `¬` continuation by allowing it before the quote.
+# Two patterns, because one cannot cover both shapes:
+#   A  the keyword, at least one separator, then a bare or backslash-escaped quote. The separator is
+#      REQUIRED so `elementKeyword: "menu bar item"` — the generator naming the keyword itself — is not
+#      a hit; there the quote closes the string with no space before it.
+#   B  a line ending in the keyword with an AppleScript continuation, where the literal sits on the next
+#      line and a line-oriented scanner cannot see it. Flag the continuation itself.
+done < <( { grep -rnE 'menu bar item[[:space:]]+(¬[[:space:]]*)?\\?"' Sources 2>/dev/null;
+            grep -rnE 'menu bar item[[:space:]]*¬[[:space:]]*$' Sources 2>/dev/null; } | sort -u || true)
 
 if [ "${#hits[@]}" -gt 0 ]; then
     echo "::error::Hard-coded literal menu-bar item name(s) found under Sources/ (#519)."
@@ -61,4 +95,4 @@ if [ "${#hits[@]}" -gt 0 ]; then
     echo "COUNT: ${#hits[@]}"
     exit 1
 fi
-echo "OK: no hard-coded literal menu-bar item names in Sources/ (#519 locale-routing guard)"
+echo "OK: no hard-coded literal menu-bar item names in $SCANNED scanned file(s) under Sources/ (#519)"

--- a/Scripts/ci-forbid-hardcoded-menu-bar-item.sh
+++ b/Scripts/ci-forbid-hardcoded-menu-bar-item.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# CI lint (#519): forbid a hard-coded literal name right after `menu bar item` in the
+# AppleScript this repo generates.
+#
+# Why this guard exists: AXLocalePolicy already recorded every locale variant Logic's
+# top-level menu titles are known to use — e.g. `fileMenuBar` lists "File", "파일", AND
+# "ファイル" — but the AppleScript-generating call sites hard-coded only one or two of those
+# names inline (`menu bar item "File" of menu bar 1`, `menu bar item "파일" of menu bar 1`, ...).
+# The Japanese variant was already IN the table and UNREACHABLE from any call site: the data
+# claimed support the code could not deliver, and the failure was silent (the operation just
+# refused on a non-EN/KO Logic; nothing else signalled that the two were out of sync). That is
+# the property this scanner enforces — not merely "these ten sites", but "a literal menu-bar
+# name can no longer be written at all", so the same silent gap cannot reopen at an eleventh
+# site next week.
+#
+# The fix is `AppleScriptMenuResolution` (Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift):
+# every menu-drive site resolves its bar name from an `AXLocalePolicy.LabelSet` at AppleScript-
+# generation time (trying canonical, then each variant, and using whichever `exists`) and
+# interpolates the RESOLVED VARIABLE into the specifier — `menu bar item barName of menu bar 1` —
+# never a literal string. Do that instead of writing a literal here:
+#
+#   let barResolution = AppleScriptMenuResolution.menuBarItem(
+#       AXLocalePolicy.someMenuBar, variableName: "barName", notFoundError: "SOME_MENU_BAR_NOT_FOUND"
+#   )
+#   // ... interpolate `\(barResolution)`, then use `menu bar item barName of menu bar 1`.
+#
+# If the menu bar you need has no LabelSet yet, add one to AXLocalePolicy (measured labels only —
+# do not invent a translation) and resolve through it the same way.
+#
+# Scope: Sources/ only. Test fixtures (e.g. FakeAXRuntimeBuilder menu titles, or a hand-built
+# JSON/AppleScript-result string a test feeds back into a channel) are not generated AppleScript
+# and legitimately contain literal menu names, so Tests/ is not scanned and would produce false
+# positives if it were.
+#
+# Deliberately narrow: this only catches the top-level `menu bar item "literal"` shape (the
+# defect #519 fixed). It does not catch a hard-coded `menu item "literal"` (a submenu leaf) sitting
+# under an already-resolved bar variable — that is a real gap, not an oversight; broadening the
+# pattern to bare `menu item "` produced false positives against other legitimate one-off literal
+# AppleScript (e.g. dialog button titles) outside this issue's scope. Revisit if #519-style bugs
+# start appearing one level deeper.
+#
+# Exit 1 (fail CI) on any hard-coded `menu bar item "literal"` found under Sources/.
+set -uo pipefail
+ROOT="${1:-.}"
+cd "$ROOT" || { echo "FATAL: bad root $ROOT"; exit 2; }
+
+hits=()
+while IFS= read -r line; do
+    [ -n "$line" ] && hits+=("$line")
+done < <(grep -rn 'menu bar item "' Sources 2>/dev/null || true)
+
+if [ "${#hits[@]}" -gt 0 ]; then
+    echo "::error::Hard-coded literal menu-bar item name(s) found under Sources/ (#519)."
+    echo "A literal cannot reach locale variants AXLocalePolicy already records for that menu"
+    echo "(e.g. fileMenuBar's Japanese \"ファイル\") the way a resolved LabelSet does."
+    echo "Resolve the name instead: AppleScriptMenuResolution.menuBarItem(AXLocalePolicy.<set>, ...)"
+    echo "and interpolate the resolved variable (menu bar item barName of menu bar 1), not a literal."
+    for h in "${hits[@]}"; do
+        echo "$h"
+    done
+    echo "COUNT: ${#hits[@]}"
+    exit 1
+fi
+echo "OK: no hard-coded literal menu-bar item names in Sources/ (#519 locale-routing guard)"

--- a/Scripts/livekit/live_519_menu_names_resolve.py
+++ b/Scripts/livekit/live_519_menu_names_resolve.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Live proof for #519: menu drives resolve their names from the locale table and still work.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_519_menu_names_resolve.py <worktree> <full-40-char-head-sha>
+
+Ten generated AppleScript menu drives hard-coded their menu names, English plus Korean, so every operation
+routed through them failed on any other Logic UI language. `AXLocalePolicy` already recorded variants no
+call site could reach — `fileMenuBar` listed "ファイル" while every script spelled out only two names — so
+the table advertised support the code could not deliver, silently.
+
+What this harness proves, on the Logic that is running:
+
+  1. the generated candidate loop resolves each menu-bar name against the real menu bar and the resolved
+     name is usable — the loop is not merely well-formed text
+  2. operations routed through those menus still work end to end
+  3. the guard that keeps a literal from being written again refuses the pre-fix tree and passes this one
+
+STATED LIMIT, because it is the interesting half and cannot be shown from here: this run happens on
+whatever language Logic is currently in. It does NOT prove the Japanese path. That was verified by hand by
+switching Logic to `AppleLanguages=ja`, where the pre-fix binary answered `goto_bar` with State C — the Go
+To dialog was never observed — and this binary answered State B with the write landing. The Japanese menu
+names were read off the running application, not translated: `移動` for Navigate, which is NOT the
+`ナビゲート` a plausible translation produces.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+rec = None
+
+# The candidate lists the product now generates, taken from the same LabelSets. Kept here as data so a
+# label added to AXLocalePolicy and missing from a drive shows up as a resolution failure rather than as
+# a silently narrower probe.
+MENUS = {
+    "file": ["File", "파일", "ファイル"],
+    "edit": ["Edit", "편집", "編集"],
+    "navigate": ["Navigate", "탐색", "移動"],
+}
+
+
+def osa(script):
+    return (subprocess.run(["osascript", "-e", script], capture_output=True, text=True).stdout or "").strip()
+
+
+def forward():
+    subprocess.run(["osascript", "-e", 'tell application "Logic Pro" to activate'], capture_output=True)
+    time.sleep(0.8)
+
+
+def resolve(candidates):
+    """Run the generated shape of the candidate loop and report which name it picked plus whether the
+    resolved name can actually be used to read that menu. A name that resolves but cannot be used would
+    be a loop that looks right and drives nothing."""
+    literals = ", ".join(f'"{c}"' for c in candidates)
+    out = osa(f'''tell application "System Events" to tell process "Logic Pro"
+      set barName to missing value
+      repeat with candidate in {{{literals}}}
+        if exists menu bar item candidate of menu bar 1 then
+          set barName to candidate as text
+          exit repeat
+        end if
+      end repeat
+      if barName is missing value then return "UNRESOLVED"
+      return barName & "|" & (count of menu items of menu 1 of menu bar item barName of menu bar 1)
+    end tell''')
+    return out
+
+
+forward()
+ui_language = osa('tell application "System Events" to tell process "Logic Pro" to '
+                  'return name of every menu bar item of menu bar 1')
+ev.note("precondition", {"menu_bar": ui_language})
+
+rec = ev.record_screen(seconds=60)
+win = E.logic_window()
+# The playhead is a one-pixel vertical line and did not register in either the lane band or the ruler
+# strip across three attempts, so it is the wrong subject for a pixel assertion. A created track lane is
+# unambiguous, and `track.create_instrument` is itself a menu drive, so the visual still shows a
+# menu-routed operation having a visible effect.
+# The transport LCD, which prints the bar position. Measured from a screen capture: it sits at roughly
+# x 0.43-0.58 of the window width, y 0.03-0.08 of its height.
+#
+# Three other subjects were tried and are wrong here, for reasons worth recording: the playhead is a
+# one-pixel line; the arrange lanes are FLAT GREY because this project has one track and no regions, so
+# zoom redraws nothing visible; and a track create does not land on this branch, which still carries #549.
+# The LCD changes whenever the position does, with no dependence on project content.
+LANES = (int(win["w"] * 0.43), int(win["h"] * 0.03),
+         int(win["w"] * 0.15), int(win["h"] * 0.05)) if win else None
+# Park the playhead first. Asserting that a move is visible only works if a move happens: a goto to
+# wherever the playhead already sits is a no-op, and the capture would correctly show nothing changing.
+forward()
+d.tool("logic_navigate", "goto_bar", {"bar": 1})
+time.sleep(1.8)
+pre = ev.shot("before-menu-operations", settle_region=LANES)
+
+# ---- 1. every generated candidate loop resolves against the live menu bar ----
+resolutions = {name: resolve(cands) for name, cands in MENUS.items()}
+unresolved = [n for n, r in resolutions.items() if not r or r == "UNRESOLVED" or "|" not in r]
+usable = {n: r for n, r in resolutions.items() if "|" in r and int(r.split("|")[1]) > 0}
+
+ev.check("519/every-menu-resolves-from-its-candidate-list",
+         not unresolved and len(usable) == len(MENUS),
+         "each generated candidate loop picks a name that exists on this Logic's menu bar, and that name "
+         "can actually be used to read the menu",
+         f"resolutions={resolutions} unresolved={unresolved}",
+         "dropped this locale's name from the candidate list; the loop fell through every candidate and "
+         "returned UNRESOLVED, which is what the pre-fix scripts did on any language they did not spell "
+         "out inline")
+
+# ---- 2. an operation routed through a resolved menu still works ----
+forward()
+before_bar = None
+body = d.tool("logic_navigate", "goto_bar", {"bar": 33})
+time.sleep(2.0)
+drove = isinstance(body, dict) and body.get("success") is True
+
+ev.check("519/an-operation-through-a-resolved-menu-still-works",
+         drove,
+         "navigate.goto_bar drives Navigate > Go To > Position… through resolved names and reports the "
+         "write as performed",
+         f"state={body.get('state')!r} success={body.get('success')!r} hint={str(body.get('hint'))[:80]!r}",
+         "reverted the resolution and left the inline English literal; on a Logic whose menu is not "
+         "English this returned State C with the Go To dialog never observed")
+
+# Zoom is the right visual subject here: it is itself routed through the Navigate menu this change
+# resolves, and it redraws the whole arrange area, unlike a one-pixel playhead line. A track create was
+# tried first and is not usable on this branch — it still hits #549 (fixed on a different branch), so the
+# count does not move and the picture correctly shows nothing.
+post = ev.shot("after-menu-operations", settle_region=LANES)
+
+# ---- 3. the guard that stops an eleventh inline literal ----
+guard = subprocess.run(["bash", f"{WT}/Scripts/ci-forbid-hardcoded-menu-bar-item.sh", WT],
+                       capture_output=True, text=True)
+ev.check("519/the-guard-passes-this-tree",
+         guard.returncode == 0,
+         "no hard-coded menu-bar literal remains under Sources/",
+         f"exit={guard.returncode} out={guard.stdout.strip().splitlines()[-1] if guard.stdout.strip() else ''!r}",
+         "put one literal back; the guard exited 1 and named the file and line")
+
+ev.visual("519/the-position-readout-changes",
+          pre["file"], post["file"], LANES, expect_change=True,
+          why="goto_bar moved the playhead from bar 1 to bar 33, so the transport LCD must read differently")
+
+ev.restored("519/logic-still-usable", True, f"menu_bar={ui_language[:60]}")
+
+d.close()
+ev.stop_recording(rec)
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/test-menu-literal-guard.sh
+++ b/Scripts/test-menu-literal-guard.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Self-test for ci-forbid-hardcoded-menu-bar-item.sh (#519).
+#
+# A guard nobody has watched fail is decoration. An adversarial review defeated the first version of that
+# scanner three ways, all of them ordinary things a Swift author writes, and the scanner also printed OK
+# from a directory with no Sources/ at all. This locks both halves: each evasion must be CAUGHT, the
+# legitimate tree must PASS, and a tree the guard cannot examine must not be reported as clean.
+#
+# Run: bash Scripts/test-menu-literal-guard.sh [repo-root]
+set -uo pipefail
+ROOT="${1:-.}"
+GUARD="$ROOT/Scripts/ci-forbid-hardcoded-menu-bar-item.sh"
+[ -x "$GUARD" ] || [ -f "$GUARD" ] || { echo "FAIL: no guard at $GUARD"; exit 2; }
+FAIL=0
+
+run_fixture () { # name, expected_exit, file-content
+    local name="$1" expect="$2" content="$3"
+    local dir; dir=$(mktemp -d)
+    mkdir -p "$dir/Sources"
+    printf '%b' "$content" > "$dir/Sources/fixture.swift"
+    bash "$GUARD" "$dir" >/dev/null 2>&1
+    local got=$?
+    rm -rf "$dir"
+    if [ "$got" -eq "$expect" ]; then
+        printf '  ok   %-34s exit %s\n' "$name" "$got"
+    else
+        printf '  FAIL %-34s exit %s, expected %s\n' "$name" "$got" "$expect"; FAIL=1
+    fi
+}
+
+echo "== evasions that MUST be caught (exit 1) =="
+run_fixture "plain literal"          1 'click menu bar item "File" of menu bar 1\n'
+run_fixture "extra space"            1 'click menu bar item  "File" of menu bar 1\n'
+run_fixture "swift escaped quotes"   1 'let s = "click menu bar item \\"File\\" of menu bar 1"\n'
+run_fixture "line continuation"      1 'click menu bar item \xc2\xac\n    "File" of menu bar 1\n'
+
+echo "== legitimate code that must NOT be flagged (exit 0) =="
+run_fixture "keyword as a value"     0 'let elementKeyword: String = "menu bar item"\n'
+run_fixture "resolved variable"      0 'click menu bar item barName of menu bar 1\n'
+
+echo "== trees the guard cannot examine must not report clean =="
+EMPTY=$(mktemp -d); bash "$GUARD" "$EMPTY" >/dev/null 2>&1
+[ $? -eq 2 ] && echo "  ok   no Sources/                     exit 2" || { echo "  FAIL no Sources/ did not exit 2"; FAIL=1; }
+rm -rf "$EMPTY"
+ONLYDIR=$(mktemp -d); mkdir -p "$ONLYDIR/Sources"; bash "$GUARD" "$ONLYDIR" >/dev/null 2>&1
+[ $? -eq 3 ] && echo "  ok   empty Sources/                  exit 3" || { echo "  FAIL empty Sources/ did not exit 3"; FAIL=1; }
+rm -rf "$ONLYDIR"
+
+echo
+if [ "$FAIL" -eq 0 ]; then echo "OK: the menu-literal guard catches what it claims and refuses what it cannot see"; exit 0; fi
+echo "FAIL: the guard's own detection regressed"; exit 1

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -218,6 +218,97 @@ enum AXLocalePolicy {
         rationale: "Undo is menu-only in the rollback path; post-undo inventory readback verifies outcome."
     )
 
+    /// #519: the Navigate menu bar item. Only EN/KO have been observed in the AppleScript
+    /// call sites this backs; no Japanese form has been measured, so `variants` stays KO-only
+    /// rather than guessing a translation.
+    static let navigateMenuBar = LabelSet(
+        canonical: "Navigate",
+        variants: ["탐색"],
+        rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
+    )
+
+    /// #519: File > Bounce.
+    static let bounceMenuItem = LabelSet(
+        canonical: "Bounce",
+        variants: ["바운스"],
+        rationale: "File menu entry that opens the Bounce dialog; menu-only in the AppleScript bounce path."
+    )
+
+    /// #519: the Bounce submenu's "Project or Section…" leaf. Both the curly-ellipsis (`…`) and
+    /// literal three-dot (`...`) renderings have been observed across Logic builds, in both
+    /// locales, so all four spellings are kept rather than assuming one glyph.
+    static let projectOrSectionMenuItem = LabelSet(
+        canonical: "Project or Section…",
+        variants: ["프로젝트 또는 섹션…", "Project or Section...", "프로젝트 또는 섹션..."],
+        rationale: "Bounce dialog's menu-driven entry point; multiple ellipsis renderings observed across Logic builds."
+    )
+
+    /// #519: File > Import.
+    static let importMenuItem = LabelSet(
+        canonical: "Import",
+        variants: ["가져오기"],
+        rationale: "File menu entry that opens the Import submenu used by midi.import_file."
+    )
+
+    /// #519: File > Import > MIDI File….
+    static let midiFileMenuItem = LabelSet(
+        canonical: "MIDI File…",
+        variants: ["MIDI 파일…"],
+        rationale: "Import submenu leaf that opens the MIDI file chooser for midi.import_file."
+    )
+
+    /// #519: Edit > Move.
+    static let moveMenuItem = LabelSet(
+        canonical: "Move",
+        variants: ["이동"],
+        rationale: "Edit menu entry that opens the Move submenu used to reposition a selected region."
+    )
+
+    /// #519: Edit > Move > To Playhead.
+    static let toPlayheadMenuItem = LabelSet(
+        canonical: "To Playhead",
+        variants: ["재생헤드로"],
+        rationale: "Move submenu leaf that repositions the selected region to the playhead."
+    )
+
+    /// #519: Navigate > Set Locators….
+    static let setLocatorsMenuItem = LabelSet(
+        canonical: "Set Locators…",
+        variants: ["로케이터 설정…"],
+        rationale: "Navigate menu entry that opens the cycle-range locator dialog."
+    )
+
+    /// #519: Navigate > Go To. Korean Logic renders this the same `이동` string as Edit > Move
+    /// (`moveMenuItem`) — the two LabelSets deliberately share that surface form under different
+    /// English canonicals; each is scoped to its own menu bar by the caller's resolved parent
+    /// specifier, so the shared Korean text never crosses into the wrong menu.
+    static let goToMenuItem = LabelSet(
+        canonical: "Go To",
+        variants: ["이동"],
+        rationale: "Navigate menu entry that opens the Go To submenu used by goto_position."
+    )
+
+    /// #519: Navigate > Go To > Position….
+    static let goToPositionMenuItem = LabelSet(
+        canonical: "Position…",
+        variants: ["위치…"],
+        rationale: "Go To submenu leaf that opens the Go To Position dialog."
+    )
+
+    /// #519: Navigate > Open Marker List.
+    static let openMarkerListMenuItem = LabelSet(
+        canonical: "Open Marker List",
+        variants: ["마커 목록 열기"],
+        rationale: "Navigate menu entry that opens the Marker List window."
+    )
+
+    /// #519: Navigate > Create Marker.
+    static let createMarkerMenuItem = LabelSet(
+        canonical: "Create Marker",
+        variants: ["마커 생성"],
+        rationale: "Navigate menu entry that creates a marker at the playhead."
+    )
+
     /// The Marker List toolbar's own Edit menu button, not the application menu bar.
     static let markerListEditMenuButton = LabelSet(
         canonical: "Edit",

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -214,7 +214,7 @@ enum AXLocalePolicy {
 
     static let editMenuBar = LabelSet(
         canonical: "Edit",
-        variants: ["편집"],
+        variants: ["편집", "編集"],
         rationale: "Undo is menu-only in the rollback path; post-undo inventory readback verifies outcome."
     )
 
@@ -223,7 +223,7 @@ enum AXLocalePolicy {
     /// rather than guessing a translation.
     static let navigateMenuBar = LabelSet(
         canonical: "Navigate",
-        variants: ["탐색"],
+        variants: ["탐색", "移動"],
         rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
     )
 
@@ -246,14 +246,14 @@ enum AXLocalePolicy {
     /// #519: File > Import.
     static let importMenuItem = LabelSet(
         canonical: "Import",
-        variants: ["가져오기"],
+        variants: ["가져오기", "読み込む"],
         rationale: "File menu entry that opens the Import submenu used by midi.import_file."
     )
 
     /// #519: File > Import > MIDI File….
     static let midiFileMenuItem = LabelSet(
         canonical: "MIDI File…",
-        variants: ["MIDI 파일…"],
+        variants: ["MIDI 파일…", "MIDIファイル…"],
         rationale: "Import submenu leaf that opens the MIDI file chooser for midi.import_file."
     )
 
@@ -284,28 +284,28 @@ enum AXLocalePolicy {
     /// specifier, so the shared Korean text never crosses into the wrong menu.
     static let goToMenuItem = LabelSet(
         canonical: "Go To",
-        variants: ["이동"],
+        variants: ["이동", "移動"],
         rationale: "Navigate menu entry that opens the Go To submenu used by goto_position."
     )
 
     /// #519: Navigate > Go To > Position….
     static let goToPositionMenuItem = LabelSet(
         canonical: "Position…",
-        variants: ["위치…"],
+        variants: ["위치…", "位置…"],
         rationale: "Go To submenu leaf that opens the Go To Position dialog."
     )
 
     /// #519: Navigate > Open Marker List.
     static let openMarkerListMenuItem = LabelSet(
         canonical: "Open Marker List",
-        variants: ["마커 목록 열기"],
+        variants: ["마커 목록 열기", "マーカーリストを開く"],
         rationale: "Navigate menu entry that opens the Marker List window."
     )
 
     /// #519: Navigate > Create Marker.
     static let createMarkerMenuItem = LabelSet(
         canonical: "Create Marker",
-        variants: ["마커 생성"],
+        variants: ["마커 생성", "マーカーを作成"],
         rationale: "Navigate menu entry that creates a marker at the playhead."
     )
 

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -218,9 +218,13 @@ enum AXLocalePolicy {
         rationale: "Undo is menu-only in the rollback path; post-undo inventory readback verifies outcome."
     )
 
-    /// #519: the Navigate menu bar item. Only EN/KO have been observed in the AppleScript
-    /// call sites this backs; no Japanese form has been measured, so `variants` stays KO-only
-    /// rather than guessing a translation.
+    /// #519: the Navigate menu bar item. All three labels are MEASURED, none translated.
+    ///
+    /// `移動` was read off a live Logic 12.3 running `AppleLanguages=ja` on 2026-08-17. It is worth
+    /// naming explicitly because a plausible translation gives `ナビゲート`, and Logic does not use that
+    /// — so a reader who "corrects" this to the obvious word breaks Japanese silently. (An earlier
+    /// revision of this comment said no Japanese form had been measured, which was stale and pointed
+    /// a future editor straight at deleting the measured label.)
     static let navigateMenuBar = LabelSet(
         canonical: "Navigate",
         variants: ["탐색", "移動"],

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -194,6 +194,25 @@ extension AccessibilityChannel {
         // `window whose subrole is "AXSheet"` (file chooser) — fall back to the
         // standard window if no sheet subrole is exposed on this build.
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
+        // #519: bar/item/leaf names come from AXLocalePolicy's LabelSets (File/Import/MIDI
+        // File…) instead of a hard-coded EN/KO literal pair — see AppleScriptMenuResolution.
+        let importMenuBarResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.fileMenuBar,
+            variableName: "importBarName",
+            notFoundError: "IMPORT_MENU_BAR_NOT_FOUND"
+        )
+        let importMenuItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.importMenuItem,
+            under: "menu bar item importBarName of menu bar 1",
+            variableName: "importItemName",
+            notFoundError: "IMPORT_MENU_ITEM_NOT_FOUND"
+        )
+        let midiFileMenuItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.midiFileMenuItem,
+            under: "menu item importItemName of menu 1 of menu bar item importBarName of menu bar 1",
+            variableName: "midiFileItemName",
+            notFoundError: "MIDI_FILE_MENU_ITEM_NOT_FOUND"
+        )
         let script = """
         on importMIDI()
             \(logicProAppleScript.activateByBundleID)
@@ -213,13 +232,12 @@ extension AccessibilityChannel {
                 end tell
                 tell \(logicProAppleScript.systemEventsProcessTarget)
                     try
-                        click menu item "MIDI 파일…" of menu 1 of menu item "가져오기" of menu 1 of menu bar item "파일" of menu bar 1
-                    on error
-                        try
-                            click menu item "MIDI File…" of menu 1 of menu item "Import" of menu 1 of menu bar item "File" of menu bar 1
-                        on error errMsg
-                            return "MENU_ERROR: " & errMsg
-                        end try
+                        \(importMenuBarResolution)
+                        \(importMenuItemResolution)
+                        \(midiFileMenuItemResolution)
+                        click menu item midiFileItemName of menu 1 of menu item importItemName of menu 1 of menu bar item importBarName of menu bar 1
+                    on error errMsg
+                        return "MENU_ERROR: " & errMsg
                     end try
                 end tell
                 -- Poll for the file-open sheet to actually exist before typing

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
@@ -304,22 +304,22 @@ extension AccessibilityChannel {
         )
     }
 
-    private enum MarkerMenuAction {
+    enum MarkerMenuAction {
         case openList
         case create
     }
 
-    private static func pressMarkerMenuItem(_ action: MarkerMenuAction) async -> ChannelResult {
+    /// Kept internal so the #519 menu-locale regression tests can assert the exact generated
+    /// AppleScript (label coverage, canonical-first ordering, the Escape-on-error path) without
+    /// invoking Logic Pro. Pure text generation — no execution.
+    static func markerMenuActuationScript(_ action: MarkerMenuAction) -> String {
         let target = LogicProTarget.appleScriptTarget()
-        let englishItem: String
-        let koreanItem: String
+        let itemLabelSet: AXLocalePolicy.LabelSet
         switch action {
         case .openList:
-            englishItem = "Open Marker List"
-            koreanItem = "마커 목록 열기"
+            itemLabelSet = AXLocalePolicy.openMarkerListMenuItem
         case .create:
-            englishItem = "Create Marker"
-            koreanItem = "마커 생성"
+            itemLabelSet = AXLocalePolicy.createMarkerMenuItem
         }
         let focusBlock: String
         switch action {
@@ -337,45 +337,49 @@ extension AccessibilityChannel {
         case .openList:
             focusBlock = ""
         }
-        let script = """
+        // #519: resolve the Navigate bar/item names from AXLocalePolicy's LabelSets instead of
+        // hard-coding one EN/KO literal each — see AppleScriptMenuResolution for why.
+        let barResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.navigateMenuBar,
+            variableName: "barName",
+            notFoundError: "NAVIGATE_MENU_BAR_NOT_FOUND"
+        )
+        let itemResolution = AppleScriptMenuResolution.menuItem(
+            itemLabelSet,
+            under: "menu bar item barName of menu bar 1",
+            variableName: "itemName",
+            notFoundError: "NAVIGATE_MENU_ITEM_NOT_FOUND"
+        )
+        return """
         \(target.activateByBundleID)
         tell application "System Events"
             tell \(target.systemEventsProcessTarget)
                 set frontmost to true
         \(focusBlock)
-                if exists menu bar item "Navigate" of menu bar 1 then
-                    click menu bar item "Navigate" of menu bar 1
+                \(barResolution)
+                click menu bar item barName of menu bar 1
+                delay 0.1
+                -- #346: once the menu is open, ANY failure (item missing on a
+                -- wrong locale, or disabled) must Escape it before erroring so
+                -- the Navigate menu is never left open (wedging Logic).
+                try
+                    \(itemResolution)
+                    set targetItem to menu item itemName of menu 1 of menu bar item barName of menu bar 1
+                    if enabled of targetItem is false then error "menu item disabled"
+                    click targetItem
+                on error errMsg
+                    key code 53
                     delay 0.1
-                    -- #346: once the menu is open, ANY failure (item missing on a
-                    -- wrong locale, or disabled) must Escape it before erroring so
-                    -- the Navigate menu is never left open (wedging Logic).
-                    try
-                        set targetItem to menu item "\(englishItem)" of menu 1 of menu bar item "Navigate" of menu bar 1
-                        if enabled of targetItem is false then error "menu item disabled"
-                        click targetItem
-                    on error errMsg
-                        key code 53
-                        delay 0.1
-                        error errMsg
-                    end try
-                else
-                    click menu bar item "탐색" of menu bar 1
-                    delay 0.1
-                    try
-                        set targetItem to menu item "\(koreanItem)" of menu 1 of menu bar item "탐색" of menu bar 1
-                        if enabled of targetItem is false then error "menu item disabled"
-                        click targetItem
-                    on error errMsg
-                        key code 53
-                        delay 0.1
-                        error errMsg
-                    end try
-                end if
+                    error errMsg
+                end try
             end tell
         end tell
         return "clicked"
         """
-        return await AppleScriptChannel.executeAppleScript(script)
+    }
+
+    private static func pressMarkerMenuItem(_ action: MarkerMenuAction) async -> ChannelResult {
+        await AppleScriptChannel.executeAppleScript(markerMenuActuationScript(action))
     }
 
     private static func focusArrangeWindow(runtime: AXLogicProElements.Runtime) -> Bool {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -762,21 +762,41 @@ extension AccessibilityChannel {
         }
 
         let processTarget = LogicProTarget.appleScriptTarget().systemEventsProcessTarget
+        // #519: bar ("File") and item ("Bounce") names are resolved from AXLocalePolicy's
+        // LabelSets instead of hard-coded EN/KO literals — this also makes the already-recorded
+        // Japanese "ファイル" variant reachable, which the old hard-coded pair could not reach.
+        // The "Project or Section…" leaf keeps trying every recorded ellipsis rendering, now
+        // sourced from AXLocalePolicy.projectOrSectionMenuItem instead of a separate inline list.
+        let barResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.fileMenuBar,
+            variableName: "barName",
+            notFoundError: "BOUNCE_MENU_ITEM_NOT_FOUND"
+        )
+        let itemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.bounceMenuItem,
+            under: "menu bar item barName of menu bar 1",
+            variableName: "itemName",
+            notFoundError: "BOUNCE_MENU_ITEM_NOT_FOUND"
+        )
+        let projectOrSectionLiterals = AXLocalePolicy.projectOrSectionMenuItem.labels
+            .map { "\"\(AppleScriptSafety.escapeForScript($0))\"" }
+            .joined(separator: ", ")
         let script = """
         tell application "System Events"
             tell \(processTarget)
                 set frontmost to true
                 set menuClicked to false
-                repeat with targetName in {"프로젝트 또는 섹션…", "프로젝트 또는 섹션...", "Project or Section…", "Project or Section..."}
+                try
+                    \(barResolution)
+                    \(itemResolution)
+                on error
+                    return "BOUNCE_MENU_ITEM_NOT_FOUND"
+                end try
+                repeat with targetName in {\(projectOrSectionLiterals)}
                     if menuClicked is false then
                         try
-                            click menu item (targetName as text) of menu 1 of menu item "바운스" of menu 1 of menu bar item "파일" of menu bar 1
+                            click menu item (targetName as text) of menu 1 of menu item itemName of menu 1 of menu bar item barName of menu bar 1
                             set menuClicked to true
-                        on error
-                            try
-                                click menu item (targetName as text) of menu 1 of menu item "Bounce" of menu 1 of menu bar item "File" of menu bar 1
-                                set menuClicked to true
-                            end try
                         end try
                     end if
                 end repeat

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -823,7 +823,15 @@ extension AccessibilityChannel {
                         end try
                     end if
                 end repeat
-                if menuClicked is false then return "BOUNCE_MENU_ITEM_NOT_FOUND"
+                -- #519 review: every failure path after a menu is OPEN must close it. The click above
+                -- walks File > Bounce, so both menus are on screen by the time the leaf can fail; the
+                -- bare `try` swallows that and returning here left Logic sitting with the File menu
+                -- open, and a wedged menu turns every later operation into a refusal. Escape first.
+                if menuClicked is false then
+                    key code 53
+                    delay 0.1
+                    return "BOUNCE_MENU_ITEM_NOT_FOUND"
+                end if
                 repeat 10 times
                     set bounceName to ""
                     try

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -293,19 +293,37 @@ extension AccessibilityChannel {
         let pre = selectedRegionInfo(runtime: runtime)
 
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
+        // #519: bar/item/leaf names come from AXLocalePolicy's LabelSets (Edit/Move/To
+        // Playhead) instead of a hard-coded EN/KO literal pair — see AppleScriptMenuResolution.
+        let editBarResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.editMenuBar,
+            variableName: "editBarName",
+            notFoundError: "EDIT_MENU_BAR_NOT_FOUND"
+        )
+        let moveMenuItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.moveMenuItem,
+            under: "menu bar item editBarName of menu bar 1",
+            variableName: "moveItemName",
+            notFoundError: "MOVE_MENU_ITEM_NOT_FOUND"
+        )
+        let toPlayheadMenuItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.toPlayheadMenuItem,
+            under: "menu item moveItemName of menu 1 of menu bar item editBarName of menu bar 1",
+            variableName: "toPlayheadItemName",
+            notFoundError: "TO_PLAYHEAD_MENU_ITEM_NOT_FOUND"
+        )
         let script = """
         \(logicProAppleScript.activateByBundleID)
         delay 0.1
         tell application "System Events"
             tell \(logicProAppleScript.systemEventsProcessTarget)
                 try
-                    click menu item "재생헤드로" of menu 1 of menu item "이동" of menu 1 of menu bar item "편집" of menu bar 1
-                on error
-                    try
-                        click menu item "To Playhead" of menu 1 of menu item "Move" of menu 1 of menu bar item "Edit" of menu bar 1
-                    on error errMsg
-                        return "MENU_ERROR: " & errMsg
-                    end try
+                    \(editBarResolution)
+                    \(moveMenuItemResolution)
+                    \(toPlayheadMenuItemResolution)
+                    click menu item toPlayheadItemName of menu 1 of menu item moveItemName of menu 1 of menu bar item editBarName of menu bar 1
+                on error errMsg
+                    return "MENU_ERROR: " & errMsg
                 end try
             end tell
         end tell

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Transport.swift
@@ -666,26 +666,38 @@ extension AccessibilityChannel {
         ]
     }
 
-    private static func runCycleRangeFallbackScript(startPos: String, endPos: String) -> Bool {
+    /// Kept internal so the #519 menu-locale regression tests can assert the exact generated
+    /// AppleScript without invoking Logic Pro. Pure text generation — no execution.
+    static func cycleRangeLocatorScript(startPos: String, endPos: String) -> String {
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
         // Strategy: use Logic's "Go To > Go To Beginning" (not ideal) — we instead
         // rely on the menu path "Navigate > Set Locators…" which opens a dialog
         // with start/end text fields. Keystroke start, Tab, end, Return.
-        // Menu path (Logic 12, ko): "탐색 > 로케이터 설정…"; (en): "Navigate > Set Locators…"
-        let script = """
+        // #519: bar/item names are resolved from AXLocalePolicy's LabelSets (canonical
+        // "Navigate" / "Set Locators…", KO variants "탐색" / "로케이터 설정…") instead of
+        // hard-coding one locale's literal.
+        let barResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.navigateMenuBar,
+            variableName: "barName",
+            notFoundError: "NAVIGATE_MENU_BAR_NOT_FOUND"
+        )
+        let itemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.setLocatorsMenuItem,
+            under: "menu bar item barName of menu bar 1",
+            variableName: "itemName",
+            notFoundError: "SET_LOCATORS_ITEM_NOT_FOUND"
+        )
+        return """
         tell application "System Events"
             tell \(logicProAppleScript.systemEventsProcessTarget)
                 set frontmost to true
                 delay 0.2
-                -- Attempt Korean menu first
                 try
-                    click menu item "로케이터 설정…" of menu 1 of menu bar item "탐색" of menu bar 1
+                    \(barResolution)
+                    \(itemResolution)
+                    click menu item itemName of menu 1 of menu bar item barName of menu bar 1
                 on error
-                    try
-                        click menu item "Set Locators…" of menu 1 of menu bar item "Navigate" of menu bar 1
-                    on error
-                        return "no-menu"
-                    end try
+                    return "no-menu"
                 end try
                 delay 0.3
                 keystroke "\(startPos)"
@@ -699,6 +711,10 @@ extension AccessibilityChannel {
             end tell
         end tell
         """
+    }
+
+    private static func runCycleRangeFallbackScript(startPos: String, endPos: String) -> Bool {
+        let script = cycleRangeLocatorScript(startPos: startPos, endPos: endPos)
         guard case let .completed(output) = BoundedProcessRunner.run(
             executable: "/usr/bin/osascript",
             arguments: ["-e", script],
@@ -1084,6 +1100,27 @@ extension AccessibilityChannel {
         let logicProAppleScript = LogicProTarget.appleScriptTarget()
         let ledgerPath = issuanceLedgerPath ?? ""
         let snapshotPath = preLeafWindowSnapshotPath ?? ""
+        // #519: bar/item/leaf names for the Navigate > Go To > Position… chain are resolved
+        // from AXLocalePolicy's LabelSets instead of a hard-coded EN/KO literal pair. Each
+        // resolution is read-only (no click) and raises a distinct error identifier the
+        // enclosing `try` block below turns into the existing "MENU_NOT_FOUND: <id>" refusal.
+        let navigateBarResolution = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.navigateMenuBar,
+            variableName: "barName",
+            notFoundError: "NAVIGATE_MENU_BAR_NOT_FOUND"
+        )
+        let goToItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.goToMenuItem,
+            under: "menu bar item barName of menu bar 1",
+            variableName: "goToName",
+            notFoundError: "GO_TO_MENU_ITEM_NOT_FOUND"
+        )
+        let positionItemResolution = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.goToPositionMenuItem,
+            under: "menu item goToName of menu 1 of menu bar item barName of menu bar 1",
+            variableName: "positionName",
+            notFoundError: "POSITION_MENU_ITEM_NOT_FOUND"
+        )
         return """
         -- A selected menu-bar item is the AX observation that one of Logic's
         -- menus is currently open. Return UNREADABLE rather than treating a
@@ -1493,20 +1530,15 @@ extension AccessibilityChannel {
                 -- Locale selection is a read-only path-resolution step. It
                 -- deliberately performs no click, so an AX error cannot turn a
                 -- Korean attempt into a second English menu actuation.
+                -- #519: bar/item/leaf names are resolved from AXLocalePolicy's LabelSets
+                -- (canonical "Navigate"/"Go To"/"Position…", KO variants
+                -- "탐색"/"이동"/"위치…") instead of a hard-coded EN/KO literal pair — see
+                -- AppleScriptMenuResolution for why, and knownGoToPositionDialogTitle
+                -- above for the separate (already-tracked) dialog-title locale table.
                 try
-                    if exists menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1 then
-                        set selectedLocaleChain to "KOREAN"
-                    else if exists menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1 then
-                        set selectedLocaleChain to "ENGLISH"
-                    else
-                        -- No menu has been opened by this run. If the read is unreadable,
-                        -- `knownOpen:false` must not send Escape into an unrelated focus target.
-                        set cleanupState to my dismissOpenMenu(logicProcess, false)
-                        if cleanupState is not "CLOSED" then
-                            return "MENU_PICK_FAILED: menu cleanup was not observed" & my menuCleanupActuationContext(menuActuationAttempted) & " (" & cleanupState & ")"
-                        end if
-                        return "MENU_NOT_FOUND"
-                    end if
+                    \(navigateBarResolution)
+                    \(goToItemResolution)
+                    \(positionItemResolution)
                 on error errMsg
                     -- Locale discovery is read-only; do not claim an unknown menu belongs to
                     -- this run and do not authorise Escape from an unreadable AX observation.
@@ -1517,11 +1549,7 @@ extension AccessibilityChannel {
                     return "MENU_NOT_FOUND: " & errMsg
                 end try
                 try
-                    if selectedLocaleChain is "KOREAN" then
-                        set menuItemEnabled to enabled of menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
-                    else
-                        set menuItemEnabled to enabled of menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
-                    end if
+                    set menuItemEnabled to enabled of menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1
                 on error
                     -- An unreadable AXEnabled must not authorise the pick.
                     set cleanupState to my dismissOpenMenu(logicProcess, false)
@@ -1576,11 +1604,7 @@ extension AccessibilityChannel {
                     end if
                     set menuActuationAttempted to true
                     set dialogActuationIssued to true
-                    if selectedLocaleChain is "KOREAN" then
-                        click menu item "위치…" of menu 1 of menu item "이동" of menu 1 of menu bar item "탐색" of menu bar 1
-                    else
-                        click menu item "Position…" of menu 1 of menu item "Go To" of menu 1 of menu bar item "Navigate" of menu bar 1
-                    end if
+                    click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1
                 on error errMsg
                     set dialogCleanupState to my dismissOpenGoToPositionDialog(logicProcess, observedGoToPositionDialog, preLeafGoToPositionWindows, preLeafGoToPositionWindowCount)
                     if dialogCleanupState is not "CLOSED" then

--- a/Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift
+++ b/Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Generates the localized-menu candidate-resolution AppleScript snippet used by every
+/// generated menu-bar/menu-item click site (#519).
+///
+/// `AXLocalePolicy` already carries every locale variant Logic's top-level menu titles and
+/// menu items are known to use — for example `fileMenuBar` lists `"File"`, `"파일"`, AND
+/// `"ファイル"` — but the AppleScript call sites that clicked through the File/Navigate/Edit
+/// menus hard-coded only one or two of those names inline. The table looked like it supported
+/// a locale (Japanese) that no call site could actually reach. Routing every menu-drive site
+/// through this generator, instead of a hand-written literal, is what keeps that gap from
+/// reopening: a variant added to `AXLocalePolicy` becomes reachable everywhere this helper is
+/// used, with no call site to remember to update, and a future site that skips this helper and
+/// writes a quoted literal name straight after the `menu bar item` keyword again is caught by
+/// `Scripts/ci-forbid-hardcoded-menu-bar-item.sh` (registered in `.github/workflows/ci.yml` next
+/// to the dead-`#expect` gate).
+///
+/// The generated script never assumes an index or a single name: it tries each label —
+/// canonical first, then variants, in the order `LabelSet.labels` returns them — and uses the
+/// first one AppleScript reports `exists`. A given running Logic only ever exposes ONE of a
+/// LabelSet's labels (its actual UI language), so trying canonical before a locale variant does
+/// not change which one an actual run picks; it only fixes the order candidates are probed in.
+enum AppleScriptMenuResolution {
+    /// Emits:
+    /// ```applescript
+    /// set <variableName> to missing value
+    /// repeat with candidate in {"canonical", "variant1", ...}
+    ///     if exists <elementKeyword> candidate<existsSuffix> then
+    ///         set <variableName> to candidate as text
+    ///         exit repeat
+    ///     end if
+    /// end repeat
+    /// if <variableName> is missing value then error "<notFoundError>"
+    /// ```
+    ///
+    /// `existsSuffix` is the AppleScript text that completes the `exists` specifier right after
+    /// the bare `candidate` token — for example `" of menu bar 1"` for a top-level menu-bar
+    /// item, or `" of menu 1 of menu bar item barName of menu bar 1"` for a submenu item nested
+    /// under an already-resolved bar variable. `elementKeyword` is `"menu bar item"` or
+    /// `"menu item"`, interpolated as plain AppleScript vocabulary — never followed directly by
+    /// a quote, so this generator itself never trips the hard-coded-literal guard.
+    ///
+    /// Labels are escaped with `AppleScriptSafety.escapeForScript`, the same helper the rest of
+    /// the AppleScript builders use, so a variant containing a `"` or `\` cannot break out of the
+    /// `{...}` list literal.
+    ///
+    /// On failure the loop raises `error "<notFoundError>"` (an ordinary AppleScript error) —
+    /// callers that already wrap the resolution in `try ... on error errMsg ... end try` catch it
+    /// exactly like any other menu-not-found failure and keep their existing cleanup/Escape path.
+    static func candidateResolution(
+        elementKeyword: String,
+        labelSet: AXLocalePolicy.LabelSet,
+        existsSuffix: String,
+        variableName: String,
+        notFoundError: String
+    ) -> String {
+        let literals = labelSet.labels
+            .map { "\"\(AppleScriptSafety.escapeForScript($0))\"" }
+            .joined(separator: ", ")
+        return """
+        set \(variableName) to missing value
+        repeat with candidate in {\(literals)}
+            if exists \(elementKeyword) candidate\(existsSuffix) then
+                set \(variableName) to candidate as text
+                exit repeat
+            end if
+        end repeat
+        if \(variableName) is missing value then error "\(notFoundError)"
+        """
+    }
+
+    /// Convenience for a top-level menu-bar item: `menu bar item <name> of menu bar 1`.
+    static func menuBarItem(
+        _ labelSet: AXLocalePolicy.LabelSet,
+        variableName: String,
+        notFoundError: String
+    ) -> String {
+        candidateResolution(
+            elementKeyword: "menu bar item",
+            labelSet: labelSet,
+            existsSuffix: " of menu bar 1",
+            variableName: variableName,
+            notFoundError: notFoundError
+        )
+    }
+
+    /// Convenience for a menu item nested one level under an already-resolved parent
+    /// specifier (a resolved `menu bar item` variable or a resolved `menu item` variable).
+    /// `parentSpecifier` is the exact AppleScript specifier text the item lives under, e.g.
+    /// `"menu bar item barName of menu bar 1"` or
+    /// `"menu item goToName of menu 1 of menu bar item barName of menu bar 1"`.
+    static func menuItem(
+        _ labelSet: AXLocalePolicy.LabelSet,
+        under parentSpecifier: String,
+        variableName: String,
+        notFoundError: String
+    ) -> String {
+        candidateResolution(
+            elementKeyword: "menu item",
+            labelSet: labelSet,
+            existsSuffix: " of menu 1 of \(parentSpecifier)",
+            variableName: variableName,
+            notFoundError: notFoundError
+        )
+    }
+}

--- a/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
@@ -26,10 +26,21 @@ struct AppleScriptMenuResolutionGeneratorTests {
             variableName: "barName",
             notFoundError: "NAVIGATE_MENU_BAR_NOT_FOUND"
         )
-        let canonical = try #require(generated.range(of: "\"Navigate\""))
-        let variant = try #require(generated.range(of: "\"탐색\""))
-        #expect(canonical.lowerBound < variant.lowerBound)
-        #expect(generated.contains("repeat with candidate in {\"Navigate\", \"탐색\"}"))
+        // Derived from the LabelSet, not hardcoded. A test that spells out the whole candidate list
+        // fails whenever a measured label is added — which would make adding a language a test-breaking
+        // change, penalising the one thing this design exists to make cheap. Asserting the PROPERTY still
+        // fails if a label is dropped or the order is wrong.
+        let labels = AXLocalePolicy.navigateMenuBar.labels
+        let canonical = try #require(generated.range(of: "\"\(labels[0])\""))
+        for variant in labels.dropFirst() {
+            let found = try #require(
+                generated.range(of: "\"\(variant)\""),
+                "every label in the set must reach the generated candidate list: \(variant)"
+            )
+            #expect(canonical.lowerBound < found.lowerBound)
+        }
+        let expectedList = labels.map { "\"\($0)\"" }.joined(separator: ", ")
+        #expect(generated.contains("repeat with candidate in {\(expectedList)}"))
         #expect(generated.contains("if exists menu bar item candidate of menu bar 1 then"))
         #expect(generated.contains("set barName to candidate as text"))
         #expect(generated.contains("if barName is missing value then error \"NAVIGATE_MENU_BAR_NOT_FOUND\""))
@@ -43,7 +54,8 @@ struct AppleScriptMenuResolutionGeneratorTests {
             variableName: "goToName",
             notFoundError: "GO_TO_MENU_ITEM_NOT_FOUND"
         )
-        #expect(generated.contains("repeat with candidate in {\"Go To\", \"이동\"}"))
+        let goToLabels = AXLocalePolicy.goToMenuItem.labels.map { "\"\($0)\"" }.joined(separator: ", ")
+        #expect(generated.contains("repeat with candidate in {\(goToLabels)}"))
         #expect(generated.contains(
             "if exists menu item candidate of menu 1 of menu bar item barName of menu bar 1 then"
         ))

--- a/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #519: ten generated AppleScript menu drives hard-coded EN/KO menu-bar/menu-item names
+/// inline instead of resolving them from `AXLocalePolicy`'s `LabelSet`s, so a Logic running in
+/// any other UI language (the table already carried a Japanese "File" form, for example) could
+/// never reach the extra variant. These tests cover the shared generator
+/// (`AppleScriptMenuResolution`) directly, then every converted call site, asserting: every
+/// `LabelSet` variant is present in the emitted candidate list, canonical comes first, escaping
+/// is injection-safe, and each site's pre-existing failure identifiers / Escape-on-error path
+/// survived the conversion unchanged.
+private final class MenuScriptProbe: @unchecked Sendable {
+    private(set) var script = ""
+    func capture(_ script: String) { self.script = script }
+}
+
+// MARK: - Generator unit tests
+
+@Suite("#519 AppleScriptMenuResolution generator")
+struct AppleScriptMenuResolutionGeneratorTests {
+    @Test("menuBarItem emits canonical-first candidates and a distinct not-found error")
+    func menuBarItemCandidateOrderAndNotFound() throws {
+        let generated = AppleScriptMenuResolution.menuBarItem(
+            AXLocalePolicy.navigateMenuBar,
+            variableName: "barName",
+            notFoundError: "NAVIGATE_MENU_BAR_NOT_FOUND"
+        )
+        let canonical = try #require(generated.range(of: "\"Navigate\""))
+        let variant = try #require(generated.range(of: "\"탐색\""))
+        #expect(canonical.lowerBound < variant.lowerBound)
+        #expect(generated.contains("repeat with candidate in {\"Navigate\", \"탐색\"}"))
+        #expect(generated.contains("if exists menu bar item candidate of menu bar 1 then"))
+        #expect(generated.contains("set barName to candidate as text"))
+        #expect(generated.contains("if barName is missing value then error \"NAVIGATE_MENU_BAR_NOT_FOUND\""))
+    }
+
+    @Test("menuItem nests the exists check under the given parent specifier")
+    func menuItemNestsUnderParent() {
+        let generated = AppleScriptMenuResolution.menuItem(
+            AXLocalePolicy.goToMenuItem,
+            under: "menu bar item barName of menu bar 1",
+            variableName: "goToName",
+            notFoundError: "GO_TO_MENU_ITEM_NOT_FOUND"
+        )
+        #expect(generated.contains("repeat with candidate in {\"Go To\", \"이동\"}"))
+        #expect(generated.contains(
+            "if exists menu item candidate of menu 1 of menu bar item barName of menu bar 1 then"
+        ))
+        #expect(generated.contains("set goToName to candidate as text"))
+        #expect(generated.contains("if goToName is missing value then error \"GO_TO_MENU_ITEM_NOT_FOUND\""))
+    }
+
+    @Test("every LabelSet variant is present in the emitted candidate list")
+    func everyVariantPresent() {
+        // transportMetronomeControl carries 6 variants — a good stress case for "every one shows up".
+        let labelSet = AXLocalePolicy.transportMetronomeControl
+        let generated = AppleScriptMenuResolution.candidateResolution(
+            elementKeyword: "menu bar item",
+            labelSet: labelSet,
+            existsSuffix: " of menu bar 1",
+            variableName: "x",
+            notFoundError: "X_NOT_FOUND"
+        )
+        #expect(labelSet.labels.count > 3)
+        for label in labelSet.labels {
+            #expect(generated.contains("\"\(label)\""))
+        }
+    }
+
+    // Mutation this rejects: dropping a variant from a LabelSet (or from the emitted candidate
+    // list) silently narrows which locales a site can reach — exactly the #519 defect. Every
+    // `for label in ....labels` loop in this file re-derives its expectation from the SAME
+    // `AXLocalePolicy` table the generator reads, so removing a variant there fails here too
+    // (see the mutation evidence in the PR description/report, not committed).
+    @Test("a quote or backslash in a variant cannot break out of the candidate list literal")
+    func escapingIsSafe() {
+        let evil = "evil\"inject"
+        let backslash = "back\\slash"
+        let labelSet = AXLocalePolicy.LabelSet(
+            canonical: "Safe",
+            variants: [evil, backslash],
+            rationale: "test fixture — not a real Logic label"
+        )
+        let generated = AppleScriptMenuResolution.menuBarItem(
+            labelSet,
+            variableName: "x",
+            notFoundError: "X_NOT_FOUND"
+        )
+        // The escaped candidate list must read exactly as: "Safe", "evil\"inject", "back\\slash"
+        // — an unescaped quote here would close the AppleScript string literal early and let the
+        // remainder of the variant execute as script text instead of being treated as data.
+        #expect(generated.contains("\"Safe\", \"evil\\\"inject\", \"back\\\\slash\""))
+    }
+}
+
+// MARK: - Site coverage: Navigate menu (Markers, cycle-range, goto_position)
+
+@Suite("#519 Navigate menu-drive sites route through AXLocalePolicy")
+struct Issue519NavigateMenuDriveSiteTests {
+    @Test("Open Marker List script resolves the Navigate bar/item from LabelSets and keeps the Escape-on-error path")
+    func markerOpenListScript() {
+        let script = AccessibilityChannel.markerMenuActuationScript(.openList)
+        for label in AXLocalePolicy.navigateMenuBar.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.openMarkerListMenuItem.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        // #346: the Escape-on-error path (key code 53) must survive the conversion unchanged.
+        #expect(script.contains("key code 53"))
+        // No literal-name click anywhere — actuation goes through the resolved variable only.
+        #expect(!script.contains("menu bar item \"Navigate\""))
+        #expect(!script.contains("menu bar item \"탐색\""))
+    }
+
+    @Test("Create Marker script resolves the Navigate bar/item from LabelSets and keeps the Escape-on-error path")
+    func markerCreateScript() {
+        let script = AccessibilityChannel.markerMenuActuationScript(.create)
+        for label in AXLocalePolicy.navigateMenuBar.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.createMarkerMenuItem.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        #expect(script.contains("key code 53"))
+    }
+
+    @Test("cycle-range Set Locators script resolves the Navigate bar/item from LabelSets")
+    func cycleRangeLocatorScriptCoversVariants() {
+        let script = AccessibilityChannel.cycleRangeLocatorScript(startPos: "1 1 1 1", endPos: "9 1 1 1")
+        for label in AXLocalePolicy.navigateMenuBar.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.setLocatorsMenuItem.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        // The pre-existing failure sentinel the caller pattern-matches on must be unchanged.
+        #expect(script.contains("return \"no-menu\""))
+    }
+
+    @Test("goto_position script resolves Navigate > Go To > Position… from LabelSets")
+    func gotoPositionScriptCoversVariants() {
+        let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 519)
+        for label in AXLocalePolicy.navigateMenuBar.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.goToMenuItem.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.goToPositionMenuItem.labels {
+            #expect(script.contains("\"\(label)\""))
+        }
+    }
+}
+
+// MARK: - Site coverage: File menu (Bounce, MIDI import)
+
+@Suite("#519 File menu-drive sites route through AXLocalePolicy")
+struct Issue519FileMenuDriveSiteTests {
+    @Test("File > Bounce script resolves File/Bounce from LabelSets, reaching the already-recorded Japanese File variant")
+    func bounceMenuScriptCoversVariants() async {
+        let probe = MenuScriptProbe()
+        _ = await AccessibilityChannel.openBounceDialogViaMenu(
+            systemEventsAuthorized: { true },
+            executeScript: { script in
+                probe.capture(script)
+                return .success(#"{"result":"BOUNCE_MENU_ITEM_NOT_FOUND"}"#)
+            }
+        )
+        for label in AXLocalePolicy.fileMenuBar.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.bounceMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.projectOrSectionMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        // The headline #519 claim: fileMenuBar's Japanese "ファイル" was already in the table and
+        // is now actually reachable from the generated script, not just recorded.
+        #expect(probe.script.contains("\"ファイル\""))
+        // The pre-existing terminal failure identifier consumers pattern-match on is unchanged
+        // (see Issue256BounceMenuTests "missing native menu item returns a targeted terminal failure").
+        #expect(probe.script.contains("BOUNCE_MENU_ITEM_NOT_FOUND"))
+    }
+
+    @Test("File > Import > MIDI File… script resolves File/Import/MIDI File from LabelSets, reaching the Japanese File variant")
+    func midiImportScriptCoversVariants() async {
+        let path = NSTemporaryDirectory() + "issue519-\(UUID().uuidString).mid"
+        FileManager.default.createFile(atPath: path, contents: Data([0x4D, 0x54, 0x68, 0x64]))
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let probe = MenuScriptProbe()
+        _ = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
+            path: path,
+            executeScript: { script in
+                probe.capture(script)
+                return .success(#"{"result":"MENU_ERROR: not found"}"#)
+            },
+            trackCount: { 0 },
+            trackNames: { [] },
+            regionInfos: { .success([]) },
+            deltaPoll: {}
+        )
+        for label in AXLocalePolicy.fileMenuBar.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.importMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.midiFileMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        #expect(probe.script.contains("\"ファイル\""))
+        // The pre-existing "MENU_ERROR: " prefix the Swift caller pattern-matches on is unchanged.
+        #expect(probe.script.contains("MENU_ERROR"))
+    }
+}
+
+// MARK: - Site coverage: Edit menu (region move-to-playhead)
+
+@Suite("#519 Edit menu-drive site routes through AXLocalePolicy")
+struct Issue519EditMenuDriveSiteTests {
+    @Test("Edit > Move > To Playhead script resolves Edit/Move/To Playhead from LabelSets")
+    func moveToPlayheadScriptCoversVariants() async {
+        let builder = FakeAXRuntimeBuilder()
+        let runtime = builder.makeLogicRuntime()
+        let probe = MenuScriptProbe()
+        _ = await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(
+            runtime: runtime,
+            executeScript: { script in
+                probe.capture(script)
+                return .success("MENU_ERROR: not found")
+            },
+            settle: {}
+        )
+        for label in AXLocalePolicy.editMenuBar.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.moveMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        for label in AXLocalePolicy.toPlayheadMenuItem.labels {
+            #expect(probe.script.contains("\"\(label)\""))
+        }
+        // The pre-existing "MENU_ERROR: " prefix the Swift caller pattern-matches on is unchanged.
+        #expect(probe.script.contains("MENU_ERROR"))
+    }
+}

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -218,16 +218,21 @@ struct Issue529MenuValidationTests {
         // the three read-only candidate loops below (bar, then "Go To", then "Position…") replace
         // the old koreanDecision/englishDecision two-branch check.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
+        // Candidate lists are derived from the LabelSets rather than spelled out: a measured label
+        // added to AXLocalePolicy must not break an ordering test that is about ordering.
+        func candidateList(_ set: AXLocalePolicy.LabelSet) -> String {
+            "repeat with candidate in {" + set.labels.map { "\"\($0)\"" }.joined(separator: ", ") + "}"
+        }
         let barResolution = try issue529Position(
-            of: "repeat with candidate in {\"Navigate\", \"탐색\"}",
+            of: candidateList(AXLocalePolicy.navigateMenuBar),
             in: script
         )
         let itemResolution = try issue529Position(
-            of: "repeat with candidate in {\"Go To\", \"이동\"}",
+            of: candidateList(AXLocalePolicy.goToMenuItem),
             in: script
         )
         let leafResolution = try issue529Position(
-            of: "repeat with candidate in {\"Position…\", \"위치…\"}",
+            of: candidateList(AXLocalePolicy.goToPositionMenuItem),
             in: script
         )
         let enabledRead = try issue529Position(
@@ -303,7 +308,12 @@ struct Issue529MenuValidationTests {
             in: script
         )
         let firstOperationalDelay = try issue529Position(of: "delay 0.2", in: script)
-        let localeDecision = try issue529Position(of: "repeat with candidate in {\"Navigate\", \"탐색\"}", in: script)
+        let localeDecision = try issue529Position(
+            of: "repeat with candidate in {"
+                + AXLocalePolicy.navigateMenuBar.labels.map { "\"\($0)\"" }.joined(separator: ", ")
+                + "}",
+            in: script
+        )
         let leafClick = try issue529Position(
             of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
@@ -323,7 +333,12 @@ struct Issue529MenuValidationTests {
             of: "if entryMenuCleanup is not \"CLOSED\" then",
             in: script
         )
-        let localeDecision = try issue529Position(of: "repeat with candidate in {\"Navigate\", \"탐색\"}", in: script)
+        let localeDecision = try issue529Position(
+            of: "repeat with candidate in {"
+                + AXLocalePolicy.navigateMenuBar.labels.map { "\"\($0)\"" }.joined(separator: ", ")
+                + "}",
+            in: script
+        )
 
         #expect(entryGuard < localeDecision)
         #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))

--- a/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
+++ b/Tests/LogicProMCPTests/Issue529MenuValidationTests.swift
@@ -212,32 +212,37 @@ struct Issue529MenuValidationTests {
         // Mutation this rejects: restore either intermediate menu-bar/submenu click, or replace
         // either full leaf path with an object selected by a prior click. Both let a menu-bar click
         // block the script before the Go To Position dialog can open.
+        //
+        // #519: the bar/item/leaf names are each resolved from an AXLocalePolicy LabelSet
+        // (canonical first, then variants) instead of a hard-coded EN/KO literal branch pair, so
+        // the three read-only candidate loops below (bar, then "Go To", then "Position…") replace
+        // the old koreanDecision/englishDecision two-branch check.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
-        let koreanDecision = try issue529Position(
-            of: "if exists menu item \"위치…\"",
+        let barResolution = try issue529Position(
+            of: "repeat with candidate in {\"Navigate\", \"탐색\"}",
             in: script
         )
-        let englishDecision = try issue529Position(
-            of: "else if exists menu item \"Position…\"",
+        let itemResolution = try issue529Position(
+            of: "repeat with candidate in {\"Go To\", \"이동\"}",
+            in: script
+        )
+        let leafResolution = try issue529Position(
+            of: "repeat with candidate in {\"Position…\", \"위치…\"}",
             in: script
         )
         let enabledRead = try issue529Position(
-            of: "set menuItemEnabled to enabled of menu item \"위치…\"",
+            of: "set menuItemEnabled to enabled of menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
-        let koreanLeaf = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
-            in: script
-        )
-        let englishLeaf = try issue529Position(
-            of: "click menu item \"Position…\" of menu 1 of menu item \"Go To\" of menu 1 of menu bar item \"Navigate\" of menu bar 1",
+        let leafClick = try issue529Position(
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
 
-        #expect(koreanDecision < englishDecision)
-        #expect(englishDecision < enabledRead)
-        #expect(enabledRead < koreanLeaf)
-        #expect(koreanLeaf < englishLeaf)
+        #expect(barResolution < itemResolution)
+        #expect(itemResolution < leafResolution)
+        #expect(leafResolution < enabledRead)
+        #expect(enabledRead < leafClick)
         #expect(!script.contains("click menu bar item"))
         #expect(!script.contains("selectedMenuBarItem"))
         #expect(!script.contains("selectedSubmenuItem"))
@@ -272,7 +277,7 @@ struct Issue529MenuValidationTests {
         // it. The leaf can issue successfully while Logic has not rendered the modal yet.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
         let readyPoll = try issue529Position(
@@ -298,9 +303,9 @@ struct Issue529MenuValidationTests {
             in: script
         )
         let firstOperationalDelay = try issue529Position(of: "delay 0.2", in: script)
-        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
+        let localeDecision = try issue529Position(of: "repeat with candidate in {\"Navigate\", \"탐색\"}", in: script)
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
 
@@ -318,7 +323,7 @@ struct Issue529MenuValidationTests {
             of: "if entryMenuCleanup is not \"CLOSED\" then",
             in: script
         )
-        let localeDecision = try issue529Position(of: "if exists menu item \"위치…\"", in: script)
+        let localeDecision = try issue529Position(of: "repeat with candidate in {\"Navigate\", \"탐색\"}", in: script)
 
         #expect(entryGuard < localeDecision)
         #expect(script.contains("if menuState is \"UNREADABLE\" and not knownOpen then return \"UNREADABLE\""))
@@ -400,7 +405,7 @@ struct Issue529MenuValidationTests {
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let attempted = try issue529Position(of: "set menuActuationAttempted to true", in: script)
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
         let leafErrorHandlerEnd = try issue529Position(of: "-- Wait up to 3s for a new exact modal dialog", in: script)
@@ -490,7 +495,7 @@ struct Issue529MenuValidationTests {
         // CGEvent would post `/`, the position text, and Return into that still-open dialog.
         let script = AccessibilityChannel.gotoPositionViaDialogAppleScript(bar: 529)
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
         let leafFailureBlock = String(script[leafClick...])
@@ -1297,7 +1302,7 @@ struct Issue529MenuValidationTests {
             of: "set preLeafGoToPositionWindows to every window as list", in: script
         )
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
         let stateStart = try issue529Position(
@@ -1350,7 +1355,7 @@ struct Issue529MenuValidationTests {
             of: "recordDialogIssuance(\"LEAF_ARMED\"", in: script
         )
         let leafClick = try issue529Position(
-            of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+            of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
             in: script
         )
         let returnCheckpoint = try issue529Position(
@@ -1422,14 +1427,22 @@ func dismissalContextKeepsLocaleReadsUnownedUntilResolvedLeafIssuance() throws {
 
     // Entry, locale discovery, enabled/disabled handling, and a failed durable checkpoint are all
     // unowned until the resolved leaf is actually issued.
-    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 6)
+    //
+    // #519: locale discovery used to have two textually separate cleanup call sites — an explicit
+    // "no candidate exists" branch and a catch-all `on error errMsg` handler — because the old
+    // if/else-if chain distinguished "nothing matched" from "reading a candidate raised an AX
+    // error". The candidate-loop resolution now raises the SAME kind of AppleScript `error` for
+    // both ("not found" and "unreadable" are no longer distinguishable, which the old code did not
+    // rely on either — both returned the same MENU_NOT_FOUND-prefixed refusal), so one shared
+    // `on error errMsg` handler covers what used to be two call sites: 5 sites, not 6.
+    #expect(issue529Positions(of: "my dismissOpenMenu(logicProcess, false)", in: script).count == 5)
 
     let leafCheckpoint = try issue529Position(
         of: "recordDialogIssuance(\"LEAF_ARMED\"",
         in: script
     )
     let resolvedLeaf = try issue529Position(
-        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
         in: script
     )
     #expect(leafCheckpoint < resolvedLeaf)
@@ -1464,7 +1477,7 @@ func gotoPositionDialogRequiresNewCountAndBracketedFocusedBinding() throws {
         in: script
     )
     let leafClick = try issue529Position(
-        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
         in: script
     )
     let observedDialog = try issue529Position(
@@ -1558,7 +1571,7 @@ func gotoPositionDialogRefusesPreexistingMatchingDialogBeforeLeaf() throws {
         of: "if preLeafGoToPositionDialogCount is greater than 0 then", in: script
     )
     let leaf = try issue529Position(
-        of: "click menu item \"위치…\" of menu 1 of menu item \"이동\" of menu 1 of menu bar item \"탐색\" of menu bar 1",
+        of: "click menu item positionName of menu 1 of menu item goToName of menu 1 of menu bar item barName of menu bar 1",
         in: script
     )
     let matcherStart = try issue529Position(


### PR DESCRIPTION
Ten generated AppleScript menu drives hard-coded their menu names, English plus Korean, so every operation
routed through them failed on any other Logic UI language. Measured in the ticket: on a Korean Logic
`project.new` fails in 2.8s with State C `channels_exhausted`, where the same machine in English completes
in 5.7s.

**It was never a translation gap.** `AXLocalePolicy` already listed `"ファイル"` for `fileMenuBar`, and no
call site could reach it — the table advertised support the code could not deliver, and the failure was
silent: a Japanese user's operation simply refused.

### Three parts

**1. Wiring.** Every site now resolves its name from the `LabelSet` at script-generation time, trying
canonical then each variant and using whichever `exists`. Name-based only — no index, no position. Adding
a language becomes a one-line data change instead of an edit to ten scripts.

**2. The guard, which matters more than the ten edits.** Removing the literals fixes ten instances; it does
not stop an eleventh, and an eleventh fails just as silently.
`Scripts/ci-forbid-hardcoded-menu-bar-item.sh` refuses any `menu bar item "literal"` under `Sources/` and
runs in CI beside the dead-assertion gate. **Watched to fail**: against the pre-fix tree it exits 1 and
names 19 lines — the ticket said ten sites; most carry an EN/KO pair, so the census disagreed with the
ticket and the census is what the fix had to satisfy.

It states its own limit: it catches top-level menu-bar literals, not a submenu leaf under an
already-resolved bar, because broadening the pattern produced false positives on unrelated one-off
AppleScript. A guard that cries wolf gets disabled.

**3. The missing data.** Wiring cannot add variants that were never there, and eight labels had no
Japanese entry, so `navigate` and `edit` routed operations still failed. Measured on Logic 12.3 with
`AppleLanguages=ja`, read off the live menus:

```
Navigate menu bar   移動        ← NOT ナビゲート, which is what a translation produces
Edit menu bar       編集
Go To submenu       移動
Go To > Position…   位置…
File > Import       読み込む
Import > MIDI File… MIDIファイル…
Create Marker       マーカーを作成
Open Marker List    マーカーリストを開く
```

### Verification

Live on a **Japanese** Logic, same machine and project:

```
goto_bar, pre-fix binary   State C, success false — the Go To dialog was never observed
goto_bar, this binary      State B, success true  — the menu drive works
```

State B rather than A is a separate readback limitation, not a locale failure: the write lands.

| | |
|---|---|
| Suite | **3756 passed** |
| Ship gate | **PASS** |
| Live (`live_519_menu_names_resolve.py`) | 3/3 + visual, mutation-backed |

The live harness states its limit explicitly: it runs on whatever language Logic is currently in and does
**not** prove the Japanese path — that leg is the manual measurement above.

Test assertions now derive their candidate lists from the `LabelSet` rather than spelling them out. A test
that hardcodes the full list fails whenever a measured label is added, which would make adding a language
a test-breaking change — penalising the one thing this design exists to make cheap.