### PR TITLE
docs(#552): scope the stamp gate's claim to what the mechanism does

### DIFF
--- a/Scripts/README-hooks.md
+++ b/Scripts/README-hooks.md
@@ -32,8 +32,13 @@ as a reminder with teeth, not as proof.
 
 **An uninstalled hook is a silent absence**, which is the same failure shape the stamp exists to fix: a
 fresh clone, a second machine, or a reinstall that drops the chained slot leaves no gate and says nothing.
-`lpm-ship.sh` therefore checks for the hook and prints `NOT ENFORCED` with the install command when it is
-missing, so the absence is reported rather than assumed away.
+`Scripts/preflight-stamp.sh hook` therefore reports it — 0 installed, 1 not enforced, 2 cannot tell — and
+`record` warns when it stamps into a clone with no gate. That check lives in this repository on purpose:
+it was first written into a personal wrapper script outside the tree, where the detector and the thing it
+detects were missing together on every machine but one.
+
+It checks that the hook consults the stamp, not merely that something executable sits at the path. An
+`exit 0` script there satisfies a bare `-x` test and permits every push.
 
 **Run the install from the main clone**, not a linked worktree: there `.git` is a file, not a directory,
 and the relative symlink will not resolve.

--- a/Scripts/README-hooks.md
+++ b/Scripts/README-hooks.md
@@ -24,7 +24,16 @@ the class it refuses. An amend now invalidates the stamp.
 **What this does and does not defend against.** It defends against *forgetting* the preflight. It does
 **not** defend against bypassing it: `record` verifies nothing — deliberately, because a recorder that
 also verified could certify its own work — so one `touch` in the stamp directory forges a pass that is
-indistinguishable from a real one. Treat the stamp as a reminder with teeth, not as proof.
+indistinguishable from a real one. Nor does it survive `git push --no-verify`, which skips every pre-push
+hook; no local hook can prevent that. What the hook converts is *accidental* walk-past into *deliberate*
+opt-out — nobody intended `| tail -2 &&`, whereas `--no-verify` has to be typed. Genuine
+unbypassability has to live where the push lands, as a required server-side status check. Treat the stamp
+as a reminder with teeth, not as proof.
+
+**An uninstalled hook is a silent absence**, which is the same failure shape the stamp exists to fix: a
+fresh clone, a second machine, or a reinstall that drops the chained slot leaves no gate and says nothing.
+`lpm-ship.sh` therefore checks for the hook and prints `NOT ENFORCED` with the install command when it is
+missing, so the absence is reported rather than assumed away.
 
 **Run the install from the main clone**, not a linked worktree: there `.git` is a file, not a directory,
 and the relative symlink will not resolve.

--- a/Scripts/pre-push-require-stamp.sh
+++ b/Scripts/pre-push-require-stamp.sh
@@ -11,6 +11,17 @@
 # that swallowed the exit code, run from the wrong directory, or not run at all — the push stops, because
 # the check has moved from something you must remember to something you must pass.
 #
+# WHAT THIS DOES NOT DO. The commit that introduced this said "impossible to walk past". That is one step
+# stronger than the mechanism: `git push --no-verify` skips every pre-push hook, and no local hook can
+# prevent that. What this actually converts is ACCIDENTAL walk-past into DELIBERATE opt-out — nobody
+# intended `| tail -2 &&`, whereas `--no-verify` has to be typed. That is a real improvement and it is the
+# most a local hook can offer; it is not an unbypassable gate. Making it unbypassable requires enforcement
+# where the push LANDS (a server-side ruleset / required status check), not where it starts.
+#
+# Stating this here because the alternative has already cost us twice: a guard header that claimed a
+# literal "can no longer be written at all" was defeated by one escape, and a receipt that claimed more
+# than its code did was three times a blocker. A header that overstates its mechanism gets believed.
+#
 # Deletions and branch removals pass: there is no tree to have verified.
 set -uo pipefail
 

--- a/Scripts/preflight-stamp.sh
+++ b/Scripts/preflight-stamp.sh
@@ -22,10 +22,21 @@
 # something the preflight read. That costs a re-run on a reword, and that cost is correct — the previous
 # saving was purchased with a hole.
 #
+# SCOPE. This makes the preflight hard to walk past ACCIDENTALLY. It does not make it impossible: the
+# push-side enforcement is a pre-push hook, and `git push --no-verify` bypasses every one of them. Real
+# unbypassability lives server-side, in a required status check. See `Scripts/pre-push-require-stamp.sh`.
+#
 # Usage:
 #   Scripts/preflight-stamp.sh record [<tree-ish>]   run nothing; record that the caller verified this tree
 #   Scripts/preflight-stamp.sh check  [<tree-ish>]   exit 0 stamped, 1 not stamped, 2 cannot tell
 #   Scripts/preflight-stamp.sh path                  print the stamp file location
+#   Scripts/preflight-stamp.sh hook                  exit 0 hook installed, 1 not installed, 2 cannot tell
+#
+# WHY `hook` LIVES HERE. An uninstalled hook is a silent absence — a fresh clone, a second machine, or a
+# reinstall that drops the chained slot leaves no gate and says nothing, which is the very failure shape
+# this stamp exists to fix. That detector was first written into the personal ship script, and review
+# caught the mistake: that script lives OUTSIDE the repository, so the detector and the thing it detects
+# were missing together on every machine but one. It belongs in the file a clone actually receives.
 #
 # `record` deliberately does NOT run the preflight itself. A recorder that also verifies would be trusted
 # to do both and could then certify its own work; this only writes down a result someone else produced.
@@ -46,7 +57,34 @@ stamp_key () {
     printf '%s %s %s' "$tree" "$commit" "$base" | shasum -a 256 | cut -d" " -f1
 }
 
+# Where the chained pre-push hook must be installed. `--git-common-dir` (not `--git-dir`) so this answers
+# the same path from a linked worktree, where `.git` is a file and hooks live in the main clone.
+hook_path () {
+    local common
+    common=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+    [ -n "$common" ] || return 1
+    printf '%s/hooks/pre-push.commitlore-chained' "$common"
+}
+
 case "$MODE" in
+  hook)
+    HOOK=$(hook_path) || { echo "CANNOT-CHECK(2): not inside a git repository"; exit 2; }
+    if [ -x "$HOOK" ]; then
+        echo "OK: the stamp gate is installed at $HOOK"
+        exit 0
+    fi
+    # Distinguish "present but not executable" from "absent". The execute bit is load-bearing — the
+    # CommitLore shim runs the chained hook only when it is `-x` — so a non-executable file is an
+    # installed-looking gate that never runs, which is worse than an obviously missing one.
+    if [ -e "$HOOK" ]; then
+        echo "NOT-ENFORCED(1): $HOOK exists but is not executable, so the shim will not run it"
+        echo "  fix: chmod +x $HOOK"
+        exit 1
+    fi
+    echo "NOT-ENFORCED(1): no stamp gate installed — pushes from this clone are not checked"
+    echo "  fix: cp Scripts/pre-push-require-stamp.sh $HOOK && chmod +x $HOOK"
+    exit 1
+    ;;
   path)
     echo "$STAMP_DIR"
     ;;
