### PR TITLE
feat(#543): make the mixer refusal say which lookup step failed

### DIFF
--- a/Scripts/livekit/live_543_lookup_names_the_step.py
+++ b/Scripts/livekit/live_543_lookup_names_the_step.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Live proof for #543's mixer control-lookup diagnostics against the running Logic Pro.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_543_lookup_names_the_step.py <worktree> <full-40-char-head-sha>
+
+What this run is actually for, stated plainly rather than implied.
+
+The #543 fix replaced `allTrackHeaders` with `allTrackHeadersRead` in the refusal path. Those two are
+NOT the same reader. The old one is tolerant: any traversal failure becomes an empty array. The new one
+is strict and status-preserving: it distinguishes "rail absent", "rail found but not enumerable", and
+"rail read, zero rows". That is the whole point of the change — but it is also the risk the change
+introduces, and it is a risk only the real application can settle. If Logic's live track-header rail does
+not satisfy the strict reader, then every real-world lookup failure would now report
+`track_header_list_unreadable` instead of naming the step, and the fix would have made the diagnostic
+worse than the bug it replaced. No unit fixture can answer that: the fake tree is built to be readable.
+
+So the load-bearing check is: drive a genuinely out-of-range index at the REAL rail and confirm the
+receipt says `no_header_at_index` with a truthful `header_count` — which is possible only if the strict
+reader successfully enumerated the live rail.
+
+What this run does NOT prove, and no live run here can:
+
+- The `.unreadable` branch itself. Forcing a real `kAXErrorCannotComplete` from Logic's window server on
+  demand is not something this harness can do, so that branch is locked by the unit fixture, which was
+  watched to fail in both directions (mutation-tested at commit time).
+- The re-read race. It needs a track added or removed between two AX reads inside one refusal, which is a
+  timing window this harness cannot force. Also locked by fixture.
+
+`header_count` is corroborated against the product's own `logic://tracks` resource. That is a DIFFERENT
+function from the one under test, but it is still the product reading AX, so it corroborates rather than
+witnesses — labelled as such below. System Events cannot supply an independent per-row count: Logic does
+not vend the "Track Headers" list at any depth addressable from the Tracks window (probed during #542;
+`-1719` at the window, no list under any of its groups). The screenshot is the independent witness that
+rows exist at all.
+
+This harness mutates nothing: the operation under test is refused before any write, and the requested
+index does not exist. There is no state to restore, and that is asserted rather than assumed.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+
+# An index no real project reaches. Chosen far above any plausible track count so that a pass cannot be
+# an accident of this project happening to have that many tracks.
+OUT_OF_RANGE = 4096
+
+
+def tracks():
+    """A `select` forces a live AX read; without it the resource answers with synthesised names."""
+    d.tool("logic_tracks", "select", {"index": 0})
+    return d.resource("logic://tracks").get("data", []) or []
+
+
+win = E.logic_window()
+if not win:
+    ev.check("543/precondition-logic-window", False, "Logic's Tracks window is on screen",
+             "no window found", "closed the Tracks window; this check went red")
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+
+live_tracks = tracks()
+ev.note("precondition", {"track_count": len(live_tracks),
+                         "names": [t.get("name") for t in live_tracks]})
+
+# The rail must be non-empty for this run to mean anything. With zero tracks the expected answer would be
+# `track_header_list_empty`, and a pass on `no_header_at_index` would be impossible — but so would the
+# claim that the strict reader can enumerate a populated rail, which is the point of the run.
+ok_pre = len(live_tracks) > 0
+ev.check("543/precondition-the-rail-has-rows", ok_pre,
+         "the open project has at least one track, so the strict reader has a populated rail to enumerate",
+         f"track_count={len(live_tracks)}",
+         "opened an empty project; the expected step becomes track_header_list_empty and this went red")
+if not ok_pre:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=60)
+shot = ev.shot("rail-with-rows", settle_region=RAIL)
+
+# ---- the operation under test ----
+body = d.tool("logic_mixer", "set_volume", {"index": str(OUT_OF_RANGE), "value": "0.5"})
+ev.note("response", {"body": body})
+
+lookup = body.get("control_lookup") if isinstance(body, dict) else None
+lookup = lookup if isinstance(lookup, dict) else {}
+step = lookup.get("failed_step")
+count = lookup.get("header_count")
+
+# THE load-bearing check. `no_header_at_index` is reachable only from the `.read(headers)` branch, so
+# observing it proves `allTrackHeadersRead` enumerated the live rail rather than refusing it.
+ev.check("543/strict-reader-enumerates-the-live-rail",
+         step == "no_header_at_index",
+         "the refusal names the index step, which only the .read branch can produce — so the strict "
+         "reader succeeded against real Logic",
+         f"failed_step={step!r} header_count={count!r}",
+         "pointed the lookup at a reader that refuses Logic's real rail; the step became "
+         "track_header_list_unreadable and this went red")
+
+# Pre-fix this said `track_header_list_not_found` whenever the tolerant reader returned empty for ANY
+# reason. Naming the absent-rail step while the rail is visibly populated is the specific false statement
+# the fix exists to stop, so assert against it directly.
+ev.check("543/the-receipt-does-not-claim-a-missing-rail",
+         step != "track_header_list_not_found",
+         "with a populated rail on screen, the receipt must not report the rail as absent",
+         f"failed_step={step!r}",
+         "collapsed the three read answers back into one empty array; a strict-read failure reported "
+         "track_header_list_not_found and this went red")
+
+ev.check("543/header-count-matches-the-project",
+         count == len(live_tracks),
+         "the published header_count equals the number of tracks the project actually has",
+         f"header_count={count!r} tracks_via_resource={len(live_tracks)}",
+         "published a hard-coded 0 for header_count; this went red against a project with tracks")
+# Deliberately a note, not a `provenance` record. That affordance means "this value came from a cache
+# and is therefore not live", and the gate refuses a run that leans on one. This read is live and fresh
+# — it is simply a DIFFERENT product function reading the same application, so it corroborates the count
+# rather than independently witnessing it. Saying so here is the honest form of that distinction.
+ev.note("543/header-count-corroboration",
+        {"source": "product logic://tracks AX read, fresh", "independent_of_product": False,
+         "why": "System Events cannot address Logic's Track Headers list, so no non-product per-row "
+                "count exists; the screenshot witnesses that rows are present at all"})
+
+# The requested index is out of range, so nothing may be written. A receipt that reports a write here
+# would be the identity defect this whole surface exists to prevent.
+state = body.get("state") if isinstance(body, dict) else None
+ev.check("543/an-impossible-index-writes-nothing",
+         state == "C",
+         "an out-of-range index is refused as State C, not reported as a performed write",
+         f"state={state!r} error={body.get('error')!r}",
+         "let the lookup fall through to the first slider; the op reported a write to a track the "
+         "caller never named and this went red")
+
+after_tracks = tracks()
+ev.restored("543/no-state-was-mutated", len(after_tracks) == len(live_tracks),
+            f"track count {len(live_tracks)} -> {len(after_tracks)}; the op is refused before any write")
+
+ev.visual("543/the-rail-is-unchanged", shot["file"], ev.shot("rail-after", settle_region=RAIL)["file"],
+          RAIL, expect_change=False,
+          why="a refused lookup must leave the track rail exactly as it was; this is the pixel witness "
+              "that the run mutated nothing")
+
+ev.stop_recording(rec)
+
+d.close()
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if out.get("passed") else 1)

