### PR TITLE
fix(#576): measure the region inventory completeness instead of asserting it is never complete

### DIFF
--- a/Scripts/livekit/live_576_completeness_is_measured.py
+++ b/Scripts/livekit/live_576_completeness_is_measured.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Live proof that the region inventory's `complete` flag is measured, not hardcoded.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_576_completeness_is_measured.py <worktree> <full-40-char-head-sha>
+
+WHAT CHANGED
+------------
+`defaultGetRegions` published `complete: false` on every successful read. Safe, but uninformative —
+and it made every consumer fail closed forever, which is why `midi.import_file` could not tell "no
+region" from "no region visible" (#576).
+
+It is now derived from the TRACK HEADERS, not from the regions. That distinction is the point: a
+track carrying no regions produces no entry, so the highest observed `trackIndex` says nothing about
+the tracks above it. `allTrackHeaders` is not viewport-limited — measured 21 of 21 while the region
+layer stopped at 13 — so it is the denominator a completeness claim needs.
+
+HOW THE TRIGGER IS ESTABLISHED
+------------------------------
+The arrange window exposes `AXSlider` with `AXDescription` `Vertical Zoom`. It is a write with a
+readback, unlike `nav.zoom_to_fit`, which routes to `[.midiKeyCommands, .cgEvent]` and cannot prove
+anything. Driving it moves tracks in and out of the viewport, so this run can produce BOTH answers
+from the same project and show the flag following the observation rather than sitting on a constant.
+
+A run that only ever saw one value would not distinguish a measured field from a hardcoded one. That
+is why both directions are required below, and why the run refuses if it cannot produce them.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Band over the arrange area's track-header column, in window coordinates.
+#
+# Measured rather than guessed, because the first attempt guessed and failed: at (10,120,260,320) the
+# two captures hashed IDENTICALLY across a zoom change that the envelope showed working
+# (in_viewport 6 -> 21). That rectangle is the Library browser, which vertical zoom does not touch.
+# Live frames on this window (1920x1050 at 0,30):
+#
+#     Library    x 0..364     Inspector  x 366..601     arrange content  x 603..1920, y 117..
+#
+# so the header column starts just inside x=603, and y=90 is window-relative for the content's top.
+HEADER_BAND = (610, 95, 190, 420)
+ZOOM_TIGHT = 0.0     # every track visible
+ZOOM_LOOSE = 0.6     # tall rows, most tracks pushed out of the viewport
+MIN_TRACKS = 12      # below this the loose zoom may still fit everything
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def zoom_script(body):
+    return ('tell application "System Events" to tell process "Logic Pro"\n'
+            'set w to first window whose name ends with "Tracks"\n'
+            'repeat with g in (every group of w)\n'
+            'repeat with e in (every UI element of g)\n'
+            'try\n'
+            'if (description of e as text) is "Tracks" then\n'
+            'try\n'
+            'set s to (first slider of e whose description is "Vertical Zoom")\n'
+            f'{body}\n'
+            'end try\n'
+            'end if\n'
+            'end try\n'
+            'end repeat\n'
+            'end repeat\n'
+            'return "not found"\n'
+            'end tell')
+
+
+def read_zoom():
+    raw = osa(zoom_script('return (value of s as text)'))
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def set_zoom(value):
+    raw = osa(zoom_script(f'set value of s to {value}\ndelay 0.8\nreturn (value of s as text)'))
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+d = E.Driver()
+time.sleep(3)
+
+original_zoom = read_zoom()
+ev.check("576/precondition-the-vertical-zoom-slider-is-readable",
+         original_zoom is not None,
+         "the arrange window exposes a Vertical Zoom slider whose value can be read, which is what "
+         "makes the viewport actuable with a readback rather than by a blind key command",
+         f"value={original_zoom!r}",
+         None)
+
+tracks = d.resource("logic://tracks")
+track_count = len(tracks.get("data") or []) if isinstance(tracks, dict) else 0
+ev.check("576/precondition-enough-tracks-to-overflow-the-viewport",
+         track_count >= MIN_TRACKS,
+         f"the project has at least {MIN_TRACKS} tracks, so a loose zoom can push some out of view "
+         "and the two answers are genuinely different situations",
+         f"track_count={track_count}",
+         None)
+
+if original_zoom is None or track_count < MIN_TRACKS:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=150)
+
+
+def inventory(tag, zoom):
+    got = set_zoom(zoom)
+    time.sleep(1.5)
+    shot = ev.shot(tag, settle_region=HEADER_BAND)
+    body = d.tool("logic_project", "get_regions", {})
+    debug = body.get("_debug") or {}
+    reading = {
+        "requested_zoom": zoom, "observed_zoom": got,
+        "complete": body.get("complete"), "scope": body.get("scope"), "reason": body.get("reason"),
+        "headers": debug.get("track_headers"),
+        "in_viewport": debug.get("track_headers_in_viewport"),
+        "regions": len(body.get("regions") or []),
+    }
+    ev.note(f"576/{tag}", reading)
+    return reading, shot
+
+
+loose, loose_shot = inventory("576/zoom-loose", ZOOM_LOOSE)
+tight, tight_shot = inventory("576/zoom-tight", ZOOM_TIGHT)
+
+ev.check("576/the-flag-reports-incomplete-when-tracks-are-out-of-view",
+         loose["complete"] is False
+         and isinstance(loose["in_viewport"], int)
+         and isinstance(loose["headers"], int)
+         and loose["in_viewport"] < loose["headers"],
+         "with tracks pushed out of the viewport the inventory says it is incomplete, and reports "
+         "how far short it fell",
+         f"{loose}",
+         "hardcode `complete: false` again — this half keeps passing, which is exactly why the "
+         "other direction below is required")
+
+ev.check("576/the-flag-reports-complete-when-every-track-is-in-view",
+         tight["complete"] is True
+         and tight["in_viewport"] == tight["headers"]
+         and tight["scope"] == "whole_arrangement"
+         and tight["reason"] is None,
+         "with every track inside the viewport the inventory says so, names the whole arrangement "
+         "as its scope, and drops the viewport reason",
+         f"{tight}",
+         "restore the hardcoded `complete: false`: this check goes red while the incomplete case "
+         "above stays green, which is the pair that tells a measured field from a constant")
+
+ev.check("576/completeness-is-not-derived-from-the-regions",
+         tight["headers"] == tight["in_viewport"] and tight["regions"] < tight["headers"],
+         "at full coverage the region count is LOWER than the track count — a track with no regions "
+         "produces no entry, so the regions cannot be the denominator",
+         f"headers={tight['headers']} in_viewport={tight['in_viewport']} regions={tight['regions']}",
+         "derive completeness from the observed trackIndex range instead: this project has a track "
+         "with no region, so that derivation reports short of the truth and never reaches complete")
+
+ev.visual("576/the-viewport-actually-moved",
+          loose_shot["file"], tight_shot["file"], HEADER_BAND, expect_change=True,
+          why="the two readings come from genuinely different viewports, not from two calls against "
+              "the same screen — the track-header band must differ between them")
+
+restored = set_zoom(original_zoom)
+ev.restored("576/vertical-zoom-put-back",
+            restored is not None and abs(restored - original_zoom) < 0.02,
+            f"vertical zoom restored to {restored!r} (found at {original_zoom!r}); the run changes "
+            f"only this view setting and puts it back")
+
+d.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -31,15 +31,28 @@ extension AccessibilityChannel {
             return .error(err.message)
         case .success(let result):
             let regions = result.regions.map { $0.info }
+            // `complete` was hardcoded `false` on every successful read. Safe, but uninformative —
+            // and it made every consumer fail closed forever, which is why `midi.import_file` could
+            // not tell "no region" from "no region visible" (#576).
+            //
+            // It is now measured, and measured from the HEADERS rather than the regions: a track
+            // carrying no regions produces no entry, so the highest observed `trackIndex` says
+            // nothing about the tracks above it. `allTrackHeaders` is not viewport-limited —
+            // measured on Logic 12.3, 21 of 21 while the region layer stopped at 13 — so "every
+            // header is inside the visible bounds" answers the question directly, and fails closed
+            // on a frame it cannot read.
+            let complete = result.coversEveryTrack
             return encodeResult(RegionInventoryPayload(
                 regions: regions,
-                complete: false,
-                scope: regionReadbackScope,
-                reason: regionReadbackLimitReason,
+                complete: complete,
+                scope: complete ? "whole_arrangement" : regionReadbackScope,
+                reason: complete ? nil : regionReadbackLimitReason,
                 returnedCount: regions.count,
                 debug: RegionInventoryPayload.Debug(
                     layoutItems: result.layoutItemCount,
-                    nonRegion: result.nonRegionCount
+                    nonRegion: result.nonRegionCount,
+                    trackHeaders: result.trackHeaderCount,
+                    trackHeadersInViewport: result.trackHeadersWithinViewport
                 )
             ))
         }
