### PR TITLE
fix(#576): neither an absent nor a legacy payload may claim coverage it was never given

### DIFF
--- a/Scripts/livekit/live_576_completeness_is_measured.py
+++ b/Scripts/livekit/live_576_completeness_is_measured.py
@@ -114,13 +114,21 @@ ev.check("576/precondition-the-vertical-zoom-slider-is-readable",
          f"value={original_zoom!r}",
          None)
 
-tracks = d.resource("logic://tracks")
-track_count = len(tracks.get("data") or []) if isinstance(tracks, dict) else 0
+# The track count comes from a LIVE AX read, not from `logic://tracks`.
+#
+# That resource is served from the poller's cache, and a run that reads it seconds after the server
+# starts sees whatever has been polled by then — measured on this branch: `track_count=0` on a
+# project with 21 tracks, which failed the precondition and stopped a run that had nothing wrong with
+# it. `get_regions` reports `_debug.track_headers` from `allTrackHeaders()` at call time, which is the
+# same number the completeness rule itself uses.
+probe = d.tool("logic_project", "get_regions", {})
+track_count = ((probe.get("_debug") or {}).get("track_headers") or 0) if isinstance(probe, dict) else 0
 ev.check("576/precondition-enough-tracks-to-overflow-the-viewport",
          track_count >= MIN_TRACKS,
-         f"the project has at least {MIN_TRACKS} tracks, so a loose zoom can push some out of view "
-         "and the two answers are genuinely different situations",
-         f"track_count={track_count}",
+         f"the project has at least {MIN_TRACKS} tracks, read live rather than from the poller's "
+         "cache, so a loose zoom can push some out of view and the two answers are genuinely "
+         "different situations",
+         f"track_headers={track_count}",
          None)
 
 if original_zoom is None or track_count < MIN_TRACKS:

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -310,7 +310,16 @@ struct RegionInventoryPayload: Codable, Sendable {
     let returnedCount: Int?
     let debug: Debug?
 
-    var isComplete: Bool { complete ?? true }
+    /// An ABSENT completeness claim is not a completeness claim.
+    ///
+    /// This defaulted to `true`, which was harmless while `complete` was a hardcoded `false` that
+    /// every producer set. It stopped being harmless the moment completeness began deciding whether
+    /// an absent region is evidence (#576): a payload that says nothing about its own coverage —
+    /// legacy, malformed, or from a producer that has not been taught to report it — would mark the
+    /// cache exhaustively read. Two callers feed this straight into `cache.updateRegions(complete:)`.
+    ///
+    /// Fail closed instead. Silence is not coverage.
+    var isComplete: Bool { complete ?? false }
 
     enum CodingKeys: String, CodingKey {
         case regions
@@ -325,11 +334,18 @@ struct RegionInventoryPayload: Codable, Sendable {
 extension RegionInfo {
     static func decodeInventoryPayload(_ text: String) throws -> RegionInventoryPayload {
         if let direct: [RegionInfo] = try? decodeJSON(text) {
+            // A bare array is the legacy wire shape: a list of regions and nothing else. It makes no
+            // statement about its own coverage, so this decoder must not make one on its behalf.
+            //
+            // It used to synthesise `complete: true, scope: "project"` here — the same fail-open the
+            // `isComplete` default had, one layer down and hardcoded, so flipping that default alone
+            // left this path still asserting a whole-project inventory for input that claimed
+            // nothing. Both callers feed the result into `cache.updateRegions(complete:)`.
             return RegionInventoryPayload(
                 regions: direct,
-                complete: true,
-                scope: "project",
-                reason: nil,
+                complete: false,
+                scope: nil,
+                reason: "legacy_array_payload_declares_no_scope",
                 returnedCount: direct.count,
                 debug: nil
             )

--- a/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
+++ b/Tests/LogicProMCPTests/Issue576MeasuredCompletenessTests.swift
@@ -70,3 +70,74 @@ struct Issue576MeasuredCompletenessTests {
         #expect(!result(headers: 0, inViewport: 0).coversWholeArrangement)
     }
 }
+
+/// `RegionInventoryPayload.isComplete` decides what the CACHE records, and it used to default to
+/// `true` when the payload said nothing about its own coverage.
+///
+/// That was harmless while `complete` was a hardcoded `false` every producer set. It stopped being
+/// harmless the moment completeness began deciding whether an absent region is evidence: a payload
+/// from a producer that has not been taught to report coverage — legacy, malformed, decoded from an
+/// older wire — would mark the cache exhaustively read. Found by an adversarial review of the design
+/// that would have consumed it.
+@Suite("#576 an absent completeness claim is not a completeness claim")
+struct Issue576AbsentCompletenessTests {
+    private func payload(complete: Bool?) -> RegionInventoryPayload {
+        RegionInventoryPayload(
+            regions: [],
+            complete: complete,
+            scope: nil,
+            reason: nil,
+            returnedCount: 0,
+            debug: nil
+        )
+    }
+
+    @Test("silence is not coverage")
+    func absentIsNotComplete() {
+        #expect(!payload(complete: nil).isComplete)
+    }
+
+    @Test("an explicit claim is still honoured in both directions")
+    func explicitClaimsSurvive() {
+        #expect(payload(complete: true).isComplete)
+        #expect(!payload(complete: false).isComplete)
+    }
+}
+
+/// The legacy wire shape — a bare JSON array of regions, with no envelope around it.
+///
+/// `decodeInventoryPayload` synthesised `complete: true, scope: "project"` for it. That is the same
+/// fail-open as the `isComplete` default, one layer down and hardcoded, so closing the default alone
+/// left this path still asserting a whole-project inventory for input that claimed nothing.
+///
+/// An adversarial review found it by asking the question the commit could not answer both ways: if
+/// legacy input is unreachable the default flip is dead code, and if it is reachable the flip missed
+/// the path that still fail-opens. It was the second.
+@Suite("#576 the legacy array shape claims no coverage")
+struct Issue576LegacyArrayPayloadTests {
+    @Test("a bare array is not a complete inventory")
+    func bareArrayIsNotComplete() throws {
+        let payload = try RegionInfo.decodeInventoryPayload("""
+        [{"name":"MIDI Region","trackIndex":0,"startBar":1,"endBar":2,"kind":"midi"}]
+        """)
+        #expect(payload.regions.count == 1)
+        #expect(!payload.isComplete)
+        // And it does not invent a scope it was never told.
+        #expect(payload.scope == nil)
+        #expect(payload.reason == "legacy_array_payload_declares_no_scope")
+    }
+
+    @Test("an enveloped payload still carries its own claim")
+    func envelopedPayloadKeepsItsClaim() throws {
+        let complete = try RegionInfo.decodeInventoryPayload("""
+        {"regions":[],"complete":true,"scope":"whole_arrangement","returned_count":0}
+        """)
+        #expect(complete.isComplete)
+        #expect(complete.scope == "whole_arrangement")
+
+        let partial = try RegionInfo.decodeInventoryPayload("""
+        {"regions":[],"complete":false,"scope":"visible_arrange_area","returned_count":0}
+        """)
+        #expect(!partial.isComplete)
+    }
+}


### PR DESCRIPTION
Closes the last two fail-opens in the completeness work shipped by #581/#582.

## Two fail-opens, one principle: silence is not coverage

**`RegionInventoryPayload.isComplete` returned `complete ?? true`.** A payload saying nothing about
its own reach marked the region cache exhaustively read. Both production callers feed that value
straight into `cache.updateRegions(complete:)`.

**`decodeInventoryPayload` was worse, because it was not a default but an assertion.** For the legacy
bare-array wire shape it synthesised `complete: true, scope: "project"` — a whole-project inventory
claim invented on behalf of input that claimed nothing.

```swift
// before
if let direct: [RegionInfo] = try? decodeJSON(text) {
    return RegionInventoryPayload(regions: direct, complete: true, scope: "project", …)
```

## Why the first fix alone was wrong

An adversarial review put it as a dilemma the earlier version of this change could not answer both
ways:

> either legacy input is unreachable and flipping the default is dead code, or it is reachable and
> the flip missed the path that still fail-opens

It was the second. The legacy branch now reports no coverage and no scope, and names the shape it
came from (`legacy_array_payload_declares_no_scope`).

## Neither path was reachable by the existing suite, by construction

Every prior test either sets `complete` explicitly or never decodes the bare-array shape. No amount
of running them would have touched either default — which is why both survived until something asked
the question from outside.

Both are mutation-tested: restoring `?? true` reddens only the absent-claim test, and restoring the
synthesised `complete: true, scope: "project"` reddens only the legacy-array test.

## Also fixed: the live harness read its own precondition from a cache

`live_576_completeness_is_measured.py` took its track count from `logic://tracks`, which is served
from the poller's cache. Measured on this branch: `track_count=0` on a project with 21 tracks,
seconds after the server started — a precondition failure that stopped a run with nothing wrong with
it. It now reads `_debug.track_headers` from `get_regions`, which is a live `allTrackHeaders()` read
at call time and the same number the completeness rule itself uses.

Live evidence re-bound to this head: 5 checks, 3 mutation-backed, one visual assertion, both zoom
directions.
