### PR TITLE
fix(#567): recognise Logic's window-owner name when macOS localizes its separator

### DIFF
--- a/Scripts/livekit/live_567_localized_owner_name.py
+++ b/Scripts/livekit/live_567_localized_owner_name.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Live measurement of Logic's window-owner name under a localized UI.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_567_localized_owner_name.py <worktree> <full-40-char-head-sha> [--locale ko|ja|en]
+
+WHAT THIS PROVES, AND WHAT IT DOES NOT
+--------------------------------------
+It proves the FACT the fix is built on: that `CGWindowListCopyWindowInfo`'s `kCGWindowOwnerName`
+for Logic Pro carries a NO-BREAK SPACE under a Korean UI and an ordinary space under English, on
+this machine, today. That string is the whole premise of `LogicProTarget.isLogicProcessName`
+normalising its separator, and a premise taken from memory rather than from the running system is
+how a fix ends up correct about nothing.
+
+It does NOT prove that `ProcessUtils.logicProPID(fromWindowList:)` now returns a PID on a Korean
+Mac. No tool surfaces that resolver's result — it is a fallback behind `logicProApp()` — so there is
+nothing to drive it through from out here. That half is covered by
+`Issue567LocalizedOwnerNameTests.windowListResolverAcceptsTheKoreanName`, which feeds the measured
+string straight into the resolver, and by the mutation showing it returns nil without the fix.
+
+Saying so here rather than letting six green checks imply the whole chain was verified.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+LOCALE = sys.argv[sys.argv.index("--locale") + 1] if "--locale" in sys.argv else "en"
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+# Measured window-title suffixes; used only as the locale witness, so a run cannot be filed under a
+# language the running Logic is not in.
+ARRANGE_SUFFIX = {"en": "Tracks", "ko": "트랙", "ja": "トラック"}[LOCALE]
+NBSP = " "
+# Band over the arrange window's track headers. Nothing this run does is a write, so the assertion
+# over it is a NEGATIVE one.
+TRACK_BAND = (10, 120, 260, 200)
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+d = E.Driver()
+
+
+def raw_owner_names():
+    """Every Logic-owned window's owner name, straight from CoreGraphics.
+
+    Deliberately NOT `evidence.logic_window()`: that helper normalises the separator itself (it hit
+    this same bug first), so reading through it would hide the very byte under test.
+    """
+    try:
+        import Quartz
+    except ImportError:
+        return []
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID)
+    names = []
+    for w in wins or []:
+        name = w.get("kCGWindowOwnerName") or ""
+        if "Logic" in name:
+            names.append(name)
+    return names
+
+
+def window_titles():
+    r = subprocess.run(
+        ["osascript", "-e",
+         'tell application "System Events" to tell process "Logic Pro" to get name of every window'],
+        capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+titles = window_titles()
+locale_ok = ARRANGE_SUFFIX in titles
+ev.check(f"567/{LOCALE}/precondition-logic-is-actually-in-this-locale", locale_ok,
+         f"a window title carries this locale's arrange name ({ARRANGE_SUFFIX!r})",
+         f"locale={LOCALE} titles={titles!r}",
+         # No mutation: the locale witness, not an assertion about the fix.
+         None)
+if not locale_ok:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=90)
+before = ev.shot(f"567/{LOCALE}/before", settle_region=TRACK_BAND, window_title=ARRANGE_SUFFIX)
+
+owners = raw_owner_names()
+ev.note(f"567/{LOCALE}/owner-names", {"raw": owners,
+                                      "codepoints": [[hex(ord(c)) for c in n] for n in owners]})
+
+ev.check(f"567/{LOCALE}/logic-owns-at-least-one-window", bool(owners),
+         "CoreGraphics reports at least one Logic-owned window to read the name from",
+         f"owners={owners!r}",
+         None)
+
+separators = {n[len("Logic")] for n in owners if n.startswith("Logic") and len(n) > len("Logic")}
+if LOCALE == "ko":
+    ev.check(f"567/{LOCALE}/the-owner-name-carries-a-no-break-space",
+             NBSP in separators,
+             "under a Korean UI the separator in the owner name is U+00A0, which is the byte the "
+             "product's exact compare could not match",
+             f"separators={[hex(ord(s)) for s in separators]} owners={owners!r}",
+             "remove the normalisation from LogicProTarget.isLogicProcessName: this exact string "
+             "then matches nothing, and the window-list PID route silently finds no Logic window")
+else:
+    ev.check(f"567/{LOCALE}/the-owner-name-uses-an-ordinary-space",
+             separators == {" "},
+             "outside Korean the separator is U+0020 — the measurement runs in both directions, so "
+             "the Korean reading is a locale difference and not a property of this machine",
+             f"separators={[hex(ord(s)) for s in separators]} owners={owners!r}",
+             None)
+
+# The product must still be able to see Logic while its owner name reads this way.
+health = d.tool("logic_system", "health", {})
+ev.note(f"567/{LOCALE}/health", health)
+running = health.get("logic_pro_running") if isinstance(health, dict) else None
+product_locale = health.get("logic_pro_ui_locale") if isinstance(health, dict) else None
+ev.check(f"567/{LOCALE}/the-product-still-sees-logic-running",
+         running is True,
+         "the server reports Logic running while its owner name carries this separator, and reports "
+         "the same UI language the window titles show",
+         f"logic_pro_running={running!r} logic_pro_ui_locale={product_locale!r}",
+         # No mutation: this passes with and without the fix, because `logicProApp()` resolves by
+         # bundle ID before the window-list fallback is reached. Recorded to show the locale did not
+         # break the primary route, NOT as evidence for the fix.
+         None)
+
+after = ev.shot(f"567/{LOCALE}/after", settle_region=TRACK_BAND, window_title=ARRANGE_SUFFIX)
+ev.visual(f"567/{LOCALE}/nothing-in-the-project-was-touched",
+          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          why="this run only reads names and health; the arrange window's track headers must be "
+              "identical across it")
+
+ev.restored(f"567/{LOCALE}/no-project-state-was-changed", True,
+            "the run performs no write; the only state it depends on is Logic's UI language, which "
+            "the operator sets and restores around it")
+
+ev.stop_recording(rec)
+d.close()
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Server/LogicProTarget.swift
+++ b/Sources/LogicProMCP/Server/LogicProTarget.swift
@@ -416,8 +416,28 @@ struct LogicProTarget: Sendable, Equatable {
         return isKnownBundleID(bundleID)
     }
 
