### PR TITLE
feat(#575): register move_to_playhead as an edit verb, with its oracle

### DIFF
--- a/Scripts/livekit/ax_region_select.swift
+++ b/Scripts/livekit/ax_region_select.swift
@@ -1,0 +1,133 @@
+// A product-independent way for a harness to put Logic's selection on a KNOWN region.
+//
+// `logic_edit.move_to_playhead` acts on whatever is selected. To prove it moved the right thing, a
+// run has to establish the selection itself and be able to say what it selected — otherwise the
+// operation's own envelope is the only witness to its own subject.
+//
+// This tool does not follow the product's addressing contract, and it does not need to: it reports
+// exactly which region it acted on (Logic's own help string, which carries the bars) so the harness
+// can hold the envelope against something it observed rather than against something it assumed.
+//
+//   swiftc -O ax_region_select.swift -o ax_region_select
+//   ./ax_region_select                 -> {"regions":[{"index":0,"name":…,"help":…,"selected":…}, …],
+//                                          "selected":[…]}
+//
+// READ-ONLY, and that is a finding rather than a simplification. An earlier version of this tool
+// wrote `AXSelected` to put the selection on a chosen region. Measured on Logic 12.3, that write
+// does not behave as a setter: setting it true ADDS to the selection instead of replacing it, and a
+// pass that set it false on every other region left eighteen of them selected and the target NOT
+// selected — the opposite of both writes. The return codes were `.success` throughout.
+//
+// So the harness does not drive the selection. It reads it, requires exactly one, and lets the
+// product establish that one (an import leaves its new region selected). A witness that cannot
+// write also cannot be accused of having caused what it reports.
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+func attr(_ element: AXUIElement, _ name: String) -> AnyObject? {
+    var value: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+        return nil
+    }
+    return value
+}
+
+func role(_ element: AXUIElement) -> String {
+    (attr(element, kAXRoleAttribute as String) as? String) ?? ""
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    (attr(element, kAXChildrenAttribute as String) as? [AXUIElement]) ?? []
+}
+
+func help(_ element: AXUIElement) -> String {
+    (attr(element, kAXHelpAttribute as String) as? String) ?? ""
+}
+
+/// The arrange window's track-content group — the same landmark `enumerateRegionItems` uses.
+///
+/// Scoping matters: walking the whole application picked up the Piano Roll's own region item and the
+/// Inspector's, so the count moved between two calls seconds apart (23, then 40) and an index meant
+/// different things each time. A witness whose index space is unstable is not a witness.
+func trackContentGroup(_ root: AXUIElement, depth: Int = 0) -> AXUIElement? {
+    guard depth < 16 else { return nil }
+    for child in children(root) {
+        if role(child) == (kAXGroupRole as String) {
+            let description = (attr(child, kAXDescriptionAttribute as String) as? String) ?? ""
+            // Measured live: Logic labels it "Tracks contents" on this build, not "Track Content".
+            // Compared case- and space-insensitively against the same renderings AXLocalePolicy
+            // carries, so a guess about the exact wording cannot silently return the wrong group.
+            let normalized = description.lowercased().replacingOccurrences(of: " ", with: "")
+            let isContent = (normalized.contains("track") && normalized.contains("content"))
+                || (normalized.contains("트랙") && normalized.contains("콘텐츠"))
+            if isContent {
+                return child
+            }
+        }
+        if let hit = trackContentGroup(child, depth: depth + 1) { return hit }
+    }
+    return nil
+}
+
+/// Every layout item whose help text names it a region, depth-first. The keyword is matched in the
+/// English and Korean renderings Logic uses; a locale this does not cover yields an empty list,
+/// which fails the harness's precondition rather than silently reporting nothing selected.
+func regionItems(_ root: AXUIElement, depth: Int = 0) -> [AXUIElement] {
+    guard depth < 24 else { return [] }
+    var found: [AXUIElement] = []
+    for child in children(root) {
+        if role(child) == (kAXLayoutItemRole as String) {
+            let text = help(child)
+            if text.contains("Region") || text.contains("region") || text.contains("리전") {
+                found.append(child)
+            }
+        }
+        found.append(contentsOf: regionItems(child, depth: depth + 1))
+    }
+    return found
+}
+
+func jsonString(_ value: String?) -> String {
+    guard let value, let data = try? JSONSerialization.data(withJSONObject: [value]),
+          let text = String(data: data, encoding: .utf8) else { return "null" }
+    return String(text.dropFirst().dropLast())
+}
+
+func describe(_ item: AXUIElement, index: Int) -> String {
+    let name = attr(item, kAXDescriptionAttribute as String) as? String
+    let selected = (attr(item, kAXSelectedAttribute as String) as? NSNumber)?.boolValue
+    var y = "null"
+    if let raw = attr(item, kAXPositionAttribute as String) {
+        var point = CGPoint.zero
+        // swiftlint:disable:next force_cast
+        if AXValueGetValue(raw as! AXValue, .cgPoint, &point) { y = "\(Int(point.y))" }
+    }
+    return """
+    {"index":\(index),"name":\(jsonString(name)),"help":\(jsonString(help(item))),\
+    "selected":\(selected.map { $0 ? "true" : "false" } ?? "null"),"y":\(y)}
+    """
+}
+
+guard let app = NSWorkspace.shared.runningApplications.first(where: {
+    $0.bundleIdentifier == "com.apple.logic10"
+}) else {
+    print("{\"error\":\"logic_not_running\"}")
+    exit(2)
+}
+
+let appElement = AXUIElementCreateApplication(app.processIdentifier)
+guard let content = trackContentGroup(appElement) else {
+    print("{\"error\":\"track_content_group_not_found\"}")
+    exit(3)
+}
+
+let items = regionItems(content)
+let listing = items.enumerated().map { describe($0.element, index: $0.offset) }.joined(separator: ",")
+let selected = items.enumerated()
+    .filter { (attr($0.element, kAXSelectedAttribute as String) as? NSNumber)?.boolValue == true }
+    .map(\.offset)
+print("""
+{"regions":[\(listing)],"selected":[\(selected.map(String.init).joined(separator: ","))]}
+""")

