### PR TITLE
feat(#448): read whether a track is a stack, and whether it is collapsed

### DIFF
--- a/Scripts/livekit/ax_stack_arrow.swift
+++ b/Scripts/livekit/ax_stack_arrow.swift
@@ -1,0 +1,107 @@
+// A minimal, product-independent actuator for the track-stack disclosure arrow.
+//
+// It exists because `osascript`'s System Events `perform action` is INERT against Logic's arrange
+// window on this host — measured 2026-08-18: pressing the arrow reported success and moved nothing,
+// and the same press on the Mute checkbox next to it also moved nothing, so the failure is the
+// instrument rather than the control. Reads through System Events work fine; only actuation is dead.
+//
+// The harness needs an actuator that is not the code under test, so this is a direct
+// `AXUIElementPerformAction` rather than a call into LogicProMCP. It takes no coordinates: the arrow
+// is found by walking the accessibility tree for a disclosure triangle whose parent is a track
+// header (`AXLayoutItem`).
+//
+//   swiftc -O ax_stack_arrow.swift -o ax_stack_arrow
+//   ./ax_stack_arrow read     -> {"arrows":N,"value":0,"owner":"Absolute Zero"}
+//   ./ax_stack_arrow press    -> {...,"press_status":0,"value_after":0}   (measured inert; see below)
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+func attr(_ element: AXUIElement, _ name: String) -> AnyObject? {
+    var value: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+        return nil
+    }
+    return value
+}
+
+func role(_ element: AXUIElement) -> String {
+    (attr(element, kAXRoleAttribute as String) as? String) ?? ""
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    (attr(element, kAXChildrenAttribute as String) as? [AXUIElement]) ?? []
+}
+
+/// Every disclosure triangle whose parent is a track header, depth-first from the app element.
+func stackArrows(_ root: AXUIElement, depth: Int = 0) -> [AXUIElement] {
+    guard depth < 32 else { return [] }
+    var found: [AXUIElement] = []
+    for child in children(root) {
+        if role(child) == (kAXDisclosureTriangleRole as String),
+           let parent = attr(root, kAXRoleAttribute as String) as? String,
+           parent == (kAXLayoutItemRole as String) {
+            found.append(child)
+        }
+        found.append(contentsOf: stackArrows(child, depth: depth + 1))
+    }
+    return found
+}
+
+func intValue(_ element: AXUIElement) -> Int? {
+    (attr(element, kAXValueAttribute as String) as? NSNumber)?.intValue
+}
+
+/// The name of the track whose header carries this arrow, so a harness can bind the arrow it reads
+/// to the row it checks by IDENTITY rather than by both being "the first one".
+func ownerTrackName(_ arrow: AXUIElement) -> String? {
+    guard let header = attr(arrow, kAXParentAttribute as String) else { return nil }
+    // swiftlint:disable:next force_cast
+    let headerElement = header as! AXUIElement
+    for child in children(headerElement) where role(child) == (kAXTextFieldRole as String) {
+        if let name = attr(child, kAXDescriptionAttribute as String) as? String {
+            return name
+        }
+    }
+    return nil
+}
+
+func jsonString(_ value: String?) -> String {
+    guard let value, let data = try? JSONSerialization.data(withJSONObject: [value]),
+          let text = String(data: data, encoding: .utf8) else { return "null" }
+    return String(text.dropFirst().dropLast())
+}
+
+let command = CommandLine.arguments.dropFirst().first ?? "read"
+guard let app = NSWorkspace.shared.runningApplications.first(where: {
+    $0.bundleIdentifier == "com.apple.logic10"
+}) else {
+    print("{\"error\":\"logic_not_running\"}")
+    exit(2)
+}
+
+let arrows = stackArrows(AXUIElementCreateApplication(app.processIdentifier))
+guard let arrow = arrows.first else {
+    print("{\"arrows\":0,\"error\":\"no_stack_arrow\"}")
+    exit(3)
+}
+
+let before = intValue(arrow)
+if command == "press" {
+    let status = AXUIElementPerformAction(arrow, kAXPressAction as CFString)
+    // The return code is reported but never trusted: this repository has measured AX calls that
+    // answer `.success` and change nothing. The value after the press is the only evidence.
+    Thread.sleep(forTimeInterval: 1.2)
+    let after = intValue(arrow)
+    print("""
+    {"arrows":\(arrows.count),"value":\(before.map(String.init) ?? "null"),\
+    "owner":\(jsonString(ownerTrackName(arrow))),\
+    "press_status":\(status.rawValue),"value_after":\(after.map(String.init) ?? "null")}
+    """)
+} else {
+    print("""
+    {"arrows":\(arrows.count),"value":\(before.map(String.init) ?? "null"),\
+    "owner":\(jsonString(ownerTrackName(arrow)))}
+    """)
+}