+    /// Whether a process/window-owner name is one of Logic's, compared with its internal spacing
+    /// normalised.
+    ///
+    /// Measured on macOS 15 with Logic Pro 12.3, 2026-08-17, by switching
+    /// `defaults write com.apple.logic10 AppleLanguages` and restarting:
+    /// `CGWindowListCopyWindowInfo`'s `kCGWindowOwnerName` answers `"Logic Pro"` with an ordinary
+    /// space in English and Japanese, and with a **NO-BREAK SPACE (U+00A0)** in Korean. An exact
+    /// compare against the manifest's `"Logic Pro"` therefore matched nothing on a Korean-UI Mac,
+    /// and `ProcessUtils.logicProPID(fromWindowList:)` silently found no Logic window at all — a
+    /// discriminator contributing nothing, for a reason having nothing to do with Logic.
+    ///
+    /// The normalisation is deliberately narrow: whitespace characters collapse to `U+0020`, so any
+    /// separator macOS localises to (U+00A0 here, U+202F elsewhere) still matches, while `LogicPro`
+    /// with the separator REMOVED does not. Fixing it here rather than adding a second literal to
+    /// the manifest keeps one locale's rendering from becoming a second product name.
     static func isLogicProcessName(_ name: String) -> Bool {
-        knownProcessNames.contains(name)
+        let normalized = normalizedProcessName(name)
+        return knownProcessNames.contains { normalizedProcessName($0) == normalized }
+    }
+
+    static func normalizedProcessName(_ name: String) -> String {
+        String(name.map { $0.isWhitespace ? " " : $0 })
     }
 
     /// Health/diagnostic label for the resolved variant.

