### PR TITLE
fix(#590): the project chooser is not an open document

### DIFF
--- a/Scripts/livekit/live_590_project_new_from_cold_launch.py
+++ b/Scripts/livekit/live_590_project_new_from_cold_launch.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Live proof that `project.new` works from the state Logic lands in at launch.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_590_project_new_from_cold_launch.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+A freshly launched Logic shows "Choose a Project". `project.new`'s open-document precondition counted
+raw AX windows, so that chooser was an open document and the operation refused:
+
+    {"error":"unsupported_state","failure_stage":"precondition_open_document",
+     "observed_window_count":1,
+     "hint":"project.new requires Logic to have no open document; 1 window(s) are open. …"}
+
+There was no open document. This is the state every first-time caller is in, and it needs no unusual
+configuration — only a Logic that was launched and not yet given a project. Measured in English and
+in Korean; it is not a locale defect.
+
+The precondition's reasoning is untouched and still right: with a real document open, a newly created
+project's window cannot be told apart from the ones already on screen. A chooser does not create that
+ambiguity, and driving File > New with the chooser still on screen was measured to create the project
+anyway. So the count now excludes chooser windows, using the classifier `getTrackHeaders` already
+uses for the same purpose.
+
+WHY THIS RUN RELAUNCHES LOGIC
+-----------------------------
+The defect exists only at a cold launch. A harness that started from an already-open project would
+exercise a different branch and pass while measuring nothing, so this one quits Logic and waits for
+the chooser before it begins. It says so here rather than leaving a reader to infer why Logic
+restarted.
+
+A fresh launch also raises Logic's own single-button audio-interface alert on this host. That is
+acknowledged before the test — it is Logic's, informational, and its own preflight refusal
+(`preflight_blocking_dialog`) is a separate and defensible one that would otherwise mask the branch
+under test.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+LAUNCH_TIMEOUT = 90.0
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",")] if raw else []
+
+
+def logic_running():
+    return osa('tell application "System Events" to return (count of (every process whose '
+               'name is "Logic Pro"))') == "1"
+
+
+def dismiss_single_button_alert():
+    """Acknowledge Logic's own informational alert, but ONLY when it has exactly one button.
+
+    The count is the gate, not the text: measured, the same audio-interface alert read its static
+    texts on one launch and returned nothing on the next, and an earlier version of this function
+    keyed the click on the text being readable — so it silently declined to dismiss anything and the
+    run failed at a later stage for a reason that was not the one under test.
+
+    One button means there is no choice to make and nothing this run could decide on the operator's
+    behalf. Two or more, and it declines and says so, which is the same rule the product's own modal
+    reconciler follows.
+    """
+    # The alert does not appear the instant the chooser does. An earlier version looked once, saw
+    # nothing, and declined — and the operation then refused on the alert that arrived a moment
+    # later, failing the run for a reason that was not the one under test. So this waits for it.
+    #
+    # The count comes from `count of every button`, not from reading their names: measured, the same
+    # dialog reported ["OK"] to the product while `name of every button` came back empty through
+    # System Events, so a name-based count would have declined on a dialog that was plainly there.
+    deadline = time.time() + 15
+    count = 0
+    while time.time() < deadline:
+        raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+                  'return (count of (every button of (first window whose subrole is "AXDialog")))')
+        count = int(raw) if raw.isdigit() else 0
+        if count:
+            break
+        time.sleep(2)
+    if count != 1:
+        return {"dismissed": False, "button_count": count,
+                "why": "no dialog" if not count else "more than one button — not this run's choice"}
+    text = osa('tell application "System Events" to tell process "Logic Pro" to '
+               'return value of every static text of (first window whose subrole is "AXDialog")')
+    osa('tell application "System Events" to tell process "Logic Pro" to '
+        'click button 1 of (first window whose subrole is "AXDialog")')
+    time.sleep(2)
+    return {"dismissed": True, "button_count": count, "text": text[:200]}
+
+
+# ---- reach a cold launch -------------------------------------------------------------------------
+
+# Quitting can be refused by a sheet Logic has open — measured, a freshly created project leaves its
+# "New Track" chooser up, and `quit` then does nothing while the process stays alive. So the shutdown
+# escapes any sheet once and asks again, and the precondition below judges the OUTCOME rather than
+# the fact that a quit was sent.
+if logic_running():
+    for attempt in range(3):
+        osa('tell application "Logic Pro" to quit')
+        deadline = time.time() + 20
+        while logic_running() and time.time() < deadline:
+            time.sleep(2)
+        if not logic_running():
+            break
+        osa('tell application "Logic Pro" to activate')
+        time.sleep(1)
+        osa('tell application "System Events" to key code 53')
+        time.sleep(2)
+
+ev.check("590/precondition-logic-was-shut-down",
+         not logic_running(),
+         "Logic is not running, so the launch below is a genuine cold start rather than a reuse of "
+         "whatever state an earlier run left behind",
+         f"running={logic_running()}", None)
+
+subprocess.run(["open", "-a", "Logic Pro"], capture_output=True)
+deadline = time.time() + LAUNCH_TIMEOUT
+titles = []
+while time.time() < deadline:
+    titles = window_titles()
+    if any(any(c in t for c in CHOOSER_TITLES) for t in titles):
+        break
+    time.sleep(3)
+
+alert = dismiss_single_button_alert()
+time.sleep(2)
+titles = window_titles()
+ev.note("590/launch", {"titles": titles, "dismissed_alert": alert})
+
+ev.check("590/precondition-the-launch-lands-on-the-project-chooser",
+         any(any(c in t for c in CHOOSER_TITLES) for t in titles),
+         "Logic came up showing its project chooser and no document — the exact state this defect "
+         "is about, and the one a first-time caller is in",
+         f"titles={titles!r} · alert={json.dumps(alert)[:200]}", None)
+
+ev.check("590/precondition-no-document-window-is-open",
+         not any("Tracks" in t or "트랙" in t for t in titles),
+         "no arrange window is on screen, so nothing that follows can be explained by a project "
+         "that was already open",
+         f"titles={titles!r}", None)
+
+if not any(any(c in t for c in CHOOSER_TITLES) for t in titles):
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+chooser_title = next(t for t in titles if any(c in t for c in CHOOSER_TITLES))
+rec = ev.record_screen(seconds=150)
+# A band over the chooser window itself: it is what is on screen before, and a created project puts
+# its arrange window over the same area.
+before = ev.shot("590/chooser", settle_region=None, window_title=chooser_title)
+
+# ---- the operation -------------------------------------------------------------------------------
+
+d = E.Driver()
+time.sleep(4)
+created = d.tool("logic_project", "new", {})
+time.sleep(8)
+after_titles = window_titles()
+ev.note("590/new", {"result": created if isinstance(created, dict) else str(created)[:300],
+                    "titles_after": after_titles})
+
+body = created if isinstance(created, dict) else {}
+ev.check("590/the-chooser-is-no-longer-treated-as-an-open-document",
+         body.get("failure_stage") != "precondition_open_document",
+         "`project.new` is not refused for having a document open, because the only window on "
+         "screen was the chooser and a chooser is not a document",
+         f"failure_stage={body.get('failure_stage')!r} error={body.get('error')!r} "
+         f"all_windows={body.get('observed_all_window_count')!r} "
+         f"documents={body.get('observed_window_count')!r}",
+         "count raw windows again in `documentWindowCount`: the call comes back "
+         "`precondition_open_document` with the chooser as the one window, which is the defect")
+
+ev.check("590/a-project-was-actually-created",
+         any("Tracks" in t or "트랙" in t for t in after_titles),
+         "an arrange window exists that did not exist before the call — read from the window list "
+         "rather than from the operation's own report of itself",
+         f"before={titles!r} after={after_titles!r}",
+         "return early from `createEmptyProjectFromQualifiedState` without driving the menu: the "
+         "envelope can still claim a phase, and this check — which never reads it — goes red")
+
+ev.check("590/the-operation-does-not-overclaim-what-it-verified",
+         body.get("success") is True and body.get("state") in ("A", "B"),
+         "the envelope is an Honest Contract state rather than a bare error, and it does not claim "
+         "more than the readback it had — State B here is the honest answer when the created "
+         "window cannot be independently confirmed by the handler",
+         f"state={body.get('state')!r} success={body.get('success')!r} "
+         f"reason={body.get('reason')!r} phase={body.get('phase')!r}",
+         None)
+
+created_title = next((t for t in after_titles if "Tracks" in t or "트랙" in t), chooser_title)
+after = ev.shot("590/created", settle_region=None, window_title=created_title)
+ev.visual("590/the-screen-shows-a-project-where-it-showed-a-chooser",
+          before["file"], after["file"], (0, 0, 400, 200), expect_change=True,
+          why="the capture before the call is the chooser window and the one after is the new "
+              "arrange window, so the top-left corner of what was captured must differ — an "
+              "envelope claiming a project that nobody can see would not move it")
+
+d.close()
+ev.restored("590/an-empty-project-is-left-open",
+            any("Tracks" in t or "트칙" in t or "트랙" in t for t in after_titles),
+            f"this run restarts Logic and creates an empty project on purpose — that is the state "
+            f"under test — and leaves it open rather than quitting, so the application is usable "
+            f"afterwards. Windows now: {after_titles!r}. Logic's own audio-interface alert was "
+            f"acknowledged during the launch: {json.dumps(alert)[:200]}")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_590_project_new_from_cold_launch.py
+++ b/Scripts/livekit/live_590_project_new_from_cold_launch.py
@@ -118,11 +118,57 @@ def dismiss_single_button_alert():
 
 # ---- reach a cold launch -------------------------------------------------------------------------
 
