### PR TITLE
fix(#575): stop move_to_playhead certifying a region the caller never asked about

### DIFF
--- a/Scripts/livekit/live_575_move_to_playhead_identity.py
+++ b/Scripts/livekit/live_575_move_to_playhead_identity.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Live context for the same-region gate added to `region.move_to_playhead`.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_575_move_to_playhead_identity.py <worktree> <full-40-char-head-sha>
+
+WHAT THE CHANGE IS
+------------------
+`defaultMoveSelectedRegionToPlayhead` reads "the selected region" before the Edit ▸ Move ▸ To
+Playhead click and again after it, then returned State A whenever the post-read's start bar sat on
+the playhead. Nothing required the two reads to be about the SAME region. A selection that drifted
+during the click could therefore certify State A on a region the caller never asked about, purely
+because it happens to sit on the playhead. `startBar` cannot be the identity that decides it — that
+is the property the operation exists to change.
+
+The gate now requires the same name AND the same track index, with a `trackIndex` of -1 treated as a
+readback gap rather than a match.
+
+WHAT THIS RUN CAN AND CANNOT SHOW — READ THIS FIRST
+---------------------------------------------------
+`region.move_to_playhead` is reachable from NO tool. There is no live call that reaches the changed
+branch, and this document does not pretend otherwise. The branch is covered by unit tests, including
+a mutation (`sameRegion = true`) that reddens only the two new drift tests.
+
+What the run does show is two things a unit test cannot:
+
+1. The reachable region surface is undisturbed. The change sits in the same file and leans on the
+   same enumeration that `logic_project.get_regions` uses, so the observable half of that machinery
+   is exercised against the real application.
+
+2. Why the gate needs BOTH fields. Logic names regions non-uniquely — measured here, against the real
+   project — so a same-name check on its own would let one region certify another. That is the
+   measurement that makes the shape of the fix a finding rather than a preference.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
+# frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call here is a read.
+HEADER_BAND = (603, 162, 325, 406)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic is up with a project, so the region enumeration has something to read",
+         f"titles={titles!r}", None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("575/before", settle_region=HEADER_BAND)
+
+d = E.Driver()
+time.sleep(4)
+
+body = d.tool("logic_project", "get_regions", {})
+regions = (body.get("regions") or []) if isinstance(body, dict) else []
+names = Counter(r.get("name") for r in regions)
+tracks = [r.get("trackIndex") for r in regions]
+ev.note("575/inventory", {"count": len(regions), "names": dict(names),
+                          "track_indexes": sorted(set(t for t in tracks if t is not None))})
+
+ev.check("575/the-region-enumeration-still-works",
+         isinstance(body, dict) and body.get("error") is None and len(regions) > 0,
+         "`logic_project.get_regions` still routes, reaches Accessibility and returns regions — the "
+         "observable half of the machinery the changed handler leans on is undisturbed",
+         f"error={body.get('error') if isinstance(body, dict) else None!r} regions={len(regions)}",
+         "break `enumerateRegionItems`' content-group lookup: this call returns a failure instead "
+         "of an inventory")
+
+duplicates = {name: n for name, n in names.items() if n > 1}
+ev.check("575/logic-does-not-name-regions-uniquely",
+         bool(duplicates),
+         "more than one region on this project carries the same name, so a same-NAME check alone "
+         "would let one region certify another — which is why the gate compares the track index too",
+         f"duplicate names={duplicates} of {len(regions)} regions",
+         # No mutation: this is a measurement of Logic's naming, not of this repository's code. It
+         # is the reason the fix has the shape it has, and it is recorded as an observation that
+         # could have come out the other way — a project of uniquely named regions would have left
+         # the name-only check defensible.
+         None)
+
+ev.check("575/every-region-carries-a-placed-track-index",
+         all(isinstance(t, int) and t >= 0 for t in tracks),
+         "each region resolved to a real track, so the second half of the gate has a value to "
+         "compare here; a -1 would be the enumeration saying it could not place the region, which "
+         "the gate treats as a readback gap rather than as a match",
+         f"track_indexes={sorted(set(tracks))}",
+         "return -1 from the nearest-header match: the gate stops reaching State A at all, which is "
+         "the fail-closed direction")
+
+sweep = {
+    "logic_system.health": d.tool("logic_system", "health", {}),
+    "logic_project.is_running": d.tool("logic_project", "is_running", {}),
+}
+resources = {
+    "logic://tracks": d.resource("logic://tracks"),
+    "logic://transport/state": d.resource("logic://transport/state"),
+}
+broken = {k: v for k, v in sweep.items()
+          if not isinstance(v, dict) or v.get("error") is not None}
+unreadable = [k for k, v in resources.items() if not isinstance(v, dict)]
+ev.check("575/the-reachable-surface-is-unchanged",
+         not broken and not unreadable,
+         "health, is_running and the state resources all still answer, so the edit to the region "
+         "channel did not disturb anything a caller can reach",
+         f"broken={list(broken)} unreadable={unreadable}",
+         "return a hard error from `defaultGetRegions`: `logic://tracks` is unaffected but the "
+         "region call above goes red, which is how the two checks divide the surface")
+
+after = ev.shot("575/after", settle_region=HEADER_BAND)
+ev.visual("575/no-project-state-was-touched",
+          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          why="every call in this run is a read, so the track-header rail must be byte-identical "
+              "across it — a change here would mean a read path wrote something")
+
+d.close()
+ev.restored("575/nothing-to-restore", True,
+            "this run performs reads only; the negative visual assertion above is the evidence for "
+            "that rather than a claim made here")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -457,12 +457,35 @@ extension AccessibilityChannel {
             let extrasBase: [String: Any] = [
                 "via": "applescript_menu",
                 "region_name": pre.name,
+                "post_region_name": post.name,
+                "pre_track_index": pre.trackIndex,
+                "post_track_index": post.trackIndex,
                 "pre_start_bar": pre.startBar,
                 "post_start_bar": post.startBar,
                 "playhead_bar": playheadBar ?? NSNull()
             ]
 
-            // Verified: post.startBar landed on the playhead bar (±1 tolerance
+            // The pre- and post-reads both ask Logic for "the selected region", and nothing forces
+            // that to be the SAME region across the menu click. Without this, a selection that
+            // drifted mid-click could certify State A on a region the caller never asked about,
+            // purely because it happens to sit on the playhead. `startBar` cannot serve as the
+            // identity here — it is the property this operation exists to change.
+            //
+            // A `trackIndex` of -1 is the enumeration saying it could not place the region against
+            // a track header, so it is a readback gap and not a match.
+            let sameRegion = post.name == pre.name
+                && pre.trackIndex >= 0
+                && post.trackIndex == pre.trackIndex
+            guard sameRegion else {
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackMismatch,
+                    extras: extrasBase.merging([
+                        "note": "the region selected after the move is not the one selected before it"
+                    ]) { _, new in new }
+                ))
+            }
+
+            // Verified: the SAME region's startBar landed on the playhead bar (±1 tolerance
             // for snap rounding). State A.
             if let head = playheadBar, abs(post.startBar - head) <= 1 {
                 var extras = extrasBase

--- a/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
@@ -134,6 +134,92 @@ private func makeRegionFixture(
     #expect(obj["observed"] as? Int == 9)
 }
 
+/// The pre- and post-reads both ask for "the selected region". Nothing in Logic guarantees that is
+/// the SAME region across the menu click, and `startBar` cannot be the identity that decides it —
+/// it is the property this operation exists to change.
+///
+/// Without a same-region gate, a selection that drifted mid-click certifies State A on a region the
+/// caller never asked about, purely because it happens to sit on the playhead. That is a false
+/// State A: performed, and "verified" against the wrong subject.
+@Test func testMoveToPlayheadRefusesStateAWhenTheSelectionDrifted() async {
+    let regionAHelp = "리전은 1 마디 에서 시작하여 3 마디 에서 끝납니다., MIDI 리전."
+    // Already sitting on the playhead, on a different track. If the gate only compared startBar to
+    // the playhead, this region would satisfy it.
+    let regionBHelp = "리전은 9 마디 에서 시작하여 11 마디 에서 끝납니다., MIDI 리전."
+
+    let fixture = makeRegionFixture(
+        headers: [(axPoint(0, 100), axSize(200, 40)), (axPoint(0, 200), axSize(200, 40))],
+        regions: [
+            (name: "RegionA", help: regionAHelp, pos: axPoint(240, 108),
+             size: axSize(320, 24), selected: true),
+            (name: "RegionB", help: regionBHelp, pos: axPoint(900, 208),
+             size: axSize(320, 24), selected: false),
+        ],
+        playheadPosition: "9.1.1.1"
+    )
+
+    let result = await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(
+        runtime: fixture.runtime,
+        executeScript: { _ in
+            // Logic's selection moves to RegionB during the click. RegionA never moves.
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_000), kAXSelectedAttribute as String, false
+            )
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_001), kAXSelectedAttribute as String, true
+            )
+            return .success("OK")
+        },
+        settle: { /* skip in tests */ }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeJSON(result.message)
+    let verified = obj["verified"] as? Bool ?? true
+    #expect(!verified)
+    #expect(obj["state"] as? String == "B")
+    #expect(obj["reason"] as? String == "readback_mismatch")
+    // The envelope has to say WHICH region it ended up looking at, or the caller cannot tell this
+    // from a region that simply failed to move.
+    #expect(obj["region_name"] as? String == "RegionA")
+    #expect(obj["post_region_name"] as? String == "RegionB")
+}
+
+/// A region the enumeration could not place against any track header reports `trackIndex == -1`.
+/// That is a readback gap, and a gap is not a match — pairing it with an equal name would let two
+/// different unplaced regions certify each other.
+@Test func testMoveToPlayheadRefusesStateAWhenTheTrackCannotBePlaced() async {
+    let preHelp = "리전은 1 마디 에서 시작하여 3 마디 에서 끝납니다., MIDI 리전."
+    let postHelp = "리전은 9 마디 에서 시작하여 11 마디 에서 끝납니다., MIDI 리전."
+
+    // No track headers at all, so every region's trackIndex resolves to -1.
+    let fixture = makeRegionFixture(
+        headers: [],
+        regions: [(
+            name: "RegionA", help: preHelp, pos: axPoint(240, 108),
+            size: axSize(320, 24), selected: true
+        )],
+        playheadPosition: "9.1.1.1"
+    )
+
+    let result = await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(
+        runtime: fixture.runtime,
+        executeScript: { _ in
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_000), kAXHelpAttribute as String, postHelp
+            )
+            return .success("OK")
+        },
+        settle: { /* skip in tests */ }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeJSON(result.message)
+    let verified = obj["verified"] as? Bool ?? true
+    #expect(!verified)
+    #expect(obj["pre_track_index"] as? Int == -1)
+}
+
 @Test func testMoveToPlayheadReturnsStateBOnMismatch() async {
     // Pre: bar 1. Action moves region to bar 5 but playhead is at bar 9 →
     // post.startBar(5) ≠ playhead(9) → State B readback_mismatch.


### PR DESCRIPTION
Part of #575. Prerequisite for registering `region.move_to_playhead`, which is the "expose one" half
of that issue.

## The defect

`defaultMoveSelectedRegionToPlayhead` reads *"the selected region"* before the Edit ▸ Move ▸ To
Playhead click and again after it, then returned **State A** whenever the post-read's start bar sat
on the playhead. Nothing required the two reads to be about the **same region**.

A selection that drifts during the click therefore reaches State A on a region nobody asked about,
purely because that region happens to sit on the playhead. State A means performed *and
independently verified*; this one was verified against a subject it never established.

`startBar` cannot be the identity that decides it — it is the property the operation exists to
change.

## The gate

Same name **and** same track index. A `trackIndex` of `-1` is the enumeration saying it could not
place the region against any track header, so it is treated as a readback gap and not as a match.
Both new branches return State B `readback_mismatch` carrying `region_name` and `post_region_name`,
so a caller can tell *"it did not move"* from *"something else moved"*.

## Why both fields — measured, and it could have come out the other way

```
regions: 20   names: {"MIDI Region": 20}   track_indexes: [1 … 20]
```

**Every region on the probe project carries the same name.** A same-name check on its own would let
any one of the twenty certify any other. That is Logic's naming, not this project's — a project of
uniquely named regions would have left a name-only check defensible.

## What the live run covers, and what it does not

`region.move_to_playhead` is reachable from **no tool**, so no live call reaches the changed branch,
and the evidence document says that rather than implying a coverage it does not have. The branch is
covered by unit tests, including mutation `sameRegion = true`, which reddens **only** the two new
drift tests.

What the run adds is what a unit test cannot reach:

```
5 checks · 5 passed · 3 mutation-backed · visual 1/1 (negative) · reads only
```

- the region enumeration this handler leans on still works against the real application
- every region resolves to a real track, so the second half of the gate has a value to compare
- the reachable surface is undisturbed

## Deliberately not in this change

Registering the operation. It is a verified-write mutating operation, so it needs an entry in the
semantic oracle table (#373) — a governed artifact whose phase increments record *when* each contract
was pinned. That belongs in a change reviewable as oracle work, not as a rider on a soundness fix.
The scope is written up on #575.

## Gate

`lpm-ship.sh` PASS — 3826 tests, preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.