### PR TITLE
fix(#565): let a Marker List with no markers read as empty instead of unreadable

### DIFF
--- a/Scripts/livekit/live_565_empty_marker_list.py
+++ b/Scripts/livekit/live_565_empty_marker_list.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Live proof that a Marker List with no markers reads as EMPTY, not as unreadable.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_565_empty_marker_list.py <worktree> <full-40-char-head-sha>
+
+WHAT WENT WRONG
+---------------
+Measured on Logic Pro 12.3: the Marker List table vends four `AXColumn` children plus one `AXGroup`
+at every row count. The row reader's corroboration guard was `children.isEmpty || !rows.isEmpty`, so
+on the live tree the first clause never held and the guard meant *an empty row set is always
+unreadable*. In a project with no markers every marker operation returned State C — including
+`create_marker`, the only route to a first marker — and deleting the LAST marker could not certify.
+
+THE TRIGGER IS ZERO MARKERS, SO THE RUN ESTABLISHES IT FIRST
+------------------------------------------------------------
+Against a project that already has markers every check below passes while testing nothing: the
+defect only exists at a row count of zero. So the run drives the list to zero through the product's
+own delete and REFUSES to continue unless an instrument outside the product agrees the list is
+empty. Following #549, an unestablished trigger is a failed run, not a quiet pass.
+
+INSTRUMENTS
+-----------
+The marker count is read two ways that do not share a code path:
+
+  product   each operation's own envelope (`marker_count_before`, `observed_marker_count_after`)
+  witness   Logic's own "Number of Items" static text, read through System Events
+
+The witness is what makes "the list really was empty" a measurement rather than the product's
+opinion of itself. It is also the discriminator the fix uses, so a run where the two disagree is
+reporting something worth seeing, not a harness bug to paper over.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+
+MARKER_WINDOW = "Marker List"
+# Window-relative rectangle over the first rows of the Marker List table, derived from a live
+# measurement (window at 452x746, table origin 142 points below the window's own origin). The band
+# stops well short of the table's full height so the assertion is about ROWS appearing, not about
+# the window being repainted.
+ROW_BAND = (4, 145, 420, 60)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def witness():
+    """Logic's own Number of Items rendering. Not a path the product uses.
+
+    Returns the raw string (`"0 Markers"`, `"1 Marker"`) or "" when it could not be read — an
+    unreadable witness is never reported as a count.
+    """
+    return osa(
+        'tell application "System Events" to tell process "Logic Pro"\n'
+        'set w to first window whose name ends with "Marker List"\n'
+        'return value of (first static text of (first group of w) whose description is "Number of Items")\n'
+        'end tell')
+
+
+def witness_count(tries=5):
+    """The witness as an integer, or None when it could not be read.
+
+    Retried because a single failed UI read is not an answer — the window can be mid-open. None is
+    still a real outcome and callers must not spell it as zero.
+    """
+    for attempt in range(tries):
+        raw = witness()
+        head = raw.split(" ")[0] if raw else ""
+        if head.isdigit():
+            return int(head)
+        if attempt < tries - 1:
+            time.sleep(0.8)
+    return None
+
+
+def state_of(body):
+    return body.get("state") if isinstance(body, dict) else None
+
+
+def open_marker_list():
+    if MARKER_WINDOW in osa('tell application "System Events" to tell process "Logic Pro" to '
+                            'return name of every window'):
+        return
+    osa('tell application "System Events" to tell process "Logic Pro"\n'
+        'set frontmost to true\n'
+        'delay 0.5\n'
+        'click menu item "Open Marker List" of menu 1 of menu bar item "Navigate" of menu bar 1\n'
+        'end tell')
+    time.sleep(2)
+
+
+def seed_marker_via_menu():
+    """Put one marker in the list using Logic's own menu, never the product.
+
+    The delete that empties the list is half of what is under test, so the run needs something to
+    delete. Seeding through the product would make the setup depend on the operation being proven.
+
+    The click is VERIFIED against the witness and retried. Measured on this branch: a click issued
+    moments after the server process starts can land with no effect, and a seed that quietly does
+    nothing leaves the run with nothing to delete — which reads downstream as "the delete path was
+    not exercised", the precise shape of an unestablished trigger.
+    """
+    for _ in range(3):
+        before = witness_count()
+        osa('tell application "System Events" to tell process "Logic Pro"\n'
+            'set frontmost to true\n'
+            'delay 0.8\n'
+            'click menu item "Create Marker" of menu 1 of menu bar item "Navigate" of menu bar 1\n'
+            'end tell')
+        time.sleep(1.5)
+        after = witness_count()
+        if after is not None and after > (before or 0):
+            return True
+    return False
+
+
+open_marker_list()
+if witness_count() == 0:
+    seed_marker_via_menu()
+started_with = witness_count()
+rec = ev.record_screen(seconds=200)
+
+# ---- establish the trigger: drive the list to zero through the product ----------------------
+deletes = []
+for _ in range(8):
+    if witness_count() == 0:
+        break
+    body = d.tool("logic_navigate", "delete_marker", {"index": 0})
+    deletes.append({"state": state_of(body), "witness_after": witness()})
+    if state_of(body) not in ("A", "B"):
+        break
+
+empty_witness = witness_count()
+ev.note("565/drive-to-empty", {"started_with": started_with, "deletes": deletes,
+                               "witness_now": witness()})
+
+# The LAST delete is half the defect: with zero rows left the post-write read had nothing it would
+# accept, so emptying the list could not certify. This asserts the tail of that sequence directly.
+last_delete = deletes[-1] if deletes else None
+ev.check("565/emptying-the-list-certifies",
+         bool(last_delete) and last_delete["state"] == "A",
+         "the delete that leaves zero markers reaches State A",
+         f"last_delete={last_delete} deletes={len(deletes)} started_with={started_with}"
+         + ("" if deletes else " — NOTHING WAS DELETED, so this path was never exercised"),
+         "restore `children.isEmpty || !rows.isEmpty`: the post-write read of a table with no rows "
+         "left becomes unreadable and the delete can no longer certify")
+
+ev.check("565/precondition-the-list-is-actually-empty", empty_witness == 0,
+         "Logic's own Number of Items reads zero, so the run is exercising the empty-list path",
+         f"witness={witness()!r} parsed={empty_witness!r}",
+         "none — this is the trigger, not the fix. A run that reaches the checks below without it "
+         "passes them against a NON-empty list and proves nothing about the defect")
+
+if empty_witness != 0:
+    ev.stop_recording(rec)
+    d.close()
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(1)
+
+before = ev.shot("565/list-empty", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
+
+# ---- the operation the defect made impossible -------------------------------------------------
+# The playhead is moved first: `Create Marker` at a position that already carries one is a no-op in
+# Logic, which would produce an honest readback_mismatch for a reason unrelated to this fix.
+goto = d.tool("logic_transport", "goto_position", {"bar": "33"})
+created = d.tool("logic_navigate", "create_marker", {})
+time.sleep(1.5)
+after_witness = witness_count()
+ev.note("565/create-on-empty", {"goto": goto, "created": created, "witness_after": witness()})
+
+ev.check("565/create-marker-works-on-an-empty-list",
+         state_of(created) == "A",
+         "create_marker reaches State A in a project that has no markers",
+         f"state={state_of(created)!r} error={created.get('error')!r} "
+         f"before={created.get('marker_count_before')!r} after={created.get('marker_count_after')!r}",
+         "restore `children.isEmpty || !rows.isEmpty`: the pre-write read fails and the operation "
+         "returns State C readback_unavailable before it ever presses the menu item")
+
+ev.check("565/the-product-saw-the-empty-list-as-empty",
+         created.get("marker_count_before") == 0,
+         "the operation's own pre-write count is zero, so it read the empty list rather than "
+         "refusing it",
+         f"marker_count_before={created.get('marker_count_before')!r}",
+         "publish the empty row set without corroboration — the count would still be 0 here, so "
+         "this check alone cannot tell the fix from the unsafe version; it is paired with the "
+         "witness check below")
+
+ev.check("565/an-independent-witness-agrees-a-marker-appeared",
+         after_witness == 1,
+         "Logic's own Number of Items goes from 0 to 1, measured outside the product",
+         f"witness={witness()!r} parsed={after_witness!r}",
+         "make create_marker return State A without pressing the menu item: the envelope would "
+         "still claim a create while this count stayed at 0")
+
+after = ev.shot("565/marker-created", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
+ev.visual("565/a-row-appears-in-the-marker-table",
+          before["file"], after["file"], ROW_BAND, expect_change=True,
+          why="the first rows of the Marker List table are empty before the create and carry the "
+              "new marker after it")
+
+# ---- restore ----------------------------------------------------------------------------------
+# The run leaves the project with the marker count it found. It cannot restore the specific markers
+# it deleted — Logic does not undo marker mutations within a session — so it says exactly what it
+# put back rather than claiming the project is untouched.
+for _ in range(4):
+    now = witness_count()
+    if now is None or started_with is None or now <= started_with:
+        break
+    d.tool("logic_navigate", "delete_marker", {"index": 0})
+    time.sleep(0.5)
+restored_to = witness_count()
+# An unread baseline is not a baseline of zero. Spelling `started_with or 0` here would let a run
+# that never measured what it started from report a successful restore — the same shape as the
+# defect this branch fixes, in the instrument rather than the product.
+ev.restored("565/marker-count-back-to-what-the-run-found",
+            started_with is not None and restored_to is not None and restored_to <= started_with,
+            f"started_with={started_with} now={restored_to}; the run's own markers are removed, but "
+            f"markers this run deleted to reach the empty state are NOT restorable in-session"
+            + ("" if started_with is not None
+               else " — and the starting count was never read, so there is nothing to restore TO"))
+
+ev.stop_recording(rec)
+d.close()
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
@@ -400,8 +400,8 @@ extension AXLogicProElements {
                 }
                 rows = observedRows
                 rowSource = .axRows
-            case .failure(let error):
-                return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
+            case .failure(let failure):
+                return .failure(failure)
             }
         case .failure(let error) where error.isDefinitiveAbsence:
             // `AXRows` unavailable is an answer about that attribute, not evidence that a
@@ -412,8 +412,8 @@ extension AXLogicProElements {
             case .success(let structuralRows):
                 rows = structuralRows
                 rowSource = .structuralChildren
-            case .failure(let error):
-                return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
+            case .failure(let failure):
+                return .failure(failure)
             }
         case .success(nil):
             // A successful nil carries the same attribute-absence answer as a definitive
@@ -422,8 +422,8 @@ extension AXLogicProElements {
             case .success(let structuralRows):
                 rows = structuralRows
                 rowSource = .structuralChildren
-            case .failure(let error):
-                return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
+            case .failure(let failure):
+                return .failure(failure)
             }
         case .failure(let error):
             return .failure(MarkerListReadFailure(site: .axRows, status: error))
@@ -501,16 +501,30 @@ extension AXLogicProElements {
     /// The table's direct structure corroborates an `AXRows` answer. A non-empty child list
     /// whose children no longer identify as rows is not evidence of an empty Marker List: the
     /// table is rebuilding and no complete row list is observable yet.
+    ///
+    /// That rule stands, but "the child list is empty" cannot be the escape hatch for a genuinely
+    /// empty list. Measured on Logic 12.3, the Marker List table ALWAYS vends four `AXColumn`
+    /// children plus one `AXGroup`, whatever the row count — so on the live tree the child list is
+    /// never empty and the old `children.isEmpty || !rows.isEmpty` guard reduced to *an empty row
+    /// set is always unreadable*. In a project with no markers that refused every marker
+    /// operation, including `create_marker`, which is the only way to obtain the first one. The
+    /// suite missed it because its empty fixture gave the table zero children, a shape Logic does
+    /// not present.
+    ///
+    /// The honest discriminator is Logic's own "Number of Items" rendering, which is not a
+    /// projection of this table: an empty row set is published only when that independent witness
+    /// parses to zero. A witness that reports a non-zero count, or that will not answer, keeps the
+    /// read unreadable — so a rebuilding table still cannot be mistaken for an empty marker list.
     private static func markerListStructuralRows(
         from table: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+    ) -> Result<[AXUIElement], MarkerListReadFailure> {
         let children: [AXUIElement]
         switch AXHelpers.childrenResult(table, runtime: runtime) {
         case .success(let observedChildren):
             children = observedChildren
         case .failure(let error):
-            return .failure(error)
+            return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
         }
         var rows: [AXUIElement] = []
         for child in children {
@@ -520,13 +534,213 @@ extension AXLogicProElements {
             case .success(let role):
                 if role == (kAXRowRole as String) { rows.append(child) }
             case .failure(let error):
-                return .failure(error)
+                return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
             }
         }
-        guard children.isEmpty || !rows.isEmpty else {
-            return .failure(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+        // A table that vends NO children at all keeps its pre-existing answer: that shape was
+        // already accepted as an empty list and is not what this fix is about. The change is
+        // confined to the shape Logic actually presents — children present, none of them rows.
+        guard !rows.isEmpty || !children.isEmpty else { return .success([]) }
+        guard rows.isEmpty else { return .success(rows) }
+        switch markerListZeroItemsWitness(forTableOf: table, runtime: runtime) {
+        case .zero:
+            return .success([])
+        case .nonZero:
+            // The corroboration counts on `MarkerListReadFailure` describe the two ROW collections
+            // this reader compares; the witness count is a third, differently-sourced number and
+            // must not be published in a field that names row collections.
+            return .failure(MarkerListReadFailure(
+                site: .itemCount,
+                status: AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue),
+                origin: .corroboration
+            ))
+        case .unreadable(let error):
+            return .failure(MarkerListReadFailure(site: .itemCount, status: error))
         }
-        return .success(rows)
+    }
+
+    /// What Logic's own Number of Items text says about a Marker List that exposed no rows.
+    enum MarkerListZeroItemsWitness: Equatable {
+        case zero
+        case nonZero(Int)
+        case unreadable(AXHelpers.AXStatusError)
+    }
+
+    /// Reads the Number of Items witness for the window that owns `table`.
+    ///
+    /// The window is resolved through the table's own `AXWindow` attribute (present on the live
+    /// element, measured 2026-08-17) so the post-write reader — which is deliberately handed the
+    /// already-bound table and must never re-discover one from a window — can corroborate an
+    /// empty survivor set without gaining a second table-discovery path.
+    ///
+    /// Anything short of a parsed count is `unreadable`. A missing, ambiguous, or unparseable
+    /// witness is not a zero.
+    static func markerListZeroItemsWitness(
+        forTableOf table: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> MarkerListZeroItemsWitness {
+        let window: AXUIElement
+        switch AXHelpers.getAttributeResult(
+            table, kAXWindowAttribute as String, runtime: runtime
+        ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
+        case .success(let owner?):
+            window = owner
+        case .success(nil):
+            return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+        case .failure(let error):
+            return .unreadable(error)
+        }
+        switch markerListNumberOfItemsNodes(in: window, runtime: runtime) {
+        case .failure(let error):
+            return .unreadable(error)
+        case .success(let nodes) where nodes.count != 1:
+            // Zero matches is a missing witness and more than one is an ambiguous witness; neither
+            // establishes a count, so both leave the empty row set uncorroborated.
+            return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+        case .success(let nodes):
+            switch AXHelpers.getAttributeResult(
+                nodes[0], kAXValueAttribute as String, runtime: runtime
+            ) as Result<AnyObject?, AXHelpers.AXStatusError> {
+            case .failure(let error):
+                return .unreadable(error)
+            case .success(let value):
+                let raw: String
+                if let string = value as? String {
+                    raw = string
+                } else if let number = value as? NSNumber {
+                    raw = number.stringValue
+                } else {
+                    return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+                }
+                guard let parsed = parseMarkerListItemCount(raw) else {
+                    return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+                }
+                return parsed == 0 ? .zero : .nonZero(parsed)
+            }
+        }
+    }
+
+    /// Walks the already-bound Marker List window for AXStaticText nodes matching
+    /// `AXLocalePolicy.markerListNumberOfItemsLabel`, by AXDescription OR AXHelp — the same
+    /// two-attribute precedent `EventListReadbackCollector.readStaticText(help:)` uses for its
+    /// own "Number of Items" node. The table, button, and menu-button subtrees are skipped:
+    /// none of them can contain this witness (it sits under an AXGroup), and descending into
+    /// AXRows/AXChildren or the Edit control's own menu-negotiation subtree would couple this
+    /// witness to failure modes it exists to outvote, or to the unrelated menu route's own
+    /// read/retry discipline.
+    ///
+    /// Uniqueness can only be trusted when the entire searched subtree answered. A node that
+    /// will not answer might have been hiding a second "Number of Items" node — one whose
+    /// parent alone refuses to vend AXChildren, for instance — so finding exactly one match
+    /// elsewhere does NOT prove that match is unique. Any unreadable node anywhere in the
+    /// SEARCHED subtree therefore makes the whole search unreadable, regardless of how many
+    /// matches were already collected; only a walk that saw every candidate in scope can call
+    /// a single match unique.
+    static func markerListNumberOfItemsNodes(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        var matches: [AXUIElement] = []
+        var parents = [window]
+        var unreadable: AXHelpers.AXStatusError?
+        for _ in 0..<12 {
+            var next: [AXUIElement] = []
+            for parent in parents {
+                let children: [AXUIElement]
+                switch AXHelpers.childrenResult(parent, runtime: runtime) {
+                case .success(let observedChildren):
+                    children = observedChildren
+                case .failure(let error) where error.isDefinitiveAbsence:
+                    children = []
+                case .failure(let error):
+                    unreadable = unreadable ?? error
+                    children = []
+                }
+                for child in children {
+                    var childRole: String?
+                    switch AXHelpers.getAttributeResult(
+                        child, kAXRoleAttribute as String, runtime: runtime
+                    ) as Result<String?, AXHelpers.AXStatusError> {
+                    case .success(let role):
+                        childRole = role
+                        if role == (kAXStaticTextRole as String) {
+                            var matched = false
+                            switch AXHelpers.getAttributeResult(
+                                child, kAXDescriptionAttribute as String, runtime: runtime
+                            ) as Result<String?, AXHelpers.AXStatusError> {
+                            case .success(let description):
+                                matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
+                                    description, mode: .exactStrict
+                                )
+                            case .failure(let error) where error.isDefinitiveAbsence:
+                                break
+                            case .failure(let error):
+                                unreadable = unreadable ?? error
+                            }
+                            if !matched {
+                                switch AXHelpers.getAttributeResult(
+                                    child, kAXHelpAttribute as String, runtime: runtime
+                                ) as Result<String?, AXHelpers.AXStatusError> {
+                                case .success(let help):
+                                    matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
+                                        help, mode: .exactStrict
+                                    )
+                                case .failure(let error) where error.isDefinitiveAbsence:
+                                    break
+                                case .failure(let error):
+                                    unreadable = unreadable ?? error
+                                }
+                            }
+                            if matched {
+                                matches.append(child)
+                            }
+                        }
+                    case .failure(let error) where error.isDefinitiveAbsence:
+                        break
+                    case .failure(let error):
+                        unreadable = unreadable ?? error
+                    }
+                    // The independent count is not inside the Marker Table, and not inside a
+                    // button or menu button — Logic's own "Number of Items" text sits under an
+                    // AXGroup, never under a control. Do not descend into a projection we
+                    // already know can omit rows, or into the Edit control's OWN subtree: that
+                    // subtree's read health is coupled to the unrelated menu-route negotiation
+                    // (`AXShowMenu`/`AXCancel` observation), which has its own retry discipline
+                    // and must not be able to poison this witness by proxy.
+                    if childRole != (kAXTableRole as String),
+                       childRole != (kAXMenuButtonRole as String),
+                       childRole != (kAXButtonRole as String) {
+                        next.append(child)
+                    }
+                }
+            }
+            parents = next
+        }
+        // An unreadable node anywhere in this walk means uniqueness was never established,
+        // even when exactly one match was found: the part of the tree that would not answer
+        // could have been hiding a second candidate. Check this BEFORE looking at `matches`.
+        if let unreadable {
+            return .failure(unreadable)
+        }
+        return .success(matches)
+    }
+
+    /// Defensive parse of Logic's Number of Items value, following the same leading-token rule
+    /// as the Event List reader's `parseCount`: the value must OPEN with an ASCII digit run,
+    /// immediately followed by end-of-string or whitespace, with no further digits anywhere
+    /// after. `runs.count == 1` alone is not that rule — it accepts a single digit run
+    /// ANYWHERE in the string, so a value like `"Marker 2"` (a decoy or a differently-labelled
+    /// sibling) parses as `2` even though its single ASCII run is not the item count. That
+    /// manufactured number can look exactly like a genuine drop while the selection merely
+    /// moved. A failed parse is never published as zero.
+    static func parseMarkerListItemCount(_ text: String) -> Int? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first, first.isASCII, first.isNumber else { return nil }
+        let leadingDigits = trimmed.prefix { $0.isASCII && $0.isNumber }
+        let rest = trimmed[leadingDigits.endIndex...]
+        guard rest.isEmpty || (rest.first?.isWhitespace ?? false) else { return nil }
+        guard !rest.contains(where: { $0.isASCII && $0.isNumber }) else { return nil }
+        return Int(leadingDigits)
     }
 
     private static func sameElementMultiset(_ lhs: [AXUIElement], _ rhs: [AXUIElement]) -> Bool {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -688,7 +688,7 @@ extension AccessibilityChannel {
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> MarkerListItemCountRead {
-        switch findMarkerListNumberOfItemsNodes(in: window, runtime: runtime) {
+        switch AXLogicProElements.markerListNumberOfItemsNodes(in: window, runtime: runtime) {
         case .failure(let error):
             return .unreadable(error)
         case .success(let nodes) where nodes.isEmpty:
@@ -711,7 +711,7 @@ extension AccessibilityChannel {
                 } else {
                     return .unparseable(raw: "")
                 }
-                guard let parsed = parseMarkerListItemCount(raw) else {
+                guard let parsed = AXLogicProElements.parseMarkerListItemCount(raw) else {
                     return .unparseable(raw: raw)
                 }
                 return .parsed(parsed, raw: raw)
@@ -719,128 +719,6 @@ extension AccessibilityChannel {
         }
     }
 
-    /// Walks the already-bound Marker List window for AXStaticText nodes matching
-    /// `AXLocalePolicy.markerListNumberOfItemsLabel`, by AXDescription OR AXHelp — the same
-    /// two-attribute precedent `EventListReadbackCollector.readStaticText(help:)` uses for its
-    /// own "Number of Items" node. The table, button, and menu-button subtrees are skipped:
-    /// none of them can contain this witness (it sits under an AXGroup), and descending into
-    /// AXRows/AXChildren or the Edit control's own menu-negotiation subtree would couple this
-    /// witness to failure modes it exists to outvote, or to the unrelated menu route's own
-    /// read/retry discipline.
-    ///
-    /// Uniqueness can only be trusted when the entire searched subtree answered. A node that
-    /// will not answer might have been hiding a second "Number of Items" node — one whose
-    /// parent alone refuses to vend AXChildren, for instance — so finding exactly one match
-    /// elsewhere does NOT prove that match is unique. Any unreadable node anywhere in the
-    /// SEARCHED subtree therefore makes the whole search unreadable, regardless of how many
-    /// matches were already collected; only a walk that saw every candidate in scope can call
-    /// a single match unique.
-    private static func findMarkerListNumberOfItemsNodes(
-        in window: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
-        var matches: [AXUIElement] = []
-        var parents = [window]
-        var unreadable: AXHelpers.AXStatusError?
-        for _ in 0..<12 {
-            var next: [AXUIElement] = []
-            for parent in parents {
-                let children: [AXUIElement]
-                switch AXHelpers.childrenResult(parent, runtime: runtime) {
-                case .success(let observedChildren):
-                    children = observedChildren
-                case .failure(let error) where error.isDefinitiveAbsence:
-                    children = []
-                case .failure(let error):
-                    unreadable = unreadable ?? error
-                    children = []
-                }
-                for child in children {
-                    var childRole: String?
-                    switch AXHelpers.getAttributeResult(
-                        child, kAXRoleAttribute as String, runtime: runtime
-                    ) as Result<String?, AXHelpers.AXStatusError> {
-                    case .success(let role):
-                        childRole = role
-                        if role == (kAXStaticTextRole as String) {
-                            var matched = false
-                            switch AXHelpers.getAttributeResult(
-                                child, kAXDescriptionAttribute as String, runtime: runtime
-                            ) as Result<String?, AXHelpers.AXStatusError> {
-                            case .success(let description):
-                                matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
-                                    description, mode: .exactStrict
-                                )
-                            case .failure(let error) where error.isDefinitiveAbsence:
-                                break
-                            case .failure(let error):
-                                unreadable = unreadable ?? error
-                            }
-                            if !matched {
-                                switch AXHelpers.getAttributeResult(
-                                    child, kAXHelpAttribute as String, runtime: runtime
-                                ) as Result<String?, AXHelpers.AXStatusError> {
-                                case .success(let help):
-                                    matched = AXLocalePolicy.markerListNumberOfItemsLabel.matches(
-                                        help, mode: .exactStrict
-                                    )
-                                case .failure(let error) where error.isDefinitiveAbsence:
-                                    break
-                                case .failure(let error):
-                                    unreadable = unreadable ?? error
-                                }
-                            }
-                            if matched {
-                                matches.append(child)
-                            }
-                        }
-                    case .failure(let error) where error.isDefinitiveAbsence:
-                        break
-                    case .failure(let error):
-                        unreadable = unreadable ?? error
-                    }
-                    // The independent count is not inside the Marker Table, and not inside a
-                    // button or menu button — Logic's own "Number of Items" text sits under an
-                    // AXGroup, never under a control. Do not descend into a projection we
-                    // already know can omit rows, or into the Edit control's OWN subtree: that
-                    // subtree's read health is coupled to the unrelated menu-route negotiation
-                    // (`AXShowMenu`/`AXCancel` observation), which has its own retry discipline
-                    // and must not be able to poison this witness by proxy.
-                    if childRole != (kAXTableRole as String),
-                       childRole != (kAXMenuButtonRole as String),
-                       childRole != (kAXButtonRole as String) {
-                        next.append(child)
-                    }
-                }
-            }
-            parents = next
-        }
-        // An unreadable node anywhere in this walk means uniqueness was never established,
-        // even when exactly one match was found: the part of the tree that would not answer
-        // could have been hiding a second candidate. Check this BEFORE looking at `matches`.
-        if let unreadable {
-            return .failure(unreadable)
-        }
-        return .success(matches)
-    }
-
-    /// Defensive parse of Logic's Number of Items value, following the same leading-token rule
-    /// as the Event List reader's `parseCount`: the value must OPEN with an ASCII digit run,
-    /// immediately followed by end-of-string or whitespace, with no further digits anywhere
-    /// after. `runs.count == 1` alone is not that rule — it accepts a single digit run
-    /// ANYWHERE in the string, so a value like `"Marker 2"` (a decoy or a differently-labelled
-    /// sibling) parses as `2` even though its single ASCII run is not the item count. That
-    /// manufactured number can look exactly like a genuine drop while the selection merely
-    /// moved. A failed parse is never published as zero.
-    private static func parseMarkerListItemCount(_ text: String) -> Int? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let first = trimmed.first, first.isASCII, first.isNumber else { return nil }
-        let leadingDigits = trimmed.prefix { $0.isASCII && $0.isNumber }
-        let rest = trimmed[leadingDigits.endIndex...]
-        guard rest.isEmpty || (rest.first?.isWhitespace ?? false) else { return nil }
-        guard !rest.contains(where: { $0.isASCII && $0.isNumber }) else { return nil }
-        return Int(leadingDigits)
-    }
 
     /// The terminal outcome of the fixed six-poll settle budget. Keeping these cases separate
     /// prevents a readable ambiguous inventory from being reported as an unreadable readback

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -801,7 +801,12 @@ extension ResourceHandlers {
             "positions_canonical": readable && markers.allSatisfy { $0.positionSource == .parser },
         ]
         if !readable {
-            extras["reason"] = "marker_list_not_open"
+            // `readable == false` is the INITIAL value as well as a poll outcome, and the poller
+            // visits markers only every fifth tick — so a read in a process's first seconds sees
+            // a value nobody measured. Naming the closed Marker List window there attributes a
+            // cause that was never observed: measured 2026-08-17, a read at t+4s reported
+            // `marker_list_not_open` while the window was open and the channel path read it.
+            extras["reason"] = fetchedAt == .distantPast ? "markers_not_polled_yet" : "marker_list_not_open"
         }
         let envelope = wrapWithCacheEnvelope(
             bodyJSON: body,

--- a/Tests/LogicProMCPTests/AXMarkers12MarkerListTests.swift
+++ b/Tests/LogicProMCPTests/AXMarkers12MarkerListTests.swift
@@ -11,12 +11,28 @@ import Testing
 // real 12.2 install (see issue #8) and verify that
 // `AXLogicProElements.enumerateMarkers` resolves them via the new tier.
 
+/// Builds the tree Logic actually presents, measured on 12.3 (2026-08-17):
+///
+/// - the table's `AXChildren` carry FOUR `AXColumn` nodes and one `AXGroup` at every row count,
+///   so an empty Marker List is a table with children and no rows — not a childless table;
+/// - the window carries Logic's own "Number of Items" static text (`"0 Markers"`, `"3 Markers"`),
+///   which is the independent witness that tells an empty list apart from a rebuilding one;
+/// - the table answers `AXWindow`.
+///
+/// Before this, the empty fixture gave the table zero children. That shape does not occur in
+/// Logic, and building it is what let a reader that refused every empty Marker List pass its
+/// own emptiness test — see `AXLogicProElements.markerListStructuralRows`.
+///
+/// `itemCountText` overrides the witness so a test can present a list whose witness disagrees
+/// with its rows; `omitItemCount` removes the witness node entirely.
 private func makeMarkerListTree(
     builder: FakeAXRuntimeBuilder,
     appElement: AXUIElement,
     arrangeWindow: AXUIElement,
     markerListWindow: AXUIElement,
-    rows: [(position: String, name: String, length: String)]
+    rows: [(position: String, name: String, length: String)],
+    itemCountText: String? = nil,
+    omitItemCount: Bool = false
 ) -> AXUIElement {
     // appRoot exposes both windows via kAXWindowsAttribute
     builder.setAttribute(appElement, kAXWindowsAttribute as String, [arrangeWindow, markerListWindow])
@@ -33,7 +49,21 @@ private func makeMarkerListTree(
     // Table inside marker list window
     let table = builder.element(8000)
     builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
-    builder.setChildren(markerListWindow, [table])
+    builder.setAttribute(table, kAXWindowAttribute as String, markerListWindow)
+
+    var windowChildren: [AXUIElement] = [table]
+    if !omitItemCount {
+        let itemCount = builder.element(8900)
+        builder.setAttribute(itemCount, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        builder.setAttribute(itemCount, kAXDescriptionAttribute as String, "Number of Items")
+        builder.setAttribute(
+            itemCount,
+            kAXValueAttribute as String,
+            itemCountText ?? (rows.count == 1 ? "1 Marker" : "\(rows.count) Markers")
+        )
+        windowChildren.append(itemCount)
+    }
+    builder.setChildren(markerListWindow, windowChildren)
 
     // Build N rows; each row has 4 cells: [Lock, Position, Name, Length]
     var rowElements: [AXUIElement] = []
@@ -78,7 +108,19 @@ private func makeMarkerListTree(
         _ = rowIdx
     }
     builder.setAttribute(table, "AXRows", rowElements)
-    builder.setChildren(table, rowElements)
+    // Measured: the four column nodes and the trailing group are children of the table at every
+    // row count, so the structural reader always sees a non-empty child list.
+    var tableChildren: [AXUIElement] = []
+    for column in 0..<4 {
+        let columnElement = builder.element(8800 + column)
+        builder.setAttribute(columnElement, kAXRoleAttribute as String, kAXColumnRole as String)
+        tableChildren.append(columnElement)
+    }
+    tableChildren.append(contentsOf: rowElements)
+    let tableGroup = builder.element(8890)
+    builder.setAttribute(tableGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    tableChildren.append(tableGroup)
+    builder.setChildren(table, tableChildren)
 
     return arrangeWindow
 }
@@ -130,12 +172,59 @@ func enumerateMarkers_emptyMarkerListWindow_returnsEmpty() async {
     let runtime = builder.makeLogicRuntime(appElement: app)
     let result = AXLogicProElements.enumerateMarkersFromListWindow(listWin, runtime: runtime.ax)
 
+    // This is the shape a project with no markers presents: columns and a group under the table,
+    // no rows, and Logic's own witness reading "0 Markers". Measured live 2026-08-17, reading it
+    // as unreadable made `create_marker` — the only route to a first marker — permanently State C.
     // Source mutation applied once: turn the successful empty `AXRows` result into a failure.
     // This table genuinely exposes zero rows, so the restored reader must preserve its empty answer.
     if case .success(let markers) = result {
         #expect(markers.isEmpty)
     } else {
         #expect(false, "an exposed table with zero rows must be a readable empty list")
+    }
+}
+
+@Test
+func enumerateMarkers_zeroRowsWithANonZeroWitnessStaysUnreadable() async {
+    // A rebuilding table: the rows are gone from the projection while Logic's own count still
+    // says three. Publishing `[]` here is what the corroboration guard exists to prevent — it once
+    // certified the delete of a marker that was still present. Loosening the guard for the empty
+    // list must not reopen that.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(7_200)
+    let arrange = builder.element(7_201)
+    let listWin = builder.element(7_202)
+    _ = makeMarkerListTree(
+        builder: builder, appElement: app,
+        arrangeWindow: arrange, markerListWindow: listWin,
+        rows: [], itemCountText: "3 Markers"
+    )
+    let result = AXLogicProElements.enumerateMarkersFromListWindow(
+        listWin, runtime: builder.makeLogicRuntime(appElement: app).ax
+    )
+    if case .success(let markers) = result {
+        #expect(Bool(false), "a witness reporting 3 markers cannot yield an empty list, got \(markers.count)")
+    }
+}
+
+@Test
+func enumerateMarkers_zeroRowsWithNoWitnessStaysUnreadable() async {
+    // Absence of the witness is not a zero. Without the independent count there is nothing to
+    // tell an empty Marker List apart from a table that has not finished rebuilding.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(7_300)
+    let arrange = builder.element(7_301)
+    let listWin = builder.element(7_302)
+    _ = makeMarkerListTree(
+        builder: builder, appElement: app,
+        arrangeWindow: arrange, markerListWindow: listWin,
+        rows: [], omitItemCount: true
+    )
+    let result = AXLogicProElements.enumerateMarkersFromListWindow(
+        listWin, runtime: builder.makeLogicRuntime(appElement: app).ax
+    )
+    if case .success(let markers) = result {
+        #expect(Bool(false), "a missing witness cannot yield an empty list, got \(markers.count)")
     }
 }
 

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -109,6 +109,26 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     #expect(await cache.getMarkers().first?.name == "Cached Marker")
 }
 
+/// Before the first marker poll, `readable` is still its initial `false` — nobody has looked at
+/// the Marker List yet. Reporting `marker_list_not_open` there states a cause that was never
+/// observed. Measured live on 2026-08-17: a read four seconds into a process said the list was
+/// not open while the window was open and the channel path read it without trouble. The poller
+/// visits markers every fifth tick, so that window is ordinary, not exotic.
+@Test func markerResourceDoesNotBlameAClosedListBeforeTheFirstPoll() async throws {
+    let cache = StateCache()
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://markers",
+        cache: cache,
+        router: ChannelRouter()
+    )
+    let envelope = try issue254Envelope(result)
+
+    let readable = try #require(envelope["readable"] as? Bool)
+    #expect(!readable)
+    #expect(envelope["reason"] as? String == "markers_not_polled_yet")
+}
+
 /// `nav.delete_marker` must work on a default install.
 ///
 /// It used to route only to `[.midiKeyCommands, .cgEvent]`, so it did nothing at all until the


### PR DESCRIPTION
Closes #565.

## What was broken

In a project with zero markers, every marker operation returned State C
`readback_unavailable` — including `create_marker`, which is the only route to a first marker. The
marker surface was unreachable from a fresh project, and the delete that removes the LAST marker
could not certify either.

## Root cause, measured on Logic Pro 12.3 (2026-08-17)

The Marker List table vends **four `AXColumn` children plus one `AXGroup` at every row count**:

```
witness "0 Markers" -> table children = AXColumn|AXColumn|AXColumn|AXColumn|AXGroup, rows = 0
```

`markerListStructuralRows` guarded with `children.isEmpty || !rows.isEmpty`. On the live tree the
first clause is never true, so the guard reduced to *an empty row set is always unreadable*.

Control taken live, same project, same shipped binary, only the marker count changed:

| markers | `create_marker` |
|---|---|
| 0 | State C `readback_unavailable` |
| 1, created through the menu | State B `readback_mismatch` — the list was read |
| 1, playhead moved | **State A** |

## Why the suite passed anyway

`enumerateMarkers_emptyMarkerListWindow_returnsEmpty` built its empty table with **zero children**,
a shape Logic does not present, so it took the escape branch and went green while the live path
refused every empty list. The shared fixture now builds the measured tree — four columns, the
trailing group, the window's own "Number of Items" text, and `AXWindow` on the table.

## The fix

The guard's purpose stands: an empty `AXRows` must be corroborated, because believing it alone once
certified the delete of a marker that was still present. What changes is the discriminator.

Logic's own "Number of Items" rendering is not a projection of the table, so the empty row set is
published only when that independent witness parses to zero. A non-zero count, or a witness that
will not answer, keeps the read unreadable — a rebuilding table still cannot pass as an empty
marker list. A table that vends no children at all keeps its previous answer; that shape is not what
this fix is about.

The witness node lookup and its parse move down beside the row reader so both callers share one
definition of where the count lives and how it parses.

## Second finding in the same surface

`logic://markers` reported `reason: "marker_list_not_open"` whenever `readable` was false, including
before the first marker poll — which happens only every fifth poller tick. Measured: a read four
seconds into a process claimed the list was closed while the window was open and the channel path
read it fine. It now says `markers_not_polled_yet` until something has actually looked.

## Evidence

Unit — 3786 tests pass under the CI gate (`swift test --no-parallel`). Both directions are
mutation-tested: restoring the old guard reddens only the empty-list test; publishing the empty set
without corroboration reddens only the two new witness tests.

Live — `Scripts/livekit/live_565_empty_marker_list.py`, five mutation-backed checks, one visual
assertion over the Marker List table's row band, driven through the release binary:

```
emptying-the-list-certifies              last delete -> State A, witness "1 Marker" -> "0 Markers"
precondition-the-list-is-actually-empty  witness "0 Markers"
create-marker-works-on-an-empty-list     State A
the-product-saw-the-empty-list-as-empty  marker_count_before = 0
an-independent-witness-agrees            witness "0 Markers" -> "1 Marker"
```

The harness establishes its trigger before asserting anything: against a project that already has
markers every check would pass while testing nothing, so the run drives the list to zero through the
product's own delete and refuses to continue unless an instrument outside the product agrees the
list is empty.