+def close_open_documents():
+    """Close document windows before quitting, so the next launch lands on the chooser.
+
+    The run cannot ASSUME a cold launch shows "Choose a Project": Logic reopens the document that was
+    open when it quit. Measured — a relaunch after quitting with a project open came back straight to
+    `Untitled 56 - Tracks`, and the branch under test was never reached. The state has to be
+    established, not hoped for.
+
+    Only an UNTITLED document is discarded at the save prompt. A named project is the operator's, and
+    this run has no business deciding not to save it: it stops instead, and the precondition below
+    reports why.
+    """
+    closed, refused = [], []
+    for _ in range(6):
+        titles = [t for t in window_titles()
+                  if t and not any(c in t for c in CHOOSER_TITLES)]
+        if not titles:
+            break
+        target = titles[0]
+        osa(f'tell application "System Events" to tell process "Logic Pro" to click '
+            f'(first button of (first window whose name is "{target}") whose description is "close button")')
+        time.sleep(2)
+        # A save prompt is three buttons — a real choice — so it is answered only for a scratch
+        # document this run can identify as untitled.
+        buttons = osa('tell application "System Events" to tell process "Logic Pro" to '
+                      'return name of every button of window 1')
+        if "Save" in buttons or "저장" in buttons:
+            if target.startswith("Untitled") or target.startswith("무제"):
+                discard = "Don’t Save" if "Don’t Save" in buttons else (
+                    "Don't Save" if "Don't Save" in buttons else "저장 안 함")
+                osa('tell application "System Events" to tell process "Logic Pro" to '
+                    f'click button "{discard}" of window 1')
+                time.sleep(2)
+                closed.append(f"{target} (discarded)")
+            else:
+                refused.append(target)
+                osa('tell application "System Events" to tell process "Logic Pro" to '
+                    'click button "Cancel" of window 1')
+                break
+        else:
+            closed.append(target)
+    return {"closed": closed, "refused_named_projects": refused}
+
+
 # Quitting can be refused by a sheet Logic has open — measured, a freshly created project leaves its
 # "New Track" chooser up, and `quit` then does nothing while the process stays alive. So the shutdown
 # escapes any sheet once and asks again, and the precondition below judges the OUTCOME rather than
 # the fact that a quit was sent.
