### PR TITLE
chore(#575): retire two table entries that named nothing

### DIFF
--- a/Scripts/livekit/live_575_retired_routes_change_nothing.py
+++ b/Scripts/livekit/live_575_retired_routes_change_nothing.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Live proof that retiring two unreachable table entries changed nothing reachable.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_575_retired_routes_change_nothing.py <worktree> <full-40-char-head-sha>
+
+WHAT THIS IS FOR
+----------------
+`system.cache_state` and `system.refresh` were removed from the table. They had an empty channel
+chain — which is not itself a defect: `system.health` and `system.permissions` share it and work,
+because the dispatcher answers them directly and the entry only tells the router the operation is
+real. What made these two dead is that nothing in `Sources/` named either, and `system.refresh` was
+shadowed by the registered `system.refresh_cache` that every caller actually uses.
+
+A removal's risk is not in what it deletes but in what it takes with it. So the assertions here are
+about the NEIGHBOURS: the operations that share the empty-chain pattern, and the one that shadowed
+the removed name, must all still work against the real application.
+
+The removed names are checked too, but that check is weak on its own — they answered
+`invalid_params` before the change as well. It is recorded for completeness, not as the proof.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Band over the arrange window's track headers. Every call below is a read or a cache refresh, so
+# the assertion over it is a NEGATIVE one.
+TRACK_BAND = (10, 120, 260, 220)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic is up with a project, so the surviving operations have something to answer about",
+         f"titles={titles!r}",
+         None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("575/before", settle_region=TRACK_BAND)
+
+d = E.Driver()
+time.sleep(3)
+
+# The neighbours: same empty-chain pattern, and the operation that shadowed the removed name.
+survivors = {
+    "logic_system.health": d.tool("logic_system", "health", {}),
+    "logic_system.permissions": d.tool("logic_system", "permissions", {}),
+    "logic_system.refresh_cache": d.tool("logic_system", "refresh_cache", {}),
+    "logic_project.is_running": d.tool("logic_project", "is_running", {}),
+}
+ev.note("575/survivors", {k: str(v)[:300] for k, v in survivors.items()})
+
+broken = {k: v for k, v in survivors.items()
+          if not isinstance(v, dict) or v.get("error") is not None}
+ev.check("575/the-operations-that-share-the-empty-chain-still-work",
+         not broken,
+         "health, permissions, refresh_cache and is_running all answer without an error — the "
+         "empty-chain pattern survived the removal of two entries that used it",
+         f"broken={list(broken)} keys={{k: sorted(v)[:4] for k, v in survivors.items() "
+         f"if isinstance(v, dict)}}",
+         "remove `system.health` or `system.permissions` from the table alongside them: the router "
+         "stops recognising the operation and the dispatcher's answer never reaches the caller")
+
+ev.check("575/refresh_cache-still-refreshes",
+         isinstance(survivors["logic_system.refresh_cache"], dict)
+         and survivors["logic_system.refresh_cache"].get("refreshed") is True,
+         "the operation that shadowed the removed `system.refresh` still performs a refresh, so the "
+         "removal took the dead name and not the live one",
+         f"body={str(survivors['logic_system.refresh_cache'])[:200]}",
+         "remove `system.refresh_cache` instead of `system.refresh` — the names differ by a suffix "
+         "and the dead one is the shorter")
+
+# Weak on its own: these answered the same way before the change. Recorded for completeness.
+removed = {
+    "logic_system.cache_state": d.tool("logic_system", "cache_state", {}),
+    "logic_system.refresh": d.tool("logic_system", "refresh", {}),
+}
+ev.note("575/removed", {k: str(v)[:200] for k, v in removed.items()})
+ev.check("575/the-removed-names-are-still-unreachable",
+         all(isinstance(v, dict) and v.get("error") == "invalid_params"
+             for v in removed.values()),
+         "neither removed name became reachable or started answering differently",
+         f"{ {k: (v.get('error') if isinstance(v, dict) else None) for k, v in removed.items()} }",
+         # No mutation: they answered `invalid_params` before the change too, so this check cannot
+         # distinguish the two versions. It is here to show the removal did not accidentally BIND
+         # them to something, not as evidence the removal was correct.
+         None)
+
+after = ev.shot("575/after", settle_region=TRACK_BAND)
+ev.visual("575/no-project-state-was-touched",
+          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          why="every call in this run is a read or a cache refresh, so the arrange window's track "
+              "headers must be byte-identical across it")
+
+d.close()
+ev.restored("575/nothing-to-restore", True,
+            "the run performs no write; it reads health, permissions and running state and refreshes "
+            "the cache, none of which changes the project")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -265,10 +265,15 @@ extension ChannelRouter {
         "note.up_octave":             [.midiKeyCommands, .cgEvent],
         "note.down_octave":           [.midiKeyCommands, .cgEvent],
 
-        // System — no channel needed
+        // System — no channel needed. An empty chain is not a defect here: these are answered by
+        // the dispatcher itself, and the entry exists so the router knows the operation is real.
+        //
+        // `system.cache_state` and `system.refresh` used to sit here too and were removed (#575).
+        // Nothing in Sources/ routed either, and `system.refresh` was shadowed by the registered
+        // `system.refresh_cache` that every caller and every hint string actually names. A routed
+        // operation nobody calls is also absent from `OperationRegistry`, so the exhaustiveness
+        // gates cannot see it — the entry was carrying no contract and no caller.
         "system.health":              [],
-        "system.cache_state":         [],
-        "system.refresh":             [],
         "system.permissions":         [],
     ]
 }

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -308,7 +308,10 @@ private func waitUntil(
 
 @Test func testRouterAllOperationsHaveChannel() async {
     let table = ChannelRouter.v2RoutingTable
-    let systemOps = ["system.health", "system.cache_state", "system.refresh", "system.permissions", "project.is_running"]
+    // `system.cache_state` and `system.refresh` were removed from the table in #575: nothing routed
+    // either, and `system.refresh` was shadowed by the registered `system.refresh_cache`. Leaving
+    // them in this exclusion list would let them be reintroduced without anyone noticing.
+    let systemOps = ["system.health", "system.permissions", "project.is_running"]
     for (op, channels) in table {
         if systemOps.contains(op) {
             continue // System ops intentionally have no channel


### PR DESCRIPTION
Partial cleanup for #575. Two of the twelve entries in that census are retired; the other ten are
untouched, because they are implemented surfaces whose exposure is a decision rather than dead weight.

## What was dead, and what was not the problem

`system.cache_state` and `system.refresh` sat in the table with an empty channel chain.

**The empty chain was never the defect.** `system.health` and `system.permissions` share it and work:
the dispatcher answers them directly, and the entry exists so the router knows the operation is real.

What made these two dead is that **nothing in `Sources/` named either one**, and `system.refresh` was
shadowed by the registered `system.refresh_cache` that every caller — and every recovery hint string
in the codebase — actually uses. An operation nothing calls is also absent from `OperationRegistry`,
so the exhaustiveness gates have nothing to check. Both entries carried no contract and no caller.

Verified against the running server before removal, not only by grep: each answers
`invalid_params: Command ... is not registered` under every tool spelling.

## The test's exclusion list is trimmed with them

`ChannelRouterTests.testRouterAllOperationsHaveChannel` listed both names as "system ops intentionally
have no channel". Leaving them there would let either be reintroduced without anyone noticing — which
is how they survived this long.

## Evidence

The risk in a removal is not what it deletes but what it takes with it, so the live harness asserts on
the **neighbours**: the operations that share the empty-chain pattern, and the one that shadowed the
removed name.

```
575/the-operations-that-share-the-empty-chain-still-work
    health · permissions · refresh_cache · is_running   all answer, no error
575/refresh_cache-still-refreshes                       refreshed: true
575/no-project-state-was-touched                        track-header band byte-identical
```

The fourth check — that the removed names are still unreachable — is recorded with **no mutation
claim**, deliberately. They answered `invalid_params` before this change too, so it cannot tell the
two versions apart. It is there to show the removal did not accidentally bind them to something, not
as evidence that removing them was right.

3792 tests pass under the CI gate.
