### PR TITLE
fix(#568): corroborate every empty Marker List, and read its count in Korean and Japanese

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -85,7 +85,12 @@ def logic_window(title_contains="Tracks"):
         Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
         Quartz.kCGNullWindowID)
     for w in wins or []:
-        if w.get("kCGWindowOwnerName") != "Logic Pro":
+        # Measured 2026-08-17: with Logic running in Korean, `kCGWindowOwnerName` comes back as
+        # "Logic Pro" — a NO-BREAK SPACE — while English and Japanese give an ordinary space.
+        # An exact compare therefore found ZERO Logic windows on a Korean Logic, and every capture
+        # in the run recorded `window: null` while Logic was plainly on screen.
+        owner = (w.get("kCGWindowOwnerName") or "").replace(" ", " ")
+        if owner != "Logic Pro":
             continue
         name = w.get("kCGWindowName") or ""
         if title_contains and title_contains not in name:

--- a/Scripts/livekit/live_565_empty_marker_list.py
+++ b/Scripts/livekit/live_565_empty_marker_list.py
@@ -2,7 +2,7 @@
 """Live proof that a Marker List with no markers reads as EMPTY, not as unreadable.
 
 Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
-        python3 live_565_empty_marker_list.py <worktree> <full-40-char-head-sha>
+        python3 live_565_empty_marker_list.py <worktree> <full-40-char-head-sha> [--locale en|ko|ja]
 
 WHAT WENT WRONG
 ---------------
@@ -19,6 +19,18 @@ defect only exists at a row count of zero. So the run drives the list to zero th
 own delete and REFUSES to continue unless an instrument outside the product agrees the list is
 empty. Following #549, an unestablished trigger is a failed run, not a quiet pass.
 
+LOCALE
+------
+`--locale` does NOT change Logic's language — the operator sets that with
+`defaults write com.apple.logic10 AppleLanguages` and restarts, because quitting Logic can raise a
+save prompt that needs a human decision. It selects the strings this harness uses to FIND things,
+and the run refuses to continue unless the running Logic actually presents them, so a run can never
+be filed under a locale it did not exercise.
+
+Every string in LOCALES was read off a live Logic 12.3 on 2026-08-17, never translated. The empty
+Marker List is unreadable in a locale whose count label is not measured, so "does this work in
+Japanese" is a question only a Japanese Logic can answer.
+
 INSTRUMENTS
 -----------
 The marker count is read two ways that do not share a code path:
@@ -31,6 +43,7 @@ opinion of itself. It is also the discriminator the fix uses, so a run where the
 reporting something worth seeing, not a harness bug to paper over.
 """
 
+import itertools
 import json
 import os
 import subprocess
@@ -54,7 +67,25 @@ if missing:
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 d = E.Driver()
 
-MARKER_WINDOW = "Marker List"
+# Measured on a live Logic 12.3, 2026-08-17: window title suffix, the count node's AXDescription,
+# and the value it renders. The value forms matter — Korean and Japanese abut the counter word
+# against the digits (`2개의 마커`, `0個のマーカー`), which is what the count parser had to learn.
+LOCALES = {
+    "en": {"window": "Marker List",   "count_label": "Number of Items", "create": "Create Marker",
+           "navigate": "Navigate", "open_list": "Open Marker List"},
+    "ko": {"window": "마커 목록",       "count_label": "항목 수",         "create": "마커 생성",
+           "navigate": "탐색",     "open_list": "마커 목록 열기"},
+    "ja": {"window": "マーカーリスト", "count_label": "項目数",          "create": "マーカーを作成",
+           "navigate": "移動",     "open_list": "マーカーリストを開く"},
+}
+
+LOCALE = "en"
+if "--locale" in sys.argv:
+    LOCALE = sys.argv[sys.argv.index("--locale") + 1]
+if LOCALE not in LOCALES:
+    sys.exit(f"unknown locale {LOCALE!r}; measured locales are {sorted(LOCALES)}")
+L = LOCALES[LOCALE]
+MARKER_WINDOW = L["window"]
 # Window-relative rectangle over the first rows of the Marker List table, derived from a live
 # measurement (window at 452x746, table origin 142 points below the window's own origin). The band
 # stops well short of the table's full height so the assertion is about ROWS appearing, not about
@@ -75,8 +106,8 @@ def witness():
     """
     return osa(
         'tell application "System Events" to tell process "Logic Pro"\n'
-        'set w to first window whose name ends with "Marker List"\n'
-        'return value of (first static text of (first group of w) whose description is "Number of Items")\n'
+        f'set w to first window whose name ends with "{MARKER_WINDOW}"\n'
+        f'return value of (first static text of (first group of w) whose description is "{L["count_label"]}")\n'
         'end tell')
 
 
@@ -88,8 +119,10 @@ def witness_count(tries=5):
     """
     for attempt in range(tries):
         raw = witness()
-        head = raw.split(" ")[0] if raw else ""
-        if head.isdigit():
+        # Leading digit run, NOT a whitespace split: `2개의 마커` and `0個のマーカー` have no space
+        # after the number, so splitting on " " yields `2개의` and reads as "no count".
+        head = "".join(itertools.takewhile(str.isdigit, raw)) if raw else ""
+        if head:
             return int(head)
         if attempt < tries - 1:
             time.sleep(0.8)
@@ -107,7 +140,7 @@ def open_marker_list():
     osa('tell application "System Events" to tell process "Logic Pro"\n'
         'set frontmost to true\n'
         'delay 0.5\n'
-        'click menu item "Open Marker List" of menu 1 of menu bar item "Navigate" of menu bar 1\n'
+        f'click menu item "{L["open_list"]}" of menu 1 of menu bar item "{L["navigate"]}" of menu bar 1\n'
         'end tell')
     time.sleep(2)
 
@@ -128,7 +161,7 @@ def seed_marker_via_menu():
         osa('tell application "System Events" to tell process "Logic Pro"\n'
             'set frontmost to true\n'
             'delay 0.8\n'
-            'click menu item "Create Marker" of menu 1 of menu bar item "Navigate" of menu bar 1\n'
+            f'click menu item "{L["create"]}" of menu 1 of menu bar item "{L["navigate"]}" of menu bar 1\n'
             'end tell')
         time.sleep(1.5)
         after = witness_count()
