### PR TITLE
fix(#570): tell the caller why project.new refused, in terms they can act on

### DIFF
--- a/Scripts/livekit/live_570_project_new_refusal.py
+++ b/Scripts/livekit/live_570_project_new_refusal.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Live proof that `project.new` explains its refusal instead of misdescribing it.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_570_project_new_refusal.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+Measured on desktop Logic Pro 12.3 with one project open:
+
+    {"error":"channels_exhausted",
+     "hint":"Creator Studio has a non-chooser window; refusing project.new"}
+
+Two false statements about the caller's situation. The operator is running Logic Pro, not Creator
+Studio. And `channels_exhausted` means "every channel in the chain reported itself unavailable",
+while here the single accessibility channel ran and declined on purpose — a bare sentence is not
+something `ChannelRouter` can recognise as a State C envelope, so it fell through to the exhaustion
+wrapper.
+
+THE REFUSAL IS CORRECT AND STAYS
+--------------------------------
+With a document already open, a newly created project's window cannot be told apart from the ones
+already on screen. This run does NOT assert that `project.new` succeeds with a project open; it
+asserts that the refusal says which precondition failed, what was observed, that nothing was
+written, and how to recover — and that the recovery it names actually works.
+
+THE TRIGGER IS AN OPEN DOCUMENT, SO THE RUN ESTABLISHES IT FIRST
+----------------------------------------------------------------
+Against a Logic with no document open the refusal never happens and every check below would be
+vacuous. The run therefore requires a window to be present and stops if it cannot get one.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+
+# Window-relative band over the track headers of the arrange window (measured 1920x1050 at 0,30).
+# Deliberately over content the caller owns: the claim is that a REFUSED project.new leaves it alone.
+TRACK_BAND = (10, 120, 260, 200)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_names():
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'return name of every window')
+
+
+def window_count():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return count of every window')
+    return int(raw) if raw.isdigit() else None
+
+
+def body_of(result):
+    return result if isinstance(result, dict) else {}
+
+
+# ---- establish the trigger: a document must be open ------------------------------------------
+if (window_count() or 0) == 0:
+    d.tool("logic_project", "new", {})
+    time.sleep(6)
+
+open_windows = window_count()
+ev.check("570/precondition-a-document-is-open", (open_windows or 0) > 0,
+         "Logic has at least one window, which is the state this refusal is about",
+         f"window_count={open_windows!r} names={window_names()!r}",
+         # No mutation: this is the trigger. Against a Logic with nothing open the refusal never
+         # fires and every check below would pass without observing it.
+         None)
+if not open_windows:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=150)
+before = ev.shot("570/before-refused-new", settle_region=TRACK_BAND)
+
+refused = body_of(d.tool("logic_project", "new", {}))
+time.sleep(1.5)
+ev.note("570/refusal", refused)
+
+ev.check("570/refusal-names-the-precondition-not-the-channel-chain",
+         refused.get("error") == "unsupported_state",
+         "the refusal is classified as an unsupported state, not as an exhausted channel chain",
+         f"error={refused.get('error')!r} failure_stage={refused.get('failure_stage')!r}",
+         "return the refusal as a bare sentence again: ChannelRouter cannot recognise prose as a "
+         "State C envelope and relabels it channels_exhausted, which sends the caller to look at "
+         "channel health when no channel is unhealthy")
+
+hint = refused.get("hint") or ""
+ev.check("570/refusal-does-not-blame-a-product-the-operator-is-not-running",
+         "Creator Studio" not in hint,
+         "the hint describes THIS Logic, not Creator Studio",
+         f"hint={hint!r}",
+         "restore the Creator Studio wording — it is what a desktop Logic Pro operator was told, "
+         "about a product they may never have installed")
+
+ev.check("570/refusal-reports-what-it-observed",
+         refused.get("observed_window_count") == open_windows,
+         "the reported window count equals the count read outside the product",
+         f"reported={refused.get('observed_window_count')!r} externally_observed={open_windows!r}",
+         "drop observed_window_count: the caller is told a precondition failed with no way to see "
+         "how far off they are")
+
+ev.check("570/refusal-is-pre-write",
+         refused.get("write_attempted") is False and refused.get("safe_to_retry") is True,
+         "nothing was attempted and the call is safe to retry, and the envelope says both",
+         f"write_attempted={refused.get('write_attempted')!r} "
+         f"safe_to_retry={refused.get('safe_to_retry')!r}",
+         "omit write_attempted: a caller cannot tell a refusal-before-acting from a failed write")
+
+after = ev.shot("570/after-refused-new", settle_region=TRACK_BAND)
+ev.visual("570/a-refused-new-leaves-the-open-project-alone",
+          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          why="the refusal reports write_attempted:false, so the open project's track headers must "
+              "be untouched across it")
+
+# ---- the recovery the envelope names must actually work ---------------------------------------
+recovery = refused.get("recovery_action") or ""
+ev.check("570/recovery-action-names-the-confirmed-close",
+         "confirmed: true" in recovery,
+         "the recovery names the confirmed form of close",
+         f"recovery_action={recovery!r}",
+         "name the bare `project.close`: it answers confirmation_required, so following the "
+         "instruction lands the caller in a second refusal")
+
+bare_close = body_of(d.tool("logic_project", "close", {}))
+ev.check("570/the-bare-close-really-is-refused",
+         bare_close.get("status") == "confirmation_required",
+         "close without confirmation is refused, which is why the recovery text names the "
+         "confirmed form",
+         f"status={bare_close.get('status')!r}",
+         # No mutation: this measures Logic-side/product gating that this change does not touch. It
+         # is here so the recovery wording is checked against behaviour, not against my memory of it.
+         None)
+
+d.tool("logic_project", "close", {"confirmed": True})
+time.sleep(5)
+after_close = window_count()
+created = body_of(d.tool("logic_project", "new", {}))
+time.sleep(4)
+after_new = window_names()
+ev.note("570/recovery", {"after_close_window_count": after_close, "created": created,
+                         "windows_after": after_new})
+
+ev.check("570/the-named-recovery-actually-creates-a-project",
+         after_close == 0 and created.get("state") in ("A", "B")
+         and bool(created.get("window_title")),
+         "closing with confirmation empties Logic, and project.new then creates a document",
+         f"after_close={after_close!r} state={created.get('state')!r} "
+         f"window_title={created.get('window_title')!r} error={created.get('error')!r}",
+         "point the recovery at something that does not clear the precondition — the caller would "
+         "follow the instruction and hit the same refusal")
+
+ev.restored("570/logic-is-left-with-a-project-open",
+            bool(after_new),
+            f"windows after the run: {after_new!r}. The run closes the document it found — that is "
+            f"the recovery being proven, not a side effect — and leaves the project it created.")
+
+ev.stop_recording(rec)
+d.close()
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -18,13 +18,54 @@ extension AccessibilityChannel {
         }
 
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
-            return .error("Logic Pro AX application root is unavailable")
+            return .error(HonestContract.encodeStateC(
+                error: .logicNotRunning,
+                hint: "Logic Pro's accessibility root is unavailable, so no project could be created.",
+                extras: ["operation": "project.new", "write_attempted": false]
+            ))
         }
         let windows: [AXUIElement]? = AXHelpers.getAttribute(
             app, kAXWindowsAttribute as String, runtime: runtime.ax
         )
         guard blankApplicationCanRevealChooser(windowCount: windows?.count) else {
-            return .error("Creator Studio has a non-chooser window; refusing project.new")
+            // A DESIGNED precondition, not a failure to try: with a document already open, a second
+            // project's window cannot be told apart from the ones already on screen, so this route
+            // refuses rather than certify an ambiguous creation
+            // (`Issue516DirectProjectCreationTests.onlyFromZeroWindows`).
+            //
+            // What it used to say was "Creator Studio has a non-chooser window" — a claim about a
+            // product the operator is probably not running (measured on desktop Logic Pro 12.3,
+            // 2026-08-17), delivered as bare prose that the router could not recognise as a State C
+            // envelope and therefore relabelled `channels_exhausted`. That code means "every channel
+            // in the chain reported itself unavailable"; here the one channel ran and declined on
+            // purpose. Two false statements about the caller's situation, in one refusal.
+            let count = windows?.count
+            var extras: [String: Any] = [
+                "operation": "project.new",
+                "write_attempted": false,
+                "safe_to_retry": true,
+                "failure_stage": "precondition_open_document",
+                // Driven end to end on 2026-08-17 before being written down. `project.close` alone
+                // answers `confirmation_required` (it is L3-gated), so a recovery action naming the
+                // bare command would send the operator into a second refusal. With the confirmation
+                // supplied the chain does work: close -> zero windows -> project.new creates
+                // `Untitled 56 - Tracks`.
+                "recovery_action": "Close the open project with "
+                    + "logic_project(\"close\", {confirmed: true}) — the bare close is refused as "
+                    + "confirmation_required — so Logic has no document window, then retry "
+                    + "project.new.",
+            ]
+            if let count { extras["observed_window_count"] = count }
+            return .error(HonestContract.encodeStateC(
+                error: .unsupportedState,
+                hint: count.map {
+                    "project.new requires Logic to have no open document; \($0) window(s) are open. "
+                        + "With a document already open a newly created project cannot be told apart "
+                        + "from the windows already on screen, so nothing was attempted."
+                } ?? "project.new could not read Logic's window list, so it cannot establish that no "
+                    + "document is open; nothing was attempted.",
+                extras: extras
+            ))
         }
 
         // Drive the menu through AX with locale-resolved titles instead of an AppleScript that
