### PR TITLE
fix(#519,#545): measure the Korean and Japanese track-delete path

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -397,7 +397,7 @@ enum AXLocalePolicy {
     /// (a wrong-title guess or keyboard fallback is never fabricated).
     static let deleteTracksPrimaryButton = LabelSet(
         canonical: "Delete Tracks and Content",
-        variants: ["Delete", "삭제"],
+        variants: ["Delete", "삭제", "削除"],
         rationale: """
         Primary destructive button on a track-delete confirm sheet; the reconciler presses only the \
         classifier-bound AX element. Logic uses more than one of these sheets and they do NOT share a \

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -397,7 +397,7 @@ enum AXLocalePolicy {
     /// (a wrong-title guess or keyboard fallback is never fabricated).
     static let deleteTracksPrimaryButton = LabelSet(
         canonical: "Delete Tracks and Content",
-        variants: ["Delete"],
+        variants: ["Delete", "삭제"],
         rationale: """
         Primary destructive button on a track-delete confirm sheet; the reconciler presses only the \
         classifier-bound AX element. Logic uses more than one of these sheets and they do NOT share a \

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -1637,7 +1637,11 @@ extension AccessibilityChannel {
             beforeCount = nil
         }
         let click = clickTrackMenu(
-            ["Delete Track", "트랙 삭제"],
+            // `トラックを削除` measured 2026-08-17 (Logic 12.3, AppleLanguages=ja). EXACT matching is
+            // load-bearing here: the same menu also carries `使用されていないトラックを削除`
+            // (Delete Unused Tracks), which ENDS WITH the same string — a suffix or containment match
+            // would reach a different destructive command that deletes tracks the caller never named.
+            ["Delete Track", "트랙 삭제", "トラックを削除"],
             menuName: "트랙",
             englishMenuName: "Track",
             runtime: runtime
@@ -1867,7 +1871,10 @@ extension AccessibilityChannel {
         englishMenuName: String = "Track",
         runtime: AXLogicProElements.Runtime = .production
     ) -> ChannelResult {
-        for menuTitle in [menuName, englishMenuName] {
+        // #519: the Japanese menu bar is a third spelling, not a variant of either of the other two.
+        // Measured 2026-08-17 on Logic 12.3 with AppleLanguages=ja: the menu is `トラック`. Without it
+        // every menu-driven track operation returned `element_not_found` on a Japanese Logic.
+        for menuTitle in [menuName, englishMenuName, "トラック"] {
             for itemTitle in menuItemTitles {
                 guard let item = AXLogicProElements.menuItem(path: [menuTitle, itemTitle], runtime: runtime) else {
                     continue

--- a/Tests/LogicProMCPTests/Issue545DeleteConfirmBareLabelTests.swift
+++ b/Tests/LogicProMCPTests/Issue545DeleteConfirmBareLabelTests.swift
@@ -74,10 +74,11 @@ struct Issue545DeleteConfirmBareLabelTests {
         // So the absence is asserted deliberately. Outside English these sheets classify as unknown and
         // are left on screen — fail-closed, and the honest state of the gap (tracked in #519). Restoring
         // the variants means changing this test, and changing it should require naming a measurement.
-        // 삭제 is now MEASURED (Logic 12.3, AppleLanguages=ko, 2026-08-17: buttons `취소, 삭제`), so it
-        // classifies. 削除 has not been read off a live Japanese dialog and therefore must not.
+        // Both are now MEASURED off live dialogs on Logic 12.3 — KO `취소, 삭제`, JA `キャンセル, 削除`
+        // (2026-08-17). They classify because they were read, not because they were plausible; an
+        // earlier revision carried these same two strings as hand translations and they were removed.
         #expect(classifiedKind(primaryButtonTitle: "삭제") == .deleteConfirm)
-        #expect(classifiedKind(primaryButtonTitle: "削除") != .deleteConfirm)
+        #expect(classifiedKind(primaryButtonTitle: "削除") == .deleteConfirm)
     }
 
     @Test("the channel-strip sheet's full canonical label still classifies (no regression)")

--- a/Tests/LogicProMCPTests/Issue545DeleteConfirmBareLabelTests.swift
+++ b/Tests/LogicProMCPTests/Issue545DeleteConfirmBareLabelTests.swift
@@ -74,7 +74,9 @@ struct Issue545DeleteConfirmBareLabelTests {
         // So the absence is asserted deliberately. Outside English these sheets classify as unknown and
         // are left on screen — fail-closed, and the honest state of the gap (tracked in #519). Restoring
         // the variants means changing this test, and changing it should require naming a measurement.
-        #expect(classifiedKind(primaryButtonTitle: "삭제") != .deleteConfirm)
+        // 삭제 is now MEASURED (Logic 12.3, AppleLanguages=ko, 2026-08-17: buttons `취소, 삭제`), so it
+        // classifies. 削除 has not been read off a live Japanese dialog and therefore must not.
+        #expect(classifiedKind(primaryButtonTitle: "삭제") == .deleteConfirm)
         #expect(classifiedKind(primaryButtonTitle: "削除") != .deleteConfirm)
     }
 

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -401,7 +401,7 @@ private func makeSignals(
     // forms are actually measured, this test is what will have to be changed, and
     // changing it should require saying where the measurement came from.
     #expect(AXLocalePolicy.deleteTracksPrimaryButton.matches("삭제"))
-    #expect(!AXLocalePolicy.deleteTracksPrimaryButton.matches("削除"))
+    #expect(AXLocalePolicy.deleteTracksPrimaryButton.matches("削除"))
 }
 
 @Test func testDeleteTracksPrimaryButtonLabelSetDoesNotOvermatchUnrelatedLabels() {

--- a/Tests/LogicProMCPTests/ModalReconciliationTests.swift
+++ b/Tests/LogicProMCPTests/ModalReconciliationTests.swift
@@ -400,7 +400,7 @@ private func makeSignals(
     // as unknown and are left on screen, which is fail-closed and honest. When the
     // forms are actually measured, this test is what will have to be changed, and
     // changing it should require saying where the measurement came from.
-    #expect(!AXLocalePolicy.deleteTracksPrimaryButton.matches("삭제"))
+    #expect(AXLocalePolicy.deleteTracksPrimaryButton.matches("삭제"))
     #expect(!AXLocalePolicy.deleteTracksPrimaryButton.matches("削除"))
 }
 


### PR DESCRIPTION
Closes the delete path outside English by **measuring** it — running Logic 12.3 under `AppleLanguages=ko` and `=ja` and reading the live dialogs.

## Japanese had three gaps, stacked

Each one hid the next, which is why the order matters more than any individual fix:

```
1  menu bar is `トラック`         without it, every menu-driven track op -> element_not_found
2  item is `トラックを削除`
3  dialog is `キャンセル, 削除`

before (1)    state C  element_not_found   dialog never raised
after  (1,2)  state B  unknown_sheet       dialog raised, label unknown
after  (3)    state A  verified true       dialogs 0, tracks 7 -> 6
```

**Patching only the label would have hit gap 1 and done nothing** — leaving the false conclusion "the variant is there and it still fails".

Korean measured the same way: buttons `취소, 삭제`. And #545 **reproduced** there before the fix — `state: B, unknown_sheet, retry_exhausted`, dialog left on screen — exactly as predicted when the guessed variants were removed.

## The dangerous one

`使用されていないトラックを削除` (Delete Unused Tracks) sits in the same menu and **ends with** `トラックを削除`. A containment or suffix match reaches a different destructive command that deletes tracks the caller never named.

That is not fail-closed, it is **fail-wrong**. Exact matching is load-bearing here and the comment says so.

## About these two strings specifically

`삭제` and `削除` were in this LabelSet earlier as **hand translations** and were removed. They turn out to be correct — and removing them was still right. Being right is not the same as being read, and at that point there was no evidence. `AXLocalePolicy`'s header forbids the method because a translation was already wrong here once (New is `신규`, not the `새로 만들기` a translator reaches for). They are back because they came off live dialogs, and the rationale records which measurement, on which build, on which date.

The absence test now distinguishes measured from unmeasured rather than asserting both.

## Method, for reuse

`defaults write com.apple.logic10 AppleLanguages -array ko|ja` → restart Logic → drive the operation → read the dialog → restore `en`. Four minutes. I had previously recorded this as needing environments that do not exist on this host; that was wrong, and it was never attempted.

Logic's override was restored to `en` and the project closed without saving.

Ship gate PASS — 3783 tests, live evidence bound to head.