### PR TITLE
fix(#572): give the goto route the transport read it needs, at the route

### DIFF
--- a/Scripts/livekit/live_572_record_sequence_first_call.py
+++ b/Scripts/livekit/live_572_record_sequence_first_call.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Live proof that `record_sequence` works as the FIRST operation of a fresh server process.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_572_record_sequence_first_call.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+`record_sequence` resets the playhead to bar 1 as a hard precondition before importing its SMF. As
+the first operation of a fresh process that reset failed, every time:
+
+    {"operation":"transport.goto_position","requested":"1.1.1.1","error":"ax_write_failed",
+     "menu_state":"could_not_be_closed","menu_actuation_attempted":false,
+     "dialog_actuation_attempted":false,"write_attempted":false}
+
+Nothing was actuated, and no menu was open — an external System Events read counted zero.
+
+WHAT THE MEASUREMENT SHOWED
+---------------------------
+Three samples each way on a freshly created project, same binary otherwise:
+
+    with the pre-read at the channel's goto dispatch        OK  OK  OK
+    with it removed                                        FAIL FAIL FAIL
+
+and, from the isolation that led there: the same `transport.get_state` issued SECONDS EARLIER as a
+separate request does not help (3/3 FAIL), while issued inside the request it does. Not elapsed
+time, not the track count, not the parameter key.
+
+Every caller that reached the operation through `TransportDispatcher.handleGotoPosition` was already
+covered by its `liveTransportState` pre-read. `record_sequence` routes the operation directly and was
+the only caller without it — so the read now belongs to the operation, where no caller can miss it.
+
+THE TRIGGER IS "FIRST CALL", SO THE RUN PROTECTS IT
+---------------------------------------------------
+`record_sequence` must be the first TOOL call this driver makes. Anything issued before it — even a
+resource read — changes the condition under test, and the run would pass while measuring the
+second-call case, which never failed. The captures and the recording below use Quartz and
+screencapture, not the product, precisely so they cannot warm it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Band over the arrange window's track lane area, where an imported region becomes visible.
+REGION_BAND = (280, 120, 700, 220)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'return name of every window')
+
+
+def menus_open():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return count of (every menu bar item of menu bar 1 whose selected is true)')
+    return int(raw) if raw.isdigit() else None
+
+
+titles = window_titles()
+ev.check("572/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic has an arrange window, so there is a project to import into",
+         f"titles={titles!r}",
+         None)
+
+standing_menus = menus_open()
+ev.check("572/precondition-no-menu-is-open-before-the-run", standing_menus == 0,
+         "no menu bar item is selected, so a later `could_not_be_closed` cannot be blamed on one "
+         "that was already standing",
+         f"menus_open={standing_menus!r}",
+         None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("572/before-first-call", settle_region=REGION_BAND)
+
+# The driver is created HERE and record_sequence is its first tool call. Nothing above touched the
+# product.
+d = E.Driver()
+result = d.tool("logic_tracks", "record_sequence", {"notes": "60,0,500;64,500,500;67,1000,500"})
+time.sleep(2)
+ev.note("572/first-call", result)
+
+ev.check("572/record-sequence-succeeds-as-the-first-call-of-a-fresh-process",
+         result.get("verified") is True,
+         "the very first operation a fresh server process performs reaches a verified import",
+         f"verified={result.get('verified')!r} error={result.get('error')!r} "
+         f"message={str(result.get('message'))[:160]!r}",
+         "remove the `runtime.transportState()` read from the channel's transport.goto_position "
+         "dispatch: measured 3/3, record_sequence then fails its mandatory playhead reset with "
+         "menu_state could_not_be_closed and menu_actuation_attempted false")
+
+ev.check("572/the-playhead-reset-is-not-what-failed",
+         "reset playhead" not in str(result.get("message") or ""),
+         "the failure this issue is about — the mandatory reset to bar 1 — did not occur",
+         f"message={str(result.get('message'))[:200]!r}",
+         "remove the pre-read: the message becomes "
+         "'record_sequence failed to reset playhead to bar 1 (required for accurate import)'")
+
+ev.check("572/a-region-was-actually-created",
+         bool(result.get("region_name")) and result.get("start_bar") == 1,
+         "the import produced a MIDI region anchored at bar 1, which is what the reset exists for",
+         f"region_name={result.get('region_name')!r} start_bar={result.get('start_bar')!r} "
+         f"end_bar={result.get('end_bar')!r} created_track={result.get('created_track')!r}",
+         "leave the playhead where it was: the SMF's bar offset is relative to tick 0, so the "
+         "region lands at playhead+offset instead of at bar 1")
+
+after = ev.shot("572/after-first-call", settle_region=REGION_BAND)
+ev.visual("572/the-region-appears-in-the-arrange-window",
+          before["file"], after["file"], REGION_BAND, expect_change=True,
+          why="a new track carrying the imported region is drawn in the arrange area, so this band "
+              "must differ across the call")
+
+trailing_menus = menus_open()
+ev.check("572/no-menu-was-left-standing",
+         trailing_menus == 0,
+         "the run leaves no menu open for the next operation to trip over",
+         f"menus_open={trailing_menus!r}",
+         "let the goto route abandon its menu: the next operation refuses with a blocking-dialog "
+         "preflight that has nothing to do with it")
+
+d.close()
+ev.restored("572/the-imported-track-is-left-in-place",
+            True,
+            f"the run imports one sequence and leaves it: created_track="
+            f"{result.get('created_track')!r}. Removing it would need a destructive delete this "
+            f"run has no reason to perform, and the project is a scratch document.")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -345,6 +345,25 @@ actor AccessibilityChannel: Channel {
             return runtime.setCycleRange(params)
 
         case "transport.goto_position":
+            // The Go To Position dialog route needs a live transport read immediately before it, in
+            // the same request. Measured 2026-08-17 on Logic 12.3, three samples each way: as the
+            // first thing a fresh server process does, the route reports `menu_state:
+            // could_not_be_closed` with `menu_actuation_attempted: false` — it never tries, and no
+            // menu is open (an external System Events read counts zero). Adding this read turns
+            // 3/3 FAIL into 3/3 OK. The same read issued seconds earlier as a separate request does
+            // NOT help, so it is the immediacy that matters, not the warmth.
+            //
+            // It lives HERE rather than in the callers because that is what went wrong: every
+            // caller reaching this operation through `TransportDispatcher.handleGotoPosition` was
+            // covered by its `liveTransportState` pre-read, and `record_sequence` — the one caller
+            // that routes the operation directly — was not, so its mandatory playhead reset failed
+            // on every fresh process (#572). A precondition kept in each caller is a precondition
+            // one caller will miss.
+            //
+            // Why the route needs it is NOT established. What is established is the pair above: an
+            // in-request read fixes it and an earlier one does not. Do not delete this as a
+            // pointless warm-up without reproducing that pair first.
+            _ = runtime.transportState()
             return await AccessibilityChannel.gotoPositionViaBarSlider(
                 params: params, runtime: runtime.logicRuntime
             )

--- a/Tests/LogicProMCPTests/Issue572GotoPreReadTests.swift
+++ b/Tests/LogicProMCPTests/Issue572GotoPreReadTests.swift
@@ -1,0 +1,113 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// Records the order in which the channel touched things.
+private final class GotoOrderProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [String] = []
+
+    func note(_ event: String) {
+        lock.lock(); defer { lock.unlock() }
+        events.append(event)
+    }
+
+    var recorded: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return events
+    }
+}
+
+/// `transport.goto_position` must read the live transport state before it drives the Go To Position
+/// dialog route, in the same request.
+///
+/// Measured on Logic 12.3, 2026-08-17, three samples each way on a freshly created project: as the
+/// FIRST operation of a fresh server process the route answers `menu_state: could_not_be_closed`
+/// with `menu_actuation_attempted: false` — it never actuates, and no menu is open (an external
+/// System Events read counts zero). With the read in place, 3/3 succeed; with it removed, 3/3 fail.
+/// The same read issued seconds earlier as a separate request does not help, so what matters is that
+/// it happens inside this request, not that the process is warm.
+///
+/// The read belongs to the OPERATION, not to its callers. That is precisely what went wrong:
+/// `TransportDispatcher.handleGotoPosition` did it via `liveTransportState`, so every caller that
+/// went through the dispatcher was covered — and `record_sequence`, the one caller that routes the
+/// operation directly, was not. Its mandatory playhead reset failed on every fresh process (#572).
+@Suite("#572 the goto route reads the transport before it actuates")
+struct Issue572GotoPreReadTests {
+    private func runtime(probe: GotoOrderProbe) -> AccessibilityChannel.Runtime {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(57_200)
+        let base = builder.makeLogicRuntime(appElement: app)
+        let axBase = base.ax
+        let logic = AXLogicProElements.Runtime(
+            logicProPID: base.logicProPID,
+            ax: AXHelpers.Runtime(
+                axApp: axBase.axApp,
+                attributeValue: { element, attribute in
+                    probe.note("ax:\(attribute)")
+                    return axBase.attributeValue(element, attribute)
+                },
+                setAttributeValue: axBase.setAttributeValue,
+                children: { element in
+                    probe.note("ax:AXChildren")
+                    return axBase.children(element)
+                },
+                performAction: axBase.performAction,
+                childCount: axBase.childCount
+            ),
+            executeAppleScript: base.executeAppleScript
+        )
+        return AccessibilityChannel.Runtime(
+            isTrusted: { true },
+            isLogicProRunning: { true },
+            appRoot: { app },
+            transportState: {
+                probe.note("transport_read")
+                return .success("{\"transport\":true}")
+            },
+            toggleTransportButton: { _ in .success("{}") },
+            setTempo: { _ in .success("{}") },
+            setCycleRange: { _ in .success("{}") },
+            tracks: { .success("[]") },
+            selectedTrack: { .success("{}") },
+            selectTrack: { _ in .success("{}") },
+            setTrackToggle: { _, _ in .success("{}") },
+            renameTrack: { _ in .success("{}") },
+            mixerState: { .success("{}") },
+            channelStrip: { _ in .success("{}") },
+            setMixerValue: { _, _ in .success("{}") },
+            projectInfo: { .success("{}") },
+            logicRuntime: logic
+        )
+    }
+
+    @Test("the transport is read, and read before the route touches the AX tree")
+    func transportIsReadFirst() async throws {
+        let probe = GotoOrderProbe()
+        let channel = AccessibilityChannel(runtime: runtime(probe: probe))
+
+        _ = await channel.execute(operation: "transport.goto_position", params: ["bar": "5"])
+
+        let recorded = probe.recorded
+        // Without this read the dialog route fails as the first operation of a fresh process.
+        let readIndex = try #require(recorded.firstIndex(of: "transport_read"))
+        if let firstAX = recorded.firstIndex(where: { $0.hasPrefix("ax:") }) {
+            // Ordering, not merely presence: a read that happens after the route has begun is not
+            // the read the route needs.
+            #expect(readIndex < firstAX)
+        }
+    }
+
+    @Test("a different transport operation does not acquire the pre-read")
+    func onlyTheGotoRouteReadsFirst() async {
+        // Guards against "read the transport before everything", which would be a wider change than
+        // the measurement supports and would double every transport request's AX work.
+        let probe = GotoOrderProbe()
+        let channel = AccessibilityChannel(runtime: runtime(probe: probe))
+
+        _ = await channel.execute(operation: "transport.toggle_cycle", params: [:])
+
+        #expect(!probe.recorded.contains("transport_read"))
+    }
+}