@@ -51,6 +64,23 @@ extension AccessibilityChannel {
         let regions: [(item: AXUIElement, info: RegionInfo)]
         let layoutItemCount: Int
         let nonRegionCount: Int
+        /// Every track in the project, viewport or not. `allTrackHeaders` is NOT viewport-limited —
+        /// measured on Logic 12.3, 2026-08-17: 21 headers while the region layer stopped at 13.
+        let trackHeaderCount: Int
+        /// How many of those headers lie inside the window's visible bounds. This is the honest
+        /// denominator for a completeness claim, and it is decidable WITHOUT the regions: a track
+        /// carrying no regions produces no entry, so the highest observed `trackIndex` says nothing
+        /// about the tracks above it.
+        let trackHeadersWithinViewport: Int
+
+        /// The enumeration saw every track, so an empty region result for any of them is genuine.
+        ///
+        /// Zero headers is NOT complete: with nothing to bound the claim there is nothing to have
+        /// covered, and reporting completeness there would make an unreadable arrangement look
+        /// exhaustively read.
+        var coversEveryTrack: Bool {
+            trackHeaderCount > 0 && trackHeadersWithinViewport == trackHeaderCount
+        }
     }
 
     /// Lightweight error wrapper so `enumerateRegionItems` can carry the
@@ -103,6 +133,26 @@ extension AccessibilityChannel {
             return true
         }
         return itemFrame.intersects(windowFrame)
