### PR TITLE
fix(#554): the AX status pair moves with the reason it annotates

### DIFF
--- a/Scripts/livekit/live_549_cell_does_not_veto.py
+++ b/Scripts/livekit/live_549_cell_does_not_veto.py
@@ -137,12 +137,16 @@ if present is not True:
 
 rec = ev.record_screen(seconds=100)
 win = E.logic_window()
-# NOT the track rail: the Marker List window floats over the left of the arrange window, and it has to
-# stay open because it carries the trigger. A crop there shows the Marker List, which does not change when
-# tracks are added, so the assertion compared two identical wrong pictures and read as "nothing happened"
-# on a run that plainly worked. Sample the arrange lanes to the right of it instead.
-RAIL = (int(win["w"] * 0.45), int(win["h"] * 0.15),
-        int(win["w"] * 0.45), int(win["h"] * 0.60)) if win else None
+# Move the Marker List OFF the track rail rather than photographing somewhere else. It has to stay OPEN —
+# it carries the trigger — but it does not have to sit on top of the subject. Two earlier region choices
+# failed for opposite reasons: cropping the rail while it was covered compared two identical pictures of
+# the Marker List, and cropping the arrange lanes instead never SETTLED, because Logic animates indicators
+# there and `shot()` requires two identical frames before it will record one. The track name band changes
+# when a track is added and does not animate.
+osa('tell application "System Events" to tell process "Logic Pro" to '
+    'set position of (first window whose name contains "Marker List") to {1200, 640}')
+time.sleep(1.2)
+RAIL = (0, int(win["h"] * 0.12), int(win["w"] * 0.19), int(win["h"] * 0.45)) if win else None
 pre = ev.shot("before-create", settle_region=RAIL)
 
 # ---- the defect: create must certify with the failing node present ----
@@ -154,6 +158,14 @@ def bring_logic_forward():
     posting.
     """
     subprocess.run(["osascript", "-e", 'tell application "Logic Pro" to activate'],
+                   capture_output=True, text=True)
+    # Activating the APP is not enough: the menu drive needs the arrange window to be the front WINDOW,
+    # and the Marker List — which this harness has to keep open, because it carries the trigger — takes
+    # that position. Without this raise the creates fail for an environment reason and the run reads as a
+    # product regression; that happened repeatedly today while manual runs seconds earlier certified.
+    subprocess.run(["osascript", "-e",
+                    'tell application "System Events" to tell process "Logic Pro" to '
+                    'perform action "AXRaise" of (first window whose name contains "Tracks")'],
                    capture_output=True, text=True)
     time.sleep(1.0)
 
@@ -189,8 +201,8 @@ ev.check("549/the-writes-actually-landed",
 
 post = ev.shot("after-create", settle_region=RAIL)
 if RAIL:
-    ev.visual("549/new-track-lanes-appear", pre["file"], post["file"], RAIL, expect_change=True,
-              why="three tracks were added, so their lanes must appear in the arrange area")
+    ev.visual("549/new-track-name-bands-appear", pre["file"], post["file"], RAIL, expect_change=True,
+              why="three tracks were added, so their name bands must appear in the header rail")
 
 # ---- the dangerous direction: the scan must still see a REAL sheet ----
 t = tracks()

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -86,14 +86,28 @@ extension AccessibilityChannel {
         }
 
         var envelopeExtras: [String: Any] {
-            var extras: [String: Any] = [
-                "reconciled_modal_unreadable_reason": wireReason
-            ]
+            var extras: [String: Any] = [:]
+            apply(to: &extras)
+            return extras
+        }
+
+        /// #554: write this failure's fields TOTALLY — set the status pair, or remove it.
+        ///
+        /// `verifyTrackCreation` merges twice into one dictionary, and the status keys were written only
+        /// when the reason carried a status. A reason that carries none — `stray_menu_read_failed`,
+        /// `descendant_traversal_depth_cap` — therefore left the PREVIOUS reason's status standing beside
+        /// it, so a receipt could read `stray_menu_read_failed` with a `-25200` that belonged to a sheet
+        /// scan in an earlier poll. These two fields annotate whichever reason is currently reported;
+        /// they have to move with it or they describe something else.
+        func apply(to extras: inout [String: Any]) {
+            extras["reconciled_modal_unreadable_reason"] = wireReason
             if let status, let symbolicName = status.symbolicName {
                 extras["reconciled_modal_unreadable_ax_status"] = Int(status.raw)
                 extras["reconciled_modal_unreadable_ax_status_name"] = symbolicName
+            } else {
+                extras.removeValue(forKey: "reconciled_modal_unreadable_ax_status")
+                extras.removeValue(forKey: "reconciled_modal_unreadable_ax_status_name")
             }
-            return extras
         }
     }
 
@@ -2016,9 +2030,7 @@ extension AccessibilityChannel {
             // The classifier kind alone does not explain whether a discovered
             // blocker was unknown or a no-modal observation was incomplete.
             // This fixed diagnostic provenance carries that distinction.
-            for (key, value) in unreadableReason.envelopeExtras {
-                extras[key] = value
-            }
+            unreadableReason.apply(to: &extras)
         }
         // #549: which exact node/scan/attribute the sheet scan gave up on,
         // ADDITIVE beside the existing status-only fields above.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+ModalReconcile.swift
@@ -85,12 +85,6 @@ extension AccessibilityChannel {
             }
         }
 
-        var envelopeExtras: [String: Any] {
-            var extras: [String: Any] = [:]
-            apply(to: &extras)
-            return extras
-        }
-
         /// #554: write this failure's fields TOTALLY — set the status pair, or remove it.
         ///
         /// `verifyTrackCreation` merges twice into one dictionary, and the status keys were written only
@@ -101,9 +95,15 @@ extension AccessibilityChannel {
         /// they have to move with it or they describe something else.
         func apply(to extras: inout [String: Any]) {
             extras["reconciled_modal_unreadable_reason"] = wireReason
-            if let status, let symbolicName = status.symbolicName {
+            // Gate on the STATUS, not on its symbolic name. `AXStatusError.malformedAttribute` is a
+            // production sentinel (`Int32.min + 1`) that is deliberately outside `AXError`, so it has no
+            // symbolic name — and keying on the name deleted both fields for a failure that HAD a status,
+            // turning "we did not read one" into an assertion that none existed. That sentinel exists
+            // precisely to publish "a malformed payload has not said false"; dropping it at the exposure
+            // boundary destroys the distinction it was added for. `diagnosticLabel` names both kinds.
+            if let status {
                 extras["reconciled_modal_unreadable_ax_status"] = Int(status.raw)
-                extras["reconciled_modal_unreadable_ax_status_name"] = symbolicName
+                extras["reconciled_modal_unreadable_ax_status_name"] = status.symbolicName ?? status.diagnosticLabel
             } else {
                 extras.removeValue(forKey: "reconciled_modal_unreadable_ax_status")
                 extras.removeValue(forKey: "reconciled_modal_unreadable_ax_status_name")

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -257,9 +257,7 @@ extension AccessibilityChannel {
             // boundary, but the bounded observer retried this read throughout
             // its budget.
             extras["modal_observation"] = "incomplete"
-            for (key, value) in modalUnreadableReason.envelopeExtras {
-                extras[key] = value
-            }
+            modalUnreadableReason.apply(to: &extras)
             // See mergeReconcileExtras: a sheet-scan failure carrying no companion detail says so
             // rather than omitting the field, because an omitted field reads as "no unreadable node".
             if let modalSheetScanFailureDetail {
@@ -447,9 +445,7 @@ extension AccessibilityChannel {
                     "safe_to_retry": false,
                 ]
                 if let lastModalUnreadableReason {
-                    for (key, value) in lastModalUnreadableReason.envelopeExtras {
-                        extras[key] = value
-                    }
+                    lastModalUnreadableReason.apply(to: &extras)
                 }
                 // See mergeReconcileExtras: an omitted field would read as "no unreadable node".
                 if let lastModalSheetScanFailureDetail {

--- a/Tests/LogicProMCPTests/Issue554StatusFollowsItsReasonTests.swift
+++ b/Tests/LogicProMCPTests/Issue554StatusFollowsItsReasonTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import LogicProMCP
+
+/// #554 — the AX-status pair annotates whichever unreadable reason a receipt currently reports, so it has
+/// to be written totally: set when the reason carries a status, REMOVED when it does not.
+///
+/// `verifyTrackCreation` merges twice into one dictionary. The status keys used to be written only when a
+/// status existed, so a second reason without one left the first reason's status standing beside it — a
+/// `stray_menu_read_failed` envelope carrying a `-25200` that belonged to a sheet scan in an earlier
+/// poll. That is a number describing a different failure, which is worse than no number.
+@Suite("Issue #554 — the AX status pair moves with the reason it annotates")
+struct Issue554StatusFollowsItsReasonTests {
+
+    @Test("a reason with no status clears a status left by an earlier reason")
+    func statusIsClearedWhenTheNewReasonHasNone() throws {
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.ModalReadFailure
+            .windowSheetReadFailed(AXHelpers.AXStatusError(raw: -25200))
+            .apply(to: &extras)
+        let first = try #require(extras["reconciled_modal_unreadable_ax_status"] as? Int)
+        #expect(first == -25200)
+
+        // A later poll fails for a reason that carries no AX status at all.
+        AccessibilityChannel.ModalReadFailure.strayMenuReadFailed.apply(to: &extras)
+
+        let reason = try #require(extras["reconciled_modal_unreadable_reason"] as? String)
+        #expect(reason == "stray_menu_read_failed")
+        #expect(
+            extras["reconciled_modal_unreadable_ax_status"] == nil,
+            "a status from the previous reason must not survive beside a reason that has none"
+        )
+        #expect(extras["reconciled_modal_unreadable_ax_status_name"] == nil)
+    }
+
+    @Test("a reason that carries a status still publishes it")
+    func statusIsPublishedWhenPresent() throws {
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.ModalReadFailure
+            .mainWindowReadFailed(AXHelpers.AXStatusError(raw: -25204))
+            .apply(to: &extras)
+        let status = try #require(extras["reconciled_modal_unreadable_ax_status"] as? Int)
+        #expect(status == -25204)
+        let name = try #require(extras["reconciled_modal_unreadable_ax_status_name"] as? String)
+        #expect(!name.isEmpty)
+    }
+
+    @Test("a later status replaces an earlier one rather than either surviving")
+    func aNewStatusReplacesTheOld() throws {
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.ModalReadFailure
+            .windowSheetReadFailed(AXHelpers.AXStatusError(raw: -25200))
+            .apply(to: &extras)
+        AccessibilityChannel.ModalReadFailure
+            .axWindowsReadFailed(AXHelpers.AXStatusError(raw: -25204))
+            .apply(to: &extras)
+        let status = try #require(extras["reconciled_modal_unreadable_ax_status"] as? Int)
+        #expect(status == -25204)
+        let reason = try #require(extras["reconciled_modal_unreadable_reason"] as? String)
+        #expect(reason == "axwindows_read_failed")
+    }
+}

--- a/Tests/LogicProMCPTests/Issue554StatusFollowsItsReasonTests.swift
+++ b/Tests/LogicProMCPTests/Issue554StatusFollowsItsReasonTests.swift
@@ -1,3 +1,4 @@
+@preconcurrency import ApplicationServices
 import Testing
 import Foundation
 @testable import LogicProMCP
@@ -59,4 +60,40 @@ struct Issue554StatusFollowsItsReasonTests {
         let reason = try #require(extras["reconciled_modal_unreadable_reason"] as? String)
         #expect(reason == "axwindows_read_failed")
     }
+}
+
+// MARK: - The sentinel sources have no symbolic name, and are not "no status"
+
+/// `AXStatusError.malformedAttribute` and `.malformedChildren` are production sentinels deliberately
+/// outside `AXError`, so `symbolicName` is nil for both. Gating the pair on the NAME deleted the status
+/// field as well, publishing a receipt that says no unreadable status existed — for the exact failures
+/// those sentinels were introduced to make visible.
+@Test func testIssue554MalformedSourcesStillPublishTheirStatusPair() throws {
+    let cases: [(AXHelpers.AXStatusError, String, Int)] = [
+        (.malformedAttribute, "malformed_attribute", Int(Int32.min) + 1),
+        (.malformedChildren, "malformed_children", Int(Int32.min)),
+    ]
+    for (status, expectedName, expectedRaw) in cases {
+        // Precondition: this is the shape that broke it. If a future change gives these sources a
+        // symbolic name this test would silently stop covering the regression, so assert the absence.
+        #expect(status.symbolicName == nil)
+
+        var extras: [String: Any] = [:]
+        AccessibilityChannel.ModalReadFailure.windowSheetReadFailed(status).apply(to: &extras)
+
+        #expect(try #require(extras["reconciled_modal_unreadable_ax_status"] as? Int) == expectedRaw)
+        #expect(try #require(extras["reconciled_modal_unreadable_ax_status_name"] as? String) == expectedName)
+    }
+}
+
+/// Control: an ordinary `AXError`-backed status must still publish its symbolic spelling, not the bare
+/// number. Without this, the fix above could be satisfied by rendering every status as `diagnosticLabel`,
+/// which degrades the common case from `cannotComplete` to `-25204`.
+@Test func testIssue554OrdinaryStatusStillPublishesItsSymbolicName() throws {
+    var extras: [String: Any] = [:]
+    AccessibilityChannel.ModalReadFailure
+        .windowSheetReadFailed(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+        .apply(to: &extras)
+    #expect(try #require(extras["reconciled_modal_unreadable_ax_status_name"] as? String) == "cannotComplete")
+    #expect(try #require(extras["reconciled_modal_unreadable_ax_status"] as? Int) == Int(AXError.cannotComplete.rawValue))
 }


### PR DESCRIPTION
Fixes the unambiguous half of #554. The rest is deliberately left open.

`verifyTrackCreation` merges twice into one dictionary, and the status keys were written only when the
reason carried a status. A later reason that carries none — `stray_menu_read_failed`,
`descendant_traversal_depth_cap` — left the earlier reason's status standing beside it, so a receipt could
read `stray_menu_read_failed` with a `-25200` that belonged to a sheet scan in an earlier poll.

**A number describing a different failure is worse than no number**, because it is specific and therefore
believed. That is the property the #549 node field exists to protect, and this was the same defect one
field over.

`ModalReadFailure.apply(to:)` now writes the reason and its status pair totally — set when there is one,
removed when there is not — and every site that copied `envelopeExtras` key by key calls it.

### What is NOT fixed here, and why

#554 lists the other conditionally-written keys in that function. They are untouched on purpose: some of
that survival is **intended**. #348 records a pre-create reconciliation deliberately, so
`reconciled_modal_kind` surviving the first merge is documented behaviour, not a bug. Deciding which of the
remaining fields are latest-wins and which are historical changes published receipt meaning — wider than
this defect needed. Two of them I could not classify from the code at all, and said so in the issue rather
than guessing.

These two are unambiguous because they annotate whichever reason is currently reported.

| | |
|---|---|
| Suite | **3763 passed** |
| Ship gate | **PASS** |
| Live | 5/5, mutation-backed, captures settled, visual passing |

Mutation: removing the clearing branch reproduces the stale pair exactly — `-25200` and `failure` sitting
beside `stray_menu_read_failed`.