+closed_documents = {"closed": [], "refused_named_projects": []}
 if logic_running():
+    closed_documents = close_open_documents()
     for attempt in range(3):
         osa('tell application "Logic Pro" to quit')
         deadline = time.time() + 20
@@ -153,13 +199,15 @@ while time.time() < deadline:
 alert = dismiss_single_button_alert()
 time.sleep(2)
 titles = window_titles()
-ev.note("590/launch", {"titles": titles, "dismissed_alert": alert})
+ev.note("590/launch", {"titles": titles, "dismissed_alert": alert,
+                       "documents_closed_before_quit": closed_documents})
 
 ev.check("590/precondition-the-launch-lands-on-the-project-chooser",
          any(any(c in t for c in CHOOSER_TITLES) for t in titles),
          "Logic came up showing its project chooser and no document — the exact state this defect "
          "is about, and the one a first-time caller is in",
-         f"titles={titles!r} · alert={json.dumps(alert)[:200]}", None)
+         f"titles={titles!r} · alert={json.dumps(alert)[:120]} · "
+         f"closed before quit={json.dumps(closed_documents, ensure_ascii=False)[:160]}", None)
 
 ev.check("590/precondition-no-document-window-is-open",
          not any("Tracks" in t or "트랙" in t for t in titles),

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -27,7 +27,36 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime
     ) -> Int? {
         guard let windows else { return nil }
-        return windows.filter { !AXLogicProElements.isProjectPickerWindow($0, runtime: runtime) }.count
+        return windows.filter { !isPositivelyTheProjectChooser($0, runtime: runtime) }.count
+    }
+
+    /// A window is excluded from the document count only when BOTH signals say chooser.
+    ///
+    /// The title alone is not safe in the direction that matters. `isProjectPickerWindow` matches
+    /// the title by CONTAINMENT, so a real project the user named "Choose a Project" produces the
+    /// arrange window "Choose a Project - Tracks" and would stop being counted — and then
+    /// `project.new` would proceed with a genuine document open, which is the ambiguity the
+    /// precondition exists to prevent. The old defect refused too often; a fix that accepts too
+    /// often is worse.
+    ///
+    /// So the title is paired with a structural signal. Measured on Logic Pro 12.3:
+    ///
+    ///     [Untitled 56 - Tracks]  AXDocument = file:///…/Untitled%2056.logicx/
+    ///     [Choose a Project]      AXDocument = missing value
+    ///
+    /// A document window carries `AXDocument`; the chooser does not. Every uncertain case falls to
+    /// "this is a document": an unreadable title, an unreadable `AXDocument`, or a title that does
+    /// not match all count as documents, so a failure to identify the chooser costs a refusal rather
+    /// than an ambiguous creation.
+    static func isPositivelyTheProjectChooser(
+        _ window: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        guard AXLogicProElements.isProjectPickerWindow(window, runtime: runtime) else { return false }
+        let document: String? = AXHelpers.getAttribute(
+            window, kAXDocumentAttribute as String, runtime: runtime.ax
+        )
+        return document == nil
     }
 
     static func createEmptyProjectFromQualifiedState(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -10,6 +10,26 @@ extension AccessibilityChannel {
         windowCount == 0
     }
 
+    /// How many of Logic's windows are DOCUMENTS, which is what the open-document precondition is
+    /// really asking about (#590).
+    ///
+    /// A freshly launched Logic shows "Choose a Project". Counting raw windows made that chooser an
+    /// open document, so `project.new` refused from the exact state Logic lands in at launch — the
+    /// state every first-time caller is in, needing no unusual configuration at all. The classifier
+    /// this needs already existed and is already used by `getTrackHeaders` for the same reason.
+    ///
+    /// The precondition's own reasoning is untouched and still sound: with a real document open, a
+    /// newly created project's window cannot be told apart from the ones already on screen. A
+    /// chooser does not create that ambiguity — it is titled, it is not a project, and driving
+    /// File > New with it still on screen was measured to create the project anyway.
+    static func documentWindowCount(
+        _ windows: [AXUIElement]?,
+        runtime: AXLogicProElements.Runtime
+    ) -> Int? {
+        guard let windows else { return nil }
+        return windows.filter { !AXLogicProElements.isProjectPickerWindow($0, runtime: runtime) }.count
+    }
+
     static func createEmptyProjectFromQualifiedState(
         runtime: AXLogicProElements.Runtime = .production
     ) async -> ChannelResult {
@@ -27,7 +47,8 @@ extension AccessibilityChannel {
         let windows: [AXUIElement]? = AXHelpers.getAttribute(
             app, kAXWindowsAttribute as String, runtime: runtime.ax
         )
-        guard blankApplicationCanRevealChooser(windowCount: windows?.count) else {
+        let documentWindows = documentWindowCount(windows, runtime: runtime)
+        guard blankApplicationCanRevealChooser(windowCount: documentWindows) else {
             // A DESIGNED precondition, not a failure to try: with a document already open, a second
             // project's window cannot be told apart from the ones already on screen, so this route
             // refuses rather than certify an ambiguous creation
@@ -39,12 +60,15 @@ extension AccessibilityChannel {
             // envelope and therefore relabelled `channels_exhausted`. That code means "every channel
             // in the chain reported itself unavailable"; here the one channel ran and declined on
             // purpose. Two false statements about the caller's situation, in one refusal.
-            let count = windows?.count
+            let count = documentWindows
             var extras: [String: Any] = [
                 "operation": "project.new",
                 "write_attempted": false,
                 "safe_to_retry": true,
                 "failure_stage": "precondition_open_document",
+                // Both numbers, so a reader can see that a chooser on screen was NOT the reason
+                // (#590). When they differ, the difference is chooser windows.
+                "observed_all_window_count": windows?.count ?? NSNull(),
                 // Driven end to end on 2026-08-17 before being written down. `project.close` alone
                 // answers `confirmation_required` (it is L3-gated), so a recovery action naming the
                 // bare command would send the operator into a second refusal. With the confirmation

--- a/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
+++ b/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
@@ -50,6 +50,43 @@ struct Issue516DirectProjectCreationTests {
         #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: 1))
         #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: nil))
     }
+
+    /// #590 — "blank" means no DOCUMENT, not no window.
+    ///
+    /// A freshly launched Logic shows "Choose a Project". Counting raw windows made that chooser an
+    /// open document, so this route refused from the exact state Logic lands in at launch. Measured
+    /// on 12.3 in English and Korean alike; and File > New driven with the chooser still on screen
+    /// creates the project anyway, so the ambiguity the precondition guards against is not present.
+    @Test("the project chooser is not a document")
+    func chooserDoesNotCountAsAnOpenDocument() {
+        let builder = FakeAXRuntimeBuilder()
+        let chooser = builder.element(59_000)
+        builder.setAttribute(chooser, kAXTitleAttribute as String, "Choose a Project")
+        let koreanChooser = builder.element(59_001)
+        builder.setAttribute(koreanChooser, kAXTitleAttribute as String, "프로젝트 선택")
+        let document = builder.element(59_002)
+        builder.setAttribute(document, kAXTitleAttribute as String, "Untitled 56 - Tracks")
+        let runtime = builder.makeLogicRuntime()
+
+        let choosersOnly = AccessibilityChannel.documentWindowCount(
+            [chooser, koreanChooser], runtime: runtime
+        )
+        #expect(choosersOnly == 0)
+        #expect(AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: choosersOnly))
+
+        let withDocument = AccessibilityChannel.documentWindowCount(
+            [chooser, document], runtime: runtime
+        )
+        #expect(withDocument == 1)
+        #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(windowCount: withDocument))
+
+        // An unreadable window list is still not a blank application: "we could not look" must not
+        // read as "there is nothing there".
+        #expect(AccessibilityChannel.documentWindowCount(nil, runtime: runtime) == nil)
+        #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(
+            windowCount: AccessibilityChannel.documentWindowCount(nil, runtime: runtime)
+        ))
+    }
 }
 
 /// The refusal `project.new` gives when a document is already open.

--- a/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
+++ b/Tests/LogicProMCPTests/Issue516DirectProjectCreationTests.swift
@@ -87,6 +87,38 @@ struct Issue516DirectProjectCreationTests {
             windowCount: AccessibilityChannel.documentWindowCount(nil, runtime: runtime)
         ))
     }
+
+    /// #590 — the title alone must not be able to hide a real document.
+    ///
+    /// `isProjectPickerWindow` matches by CONTAINMENT, so a project the user named "Choose a
+    /// Project" produces the arrange window "Choose a Project - Tracks". On a title-only rule that
+    /// window stops being counted and `project.new` proceeds with a genuine document open — the
+    /// exact ambiguity the precondition exists to prevent, and a worse failure than the refusal it
+    /// replaced.
+    ///
+    /// Measured on Logic Pro 12.3: a document window carries `AXDocument`
+    /// (`file:///…/Untitled%2056.logicx/`) and the chooser does not, so the two signals together
+    /// separate them regardless of what the user called the project.
+    @Test("a project named like the chooser is still a document")
+    func aDocumentNamedLikeTheChooserIsStillCounted() {
+        let builder = FakeAXRuntimeBuilder()
+        let chooser = builder.element(59_100)
+        builder.setAttribute(chooser, kAXTitleAttribute as String, "Choose a Project")
+
+        let trap = builder.element(59_101)
+        builder.setAttribute(trap, kAXTitleAttribute as String, "Choose a Project - Tracks")
+        builder.setAttribute(
+            trap, kAXDocumentAttribute as String, "file:///Users/x/Music/Logic/Choose a Project.logicx/"
+        )
+        let runtime = builder.makeLogicRuntime()
+
+        #expect(AccessibilityChannel.isPositivelyTheProjectChooser(chooser, runtime: runtime))
+        #expect(!AccessibilityChannel.isPositivelyTheProjectChooser(trap, runtime: runtime))
+        #expect(AccessibilityChannel.documentWindowCount([chooser, trap], runtime: runtime) == 1)
+        #expect(!AccessibilityChannel.blankApplicationCanRevealChooser(
+            windowCount: AccessibilityChannel.documentWindowCount([chooser, trap], runtime: runtime)
+        ))
+    }
 }
 
 /// The refusal `project.new` gives when a document is already open.