--- a/Scripts/livekit/live_549_cell_does_not_veto.py
+++ b/Scripts/livekit/live_549_cell_does_not_veto.py
@@ -155,6 +155,14 @@ def bring_logic_forward():
     """
     subprocess.run(["osascript", "-e", 'tell application "Logic Pro" to activate'],
                    capture_output=True, text=True)
+    # Activating the APP is not enough: the menu drive needs the arrange window to be the front WINDOW,
+    # and the Marker List — which this harness has to keep open, because it carries the trigger — takes
+    # that position. Without this raise the creates fail for an environment reason and the run reads as a
+    # product regression; that happened repeatedly today while manual runs seconds earlier certified.
+    subprocess.run(["osascript", "-e",
+                    'tell application "System Events" to tell process "Logic Pro" to '
+                    'perform action "AXRaise" of (first window whose name contains "Tracks")'],
+                   capture_output=True, text=True)
     time.sleep(1.0)
 
 

--- a/Scripts/livekit/live_549_cell_does_not_veto.py
+++ b/Scripts/livekit/live_549_cell_does_not_veto.py
@@ -137,12 +137,16 @@ if present is not True:
 
 rec = ev.record_screen(seconds=100)
 win = E.logic_window()
-# NOT the track rail: the Marker List window floats over the left of the arrange window, and it has to
-# stay open because it carries the trigger. A crop there shows the Marker List, which does not change when
-# tracks are added, so the assertion compared two identical wrong pictures and read as "nothing happened"
-# on a run that plainly worked. Sample the arrange lanes to the right of it instead.
-RAIL = (int(win["w"] * 0.45), int(win["h"] * 0.15),
-        int(win["w"] * 0.45), int(win["h"] * 0.60)) if win else None
+# Move the Marker List OFF the track rail rather than photographing somewhere else. It has to stay OPEN —
+# it carries the trigger — but it does not have to sit on top of the subject. Two earlier region choices
+# failed for opposite reasons: cropping the rail while it was covered compared two identical pictures of
+# the Marker List, and cropping the arrange lanes instead never SETTLED, because Logic animates indicators
+# there and `shot()` requires two identical frames before it will record one. The track name band changes
+# when a track is added and does not animate.
+osa('tell application "System Events" to tell process "Logic Pro" to '
+    'set position of (first window whose name contains "Marker List") to {1200, 640}')
+time.sleep(1.2)
+RAIL = (0, int(win["h"] * 0.12), int(win["w"] * 0.19), int(win["h"] * 0.45)) if win else None
 pre = ev.shot("before-create", settle_region=RAIL)
 
 # ---- the defect: create must certify with the failing node present ----
@@ -197,8 +201,8 @@ ev.check("549/the-writes-actually-landed",
 
 post = ev.shot("after-create", settle_region=RAIL)
 if RAIL:
-    ev.visual("549/new-track-lanes-appear", pre["file"], post["file"], RAIL, expect_change=True,
-              why="three tracks were added, so their lanes must appear in the arrange area")
+    ev.visual("549/new-track-name-bands-appear", pre["file"], post["file"], RAIL, expect_change=True,
+              why="three tracks were added, so their name bands must appear in the header rail")
 
 # ---- the dangerous direction: the scan must still see a REAL sheet ----
 t = tracks()

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
@@ -105,30 +105,58 @@ extension AccessibilityChannel {
             // after it), or the header was found and contains no `AXSlider` within the search depth.
             // Report which, with the counts that distinguish them. Structural facts only — roles,
             // counts, an index — no track name or other user content.
-            let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
-            let headerAtIndex = AXLogicProElements.findTrackHeader(at: index, runtime: runtime)
+            // Read the rail ONCE, status-preserving. `allTrackHeaders` flattens three
+            // different answers into one empty array, and this receipt's entire job is to
+            // name which of them happened — reporting "list not found, header_count 0" for
+            // a rail that WAS found but could not be traversed sends the reader hunting for
+            // a missing Tracks area that is on screen. Zero is evidence only in `.read([])`.
+            let headersRead: AXLogicProElements.TrackHeaderRead = AXLogicProElements
+                .mainWindow(runtime: runtime)
+                .map { AXLogicProElements.allTrackHeadersRead(in: $0, runtime: runtime) }
+                ?? .unavailable
+
+            // nil = the header at `index` WAS resolved; the slider search decides the step.
+            var stepBeforeHeader: String?
+            var headerCount: Int?
+            var headerAtIndex: AXUIElement?
+            switch headersRead {
+            case .unavailable:
+                stepBeforeHeader = "track_header_list_not_found"
+            case .unreadable:
+                // The rail exists; AX refused to enumerate it. Not an empty project.
+                stepBeforeHeader = "track_header_list_unreadable"
+            case .read(let headers):
+                headerCount = headers.count
+                // Index into the array we just read. Re-resolving via `findTrackHeader`
+                // walks the tree a second time, so a track added or removed between the
+                // two reads produced a receipt that contradicted itself — a header_count
+                // of 3 next to "no_header_at_index" for index 1 — and named a wrong root
+                // cause with full confidence.
+                if headers.isEmpty {
+                    stepBeforeHeader = "track_header_list_empty"
+                } else if index >= 0 && index < headers.count {
+                    headerAtIndex = headers[index]
+                } else {
+                    stepBeforeHeader = "no_header_at_index"
+                }
+            }
             let sliderCount = headerAtIndex.map {
                 AXHelpers.findAllDescendants(of: $0, role: kAXSliderRole, maxDepth: 4, runtime: runtime.ax).count
             }
-            let failedStep: String
-            if headers.isEmpty {
-                failedStep = "track_header_list_not_found"
-            } else if headerAtIndex == nil {
-                failedStep = "no_header_at_index"
-            } else if (sliderCount ?? 0) == 0 {
-                failedStep = "header_has_no_slider_within_depth_4"
-            } else {
-                failedStep = "sliders_present_but_none_selected"
-            }
+            let resolvedStep = stepBeforeHeader ?? ((sliderCount ?? 0) == 0
+                ? "header_has_no_slider_within_depth_4"
+                : "sliders_present_but_none_selected")
             var lookup: [String: Any] = [
-                "failed_step": failedStep,
-                "header_count": headers.count,
+                "failed_step": resolvedStep,
                 "requested_index": index,
             ]
+            // Only a successful read may state a count. Publishing 0 for an unreadable or
+            // absent rail asserts "this project has no tracks", which we did not observe.
+            if let headerCount { lookup["header_count"] = headerCount }
             if let sliderCount { lookup["sliders_in_header"] = sliderCount }
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "Cannot locate \(label) control for track \(index) — \(failedStep)",
+                hint: "Cannot locate \(label) control for track \(index) — \(resolvedStep)",
                 extras: [
                     "operation": operation,
                     "track": index,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
@@ -97,14 +97,44 @@ extension AccessibilityChannel {
         case .pan:    slider = AXLogicProElements.findTrackHeaderPanControl(at: index, runtime: runtime)
         }
         guard let slider else {
+            // #543: this refusal used to say only "cannot locate", which cannot be acted on by the
+            // person who hit it and cannot be diagnosed by anyone who cannot reproduce it. Three steps
+            // can fail here and they need different fixes: the track-header LIST was not found at all,
+            // the header at this INDEX was not found (a count mismatch — the enumerator keeps only
+            // `AXLayoutItem` children when any exist, so a header of another role shifts every index
+            // after it), or the header was found and contains no `AXSlider` within the search depth.
+            // Report which, with the counts that distinguish them. Structural facts only — roles,
+            // counts, an index — no track name or other user content.
+            let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
+            let headerAtIndex = AXLogicProElements.findTrackHeader(at: index, runtime: runtime)
+            let sliderCount = headerAtIndex.map {
+                AXHelpers.findAllDescendants(of: $0, role: kAXSliderRole, maxDepth: 4, runtime: runtime.ax).count
+            }
+            let failedStep: String
+            if headers.isEmpty {
+                failedStep = "track_header_list_not_found"
+            } else if headerAtIndex == nil {
+                failedStep = "no_header_at_index"
+            } else if (sliderCount ?? 0) == 0 {
+                failedStep = "header_has_no_slider_within_depth_4"
+            } else {
+                failedStep = "sliders_present_but_none_selected"
+            }
+            var lookup: [String: Any] = [
+                "failed_step": failedStep,
+                "header_count": headers.count,
+                "requested_index": index,
+            ]
+            if let sliderCount { lookup["sliders_in_header"] = sliderCount }
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,
-                hint: "Cannot locate \(label) control for track \(index)",
+                hint: "Cannot locate \(label) control for track \(index) — \(failedStep)",
                 extras: [
                     "operation": operation,
                     "track": index,
                     "requested": value,
                     "target_identity": targetIdentity,
+                    "control_lookup": lookup,
                     "recovery_hint": "Ensure track \(index) exists and the Tracks area is shown.",
                 ]
             ))

--- a/Tests/LogicProMCPTests/Issue543MixerLookupDiagnosticsTests.swift
+++ b/Tests/LogicProMCPTests/Issue543MixerLookupDiagnosticsTests.swift
@@ -108,7 +108,9 @@ private func attachOneSliderlessTrackHeader(
     #expect(try #require(body["error"] as? String) == "element_not_found")
     let lookup = try #require(body["control_lookup"] as? [String: Any])
     #expect(try #require(lookup["failed_step"] as? String) == "track_header_list_not_found")
-    #expect(try #require(lookup["header_count"] as? Int) == 0)
+    // No rail was read, so there is no count to report. Publishing `header_count: 0` here
+    // would assert "this project has zero tracks" from a read that never happened.
+    #expect(lookup["header_count"] == nil)
     #expect(try #require(lookup["requested_index"] as? Int) == 0)
     // No header was found, so there is nothing to have counted sliders in.
     #expect(lookup["sliders_in_header"] == nil)
@@ -218,4 +220,94 @@ private func attachOneSliderlessTrackHeader(
     let lookup = try #require(body["control_lookup"] as? [String: Any])
     #expect(try #require(lookup["failed_step"] as? String) == "header_has_no_slider_within_depth_4")
     #expect(!result.message.contains(sentinel))
+}
+
+// MARK: - 6. The rail was found but could not be enumerated
+
+/// A correctly identified `Track Headers` rail whose children read FAILS. The
+/// old code called `allTrackHeaders`, which flattens this into `[]`, and then
+/// reported `track_header_list_not_found` with `header_count: 0` — sending the
+/// reader to look for a Tracks area that is on screen and populated.
+@Test func testIssue543UnreadableRailIsNotReportedAsMissingOrEmpty() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_500)
+    let window = builder.element(543_501)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    let (rail, _) = attachOneWorkingTrackHeader(builder, window: window, baseID: 543_510)
+    let railID = builder.elementID(rail)
+    // Fail the children read for the rail ONLY, so the rail is still discovered as a
+    // candidate and the failure lands in enumeration, where it belongs. BOTH readers must
+    // fail: a real `kAXErrorCannotComplete` from the window server is seen as an empty
+    // array by the legacy `children` accessor and as `.failure` by the status-preserving
+    // one. Failing only the latter left the actual fader lookup succeeding, so the
+    // diagnostic branch was never entered and this test passed on the wrong path.
+    let isRail: @Sendable (AXUIElement) -> Bool = { element in
+        Int(bitPattern: Unmanaged.passUnretained(element).toOpaque()) == railID
+    }
+    let runtime = builder.makeLogicRuntime(
+        appElement: app,
+        childrenHandler: { isRail($0) ? [] : nil },
+        childrenResultHandler: {
+            isRail($0) ? .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)) : nil
+        },
+        setAttributeHandler: nil,
+        performActionHandler: nil
+    )
+
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let lookup = try #require(decodeIssue543JSON(result.message)["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "track_header_list_unreadable")
+    // The two claims this receipt must never make about an unreadable rail.
+    #expect(lookup["header_count"] == nil)
+    #expect(try #require(lookup["failed_step"] as? String) != "track_header_list_not_found")
+}
+
+/// Control for the test above: the SAME fixture without the induced failure
+/// must resolve the header. Without this, `track_header_list_unreadable` could
+/// be produced by a fixture that never built a rail at all, and the test would
+/// pass for a reason unrelated to the mutation it claims to detect.
+@Test func testIssue543UnreadableRailControlResolvesWhenChildrenReadSucceeds() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_600)
+    let window = builder.element(543_601)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    attachOneWorkingTrackHeader(builder, window: window, baseID: 543_610)
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    // Index 0 resolves a real slider here, so the op gets past the lookup guard
+    // entirely — proving the fixture's rail is well-formed and readable.
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    let body = decodeIssue543JSON(result.message)
+    #expect(body["control_lookup"] == nil)
+}
+
+// MARK: - 7. The rail was read and is genuinely empty
+
+/// A readable `Track Headers` rail with no rows. This IS the case where zero is
+/// evidence, and it must be distinguishable from both of the above.
+@Test func testIssue543EmptyButReadableRailReportsEmptyWithACount() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_700)
+    let window = builder.element(543_701)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    let rail = builder.element(543_710)
+    builder.setAttribute(rail, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(rail, kAXIdentifierAttribute as String, "Track Headers")
+    builder.setChildren(rail, [])
+    builder.setChildren(window, [rail])
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let lookup = try #require(decodeIssue543JSON(result.message)["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "track_header_list_empty")
+    // Here the read succeeded, so the count is an observation and may be stated.
+    #expect(try #require(lookup["header_count"] as? Int) == 0)
 }

--- a/Tests/LogicProMCPTests/Issue543MixerLookupDiagnosticsTests.swift
+++ b/Tests/LogicProMCPTests/Issue543MixerLookupDiagnosticsTests.swift
@@ -1,0 +1,221 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// #543: `mixer.set_volume` / `mixer.set_pan` used to refuse with only
+// "Cannot locate <label> control for track <n>" — one message for three
+// distinguishable failures (no track-header rail at all, an out-of-range
+// index, or a header with no slider). The fix names WHICH step failed in a
+// `control_lookup` object so a reporter who cannot reproduce the bug locally
+// can still tell the maintainer which of the three broke. These tests drive
+// `AccessibilityChannel.defaultSetMixerValue` directly against a fake AX
+// runtime (the same `FakeAXRuntimeBuilder` seam `AccessibilityChannelTests`
+// uses) so each of the three lookup steps is provably exercised.
+
+/// Decodes a State-C JSON receipt into a plain dictionary for field assertions.
+private func decodeIssue543JSON(_ s: String) -> [String: Any] {
+    (try? JSONSerialization.jsonObject(with: Data(s.utf8))) as? [String: Any] ?? [:]
+}
+
+/// A bare app+window with no track-header rail anywhere in the tree: the
+/// container lookup (`getTrackHeaders`) fails outright.
+private func makeNoTrackHeaderRailRuntime() -> AXLogicProElements.Runtime {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_000)
+    let window = builder.element(543_001)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    // Deliberately no children on `window` — no list/scroll-area/group/outline
+    // candidate exists for `getTrackHeaders` to find.
+    return builder.makeLogicRuntime(appElement: app)
+}
+
+/// One track-header row (Logic-12-style `AXList id="Track Headers"` rail)
+/// carrying both a volume fader and a pan slider, so index 0 resolves a
+/// working control. `trackTitle`, when supplied, is set as the header's
+/// `AXTitle` — a distinctive value used only to prove it never leaks into
+/// the failure receipt of an unrelated index.
+@discardableResult
+private func attachOneWorkingTrackHeader(
+    _ builder: FakeAXRuntimeBuilder,
+    window: AXUIElement,
+    baseID: Int,
+    trackTitle: String? = nil
+) -> (rail: AXUIElement, header: AXUIElement) {
+    let rail = builder.element(baseID)
+    builder.setAttribute(rail, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(rail, kAXIdentifierAttribute as String, "Track Headers")
+    let header = builder.element(baseID + 1)
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    if let trackTitle {
+        builder.setAttribute(header, kAXTitleAttribute as String, trackTitle)
+    }
+    let volumeSlider = builder.element(baseID + 2)
+    builder.setAttribute(volumeSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(volumeSlider, kAXDescriptionAttribute as String, "Volume")
+    builder.setAttribute(volumeSlider, kAXValueAttribute as String, 100.0)
+    builder.setAttribute(volumeSlider, kAXMinValueAttribute as String, 0.0)
+    builder.setAttribute(volumeSlider, kAXMaxValueAttribute as String, 200.0)
+    let panSlider = builder.element(baseID + 3)
+    builder.setAttribute(panSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(panSlider, kAXDescriptionAttribute as String, "")
+    builder.setAttribute(panSlider, kAXValueAttribute as String, 64.0)
+    builder.setAttribute(panSlider, kAXMinValueAttribute as String, 0.0)
+    builder.setAttribute(panSlider, kAXMaxValueAttribute as String, 127.0)
+    builder.setChildren(header, [volumeSlider, panSlider])
+    builder.setChildren(rail, [header])
+    builder.setChildren(window, [rail])
+    return (rail, header)
+}
+
+/// One track-header row with the rail correctly resolved, but the header
+/// itself has NO `AXSlider` descendants at all (its only child is an
+/// unrelated static-text row) — exercises the depth-4-slider-search miss.
+/// `trackTitle`, when supplied, is set as the header's `AXTitle`.
+@discardableResult
+private func attachOneSliderlessTrackHeader(
+    _ builder: FakeAXRuntimeBuilder,
+    window: AXUIElement,
+    baseID: Int,
+    trackTitle: String? = nil
+) -> (rail: AXUIElement, header: AXUIElement) {
+    let rail = builder.element(baseID)
+    builder.setAttribute(rail, kAXRoleAttribute as String, kAXListRole as String)
+    builder.setAttribute(rail, kAXIdentifierAttribute as String, "Track Headers")
+    let header = builder.element(baseID + 1)
+    builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+    if let trackTitle {
+        builder.setAttribute(header, kAXTitleAttribute as String, trackTitle)
+    }
+    let nameField = builder.element(baseID + 2)
+    builder.setAttribute(nameField, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(nameField, kAXValueAttribute as String, trackTitle ?? "Untitled")
+    builder.setChildren(header, [nameField])
+    builder.setChildren(rail, [header])
+    builder.setChildren(window, [rail])
+    return (rail, header)
+}
+
+// MARK: - 1. No track headers at all
+
+@Test func testIssue543MissingRailReportsTrackHeaderListNotFound() throws {
+    let runtime = makeNoTrackHeaderRailRuntime()
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let body = decodeIssue543JSON(result.message)
+    #expect(try #require(body["error"] as? String) == "element_not_found")
+    let lookup = try #require(body["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "track_header_list_not_found")
+    #expect(try #require(lookup["header_count"] as? Int) == 0)
+    #expect(try #require(lookup["requested_index"] as? Int) == 0)
+    // No header was found, so there is nothing to have counted sliders in.
+    #expect(lookup["sliders_in_header"] == nil)
+}
+
+// MARK: - 2. Headers exist, requested index out of range
+
+@Test func testIssue543OutOfRangeIndexReportsNoHeaderAtIndexWithRealCount() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_100)
+    let window = builder.element(543_101)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    attachOneWorkingTrackHeader(builder, window: window, baseID: 543_110)
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    // Only one header exists (index 0); ask for index 5.
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "5", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let body = decodeIssue543JSON(result.message)
+    #expect(try #require(body["error"] as? String) == "element_not_found")
+    let lookup = try #require(body["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "no_header_at_index")
+    #expect(try #require(lookup["header_count"] as? Int) == 1)
+    #expect(try #require(lookup["requested_index"] as? Int) == 5)
+    #expect(lookup["sliders_in_header"] == nil)
+}
+
+// MARK: - 3. Header found, no slider within depth 4
+
+@Test func testIssue543SliderlessHeaderReportsHeaderHasNoSliderWithinDepth4() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_200)
+    let window = builder.element(543_201)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    attachOneSliderlessTrackHeader(builder, window: window, baseID: 543_210)
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let body = decodeIssue543JSON(result.message)
+    #expect(try #require(body["error"] as? String) == "element_not_found")
+    let lookup = try #require(body["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "header_has_no_slider_within_depth_4")
+    #expect(try #require(lookup["header_count"] as? Int) == 1)
+    #expect(try #require(lookup["requested_index"] as? Int) == 0)
+    #expect(try #require(lookup["sliders_in_header"] as? Int) == 0)
+}
+
+// MARK: - 4. The pre-existing State-C contract is unchanged (additive only)
+
+@Test func testIssue543ControlLookupIsAdditiveToPreexistingStateCContract() throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_300)
+    let window = builder.element(543_301)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    attachOneWorkingTrackHeader(builder, window: window, baseID: 543_310)
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "9", "value": "0.5"], target: .pan, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    let body = decodeIssue543JSON(result.message)
+
+    // Pre-existing fields (#543 is additive — none of these may move).
+    #expect(try #require(body["error"] as? String) == "element_not_found")
+    #expect(try #require(body["state"] as? String) == "C")
+    #expect(try #require(body["operation"] as? String) == "mixer.set_pan")
+    #expect(try #require(body["track"] as? Int) == 9)
+    #expect(try #require(body["requested"] as? Double) == 0.5)
+    let targetIdentity = try #require(body["target_identity"] as? [String: Any])
+    #expect(try #require(targetIdentity["track_index"] as? Int) == 9)
+    #expect(try #require(targetIdentity["control"] as? String) == "pan")
+    let recoveryHint = try #require(body["recovery_hint"] as? String)
+    #expect(recoveryHint.contains("9"))
+
+    // New field is present alongside, not instead of, the above.
+    let lookup = try #require(body["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "no_header_at_index")
+}
+
+// MARK: - 5. No user content — diagnostics are structural only
+
+@Test func testIssue543DiagnosticsCarryNoTrackNameContent() throws {
+    let sentinel = "SENTINEL_TRACK_NAME_9f3c2b_DO_NOT_LEAK"
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(543_400)
+    let window = builder.element(543_401)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    // The header the code actually resolves (index 0) carries the sentinel as
+    // its title AND as a child static-text value — the two most likely spots
+    // a careless diagnostic addition would read a "name" from.
+    attachOneSliderlessTrackHeader(builder, window: window, baseID: 543_410, trackTitle: sentinel)
+    let runtime = builder.makeLogicRuntime(appElement: app)
+
+    let result = AccessibilityChannel.defaultSetMixerValue(
+        params: ["index": "0", "value": "0.5"], target: .volume, runtime: runtime
+    )
+    #expect(!result.isSuccess)
+    // Sanity: this fixture does reach the header (not the empty-rail or
+    // out-of-range branch) — otherwise the sentinel's absence would be vacuous.
+    let body = decodeIssue543JSON(result.message)
+    let lookup = try #require(body["control_lookup"] as? [String: Any])
+    #expect(try #require(lookup["failed_step"] as? String) == "header_has_no_slider_within_depth_4")
+    #expect(!result.message.contains(sentinel))
+}


### PR DESCRIPTION
**Observability, not a fix — and it says so.** #543 does not reproduce here: `set_volume` and `set_pan`
both return State A on this machine, at several track counts, in both views. There is nothing to fix
against yet.

`element_not_found` answered "Cannot locate <label> control for track <n>" and nothing else. Three
different failures produce that identical message and each needs a different fix, so neither the reporter
nor anyone reading the issue can tell them apart. The receipt now names the step:

```
track_header_list_not_found           the track-header list was not found at all
no_header_at_index                    headers exist, none at this index — a count mismatch
header_has_no_slider_within_depth_4   header found, no AXSlider inside it
sliders_present_but_none_selected
```

with `header_count`, `requested_index`, and `sliders_in_header` when a header was found.

**The middle step is the one I would look at first.** `allTrackHeaders` keeps only `AXLayoutItem` direct
children when any exist, so a header of another role is dropped and every index after it shifts — which
presents exactly as this issue describes, every index failing, and is invisible in the current receipt.
That enumerator was also flagged as a deferred MAJOR during #542's review.

**Structural facts only.** Counts, an index, a step name — no track name or other user content. A test
builds a sentinel track name and asserts it never appears in the serialized receipt, because a diagnostic
carrying the user's project cannot be pasted into the report it exists to serve.

| | |
|---|---|
| Suite | **3765 passed** |
| Ship gate | **PASS** |
| Live | 5/5, mutation-backed, visual passing, captures settled |

Additive only: `error`, `state`, `operation`, `track`, `requested`, `target_identity` and `recovery_hint`
keep their existing names and meanings, asserted by a test rather than assumed.

Also here, from fighting this branch's own live runs: the harness now raises the arrange WINDOW rather
than just activating the app (the menu drive needs it frontmost, and the Marker List was taking that
position), and moves the Marker List off the region it photographs instead of photographing somewhere
else — the previous region never settled, because Logic animates indicators there.