### PR TITLE
chore(#575): retire three table entries whose channels refuse them

### DIFF
--- a/Scripts/livekit/live_575_retired_routes_change_nothing.py
+++ b/Scripts/livekit/live_575_retired_routes_change_nothing.py
@@ -71,6 +71,26 @@ survivors = {
     "logic_system.refresh_cache": d.tool("logic_system", "refresh_cache", {}),
     "logic_project.is_running": d.tool("logic_project", "is_running", {}),
 }
+
+# A prefix neighbour of the three retired mixer rows. The removal was of three NAMED rows, not of a
+# family, and this checks that against the running server rather than against the table.
+#
+# Deliberately not driven with valid parameters: proving the neighbour survives does not require
+# moving the user's master volume. It is called with a parameter it rejects, and the discriminator is
+# the HINT, not the error code — both a live command and a retired one answer `invalid_params`:
+#
+#   live command    "Unknown parameters: …  Allowed parameters: value, volume"   <- it validated input
+#   retired command "Command '…' is not registered for …"                         <- it never existed
+neighbour = d.tool("logic_mixer", "set_master_volume", {"definitely_not_a_param": "1"})
+neighbour_hint = (neighbour.get("hint") or "") if isinstance(neighbour, dict) else ""
+ev.note("575/prefix-neighbour", neighbour)
+ev.check("575/a-prefix-neighbour-of-the-retired-rows-still-exists",
+         "not registered" not in neighbour_hint and "Allowed parameters" in neighbour_hint,
+         "mixer.set_master_volume still reaches its dispatcher and validates its input, so the "
+         "removal took three named rows and not the family that shares their prefix",
+         f"hint={neighbour_hint!r}",
+         "remove `mixer.set_master_volume` alongside them: the hint becomes "
+         "\"Command 'set_master_volume' is not registered\" and this check goes red")
 ev.note("575/survivors", {k: str(v)[:300] for k, v in survivors.items()})
 
 broken = {k: v for k, v in survivors.items()
@@ -97,6 +117,11 @@ ev.check("575/refresh_cache-still-refreshes",
 removed = {
     "logic_system.cache_state": d.tool("logic_system", "cache_state", {}),
     "logic_system.refresh": d.tool("logic_system", "refresh", {}),
+    # The three whose CHANNEL had no case for them either — a stronger case for removal than the
+    # two above, which at least named a channel that would have answered.
+    "logic_mixer.set_output_volume": d.tool("logic_mixer", "set_output_volume", {}),
+    "logic_mixer.get_bus_routing": d.tool("logic_mixer", "get_bus_routing", {}),
+    "logic_tracks.get_parameter": d.tool("logic_tracks", "get_parameter", {}),
 }
 ev.note("575/removed", {k: str(v)[:200] for k, v in removed.items()})
 ev.check("575/the-removed-names-are-still-unreachable",

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -86,13 +86,16 @@ extension ChannelRouter {
         "mixer.get_state":            [.mcu, .accessibility],
         "mixer.set_volume":           [.accessibility],
         "mixer.set_pan":              [.accessibility],
+        // #575: `mixer.set_output_volume`, `mixer.get_bus_routing` and `automation.get_parameter`
+        // were removed from this table. Each had no caller AND no implementation — the channel they
+        // named answers `Unsupported AX operation` / `Unknown MCU operation` for them, so a caller
+        // who found one would have reached an exhausted chain. That is a stronger case than the two
+        // system entries retired earlier, which at least had a channel that would have answered.
         "mixer.set_send":             [.mcu],
         "mixer.set_output":           [.accessibility],
         "mixer.set_input":            [.accessibility],
         "mixer.get_channel_strip":    [.mcu, .accessibility],
         "mixer.set_master_volume":    [.mcu],
-        "mixer.set_output_volume":    [.mcu],
-        "mixer.get_bus_routing":      [.accessibility],
         "mixer.toggle_eq":            [.mcu, .accessibility],
         "mixer.reset_strip":          [.mcu, .accessibility],
         "mixer.set_plugin_param":     [.scripter],  // public path narrowed to deterministic Scripter flow
@@ -257,7 +260,6 @@ extension ChannelRouter {
         "automation.get_mode":        [.accessibility],
         "automation.set_mode":        [.mcu, .midiKeyCommands, .cgEvent],
         "automation.toggle_view":     [.midiKeyCommands, .cgEvent],
-        "automation.get_parameter":   [.accessibility],
 
         // Note manipulation
         "note.up_semitone":           [.midiKeyCommands, .cgEvent],

--- a/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
+++ b/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
@@ -54,3 +54,43 @@ struct Issue567LocalizedOwnerNameTests {
         #expect(try #require(pid) == 4242)
     }
 }
+
+/// #575: three table entries named a channel that does not implement them.
+///
+/// `mixer.set_output_volume` routed to `.mcu`, `mixer.get_bus_routing` and
+/// `automation.get_parameter` to `.accessibility`. Neither channel has a case for any of them, so
+/// each falls to its `default` arm — `Unknown MCU operation` / `Unsupported AX operation` — and a
+/// caller who found one would have reached an exhausted chain.
+///
+/// That is a stronger case for removal than the two system entries retired earlier, which at least
+/// named a channel that would have answered. Verified live before removal: every one answers
+/// `invalid_params` under each plausible tool spelling.
+@Suite("#575 the table names no operation its channels refuse")
+struct Issue575RetiredUnimplementedRoutesTests {
+    @Test("the three unimplemented entries are gone")
+    func retiredEntriesAreAbsent() {
+        for operation in [
+            "mixer.set_output_volume",
+            "mixer.get_bus_routing",
+            "automation.get_parameter",
+        ] {
+            #expect(ChannelRouter.v2RoutingTable[operation] == nil)
+        }
+    }
+
+    /// The neighbours that share their prefixes must be untouched — the removal was of three named
+    /// entries, not of a family.
+    @Test("their neighbours still route")
+    func neighboursSurvive() throws {
+        for operation in [
+            "mixer.set_master_volume",
+            "mixer.set_send",
+            "mixer.get_state",
+            "automation.set_mode",
+            "automation.get_mode",
+        ] {
+            let chain = try #require(ChannelRouter.v2RoutingTable[operation])
+            #expect(!chain.isEmpty)
+        }
+    }
+}

--- a/docs/roadmap/roadmap-2026-08-10.md
+++ b/docs/roadmap/roadmap-2026-08-10.md
@@ -74,13 +74,22 @@ not belong to any capability train — they are the same class as Wave 0.
 
 ### Open, no PR
 
-- **#575 — twelve routed operations nothing calls.** Seven `region.*` plus `mixer.set_output_volume`,
-  `mixer.get_bus_routing`, `automation.get_parameter`, `system.cache_state` and `system.refresh`;
-  the last two route to an empty channel list. All are absent from `OperationRegistry`, so the
-  exhaustiveness gates that exist to make an operation's contract impossible to forget have nothing to
-  check. **#519's acceptance names "a region operation"; there is none to drive.** Exposing them is an
-  ADR-shaped decision and overlaps #302, so this sits with Wave 1 rather than becoming a wave of its
-  own.
+- **#575 — twelve routed operations nothing calls, five now retired.** `system.cache_state` and
+  `system.refresh` routed to an empty channel list; `mixer.set_output_volume`,
+  `mixer.get_bus_routing` and `automation.get_parameter` named a channel with no case for them, so
+  each fell to `Unknown MCU operation` / `Unsupported AX operation`. All five are gone — no caller
+  and, for the last three, no implementation either.
+
+  **Seven `region.*` entries remain, and they are the different kind:** implemented, and overlapping
+  the unmerged #302 work, which adds a parallel `project.select_region` rather than exposing
+  `region.select`. Retiring or exposing them decides that, so it belongs to Wave 1 rather than to a
+  sweep. All twelve were absent from `OperationRegistry`, which is why the exhaustiveness gates —
+  built to make an operation's contract impossible to forget — had nothing to check.
+  **#519's acceptance names "a region operation"; there is still none to drive.**
+
+  Two design documents still name `set_output_volume` as an example of the MCU-only op family
+  (`docs/prd/PRD-doctor-v3.md`, `docs/tickets/doctor-v3/T6-channels-deps.md`). They record decisions
+  taken when it existed and are left as written; the example is stale, not the reasoning.
 
 ### What this changes about the plan
 


### PR DESCRIPTION
Continues #575's cleanup. Five of the twelve entries are now retired; the seven `region.*` ones are
deliberately untouched.

## These three had no caller **and** no implementation

| entry | routed to | what that channel does with it |
|---|---|---|
| `mixer.set_output_volume` | `.mcu` | falls to `default` → `Unknown MCU operation` |
| `mixer.get_bus_routing` | `.accessibility` | falls to `default` → `Unsupported AX operation` |
| `automation.get_parameter` | `.accessibility` | same default |

That is a stronger case than the two system entries retired earlier, which at least named a channel
that would have answered. A caller who found one of these rows would have reached an exhausted chain.

Verified against the running server before removal, not only by grep: each answers `invalid_params`
under every plausible tool spelling.

## Adversarial review

Reviewed by an independent pass that read both channel `execute` switches, `ChannelRouter`,
`MixerDispatcher`, `StatePoller`, `ResourceHandlers`, `WorkflowSkillCatalog`, `OperationRegistry`,
`OperationCapabilityRegistry`, `SetupDoctor`, and the routing/capability/bypass test suites. Verdict:
neither BLOCK nor REVISE. It confirmed per-operation, with line numbers, that no `case` exists in the
destination channel, and traced every consumer surface:

- `ChannelRouterTests`' `table.count > 80` goes 140 → 137
- `OperationCatalogTests`' `specs.count == 110` is unaffected — none of the three was ever registered
- `Issue461`'s "every advertised operation has a route" is unchanged — none was ever advertised

It also flagged that two design documents still name `set_output_volume` as an example of the MCU-only
op family. Those record decisions taken when it existed; the roadmap mirror is updated, the frozen
PRD and ticket are left as written and the staleness is noted there.

## Evidence

Unit — the removal and its blast radius are pinned separately: the three entries are absent, and five
prefix neighbours (`mixer.set_master_volume`, `mixer.set_send`, `mixer.get_state`,
`automation.set_mode`, `automation.get_mode`) still route.

Live — `live_575_retired_routes_change_nothing.py` extended to cover all five retirements plus a
prefix neighbour.

**The neighbour probe is worth reading.** Proving `mixer.set_master_volume` survives does not require
moving the user's master volume, so it is called with a parameter it rejects — and the discriminator
is the **hint**, not the error code, because both a live command and a retired one answer
`invalid_params`:

```
live     "Unknown parameters: … Allowed parameters: value, volume"   <- it validated input
retired  "Command '…' is not registered for …"                       <- it never existed
```

A first version of that check drove the command with what I thought were valid parameters, failed on
the parameter name, and would have been a write against the user's project for no gain.