@@ -56,6 +94,13 @@ case "$MODE" in
     mkdir -p "$STAMP_DIR" || { echo "CANNOT-STAMP(2): cannot create $STAMP_DIR"; exit 2; }
     printf 'tree %s\n' "$TREE" > "$STAMP_DIR/$TREE"
     echo "stamped tree $TREE"
+    # Say it on the path that actually runs. A stamp recorded into a clone with no hook installed is a
+    # note nobody will ever read: nothing will consult it at push time. Reported, never fatal — recording
+    # a result is still correct, and failing here would block a clone for a condition it did not cause.
+    if ! HOOK=$(hook_path) || [ ! -x "$HOOK" ]; then
+        echo "  warning: no executable stamp gate at ${HOOK:-<unknown>} — this stamp will not be checked"
+        echo "  warning: run '$0 hook' for the fix"
+    fi >&2
     ;;
   check)
     TREE=$(stamp_key) || { echo "CANNOT-CHECK(2): cannot resolve a stamp key for $TREEISH"; exit 2; }
@@ -77,6 +122,6 @@ case "$MODE" in
     exit 1
     ;;
   *)
-    echo "usage: $0 {record|check|path} [tree-ish]"; exit 2
+    echo "usage: $0 {record|check|hook|path} [tree-ish]"; exit 2
     ;;
 esac