--- a/Scripts/livekit/live_575_move_to_playhead_identity.py
+++ b/Scripts/livekit/live_575_move_to_playhead_identity.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Live context for the same-region gate added to `region.move_to_playhead`.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_575_move_to_playhead_identity.py <worktree> <full-40-char-head-sha>
+
+WHAT THE CHANGE IS
+------------------
+`defaultMoveSelectedRegionToPlayhead` reads "the selected region" before the Edit ▸ Move ▸ To
+Playhead click and again after it, then returned State A whenever the post-read's start bar sat on
+the playhead. Nothing required the two reads to be about the SAME region. A selection that drifted
+during the click could therefore certify State A on a region the caller never asked about, purely
+because it happens to sit on the playhead. `startBar` cannot be the identity that decides it — that
+is the property the operation exists to change.
+
+The gate now requires the same name AND the same track index, with a `trackIndex` of -1 treated as a
+readback gap rather than a match.
+
+WHAT THIS RUN CAN AND CANNOT SHOW — READ THIS FIRST
+---------------------------------------------------
+`region.move_to_playhead` is reachable from NO tool. There is no live call that reaches the changed
+branch, and this document does not pretend otherwise. The branch is covered by unit tests, including
+a mutation (`sameRegion = true`) that reddens only the two new drift tests.
+
+What the run does show is two things a unit test cannot:
+
+1. The reachable region surface is undisturbed. The change sits in the same file and leans on the
+   same enumeration that `logic_project.get_regions` uses, so the observable half of that machinery
+   is exercised against the real application.
+
+2. Why the gate needs BOTH fields. Logic names regions non-uniquely — measured here, against the real
+   project — so a same-name check on its own would let one region certify another. That is the
+   measurement that makes the shape of the fix a finding rather than a preference.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
+# frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call here is a read.
+HEADER_BAND = (603, 162, 325, 406)
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic is up with a project, so the region enumeration has something to read",
+         f"titles={titles!r}", None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("575/before", settle_region=HEADER_BAND)
+
+d = E.Driver()
+time.sleep(4)
+
+body = d.tool("logic_project", "get_regions", {})
+regions = (body.get("regions") or []) if isinstance(body, dict) else []
+names = Counter(r.get("name") for r in regions)
+tracks = [r.get("trackIndex") for r in regions]
+ev.note("575/inventory", {"count": len(regions), "names": dict(names),
+                          "track_indexes": sorted(set(t for t in tracks if t is not None))})
+
+ev.check("575/the-region-enumeration-still-works",
+         isinstance(body, dict) and body.get("error") is None and len(regions) > 0,
+         "`logic_project.get_regions` still routes, reaches Accessibility and returns regions — the "
+         "observable half of the machinery the changed handler leans on is undisturbed",
+         f"error={body.get('error') if isinstance(body, dict) else None!r} regions={len(regions)}",
+         "break `enumerateRegionItems`' content-group lookup: this call returns a failure instead "
+         "of an inventory")
+
+duplicates = {name: n for name, n in names.items() if n > 1}
+ev.check("575/logic-does-not-name-regions-uniquely",
+         bool(duplicates),
+         "more than one region on this project carries the same name, so a same-NAME check alone "
+         "would let one region certify another — which is why the gate compares the track index too",
+         f"duplicate names={duplicates} of {len(regions)} regions",
+         # No mutation: this is a measurement of Logic's naming, not of this repository's code. It
+         # is the reason the fix has the shape it has, and it is recorded as an observation that
+         # could have come out the other way — a project of uniquely named regions would have left
+         # the name-only check defensible.
+         None)
+
+ev.check("575/every-region-carries-a-placed-track-index",
+         all(isinstance(t, int) and t >= 0 for t in tracks),
+         "each region resolved to a real track, so the second half of the gate has a value to "
+         "compare here; a -1 would be the enumeration saying it could not place the region, which "
+         "the gate treats as a readback gap rather than as a match",
+         f"track_indexes={sorted(set(tracks))}",
+         "return -1 from the nearest-header match: the gate stops reaching State A at all, which is "
+         "the fail-closed direction")
+
+sweep = {
+    "logic_system.health": d.tool("logic_system", "health", {}),
+    "logic_project.is_running": d.tool("logic_project", "is_running", {}),
+}
+resources = {
+    "logic://tracks": d.resource("logic://tracks"),
+    "logic://transport/state": d.resource("logic://transport/state"),
+}
+broken = {k: v for k, v in sweep.items()
+          if not isinstance(v, dict) or v.get("error") is not None}
+unreadable = [k for k, v in resources.items() if not isinstance(v, dict)]
+ev.check("575/the-reachable-surface-is-unchanged",
+         not broken and not unreadable,
+         "health, is_running and the state resources all still answer, so the edit to the region "
+         "channel did not disturb anything a caller can reach",
+         f"broken={list(broken)} unreadable={unreadable}",
+         "return a hard error from `defaultGetRegions`: `logic://tracks` is unaffected but the "
+         "region call above goes red, which is how the two checks divide the surface")
+
+after = ev.shot("575/after", settle_region=HEADER_BAND)
+ev.visual("575/no-project-state-was-touched",
+          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          why="every call in this run is a read, so the track-header rail must be byte-identical "
+              "across it — a change here would mean a read path wrote something")
+
+d.close()
+ev.restored("575/nothing-to-restore", True,
+            "this run performs reads only; the negative visual assertion above is the evidence for "
+            "that rather than a claim made here")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_575_move_to_playhead_reachable.py
+++ b/Scripts/livekit/live_575_move_to_playhead_reachable.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Live proof that `logic_edit.move_to_playhead` moves the region it says it moved.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_575_move_to_playhead_reachable.py <worktree> <full-40-char-head-sha>
+
+WHAT IS NEW
+-----------
+`region.move_to_playhead` has been implemented and verified since v3.1.3 and was reachable from no
+tool. It is now registered as `logic_edit.move_to_playhead`, an edit-family verb on the current
+selection — the same contract `cut`, `split` and `join` already ship, because Logic's selection names
+the subject and the caller does not.
+
+Its State A gate was also tightened first: it now requires the SAME region (same name, same track)
+before and after the menu click. Without that, a selection that drifted mid-click could certify a
+region the caller never asked about, purely because that region happens to sit on the playhead.
+
+HOW THE SELECTION IS ESTABLISHED, AND WHY NOT BY THIS HARNESS
+-------------------------------------------------------------
+An earlier version of the witness below wrote `AXSelected` to place the selection on a chosen
+region. Measured on Logic 12.3, that write does not behave as a setter: setting it true ADDS to the
+selection rather than replacing it, and a pass that set it false on eighteen other regions left
+those eighteen selected and the target NOT selected — the opposite of both writes, with `.success`
+returned throughout.
+
+So the selection is established the way a caller would: `record_sequence` imports a region and Logic
+leaves that region, and only that region, selected. Measured here as a precondition rather than
+assumed. The witness is READ-ONLY, which also means it cannot be accused of having caused what it
+reports.
+
+THE WITNESS IS NOT THE PRODUCT'S OWN READBACK
+---------------------------------------------
+`ax_region_select.swift` reads Logic's region help strings straight out of the arrange window's
+track-content group. The operation's envelope is checked against that, not only against itself, so
+"it moved" has a second source. The witness is scoped to that one group on purpose: an earlier pass
+walked the whole application, picked up the Piano Roll's own region item, and reported 23 regions on
+one call and 40 on the next — an index space that moves is not a witness.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Measured band over the arrange CONTENT area (right of the track-header rail, which ends at
+# x=928): the window sits at 0,30 and the content group starts just past the headers. This is where
+# a region that moved has to leave a mark.
+CONTENT_BAND = (940, 162, 500, 300)
+TARGET_BAR = 9
+WITNESS_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_region_select.swift")
+WITNESS = os.path.join(ev.dir, "ax_region_select")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def witness():
+    r = subprocess.run([WITNESS], capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"error": (r.stdout or r.stderr or "")[:200]}
+
+
+def undo_title():
+    """What Logic says its Edit > Undo entry would undo, verbatim."""
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'return name of menu item 1 of menu 1 of menu bar item "Edit" of menu bar 1')
+
+
+def start_bar(help_text):
+    """The bar Logic's own help string says a region starts at."""
+    match = re.search(r"(?:starts at|시작)\D*(\d+)", help_text or "")
+    return int(match.group(1)) if match else None
+
+
+def selected_region(state):
+    regions = state.get("regions") or []
+    picked = [regions[i] for i in (state.get("selected") or []) if i < len(regions)]
+    return picked[0] if len(picked) == 1 else None
+
+
+build = subprocess.run(["swiftc", "-O", WITNESS_SOURCE, "-o", WITNESS], capture_output=True, text=True)
+ev.check("575/precondition-the-independent-region-witness-builds",
+         build.returncode == 0 and os.path.exists(WITNESS),
+         "the harness's own region reader compiles, so the envelope is checked against something "
+         "that is not the code under test",
+         f"swiftc rc={build.returncode} {build.stderr.strip()[:200]}", None)
+
+titles = osa('tell application "System Events" to tell process "Logic Pro" to '
+             'return name of every window')
+ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
+         "Logic is up with an arrange window to move a region inside",
+         f"titles={titles!r}", None)
+
+if build.returncode != 0 or "Tracks" not in titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=240)
+d = E.Driver()
+time.sleep(4)
+
+# ---- establish a single known selection, through the product ------------------------------------
+
+created = d.tool("logic_tracks", "record_sequence", {"notes": "60,0,480"})
+time.sleep(3)
+before_state = witness()
+target = selected_region(before_state)
+ev.note("575/created", {k: v for k, v in created.items() if k != "raw_help"}
+        if isinstance(created, dict) else {"raw": str(created)[:200]})
+ev.note("575/selection-before", {"selected": before_state.get("selected"),
+                                 "regions": len(before_state.get("regions") or []),
+                                 "target_help": (target or {}).get("help", "")[:80]})
+
+ev.check("575/precondition-exactly-one-region-is-selected",
+         target is not None,
+         "the import left exactly one region selected, so 'the selected region' names one thing and "
+         "the operation below has an unambiguous subject",
+         f"selected={before_state.get('selected')!r} of "
+         f"{len(before_state.get('regions') or [])} regions", None)
+
+pre_bar = start_bar((target or {}).get("help", ""))
+ev.check("575/precondition-the-target-starts-somewhere-other-than-the-playhead",
+         pre_bar is not None and pre_bar != TARGET_BAR,
+         f"the selected region starts at a bar that is not {TARGET_BAR}, so a successful move has to "
+         f"CHANGE something — a region already sitting on the playhead would let a no-op pass",
+         f"pre_bar={pre_bar!r} target_bar={TARGET_BAR}", None)
+
+if target is None or pre_bar is None or pre_bar == TARGET_BAR:
+    d.close(); ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+undo_before = undo_title()
+before_shot = ev.shot("575/before-move", settle_region=CONTENT_BAND)
+seek = d.tool("logic_transport", "goto_position", {"bar": str(TARGET_BAR)})
+time.sleep(2)
+ev.note("575/seek", seek if isinstance(seek, dict) else {"raw": str(seek)[:200]})
+
+# ---- the operation ------------------------------------------------------------------------------
+
+moved = d.tool("logic_edit", "move_to_playhead", {})
+time.sleep(2)
+after_state = witness()
+after_target = selected_region(after_state)
+post_bar = start_bar((after_target or {}).get("help", ""))
+after_shot = ev.shot("575/after-move", settle_region=CONTENT_BAND)
+ev.note("575/move", moved if isinstance(moved, dict) else {"raw": str(moved)[:300]})
+
+body = moved if isinstance(moved, dict) else {}
+ev.check("575/the-operation-is-reachable-at-all",
+         body.get("error") != "invalid_params",
+         "`logic_edit.move_to_playhead` reaches its dispatcher instead of being refused as an "
+         "unregistered command — which is what it did before this change",
+         f"error={body.get('error')!r} hint={str(body.get('hint'))[:120]!r}",
+         "remove the registry row: the call comes back `invalid_params` with "
+         "\"is not registered for MCP tool 'logic_edit'\" and every check below is unreachable")
+
+ev.check("575/the-move-is-verified-not-merely-attempted",
+         body.get("state") == "A" and body.get("verified") is True,
+         "the envelope is State A: the operation performed the move AND read back the result, "
+         "rather than reporting an unverifiable attempt",
+         f"state={body.get('state')!r} verified={body.get('verified')!r} "
+         f"reason={body.get('reason')!r}",
+         "make `selectedRegionInfo` return nil after the click: the handler falls to State B "
+         "readback_unavailable and this check goes red while the reachability check above stays "
+         "green")
+
+ev.check("575/it-verified-against-the-same-region-it-started-with",
+         body.get("region_name") == body.get("post_region_name")
+         and isinstance(body.get("pre_track_index"), int)
+         and body.get("pre_track_index") >= 0
+         and body.get("pre_track_index") == body.get("post_track_index"),
+         "the region read after the move is the same one read before it, by name and by track — "
+         "without this a selection that drifted mid-click could certify a region the caller never "
+         "asked about, purely because it happens to sit on the playhead",
+         f"name {body.get('region_name')!r} -> {body.get('post_region_name')!r} · track "
+         f"{body.get('pre_track_index')!r} -> {body.get('post_track_index')!r}",
+         "restore `sameRegion = true`: the two drift unit tests go red, and this check is the live "
+         "counterpart that shows the fields it compares are really on the envelope")
+
+ev.check("575/it-actually-moved-and-landed-on-the-playhead",
+         isinstance(body.get("pre_start_bar"), int)
+         and isinstance(body.get("post_start_bar"), int)
+         and body["pre_start_bar"] != body["post_start_bar"]
+         and abs(body["post_start_bar"] - TARGET_BAR) <= 1,
+         f"the region's start bar changed and ended up on bar {TARGET_BAR} within the one-bar snap "
+         f"tolerance — a no-op that reported the playhead value would fail the first half",
+         f"start bar {body.get('pre_start_bar')!r} -> {body.get('post_start_bar')!r} · "
+         f"playhead={body.get('playhead_bar')!r}",
+         "return the pre-click start bar as `post_start_bar`: the equality half goes red while the "
+         "playhead half still passes, which is the pair that separates a move from a report")
+
+ev.check("575/an-independent-reader-agrees-the-region-is-there-now",
+         post_bar is not None and abs(post_bar - TARGET_BAR) <= 1 and post_bar != pre_bar,
+         "Logic's own help string on the still-selected region, read by a tool that is not the "
+         "product, says it now starts on the playhead bar and no longer where it started",
+         f"witness bar {pre_bar!r} -> {post_bar!r} (target {TARGET_BAR})",
+         "have the handler report success without performing the menu click: the envelope still "
+         "claims the move, and this check — which never reads the envelope — goes red")
+
+ev.visual("575/the-region-visibly-moved",
+          before_shot["file"], after_shot["file"], CONTENT_BAND, expect_change=True,
+          why="a region that moved from one bar to another is drawn somewhere else in the arrange "
+              "content, so the band must differ — an envelope that claimed a move the screen did "
+              "not show would be describing something other than what the user sees")
+
+# ---- restore ------------------------------------------------------------------------------------
+#
+# `logic_edit.undo` routes to the send-only key-command channels and did NOT undo the move when this
+# harness first tried it — the region stayed where it had been moved to. That is recorded below as
+# an observation, not asserted as a defect: those channels need a bound key command and this host's
+# binding was never established by this run.
+#
+# The restoration therefore goes through Logic's own Edit menu, and it is self-verifying in a way
+# that needs no knowledge of the menu's language: the entry's title is captured BEFORE the move and
+# again after it, and the click only happens if the title CHANGED — which is Logic saying this run's
+# action is what sits on top of the undo stack.
+
+tool_undo = d.tool("logic_edit", "undo", {})
+time.sleep(2)
+after_tool_undo = start_bar((selected_region(witness()) or {}).get("help", ""))
+undo_after = undo_title()
+ev.note("575/undo", {"tool_undo": str(tool_undo)[:200], "bar_after_tool_undo": after_tool_undo,
+                     "undo_title_before_move": undo_before, "undo_title_after_move": undo_after})
+
+menu_undo_ran = False
+if after_tool_undo != pre_bar and undo_after and undo_after != undo_before:
+    osa('tell application "System Events" to tell process "Logic Pro" to click '
+        f'(first menu item of menu 1 of menu bar item "Edit" of menu bar 1 whose name is "{undo_after}")')
+    time.sleep(2.5)
+    menu_undo_ran = True
+
+restored_bar = start_bar((selected_region(witness()) or {}).get("help", ""))
+d.close()
+
+ev.restored("575/the-move-was-undone",
+            restored_bar == pre_bar,
+            f"the region is back at bar {restored_bar!r} (it started at {pre_bar!r}). "
+            f"logic_edit.undo left it at {after_tool_undo!r}; the menu entry Logic titled "
+            f"{undo_after!r} (it read {undo_before!r} before the move, so the move was on top of "
+            f"the undo stack) was {'used' if menu_undo_ran else 'not needed'}. The imported track "
+            f"this run created to obtain a single selection is left in place: removing it would "
+            f"need a destructive operation this run has no reason to perform, and the project is a "
+            f"scratch document.")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_575_move_to_playhead_reachable.py
+++ b/Scripts/livekit/live_575_move_to_playhead_reachable.py
@@ -81,6 +81,16 @@ def witness():
         return {"error": (r.stdout or r.stderr or "")[:200]}
 
 