### PR DESCRIPTION
Closes #590

## The defect

A freshly launched Logic shows **Choose a Project**. `project.new`'s open-document precondition counted
raw AX windows, so that chooser *was* an open document:

```
{"error":"unsupported_state","failure_stage":"precondition_open_document",
 "observed_window_count":1,
 "hint":"project.new requires Logic to have no open document; 1 window(s) are open. …",
 "recovery_action":"Close the open project with logic_project(\"close\", {confirmed: true}) …"}
```

There was no open document. This is the state **every first-time caller is in**, and it needs no
unusual configuration — only a Logic that was launched and not yet given a project. Reproduced in
English and in Korean, so it is not a locale defect.

The recovery hint made it worse: from this state there is nothing to close.

## What did not change

The precondition's reasoning, which is right: with a real document open, a newly created project's
window cannot be told apart from the ones already on screen.

A chooser does not create that ambiguity. It is titled, it is not a project, and **driving File ▸ New
with it still on screen was measured to create the project anyway**. So the count now excludes chooser
windows using the classifier the codebase already had — `isProjectPickerWindow`, which
`getTrackHeaders` uses for exactly this reason and which already carries both the English and the
Korean window titles. The envelope now reports both numbers, so a reader can see a chooser on screen
was not the reason for a refusal.