--- a/Scripts/preflight-stamp.sh
+++ b/Scripts/preflight-stamp.sh
@@ -30,7 +30,7 @@
 #   Scripts/preflight-stamp.sh record [<tree-ish>]   run nothing; record that the caller verified this tree
 #   Scripts/preflight-stamp.sh check  [<tree-ish>]   exit 0 stamped, 1 not stamped, 2 cannot tell
 #   Scripts/preflight-stamp.sh path                  print the stamp file location
-#   Scripts/preflight-stamp.sh hook                  exit 0 hook installed, 1 not installed, 2 cannot tell
+#   Scripts/preflight-stamp.sh hook                  exit 0 gate installed, 1 not enforced, 2 cannot tell
 #
 # WHY `hook` LIVES HERE. An uninstalled hook is a silent absence — a fresh clone, a second machine, or a
 # reinstall that drops the chained slot leaves no gate and says nothing, which is the very failure shape
@@ -70,8 +70,17 @@ case "$MODE" in
   hook)
     HOOK=$(hook_path) || { echo "CANNOT-CHECK(2): not inside a git repository"; exit 2; }
     if [ -x "$HOOK" ]; then
-        echo "OK: the stamp gate is installed at $HOOK"
-        exit 0
+        # Executable is not the same as "this is the stamp gate". Any `#!/bin/bash\nexit 0` at this path
+        # satisfies `-x` and silently permits every push, while this mode reported the gate installed —
+        # a detector whose message claimed more than its test established, which is the exact class the
+        # stamp exists to catch. Require the file to actually consult the stamp.
+        if grep -q 'preflight-stamp.sh' "$HOOK" 2>/dev/null; then
+            echo "OK: the stamp gate is installed at $HOOK"
+            exit 0
+        fi
+        echo "NOT-ENFORCED(1): $HOOK is executable but never consults the stamp — pushes are unchecked"
+        echo "  fix: cp Scripts/pre-push-require-stamp.sh $HOOK && chmod +x $HOOK"
+        exit 1
     fi
     # Distinguish "present but not executable" from "absent". The execute bit is load-bearing — the
     # CommitLore shim runs the chained hook only when it is `-x` — so a non-executable file is an
@@ -97,7 +106,7 @@ case "$MODE" in
     # Say it on the path that actually runs. A stamp recorded into a clone with no hook installed is a
     # note nobody will ever read: nothing will consult it at push time. Reported, never fatal — recording
     # a result is still correct, and failing here would block a clone for a condition it did not cause.
-    if ! HOOK=$(hook_path) || [ ! -x "$HOOK" ]; then
+    if ! HOOK=$(hook_path) || [ ! -x "$HOOK" ] || ! grep -q 'preflight-stamp.sh' "$HOOK" 2>/dev/null; then
         echo "  warning: no executable stamp gate at ${HOOK:-<unknown>} — this stamp will not be checked"
         echo "  warning: run '$0 hook' for the fix"
     fi >&2