+def logic_ui_language():
+    """What language Logic's own menu bar is in, read from Logic rather than from `defaults`.
+
+    `defaults read com.apple.logic10 AppleLanguages` says what the NEXT launch will use. This says
+    what the running one actually did, which is the only thing a locale claim may rest on.
+    """
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'return name of menu bar item 4 of menu bar 1')
+
+
 def undo_title():
     """What Logic says its Edit > Undo entry would undo, verbatim."""
     return osa('tell application "System Events" to tell process "Logic Pro" to '
@@ -88,9 +98,27 @@ def undo_title():
 
 
 def start_bar(help_text):
-    """The bar Logic's own help string says a region starts at."""
-    match = re.search(r"(?:starts at|시작)\D*(\d+)", help_text or "")
-    return int(match.group(1)) if match else None
+    """The bar Logic's own help string says a region starts at.
+
+    The two languages put the number on OPPOSITE SIDES of the verb, and an earlier version of this
+    took the first digits after it in both:
+
+        en   "Region starts at 1 bar  and ends at 2 bars"      1 follows "starts at"
+        ko   "리전은 1 마디 에서 시작하여 2 마디 에서 끝납니다"    1 PRECEDES "시작", 2 follows it
+
+    So on Korean it read the END bar and called it the start. That is not a crash — it is a check
+    passing for the wrong reason: after a move to bar 9 the Korean help reads "9 마디 … 시작하여 10
+    마디", the reader returned 10, and `abs(10 - 9) <= 1` still let the assertion through. A witness
+    that agrees by accident is worse than none, because the run reports it as corroboration.
+
+    Found by a blind review of this file, not by a red run.
+    """
+    text = help_text or ""
+    korean = re.search(r"(\d+)\s*마디[^0-9]*시작", text)
+    if korean:
+        return int(korean.group(1))
+    english = re.search(r"starts at\D*(\d+)", text)
+    return int(english.group(1)) if english else None
 
 
 def selected_region(state):
@@ -106,14 +134,31 @@ ev.check("575/precondition-the-independent-region-witness-builds",
          "that is not the code under test",
          f"swiftc rc={build.returncode} {build.stderr.strip()[:200]}", None)
 
+# The arrange window's title SUFFIX is localized — "… - Tracks" in English, "… - 트랙" in Korean
+# (#519). Matching on the English word would find no window on a Korean Logic, and every capture in
+# the run would record `window: null` while Logic was plainly on screen. So the run reads the live
+# window list and carries the full title forward instead of assuming a word.
 titles = osa('tell application "System Events" to tell process "Logic Pro" to '
              'return name of every window')
-ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
-         "Logic is up with an arrange window to move a region inside",
-         f"titles={titles!r}", None)
+window_titles = [t.strip() for t in titles.split(",") if t.strip()]
+# Logic's project chooser can sit alongside an open project — since #590 it no longer blocks
+# `project.new`, so a session that created its project from a cold launch legitimately has both on
+# screen. It is not a document and it is not what this run captures, so it is set aside by name.
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+document_titles = [t for t in window_titles
+                   if not any(c in t for c in CHOOSER_TITLES)]
+arrange_title = document_titles[0] if len(document_titles) == 1 else ""
+ev.check("575/precondition-exactly-one-project-window-is-open",
+         bool(arrange_title),
+         "exactly one Logic window is a project window, so the arrange window is unambiguous and "
+         "its full title — whatever language it is in — can be used to find it on screen; the "
+         "project chooser is set aside because it may legitimately be on screen beside a project",
+         f"all={window_titles!r} project windows={document_titles!r}", None)
 
