### PR TITLE
feat(#552): make the preflight impossible to walk past

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Self-test the preflight stamp gate (#552)
+        # The stamp only helps if it actually refuses. This asserts NOT-STAMPED is 1, stamped is 0, an
+        # unresolvable tree-ish is 2, and the hook refuses an unstamped commit while allowing a deletion.
+        run: bash Scripts/test-preflight-stamp.sh
+
       - name: Self-test the menu-literal guard (#519)
         # A guard nobody has watched fail is decoration. This asserts each known evasion is caught, that
         # legitimate code is not flagged, and that a tree the guard cannot examine is never reported
@@ -73,6 +78,11 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Self-test the preflight stamp gate (#552)
+        # The stamp only helps if it actually refuses. This asserts NOT-STAMPED is 1, stamped is 0, an
+        # unresolvable tree-ish is 2, and the hook refuses an unstamped commit while allowing a deletion.
+        run: bash Scripts/test-preflight-stamp.sh
 
       - name: Self-test the menu-literal guard (#519)
         # A guard nobody has watched fail is decoration. This asserts each known evasion is caught, that

--- a/Scripts/README-hooks.md
+++ b/Scripts/README-hooks.md
@@ -1,0 +1,34 @@
+
+## #552 — the preflight stamp
+
+`Scripts/preflight-stamp.sh` records that the public-surface preflight passed for a specific **tree**, and
+`Scripts/pre-push-require-stamp.sh` refuses to push a tree with no such record.
+
+Install once per clone:
+
+```sh
+ln -sf ../../Scripts/pre-push-require-stamp.sh .git/hooks/pre-push.commitlore-chained
+chmod +x .git/hooks/pre-push.commitlore-chained
+```
+
+It goes in the *chained* slot because `.git/hooks/pre-push` is a CommitLore shim that rewrites itself on
+reinstall; the shim runs `pre-push.commitlore-chained` first and preserves it. The execute bit is
+load-bearing — the shim only runs the chained hook when it is `-x`.
+
+**Keyed over content, the commit object, and the base.** An earlier revision keyed on the tree alone and
+advertised "a message-only amend keeps its stamp" as the design win. That property was the exploit: the
+preflight's C1a check greps **commit messages** for internal-process metadata, and messages are not in the
+tree, so `git commit --amend -m "<forbidden metadata>"` kept a valid stamp and the gate permitted exactly
+the class it refuses. An amend now invalidates the stamp.
+
+**What this does and does not defend against.** It defends against *forgetting* the preflight. It does
+**not** defend against bypassing it: `record` verifies nothing — deliberately, because a recorder that
+also verified could certify its own work — so one `touch` in the stamp directory forges a pass that is
+indistinguishable from a real one. Treat the stamp as a reminder with teeth, not as proof.
+
+**Run the install from the main clone**, not a linked worktree: there `.git` is a file, not a directory,
+and the relative symlink will not resolve.
+
+`~/.claude/scripts/lpm-ship.sh` records the stamp when the preflight passes, so the normal path needs no
+extra step. `bash Scripts/test-preflight-stamp.sh` proves the gate refuses an unstamped tree; it runs in
+CI beside the other guards.

--- a/Scripts/pre-push-require-stamp.sh
+++ b/Scripts/pre-push-require-stamp.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# #552 — refuse to push a tree whose public-surface preflight was never recorded as passing.
+#
+# Install as the CommitLore chained hook, which the installed `pre-push` shim runs first and preserves
+# across reinstalls (measured in v1.0.2: it execs `pre-push.commitlore-chained` when that file is `-x`):
+#
+#   ln -sf ../../Scripts/pre-push-require-stamp.sh .git/hooks/pre-push.commitlore-chained
+#   chmod +x .git/hooks/pre-push.commitlore-chained     # the execute bit is load-bearing
+#
+# With this installed it no longer matters HOW the preflight was invoked. Chained with `&&` after a `tail`
+# that swallowed the exit code, run from the wrong directory, or not run at all — the push stops, because
+# the check has moved from something you must remember to something you must pass.
+#
+# Deletions and branch removals pass: there is no tree to have verified.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+STAMPER="$REPO_ROOT/Scripts/preflight-stamp.sh"
+if [ ! -f "$STAMPER" ]; then
+    # This used to `exit 0` silently, which meant the gate switched itself off from WORKING-TREE state:
+    # check out any branch forked before this script existed, or move one file, and pushes went through
+    # with no message at all — indistinguishable from a pass. Say so on stderr instead of vanishing.
+    echo "pre-push: no Scripts/preflight-stamp.sh in the working tree — stamp gate NOT enforced" >&2
+    exit 0
+fi
+
+FAILED=0
+# `|| [ -n ... ]` because `read` returns non-zero on a final line with no trailing newline, which
+# silently dropped that ref and left FAILED at 0 — a vacuous hook for any hand-fed stdin.
+while read -r _local_ref local_sha _remote_ref remote_sha || [ -n "${local_sha:-}" ]; do
+    [ -z "${local_sha:-}" ] && continue
+    case "$local_sha" in
+        0000000000000000000000000000000000000000) continue ;;   # deletion
+    esac
+    if ! bash "$STAMPER" check "$local_sha" >/dev/null 2>&1; then
+        TREE=$(git rev-parse "${local_sha}^{tree}" 2>/dev/null)
+        echo "pre-push REFUSED: no passing-preflight stamp for tree ${TREE:-<unresolved>} (commit ${local_sha:0:8})" >&2
+        echo "  The preflight is not recorded as having passed for this exact content." >&2
+        echo "  Run the ship gate — it records the stamp for you:" >&2
+        echo "    ~/.claude/scripts/lpm-ship.sh . --push origin <branch>" >&2
+        echo "  Amending a message alone does NOT invalidate a stamp: it is keyed to the tree." >&2
+        FAILED=1
+    fi
+done
+
+exit "$FAILED"

--- a/Scripts/preflight-stamp.sh
+++ b/Scripts/preflight-stamp.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# #552 — record that the public-surface preflight passed for a specific TREE, and answer whether a given
+# tree is stamped.
+#
+# Why a stamp exists at all: the preflight only protects what it is invoked on, and three times it was
+# walked past — piped through `tail`, which swallows its exit code, so `&&` proceeded while `PREFLIGHT
+# FAIL` scrolled by on screen. `lpm-ship.sh` was written to make that impossible and works, but only when
+# someone remembers to use it, and hand-chaining recurs exactly when people are in a hurry. A stamp moves
+# the check from a place that must be INVOKED to a place that must be PASSED.
+#
+# WHAT THE KEY MUST COVER — and an earlier version of this file got it wrong in the most dangerous way.
+#
+# The first version keyed on the TREE alone and advertised "an amend that only rewords a message keeps its
+# stamp" as the design win. That property was the exploit. The preflight this stamp attests is NOT a
+# function of the tree: its C1a check greps COMMIT MESSAGES in `$BASE..$HEAD` for internal-process
+# metadata, and messages are not in the tree. So `git commit --amend -m "<forbidden metadata>"` produced a
+# new commit, the same tree, a still-valid stamp, and a permitted push — the gate certifying precisely the
+# class it exists to refuse, by the one operation the documentation promised was safe.
+#
+# The key is therefore over (tree, HEAD commit object, BASE sha): the content, the messages, and the range
+# the preflight diffed against. An amend now DOES invalidate the stamp, because an amend can change
+# something the preflight read. That costs a re-run on a reword, and that cost is correct — the previous
+# saving was purchased with a hole.
+#
+# Usage:
+#   Scripts/preflight-stamp.sh record [<tree-ish>]   run nothing; record that the caller verified this tree
+#   Scripts/preflight-stamp.sh check  [<tree-ish>]   exit 0 stamped, 1 not stamped, 2 cannot tell
+#   Scripts/preflight-stamp.sh path                  print the stamp file location
+#
+# `record` deliberately does NOT run the preflight itself. A recorder that also verifies would be trusted
+# to do both and could then certify its own work; this only writes down a result someone else produced.
+set -uo pipefail
+
+STAMP_DIR="${LPM_STAMP_DIR:-$(git rev-parse --git-dir 2>/dev/null)/lpm-preflight}"
+MODE="${1:-check}"
+TREEISH="${2:-HEAD}"
+
+# The stamp key: content + commit object + the base the preflight diffed against. `BASE` matters because
+# every diff-based check is relative to it, and `LPM_BASE` can move it.
+stamp_key () {
+    local tree commit base
+    tree=$(git rev-parse "${TREEISH}^{tree}" 2>/dev/null) || return 1
+    commit=$(git rev-parse "${TREEISH}^{commit}" 2>/dev/null) || return 1
+    base=$(git rev-parse "${LPM_BASE:-origin/main}" 2>/dev/null || echo "no-base")
+    [ -n "$tree" ] && [ -n "$commit" ] || return 1
+    printf '%s %s %s' "$tree" "$commit" "$base" | shasum -a 256 | cut -d" " -f1
+}
+
+case "$MODE" in
+  path)
+    echo "$STAMP_DIR"
+    ;;
+  record)
+    TREE=$(stamp_key) || { echo "CANNOT-STAMP(2): cannot resolve a stamp key for $TREEISH"; exit 2; }
+    [ -n "$TREE" ] || { echo "CANNOT-STAMP(2): could not resolve a tree for $TREEISH"; exit 2; }
+    mkdir -p "$STAMP_DIR" || { echo "CANNOT-STAMP(2): cannot create $STAMP_DIR"; exit 2; }
+    printf 'tree %s\n' "$TREE" > "$STAMP_DIR/$TREE"
+    echo "stamped tree $TREE"
+    ;;
+  check)
+    TREE=$(stamp_key) || { echo "CANNOT-CHECK(2): cannot resolve a stamp key for $TREEISH"; exit 2; }
+    if [ -z "$TREE" ]; then
+        echo "CANNOT-CHECK(2): could not resolve a tree for $TREEISH"; exit 2
+    fi
+    # An ABSENT store means nothing has been stamped yet — a fresh clone, and a real verdict of 1. An
+    # store that EXISTS but cannot be read is an environment failure, and reporting that as "never
+    # verified" would collapse the distinction these exit codes exist for.
+    if [ -e "$STAMP_DIR" ] && [ ! -r "$STAMP_DIR" ]; then
+        echo "CANNOT-CHECK(2): stamp store $STAMP_DIR exists but is not readable"
+        exit 2
+    fi
+    if [ -f "$STAMP_DIR/$TREE" ]; then
+        echo "OK: $TREEISH is stamped (key $TREE)"
+        exit 0
+    fi
+    echo "NOT-STAMPED(1): $TREEISH has no passing-preflight stamp (key $TREE)"
+    exit 1
+    ;;
+  *)
+    echo "usage: $0 {record|check|path} [tree-ish]"; exit 2
+    ;;
+esac

