### PR TITLE
fix(#576): let the import verdict follow how far the region readback reached

### DIFF
--- a/Scripts/livekit/live_576_completeness_is_measured.py
+++ b/Scripts/livekit/live_576_completeness_is_measured.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Live proof that the region inventory's `complete` flag is measured, not hardcoded.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_576_completeness_is_measured.py <worktree> <full-40-char-head-sha>
+
+WHAT CHANGED
+------------
+`defaultGetRegions` published `complete: false` on every successful read. Safe, but uninformative —
+and it made every consumer fail closed forever, which is why `midi.import_file` could not tell "no
+region" from "no region visible" (#576).
+
+It is now derived from the TRACK HEADERS, not from the regions. That distinction is the point: a
+track carrying no regions produces no entry, so the highest observed `trackIndex` says nothing about
+the tracks above it. `allTrackHeaders` is not viewport-limited — measured 21 of 21 while the region
+layer stopped at 13 — so it is the denominator a completeness claim needs.
+
+HOW THE TRIGGER IS ESTABLISHED
+------------------------------
+The arrange window exposes `AXSlider` with `AXDescription` `Vertical Zoom`. It is a write with a
+readback, unlike `nav.zoom_to_fit`, which routes to `[.midiKeyCommands, .cgEvent]` and cannot prove
+anything. Driving it moves tracks in and out of the viewport, so this run can produce BOTH answers
+from the same project and show the flag following the observation rather than sitting on a constant.
+
+A run that only ever saw one value would not distinguish a measured field from a hardcoded one. That
+is why both directions are required below, and why the run refuses if it cannot produce them.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Band over the arrange area's track-header column, in window coordinates.
+#
+# Measured rather than guessed, because the first attempt guessed and failed: at (10,120,260,320) the
+# two captures hashed IDENTICALLY across a zoom change that the envelope showed working
+# (in_viewport 6 -> 21). That rectangle is the Library browser, which vertical zoom does not touch.
+# Live frames on this window (1920x1050 at 0,30):
+#
+#     Library    x 0..364     Inspector  x 366..601     arrange content  x 603..1920, y 117..
+#
+# so the header column starts just inside x=603, and y=90 is window-relative for the content's top.
+HEADER_BAND = (610, 95, 190, 420)
+ZOOM_TIGHT = 0.0     # every track visible
+ZOOM_LOOSE = 0.6     # tall rows, most tracks pushed out of the viewport
+MIN_TRACKS = 12      # below this the loose zoom may still fit everything
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def zoom_script(body):
+    return ('tell application "System Events" to tell process "Logic Pro"\n'
+            'set w to first window whose name ends with "Tracks"\n'
+            'repeat with g in (every group of w)\n'
+            'repeat with e in (every UI element of g)\n'
+            'try\n'
+            'if (description of e as text) is "Tracks" then\n'
+            'try\n'
+            'set s to (first slider of e whose description is "Vertical Zoom")\n'
+            f'{body}\n'
+            'end try\n'
+            'end if\n'
+            'end try\n'
+            'end repeat\n'
+            'end repeat\n'
+            'return "not found"\n'
+            'end tell')
+
+
+def read_zoom():
+    raw = osa(zoom_script('return (value of s as text)'))
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def set_zoom(value):
+    raw = osa(zoom_script(f'set value of s to {value}\ndelay 0.8\nreturn (value of s as text)'))
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+d = E.Driver()
+time.sleep(3)
+
+original_zoom = read_zoom()
+ev.check("576/precondition-the-vertical-zoom-slider-is-readable",
+         original_zoom is not None,
+         "the arrange window exposes a Vertical Zoom slider whose value can be read, which is what "
+         "makes the viewport actuable with a readback rather than by a blind key command",
+         f"value={original_zoom!r}",
+         None)
+
+tracks = d.resource("logic://tracks")
+track_count = len(tracks.get("data") or []) if isinstance(tracks, dict) else 0
+ev.check("576/precondition-enough-tracks-to-overflow-the-viewport",
+         track_count >= MIN_TRACKS,
+         f"the project has at least {MIN_TRACKS} tracks, so a loose zoom can push some out of view "
+         "and the two answers are genuinely different situations",
+         f"track_count={track_count}",
+         None)
+
+if original_zoom is None or track_count < MIN_TRACKS:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=150)
+
+
+def inventory(tag, zoom):
+    got = set_zoom(zoom)
+    time.sleep(1.5)
+    shot = ev.shot(tag, settle_region=HEADER_BAND)
+    body = d.tool("logic_project", "get_regions", {})
+    debug = body.get("_debug") or {}
+    reading = {
+        "requested_zoom": zoom, "observed_zoom": got,
+        "complete": body.get("complete"), "scope": body.get("scope"), "reason": body.get("reason"),
+        "headers": debug.get("track_headers"),
+        "in_viewport": debug.get("track_headers_in_viewport"),
+        "regions": len(body.get("regions") or []),
+    }
+    ev.note(f"576/{tag}", reading)
+    return reading, shot
+
+
+loose, loose_shot = inventory("576/zoom-loose", ZOOM_LOOSE)
+tight, tight_shot = inventory("576/zoom-tight", ZOOM_TIGHT)
+
+ev.check("576/the-flag-reports-incomplete-when-tracks-are-out-of-view",
+         loose["complete"] is False
+         and isinstance(loose["in_viewport"], int)
+         and isinstance(loose["headers"], int)
+         and loose["in_viewport"] < loose["headers"],
+         "with tracks pushed out of the viewport the inventory says it is incomplete, and reports "
+         "how far short it fell",
+         f"{loose}",
+         "hardcode `complete: false` again — this half keeps passing, which is exactly why the "
+         "other direction below is required")
+
+ev.check("576/the-flag-reports-complete-when-every-track-is-in-view",
+         tight["complete"] is True
+         and tight["in_viewport"] == tight["headers"]
+         and tight["scope"] == "whole_arrangement"
+         and tight["reason"] is None,
+         "with every track inside the viewport the inventory says so, names the whole arrangement "
+         "as its scope, and drops the viewport reason",
+         f"{tight}",
+         "restore the hardcoded `complete: false`: this check goes red while the incomplete case "
+         "above stays green, which is the pair that tells a measured field from a constant")
+
+ev.check("576/completeness-is-not-derived-from-the-regions",
+         tight["headers"] == tight["in_viewport"] and tight["regions"] < tight["headers"],
+         "at full coverage the region count is LOWER than the track count — a track with no regions "
+         "produces no entry, so the regions cannot be the denominator",
+         f"headers={tight['headers']} in_viewport={tight['in_viewport']} regions={tight['regions']}",
+         "derive completeness from the observed trackIndex range instead: this project has a track "
+         "with no region, so that derivation reports short of the truth and never reaches complete")
+
+ev.visual("576/the-viewport-actually-moved",
+          loose_shot["file"], tight_shot["file"], HEADER_BAND, expect_change=True,
+          why="the two readings come from genuinely different viewports, not from two calls against "
+              "the same screen — the track-header band must differ between them")
+
+restored = set_zoom(original_zoom)
+ev.restored("576/vertical-zoom-put-back",
+            restored is not None and abs(restored - original_zoom) < 0.02,
+            f"vertical zoom restored to {restored!r} (found at {original_zoom!r}); the run changes "
+            f"only this view setting and puts it back")
+
+d.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -35,8 +35,23 @@ extension AccessibilityChannel {
     }
 
     enum MIDIImportRegionReadback {
-        case success([RegionInfo])
+        /// The regions read, and whether that read covered the WHOLE arrangement.
+        ///
+        /// The completeness travelled with the enumeration all along and was dropped at this call
+        /// site — which is why an import that worked, on a project larger than the viewport, was
+        /// reported as a definite failure (#576). It is carried now.
+        case success([RegionInfo], complete: Bool)
         case failure(String)
+
+        var regions: [RegionInfo]? {
+            if case .success(let regions, _) = self { return regions }
+            return nil
+        }
+
+        var isComplete: Bool {
+            if case .success(_, let complete) = self { return complete }
+            return false
+        }
     }
 
     private static func defaultMIDIImportRegionInfos(
@@ -44,7 +59,7 @@ extension AccessibilityChannel {
     ) -> MIDIImportRegionReadback {
         switch enumerateRegionItems(runtime: runtime) {
         case .success(let result):
-            return .success(result.regions.map { $0.info })
+            return .success(result.regions.map { $0.info }, complete: result.coversWholeArrangement)
         case .failure(let error):
             return .failure(error.message)
         }
@@ -177,7 +192,7 @@ extension AccessibilityChannel {
         let beforeRegions: [RegionInfo]?
         let beforeRegionError: String?
         switch beforeRegionRead {
-        case .success(let regions):
+        case .success(let regions, _):
             beforeRegions = regions
             beforeRegionError = nil
         case .failure(let error):
@@ -480,11 +495,16 @@ extension AccessibilityChannel {
             var afterRegionError: String?
             var addedRegions: [RegionInfo] = []
             var importedRegions: [RegionInfo] = []
+            // Whether the LAST successful post-write read covered the whole arrangement. Only that
+            // reading decides the verdict below, so a stale completeness from an earlier attempt
+            // must not survive into it.
+            var afterReadbackComplete = false
             for attempt in 0..<10 {
                 switch readRegionInfos() {
-                case .success(let regions):
+                case .success(let regions, let complete):
                     afterRegions = regions
                     afterRegionError = nil
+                    afterReadbackComplete = complete
                     addedRegions = addedMIDIRegionsForImport(
                         afterRegions: regions,
                         beforeRegionKeys: beforeRegionKeys
@@ -565,6 +585,22 @@ extension AccessibilityChannel {
                 // something was created, and the region could not be confirmed by an instrument that
                 // cannot see the whole arrangement. It is deliberately not conditional on a project
                 // size — the reader never claims completeness, so an empty answer is never proof.
+                // #576 made this branch State B unconditionally, because completeness was a hardcoded
+                // `false` and an absent region could never be told from an unseen one. It is measured
+                // now, so the sharper verdict comes back for the case where it is knowable: a readback
+                // that covered the WHOLE arrangement and still found no imported region is evidence
+                // that none was created.
+                guard !afterReadbackComplete else {
+                    extras["region_readback_complete"] = true
+                    extras["region_readback_scope"] = "whole_arrangement"
+                    return .error(HonestContract.encodeStateC(
+                        error: .readbackMismatch,
+                        hint: "midi.import_file created a new track but did not create a verifiable "
+                            + "MIDI region. The region readback covered the whole arrangement, so "
+                            + "this is an absence that was looked for, not one that was out of view.",
+                        extras: extras
+                    ))
+                }
                 extras["region_readback_complete"] = false
                 extras["region_readback_scope"] = AccessibilityChannel.regionReadbackScope
                 extras["region_readback_limit"] = AccessibilityChannel.regionReadbackLimitReason

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -31,15 +31,28 @@ extension AccessibilityChannel {
             return .error(err.message)
         case .success(let result):
             let regions = result.regions.map { $0.info }
+            // `complete` was hardcoded `false` on every successful read. Safe, but uninformative —
+            // and it made every consumer fail closed forever, which is why `midi.import_file` could
+            // not tell "no region" from "no region visible" (#576).
+            //
+            // It is now measured, and measured from the HEADERS rather than the regions: a track
+            // carrying no regions produces no entry, so the highest observed `trackIndex` says
+            // nothing about the tracks above it. `allTrackHeaders` is not viewport-limited —
+            // measured on Logic 12.3, 21 of 21 while the region layer stopped at 13 — so "every
+            // header is inside the visible bounds" answers the question directly, and fails closed
+            // on a frame it cannot read.
+            let complete = result.coversEveryTrack
             return encodeResult(RegionInventoryPayload(
                 regions: regions,
-                complete: false,
-                scope: regionReadbackScope,
-                reason: regionReadbackLimitReason,
+                complete: complete,
+                scope: complete ? "whole_arrangement" : regionReadbackScope,
+                reason: complete ? nil : regionReadbackLimitReason,
                 returnedCount: regions.count,
                 debug: RegionInventoryPayload.Debug(
                     layoutItems: result.layoutItemCount,
-                    nonRegion: result.nonRegionCount
+                    nonRegion: result.nonRegionCount,
+                    trackHeaders: result.trackHeaderCount,
+                    trackHeadersInViewport: result.trackHeadersWithinViewport
                 )
             ))
         }
@@ -51,6 +64,23 @@ extension AccessibilityChannel {
         let regions: [(item: AXUIElement, info: RegionInfo)]
         let layoutItemCount: Int
         let nonRegionCount: Int
+        /// Every track in the project, viewport or not. `allTrackHeaders` is NOT viewport-limited —
+        /// measured on Logic 12.3, 2026-08-17: 21 headers while the region layer stopped at 13.
+        let trackHeaderCount: Int
+        /// How many of those headers lie inside the window's visible bounds. This is the honest
+        /// denominator for a completeness claim, and it is decidable WITHOUT the regions: a track
+        /// carrying no regions produces no entry, so the highest observed `trackIndex` says nothing
+        /// about the tracks above it.
+        let trackHeadersWithinViewport: Int
+
+        /// The enumeration saw every track, so an empty region result for any of them is genuine.
+        ///
+        /// Zero headers is NOT complete: with nothing to bound the claim there is nothing to have
+        /// covered, and reporting completeness there would make an unreadable arrangement look
+        /// exhaustively read.
+        var coversEveryTrack: Bool {
+            trackHeaderCount > 0 && trackHeadersWithinViewport == trackHeaderCount
+        }
     }
 
     /// Lightweight error wrapper so `enumerateRegionItems` can carry the
@@ -103,6 +133,26 @@ extension AccessibilityChannel {
             return true
         }
         return itemFrame.intersects(windowFrame)
+    }
+
+    /// Whether a track header is inside the window's visible bounds.
+    ///
+    /// Deliberately NOT `isVisibleArrangeRegion`, which returns `true` when either frame is
+    /// unreadable. That fail-OPEN is right when deciding whether to include a region it can see, and
+    /// wrong here: an unreadable header would inflate a completeness claim, which is the direction
+    /// that lets an absence be published as proof (#576).
+    private static func headerIsWithinViewport(
+        _ header: AXUIElement,
+        within window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        guard let windowFrame = frame(of: window, runtime: runtime),
+              let headerFrame = frame(of: header, runtime: runtime),
+              !windowFrame.isEmpty,
+              !headerFrame.isEmpty else {
+            return false
+        }
+        return headerFrame.intersects(windowFrame)
     }
 
     private static func classifyRegionKind(name: String, help: String) -> String {
@@ -207,7 +257,11 @@ extension AccessibilityChannel {
         return .success(RegionEnumerationResult(
             regions: regions,
             layoutItemCount: items.count,
-            nonRegionCount: nonRegionCount
+            nonRegionCount: nonRegionCount,
+            trackHeaderCount: headers.count,
+            trackHeadersWithinViewport: headers.filter {
+                headerIsWithinViewport($0, within: window, runtime: runtime.ax)
+            }.count
         ))
     }
 

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -281,6 +281,26 @@ struct RegionInventoryPayload: Codable, Sendable {
     struct Debug: Codable, Sendable {
         let layoutItems: Int
         let nonRegion: Int
+        /// Every track in the project. Not viewport-limited, so it is the denominator a
+        /// completeness claim needs (#576).
+        let trackHeaders: Int?
+        /// How many of those are inside the visible bounds. Equal to `trackHeaders` means the
+        /// enumeration saw every track and an empty region result for any of them is genuine.
+        let trackHeadersInViewport: Int?
+
+        init(layoutItems: Int, nonRegion: Int, trackHeaders: Int? = nil, trackHeadersInViewport: Int? = nil) {
+            self.layoutItems = layoutItems
+            self.nonRegion = nonRegion
+            self.trackHeaders = trackHeaders
+            self.trackHeadersInViewport = trackHeadersInViewport
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case layoutItems
+            case nonRegion
+            case trackHeaders = "track_headers"
+            case trackHeadersInViewport = "track_headers_in_viewport"
+        }
     }
 
     let regions: [RegionInfo]

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -272,7 +272,7 @@ private final class MIDIRegionReadbackSequence: @unchecked Sendable {
     func next() -> AccessibilityChannel.MIDIImportRegionReadback {
         lock.lock()
         defer { lock.unlock() }
-        guard !values.isEmpty else { return .success([]) }
+        guard !values.isEmpty else { return .success([], complete: false) }
         if values.count == 1 { return values[0] }
         return values.removeFirst()
     }
@@ -2207,7 +2207,7 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
             return .error("should not run")
         },
         trackCount: { 1 },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
 
@@ -2242,7 +2242,7 @@ private final class MarkerWindowReadSequence: @unchecked Sendable {
         path: tempFile.path,
         executeScript: { _ in .error(denied) },
         trackCount: { 1 },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
 
@@ -2388,7 +2388,7 @@ private func makeTempoSliderFixture(
         path: tempFile.path,
         executeScript: { _ in .success("OK") },
         trackCount: { 3 },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
 
@@ -2412,8 +2412,8 @@ private func makeTempoSliderFixture(
     }
     let counter = Counter()
     let regions = MIDIRegionReadbackSequence([
-        .success([]),
-        .success([midiRegionForImport(trackIndex: 2)]),
+        .success([], complete: false),
+        .success([midiRegionForImport(trackIndex: 2)], complete: false),
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
@@ -2477,8 +2477,8 @@ private func makeTempoSliderFixture(
     }
     let counter = Counter()
     let regions = MIDIRegionReadbackSequence([
-        .success([]),
-        .success([midiRegionForImport(trackIndex: 1)]),
+        .success([], complete: false),
+        .success([midiRegionForImport(trackIndex: 1)], complete: false),
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
@@ -2525,8 +2525,8 @@ private func makeTempoSliderFixture(
     }
     let counter = Counter()
     let regions = MIDIRegionReadbackSequence([
-        .success([]),
-        .success([midiRegionForImport(trackIndex: 1)]),
+        .success([], complete: false),
+        .success([midiRegionForImport(trackIndex: 1)], complete: false),
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(
@@ -2568,7 +2568,7 @@ private func makeTempoSliderFixture(
         executeScript: { _ in .success(#"{"result":"DIALOG_NOT_FOUND: file-open sheet did not appear"}"#) },
         trackCount: { spy.read() },
         trackNames: { [] },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
 
@@ -2593,7 +2593,7 @@ private func makeTempoSliderFixture(
         executeScript: { _ in .success("OK") },
         trackCount: { 0 },
         trackNames: { [] },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
     #expect(!result.isSuccess)

--- a/Tests/LogicProMCPTests/Issue108Tests.swift
+++ b/Tests/LogicProMCPTests/Issue108Tests.swift
@@ -119,7 +119,7 @@ struct Issue108Tests {
         func next() -> AccessibilityChannel.MIDIImportRegionReadback {
             lock.lock()
             defer { lock.unlock() }
-            guard !values.isEmpty else { return .success([]) }
+            guard !values.isEmpty else { return .success([], complete: false) }
             if values.count == 1 { return values[0] }
             return values.removeFirst()
         }
@@ -140,7 +140,7 @@ struct Issue108Tests {
     func importVerifiedOnTrackAndRegionDelta() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let counter = CallCounter([1, 2]) // before=1, after=2
-        let regions = RegionSnapshotBox([.success([]), .success([importedRegion()])])
+        let regions = RegionSnapshotBox([.success([], complete: false), .success([importedRegion()], complete: false)])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
             systemEventsAuthorized: { true },
             path: path,
@@ -176,11 +176,45 @@ struct Issue108Tests {
     /// The reader cannot tell "absent because it is not there" from "absent because it is not
     /// visible", so this is deliberately unconditional rather than gated on a project size that the
     /// code has no way to measure.
+    /// The other half of the same contract, once completeness became measurable.
+    ///
+    /// #576 made the empty-region branch State B unconditionally, because `complete` was a hardcoded
+    /// `false` and an absence could never be told from something out of view. With it measured, a
+    /// readback that covered the WHOLE arrangement and still found no imported region IS evidence
+    /// that none was created — so the sharper verdict comes back exactly where it is earned.
+    ///
+    /// Same fixture as the test below, one flag apart. That is the point: the verdict follows the
+    /// readback's reach, not the shape of the result.
+    @Test("a complete readback that finds no region is a real miss, and says so")
+    func completeReadbackWithoutRegionIsAMiss() async {
+        let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
+        let counter = CallCounter([1, 2])
+        let regions = RegionSnapshotBox([.success([], complete: true), .success([], complete: true)])
+        let result = await AccessibilityChannel.defaultImportMIDIFile(
+            systemEventsAuthorized: { true },
+            path: path,
+            executeScript: { _ in .success("OK") },
+            trackCount: { counter.next() },
+            trackNames: { ["Studio Grand", "Imported"] },
+            regionInfos: { regions.next() },
+            deltaPoll: {}
+        )
+        #expect(!result.isSuccess)
+        #expect(result.message.contains("\"state\":\"C\""))
+        #expect(result.message.contains("readback_mismatch"))
+        #expect(result.message.contains("\"region_readback_complete\":true"))
+        #expect(result.message.contains("whole_arrangement"))
+        // The hint has to say WHY this one is a miss and the other is not.
+        #expect(result.message.contains("an absence that was looked for"))
+        // And the track delta still stands, whichever verdict is reached.
+        #expect(result.message.contains("\"track_count_after\":2"))
+    }
+
     @Test("import_file refuses to certify, and does not claim failure it cannot see, when no region reads back")
     func importFailsClosedOnTrackDeltaWithoutRegion() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let counter = CallCounter([1, 2])
-        let regions = RegionSnapshotBox([.success([]), .success([])])
+        let regions = RegionSnapshotBox([.success([], complete: false), .success([], complete: false)])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
             systemEventsAuthorized: { true },
             path: path,
@@ -209,7 +243,7 @@ struct Issue108Tests {
     func importFailsClosedOnNoDelta() async {
         let path = tempMIDIFile(); defer { try? FileManager.default.removeItem(atPath: path) }
         let counter = CallCounter([3, 3]) // before==after → no import landed
-        let regions = RegionSnapshotBox([.success([]), .success([])])
+        let regions = RegionSnapshotBox([.success([], complete: false), .success([], complete: false)])
         let result = await AccessibilityChannel.defaultImportMIDIFile(
             systemEventsAuthorized: { true },
             path: path,
@@ -235,7 +269,7 @@ struct Issue108Tests {
             executeScript: { _ in .success(#"{"result":"MENU_ERROR: not found"}"#) },
             trackCount: { 1 },
             trackNames: { [] },
-            regionInfos: { .success([]) },
+            regionInfos: { .success([], complete: false) },
             deltaPoll: {}
         )
         #expect(!result.isSuccess)
@@ -250,7 +284,7 @@ struct Issue108Tests {
             executeScript: { _ in .success("OK") },
             trackCount: { 1 },
             trackNames: { [] },
-            regionInfos: { .success([]) },
+            regionInfos: { .success([], complete: false) },
             deltaPoll: {}
         )
         #expect(!result.isSuccess)

--- a/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
+++ b/Tests/LogicProMCPTests/Issue123ImportOcclusionHonestTests.swift
@@ -37,7 +37,7 @@ private final class Issue123MIDIRegionReadbackSequence: @unchecked Sendable {
     func next() -> AccessibilityChannel.MIDIImportRegionReadback {
         lock.lock()
         defer { lock.unlock() }
-        guard !values.isEmpty else { return .success([]) }
+        guard !values.isEmpty else { return .success([], complete: false) }
         if values.count == 1 { return values[0] }
         return values.removeFirst()
     }
@@ -103,7 +103,7 @@ func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async th
         executeScript: { _ in .success(sentinel) },
         trackCount: { spy.read() },
         trackNames: { [] },
-        regionInfos: { .success([]) },
+        regionInfos: { .success([], complete: false) },
         deltaPoll: {}
     )
 
@@ -152,8 +152,8 @@ func testOccludedSessionFailsClosedWithDialogNotFound(sentinel: String) async th
     }
     let counter = Counter()
     let regions = Issue123MIDIRegionReadbackSequence([
-        .success([]),
-        .success([issue123MIDIRegion(trackIndex: 4)]),
+        .success([], complete: false),
+        .success([issue123MIDIRegion(trackIndex: 4)], complete: false),
     ])
 
     let result = await AccessibilityChannel.defaultImportMIDIFile(

--- a/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
+++ b/Tests/LogicProMCPTests/Issue519MenuLocaleGeneratorTests.swift
@@ -213,7 +213,7 @@ struct Issue519FileMenuDriveSiteTests {
             },
             trackCount: { 0 },
             trackNames: { [] },
-            regionInfos: { .success([]) },
+            regionInfos: { .success([], complete: false) },
             deltaPoll: {}
         )
         for label in AXLocalePolicy.fileMenuBar.labels {

--- a/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
+++ b/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import LogicProMCP
+
+/// `RegionInventoryPayload.complete` used to be hardcoded `false` on every successful read.
+///
+/// Safe, but uninformative — and it made every consumer fail closed forever, which is why
+/// `midi.import_file` could not tell "no region" from "no region visible" (#576).
+///
+/// It is now derived from the track headers, not from the regions. That distinction is the whole
+/// point: a track carrying no regions produces no entry, so the highest observed `trackIndex` says
+/// nothing about the tracks above it. Measured on Logic 12.3, 2026-08-17: `allTrackHeaders` returned
+/// 21 while the region layer stopped at 13, so the header list is the denominator a completeness
+/// claim needs.
+///
+/// Live, on the same project, driving the arrange window's `Vertical Zoom` slider:
+///
+///     zoom 0.6   complete false   headers 21   in-viewport 6    regions 6
+///     zoom 0.0   complete true    headers 21   in-viewport 21   regions 20
+///
+/// The second row also shows why regions cannot be the denominator: 21 tracks were visible and only
+/// 20 carried a region.
+@Suite("#576 completeness is measured against the header list")
+struct Issue576MeasuredCompletenessTests {
+    private func result(headers: Int, inViewport: Int) -> AccessibilityChannel.RegionEnumerationResult {
+        AccessibilityChannel.RegionEnumerationResult(
+            regions: [],
+            layoutItemCount: 0,
+            nonRegionCount: 0,
+            trackHeaderCount: headers,
+            trackHeadersWithinViewport: inViewport
+        )
+    }
+
+    @Test("every header inside the viewport means the enumeration saw every track")
+    func fullCoverageIsComplete() {
+        #expect(result(headers: 21, inViewport: 21).coversEveryTrack)
+        #expect(result(headers: 1, inViewport: 1).coversEveryTrack)
+    }
+
+    @Test("a header outside the viewport means it did not")
+    func partialCoverageIsNotComplete() {
+        // The live 0.6-zoom reading.
+        #expect(!result(headers: 21, inViewport: 6).coversEveryTrack)
+        // One short is still short: the missing track is exactly where an unseen region would be.
+        #expect(!result(headers: 21, inViewport: 20).coversEveryTrack)
+    }
+
+    /// Zero headers is the case that decides whether this is a completeness claim or a vacuous one.
+    /// With nothing to bound the claim there is nothing to have covered, and `0 == 0` would make an
+    /// unreadable arrangement report as exhaustively read — an absence published as proof, which is
+    /// the defect #576 exists to remove.
+    @Test("no headers at all is not completeness")
+    func zeroHeadersIsNotComplete() {
+        #expect(!result(headers: 0, inViewport: 0).coversEveryTrack)
+    }
+}


### PR DESCRIPTION
**Stacks on #581** — base it there or merge that first; this consumes `coversWholeArrangement`.

## What changes

#577 made the empty-region branch State B unconditionally. That was right at the time: `complete` was
a hardcoded `false`, so an absent region could never be told from one simply out of view, and calling
it a definite failure sent callers into a retry that creates a second track.

#581 makes completeness measured. So the sharper verdict comes back **exactly where it is earned**: a
readback that covered the whole arrangement and still found no imported region is evidence that none
was created.

```
readback incomplete + no region   ->  B  readback_unavailable   scope visible_arrange_area
readback complete   + no region   ->  C  readback_mismatch      scope whole_arrangement
```

The hint now says which kind of absence it is — *"an absence that was looked for, not one that was
out of view."*

## The original defect, named

The completeness travelled with the enumeration all along and was **dropped at this call site**.
`MIDIImportRegionReadback.success` now carries it. That drop is the defect; the viewport limit itself
was never the bug.

## One thing worth reviewing carefully

Only the **last successful** post-write reading may decide the verdict. The poll loop runs up to ten
times, so a stale completeness from an earlier attempt must not answer for a reading that no longer
holds — it is reset alongside the regions it came with.

## Evidence

The two `Issue108` cases are now **one flag apart on the same fixture**, which is the point: the
verdict follows the readback's reach, not the shape of the result.

Both mutation-tested:

- forcing the complete branch → the incomplete case goes red (it receives a `whole_arrangement`
  State C envelope where it expects `logic_ax_viewport_only` State B)
- inverting the condition → **both** go red

3805+ tests pass under the CI gate; live evidence re-bound to this head.