--- a/Scripts/livekit/live_448_track_stack_readback.py
+++ b/Scripts/livekit/live_448_track_stack_readback.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Live proof that `is_stack_header` / `stack_collapsed` are read from Logic, not assumed.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_448_track_stack_readback.py <worktree> <full-40-char-head-sha>
+
+WHAT #448 ASSUMED, AND WHAT IS ACTUALLY THERE
+---------------------------------------------
+The roadmap parks #448 as an expected scope decision on the reading that track-stack hierarchy is
+not exposed to Accessibility. Half of that is wrong. Logic puts an `AXDisclosureTriangle` on the
+main track of a track stack — exactly one of the 46 layout items in this arrange window carries one
+— and its help text says what it is:
+
+    "Track stack disclosure arrow. Show or hide subtracks. Use the controls on the main track to
+     control all subtracks in the track stack."
+
+So `logic://tracks` now carries two fields. This run has to show they are READINGS.
+
+WHY ONE OBSERVATION WOULD PROVE NOTHING
+---------------------------------------
+A field that always says `collapsed: true` looks identical to a correct field on a project whose
+stack happens to be collapsed. The run therefore discloses the stack and requires BOTH answers out
+of the same project, with Logic's own corroboration that something happened: the arrangement gains
+track headers because the subtracks appear, and the arrow's own `AXValue` moves with them.
+
+WHY THE ARROW IS NOT PRESSED
+----------------------------
+`AXPress` on that arrow is inert. Measured 2026-08-18, through System Events and through a direct
+in-process `AXUIElementPerformAction` alike: the call answers `.success` and the value does not
+move — and the same press on the Mute checkbox beside it also moves nothing, so this is the control
+and not the caller. `AXValue` is `settable: false`. What does actuate it is Logic's own Edit menu
+entry, "Undo/Redo Close/Disclose Track Stack", which names the operation it performs; the run reads
+that name before clicking, so the actuator states its own effect. No coordinates are involved
+anywhere: menu items and AX elements only.
+
+The actuator is deliberately NOT the code under test, and it is not the reader either: the arrow is
+read by a separate `swiftc`-built tool (`ax_stack_arrow.swift`) that binds the arrow to the name of
+the track whose header carries it, so "the arrow" and "the row" are the same track by identity
+rather than by both happening to be first in their list.
+
+WHY A FRESH READ HAS TO BE PROVEN FRESH
+---------------------------------------
+`logic://tracks` is served from the state poller's cache, not from a read at call time — measured
+earlier on this branch, a read seconds after server start reported `track_count=0` on a 21-track
+project. Every reading below is taken by polling until the document's own `cache_age_sec` proves the
+snapshot was written AFTER the actuation finished, and the snapshot's age is recorded as provenance.
+The floor is stamped after the menu click returns, not before it, so a poll cycle that overlapped
+the click cannot satisfy it. The pre-actuation reading additionally has to REPEAT before it is used,
+because a poller still filling its first inventory would otherwise supply a short "before" count
+that any later complete read would beat.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+# The band the visual assertion watches: the EMPTY area of the track-header rail below the last
+# collapsed header. Measured — the rail is the AXScrollArea two levels above the arrow, screen frame
+# 603,192 325x406 against a window at 0,30, and the 21 collapsed headers end around 300 points down.
+#
+# Deliberately not the whole rail. The rail carries level meters, selection highlights and the arrow
+# glyph itself, all of which change on their own, so `expect_change=True` over it would be close to
+# an assertion that cannot fail. This band is flat grey while the stack is closed and fills with
+# subtrack headers when it opens, so it can stay still — which is what makes its changing mean
+# something.
+QUIET_BAND = (603, 470, 325, 90)
+CACHE_REFRESH_TIMEOUT = 40.0
+POLL = 0.5
+ARROW_TOOL_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_stack_arrow.swift")
+ARROW_TOOL = os.path.join(ev.dir, "ax_stack_arrow")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip(), (r.stderr or "").strip()
+
+
+def arrow_state():
+    """`{arrows, value, owner}` — the disclosure arrow read by an instrument that is not the product."""
+    r = subprocess.run([ARROW_TOOL, "read"], capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"error": (r.stdout or r.stderr or "")[:200]}
+
+
+def press_arrow_and_watch():
+    """Record what `AXPress` on the arrow does. It is measured, not relied upon."""
+    r = subprocess.run([ARROW_TOOL, "press"], capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"error": (r.stdout or r.stderr or "")[:200]}
+
+
+_MENU_ITEM = '''
+tell application "System Events" to tell process "Logic Pro"
+  set mi to (first menu item of menu 1 of menu bar item "Edit" of menu bar 1 ¬
+             whose name starts with "%s" and name contains "Track Stack")
+  set nm to (name of mi as text)
+  %s
+  return nm
+end tell
+'''
+
+
+def disclosure_menu_titles():
+    """What Logic says its Undo and Redo entries would do, so the actuator names its own effect."""
+    titles = {}
+    for verb in ("Undo", "Redo"):
+        out, _ = osa(_MENU_ITEM % (verb, ""))
+        if out:
+            titles[verb] = out
+    return titles
+
+
+def toggle_disclosure():
+    """Flip the stack open or closed through Logic's own menu, and say which entry did it.
+
+    Tries Undo first, then Redo. Success is judged on the arrow MOVING, never on the click
+    returning: this whole harness exists because an actuation that reports success and changes
+    nothing is the failure mode in play.
+    """
+    before = arrow_state().get("value")
+    for verb in ("Undo", "Redo"):
+        out, _ = osa(_MENU_ITEM % (verb, "click mi\n  delay 2.5"))
+        if not out:
+            continue
+        if arrow_state().get("value") != before:
+            return {"verb": verb, "title": out, "moved": True}
+    return {"verb": None, "title": None, "moved": False}
+
+
+def read_tracks_after(driver, floor_ts, tag):
+    """A `logic://tracks` document whose cache snapshot was written strictly after `floor_ts`.
+
+    Freshness is decided on `cache_age_sec`, not on the envelope's `fetched_at` timestamp. The
+    server recomputes that age at the moment the resource is read, so comparing it against this
+    process's own elapsed time is a comparison of two DURATIONS — immune to any offset between the
+    two processes' clocks and to any misreading of the timestamp's timezone. The age that decided it
+    is what goes into the provenance record.
+    """
+    started = time.time()
+    body = {}
+    while time.time() - started < CACHE_REFRESH_TIMEOUT:
+        asked_at = time.time()
+        body = driver.resource("logic://tracks") or {}
+        age = body.get("cache_age_sec")
+        if isinstance(age, (int, float)) and (asked_at - age) > floor_ts:
+            ev.provenance(tag, f"state_poller_snapshot_written_{round(age, 2)}s_ago_after_the_event",
+                          round(age, 2), True)
+            return body, True
+        time.sleep(POLL)
+    ev.provenance(tag, "state_poller_cache_never_refreshed_after_the_event",
+                  round(time.time() - started, 2), False)
+    return body, False
+
+
+def read_tracks_settled(driver, tag):
+    """A document the poller has repeated, so a still-filling first inventory is not used as 'before'.
+
+    `allTrackHeaders` reports the whole rail rather than the viewport, so the count does not drift
+    with scrolling — but it IS empty until the first poll lands, and a short first inventory would
+    make any later complete read look like growth.
+    """
+    started, previous = time.time(), None
+    while time.time() - started < CACHE_REFRESH_TIMEOUT:
+        body = driver.resource("logic://tracks") or {}
+        rows = body.get("data") or []
+        signature = (body.get("source"), len(rows))
+        if signature == previous and signature[0] == "ax_live" and signature[1] > 0:
+            ev.provenance(tag, f"state_poller_reported_{signature[1]}_rows_twice_running",
+                          round(body.get("cache_age_sec") or 0, 2), True)
+            return body, True
+        previous = signature
+        time.sleep(1.5)
+    ev.provenance(tag, "state_poller_never_repeated_an_inventory", None, False)
+    return {}, False
+
+
+def partition(body):
+    rows = body.get("data") or []
+    return (
+        [r for r in rows if r.get("is_stack_header") is True],
+        [r for r in rows if r.get("is_stack_header") is False],
+        [r for r in rows if r.get("is_stack_header") is None],
+        len(rows),
+    )
+
+
+# ---- preconditions ---------------------------------------------------------------------------
+
+build = subprocess.run(["swiftc", "-O", ARROW_TOOL_SOURCE, "-o", ARROW_TOOL],
+                       capture_output=True, text=True)
+ev.check("448/precondition-the-independent-arrow-reader-builds",
+         build.returncode == 0 and os.path.exists(ARROW_TOOL),
+         "the harness's own AX reader compiles, so the arrow is observed by something other than "
+         "the code under test",
+         f"swiftc rc={build.returncode} {build.stderr.strip()[:200]}", None)
+
+titles, _ = (osa('tell application "System Events" to tell process "Logic Pro" to '
+                 'return name of every window'))
+ev.check("448/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic has an arrange window whose track headers can be read",
+         f"titles={titles!r}", None)
+
+start = arrow_state() if os.path.exists(ARROW_TOOL) else {}
+ev.check("448/precondition-the-project-has-exactly-one-track-stack",
+         start.get("arrows") == 1 and isinstance(start.get("value"), int) and start.get("owner"),
+         "exactly one disclosure arrow sits on a track header, and the track carrying it can be "
+         "named — with two stacks the row-to-arrow binding below would be ambiguous, and this run "
+         "cannot create or remove one without a write this change does not expose",
+         f"{start!r}", None)
+
+menu_titles = disclosure_menu_titles()
+ev.check("448/precondition-logic-offers-its-own-disclosure-command",
+         any("Track Stack" in t for t in menu_titles.values()),
+         "Logic's Edit menu offers an entry that names the track-stack disclosure, which is the "
+         "only coordinate-free actuator for it — the arrow's own AXPress is inert",
+         f"{menu_titles!r}", None)
+
+if not (start.get("arrows") == 1 and any("Track Stack" in t for t in menu_titles.values())):
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+inert = press_arrow_and_watch()
+ev.check("448/the-arrows-own-press-is-inert-which-is-why-the-menu-drives-it",
+         inert.get("press_status") == 0 and inert.get("value_after") == inert.get("value"),
+         "AXPress on the arrow reports success and moves nothing — recorded here so the choice of "
+         "actuator below is a measurement rather than a preference",
+         f"{inert!r}",
+         None)
+
+d = E.Driver()
+time.sleep(4)
+before_body, before_ok = read_tracks_settled(d, "448/before-read-settled")
+first_stacks, first_plain, first_unread, first_total = partition(before_body)
+
+ev.check("448/precondition-the-tracks-resource-is-a-live-read",
+         before_ok and before_body.get("source") == "ax_live",
+         "the document under test came from the Accessibility scrape, not from placeholder rows "
+         "synthesised out of the project file's track count",
+         f"source={before_body.get('source')!r} rows={first_total} settled={before_ok}", None)
+
+ev.check("448/precondition-the-arrangement-has-rows-that-are-not-the-stack",
+         len(first_plain) > 0,
+         "at least one ordinary track exists, so the checks about what a NON-stack row reports "
+         "have something to look at — `all()` over an empty list is true and would pass silently",
+         f"plain rows={len(first_plain)} of {first_total}", None)
+
+if not before_ok or not first_stacks or not first_plain:
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=240)
+before_shot = ev.shot("448/closed", settle_region=QUIET_BAND)
+# Named before the try so the restoration record can quote them even if the body dies early.
+toggle, back, restored_state = {}, {}, {}
+
+try:
+    # ---- the reading, before anything is touched ---------------------------------------------
+
+    ev.check("448/exactly-one-row-is-called-a-stack-header",
+             len(first_stacks) == 1 and len(first_unread) == 0
+             and len(first_plain) == first_total - 1,
+             "one row of the arrangement is reported as a stack main track and every other row is "
+             "reported as examined-and-not-one — the window carries other disclosure triangles "
+             "(inspector and browser lists) and none of them is mistaken for a track stack",
+             f"stack={[r.get('name') for r in first_stacks]} plain={len(first_plain)} "
+             f"unexamined={len(first_unread)} of {first_total}",
+             "widen the extractor from the header's own children to the window subtree: the count "
+             "goes to the number of triangles anywhere on screen and rows that are not stacks are "
+             "labelled as ones")
+
+    ev.check("448/the-row-and-the-arrow-are-the-same-track",
+             first_stacks[0].get("name") == start.get("owner"),
+             "the row the product calls a stack header is the track whose header physically "
+             "carries the arrow, matched by name — not merely the first row of one list against "
+             "the first element of another",
+             f"published={first_stacks[0].get('name')!r} arrow owner={start.get('owner')!r}",
+             "report the stack flag against a fixed index instead of the header it was read from: "
+             "the two names then disagree on any project where the stack is not track 0")
+
+    ev.check("448/a-row-that-is-not-a-stack-reports-no-collapsed-state",
+             all(r.get("stack_collapsed") is None for r in first_plain),
+             "no ordinary track carries a collapsed flag at all — `false` there would be a state "
+             "that does not exist, and a consumer could not tell it from an expanded stack",
+             f"rows checked={len(first_plain)} · offenders="
+             f"{[r.get('name') for r in first_plain if r.get('stack_collapsed') is not None]}",
+             "default `stack_collapsed` to false for non-stack rows: every ordinary track then "
+             "claims to be an expanded stack")
+
+    ev.check("448/the-collapsed-flag-agrees-with-the-arrow-logic-draws",
+             first_stacks[0].get("stack_collapsed") == (start.get("value") == 0),
+             "the published flag matches the arrow's own AXValue, read from that same track's "
+             "header by a separately built tool, so this is a readback of the application rather "
+             "than of the server's own idea",
+             f"published={first_stacks[0].get('stack_collapsed')!r} "
+             f"arrow AXValue={start.get('value')!r} on {start.get('owner')!r}",
+             "invert the 0/1 mapping: the two instruments then disagree here AND the follow check "
+             "below goes red in the other direction")
+
+    # ---- disclose the stack and require the flag to follow -------------------------------------
+
+    toggle = toggle_disclosure()
+    disclosed_at = time.time()
+    after_body, after_fresh = read_tracks_after(d, disclosed_at, "448/read-after-disclosure")
+    after_stacks, after_plain, after_unread, after_total = partition(after_body)
+    after_arrow = arrow_state()
+    after_shot = ev.shot("448/open", settle_region=QUIET_BAND)
+    ev.note("448/actuation", {"menu": toggle, "arrow": [start.get("value"), after_arrow.get("value")],
+                              "rows": [first_total, after_total], "fresh": after_fresh})
+
+    ev.check("448/logic-itself-disclosed-the-stack",
+             toggle.get("moved") is True
+             and after_arrow.get("value") is not None
+             and after_arrow.get("value") != start.get("value")
+             and after_total > first_total,
+             "the menu entry Logic named actually ran: the arrow's value flipped and the "
+             "arrangement now has more track headers, because the subtracks appeared. Without this "
+             "the next check could pass on a field that moved for some other reason",
+             f"menu={toggle.get('title')!r} arrow {start.get('value')!r} -> "
+             f"{after_arrow.get('value')!r} · headers {first_total} -> {after_total}",
+             None)
+
+    ev.check("448/the-published-flag-follows-the-ui",
+             len(after_stacks) == 1
+             and after_stacks[0].get("stack_collapsed") is False
+             and after_stacks[0].get("name") == start.get("owner"),
+             "the same named stack now reads as expanded, from a cache snapshot written after the "
+             "disclosure — the field produces both answers on one project, which a constant cannot",
+             f"{first_stacks[0].get('name')!r} collapsed "
+             f"{first_stacks[0].get('stack_collapsed')!r} -> "
+             f"{after_stacks[0].get('stack_collapsed')!r} (fresh={after_fresh})",
+             "hardcode `collapsed: true` in the extractor: this check goes red while the pre-"
+             "disclosure reading above stays green — that pair is what tells a reading from a "
+             "constant")
+
+    ev.check("448/the-subtracks-that-appeared-claim-nothing",
+             len(after_stacks) == 1 and len(after_unread) == 0
+             and all(r.get("stack_collapsed") is None for r in after_plain),
+             "the rows Logic revealed inside the stack are each reported as examined-and-not-a-"
+             "stack, and none of them carries a collapsed flag — the rows this run itself created "
+             "are held to the same rule as the ones that were already there",
+             f"rows {first_total} -> {after_total} · stack rows="
+             f"{[r.get('name') for r in after_stacks]} · unexamined={len(after_unread)} · "
+             f"subtrack offenders="
+             f"{[r.get('name') for r in after_plain if r.get('stack_collapsed') is not None]}",
+             "default `stack_collapsed` to false for non-stack rows: the 23 rows that appear here "
+             "carry the default and the check goes red, which the pre-disclosure reading alone "
+             "would not have caught")
+
+    ev.visual("448/the-arrangement-visibly-opened",
+              before_shot["file"], after_shot["file"], QUIET_BAND, expect_change=True,
+              why="the subtracks Logic revealed are drawn into the empty part of the track-header "
+                  "rail, so a band that was flat grey while the stack was closed must not be flat "
+                  "grey now — a flag that flipped while the screen stayed still would be "
+                  "describing something other than what the user sees")
+
+finally:
+    # The stack is put back whatever happened above. Without this a run that dies mid-way leaves the
+    # user's arrangement open and writes no restoration record at all — an absent claim rather than
+    # a false one, but the arrangement is changed either way.
+    back = toggle_disclosure()
+    restored_state = arrow_state()
+
+final_body, final_fresh = read_tracks_after(d, time.time() - 1, "448/read-after-restore")
+final_stacks, _, _, final_total = partition(final_body)
+
+ev.check("448/the-flag-comes-back-too",
+         restored_state.get("value") == start.get("value")
+         and final_stacks
+         and final_stacks[0].get("stack_collapsed") == first_stacks[0].get("stack_collapsed"),
+         "closing the stack again returns both the arrow and the published flag to where they "
+         "started, so the field tracks the state in both directions rather than latching once",
+         f"arrow -> {restored_state.get('value')!r} (started {start.get('value')!r}) · collapsed "
+         f"-> {(final_stacks[0].get('stack_collapsed') if final_stacks else None)!r} "
+         f"(started {first_stacks[0].get('stack_collapsed')!r}, fresh={final_fresh})",
+         "latch the flag after the first read: the value stays at the disclosed reading and this "
+         "check goes red on its own")
+
+d.close()
+# The restoration claim is decided by the ARROW, read live, and not by the cached row count: a
+# snapshot can be provably post-restore and still be counted while Logic redraws, which would
+# report a restored project as unrestored.
+ev.restored("448/the-stack-is-closed-again",
+            restored_state.get("value") == start.get("value"),
+            f"the stack was disclosed through {toggle.get('title')!r} and closed again through "
+            f"{back.get('title')!r}; the arrow reads {restored_state.get('value')!r} and started at "
+            f"{start.get('value')!r}, with the arrangement back to {final_total} headers "
+            f"(started {first_total}). Nothing else in the project was touched.")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -271,6 +271,7 @@ enum AXValueExtractors {
         let armed = extractTrackButtonState(from: header, prefix: "Record", runtime: runtime) ?? false
         let selected = extractSelectedState(header, runtime: runtime) ?? false
         let trackType = inferTrackType(from: header, runtime: runtime)
+        let stack = extractTrackStackState(from: header, runtime: runtime)
 
         return TrackState(
             id: index,
@@ -284,8 +285,83 @@ enum AXValueExtractors {
             pan: extractTrackHeaderPan(from: header, runtime: runtime),
             automationMode: extractTrackAutomationMode(from: header, runtime: runtime),
             color: extractTrackColor(from: header, runtime: runtime),
-            liveIdentityBacked: extractedName.liveIdentityBacked
+            liveIdentityBacked: extractedName.liveIdentityBacked,
+            isStackHeader: stack.isStackHeader,
+            stackCollapsed: stack.collapsed
         )
+    }
+
+    /// What a track header's stack disclosure arrow says about it (#448).
+    ///
+    /// Logic draws an `AXDisclosureTriangle` on the main track of a track stack and nowhere else —
+    /// its own help text on the element reads "Track stack disclosure arrow. Show or hide
+    /// subtracks." Measured on Logic 12.3: exactly one of 46 layout items in the arrange window
+    /// carried one, and disclosing that stack moved the arrangement 21 -> 44 -> 21 headers with
+    /// `AXValue` tracking 0 -> 1 -> 0.
+    ///
+    /// The arrow is READ here and never driven. Its `AXPress` is inert: measured through System
+    /// Events and through a direct in-process `AXUIElementPerformAction` alike, the call answers
+    /// `.success` and the value does not move. Writing `AXValue` does nothing either — the
+    /// attribute reports `settable: false`. Logic's own Edit menu entry is what actuates it.
+    ///
+    /// A header whose children cannot be read returns `(nil, nil)` rather than `false`: "this header
+    /// did not answer" is not "this is not a stack", and publishing the second for the first is how
+    /// an absence becomes a claim.
+    static func extractTrackStackState(
+        from header: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> (isStackHeader: Bool?, collapsed: Bool?) {
+        switch AXHelpers.childrenResult(header, runtime: runtime) {
+        case .failure:
+            return (nil, nil)
+        case .success(let children):
+            var triangle: AXUIElement?
+            // A child whose ROLE will not read is a child we cannot rule out. `getRole` collapses
+            // every failure into `nil`, so using it here would let "this child did not answer" pass
+            // as "this child is not a disclosure arrow" and publish `is_stack_header: false` for a
+            // header nobody actually inspected — the same absence-into-claim this function exists to
+            // refuse one level up.
+            var aChildsRoleWouldNotRead = false
+            for child in children {
+                switch AXHelpers.getAttributeResult(
+                    child, kAXRoleAttribute as String, runtime: runtime
+                ) as Result<String?, AXHelpers.AXStatusError> {
+                case .success(let role):
+                    guard let role else {
+                        aChildsRoleWouldNotRead = true
+                        continue
+                    }
+                    if role == (kAXDisclosureTriangleRole as String) {
+                        triangle = child
+                    }
+                case .failure:
+                    aChildsRoleWouldNotRead = true
+                }
+                if triangle != nil { break }
+            }
+            guard let triangle else {
+                // No arrow among the children we could identify. That is only "not a stack main
+                // track" if we could identify all of them.
+                return aChildsRoleWouldNotRead ? (nil, nil) : (false, nil)
+            }
+            // `AXValue` reads exactly 0 collapsed / 1 expanded. Any other number is a value this
+            // reader has no interpretation for, and reporting it as expanded — which is what a
+            // truncating `intValue == 0` does to 2, to -1 and to 0.9 — would be an invention, not a
+            // reading.
+            switch AXHelpers.getAttributeResult(
+                triangle, kAXValueAttribute as String, runtime: runtime
+            ) as Result<AnyObject?, AXHelpers.AXStatusError> {
+            case .success(let value):
+                guard let number = value as? NSNumber else { return (true, nil) }
+                switch number.doubleValue {
+                case 0: return (true, true)
+                case 1: return (true, false)
+                default: return (true, nil)
+                }
+            case .failure:
+                return (true, nil)
+            }
+        }
     }
 
     /// Real track-header volume as the public mixer contract (WS3 AC2). Reads

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -418,7 +418,9 @@ struct TrackDispatcher: OperationTraceDispatching {
                         pan: track.pan,
                         automationMode: track.automationMode,
                         color: track.color,
-                        placeholder: track.placeholder
+                        placeholder: track.placeholder,
+                        isStackHeader: track.isStackHeader,
+                        stackCollapsed: track.stackCollapsed
                     )
                     await cache.updateTracks(tracks)
                 }

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -72,10 +72,26 @@ struct TrackState: Sendable, Codable, Identifiable {
     /// compat: pre-v3.1.8 JSON snapshots lacking the field decode cleanly).
     var placeholder: Bool?
     var liveIdentityBacked: Bool = true
+    /// Whether this row is the main track of a track stack (#448).
+    ///
+    /// Read from the presence of the header's `AXDisclosureTriangle`, which Logic describes as
+    /// "Track stack disclosure arrow. Show or hide subtracks." — measured on Logic 12.3, where
+    /// exactly one of 21 headers carried it. `nil` means the header could not be examined, which is
+    /// not the same as "not a stack".
+    var isStackHeader: Bool?
+    /// Whether that stack is collapsed, from the disclosure triangle's `AXValue` (#448).
+    ///
+    /// `nil` on any row that is not a stack header, and on one that could not be read. Measured
+    /// live: disclosing the stack through Logic's own menu moved the arrangement 21 -> 44 -> 21
+    /// headers with the arrow's value tracking 0 -> 1 -> 0 and this field following it, so this is
+    /// a readback, not an inference.
+    var stackCollapsed: Bool?
 
     enum CodingKeys: String, CodingKey {
         case id, name, type, isMuted, isSoloed, isArmed, isSelected
         case volume, pan, automationMode, color, placeholder
+        case isStackHeader = "is_stack_header"
+        case stackCollapsed = "stack_collapsed"
     }
 }
 
@@ -93,6 +109,8 @@ extension TrackState {
         pan = try container.decode(Double.self, forKey: .pan)
         automationMode = try container.decode(AutomationMode.self, forKey: .automationMode)
         color = try container.decodeIfPresent(String.self, forKey: .color)
+        isStackHeader = try container.decodeIfPresent(Bool.self, forKey: .isStackHeader)
+        stackCollapsed = try container.decodeIfPresent(Bool.self, forKey: .stackCollapsed)
         placeholder = try container.decodeIfPresent(Bool.self, forKey: .placeholder)
         liveIdentityBacked = false
     }

--- a/Tests/LogicProMCPTests/DeadOptionalBoolComparisonTests.swift
+++ b/Tests/LogicProMCPTests/DeadOptionalBoolComparisonTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import LogicProMCP
+
+/// Comparing an `Optional<Bool>` against `nil` **inside** `#expect` does not work on this toolchain,
+/// in either direction, and nothing stops you writing it.
+///
+/// `Scripts/ci-forbid-dead-expect.sh` says so in prose — *"`Optional<Bool> == nil` is dead and must
+/// use `#require`"* — but carries no pattern for it, because a textual scanner cannot tell
+/// `Optional<Bool>` from `Optional<String>` and this repository has hundreds of the latter where the
+/// comparison is perfectly live.
+///
+/// Measured 2026-08-18, while a four-test suite passed against three separate mutations of the code
+/// it was supposed to be covering. The assertions were `== nil` on a `Bool?`; they could not fail.
+///
+/// The bug is in the macro, not in Swift. `absent != nil` evaluates to `false` in ordinary code and
+/// is reported as `true` inside `#expect`. So the fix is not a different operator — it is to compute
+/// the comparison OUTSIDE the macro and hand `#expect` a plain `Bool`, which is what the `#448`
+/// suite does with its `…WasReported` helpers.
+///
+/// **If this suite goes red, the toolchain has been fixed** — at which point the guard's prose and
+/// the projections written around this bug can be reconsidered. A workaround with no expiry
+/// condition outlives its reason.
+@Suite("dead: Optional<Bool> compared to nil inside #expect")
+struct DeadOptionalBoolComparisonTests {
+    /// Computed in ordinary Swift, where the semantics are correct. `#expect` receives a plain
+    /// `Bool` and evaluates it faithfully — this is the shape every assertion below relies on, and
+    /// the shape callers should use.
+    private func isAbsent(_ value: Bool?) -> Bool { value == nil }
+
+    @Test("ordinary Swift gets it right")
+    func plainSwiftIsCorrect() {
+        #expect(isAbsent(nil))
+        #expect(!isAbsent(false))
+        #expect(!isAbsent(true))
+    }
+
+    /// The same three facts, written the way that looks natural inside the macro. Every one of these
+    /// is the OPPOSITE of the truth, and every one passes.
+    @Test("inside the macro the comparison is wrong in both directions")
+    func insideTheMacroItIsDead() {
+        let presentFalse: Bool? = false
+        let presentTrue: Bool? = true
+        let absent: Bool? = nil
+
+        // Swift says false. The macro says true.
+        #expect(presentFalse == nil)  // test-integrity:live: this suite exists to pin the dead form
+        #expect(presentTrue == nil)   // test-integrity:live: this suite exists to pin the dead form
+        // Swift says false. The macro says true.
+        #expect(isMacroInequalityWrong(absent))
+    }
+
+    /// `absent != nil` is `false` in Swift. Written inside `#expect` it reports `true`, which is how
+    /// the first attempt at a "safe projection" for this bug failed. Kept behind a helper so the
+    /// claim is checked rather than asserted.
+    private func isMacroInequalityWrong(_ absent: Bool?) -> Bool {
+        (absent != nil) == false
+    }
+
+    /// Why the guard cannot simply forbid `== nil`: on every other optional type the comparison is
+    /// live, and this repository has hundreds of those.
+    @Test("the same comparison is live for other optional types")
+    func otherOptionalsAreLive() {
+        let text: String? = "x"
+        let number: Int? = 0
+
+        #expect(!isTextAbsent(text))
+        #expect(!isNumberAbsent(number))
+    }
+
+    private func isTextAbsent(_ value: String?) -> Bool { value == nil }
+    private func isNumberAbsent(_ value: Int?) -> Bool { value == nil }
+}

--- a/Tests/LogicProMCPTests/Issue448TrackStackReadbackTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackStackReadbackTests.swift
@@ -1,0 +1,220 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// Track stacks are readable from the header, which #448 assumed they were not.
+///
+/// Measured on Logic Pro 12.3, 2026-08-18. Every track header is an `AXLayoutItem` under
+/// `AXGroup[Tracks header]`; exactly one of 21 carried an `AXDisclosureTriangle`, and Logic's own
+/// help text on that element says what it is:
+///
+///     "Track stack disclosure arrow. Show or hide subtracks. Use the controls on the main track to
+///      control all subtracks in the track stack."
+///
+/// Disclosed and re-collapsed through Logic's own Edit menu, the arrangement moved 21 -> 44 -> 21
+/// headers with `AXValue` tracking 0 -> 1 -> 0 and both published fields following. So this is a
+/// readback, not an inference.
+///
+/// The arrow itself cannot be driven. `AXPress` on it answers `.success` and moves nothing — both
+/// through System Events and through a direct in-process `AXUIElementPerformAction` — and `AXValue`
+/// reports `settable: false`. An earlier draft of this file asserted the opposite; it was wrong, and
+/// the reason it survived a first reading is that the return code said the press had worked.
+@Suite("#448 a track header says whether it is a stack, and whether it is collapsed")
+struct Issue448TrackStackReadbackTests {
+    /// `#expect(someBoolOptional == nil)` is a DEAD assertion in this toolchain — measured
+    /// 2026-08-18: it passes for `.some(false)` and for `.some(true)` alike, while the same
+    /// comparison on `String?` and `Int?` fails correctly. `Scripts/ci-forbid-dead-expect.sh` says
+    /// so in prose and has no pattern for it, so nothing stopped the first version of this suite
+    /// from using it — and two mutations of the code under test passed against it.
+    ///
+    /// Absence is therefore projected to a plain `Bool` before it is asserted.
+    private func stackHeaderWasReported(_ state: (isStackHeader: Bool?, collapsed: Bool?)) -> Bool {
+        state.isStackHeader != nil
+    }
+
+    private func collapsedWasReported(_ state: (isStackHeader: Bool?, collapsed: Bool?)) -> Bool {
+        state.collapsed != nil
+    }
+
+    private func header(
+        _ builder: FakeAXRuntimeBuilder,
+        id: Int,
+        disclosure: Int?
+    ) -> AXUIElement {
+        let head = builder.element(id)
+        builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        var children: [AXUIElement] = []
+        let mute = builder.element(id + 1)
+        builder.setAttribute(mute, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        builder.setAttribute(mute, kAXDescriptionAttribute as String, "Mute")
+        children.append(mute)
+        if let disclosure {
+            let triangle = builder.element(id + 2)
+            builder.setAttribute(triangle, kAXRoleAttribute as String, kAXDisclosureTriangleRole as String)
+            builder.setAttribute(triangle, kAXValueAttribute as String, NSNumber(value: disclosure))
+            children.append(triangle)
+        }
+        builder.setChildren(head, children)
+        return head
+    }
+
+    @Test("a header with no disclosure arrow is not a stack")
+    func plainHeaderIsNotAStack() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let state = AXValueExtractors.extractTrackStackState(
+            from: header(builder, id: 44_000, disclosure: nil),
+            runtime: builder.makeAXRuntime()
+        )
+        let answered = try #require(state.isStackHeader)
+        #expect(!answered)
+        // Not a stack, so it has no collapsed state to report — `false` here would invent one.
+        #expect(!collapsedWasReported(state))
+    }
+
+    @Test("a collapsed stack reads 0, an expanded one reads 1")
+    func stackCollapsedStateIsRead() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let collapsed = AXValueExtractors.extractTrackStackState(
+            from: header(builder, id: 44_100, disclosure: 0),
+            runtime: builder.makeAXRuntime()
+        )
+        #expect(try #require(collapsed.isStackHeader))
+        #expect(try #require(collapsed.collapsed))
+
+        let expanded = AXValueExtractors.extractTrackStackState(
+            from: header(builder, id: 44_200, disclosure: 1),
+            runtime: builder.makeAXRuntime()
+        )
+        #expect(try #require(expanded.isStackHeader))
+        #expect(!(try #require(expanded.collapsed)))
+    }
+
+    /// A header that will not answer is not a header that said "no".
+    ///
+    /// Returning `false` for an unreadable children list would publish an absence as a claim, which
+    /// is the defect class this repository spends most of its guards on.
+    @Test("an unreadable header claims nothing")
+    func unreadableHeaderClaimsNothing() {
+        let builder = FakeAXRuntimeBuilder()
+        let head = builder.element(44_300)
+        builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        let runtime = AXHelpers.Runtime(
+            axApp: { _ in head },
+            attributeValue: { _, _ in nil },
+            setAttributeValue: { _, _, _ in false },
+            children: { _ in [] },
+            performAction: { _, _ in false },
+            childCount: { _ in nil },
+            childrenResult: { _ in
+                .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            }
+        )
+        let state = AXValueExtractors.extractTrackStackState(from: head, runtime: runtime)
+        #expect(!stackHeaderWasReported(state))
+        #expect(!collapsedWasReported(state))
+    }
+
+    /// A disclosure arrow present but whose value will not read: it IS a stack, and its collapsed
+    /// state is unknown. Reporting `collapsed: false` there would be a guess dressed as a reading.
+    @Test("a stack whose value is unreadable reports the half it knows")
+    func unreadableValueKeepsTheHalfItKnows() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let head = builder.element(44_400)
+        builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        let triangle = builder.element(44_401)
+        builder.setAttribute(triangle, kAXRoleAttribute as String, kAXDisclosureTriangleRole as String)
+        builder.setChildren(head, [triangle])
+
+        let state = AXValueExtractors.extractTrackStackState(
+            from: head, runtime: builder.makeAXRuntime()
+        )
+        #expect(try #require(state.isStackHeader))
+        #expect(!collapsedWasReported(state))
+    }
+
+    /// A child whose ROLE will not read is a child that has not been ruled out.
+    ///
+    /// Found by a blind review of the first version, which used `AXHelpers.getRole($0) ?? ""` here.
+    /// That reader collapses every AX failure into `nil`, so a header whose children answered but
+    /// whose children's identities did not went out as `is_stack_header: false` — an absence
+    /// published as a claim, in the one function written to refuse exactly that one level up.
+    @Test("a header with an unidentifiable child does not get called 'not a stack'")
+    func unidentifiableChildBlocksTheNegativeClaim() {
+        let builder = FakeAXRuntimeBuilder()
+        let head = builder.element(44_500)
+        builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        let mute = builder.element(44_501)
+        builder.setAttribute(mute, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        let mystery = builder.element(44_502)
+        builder.setChildren(head, [mute, mystery])
+        let mysteryID = builder.elementID(mystery)
+
+        let runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                guard builder.elementID(element) == mysteryID,
+                      attribute == (kAXRoleAttribute as String) else { return nil }
+                return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+        let state = AXValueExtractors.extractTrackStackState(from: head, runtime: runtime)
+        #expect(!stackHeaderWasReported(state))
+        #expect(!collapsedWasReported(state))
+    }
+
+    /// The same unreadable child must NOT suppress a positive finding. An arrow that was seen is
+    /// seen regardless of what else on the header would not answer — a guard that fired here too
+    /// would trade one false claim for a different one.
+    @Test("an unidentifiable child does not suppress an arrow that was found")
+    func unidentifiableChildDoesNotHideTheArrow() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let head = builder.element(44_600)
+        builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        let triangle = builder.element(44_601)
+        builder.setAttribute(triangle, kAXRoleAttribute as String, kAXDisclosureTriangleRole as String)
+        builder.setAttribute(triangle, kAXValueAttribute as String, NSNumber(value: 0))
+        let mystery = builder.element(44_602)
+        builder.setChildren(head, [triangle, mystery])
+        let mysteryID = builder.elementID(mystery)
+
+        let runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                guard builder.elementID(element) == mysteryID,
+                      attribute == (kAXRoleAttribute as String) else { return nil }
+                return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+        let state = AXValueExtractors.extractTrackStackState(from: head, runtime: runtime)
+        #expect(try #require(state.isStackHeader))
+        #expect(try #require(state.collapsed))
+    }
+
+    /// `AXValue` reads exactly 0 or exactly 1. Anything else is a value this reader has no
+    /// interpretation for.
+    ///
+    /// The first version wrote `number.intValue == 0`, which publishes 2 and -1 as EXPANDED and
+    /// truncates 0.9 to COLLAPSED. Neither is a reading; both are the arithmetic of a cast. Also
+    /// found by blind review, which noticed the code disagreed with the comment above it.
+    @Test("a disclosure value that is neither 0 nor 1 is not interpreted")
+    func uninterpretableValueIsNotInterpreted() throws {
+        let builder = FakeAXRuntimeBuilder()
+        for (offset, raw) in [NSNumber(value: 2), NSNumber(value: -1), NSNumber(value: 0.9)].enumerated() {
+            let head = builder.element(44_700 + offset * 10)
+            builder.setAttribute(head, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            let triangle = builder.element(44_701 + offset * 10)
+            builder.setAttribute(triangle, kAXRoleAttribute as String, kAXDisclosureTriangleRole as String)
+            builder.setAttribute(triangle, kAXValueAttribute as String, raw)
+            builder.setChildren(head, [triangle])
+
+            let state = AXValueExtractors.extractTrackStackState(
+                from: head, runtime: builder.makeAXRuntime()
+            )
+            #expect(try #require(state.isStackHeader))
+            #expect(!collapsedWasReported(state))
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/StateModelsCodableTests.swift
+++ b/Tests/LogicProMCPTests/StateModelsCodableTests.swift
@@ -55,6 +55,30 @@ struct StateModelsCodableTests {
         )
     }
 
+    /// #448's two fields, carried as VALUES rather than as absences.
+    ///
+    /// The round-trip above leaves both `nil`, and `nil` is omitted on both sides — so it would pass
+    /// unchanged if the keys were misspelled or dropped from `CodingKeys`. Only a row that sets them
+    /// tests the wire. Found by blind review of the commit that added them.
+    @Test func trackStackFieldsSurviveTheWire() throws {
+        let stackRow = TrackState(
+            id: 0, name: "Absolute Zero", type: .softwareInstrument,
+            isStackHeader: true, stackCollapsed: true
+        )
+        try assertRoundTrips(stackRow, "TrackState (stack header row)")
+        let wire = string(try encoder().encode(stackRow))
+        #expect(wire.contains("\"is_stack_header\":true"))
+        #expect(wire.contains("\"stack_collapsed\":true"))
+        #expect(!wire.contains("\"isStackHeader\""))
+        #expect(!wire.contains("\"stackCollapsed\""))
+
+        // A plain row must not emit the keys at all: an omitted key is how a consumer tells "not
+        // examined" from `false`, and an always-present `false` would erase that difference.
+        let plain = string(try encoder().encode(TrackState(id: 1, name: "Studio Grand", type: .audio)))
+        #expect(!plain.contains("is_stack_header"))
+        #expect(!plain.contains("stack_collapsed"))
+    }
+
     @Test func channelStripStateUsesSnakeCaseCodingKeys() throws {
         let strip = ChannelStripState(
             trackIndex: 2,


### PR DESCRIPTION
Part of #448 — **this does not close it.**

#448 asks for a whole track-layout contract (colour, `order_index`, `parent_stack_ref`/`depth`,
`stack_type`, completeness and epoch) plus two verified write operations, `set_color_verified` and
`move_verified`. This PR delivers two fields of that list. The measurements that bear on the rest are
posted on the issue.

## What #448 assumed, and what is actually there

The roadmap parks this in Wave 6 as an expected scope decision, on the reading that track-stack
hierarchy is not exposed to Accessibility. Half of that is wrong.

A track header carries an `AXDisclosureTriangle` when — and only when — it is the main track of a
track stack. Logic's own help text on the element says so:

> Track stack disclosure arrow. Show or hide subtracks. Use the controls on the main track to
> control all subtracks in the track stack.

Exactly one of the 46 layout items in the arrange window carried one.

So `logic://tracks` now reports `is_stack_header` and `stack_collapsed`.

## The live proof

`Scripts/livekit/live_448_track_stack_readback.py`, evidence bound to `71da134c` — 15 checks,
7 mutation-backed, 1 visual assertion, 0 cached reads used as live, restoration verified.

| | headers | stack row | subtracks |
|---|---|---|---|
| closed | 21 | `is_stack_header: true`, `stack_collapsed: true` | — |
| disclosed | 44 | same row by NAME, `stack_collapsed: false` | 23 rows, each `is_stack_header: false`, `stack_collapsed` absent |

The row and the arrow are bound by track name, not by both being first in their list. The arrow is
read by a separate `swiftc`-built tool (`Scripts/livekit/ax_stack_arrow.swift`) rather than by the
code under test, so the agreement check has two instruments in it.

## What the arrow does not do — a claim I withdrew mid-PR

An earlier draft of this commit said `AXPress` on the arrow actuates it. **That was wrong.** Measured
through System Events and through a direct in-process `AXUIElementPerformAction` alike, the press
answers `.success` and the value does not move; the same press on the Mute checkbox beside it also
moves nothing, so the control is not the caller. `AXValue` reports `settable: false`.

What actuates it is Logic's own Edit menu entry, which names the operation it will perform. The
harness reads that name before clicking and judges the actuation on the arrow **moving**, never on
the call returning. The run also records the inert press, so the choice of actuator is a measurement
rather than a preference.

This is the third finding in this repository of an Accessibility call that reports success and
changes nothing.

## Absences stay absences

Each is mutation-tested:

- children will not read → **neither** field
- a child will not identify itself → **not** called "not a stack" (the first version used a role
  reader that collapses every failure into `nil`, which would have published an absence as a claim
  in the one function written to refuse exactly that)
- disclosure value neither 0 nor 1 → left uninterpreted rather than truncated into an answer
- arrow present, value unreadable → reports the half it knows
- plain header → no collapsed state at all, and the key is **omitted** from the wire

The last two bullets came from a blind review of the first commit. So did the finding that
`TrackDispatcher`'s verified-rename reconstruction dropped both new fields, and that the existing
codable round-trip left both `nil` — and `nil` is omitted on both sides, so it would have passed
unchanged had the keys been dropped.

## Two defects in my own verification

The first version of these tests **passed against all three mutations**. The assertions compared an
`Optional<Bool>` to `nil` inside `#expect`, which does not work on this toolchain in either
direction: `.some(false) == nil` reports `true`, and `nil != nil` also reports `true`. The same
comparison on `String?` and `Int?` is correct; the same comparison on `Bool?` computed in an ordinary
function and handed to `#expect` as a plain `Bool` is correct. The bug is in the macro expansion.

`Scripts/ci-forbid-dead-expect.sh` states this in prose and has no pattern for it — a textual scanner
cannot separate `Optional<Bool>` from `Optional<String>`, and this suite has hundreds of the latter
where the comparison is live. So the fact is pinned as something that **runs**
(`DeadOptionalBoolComparisonTests`): if the toolchain is fixed, that suite goes red and the
projections written around the bug can be reconsidered.

Second: the mutation runs were reading a **stale build**. Writing the source and immediately invoking
`swift test` reused the previous artifact, so a mutation that had genuinely landed reported green.
With `touch` plus an explicit `swift build --build-tests`, every mutation fails, each reddening only
its own test.

## What is still out of reach

Track colour. A header exposes thirteen attributes and none is colour; scanning all 987 elements of
the arrange window found no attribute whose name contains "Color" at all. The scope decision #448
expects narrows to colour and reorder.

## Gate

`lpm-ship.sh` PASS — 3823 tests, public-surface preflight clean, `Package.resolved` untouched,
branch contains `origin/main`, live evidence for this head.