--- a/Scripts/test-preflight-stamp.sh
+++ b/Scripts/test-preflight-stamp.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Self-test for the #552 stamp and its pre-push hook. A gate nobody has watched refuse is decoration.
+set -uo pipefail
+ROOT="${1:-.}"
+cd "$ROOT" || { echo "FAIL: bad root"; exit 2; }
+STAMPER="Scripts/preflight-stamp.sh"
+HOOK="Scripts/pre-push-require-stamp.sh"
+[ -f "$STAMPER" ] && [ -f "$HOOK" ] || { echo "CANNOT-TEST(2): scripts missing under $ROOT"; exit 2; }
+
+TMP=$(mktemp -d) || { echo "CANNOT-TEST(2): mktemp failed"; exit 2; }
+[ -d "$TMP" ] || { echo "CANNOT-TEST(2): mktemp produced no directory"; exit 2; }
+export LPM_STAMP_DIR="$TMP/stamps"
+FAIL=0
+ok () { printf '  ok   %s\n' "$1"; }
+no () { printf '  FAIL %s\n' "$1"; FAIL=1; }
+
+bash "$STAMPER" check HEAD >/dev/null 2>&1
+[ $? -eq 1 ] && ok "unstamped tree reports NOT-STAMPED (1)" || no "unstamped tree did not exit 1"
+
+bash "$STAMPER" record HEAD >/dev/null 2>&1
+bash "$STAMPER" check HEAD >/dev/null 2>&1
+[ $? -eq 0 ] && ok "stamped tree reports OK (0)" || no "stamped tree did not exit 0"
+
+bash "$STAMPER" check "definitely-not-a-ref" >/dev/null 2>&1
+[ $? -eq 2 ] && ok "unresolvable tree-ish is CANNOT-CHECK (2), not 0 or 1" || no "unresolvable tree-ish did not exit 2"
+
+# the hook: a stamped commit passes, an unstamped one is refused
+printf 'refs/heads/x %s refs/heads/x %s\n' "$(git rev-parse HEAD)" "$(git rev-parse HEAD)" \
+  | bash "$HOOK" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "hook allows a stamped commit" || no "hook refused a stamped commit"
+
+rm -rf "$LPM_STAMP_DIR"
+printf 'refs/heads/x %s refs/heads/x %s\n' "$(git rev-parse HEAD)" "$(git rev-parse HEAD)" \
+  | bash "$HOOK" >/dev/null 2>&1
+[ $? -eq 1 ] && ok "hook refuses an unstamped commit" || no "hook did NOT refuse an unstamped commit"
+
+# The exploit an earlier revision shipped: the stamp was keyed on the TREE alone, so amending a message
+# to add forbidden metadata kept it valid and the gate permitted the very class the preflight refuses.
+# Commit messages are not in the tree, and the preflight greps them. Same tree must NOT mean same stamp.
+SCRATCH=$(mktemp -d) || { echo "CANNOT-TEST(2): mktemp failed"; exit 2; }
+(
+  cd "$SCRATCH" || exit 1
+  git init -q . && git config user.email t@t && git config user.name t
+  echo x > f && git add f && git commit -qm "original message"
+  cp "$OLDPWD/$STAMPER" ./stamp.sh
+  TREE_BEFORE=$(git rev-parse HEAD^{tree})
+  LPM_STAMP_DIR="$SCRATCH/st" bash ./stamp.sh record HEAD >/dev/null 2>&1
+  git commit -q --amend -m "forbidden: worker-model routing, codex session"
+  TREE_AFTER=$(git rev-parse HEAD^{tree})
+  [ "$TREE_BEFORE" = "$TREE_AFTER" ] || exit 9   # the premise: the tree really is unchanged
+  LPM_STAMP_DIR="$SCRATCH/st" bash ./stamp.sh check HEAD >/dev/null 2>&1
+  exit $?
+)
+case $? in
+  1) ok "a message-only amend INVALIDATES the stamp (tree-only keying was the exploit)" ;;
+  9) no "scratch fixture broken: the amend changed the tree, so the case was not exercised" ;;
+  *) no "a message-only amend kept the stamp — the gate would permit forbidden commit metadata" ;;
+esac
+rm -rf "$SCRATCH"
+
+printf 'refs/heads/x 0000000000000000000000000000000000000000 refs/heads/x %s\n' "$(git rev-parse HEAD)" \
+  | bash "$HOOK" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "hook allows a branch deletion" || no "hook refused a deletion"
+
+rm -rf "$TMP"
+echo
+[ "$FAIL" -eq 0 ] && { echo "OK: the stamp refuses an unverified tree and allows a verified one"; exit 0; }
+echo "FAIL: the stamp gate does not do what it claims"; exit 1