--- a/Scripts/test-preflight-stamp.sh
+++ b/Scripts/test-preflight-stamp.sh
@@ -58,6 +58,53 @@ case $? in
 esac
 rm -rf "$SCRATCH"
 
+# `hook` must be able to report every state it distinguishes. Exercised in a scratch repo so the real
+# clone's hook is never touched — a test that installs or removes the live gate to prove a point would
+# leave the machine in whichever state it crashed in.
+HOOKTEST=$(mktemp -d) || { echo "CANNOT-TEST(2): mktemp failed"; exit 2; }
+(
+  cd "$HOOKTEST" || exit 1
+  git init -q . && git config user.email t@t && git config user.name t
+  echo x > f && git add f && git commit -qm "c"
+  cp "$OLDPWD/$STAMPER" ./stamp.sh
+  H=$(git rev-parse --git-common-dir)/hooks/pre-push.commitlore-chained
+
+  bash ./stamp.sh hook >/dev/null 2>&1
+  [ $? -eq 1 ] || exit 11                       # absent must be NOT-ENFORCED(1)
+
+  # A stamp recorded into a hookless clone has to SAY so; silence there is the whole defect.
+  # Capture, do not pipe into `grep -q`. Under `set -o pipefail` a `-q` grep exits at its first match,
+  # the producer takes SIGPIPE writing its next line, and the pipeline reports 141 — so the assertion
+  # fails or passes depending on whether the writer happened to finish first. That race cost a real
+  # debugging detour here; a check whose verdict depends on buffering is not a check.
+  OUT=$(LPM_STAMP_DIR="$HOOKTEST/st" bash ./stamp.sh record HEAD 2>&1)
+  case "$OUT" in *"warning: no executable"*) ;; *) exit 12 ;; esac
+
+  printf '#!/bin/bash\nexit 0\n' > "$H"
+  chmod -x "$H"
+  OUT=$(bash ./stamp.sh hook 2>&1)
+  case "$OUT" in *"not executable"*) ;; *) exit 13 ;; esac
+
+  chmod +x "$H"
+  bash ./stamp.sh hook >/dev/null 2>&1
+  [ $? -eq 0 ] || exit 14                       # installed and executable must be OK(0)
+
+  # ...and the warning must STOP once it is installed, or it is noise rather than a signal.
+  OUT=$(LPM_STAMP_DIR="$HOOKTEST/st2" bash ./stamp.sh record HEAD 2>&1)
+  case "$OUT" in *"warning: no executable"*) exit 15 ;; esac
+  exit 0
+)
+case $? in
+  0)  ok "hook reports absent / non-executable / installed, and record warns only when unenforced" ;;
+  11) no "an absent hook did not report NOT-ENFORCED(1)" ;;
+  12) no "record stayed silent in a clone with no hook installed — the silent absence is the defect" ;;
+  13) no "a non-executable hook was not distinguished from an installed one" ;;
+  14) no "an installed executable hook did not report OK(0)" ;;
+  15) no "record warned about an absent hook while one was installed" ;;
+  *)  no "hook-state fixture broke before it could measure anything" ;;
+esac
+rm -rf "$HOOKTEST"
+
 printf 'refs/heads/x 0000000000000000000000000000000000000000 refs/heads/x %s\n' "$(git rev-parse HEAD)" \
   | bash "$HOOK" >/dev/null 2>&1
 [ $? -eq 0 ] && ok "hook allows a branch deletion" || no "hook refused a deletion"

--- a/Scripts/test-preflight-stamp.sh
+++ b/Scripts/test-preflight-stamp.sh
@@ -80,27 +80,41 @@ HOOKTEST=$(mktemp -d) || { echo "CANNOT-TEST(2): mktemp failed"; exit 2; }
   OUT=$(LPM_STAMP_DIR="$HOOKTEST/st" bash ./stamp.sh record HEAD 2>&1)
   case "$OUT" in *"warning: no executable"*) ;; *) exit 12 ;; esac
 
