### PR TITLE
fix(#575): retire five region table rows that stood in front of no implementation

### DIFF
--- a/Scripts/livekit/live_575_region_stub_rows_retired.py
+++ b/Scripts/livekit/live_575_region_stub_rows_retired.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Live proof that retiring five region routing rows took nothing reachable with it.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_575_region_stub_rows_retired.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS REMOVED
+----------------
+`region.select`, `region.loop`, `region.set_name`, `region.move` and `region.resize` had routing
+rows. None of them had an implementation — the channel answered all five with a single arm:
+
+    case "region.select", "region.loop", "region.set_name", "region.move", "region.resize":
+        return .error("Region operations not yet implemented via AX")
+
+A routing row says an operation is real and names the surfaces that may carry it. For these it named
+a channel order for a refusal. The rows and the arm are gone; the operations now answer the way any
+unknown one does.
+
+WHAT THIS RUN CAN AND CANNOT SHOW
+---------------------------------
+The honest limit first, because it decides what the checks below are worth. Of the eight routed
+`region.*` operations, exactly ONE is reachable from a tool: `region.get_regions`, as
+`logic_project.get_regions`. `region.select_last` and `region.move_to_playhead` are implemented and
+routed but reachable from no dispatcher, so no live call can exercise them — their survival is
+visible in the table and in the unit suite, and this document does not claim otherwise.
+
+So the live question is not "do the five still work" — they never did. It is whether removing five
+named rows took anything reachable with it. The strongest available evidence for that is the
+surviving sibling of the same family answering with a real inventory, plus a sweep of the reachable
+read-only surface across every tool.
+
+The removed names are probed too. That check is weak on its own: they answered `invalid_params`
+before the change as well, because none of them was ever registered for a tool. It is recorded to
+show the removal did not accidentally BIND them to something, not as evidence the removal was right.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
+# frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call in this run is a
+# read, so the assertion over it is a NEGATIVE one.
+HEADER_BAND = (603, 162, 325, 406)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic is up with a project, so the surviving region operation has something to answer "
+         "about and an empty inventory would mean something",
+         f"titles={titles!r}", None)
+
+rec = ev.record_screen(seconds=150)
+before = ev.shot("575/before", settle_region=HEADER_BAND)
+
+d = E.Driver()
+time.sleep(4)
+
+regions = d.tool("logic_project", "get_regions", {})
+ev.note("575/get_regions", {k: v for k, v in regions.items() if k != "regions"}
+        if isinstance(regions, dict) else {"raw": str(regions)[:200]})
+
+ev.check("575/the-surviving-region-operation-still-answers",
+         isinstance(regions, dict)
+         and regions.get("error") is None
+         and isinstance(regions.get("regions"), list)
+         and isinstance((regions.get("_debug") or {}).get("track_headers"), int)
+         and (regions["_debug"]["track_headers"]) > 0,
+         "`region.get_regions` still routes, still reaches Accessibility and still comes back with "
+         "a real inventory — the removal took five named rows and not the family that shares their "
+         "prefix",
+         f"error={regions.get('error') if isinstance(regions, dict) else None!r} "
+         f"regions={len(regions.get('regions') or []) if isinstance(regions, dict) else None} "
+         f"track_headers={(regions.get('_debug') or {}).get('track_headers') if isinstance(regions, dict) else None}",
+         "remove `region.get_regions` alongside the five: the router stops recognising the "
+         "operation and this call comes back with an error instead of an inventory")
+
+# The reachable read-only surface, across every tool that has one. A removal's risk is in what it
+# takes with it, and the table is shared by every operation in the server.
+sweep = {
+    "logic_system.health": d.tool("logic_system", "health", {}),
+    "logic_system.permissions": d.tool("logic_system", "permissions", {}),
+    "logic_project.is_running": d.tool("logic_project", "is_running", {}),
+    "logic_midi.list_ports": d.tool("logic_midi", "list_ports", {}),
+}
+resources = {
+    "logic://tracks": d.resource("logic://tracks"),
+    "logic://mixer": d.resource("logic://mixer"),
+    "logic://markers": d.resource("logic://markers"),
+    "logic://transport/state": d.resource("logic://transport/state"),
+}
+ev.note("575/sweep", {k: str(v)[:160] for k, v in sweep.items()})
+ev.note("575/resources", {k: str(v)[:160] for k, v in resources.items()})
+
+broken = {k: v for k, v in sweep.items()
+          if not isinstance(v, dict) or v.get("error") is not None}
+unreadable = [k for k, v in resources.items() if not isinstance(v, dict)]
+ev.check("575/every-reachable-read-only-operation-still-answers",
+         not broken and not unreadable,
+         "health, permissions, is_running, list_ports and the four state resources all answer "
+         "without an error, so the five rows came out without disturbing the table they shared",
+         f"broken={list(broken)} unreadable={unreadable}",
+         "remove `system.health` from the table alongside them: the router stops recognising it "
+         "and the dispatcher's answer never reaches the caller")
+
+# Weak on its own — see the module docstring. Recorded so a reader can see the removal did not bind
+# these names to something rather than freeing them.
+removed = {name: d.tool("logic_project", name, {})
+           for name in ("select", "loop", "set_name", "move", "resize")}
+ev.note("575/removed", {k: str(v)[:160] for k, v in removed.items()})
+ev.check("575/the-removed-names-did-not-become-reachable",
+         all(isinstance(v, dict) and v.get("error") == "invalid_params"
+             for v in removed.values()),
+         "none of the five became reachable or started answering differently",
+         f"{ {k: (v.get('error') if isinstance(v, dict) else None) for k, v in removed.items()} }",
+         # No mutation: they answered `invalid_params` before the change too, because none of them
+         # was ever registered for a tool. This check cannot tell the two versions apart.
+         None)
+
+after = ev.shot("575/after", settle_region=HEADER_BAND)
+ev.visual("575/no-project-state-was-touched",
+          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          why="every call in this run is a read, so the track-header rail must be byte-identical "
+              "across it — a change here would mean a read path wrote something")
+
+d.close()
+ev.restored("575/nothing-to-restore", True,
+            "this run performs reads only; no project state was changed, which the negative visual "
+            "assertion above is the evidence for rather than a claim made here")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -677,8 +677,10 @@ actor AccessibilityChannel: Channel {
             return await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(runtime: runtime.logicRuntime)
         case "region.select_last":
             return await AccessibilityChannel.defaultSelectLastRegion(runtime: runtime.logicRuntime)
-        case "region.select", "region.loop", "region.set_name", "region.move", "region.resize":
-            return .error("Region operations not yet implemented via AX")
+        // #575: the five unimplemented region operations were removed from the routing table along
+        // with this arm. They now fall through to the unsupported-operation default, which is what
+        // an operation nothing implements should say — "not yet implemented via AX" reads as a
+        // promise, and the router no longer offers a path to it either way.
 
         // MARK: - Plugins
         case "plugin.insert":

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -236,18 +236,20 @@ extension ChannelRouter {
         "view.toggle_plugin_windows": [.midiKeyCommands, .cgEvent],
 
         // Regions
+        //
+        // #575: `region.select`, `.loop`, `.set_name`, `.move` and `.resize` used to sit here. They
+        // were never implemented — the channel answered all five with "Region operations not yet
+        // implemented via AX" — so the rows claimed a channel order for a refusal. A routing entry
+        // is a statement that an operation is real and says which surfaces may carry it; for these
+        // it advertised a contract to a caller who could only ever be told no. The rows come back
+        // when there is something behind them.
         "region.get_regions":         [.accessibility],
-        "region.select":              [.accessibility],
         // Reserved for a future region-editor tool that picks up the freshly
         // imported region and aligns it to the playhead. Currently unused by
         // any dispatcher (record_sequence handles positioning via SMFWriter
         // + transport.goto_position bar=1 before import).
         "region.select_last":         [.accessibility],
         "region.move_to_playhead":    [.accessibility],
-        "region.loop":                [.accessibility, .cgEvent],
-        "region.set_name":            [.accessibility],
-        "region.move":                [.accessibility],
-        "region.resize":              [.accessibility],
 
         // Plugins — bypass/remove intentionally omitted from the routing
         // table: no channel has a deterministic implementation. insert is

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -907,7 +907,14 @@ private func makeSetInstrumentFixture() -> (
         ("mixer.set_output", "I/O routing not yet implemented via AX"),
         ("mixer.toggle_eq", "EQ toggle not yet implemented via AX"),
         ("mixer.reset_strip", "Strip reset not yet implemented via AX"),
-        ("region.select", "Region operations not yet implemented via AX"),
+        // #575: the five unimplemented region operations lost both their routing rows and their
+        // channel arm. An operation nothing implements now answers the same way any unknown one
+        // does, instead of a sentence that reads as a promise.
+        ("region.select", "Unsupported AX operation"),
+        ("region.loop", "Unsupported AX operation"),
+        ("region.set_name", "Unsupported AX operation"),
+        ("region.move", "Unsupported AX operation"),
+        ("region.resize", "Unsupported AX operation"),
         ("plugin.list", "Plugin list reading not yet implemented via AX"),
         ("automation.get_mode", "Automation mode reading not yet implemented via AX"),
         ("automation.set_mode", "Automation mode setting not yet implemented via AX"),


### PR DESCRIPTION
Part of #575.

## The issue's premise was half wrong

It says seven region operations are **implemented** and reachable from no tool. Five of the seven are
not implemented. One arm answered all of them:

```swift
case "region.select", "region.loop", "region.set_name", "region.move", "region.resize":
    return .error("Region operations not yet implemented via AX")
```

A row in the channel table states that an operation is real and declares which surfaces may carry it.
For these it declared a channel order for a refusal — and the sentence it refused with reads as a
promise rather than as an answer.

| operation | in the table | reachable from a tool | implementation |
|---|---|---|---|
| `region.get_regions` | yes | yes, as `logic_project.get_regions` | real |
| `region.move_to_playhead` | yes | **no** | real |
| `region.select_last` | yes | **no** | real |
| `region.select` `.loop` `.set_name` `.move` `.resize` | **removed here** | no | **none** |

The two in the middle are finished work behind a missing registry entry — `move_to_playhead` verifies
through `kAXSelectedAttribute`, `select_last` through a post-state read of the region it selected.
Exposing them needs its own live proof and is a separate change.

## What the live run can show, and what it cannot

Only one of the eight is reachable from a tool, so **no live call can exercise the two that survive
unreachable.** The evidence document says that rather than implying a coverage it does not have.

What it does show is that removing five named rows took nothing reachable with it:

```
4 checks · 4 passed · 2 mutation-backed · visual 1/1 (negative) · restoration n/a (reads only)
```

- the surviving sibling still resolves, reaches Accessibility, and returns a real inventory
  — mutation: remove `region.get_regions` alongside the five → **3/4, that check alone goes red**
- the whole reachable read-only surface across every tool still answers
- the removed names did not become reachable — *this check names no mutation and says so*: they
  answered `invalid_params` before the change too, never having been registered for any tool

## Left alone on purpose

Eight more operations share this exact shape — `mixer.set_send`, `set_input`, `set_output`,
`toggle_eq`, `reset_strip`, `plugin.list`, `automation.get_mode`, `set_mode`. Reported, not touched:
#575 is about the region family, and widening a removal past its motivating issue is how a scoped fix
becomes an unreviewed one.

## Gate

`lpm-ship.sh` PASS — 3824 tests, preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.