-if build.returncode != 0 or "Tracks" not in titles:
+if build.returncode != 0 or not arrange_title:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+ev.note("575/locale", {"windows": window_titles, "edit_menu_bar_item": logic_ui_language()})
 
 rec = ev.record_screen(seconds=240)
 d = E.Driver()
@@ -150,10 +195,13 @@ if target is None or pre_bar is None or pre_bar == TARGET_BAR:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
 undo_before = undo_title()
-before_shot = ev.shot("575/before-move", settle_region=CONTENT_BAND)
 seek = d.tool("logic_transport", "goto_position", {"bar": str(TARGET_BAR)})
 time.sleep(2)
 ev.note("575/seek", seek if isinstance(seek, dict) else {"raw": str(seek)[:200]})
+# Captured AFTER the seek, deliberately. The playhead line moving from bar 1 to bar 9 changes this
+# band on its own, so a "before" taken ahead of the seek would let the visual assertion pass on the
+# playhead alone — it would be claiming the region moved while measuring that the cursor did.
+before_shot = ev.shot("575/before-move", settle_region=CONTENT_BAND, window_title=arrange_title)
 
 # ---- the operation ------------------------------------------------------------------------------
 
@@ -162,7 +210,7 @@ time.sleep(2)
 after_state = witness()
 after_target = selected_region(after_state)
 post_bar = start_bar((after_target or {}).get("help", ""))