### PR DESCRIPTION
Closes #572.

## What failed

`record_sequence` resets the playhead to bar 1 as a hard precondition before importing its SMF. As
the **first operation of a fresh server process** that reset failed every time:

```json
{"operation": "transport.goto_position", "requested": "1.1.1.1",
 "error": "ax_write_failed",
 "menu_state": "could_not_be_closed",
 "menu_actuation_attempted": false,
 "dialog_actuation_attempted": false,
 "write_attempted": false}
```

Nothing was actuated, and no menu was open — an external System Events read counted zero.

## The measurement

Three samples per condition, on a **freshly created project** (see the correction on #572 for why
that matters):

| condition | result |
|---|---|
| pre-read at the channel's goto dispatch | OK OK OK |
| pre-read removed | FAIL FAIL FAIL |
| `transport.get_state` seconds earlier, separate request | FAIL FAIL FAIL |
| wait 0 / 2 / 5 / 10 / 15 / 20s after server start | FAIL ×6 |
| `params: ["position": "1.1.1.1"]` instead of `["bar": "1"]` | FAIL FAIL FAIL |

So it is not elapsed time, not the track count, not the parameter key. It is a live transport read
**inside the same request**, immediately before the route.

## Why it goes at the route

Every caller that reaches `transport.goto_position` through
`TransportDispatcher.handleGotoPosition` was already covered by that function's `liveTransportState`
pre-read. `record_sequence` routes the operation directly and was the one caller without it.