@@ -38,12 +79,36 @@ extension AccessibilityChannel {
                   in: menuBarAny, matching: AXLocalePolicy.fileMenuBar, runtime: runtime.ax
               )
         else {
-            return .error("Could not resolve the File menu in this Logic's language")
+            // A locale gap is a missing target, not an exhausted channel chain. As bare prose these
+            // two were relabelled `channels_exhausted`, which tells the operator to look at channel
+            // health when what is actually missing is a measured label for their language.
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "The File menu could not be resolved in this Logic's language. Measured names: "
+                    + AXLocalePolicy.fileMenuBar.labels.joined(separator: ", ") + ".",
+                extras: [
+                    "operation": "project.new",
+                    "write_attempted": false,
+                    "failure_stage": "file_menu_resolution",
+                    "known_labels": AXLocalePolicy.fileMenuBar.labels,
+                ]
+            ))
         }
         guard let newItem = AXLocalePolicy.findMenuItem(
             under: fileItem, matching: AXLocalePolicy.newProjectMenuItem, runtime: runtime.ax
         ) else {
-            return .error("Could not resolve the New entry under the File menu in this Logic's language")
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "The New entry under the File menu could not be resolved in this Logic's "
+                    + "language. Measured names: "
+                    + AXLocalePolicy.newProjectMenuItem.labels.joined(separator: ", ") + ".",
+                extras: [
+                    "operation": "project.new",
+                    "write_attempted": false,
+                    "failure_stage": "new_menu_item_resolution",
+                    "known_labels": AXLocalePolicy.newProjectMenuItem.labels,
+                ]
+            ))
         }
         // Press the bar item first so the menu materialises, then the entry. The return codes are
         // not consulted: on Logic 12.3 a press that works can still report failure, so the observed

