### PR TITLE
docs(#549): give the doc comment back to the function it constrains

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -1170,6 +1170,19 @@ extension AccessibilityChannel {
         error.raw == AXError.invalidUIElement.rawValue
     }
 
+    /// #549: roles this scan will not treat as a possible sheet host. A failed `AXChildren` read on one
+    /// of these does not withhold the absence answer.
+    ///
+    /// The justification is SEMANTIC, not structural: AppKit attaches a sheet to a window, not to a
+    /// table cell. It is worth being exact about that, because this repository documents Logic's Marker
+    /// List `AXCell` as a container that nests further groups and cells
+    /// (`AXLogicProElements+Markers.swift`), so "an AXCell contains nothing" would simply be false. The
+    /// claim is narrower: nothing a sheet can attach to lives under one. Keyed on role because
+    /// `AXRole` is a non-localized constant, unlike titles and `AXRoleDescription` — a label-based
+    /// exclusion would silently stop working on a non-English Logic, which is the defect class of #519
+    /// and #523. One entry, the one that was measured.
+    private static let rolesThatCannotHostASheet: Set<String> = [kAXCellRole as String]
+
     /// Searches one level before descending through the fallback tree. A sheet
     /// is normally a direct `AXChildren` child of its host, so inspecting the
     /// direct roles first avoids spending the scan inside unrelated siblings
@@ -1187,13 +1200,6 @@ extension AccessibilityChannel {
     ///   - elementRole: `element`'s own role, when already known (nil only
     ///     for the initial window-root call, whose role this scan never
     ///     independently reads).
-    /// #549: roles that cannot be, or contain, an `AXSheet`. A failed `AXChildren` read on one of
-    /// these is not a hole in the sheet search: the node was never a candidate. Keyed on role because
-    /// `AXRole` is a non-localized constant, unlike titles and `AXRoleDescription` — a label-based
-    /// exclusion would silently stop working on a non-English Logic, which is the defect class of #519
-    /// and #523. One entry, the one that was measured.
-    private static let rolesThatCannotHostASheet: Set<String> = [kAXCellRole as String]
-
     private static func findSheetDescendantLookup(
         in element: AXUIElement,
         maxDepth: Int,

--- a/Tests/LogicProMCPTests/Issue549CellExclusionTests.swift
+++ b/Tests/LogicProMCPTests/Issue549CellExclusionTests.swift
@@ -16,8 +16,14 @@ import Testing
 /// `.unreadable`. These tests prove: (1) the reproduction is actually fixed, (2) the narrowing is
 /// exactly one role wide and does not casually swallow a role that COULD host a sheet, (3) a real
 /// sheet elsewhere in the same tree is still found — the narrowing must never blind the scan, and
-/// (4) a node whose OWN role read failed (so its role is unknown, not merely non-hosting) still
-/// poisons, because it could have been the sheet.
+/// (4) a node whose role this scan never read — the window root, the only such node — still poisons,
+/// because an unidentified node could have been the sheet.
+///
+/// Note what (4) does NOT cover, since the name once claimed it did: a CHILD whose own `AXRole` read
+/// fails never reaches the recursive call at all — it hits `continue` and is not descended into — so no
+/// node with a failed role read can ever arrive as `element`. That case is unreachable by construction
+/// and therefore untestable; the reachable `elementRole == nil` node is the window root, which is what
+/// this exercises.
 @Suite("Issue #549 — an AXCell that cannot host a sheet does not poison the scan")
 struct Issue549CellExclusionTests {
 
@@ -143,7 +149,7 @@ struct Issue549CellExclusionTests {
         #expect(CFEqual(sheet, sheetNode))
     }
 
-    @Test("a node whose OWN role read failed still poisons a subsequent children-read failure — identity unknown means it could have been the sheet")
+    @Test("a node whose role this scan never read still poisons its children-read failure — an unidentified node could have been the sheet")
     func unknownRoleChildrenFailureStillPoisons() throws {
         // The window root is the one node this scan ever descends into with `elementRole == nil`
         // for a reason OTHER than "role read failed": its role is never independently read at all


### PR DESCRIPTION
Follow-up to #555, from adversarial review of it. Comment and test-name only — no behaviour change.

**The constant hijacked the function's documentation.** `rolesThatCannotHostASheet` was inserted with no
blank line after `findSheetDescendantLookup`'s doc comment, so the entire 22-line docstring — summary,
`- Parameters:`, and the `elementRole` contract — attached to a `Set<String>`, and the function was left
undocumented while the constant carried a parameter list for parameters it does not have.

That matters because the `elementRole` paragraph is the correctness argument for the guard: the exclusion
is safe only because `elementRole` is nil at the window root and otherwise came from a successful role
read of that exact element. A test comment cites "findSheetDescendantLookup's `elementRole` doc comment",
a reference that no longer resolved to that function.

**The justification over-claimed.** "Roles that cannot be, or contain, an `AXSheet`" is contradicted by
this repository's own map of Logic's Marker List, where `AXCell` nests further groups and cells. The
claim that actually holds is semantic rather than structural: AppKit attaches a sheet to a window, and
nothing a sheet can attach to lives under a table cell.

**One test name claimed an unreachable case.** "A node whose OWN role read failed still poisons" — a child
whose role read fails hits `continue` and is never descended into, so no such node ever arrives as
`element`. The reachable case is the window root, whose role this scan never reads, and that is what the
test exercises. The name and suite doc now say so, and say why the other case cannot be tested at all.

| | |
|---|---|
| Suite | **3749 passed** |
| Ship gate | **PASS** |
| Live | **5/5** — create certifies 3/3 with the failing node present, writes landed, a real sheet still seen and pressed |