A precondition kept in each caller is a precondition one caller will miss — so the read now sits at
the channel's dispatch for the operation, where no caller can bypass it, rather than being copied
into `record_sequence`.

**Why the route needs it is not established, and the comment says so.** What is established is the
pair above: an in-request read fixes it and an earlier one does not. That pair is what anyone
tempted to delete this as a pointless warm-up has to reproduce first.

## Evidence

Unit — 3794 tests pass under the CI gate. The two new tests fail in **opposite** directions:
removing the read reddens the ordering test only; reading the transport before *every* transport
operation reddens only the test that holds the change to this one route.

Live — `Scripts/livekit/live_572_record_sequence_first_call.py`, six checks, four mutation-backed,
one visual assertion over the arrange window's region band. The harness protects its own trigger:
`record_sequence` must be the driver's **first** tool call, so the captures and recording use Quartz
and `screencapture` rather than the product, precisely so they cannot warm it.

```
record-sequence-succeeds-as-the-first-call-of-a-fresh-process   verified=True
the-playhead-reset-is-not-what-failed                           message=None
a-region-was-actually-created                                   "MIDI Region", bars 1→2
no-menu-was-left-standing                                       menus_open=0
```

## Two earlier characterisations of this bug were wrong

Both from single samples taken on a project my own repeated runs had grown past 30 tracks. The
Import button was never the defect — the generated SMF is valid (captured mid-run before its `defer`
cleanup) and imports by hand from its own temp path. The inoculation table I first published did not
replicate once. Withdrawn in the correction comment on #572, with the replicating data alongside.

## Noted, not changed

The refusal envelope carries `write_attempted: false` and `safe_to_retry: false` together. Nothing
was written and retrying is what worked, so the receipt talks the caller out of the one recovery
available. Left alone here rather than loosening a fail-closed field on a path this PR already
changes the behaviour of.