--- a/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
+++ b/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
@@ -1,3 +1,5 @@
+@preconcurrency import ApplicationServices
+import Foundation
 import Testing
 @testable import LogicProMCP
 
@@ -47,5 +49,90 @@ struct Issue516DirectProjectCreationTests {
         #expect(AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: 0))
         #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: 1))
         #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: nil))
+    }
+}
+
+/// The refusal `project.new` gives when a document is already open.
+///
+/// The precondition itself is deliberate and stays — with a document open, a newly created project
+/// cannot be told apart from the windows already on screen. What was wrong was everything the
+/// operator was told about it. Measured on desktop Logic Pro 12.3, 2026-08-17, with one project
+/// open:
+///
+///     {"error":"channels_exhausted",
+///      "hint":"Creator Studio has a non-chooser window; refusing project.new", ...}
+///
+/// Two false statements in one envelope. The operator was not running Creator Studio, and
+/// `channels_exhausted` is documented as "every channel in the chain reported itself unavailable" —
+/// here the one channel ran and declined on purpose. The bare prose is what caused the second one:
+/// `ChannelRouter` surfaces a single-channel State C verbatim only when it can recognise the string
+/// as an envelope, and a sentence is not an envelope.
+@Suite("#565 project.new says why it refused, in terms the operator can act on")
+struct ProjectNewOpenDocumentRefusalTests {
+    private func refusalMessage(windowCount: Int) async -> String {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(30_000)
+        var windows: [AXUIElement] = []
+        for index in 0..<windowCount {
+            let window = builder.element(30_100 + index)
+            builder.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+            builder.setAttribute(window, kAXTitleAttribute as String, "Open Project \(index) - Tracks")
+            windows.append(window)
+        }
+        builder.setAttribute(app, kAXWindowsAttribute as String, windows)
+        builder.setChildren(app, windows)
+
+        let result = await AccessibilityChannel.createEmptyProjectFromQualifiedState(
+            runtime: builder.makeLogicRuntime(appElement: app)
+        )
+        #expect(!result.isSuccess)
+        return result.message
+    }
+
+    private func refusalEnvelope(windowCount: Int) async throws -> [String: Any] {
+        // The refusal must be a JSON envelope, not prose: prose is what the router cannot
+        // recognise, and it relabels the whole thing `channels_exhausted`.
+        try #require(
+            JSONSerialization.jsonObject(
+                with: Data(await refusalMessage(windowCount: windowCount).utf8)
+            ) as? [String: Any]
+        )
+    }
+
+    @Test("it is a State C envelope the router can surface verbatim")
+    func refusalIsAnEnvelope() async throws {
+        let envelope = try await refusalEnvelope(windowCount: 2)
+        #expect(try #require(envelope["state"] as? String) == "C")
+        #expect(envelope["error"] as? String == "unsupported_state")
+        // The router only bypasses the `channels_exhausted` wrapper for a string it recognises as a
+        // State C envelope, so this is the property that keeps the classification honest.
+        #expect(HonestContract.stateCErrorCode(await refusalMessage(windowCount: 2)) != nil)
+    }
+
+    @Test("it names the precondition and the observed state, not another product")
+    func refusalNamesThePrecondition() async throws {
+        let envelope = try await refusalEnvelope(windowCount: 2)
+        let hint = try #require(envelope["hint"] as? String)
+        // The operator is not necessarily running Creator Studio; the refusal must describe THEIR
+        // Logic, not a product they may never have installed.
+        #expect(!hint.contains("Creator Studio"))
+        #expect(hint.contains("no open document"))
+        #expect(envelope["observed_window_count"] as? Int == 2)
+        #expect(envelope["failure_stage"] as? String == "precondition_open_document")
+    }
+
+    @Test("nothing was attempted, and it says so")
+    func refusalIsPreWrite() async throws {
+        let envelope = try await refusalEnvelope(windowCount: 1)
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        #expect(!writeAttempted)
+        let retryable = try #require(envelope["safe_to_retry"] as? Bool)
+        #expect(retryable)
+        // The recovery action was driven end to end before being written down. `project.close`
+        // on its own answers `confirmation_required`, so naming the bare command would have sent
+        // the operator into a second refusal — the confirmation has to be in the instruction.
+        let recovery = try #require(envelope["recovery_action"] as? String)
+        #expect(recovery.contains("close"))
+        #expect(recovery.contains("confirmed: true"))
     }
 }