@@ -137,7 +170,26 @@ def seed_marker_via_menu():
     return False
 
 
-open_marker_list()
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+if MARKER_WINDOW not in titles:
+    open_marker_list()
+    titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+                 'return name of every window')
+locale_ok = MARKER_WINDOW in titles
+ev.check(f"565/{LOCALE}/precondition-logic-is-actually-in-this-locale", locale_ok,
+         f"a window title carries this locale's Marker List name ({MARKER_WINDOW!r}), so the run "
+         "exercises the locale it claims",
+         f"locale={LOCALE} titles={titles!r}",
+         # No mutation: this is the locale witness, not an assertion about the fix. Naming one here
+         # would mark the check mutation-backed when nobody has watched it flip.
+         None)
+if not locale_ok:
+    d.close()
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(1)
+
 if witness_count() == 0:
     seed_marker_via_menu()
 started_with = witness_count()
@@ -154,13 +206,13 @@ for _ in range(8):
         break
 
 empty_witness = witness_count()
-ev.note("565/drive-to-empty", {"started_with": started_with, "deletes": deletes,
+ev.note(f"565/{LOCALE}/drive-to-empty", {"started_with": started_with, "deletes": deletes,
                                "witness_now": witness()})
 
 # The LAST delete is half the defect: with zero rows left the post-write read had nothing it would
 # accept, so emptying the list could not certify. This asserts the tail of that sequence directly.
 last_delete = deletes[-1] if deletes else None
-ev.check("565/emptying-the-list-certifies",
+ev.check(f"565/{LOCALE}/emptying-the-list-certifies",
          bool(last_delete) and last_delete["state"] == "A",
          "the delete that leaves zero markers reaches State A",
          f"last_delete={last_delete} deletes={len(deletes)} started_with={started_with}"
@@ -168,11 +220,13 @@ ev.check("565/emptying-the-list-certifies",
          "restore `children.isEmpty || !rows.isEmpty`: the post-write read of a table with no rows "
          "left becomes unreadable and the delete can no longer certify")
 
-ev.check("565/precondition-the-list-is-actually-empty", empty_witness == 0,
+ev.check(f"565/{LOCALE}/precondition-the-list-is-actually-empty", empty_witness == 0,
          "Logic's own Number of Items reads zero, so the run is exercising the empty-list path",
          f"witness={witness()!r} parsed={empty_witness!r}",
-         "none — this is the trigger, not the fix. A run that reaches the checks below without it "
-         "passes them against a NON-empty list and proves nothing about the defect")
+         # No mutation: this is the trigger, not the fix. A run that reaches the checks below without
+         # it passes them against a NON-empty list and proves nothing about the defect — which is why
+         # the run hard-exits here rather than continuing.
+         None)
 
 if empty_witness != 0:
     ev.stop_recording(rec)
@@ -181,7 +235,7 @@ if empty_witness != 0:
     print(json.dumps(out, indent=1))
     sys.exit(1)
 
-before = ev.shot("565/list-empty", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
+before = ev.shot(f"565/{LOCALE}/list-empty", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
 
 # ---- the operation the defect made impossible -------------------------------------------------
 # The playhead is moved first: `Create Marker` at a position that already carries one is a no-op in
@@ -190,9 +244,9 @@ goto = d.tool("logic_transport", "goto_position", {"bar": "33"})
 created = d.tool("logic_navigate", "create_marker", {})
 time.sleep(1.5)
 after_witness = witness_count()
-ev.note("565/create-on-empty", {"goto": goto, "created": created, "witness_after": witness()})
+ev.note(f"565/{LOCALE}/create-on-empty", {"goto": goto, "created": created, "witness_after": witness()})
 
-ev.check("565/create-marker-works-on-an-empty-list",
+ev.check(f"565/{LOCALE}/create-marker-works-on-an-empty-list",
          state_of(created) == "A",
          "create_marker reaches State A in a project that has no markers",
          f"state={state_of(created)!r} error={created.get('error')!r} "
@@ -200,7 +254,7 @@ ev.check("565/create-marker-works-on-an-empty-list",
          "restore `children.isEmpty || !rows.isEmpty`: the pre-write read fails and the operation "
          "returns State C readback_unavailable before it ever presses the menu item")
 
-ev.check("565/the-product-saw-the-empty-list-as-empty",
+ev.check(f"565/{LOCALE}/the-product-saw-the-empty-list-as-empty",
          created.get("marker_count_before") == 0,
          "the operation's own pre-write count is zero, so it read the empty list rather than "
          "refusing it",
@@ -209,15 +263,15 @@ ev.check("565/the-product-saw-the-empty-list-as-empty",
          "this check alone cannot tell the fix from the unsafe version; it is paired with the "
          "witness check below")
 
-ev.check("565/an-independent-witness-agrees-a-marker-appeared",
+ev.check(f"565/{LOCALE}/an-independent-witness-agrees-a-marker-appeared",
          after_witness == 1,
          "Logic's own Number of Items goes from 0 to 1, measured outside the product",
          f"witness={witness()!r} parsed={after_witness!r}",
          "make create_marker return State A without pressing the menu item: the envelope would "
          "still claim a create while this count stayed at 0")
 
-after = ev.shot("565/marker-created", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
-ev.visual("565/a-row-appears-in-the-marker-table",
+after = ev.shot(f"565/{LOCALE}/marker-created", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
+ev.visual(f"565/{LOCALE}/a-row-appears-in-the-marker-table",
           before["file"], after["file"], ROW_BAND, expect_change=True,
           why="the first rows of the Marker List table are empty before the create and carry the "
               "new marker after it")
@@ -236,7 +290,7 @@ restored_to = witness_count()
 # An unread baseline is not a baseline of zero. Spelling `started_with or 0` here would let a run
 # that never measured what it started from report a successful restore — the same shape as the
 # defect this branch fixes, in the instrument rather than the product.
-ev.restored("565/marker-count-back-to-what-the-run-found",
+ev.restored(f"565/{LOCALE}/marker-count-back-to-what-the-run-found",
             started_with is not None and restored_to is not None and restored_to <= started_with,
             f"started_with={started_with} now={restored_to}; the run's own markers are removed, but "
             f"markers this run deleted to reach the empty state are NOT restorable in-session"

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -321,16 +321,19 @@ enum AXLocalePolicy {
     )
 
     /// The Marker List's own "Number of Items" static text — Logic's independent rendering of
-    /// the marker count, used as a second witness alongside the table's row projections. Only
-    /// the English form has been measured on a live Logic 12.3; no Korean or Japanese variant
-    /// has been read from a live Logic. Do NOT add a translated guess here — an unmeasured
-    /// locale must stay unreadable (State B) rather than silently matching on an invented
-    /// label. Matched against both AXDescription and AXHelp, mirroring the Event List reader's
-    /// `readStaticText(help:)` precedent for the same "Number of Items" node.
+    /// the marker count, used as a second witness alongside the table's row projections. Matched
+    /// against both AXDescription and AXHelp, mirroring the Event List reader's
+    /// `readStaticText(help:)` precedent for the same node.
+    ///
+    /// All three forms are read off a live Logic 12.3, never translated: the app was switched with
+    /// `defaults write com.apple.logic10 AppleLanguages`, restarted, and the node's AXDescription
+    /// read directly. Both localized forms answer the SAME string on AXDescription and AXHelp, and
+    /// the Korean one carries a space (`항목 수`) while the Japanese one does not (`項目数`) — which
+    /// is why they are pinned as measured strings and not derived from one another.
     static let markerListNumberOfItemsLabel = LabelSet(
         canonical: "Number of Items",
-        variants: [],
-        rationale: "Live-confirmed on Logic 12.3 (English) via AXDescription. Korean/Japanese not yet measured; an unmeasured locale must fail closed rather than match a guessed translation."
+        variants: ["항목 수", "項目数"],
+        rationale: "Live-measured on Logic 12.3 on 2026-08-17: AXDescription and AXHelp both read `항목 수` in Korean and `項目数` in Japanese, alongside the English `Number of Items`. Until that date this LabelSet deliberately carried no variants because none had been measured; the values it renders were measured in the same pass (`2개의 마커`, `0個のマーカー`) and drove the count parser's separator rule."
     )
 
     /// The destructive Marker List Edit-menu command. This must always be whole-string matched.

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Markers.swift
@@ -314,7 +314,11 @@ extension AXLogicProElements {
             return .failure(MarkerListReadFailure(site: .tableLookup, status: error))
         }
 
-        return markerListInventoryWithReadFailure(from: table, runtime: runtime)
+        // The witness must be read from the window the CALLER bound, not from whatever the table's
+        // `AXWindow` answers. Resolving it again would make an empty list depend on an attribute
+        // this path never needed, and a mis-bound `AXWindow` pointing at some other window whose
+        // own count reads zero is the one wrong-window direction that is not safe.
+        return markerListInventoryWithReadFailure(from: table, ownerWindow: window, runtime: runtime)
     }
 
     /// Re-reads the exact table element a caller already bound, without resolving another table
@@ -336,9 +340,12 @@ extension AXLogicProElements {
     /// this method never re-discovers a table from the window.
     static func enumerateMarkersFromListTableWithReadFailure(
         _ table: AXUIElement,
+        ownerWindow: AXUIElement? = nil,
         runtime: AXHelpers.Runtime
     ) -> Result<[MarkerState], MarkerListReadFailure> {
-        switch markerListInventoryWithReadFailure(from: table, runtime: runtime) {
+        switch markerListInventoryWithReadFailure(
+            from: table, ownerWindow: ownerWindow, runtime: runtime
+        ) {
         case .success(let inventory):
             return .success(inventory.markers)
         case .failure(let failure):
@@ -361,8 +368,12 @@ extension AXLogicProElements {
     /// Mirrors the inventory reader's existing read/guard flow exactly, retaining where its
     /// existing `AXStatusError` arose instead of flattening it before the delete receipt can
     /// expose the result.
+    /// `ownerWindow` is the Marker List window a caller already resolved. It is nil only on the
+    /// post-write table-only path, which deliberately holds no window; there the owner is recovered
+    /// from the table's own `AXWindow`.
     private static func markerListInventoryWithReadFailure(
         from table: AXUIElement,
+        ownerWindow: AXUIElement? = nil,
         runtime: AXHelpers.Runtime
     ) -> Result<MarkerListInventory, MarkerListReadFailure> {
         enum RowSource {
@@ -387,7 +398,7 @@ extension AXLogicProElements {
             // unreadable list, not as a survivor set. The direct-child order is deliberately not
             // compared: AXRows defines marker indices, while the structural traversal can reorder
             // otherwise identical row elements.
-            switch markerListStructuralRows(from: table, runtime: runtime) {
+            switch markerListStructuralRows(from: table, ownerWindow: ownerWindow, runtime: runtime) {
             case .success(let structuralRows):
                 guard sameElementMultiset(observedRows, structuralRows) else {
                     return .failure(MarkerListReadFailure(
@@ -408,7 +419,7 @@ extension AXLogicProElements {
             // role-filtered structural `[]` is a complete Marker List. Use the same structural
             // reader as the AXRows-corrobation path: present children that temporarily cease to
             // report AXRow make this poll unreadable rather than a false empty survivor set.
-            switch markerListStructuralRows(from: table, runtime: runtime) {
+            switch markerListStructuralRows(from: table, ownerWindow: ownerWindow, runtime: runtime) {
             case .success(let structuralRows):
                 rows = structuralRows
                 rowSource = .structuralChildren
@@ -418,7 +429,7 @@ extension AXLogicProElements {
         case .success(nil):
             // A successful nil carries the same attribute-absence answer as a definitive
             // AXRows failure, so it must take the same guarded structural route.
-            switch markerListStructuralRows(from: table, runtime: runtime) {
+            switch markerListStructuralRows(from: table, ownerWindow: ownerWindow, runtime: runtime) {
             case .success(let structuralRows):
                 rows = structuralRows
                 rowSource = .structuralChildren
@@ -517,6 +528,7 @@ extension AXLogicProElements {
     /// read unreadable — so a rebuilding table still cannot be mistaken for an empty marker list.
     private static func markerListStructuralRows(
         from table: AXUIElement,
+        ownerWindow: AXUIElement?,
         runtime: AXHelpers.Runtime
     ) -> Result<[AXUIElement], MarkerListReadFailure> {
         let children: [AXUIElement]
@@ -537,12 +549,15 @@ extension AXLogicProElements {
                 return .failure(MarkerListReadFailure(site: .structuralChildren, status: error))
             }
         }
-        // A table that vends NO children at all keeps its pre-existing answer: that shape was
-        // already accepted as an empty list and is not what this fix is about. The change is
-        // confined to the shape Logic actually presents — children present, none of them rows.
-        guard !rows.isEmpty || !children.isEmpty else { return .success([]) }
         guard rows.isEmpty else { return .success(rows) }
-        switch markerListZeroItemsWitness(forTableOf: table, runtime: runtime) {
+        // Every empty row set goes through the witness, including a table that vends NO children at
+        // all. That case used to be published as an empty list with no corroboration, on the
+        // reasoning that a childless table is obviously empty — but "the table answered with
+        // nothing" is exactly the answer a rebuild gives, and it is the original unguarded path
+        // that once certified the delete of a marker that was still present. Logic's live table
+        // always carries its columns, so this branch is not a shape the application presents; the
+        // only thing keeping it separate was a test fixture that built it.
+        switch markerListZeroItemsWitness(forTableOf: table, ownerWindow: ownerWindow, runtime: runtime) {
         case .zero:
             return .success([])
         case .nonZero:
@@ -577,18 +592,23 @@ extension AXLogicProElements {
     /// witness is not a zero.
     static func markerListZeroItemsWitness(
         forTableOf table: AXUIElement,
+        ownerWindow: AXUIElement? = nil,
         runtime: AXHelpers.Runtime
     ) -> MarkerListZeroItemsWitness {
         let window: AXUIElement
-        switch AXHelpers.getAttributeResult(
-            table, kAXWindowAttribute as String, runtime: runtime
-        ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
-        case .success(let owner?):
-            window = owner
-        case .success(nil):
-            return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
-        case .failure(let error):
-            return .unreadable(error)
+        if let ownerWindow {
+            window = ownerWindow
+        } else {
+            switch AXHelpers.getAttributeResult(
+                table, kAXWindowAttribute as String, runtime: runtime
+            ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
+            case .success(let owner?):
+                window = owner
+            case .success(nil):
+                return .unreadable(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+            case .failure(let error):
+                return .unreadable(error)
+            }
         }
         switch markerListNumberOfItemsNodes(in: window, runtime: runtime) {
         case .failure(let error):
@@ -738,7 +758,20 @@ extension AXLogicProElements {
         guard let first = trimmed.first, first.isASCII, first.isNumber else { return nil }
         let leadingDigits = trimmed.prefix { $0.isASCII && $0.isNumber }
         let rest = trimmed[leadingDigits.endIndex...]
-        guard rest.isEmpty || (rest.first?.isWhitespace ?? false) else { return nil }
+        // English separates the count from its noun with a space (`"15 Markers"`), but Korean and
+        // Japanese do not: measured on a live Logic 12.3 on 2026-08-17, the same node renders
+        // `2개의 마커` and `0個のマーカー`, where the counter word abuts the digits. Requiring
+        // whitespace there made the witness unparseable in both locales, which is not a locale
+        // detail — this count is what the delete receipt needs for State A, so `nav.delete_marker`
+        // could not certify on a Korean or Japanese Logic at all.
+        //
+        // The relaxation is narrow on purpose: the character after the digits may be whitespace or
+        // NON-ASCII (a CJK counter word). An ASCII letter is still a refusal, so `"1st"` or `"0x1F"`
+        // cannot become a count, and the two original rules stand — the value must OPEN with the
+        // digit run, so a decoy like `"Marker 2"` never parses, and no digit may appear after it.
+        guard rest.isEmpty
+                || (rest.first?.isWhitespace ?? false)
+                || !(rest.first?.isASCII ?? true) else { return nil }
         guard !rest.contains(where: { $0.isASCII && $0.isNumber }) else { return nil }
         return Int(leadingDigits)
     }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MarkerDelete.swift
@@ -279,7 +279,12 @@ extension AccessibilityChannel {
         for _ in 0..<6 {
             let reading: [MarkerState]
             switch AXLogicProElements.enumerateMarkersFromListTableWithReadFailure(
-                inventory.table, runtime: runtime.ax
+                inventory.table,
+                // The witness is read from the window this flow already bound, never from the
+                // table's own `AXWindow`: a mis-bound attribute pointing at another window whose
+                // count reads zero is the one wrong-window answer that is not safe.
+                ownerWindow: window,
+                runtime: runtime.ax
             ) {
             case .success(let observedMarkers):
                 reading = observedMarkers

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Markers.swift
@@ -324,12 +324,16 @@ extension AccessibilityChannel {
         let focusBlock: String
         switch action {
         case .create:
+            // The arrange window's title suffix is localized, so it is resolved from the same
+            // LabelSet the rest of this file uses. It was an English/Korean literal pair, which
+            // made this script fail outright on a Japanese Logic and surface as a missing menu item.
+            let arrangeResolution = AppleScriptMenuResolution.windowWithTitleSuffix(
+                AXLocalePolicy.arrangeWindowTitleSuffix,
+                variableName: "targetWindow",
+                notFoundError: "ARRANGE_WINDOW_NOT_FOUND"
+            )
             focusBlock = """
-                try
-                    set targetWindow to first window whose name ends with "Tracks"
-                on error
-                    set targetWindow to first window whose name ends with "트랙"
-                end try
+                \(arrangeResolution)
                 set value of attribute "AXMain" of targetWindow to true
                 perform action "AXRaise" of targetWindow
                 delay 0.1

--- a/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers+StateReaders.swift
@@ -782,6 +782,7 @@ extension ResourceHandlers {
         let fetchedAt = await cache.getMarkersFetchedAt()
         let axOccluded = await cache.getAXOccluded()
         let readable = await cache.getMarkersReadable()
+        let attempted = await cache.getMarkersPollAttempted()
         let body = encodeMarkersWire(markers)
         let source = readable ? "ax_live" : (markers.isEmpty ? "unreadable" : "cache")
         // A stable, length-prefixed projection lets mutation oracles bind a reported survivor set
@@ -806,7 +807,12 @@ extension ResourceHandlers {
             // a value nobody measured. Naming the closed Marker List window there attributes a
             // cause that was never observed: measured 2026-08-17, a read at t+4s reported
             // `marker_list_not_open` while the window was open and the channel path read it.
-            extras["reason"] = fetchedAt == .distantPast ? "markers_not_polled_yet" : "marker_list_not_open"
+            //
+            // The question is whether anything has TRIED, which `fetchedAt` cannot answer — it
+            // advances only on a successful read, so a poll that ran and failed leaves it at
+            // `.distantPast` exactly like a poll that never ran. Keying on that would have moved
+            // the false attribution rather than removed it.
+            extras["reason"] = attempted ? "marker_list_not_open" : "markers_not_polled_yet"
         }
         let envelope = wrapWithCacheEnvelope(
             bodyJSON: body,

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -18,6 +18,13 @@ actor StateCache {
     private(set) var regionsComplete = false
     private(set) var markers: [MarkerState] = []
     private(set) var markersReadable: Bool = false
+    /// Whether anything has yet TRIED to read the Marker List in this process.
+    ///
+    /// `markersFetchedAt` advances only on a successful read, so it cannot answer this: a poll that
+    /// ran and failed leaves it at `.distantPast`, exactly like a poll that never ran. A resource
+    /// that wants to say why markers are unreadable needs the two told apart, or it names a cause
+    /// nobody looked for.
+    private(set) var markersPollAttempted: Bool = false
     private(set) var project = ProjectInfo()
     private(set) var mcuConnection = MCUConnectionState()
     private(set) var mcuDisplay = MCUDisplayState()
@@ -114,6 +121,7 @@ actor StateCache {
     func getRegionsComplete() -> Bool { regionsComplete }
     func getMarkers() -> [MarkerState] { markers }
     func getMarkersReadable() -> Bool { markersReadable }
+    func getMarkersPollAttempted() -> Bool { markersPollAttempted }
     func getProject() -> ProjectInfo { project }
     func getMCUConnection() -> MCUConnectionState { mcuConnection }
     func getMCUDisplay() -> MCUDisplayState { mcuDisplay }
@@ -428,6 +436,7 @@ actor StateCache {
         // `cache.markers` directly don't see redundant publishes.
         markersFetchedAt = Date()
         markersReadable = true
+        markersPollAttempted = true
         if markers != newMarkers {
             markers = newMarkers
         }
@@ -435,6 +444,7 @@ actor StateCache {
 
     func markMarkersUnreadable() {
         markersReadable = false
+        markersPollAttempted = true
     }
 
     func updateProject(_ info: ProjectInfo) {

--- a/Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift
+++ b/Sources/LogicProMCP/Utilities/AppleScriptMenuResolution.swift
@@ -69,6 +69,38 @@ enum AppleScriptMenuResolution {
         """
     }
 
+    /// Resolves a WINDOW by localized title suffix, in the order the LabelSet lists.
+    ///
+    /// Window titles are `"<project name> - <localized view name>"`, so this matches by
+    /// `ends with` rather than by element name. The `try` around each attempt is load-bearing:
+    /// `first window whose name ends with ...` raises `-1719` when nothing matches, which would
+    /// abort the whole script instead of moving on to the next locale's suffix.
+    ///
+    /// This exists because the marker-menu script hard-coded an English and a Korean suffix as a
+    /// `try`/`on error` pair. On a Japanese Logic both lookups failed, the script errored, and
+    /// `create_marker` reported `Navigate > Create Marker was not found or could not be pressed` —
+    /// a locale gap wearing the costume of a missing menu item. Measured live on 2026-08-17: the
+    /// menu names were already resolved from a LabelSet; only the window lookup was not.
+    static func windowWithTitleSuffix(
+        _ labelSet: AXLocalePolicy.LabelSet,
+        variableName: String,
+        notFoundError: String
+    ) -> String {
+        let literals = labelSet.labels
+            .map { "\"\(AppleScriptSafety.escapeForScript($0))\"" }
+            .joined(separator: ", ")
+        return """
+        set \(variableName) to missing value
+        repeat with candidate in {\(literals)}
+            try
+                set \(variableName) to first window whose name ends with candidate
+                exit repeat
+            end try
+        end repeat
+        if \(variableName) is missing value then error "\(notFoundError)"
+        """
+    }
+
     /// Convenience for a top-level menu-bar item: `menu bar item <name> of menu bar 1`.
     static func menuBarItem(
         _ labelSet: AXLocalePolicy.LabelSet,

--- a/Tests/LogicProMCPTests/AXMarkers12MarkerListTests.swift
+++ b/Tests/LogicProMCPTests/AXMarkers12MarkerListTests.swift
@@ -229,6 +229,64 @@ func enumerateMarkers_zeroRowsWithNoWitnessStaysUnreadable() async {
 }
 
 @Test
+func enumerateMarkers_witnessComesFromTheWindowTheCallerBoundNotTheTablesAXWindow() async {
+    // The window-scoped reader already holds the Marker List window. Resolving the witness again
+    // through the table's `AXWindow` would let a mis-bound attribute decide: an attribute pointing
+    // at some OTHER window whose own count reads zero would certify an empty list for a table whose
+    // rows are merely missing. Absent is a safe wrong answer; wrong-and-zero is not.
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(7_400)
+    let arrange = builder.element(7_401)
+    let listWin = builder.element(7_402)
+    _ = makeMarkerListTree(
+        builder: builder, appElement: app,
+        arrangeWindow: arrange, markerListWindow: listWin,
+        rows: [], itemCountText: "4 Markers"
+    )
+
+    // A decoy window that says zero, wired into the table's AXWindow.
+    let decoy = builder.element(7_410)
+    builder.setAttribute(decoy, kAXRoleAttribute as String, kAXWindowRole as String)
+    let decoyCount = builder.element(7_411)
+    builder.setAttribute(decoyCount, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(decoyCount, kAXDescriptionAttribute as String, "Number of Items")
+    builder.setAttribute(decoyCount, kAXValueAttribute as String, "0 Markers")
+    builder.setChildren(decoy, [decoyCount])
+    builder.setAttribute(builder.element(8000), kAXWindowAttribute as String, decoy)
+
+    let result = AXLogicProElements.enumerateMarkersFromListWindow(
+        listWin, runtime: builder.makeLogicRuntime(appElement: app).ax
+    )
+    if case .success(let markers) = result {
+        #expect(Bool(false),
+                "the decoy window's zero must not certify an empty list, got \(markers.count)")
+    }
+}
+
+@Test
+func enumerateMarkers_tableWithNoChildrenAtAllStillNeedsTheWitness() async {
+    // A table that answers `AXChildren` with nothing is not self-evidently an empty Marker List —
+    // "the table returned nothing" is also what a rebuild returns, and publishing it uncorroborated
+    // is the original path that once certified the delete of a marker that was still present.
+    let builder = FakeAXRuntimeBuilder()
+    let listWin = builder.element(7_500)
+    let table = builder.element(7_501)
+    builder.setAttribute(listWin, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
+    builder.setAttribute(table, "AXRows", [AXUIElement]())
+    builder.setChildren(table, [])
+    builder.setChildren(listWin, [table])
+
+    let result = AXLogicProElements.enumerateMarkersFromListWindow(
+        listWin, runtime: builder.makeAXRuntime()
+    )
+    if case .success(let markers) = result {
+        #expect(Bool(false),
+                "a childless table with no witness cannot certify an empty list, got \(markers.count)")
+    }
+}
+
+@Test
 func enumerateMarkers_missingTableIsUnavailableRatherThanEmpty() async {
     // Source mutation applied once: restore `.success([])` when markerListTable finds no table.
     // This window has no table, so that mutation fails the unavailable-read assertion.
@@ -742,4 +800,46 @@ func updateMarkers_sameNonEmpty_advancesFetchedAt() async {
     await cache.updateMarkers([m1])
     let after2 = await cache.getMarkersFetchedAt()
     #expect(after2 > after1, "fetchedAt must advance for any successful poll, not just diffs")
+}
+
+@Suite("the marker-create script resolves its window by locale, not by two literals")
+struct MarkerCreateArrangeWindowResolutionTests {
+    /// Measured live on 2026-08-17: on a Japanese Logic 12.3 with the Marker List open and zero
+    /// markers, `create_marker` returned State C `element_not_found` with the hint
+    /// "Navigate > Create Marker was not found or could not be pressed". The menu names were fine —
+    /// `移動` and `マーカーを作成` are both in their LabelSets. The script's own focus block hard-coded
+    /// `Tracks` and `트랙` as a try/on-error pair, so the window lookup failed and took the whole
+    /// script with it, reporting a locale gap as a missing menu item.
+    @Test("every measured arrange-window suffix appears in the generated script")
+    func scriptCarriesEveryArrangeWindowSuffix() {
+        let script = AccessibilityChannel.markerMenuActuationScript(.create)
+        for suffix in AXLocalePolicy.arrangeWindowTitleSuffix.labels {
+            #expect(script.contains(suffix),
+                    "the create script must be able to find an arrange window titled ...\(suffix)")
+        }
+        #expect(AXLocalePolicy.arrangeWindowTitleSuffix.labels.contains("トラック"))
+    }
+
+    /// A candidate loop only helps if a non-matching suffix does not abort the script. Logic raises
+    /// -1719 from `first window whose name ends with ...` when nothing matches, so each attempt has
+    /// to be guarded — without that the loop dies on its first miss, which is every locale but the
+    /// one listed first.
+    @Test("each suffix attempt is individually guarded so a miss continues the loop")
+    func eachSuffixAttemptIsGuarded() throws {
+        let script = AccessibilityChannel.markerMenuActuationScript(.create)
+        #expect(script.contains("ARRANGE_WINDOW_NOT_FOUND"))
+        let arrangeLoop = try #require(
+            script
+                .components(separatedBy: "repeat with candidate in")
+                .dropFirst()
+                .first { $0.contains("ends with candidate") },
+            "the script must resolve the arrange window through a candidate loop"
+        )
+        let attempt = try #require(
+            arrangeLoop.range(of: "ends with candidate"),
+            "the loop body must contain the suffix attempt"
+        )
+        let beforeAttempt = arrangeLoop[arrangeLoop.startIndex..<attempt.lowerBound]
+        #expect(beforeAttempt.contains("try"))
+    }
 }

--- a/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
+++ b/Tests/LogicProMCPTests/Issue254MarkerSurfaceTests.swift
@@ -54,7 +54,26 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     builder.setAttribute(window, kAXDocumentAttribute as String, "/Issue254.logicx")
     builder.setAttribute(table, kAXRoleAttribute as String, kAXTableRole as String)
     builder.setAttribute(table, "AXRows", [AXUIElement]())
-    builder.setChildren(window, [table])
+    // The measured empty shape (Logic 12.3): the table still vends its four columns and a group,
+    // and the window carries Logic's own count. This fixture used to give the table no children at
+    // all, which let the reader publish an empty list without consulting the count — the one route
+    // to empty that skipped corroboration entirely.
+    var tableChildren: [AXUIElement] = []
+    for column in 0..<4 {
+        let columnElement = builder.element(25_420 + column)
+        builder.setAttribute(columnElement, kAXRoleAttribute as String, kAXColumnRole as String)
+        tableChildren.append(columnElement)
+    }
+    let tableGroup = builder.element(25_430)
+    builder.setAttribute(tableGroup, kAXRoleAttribute as String, kAXGroupRole as String)
+    tableChildren.append(tableGroup)
+    builder.setChildren(table, tableChildren)
+
+    let itemCount = builder.element(25_431)
+    builder.setAttribute(itemCount, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(itemCount, kAXDescriptionAttribute as String, "Number of Items")
+    builder.setAttribute(itemCount, kAXValueAttribute as String, "0 Markers")
+    builder.setChildren(window, [table, itemCount])
 
     let result = AccessibilityChannel.defaultGetMarkers(
         runtime: builder.makeLogicRuntime(appElement: app)
@@ -127,6 +146,27 @@ private func issue254Envelope(_ result: ReadResource.Result) throws -> [String: 
     let readable = try #require(envelope["readable"] as? Bool)
     #expect(!readable)
     #expect(envelope["reason"] as? String == "markers_not_polled_yet")
+}
+
+/// The distinction is "did anything TRY", which the fetch timestamp cannot answer:
+/// `markersFetchedAt` advances only on a successful read, so a poll that ran and failed leaves it
+/// exactly where a poll that never ran leaves it. Keying the reason on the timestamp would have
+/// moved the false attribution instead of removing it — this is the case that catches that.
+@Test func markerResourceSaysTheListIsClosedOnceAPollHasActuallyFailed() async throws {
+    let cache = StateCache()
+    await cache.markMarkersUnreadable()
+
+    let result = try await ResourceHandlers.read(
+        uri: "logic://markers",
+        cache: cache,
+        router: ChannelRouter()
+    )
+    let envelope = try issue254Envelope(result)
+
+    let readable = try #require(envelope["readable"] as? Bool)
+    #expect(!readable)
+    #expect(envelope["fetched_at"] == nil || envelope["fetched_at"] is NSNull)
+    #expect(envelope["reason"] as? String == "marker_list_not_open")
 }
 
 /// `nav.delete_marker` must work on a default install.

--- a/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
+++ b/Tests/LogicProMCPTests/Issue523MarkerDeleteMenuTests.swift
@@ -2237,6 +2237,18 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     // Last-marker variant: both projections successfully answer [] and the selection is a
     // fresh non-matching element. An empty expected survivor set plus "target no longer
     // selected" is the same rebuild lie, just with one row.
+    //
+    // This used to be refused one step later than its two siblings above, and for a different
+    // reason. The reader had an escape hatch: a table whose CHILD list was also empty was accepted
+    // as an empty marker list with no corroboration at all, so the empty survivor set reached the
+    // receipt and the count comparison caught it ("did not drop by one"). The two sibling tests,
+    // whose tables still vend non-row children, were refused by the reader itself.
+    //
+    // That split was an artifact of the hatch, not a distinction worth keeping — "the table
+    // answered with nothing" is exactly what a rebuild answers, and Logic's live table always
+    // carries its columns, so the hatch covered no shape the application presents. With every
+    // empty row set now corroborated against Logic's own Number of Items, all three refuse at the
+    // same place for the same reason, and the receipt names the site.
     let fixture = issue523MarkerDeleteFixture(
         menuEntryTitle: "Delete",
         pickDeletesSelectedRow: false,
@@ -2249,15 +2261,17 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
         index: 0, runtime: fixture.runtime, mouse: fixture.mouse
     )
     let envelope = try issue523Envelope(result)
-    let reasonDetail = try #require(envelope["reason_detail"] as? String)
 
     // `!= "A"` also accepts State C; pin the exact refusal (see the mutation-demonstration
     // test above for why that distinction matters).
     #expect(try #require(envelope["state"] as? String) == "B")
-    #expect(reasonDetail.contains("did not drop by one"))
+    #expect(envelope["reason"] as? String == "readback_unavailable")
+    #expect(envelope["readback_failure_site"] as? String == "item_count")
     #expect(fixture.menuState.postWriteRowsDropReadWasObserved)
     #expect(fixture.menuState.postWriteStructuralRowsDropReadWasObserved)
-    #expect(fixture.menuState.postWriteSelectedRowsFreshElementWasObserved)
+    // The fresh-selection observation is deliberately NOT asserted any more: the poll now refuses
+    // at the inventory read, before it ever looks at the selection, so requiring that read to have
+    // happened would assert something this path no longer does.
     #expect(fixture.markerCount == 1)
 }
 
@@ -2564,17 +2578,23 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
 }
 
 @Test func testIssue523NonLeadingDigitItemCountStringsAreUnreadableNotACount() async throws {
-    // Defensive regression table for the leading-token parse rule. None of these are
-    // asserted to be real Logic strings in any locale — measuring KO/JA Number-of-Items
-    // text on a live Logic is future work — they only prove the parser fails closed on
-    // digits that are not the leading count token, in shapes a translated or differently
-    // punctuated label could plausibly take.
+    // Defensive regression table for the leading-token parse rule: the parser must fail closed on
+    // digits that are not the leading count token.
+    //
+    // `2개` and `2個` used to be listed here, on the reasoning — stated in this comment — that no
+    // KO/JA Number-of-Items text had been measured and a translated label could plausibly take that
+    // shape. Both locales were measured on a live Logic 12.3 on 2026-08-17 and render
+    // `2개의 마커` / `0個のマーカー`: the counter word abuts the digits, so a leading digit followed
+    // by a CJK counter is the REAL shape and must parse. Those two entries were guesses about a
+    // shape Logic does not produce, and the measurement retires them rather than the rule.
+    //
+    // What stays is every shape that does not OPEN with the count, including the Korean
+    // `마커 2개` — a relaxation that let that through would be the dangerous one.
     let nonCountStrings = [
         "Marker 2",
         "Selected Item: 2",
-        "2개",
         "마커 2개",
-        "2個",
+        "マーカー 2個",
         "no count here",
     ]
     for text in nonCountStrings {
@@ -2635,17 +2655,46 @@ private func issue523Envelope(_ result: ChannelResult) throws -> [String: Any] {
     #expect(fixture.markerCount == 2)
 }
 
-@Test func testIssue523UnmeasuredLocalizedItemCountDescriptionStaysUnreadableUntilMeasured() async throws {
-    // MAJOR repro: a Marker List whose Number of Items node is described in Korean
-    // ("항목 수") or Japanese ("項目数") must not silently match — no live Logic has been
-    // measured in either locale for this label, and `AXLocalePolicy.markerListNumberOfItemsLabel`
-    // deliberately carries no invented translation. This proves the label-matching policy
-    // itself fails closed on an unmeasured locale description, independent of the rest of
-    // the delete plumbing.
-    for description in ["항목 수", "項目数"] {
+@Test func testIssue523LocalizedItemCountDescriptionsMatchTheMeasuredStrings() async throws {
+    // This test used to pin the OPPOSITE: `항목 수` and `項目数` had to stay unmatched, because no
+    // live Logic had been read in either locale and a translated guess must never silently match.
+    // Both were measured on a live Logic 12.3 on 2026-08-17 — the app was switched with
+    // `defaults write com.apple.logic10 AppleLanguages`, restarted, and the node's AXDescription and
+    // AXHelp read directly; both attributes answer the same string. The absence pin did its job: it
+    // required a measurement rather than a translation, and this is that measurement arriving.
+    for description in ["Number of Items", "항목 수", "項目数"] {
+        #expect(
+            AXLocalePolicy.markerListNumberOfItemsLabel.matches(description, mode: .exactStrict),
+            "\"\(description)\" was measured on a live Logic and must match"
+        )
+    }
+    // Still fails closed on anything not measured, including a plausible near-miss.
+    for description in ["항목수", "項目 数", "Items", "Number of Item"] {
         #expect(
             !AXLocalePolicy.markerListNumberOfItemsLabel.matches(description, mode: .exactStrict),
-            "\"\(description)\" must not match until measured on a live Logic"
+            "\"\(description)\" was never measured and must not match"
         )
+    }
+}
+
+@Test func testIssue523ItemCountParsesTheMeasuredLocalizedRenderings() async throws {
+    // The values these nodes render, measured in the same pass. Korean and Japanese put the counter
+    // word straight against the digits, so a parser that demanded whitespace after them read the
+    // witness as unparseable — and that count is what State A needs, so `nav.delete_marker` could
+    // not certify on either locale.
+    let measured: [(String, Int)] = [
+        ("0 Markers", 0), ("1 Marker", 1), ("15 Markers", 15),
+        ("0개의 마커", 0), ("1개의 마커", 1), ("2개의 마커", 2),
+        ("0個のマーカー", 0), ("1個のマーカー", 1),
+    ]
+    for (raw, expected) in measured {
+        #expect(AXLogicProElements.parseMarkerListItemCount(raw) == expected,
+                "\"\(raw)\" is a measured live rendering and must parse as \(expected)")
+    }
+    // The rules the relaxation had to preserve: the value must OPEN with the digit run, no digit may
+    // follow it, and an ASCII letter abutting the digits is still a refusal.
+    for raw in ["Marker 2", "2 of 15", "1st", "0x1F", "1.1.1.1", "", "Markers"] {
+        #expect(AXLogicProElements.parseMarkerListItemCount(raw) == nil,
+                "\"\(raw)\" must not parse as a marker count")
     }
 }


### PR DESCRIPTION
Closes #568. Follow-up to #565 / #566.

An adversarial review of #566 found three gaps, and driving that fix against a non-English Logic
found three more. All six are fixed here, each with a measurement behind it.

## From review

**The witness could be read from the wrong window.** `markerListZeroItemsWitness` resolved the owner
through the table's `AXWindow`, even where the caller had already bound the Marker List window. An
absent attribute fails closed; an attribute pointing at another window whose own count reads zero
certifies a false empty. The bound window is now passed down, and `AXWindow` is consulted only on
the post-write path that deliberately holds none.

**The childless-table escape hatch bypassed corroboration entirely.** #565 kept
`children.isEmpty -> .success([])` so as not to disturb a pinned contract — but that is the original
unguarded path, and "the table answered with nothing" is exactly what a rebuild answers. Every empty
row set now goes through the witness.

**`markers_not_polled_yet` was itself a false attribution.** It keyed on
`markersFetchedAt == .distantPast`, and that advances only on a SUCCESSFUL read —
`markMarkersUnreadable()` never touches it — so a poll that ran and failed was reported as a poll
that never ran. The cache now records whether anything TRIED.

## From measuring it outside English

The empty-list fix was English-only, and the reason runs deeper than one label.

| | measured on a live Logic 12.3, 2026-08-17 |
|---|---|
| count label (AXDescription and AXHelp) | `Number of Items` · `항목 수` · `項目数` |
| count value | `1 Marker` · `1개의 마커` · `1個のマーカー` |

The value format is the sharp edge: Korean and Japanese put the counter word **against** the digits,
while the parser demanded whitespace or end-of-string after them. That count is the independent
witness `nav.delete_marker` needs for State A, so **marker delete could not certify on a Korean or
Japanese Logic at all** — with or without #565. The separator rule now accepts whitespace or a
NON-ASCII character; an ASCII letter is still a refusal, so `1st` and `0x1F` cannot become counts,
and the value must still open with the digits with none after.

`create_marker`'s own script also hard-coded `Tracks`/`트랙` as a try/on-error pair. On a Japanese
Logic both lookups failed and took the whole script with them, reporting a locale gap as a missing
menu item. The window is now resolved from `arrangeWindowTitleSuffix` through a candidate loop whose
attempts are individually guarded — `first window whose name ends with ...` raises -1719 on a miss
and would otherwise abort the loop on its first non-match.

## Evidence

`Scripts/livekit/live_565_empty_marker_list.py` takes `--locale` and refuses to run unless the live
Logic presents that locale's own window name, so a run cannot be filed under a locale it never
exercised. Six checks each, all passing, one visual assertion over the Marker List row band. All
three runs were driven through the **same binary**, sha256 `7c8bf1eb5309…`:

```
en   last delete A, witness "1 Marker"     -> "0 Markers";     create on empty -> A
ko   last delete A, witness "1개의 마커"     -> "0개의 마커";     create on empty -> A
ja   last delete A, witness "1個のマーカー"  -> "0個のマーカー";  create on empty -> A
```

The Japanese sequence peeled in two stages, which is worth recording because each gap hid the next:

```
before this PR   create_marker -> C readback_unavailable   (the row read)
read fixed       create_marker -> C element_not_found      (the window literal, now visible)
window fixed     create_marker -> A   observed_marker_name "マーカー1"
```

Unit: 3792 tests pass under the CI gate (`swift test --no-parallel`). Each review fix is
mutation-tested and reddens only its own test — resolving the witness through `AXWindow` again,
restoring the childless hatch, keying the reason on the fetch timestamp.

One pre-existing delete test pinned the old behaviour: with the escape hatch gone, the last-marker
rebuild case is refused by the reader rather than by the later count comparison. It now expects
`readback_unavailable` with `readback_failure_site: item_count`, and carries the reason — all three
sibling cases refuse at the same place, and the split they used to have was an artifact of the
hatch, not a distinction worth keeping.

## Filed separately

`kCGWindowOwnerName` renders Logic Pro with a NO-BREAK SPACE under a Korean UI, measured in both
directions. Every capture in the first Korean run recorded a null window until the harness
normalised it. The same exact compare exists in the product's window-list PID fallback — #567.