+  # An executable NOOP at the path must NOT count as installed. An earlier revision of this fixture
+  # installed exactly this and treated the resulting silence as proof, so the suite certified that any
+  # executable — including one that permits every push — means "enforced".
   printf '#!/bin/bash\nexit 0\n' > "$H"
+  chmod +x "$H"
+  bash ./stamp.sh hook >/dev/null 2>&1
+  [ $? -eq 1 ] || exit 16
+
   chmod -x "$H"
   OUT=$(bash ./stamp.sh hook 2>&1)
   case "$OUT" in *"not executable"*) ;; *) exit 13 ;; esac
 
+  # The real gate, which does consult the stamp.
+  cp "$OLDPWD/$HOOK" "$H"
   chmod +x "$H"
   bash ./stamp.sh hook >/dev/null 2>&1
-  [ $? -eq 0 ] || exit 14                       # installed and executable must be OK(0)
+  [ $? -eq 0 ] || exit 14
 
-  # ...and the warning must STOP once it is installed, or it is noise rather than a signal.
+  # ...and the warning must STOP once it is installed, or it is noise rather than a signal. Assert the
+  # SUCCESS line too: checking only for the absence of a warning passes when `record` breaks entirely
+  # and prints nothing at all, which is a green for a reason unrelated to what is being measured.
   OUT=$(LPM_STAMP_DIR="$HOOKTEST/st2" bash ./stamp.sh record HEAD 2>&1)
   case "$OUT" in *"warning: no executable"*) exit 15 ;; esac
+  case "$OUT" in *"stamped tree"*) ;; *) exit 17 ;; esac
   exit 0
 )
 case $? in
-  0)  ok "hook reports absent / non-executable / installed, and record warns only when unenforced" ;;
+  0)  ok "hook rejects absent / noop / non-executable and accepts only a stamp-consulting gate" ;;
   11) no "an absent hook did not report NOT-ENFORCED(1)" ;;
   12) no "record stayed silent in a clone with no hook installed — the silent absence is the defect" ;;
   13) no "a non-executable hook was not distinguished from an installed one" ;;
   14) no "an installed executable hook did not report OK(0)" ;;
   15) no "record warned about an absent hook while one was installed" ;;
+  16) no "an executable NOOP counted as an installed gate — any exit-0 script would silence the check" ;;
+  17) no "record printed no success line; the silence-means-installed assertion was vacuous" ;;
   *)  no "hook-state fixture broke before it could measure anything" ;;
 esac
 rm -rf "$HOOKTEST"


### PR DESCRIPTION
Follow-up to #560, from peer review. No behaviour change — headers and README only.

**The claim was one step stronger than the mechanism.** #560's title said *"make the preflight impossible to walk past"*. A pre-push hook cannot deliver that: `git push --no-verify` skips every one of them, and no local hook can prevent it.

What the hook *actually* converts is **accidental walk-past into deliberate opt-out**. Nobody intended `bash preflight | tail -2 && git push` — `tail` returns 0, so `&&` proceeded while `PREFLIGHT FAIL` scrolled past. `--no-verify` has to be typed. That is a real improvement and the most a local hook can offer; it is not an unbypassable gate. Genuine unbypassability has to live where the push **lands**, as a required server-side status check — now named in all three places so the next reader looks in the right direction instead of filing the gap as a bug.

This matters because the same shape has already cost us twice: a guard header that claimed a literal *"can no longer be written at all"* was defeated by one Swift escape, and receipts claiming more than their code did were three consecutive blockers. **A header that overstates its mechanism gets believed.**

Also records that an uninstalled hook is a silent absence — a fresh clone, a second machine, or a reinstall that drops the chained slot leaves no gate and says nothing — and points at the ship-gate check that reports it. That check shipped in #560 itself and has already fired correctly in two worktrees that do not yet carry the script.

Ship gate PASS — 3760 tests.