### PR DESCRIPTION
Closes #570.

## What the caller was told

Measured on desktop Logic Pro 12.3 with one project open:

```json
{"error": "channels_exhausted",
 "hint": "Creator Studio has a non-chooser window; refusing project.new"}
```

Two false statements about the caller's situation, in one envelope.

The operator is running **Logic Pro, not Creator Studio** — the guard sits under a
`// MARK: - Creator Studio New Project chooser` heading but is on the only route `project.new` has
for every variant.

And **`channels_exhausted` is documented as "every channel in the chain reported itself
unavailable"**, while here the single `[.accessibility]` channel ran and declined on purpose. That
one follows from the first being prose: `ChannelRouter` surfaces a single-channel State C verbatim
only when it can recognise the message as an envelope, so a sentence falls through to the exhaustion
wrapper. The other bare-prose returns on this path had the same fate — including two
locale-resolution failures, where a **missing measured label for the operator's language was
reported as channel exhaustion**.

## The refusal itself is correct and stays

With a document already open, a newly created project's window cannot be told apart from the ones
already on screen, so the route declines rather than certify an ambiguous creation
(`Issue516DirectProjectCreationTests.onlyFromZeroWindows`). This PR does not change *whether* it
refuses. It changes what the caller is told: which precondition failed, what was observed, that
nothing was written, and what to do next. The sibling failures now say which labels they know
instead of pointing at a channel problem.

Live, same conditions as the measurement above:

```json
{"error": "unsupported_state",
 "failure_stage": "precondition_open_document",
 "observed_window_count": 2,
 "write_attempted": false,
 "safe_to_retry": true,
 "hint": "project.new requires Logic to have no open document; 2 window(s) are open. …",
 "recovery_action": "Close the open project with logic_project(\"close\", {confirmed: true}) …"}
```

## The recovery was driven before it was written down

```
project.close                    -> confirmation_required   (L3-gated)
project.close {confirmed: true}  -> B, zero windows
project.new                      -> B, "Untitled 56 - Tracks"
```

The first line is why the recovery names the confirmed form. My first draft said "project.close",
which would have sent the caller into a second refusal — the harness asserts the confirmed form is
named, and separately asserts that the bare close really is refused, so the wording is checked
against behaviour rather than against my memory of it.

## Evidence

Unit — 3795 tests pass under the CI gate. The three new tests are mutation-tested: restoring the
prose refusal reddens all three, because a sentence is not parseable as the envelope the router
needs.

Live — `Scripts/livekit/live_570_project_new_refusal.py`, eight checks, six mutation-backed, one
visual assertion. The run establishes its trigger first (a document must be open, or the refusal
never fires and every check is vacuous), and the visual assertion is a **negative** one: the open
project's track headers must NOT change across the refused call, which is the envelope's
`write_attempted: false` claim made visible.

## Recorded so it is not re-investigated

`transport.goto_position` is permanently State B for a `{bar: N}` request on this surface, and that
is honest, not a defect. `{bar: 9}` is normalised to the request string `9.1.1.1`, while Logic
12.3's `Playhead Position` group vends exactly **two** AXSliders — `bar` and `beat`. There is no
subdivision or tick readout to corroborate against; the reader deliberately refuses to fabricate
`.1.1` and names the gap in `unobserved_position_components`. The limit is the AX surface.
