### PR TITLE
docs: record the correctness wave the roadmap did not have

### DIFF
--- a/docs/roadmap/roadmap-2026-08-10.md
+++ b/docs/roadmap/roadmap-2026-08-10.md
@@ -27,7 +27,8 @@ sits at the end (Wave 7) and no wave before it may claim GA.
 ## Where it stands
 
 Eighteen issues have closed since this file was written: #425 #474 #475 #476 #478 #479 #480 #489 #490 #491 #492 #493 #494 #495 #496 #497 #498 #502, plus the cache half of #505. Wave 0 shipped every branch it named; the single
-remainder is #440's finding E, which is unreproducible on this host. **20 issues remain open.**
+remainder is #440's finding E, which is unreproducible on this host. **20 issues remained open when this
+was written; see the 2026-08-17 update below for the current count.**
 
 | wave | issues | closes by |
 | --- | --- | --- |
@@ -45,6 +46,65 @@ remainder is #440's finding E, which is unreproducible on this host. **20 issues
 issue's own acceptance forbids claiming a fix without one, so it stays open rather than being closed
 on an untested claim. **#505** keeps the coverage half of the CI split; the cache half shipped in
 #509.
+
+---
+
+## Update 2026-08-17 — a correctness wave the plan did not have
+
+Eight issues closed or opened since the table above, and the count it states is stale: **24 open, not
+20.** Five of the new ones were found by driving the product rather than by reading it, and they do
+not belong to any capability train — they are the same class as Wave 0.
+
+### Closed
+
+| PR | issue | what it closed |
+| --- | --- | --- |
+| #566 | #565 | an empty Marker List read as unreadable, so `create_marker` — the only route to a first marker — was State C in every project with no markers |
+| #569 | #568 | the same reader could be corroborated from the wrong window, its childless escape hatch bypassed corroboration entirely, and `markers_not_polled_yet` keyed on a timestamp that only advances on success; plus the Korean and Japanese count label and value format, without which `nav.delete_marker` could not certify on either locale at all |
+
+### Open, with a PR awaiting merge
+
+| PR | issue | what it fixes |
+| --- | --- | --- |
+| #571 | #570 | `project.new` named Creator Studio to desktop operators and reported a deliberate precondition refusal as `channels_exhausted` |
+| #573 | #567 | `kCGWindowOwnerName` carries U+00A0 under a Korean UI, so the window-list PID fallback matched nothing |
+| #574 | #572 | the Go To Position dialog route needs a transport read immediately before it; `record_sequence` was the one caller routing the channel directly, and failed 6/6 as a fresh process's first operation |
+| #577 | #576 | `midi.import_file` reported `import_failure` from a region readback that publishes `complete: false` on every read — an import that worked, called a failure, where the retry it invites creates a second track |
+| #578 | #519 | the locale flow scenario demanded State A from two operations the semantic oracle declares cannot reach it |
+
+### Open, no PR
+
+- **#575 — twelve routed operations nothing calls.** Seven `region.*` plus `mixer.set_output_volume`,
+  `mixer.get_bus_routing`, `automation.get_parameter`, `system.cache_state` and `system.refresh`;
+  the last two route to an empty channel list. All are absent from `OperationRegistry`, so the
+  exhaustiveness gates that exist to make an operation's contract impossible to forget have nothing to
+  check. **#519's acceptance names "a region operation"; there is none to drive.** Exposing them is an
+  ADR-shaped decision and overlaps #302, so this sits with Wave 1 rather than becoming a wave of its
+  own.
+
+### What this changes about the plan
+
+**Rule 3 needs a companion.** "Every guard is mutation-tested" held, and it is what caught most of
+these. What it does not cover is a guard aimed at the wrong thing: #565's suite passed because its
+fixture built a table shape Logic never presents, and #578's scenario failed steps the project had
+formally declared could not pass. Both were green, both were mutation-testable, neither measured the
+product. The addition:
+
+> **A check states what it is aimed at, and that aim is checked against the running system —**
+> the fixture against the live tree, the expectation against the operation's own qualification.
+
+**A gate for #575's class was attempted and withdrawn.** The missing direction is routing → caller;
+nothing walks it. A static census over `Sources/` cannot: this codebase computes operation strings
+(`operation: "plugin.\(command)"`), so no textual predicate can see those callers. An execution
+census has the mirror problem — driving every handler with empty params reports un-driveable as
+unreachable. Recorded on #575 with all three predicates tried, so the next attempt starts after them
+rather than at them.
+
+**Measurement grows the fixture.** Repeated live runs pushed the scratch project past the arrange
+viewport, at which point `record_sequence` cannot read back its own region — and two published
+characterisations of #572 were wrong because they were measured there. Any live measurement of a
+create-shaped operation resets the project first and takes three samples before a rule is written
+down.
 
 ---
 


### PR DESCRIPTION
Updates the public roadmap mirror. Documentation only.

## Why

The mirror states **20 issues remain open**. It is 24. Five of the difference are issues opened while
driving the product over the last day, and none of them belongs to a capability train — they are the
same class as Wave 0, which the wave table has no row for.

| | |
|---|---|
| closed | #565, #568 |
| open, PR awaiting merge | #570 (#571), #567 (#573), #572 (#574), #576 (#577), #519 (#578) |
| open, no PR | #575 |

## Two things this changes about the plan, not just its counts

**Rule 3 needs a companion.** "Every guard is mutation-tested" held, and it is what caught most of
these. What it does not cover is a guard aimed at the wrong thing:

- #565's unit suite passed because its fixture built a table shape Logic never presents — a childless
  `AXTable`, where the live one always vends four `AXColumn` children. The reader refused every empty
  Marker List in production while its own emptiness test went green.
- the locale flow scenario failed steps the project had **formally declared** could not pass:
  `SemanticOracleTable` lists `projectNew` among the operations that structurally cannot reach State
  A, and both it and `goto_position` were reported as product failures before anyone read the oracle.

Both were green. Both were mutation-testable. Neither measured the product. Hence:

> A check states what it is aimed at, and that aim is checked against the running system — the
> fixture against the live tree, the expectation against the operation's own qualification.

**A gate for #575's class was attempted and withdrawn.** Nothing walks from the operation table to its
callers. A static census cannot do it — this codebase builds operation names by interpolation
(`operation: "plugin.\(command)"`), so no textual predicate sees those callers. An execution census
has the mirror problem: driving every handler with empty params reports un-driveable as unreachable.
All three predicates tried are recorded on #575, so the next attempt starts after them rather than at
them.

## Also recorded

Repeated live runs push the scratch project past the arrange viewport, where `record_sequence` cannot
read back its own region (#576). **Two published characterisations of #572 were wrong because they
were measured there** — the measurement had grown the thing it was measuring. Any live measurement of
a create-shaped operation now resets the project first and takes three samples before a rule is
written down.

## Scope

This file says at the top that it is a mirror and that the controlling roadmap held outside the
repository wins where they differ. That one needs the same update; this PR cannot make it.