## Measured before and after, on the same host

With the fix — 6 checks, 6 passed, 2 mutation-backed, visual 1/1, restoration verified.

With `documentWindowCount` restored to raw windows and the release binary rebuilt:

```
failure_stage 'precondition_open_document'   all_windows 1   documents 1
before ['Choose a Project']   after ['Choose a Project']
```

No project created. That is the defect, reproduced live from the same script.

The harness quits Logic and waits for the chooser before it begins — one that started from an open
project would exercise a different branch and pass while measuring nothing.

## Three things the run had to handle, recorded rather than hidden

**A fresh launch raises Logic's own single-button audio-interface alert**, and `project.new` refuses on
it at a different stage (`preflight_blocking_dialog`). That refusal is defensible and untouched here,
so the alert is acknowledged before the test and the run says which one it was.

**The alert does not arrive with the chooser.** An earlier version looked once, saw nothing, declined —
and the operation then refused on the alert that arrived a moment later, failing the run for a reason
that was not the one under test. It now waits. The gate is the *button count*, not the text: the same
dialog reported `["OK"]` to the product while `name of every button` came back empty through System
Events, so a name-based count would have declined on a dialog that was plainly there.

**Quitting can be refused by a sheet, silently.** A freshly created project leaves its "New Track"
chooser up and `quit` then does nothing while the process stays alive. The shutdown escapes a sheet
once and asks again, and the precondition judges whether Logic actually stopped rather than whether a
quit was sent.

## Gate

`lpm-ship.sh` PASS — 3825 tests, preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.