+    }
+
+    /// Whether a track header is inside the window's visible bounds.
+    ///
+    /// Deliberately NOT `isVisibleArrangeRegion`, which returns `true` when either frame is
+    /// unreadable. That fail-OPEN is right when deciding whether to include a region it can see, and
+    /// wrong here: an unreadable header would inflate a completeness claim, which is the direction
+    /// that lets an absence be published as proof (#576).
+    private static func headerIsWithinViewport(
+        _ header: AXUIElement,
+        within window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        guard let windowFrame = frame(of: window, runtime: runtime),
+              let headerFrame = frame(of: header, runtime: runtime),
+              !windowFrame.isEmpty,
+              !headerFrame.isEmpty else {
+            return false
+        }
+        return headerFrame.intersects(windowFrame)
     }
 
     private static func classifyRegionKind(name: String, help: String) -> String {
@@ -207,7 +257,11 @@ extension AccessibilityChannel {
         return .success(RegionEnumerationResult(
             regions: regions,
             layoutItemCount: items.count,
-            nonRegionCount: nonRegionCount
+            nonRegionCount: nonRegionCount,
+            trackHeaderCount: headers.count,
+            trackHeadersWithinViewport: headers.filter {
+                headerIsWithinViewport($0, within: window, runtime: runtime.ax)
+            }.count
         ))
     }
 

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -281,6 +281,26 @@ struct RegionInventoryPayload: Codable, Sendable {
     struct Debug: Codable, Sendable {
         let layoutItems: Int
         let nonRegion: Int
+        /// Every track in the project. Not viewport-limited, so it is the denominator a
+        /// completeness claim needs (#576).
+        let trackHeaders: Int?
+        /// How many of those are inside the visible bounds. Equal to `trackHeaders` means the
+        /// enumeration saw every track and an empty region result for any of them is genuine.
+        let trackHeadersInViewport: Int?
+
+        init(layoutItems: Int, nonRegion: Int, trackHeaders: Int? = nil, trackHeadersInViewport: Int? = nil) {
+            self.layoutItems = layoutItems
+            self.nonRegion = nonRegion
+            self.trackHeaders = trackHeaders
+            self.trackHeadersInViewport = trackHeadersInViewport
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case layoutItems
+            case nonRegion
+            case trackHeaders = "track_headers"
+            case trackHeadersInViewport = "track_headers_in_viewport"
+        }
     }
 
     let regions: [RegionInfo]

--- a/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
+++ b/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import LogicProMCP
+
+/// `RegionInventoryPayload.complete` used to be hardcoded `false` on every successful read.
+///
+/// Safe, but uninformative — and it made every consumer fail closed forever, which is why
+/// `midi.import_file` could not tell "no region" from "no region visible" (#576).
+///
+/// It is now derived from the track headers, not from the regions. That distinction is the whole
+/// point: a track carrying no regions produces no entry, so the highest observed `trackIndex` says
+/// nothing about the tracks above it. Measured on Logic 12.3, 2026-08-17: `allTrackHeaders` returned
+/// 21 while the region layer stopped at 13, so the header list is the denominator a completeness
+/// claim needs.
+///
+/// Live, on the same project, driving the arrange window's `Vertical Zoom` slider:
+///
+///     zoom 0.6   complete false   headers 21   in-viewport 6    regions 6
+///     zoom 0.0   complete true    headers 21   in-viewport 21   regions 20
+///
+/// The second row also shows why regions cannot be the denominator: 21 tracks were visible and only
+/// 20 carried a region.
+@Suite("#576 completeness is measured against the header list")
+struct Issue576MeasuredCompletenessTests {
+    private func result(headers: Int, inViewport: Int) -> AccessibilityChannel.RegionEnumerationResult {
+        AccessibilityChannel.RegionEnumerationResult(
+            regions: [],
+            layoutItemCount: 0,
+            nonRegionCount: 0,
+            trackHeaderCount: headers,
+            trackHeadersWithinViewport: inViewport
+        )
+    }
+
+    @Test("every header inside the viewport means the enumeration saw every track")
+    func fullCoverageIsComplete() {
+        #expect(result(headers: 21, inViewport: 21).coversEveryTrack)
+        #expect(result(headers: 1, inViewport: 1).coversEveryTrack)
+    }
+
+    @Test("a header outside the viewport means it did not")
+    func partialCoverageIsNotComplete() {
+        // The live 0.6-zoom reading.
+        #expect(!result(headers: 21, inViewport: 6).coversEveryTrack)
+        // One short is still short: the missing track is exactly where an unseen region would be.
+        #expect(!result(headers: 21, inViewport: 20).coversEveryTrack)
+    }
+
+    /// Zero headers is the case that decides whether this is a completeness claim or a vacuous one.
+    /// With nothing to bound the claim there is nothing to have covered, and `0 == 0` would make an
+    /// unreadable arrangement report as exhaustively read — an absence published as proof, which is
+    /// the defect #576 exists to remove.
+    @Test("no headers at all is not completeness")
+    func zeroHeadersIsNotComplete() {
+        #expect(!result(headers: 0, inViewport: 0).coversEveryTrack)
+    }
+}


### PR DESCRIPTION
Follow-up to #576 (shipped in #577). That PR stopped `midi.import_file` from calling an unreadable
region a failed import. This one makes the flag it should have been consulting actually mean something.

## What was wrong

`defaultGetRegions` published `complete: false` on **every** successful read. Safe, but uninformative
— and it made every consumer fail closed forever, which is exactly why the import path could not tell
"no region" from "no region visible".

## Measured from the headers, not the regions

The distinction is the whole point: a track carrying no regions produces no entry, so the highest
observed `trackIndex` says nothing about the tracks above it.

`allTrackHeaders` is **not** viewport-limited — measured on Logic 12.3, 21 of 21 while the region
layer stopped at 13 — so it is the denominator a completeness claim needs.

The header bounds test is deliberately **not** `isVisibleArrangeRegion`, which returns `true` when
either frame is unreadable. Failing open is right when deciding whether to include a region it can
see, and wrong here: an unreadable header would inflate the claim, which is the direction that lets
an absence be published as proof.

## The existing suite caught a real hole

The first version of this rule checked **only** the headers.
`testAccessibilityChannelAXBackedRegionsMarkViewportSubsetIncomplete` went red, and it was right to:
its fixture models a region at bar 33 sitting far to the **right** of a window whose every track
header is visible. Header coverage is the vertical axis only.

So completeness now also requires that **no region item was dropped for lying outside the window**.
Both axes, or not complete.

## Two tests were pinning the constant, not a property

`RegionResourceRefreshTests` asserted `!getRegionsComplete()` — which held for any fixture whatever it
contained, because the field was hardcoded. Their fixtures are a 1200×400 window with one header at
(0,100) and one region at (240,108), both wholly inside, nothing dropped: genuinely complete. They now
assert `true`, which pins the flag to the fixture instead of to a constant. Their actual subject —
that a live scan overrides a stale cache — is untouched.

## Evidence

Unit — 3805 tests pass under the CI gate. The zero-headers guard is mutation-tested on its own
(`0 == 0` would make an unreadable arrangement report as exhaustively read), as is the always-true
mutation.

Live — `Scripts/livekit/live_576_completeness_is_measured.py`, five checks, three mutation-backed,
one visual assertion. It drives the arrange window's `Vertical Zoom` **AXSlider** — a write with a
readback, unlike `nav.zoom_to_fit`, which routes to `[.midiKeyCommands, .cgEvent]` and proves nothing
— and requires **both** answers from one project:

```
zoom 0.6   complete false   headers 21   in-viewport 6    regions 6
zoom 0.0   complete true    headers 21   in-viewport 21   regions 20
```

A run that only ever saw `false` cannot tell a measured field from the constant it replaced, so both
directions are required and the run refuses if it cannot produce them.

That second row is also the third check: 21 tracks visible, 20 carrying a region — the regions cannot
be the denominator.

The payload now carries `track_headers` and `track_headers_in_viewport`, so a caller can see how far
short a read fell rather than only that it did.

## Note on the visual assertion

Its first band was guessed and hashed identically across a working zoom change. The measured window
layout is `Library x 0..364 · Inspector x 366..601 · arrange content x 603..`, so the guess was
photographing the Library browser. The band is now derived from those frames.