-after_shot = ev.shot("575/after-move", settle_region=CONTENT_BAND)
+after_shot = ev.shot("575/after-move", settle_region=CONTENT_BAND, window_title=arrange_title)
 ev.note("575/move", moved if isinstance(moved, dict) else {"raw": str(moved)[:300]})
 
 body = moved if isinstance(moved, dict) else {}

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Regions.swift
@@ -457,12 +457,35 @@ extension AccessibilityChannel {
             let extrasBase: [String: Any] = [
                 "via": "applescript_menu",
                 "region_name": pre.name,
+                "post_region_name": post.name,
+                "pre_track_index": pre.trackIndex,
+                "post_track_index": post.trackIndex,
                 "pre_start_bar": pre.startBar,
                 "post_start_bar": post.startBar,
                 "playhead_bar": playheadBar ?? NSNull()
             ]
 
-            // Verified: post.startBar landed on the playhead bar (±1 tolerance
+            // The pre- and post-reads both ask Logic for "the selected region", and nothing forces
+            // that to be the SAME region across the menu click. Without this, a selection that
+            // drifted mid-click could certify State A on a region the caller never asked about,
+            // purely because it happens to sit on the playhead. `startBar` cannot serve as the
+            // identity here — it is the property this operation exists to change.
+            //
+            // A `trackIndex` of -1 is the enumeration saying it could not place the region against
+            // a track header, so it is a readback gap and not a match.
+            let sameRegion = post.name == pre.name
+                && pre.trackIndex >= 0
+                && post.trackIndex == pre.trackIndex
+            guard sameRegion else {
+                return .success(HonestContract.encodeStateB(
+                    reason: .readbackMismatch,
+                    extras: extrasBase.merging([
+                        "note": "the region selected after the move is not the one selected before it"
+                    ]) { _, new in new }
+                ))
+            }
+
+            // Verified: the SAME region's startBar landed on the playhead bar (±1 tolerance
             // for snap rounding). State A.
             if let head = playheadBar, abs(post.startBar - head) <= 1 {
                 var extras = extrasBase

--- a/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/EditDispatcher.swift
@@ -24,6 +24,12 @@ struct EditDispatcher: OperationTraceDispatching {
         "normalize": .regular("edit.normalize"),
         "duplicate": .regular("edit.duplicate"),
         "toggle_step_input": .regular("edit.toggle_step_input"),
+        // #575: the only region verb this tool carries. It is a SELECTION-relative edit, exactly
+        // like cut/split/join above — the caller does not name a region, Logic's selection does —
+        // and it routes to the region channel rather than to an `edit.*` operation. Unverified is
+        // an error to the caller: the channel returns State A only when the same region it started
+        // with landed on the playhead, and anything short of that is not a move to build on.
+        "move_to_playhead": .unverifiedIsError("region.move_to_playhead"),
     ]
 
     private static let validQuantizeGrids = [
@@ -35,9 +41,15 @@ struct EditDispatcher: OperationTraceDispatching {
         description: """
             Editing actions in Logic Pro. \
             Commands: undo, redo, cut, copy, paste, delete, select_all, \
-            split, join, quantize, bounce_in_place, normalize, duplicate, toggle_step_input. \
+            split, join, quantize, bounce_in_place, normalize, duplicate, toggle_step_input, \
+            move_to_playhead. \
             Params by command: \
             quantize -> { value: String } ("1/4", "1/8", "1/16", etc.); \
+            move_to_playhead -> {} moves the SELECTED region to the playhead and verifies it: \
+            State A only when the same region (same name, same track) is selected after the move \
+            and its start bar landed on the playhead within one bar; State B when the readback is \
+            unavailable, when the region did not move, or when the selection changed underneath \
+            the operation; \
             Most others -> {} (operate on current selection)
             """,
         inputSchema: .object([
@@ -64,7 +76,7 @@ struct EditDispatcher: OperationTraceDispatching {
     ) async -> CallTool.Result {
         switch command {
         case "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
-             "bounce_in_place", "normalize", "duplicate", "toggle_step_input":
+             "bounce_in_place", "normalize", "duplicate", "toggle_step_input", "move_to_playhead":
             guard let route = routedCommands[command] else {
                 return toolTextResult("Internal edit route missing for \(command)", isError: true)
             }

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -213,19 +213,39 @@ enum SemanticOracleTable {
         .editToggleStepInput,
     ]
 
+    /// Mutating operations registered AFTER B4 closed the inventory.
+    ///
+    /// B4 closed the surface as it stood. It could not close it forever: the closure is a property
+    /// of the registry, and registering a new mutating operation reopens it. That is not a defect in
+    /// B4 — it is what `everyMutatingSpecIsCoveredOrAuditedExcluded` exists to catch, and it did:
+    /// registering `edit.move_to_playhead` (#575) failed that invariant until this entry existed.
+    ///
+    /// So the rule the phases encode is not "B4 was last" but "a mutating operation joins the
+    /// covered set or the audited-exclusion set IN THE SAME CHANGE THAT REGISTERS IT". Entries here
+    /// are kept separate from B1..B4 because those sets record what was pinned when, and back-dating
+    /// a later operation into them would falsify that record.
+    ///
+    /// `edit.move_to_playhead` belongs on the covered side: the handler re-reads the selected region
+    /// and the playhead after the menu click and reaches a genuine State A.
+    static let postClosureMutatingOperationIDs: Set<OperationID> = [
+        .editMoveToPlayhead,
+    ]
+
     /// Every mutating operation the table covers: the B1 verified-write increment
     /// UNION the B2 transport/navigate increment UNION the B3
     /// project/tracks/system/midi increment UNION the B4 plugin-insert / export /
-    /// cleanup / edit increment. B4 is the FINAL increment: with it, the covered set
-    /// plus `structurallyUnverifiedMutatingOperationIDs` account for the ENTIRE
-    /// mutating surface (`everyMutatingSpecIsCoveredOrAuditedExcluded`), so the
-    /// pure-code mutating oracle inventory is closed — no mutating spec is left
-    /// implicitly uncovered.
+    /// cleanup / edit increment, UNION anything registered after B4 closed the
+    /// inventory. Together with `structurallyUnverifiedMutatingOperationIDs` these
+    /// account for the ENTIRE mutating surface
+    /// (`everyMutatingSpecIsCoveredOrAuditedExcluded`), so no mutating spec is left
+    /// implicitly uncovered — an invariant that is maintained on every change, not
+    /// established once.
     static var coveredMutatingOperationIDs: Set<OperationID> {
         phaseB1MutatingOperationIDs
             .union(phaseB2MutatingOperationIDs)
             .union(phaseB3MutatingOperationIDs)
             .union(phaseB4MutatingOperationIDs)
+            .union(postClosureMutatingOperationIDs)
     }
 
     /// The mutating surface (non-`.unsupported`), from the registry. Coverage is
@@ -493,6 +513,9 @@ enum SemanticOracleTable {
         projectExportResume,
         projectCleanupApply,
         editToggleStepInput,
+        // #575 — registered after B4 closed the inventory; see
+        // `postClosureMutatingOperationIDs` for why it is kept out of the phase sets.
+        editMoveToPlayhead,
     ]
 
     static let byOperationID: [OperationID: OperationOracle] = Dictionary(
@@ -2198,6 +2221,37 @@ enum SemanticOracleTable {
             .valueEquals(key: "operation", expected: .string("edit.toggle_step_input")),
             .valueEquals(key: "via", expected: .string("window-menu")),
             .booleanFlipped(keyA: "observed_open", keyB: "previous_open"),
+        ]
+    )
+
+    // AccessibilityChannel+Regions `defaultMoveSelectedRegionToPlayhead` → encodeStateA
+    // (EditDispatcher routes the command to `region.move_to_playhead`, whose only channel is
+    // .accessibility). Derived by reading the handler, and every predicate below relates two
+    // INDEPENDENT reads rather than echoing an input back:
+    //
+    //   region_name / post_track_index   the selected region read BEFORE the menu click and the one
+    //                                    read AFTER it. State A is reached only when they are the
+    //                                    same region, which is what stops a selection that drifted
+    //                                    mid-click from certifying a region the caller never asked
+    //                                    about (#575). `startBar` cannot serve as that identity —
+    //                                    it is the property the operation changes.
+    //   observed / post_start_bar        `observed` IS the post-click start bar; pinned so a future
+    //                                    edit cannot quietly report the requested value there.
+    //   requested / playhead_bar         `requested` IS the playhead read from the transport, not a
+    //                                    caller-supplied number — this operation takes no params.
+    //   post_start_bar ~ playhead_bar    the landing rule, with the ±1 the handler allows for snap
+    //                                    rounding. NOT `.fieldsEqual`: State A does not promise an
+    //                                    exact match, and pinning one would describe a contract the
+    //                                    handler never made.
+    static let editMoveToPlayhead = SafeMutationOracle.oracle(
+        .editMoveToPlayhead,
+        semantics: [
+            .fieldsEqual(keyA: "region_name", keyB: "post_region_name"),
+            .fieldsEqual(keyA: "pre_track_index", keyB: "post_track_index"),
+            .fieldsEqual(keyA: "observed", keyB: "post_start_bar"),
+            .fieldsEqual(keyA: "requested", keyB: "playhead_bar"),
+            .numericNear(keyA: "post_start_bar", keyB: "playhead_bar", within: .absolute(1)),
+            .typedField(key: "via", type: .string),
         ]
     )
 }

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -58,6 +58,7 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case editNormalize = "edit.normalize"
     case editDuplicate = "edit.duplicate"
     case editToggleStepInput = "edit.toggle_step_input"
+    case editMoveToPlayhead = "edit.move_to_playhead"
     case projectNew = "project.new"
     case projectOpen = "project.open"
     case projectSave = "project.save"
@@ -314,6 +315,7 @@ enum OperationRegistry {
             "edit.undo", "edit.redo", "edit.cut", "edit.copy", "edit.paste", "edit.delete",
             "edit.select_all", "edit.split", "edit.join", "edit.quantize",
             "edit.bounce_in_place", "edit.normalize", "edit.duplicate", "edit.toggle_step_input",
+            "edit.move_to_playhead",
         ],
         ToolID.logicProject.rawValue: [
             "project.new", "project.open", "project.save", "project.save_as", "project.close",
@@ -369,6 +371,7 @@ enum OperationRegistry {
         ToolID.logicEdit.rawValue: [
             "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
             "quantize", "bounce_in_place", "normalize", "duplicate", "toggle_step_input",
+            "move_to_playhead",
         ],
         ToolID.logicProject.rawValue: [
             "new", "open", "save", "save_as", "close", "bounce", "is_running", "launch",
@@ -741,6 +744,11 @@ enum OperationRegistry {
         (.editNormalize, "normalize", .requiresKeyBinding, .none, []),
         (.editDuplicate, "duplicate", .requiresKeyBinding, .none, []),
         (.editToggleStepInput, "toggle_step_input", .requiresKeyBinding, .none, []),
+        // #575: implemented since v3.1.3 and reachable from nothing until now. Verification is
+        // required because the channel actually performs it — it re-reads the selected region and
+        // the playhead after the menu click and refuses State A unless the SAME region landed
+        // there.
+        (.editMoveToPlayhead, "move_to_playhead", .defaultInstall, .readbackRequired, []),
     ] as [(OperationID, String, AvailabilityPolicy, VerificationPolicy, Set<String>)]).map { entry in
         OperationSpec(
             id: entry.0,

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -533,7 +533,7 @@ enum WorkflowSkillCatalog {
         "logic_edit": [
             "undo", "redo", "cut", "copy", "paste", "delete", "select_all",
             "split", "join", "quantize", "bounce_in_place", "normalize",
-            "duplicate", "toggle_step_input",
+            "duplicate", "toggle_step_input", "move_to_playhead",
         ],
         "logic_navigate": [
             "goto_bar", "goto_marker", "create_marker", "delete_marker",

--- a/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelRegionStateATests.swift
@@ -134,6 +134,92 @@ private func makeRegionFixture(
     #expect(obj["observed"] as? Int == 9)
 }
 
+/// The pre- and post-reads both ask for "the selected region". Nothing in Logic guarantees that is
+/// the SAME region across the menu click, and `startBar` cannot be the identity that decides it —
+/// it is the property this operation exists to change.
+///
+/// Without a same-region gate, a selection that drifted mid-click certifies State A on a region the
+/// caller never asked about, purely because it happens to sit on the playhead. That is a false
+/// State A: performed, and "verified" against the wrong subject.
+@Test func testMoveToPlayheadRefusesStateAWhenTheSelectionDrifted() async {
+    let regionAHelp = "리전은 1 마디 에서 시작하여 3 마디 에서 끝납니다., MIDI 리전."
+    // Already sitting on the playhead, on a different track. If the gate only compared startBar to
+    // the playhead, this region would satisfy it.
+    let regionBHelp = "리전은 9 마디 에서 시작하여 11 마디 에서 끝납니다., MIDI 리전."
+
+    let fixture = makeRegionFixture(
+        headers: [(axPoint(0, 100), axSize(200, 40)), (axPoint(0, 200), axSize(200, 40))],
+        regions: [
+            (name: "RegionA", help: regionAHelp, pos: axPoint(240, 108),
+             size: axSize(320, 24), selected: true),
+            (name: "RegionB", help: regionBHelp, pos: axPoint(900, 208),
+             size: axSize(320, 24), selected: false),
+        ],
+        playheadPosition: "9.1.1.1"
+    )
+
+    let result = await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(
+        runtime: fixture.runtime,
+        executeScript: { _ in
+            // Logic's selection moves to RegionB during the click. RegionA never moves.
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_000), kAXSelectedAttribute as String, false
+            )
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_001), kAXSelectedAttribute as String, true
+            )
+            return .success("OK")
+        },
+        settle: { /* skip in tests */ }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeJSON(result.message)
+    let verified = obj["verified"] as? Bool ?? true
+    #expect(!verified)
+    #expect(obj["state"] as? String == "B")
+    #expect(obj["reason"] as? String == "readback_mismatch")
+    // The envelope has to say WHICH region it ended up looking at, or the caller cannot tell this
+    // from a region that simply failed to move.
+    #expect(obj["region_name"] as? String == "RegionA")
+    #expect(obj["post_region_name"] as? String == "RegionB")
+}
+
+/// A region the enumeration could not place against any track header reports `trackIndex == -1`.
+/// That is a readback gap, and a gap is not a match — pairing it with an equal name would let two
+/// different unplaced regions certify each other.
+@Test func testMoveToPlayheadRefusesStateAWhenTheTrackCannotBePlaced() async {
+    let preHelp = "리전은 1 마디 에서 시작하여 3 마디 에서 끝납니다., MIDI 리전."
+    let postHelp = "리전은 9 마디 에서 시작하여 11 마디 에서 끝납니다., MIDI 리전."
+
+    // No track headers at all, so every region's trackIndex resolves to -1.
+    let fixture = makeRegionFixture(
+        headers: [],
+        regions: [(
+            name: "RegionA", help: preHelp, pos: axPoint(240, 108),
+            size: axSize(320, 24), selected: true
+        )],
+        playheadPosition: "9.1.1.1"
+    )
+
+    let result = await AccessibilityChannel.defaultMoveSelectedRegionToPlayhead(
+        runtime: fixture.runtime,
+        executeScript: { _ in
+            fixture.builder.setAttribute(
+                fixture.builder.element(3_000), kAXHelpAttribute as String, postHelp
+            )
+            return .success("OK")
+        },
+        settle: { /* skip in tests */ }
+    )
+
+    #expect(result.isSuccess)
+    let obj = decodeJSON(result.message)
+    let verified = obj["verified"] as? Bool ?? true
+    #expect(!verified)
+    #expect(obj["pre_track_index"] as? Int == -1)
+}
+
 @Test func testMoveToPlayheadReturnsStateBOnMismatch() async {
     // Pre: bar 1. Action moves region to bar 5 but playhead is at bar 9 →
     // post.startBar(5) ≠ playhead(9) → State B readback_mismatch.

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -284,6 +284,10 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_edit", command: "split", params: [:], operation: "edit.split", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_edit", command: "join", params: [:], operation: "edit.join", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_edit", command: "quantize", params: ["value": .string("1/16")], operation: "edit.quantize", destinations: [], invariant: .minimumV1),
+            // #575: routes to the REGION channel rather than to an `edit.*` operation — the command
+            // is an edit-family verb on the current selection, the implementation lives with the
+            // other region readbacks.
+            RouteCase(tool: "logic_edit", command: "move_to_playhead", params: [:], operation: "region.move_to_playhead", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_edit", command: "bounce_in_place", params: [:], operation: "edit.bounce_in_place", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_edit", command: "normalize", params: [:], operation: "edit.normalize", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_edit", command: "duplicate", params: [:], operation: "edit.duplicate", destinations: [], invariant: .minimumV1),

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -394,7 +394,7 @@ struct OperationCatalogTests {
                     ("get_trace", "system.get_trace", ["trace_id"], .none),
                     ("clear_traces", "system.clear_traces", ["confirmed"], .l2),
                 ]
-                #expect(OperationRegistry.specs.count == 110)
+                #expect(OperationRegistry.specs.count == 111)
                 for (command, operationID, allowedParams, confirmation) in expectedSpecs {
                     let spec = OperationRegistry.spec(tool: "logic_system", command: command)
                     #expect(spec?.id.rawValue == operationID, "\(command) must have one public spec")
@@ -721,7 +721,7 @@ struct OperationCatalogTests {
 
     @Test("strict: every registered operation rejects unknown keys and accepts its pinned keys")
     func strictRegistryWideInvariant() throws {
-        #expect(OperationRegistry.specs.count == 110)
+        #expect(OperationRegistry.specs.count == 111)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
 
         for spec in OperationRegistry.specs {
@@ -888,7 +888,7 @@ struct OperationCatalogTests {
         #expect(sharedToolText(trackRejected).contains("port parameter not supported for record_sequence"))
     }
 
-    @Test("catalog: exact URI reads the generated 110-operation catalog")
+    @Test("catalog: exact URI reads the generated 111-operation catalog")
     func catalogReadsRegistryProjection() async throws {
         let result = try await ResourceHandlers.read(
             uri: Self.uri,
@@ -901,7 +901,7 @@ struct OperationCatalogTests {
         #expect(body["generated_at"] as? String != nil)
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
-        #expect(operations.count == 110)
+        #expect(operations.count == 111)
         #expect(!text.contains("\n"))
 
         let ids = operations.compactMap { $0["id"] as? String }

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -142,7 +142,7 @@ struct OperationHandlerBindingTests {
         let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
         let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
 
-        #expect(specs.count == 110)
+        #expect(specs.count == 111)   // #575 registered edit.move_to_playhead
         #expect(bindings.count == specs.count)
         #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
         #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 110)
+        #expect(OperationRegistry.specs.count == 111)   // #575 registered edit.move_to_playhead
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -85,10 +85,10 @@ struct OperationRegistryCoverageTests {
             .tracksSetInstrument,
         ]
 
-        #expect(mutating.count == 87)
+        #expect(mutating.count == 88)   // #575: move_to_playhead is a mutating edit verb
         #expect(readOnly.count == 23)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
-        #expect(targetless.count == 73)
+        #expect(targetless.count == 74)   // #575: it acts on the selection, so it bears no target
         #expect(targetBearingIDs.count + targetless.count == mutating.count)
         #expect(readOnly.allSatisfy { $0.target == .none })
     }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -496,6 +496,10 @@ struct OperationRegistryTests {
         ("edit.normalize", "normalize", .requiresKeyBinding, .none),
         ("edit.duplicate", "duplicate", .requiresKeyBinding, .none),
         ("edit.toggle_step_input", "toggle_step_input", .requiresKeyBinding, .none),
+        // #575: the one edit command that verifies. It re-reads the selected region and the
+        // playhead after the menu click, so `.readbackRequired` here is a claim the channel has to
+        // keep — the rest of this family cannot read back what they did.
+        ("edit.move_to_playhead", "move_to_playhead", .defaultInstall, .readbackRequired),
     ]
 
     @Test("edit registry is exact, unique, and isolated")

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -186,8 +186,8 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 110)
-        #expect(mutatingSpecs.count == 87)
+        #expect(OperationRegistry.specs.count == 111)
+        #expect(mutatingSpecs.count == 88)   // #575 registered edit.move_to_playhead
 
         // A mutating op that refuses BEFORE dispatch starts its trace (the
         // consent-first setup_arm_key, #413) starts no trace with the coverage
@@ -297,7 +297,7 @@ extension OperationTraceTests {
 
         let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
-        #expect(OperationRegistry.specs.count == 110)
+        #expect(OperationRegistry.specs.count == 111)
         #expect(readOnlySpecs.count == 23)
         // Mutability is total: the mutating census (87) and this inverse gate
         // (23) together account for every registered spec, so a new operation

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -58,10 +58,10 @@ struct QualificationRunnerTests {
         // real payload qualifies: passed == 23 (22 oracles + health's bespoke
         // validator), protocolSmoke == 0. The 87 mutating ops are unchanged —
         // they still defer to ADR-001-c for live mutation.
-        #expect(operationCases.count == 110)
+        #expect(operationCases.count == 111)
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 88)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
         #expect(operationCases.filter { $0.status == .passed }.allSatisfy {
             $0.verificationKind == .semanticReadback
@@ -249,7 +249,7 @@ struct QualificationRunnerTests {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 0)
         #expect(driveResult.operationResults.values.filter { $0.status == .passed }.isEmpty)
-        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 110)
+        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 111)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -1184,7 +1184,7 @@ struct QualificationRunnerTests {
         ))
 
         #expect(result.handshakeOK)
-        #expect(result.catalog?.operationCount == 110)
+        #expect(result.catalog?.operationCount == 111)   // #575 registered edit.move_to_playhead
         #expect(result.catalogCountMatch)
         #expect(result.traceOK)
 
@@ -1196,7 +1196,7 @@ struct QualificationRunnerTests {
         let smoke = operationResults.filter { $0.status == .protocolSmoke }
 
         #expect(operationResults.count == OperationRegistry.specs.count)
-        #expect(mutating.count == 87)
+        #expect(mutating.count == 88)
         #expect(readOnly.count == 23)
         #expect(operationResults.allSatisfy { $0.status != .failed })
         #expect(operationResults.allSatisfy { $0.responseData != nil && $0.readback != nil })
@@ -1694,7 +1694,7 @@ struct QualificationRunnerTests {
         // #373 Phase A: the read-only surface now qualifies semantically.
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 87)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 88)
         // #373 Phase A: 22 oracled read-only ops + system.health's bespoke
         // validator. The aggregate axes contribute no passes here.
         #expect(attestation.passed == 23)

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -1096,5 +1096,20 @@ enum SemanticOracleFixtures {
                 """,
             readback: "{}"
         ),
+        // AccessibilityChannel+Regions.defaultMoveSelectedRegionToPlayhead State A: the SAME region
+        // (same name, same track index) is selected before and after the Edit > Move > To Playhead
+        // click, and its start bar landed on the playhead. The one-bar gap between post_start_bar
+        // and playhead_bar is deliberate — it is inside the snap-rounding tolerance the handler
+        // allows, so a fixture that used an exact match would not exercise the tolerance at all.
+        .editMoveToPlayhead: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "via":"applescript_menu","region_name":"MIDI Region",\
+                "post_region_name":"MIDI Region","pre_track_index":3,"post_track_index":3,\
+                "pre_start_bar":1,"post_start_bar":9,"playhead_bar":9,\
+                "requested":9,"observed":9}
+                """,
+            readback: "{}"
+        ),
     ]
 }

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -468,7 +468,8 @@ struct SemanticOracleCensusTests {
                 )
             }
         }
-        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 49)
+        // 49 through B4, plus the one registered after the inventory closed (#575).
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 50)
     }
 
     /// #373 B4 — the mutating oracle inventory is CLOSED. Every supported
@@ -1378,6 +1379,10 @@ struct SemanticOracleB0CensusTests {
                 + SemanticOracleTable.phaseB2MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB3MutatingOperationIDs.count
                 + SemanticOracleTable.phaseB4MutatingOperationIDs.count
+                // #575: B4 closed the inventory as it stood, and registering a new mutating
+                // operation reopens it. The sum stays exact because the new entry joins a NAMED
+                // set of its own rather than being back-dated into a phase that never contained it.
+                + SemanticOracleTable.postClosureMutatingOperationIDs.count
         )
     }
 }


### PR DESCRIPTION
Part of #575 — the "expose" half. Stacked on #588 (the State A identity fix), which is in this
branch's history.

## What becomes reachable

`region.move_to_playhead` has been implemented and verified since v3.1.3 and reachable from **no
tool** the whole time. It is now `logic_edit.move_to_playhead`.

The edit tool is where it belongs. It is a **selection-relative** verb — the caller does not name a
region, Logic's selection does — the same contract `cut`, `split` and `join` already ship with
`target: .none`. That is not the same defect as a positional index: a bare index is a false claim of
identity, a selection verb is the opposite admission, and this project ships thirteen of them.

## `region.select_last` stays unregistered — a decision, not an omission

It selects by screen geometry, and measured live its filter excludes every region on screen:

```
regions on this project   21, each 48x13
the filter                w > 20 and w < 2000 and h > 20 and h < 200
matched                   0
```

Regions are **13 points tall** at this vertical zoom, so it answers "no region" on a project with
twenty of them. Its actuation and its verification also disagree about what *last* means —
bottom-most-then-right-most by position when choosing, largest start bar when checking. It waits for
a region target kind (#302 / ADR-002).

## The oracle, and why it is not in B1..B4

B4's prose said it was the **final** increment: with it, the covered set plus the audited exclusions
accounted for the entire mutating surface. That closure is a property of the registry, so registering
a new mutating operation reopens it — which `everyMutatingSpecIsCoveredOrAuditedExcluded` caught
immediately, exactly as designed.

So the rule the phases encode is not *"B4 was last"* but *"an operation joins the covered set or the
audited-exclusion set in the same change that registers it"*. The new entry sits in a named set of
its own rather than being back-dated into a phase that never contained it, because those sets record
**what was pinned when**.

Every predicate relates two independent reads rather than echoing an input back — the region read
before the click against the one read after it, `observed` against the post-click start bar,
`requested` against the playhead read from the transport. The landing rule is `numericNear` within
one bar, **not** equality: State A does not promise an exact match, and pinning one would describe a
contract the handler never made.

## Measured live

```
record_sequence   -> exactly one region selected, starting at bar 1
goto_position 9   -> playhead at bar 9
move_to_playhead  -> State A, verified, same region (name + track 22), bar 1 -> 9
independent reader-> Logic's own help string now says bar 9
arrange content   -> visibly changed
```

9 checks · 9 passed · 5 mutation-backed · visual 1/1 · restoration verified.

## Three measurements the harness had to make first

**Writing `AXSelected` is not a setter.** Setting it `true` *adds* to Logic's selection instead of
replacing it, and a pass that set it `false` on eighteen other regions left those eighteen selected
and the target **not** selected — the opposite of both writes, with `.success` returned throughout.
So the witness is read-only and the product establishes the selection.

**A witness has to be scoped.** An earlier version walked the whole application, picked up the Piano
Roll's own region item, and reported 23 regions on one call and 40 on the next. An index space that
moves between two calls is not a witness. It now reads only the arrange window's track-content group
— whose description on this build is `Tracks contents`, not the `Track Content` a guess would have
written.

**`logic_edit.undo` did not undo the move.** It routes to the send-only key-command channels, which
need a bound key command this run never established. Restoration goes through Logic's own menu entry
instead, and only when that entry's title *changed* across the operation — which is Logic saying this
run's action is on top of the undo stack, and needs no knowledge of the menu's language.

## Gate

`lpm-ship.sh` PASS — 3826 tests, preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.