--- a/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
+++ b/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import LogicProMCP
+
+/// `kCGWindowOwnerName` for Logic Pro is locale-dependent.
+///
+/// Measured on macOS 15 with Logic Pro 12.3 on 2026-08-17, in both directions, by switching
+/// `defaults write com.apple.logic10 AppleLanguages` and restarting:
+///
+///     English   "Logic Pro"      U+0020
+///     Japanese  "Logic Pro"      U+0020
+///     Korean    "Logic\u{00A0}Pro"   NO-BREAK SPACE
+///
+/// `manifest.json` declares `"process_name": "Logic Pro"` with an ordinary space, so an exact
+/// compare found ZERO Logic windows on a Korean-UI Mac. The harness hit the identical bug first —
+/// every capture in a Korean run recorded `window: null` while Logic was plainly on screen.
+@Suite("#567 the window-owner name survives a localized separator")
+struct Issue567LocalizedOwnerNameTests {
+    /// The exact string CoreGraphics returned under a Korean UI.
+    private static let koreanOwnerName = "Logic\u{00A0}Pro"
+
+    @Test("the measured Korean owner name is recognised")
+    func koreanOwnerNameMatches() {
+        #expect(LogicProTarget.isLogicProcessName(Self.koreanOwnerName))
+        // The premise: it is genuinely a different string, so this is not a tautology.
+        #expect(Self.koreanOwnerName != "Logic Pro")
+    }
+
+    @Test("the ordinary-space name keeps matching")
+    func englishOwnerNameStillMatches() {
+        #expect(LogicProTarget.isLogicProcessName("Logic Pro"))
+        #expect(LogicProTarget.isLogicProcessName("Logic Pro Creator Studio"))
+    }
+
+    /// Any separator macOS localises to has to work, but a name with the separator REMOVED is a
+    /// different application name and must stay unmatched — otherwise the fix would be "ignore
+    /// spacing", which is a wider claim than the measurement supports.
+    @Test("other whitespace separators match, a removed separator does not")
+    func separatorHandlingIsNarrow() {
+        #expect(LogicProTarget.isLogicProcessName("Logic\u{202F}Pro"))
+        #expect(!LogicProTarget.isLogicProcessName("LogicPro"))
+        #expect(!LogicProTarget.isLogicProcessName("Logic Pro X"))
+        #expect(!LogicProTarget.isLogicProcessName("Not Logic Pro"))
+    }
+
+    @Test("the window-list resolver finds Logic under a Korean owner name")
+    func windowListResolverAcceptsTheKoreanName() throws {
+        // The one caller, exercised end to end: without the normalisation this returns nil and the
+        // visible-window PID route contributes nothing on a Korean Mac.
+        let pid = ProcessUtils.logicProPID(fromWindowList: [[
+            "kCGWindowOwnerName": Self.koreanOwnerName,
+            "kCGWindowOwnerPID": 4242,
+            "kCGWindowBounds": ["Width": 1920, "Height": 1050],
+        ]])
+        #expect(try #require(pid) == 4242)
+    }
+}


### PR DESCRIPTION
Closes #567.

## Measured, in both directions

macOS 15, Logic Pro 12.3, 2026-08-17, by switching `defaults write com.apple.logic10 AppleLanguages`
and restarting. The codepoints are recorded in the live evidence document, not paraphrased:

```
English   "Logic Pro"   4c 6f 67 69 63 20 50 72 6f      U+0020
Korean    "Logic Pro"   4c 6f 67 69 63 a0 50 72 6f      U+00A0  NO-BREAK SPACE
```

`kCGWindowOwnerName` for Logic Pro is locale-dependent. `manifest.json` declares
`"process_name": "Logic Pro"` with an ordinary space and `isLogicProcessName` compared exactly, so
on a Korean-UI Mac `ProcessUtils.logicProPID(fromWindowList:)` matched nothing and the
visible-window PID route silently contributed nothing — a discriminator answering "no Logic here"
for a reason that has nothing to do with Logic.

It is a fallback behind the bundle-ID lookup, so nothing broke outright. What was lost is a route
the operator cannot see failing.

## The fix is narrow on purpose

Whitespace collapses to `U+0020` before the comparison, so any separator macOS localizes to (U+00A0
here, U+202F elsewhere) matches, while `LogicPro` with the separator **removed** does not — the
measurement supports "the separator is localized", not "ignore spacing". Fixing it in the comparison
rather than adding a second literal to the manifest keeps one locale's rendering from becoming a
second product name.

## How it was found

The livekit harness had the identical exact compare and hit it first: every capture in a Korean run
recorded `window: null` while Logic was plainly on screen, and the visual assertion failed with
nothing to compare. That harness fix shipped in #569; this is the product half.

## Evidence

Unit — 3796 tests pass under the CI gate. Three of the four new tests go red when the exact compare
is restored, including the one that feeds the measured Korean string through the real resolver and
gets `nil` back.

Live — `Scripts/livekit/live_567_localized_owner_name.py --locale ko|en`, run in both directions on
the same binary. It reads `kCGWindowOwnerName` straight from CoreGraphics rather than through
`evidence.logic_window()`, because that helper normalises the separator itself and reading through
it would hide the byte under test.

**What the live run does not prove, stated in the harness header:** that
`logicProPID(fromWindowList:)` now returns a PID on a Korean Mac. No tool surfaces that resolver's
result — `hasVisibleWindow()` matches by PID, not by name — so there is nothing to drive it through
from outside. The run proves the premise (the owner name really does carry U+00A0 under Korean, and
an ordinary space under English, on this machine today); the resolver half is the unit test that
feeds it that exact string.