### PR DESCRIPTION
`lpm-ship.sh` exists because the preflight kept being walked past, and names the failure in its own header.
It happened a third time today:

```sh
bash preflight ... | tail -2 && git push ...
```

`tail` exits 0, so the pipeline exits 0, so `&&` proceeds. `PREFLIGHT FAIL` printed to the screen and the
push went out anyway. **Two occurrences read as human error; three is a property of the arrangement** — a
script that prevents this only prevents it when it is used, and hand-chaining recurs exactly when someone
is in a hurry, which is when the gate matters most.

So the check moves from something that must be **invoked** to something that must be **passed**: a passing
preflight records a stamp, and a pre-push hook refuses a tree that has none.

### Keyed to the tree, not the commit

`8895070b` was amended to `d45f6bc3` today to reword a message — same tree, `c820f0860b8d`, both times.
Keyed to the SHA, that amend would have invalidated a stamp backed by a 400-second suite run, forcing a
re-run for a change that altered no bytes. **A gate that demands pointless work is one people learn to
route around.** Keyed to the tree, a stamp dies exactly when content changes.

### Two deliberate limits

`record` does **not** run the preflight itself. A recorder that also verified would be trusted to do both
and could then certify its own work; this only writes down a result something else produced.

The hook installs in the CommitLore **chained** slot, because `.git/hooks/pre-push` is a shim that
rewrites itself on reinstall and runs `pre-push.commitlore-chained` first — measured in the installed
v1.0.2 shim, where the execute bit is load-bearing. Install is one symlink, documented in
`Scripts/README-hooks.md`.

### Watched to refuse

`Scripts/test-preflight-stamp.sh`, registered in CI beside the other guards:

```
unstamped tree            → 1
stamped tree             → 0
unresolvable tree-ish    → 2      distinct, so a rule tolerating one cannot silently tolerate the others
hook, unstamped commit   → refused
hook, stamped commit     → allowed
hook, branch deletion    → allowed      no tree to have verified
```

Scripts and CI only — no Sources change, so the ship gate correctly reports live evidence as `n/a`.