### PR TITLE
fix(#592): retire six more table rows that stood in front of no implementation

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -14,6 +14,10 @@ What it refuses to let you record:
   resulting image is not what the user sees. Every capture records which display it fell wholly within.
 - **A whole-window diff as a visual assertion.** A full-window comparison changes when the clock ticks.
   `visual()` requires an explicit region and states what it expected to happen there.
+- **A region measured once and carried as a constant.** A rectangle taken on one window shape silently
+  watches something else after a resize — measured, a stale band landed on the Step Sequencer and made
+  a negative assertion report movement in a part of the screen the run never touched. Derive the band
+  at run time; `track_header_band()` does it for the arrange rail.
 - **A check that cannot fail.** `check()` requires you to name the mutation you applied to the product
   that flipped it. A check nobody has seen fail is not evidence.
 - **A cached read presented as live.** `provenance()` records the source and age of any value that did
@@ -100,6 +104,74 @@ def logic_window(title_contains="Tracks"):
                 "x": int(b["X"]), "y": int(b["Y"]),
                 "w": int(b["Width"]), "h": int(b["Height"])}
     return None
+
+
+def track_header_band():
+    """The arrange window's track-header rail, in window coordinates, read from AX at run time.
+
+    Use this instead of writing a rectangle into a harness. Every band in this directory started as a
+    number measured once, and a number measured once is right until someone resizes a window: the
+    #592 harness carried `(603, 162, 325, 406)`, taken on a 1920x1050 window with the Library closed,
+    and after the window changed shape that rectangle landed on the Step Sequencer — which animates
+    on its own. A NEGATIVE visual assertion over it then reported movement in a part of the screen
+    the run had never touched, and failed a run in which nothing was written.
+
+    Against the window that broke it, this returns 366,707 235x1182. Nowhere near the constant.
+
+    Returns None when the rail cannot be located, which a caller should treat as a failed
+    precondition rather than a reason to fall back to a guess.
+
+    Two AppleScript hazards are handled here so a caller does not rediscover them:
+
+    - `by` is a reserved word, so a variable named that fails to PARSE rather than to run.
+    - `first window whose name is "…"` has been measured answering "invalid index" for a window that
+      `name of every window` listed a moment earlier, with a plain-ASCII title that matched exactly.
+      So the window is not chosen by name at all: every window is tried until one yields a rail.
+      Excluding the chooser by title was not enough either — a run that overlapped an "Import" dialog
+      picked that dialog and got nothing.
+    """
+    script = """
+    tell application "System Events" to tell process "Logic Pro"
+      -- Chosen by WHAT IT CONTAINS, not by its name. Excluding the project chooser by title was not
+      -- enough: a run that overlapped an "Import" dialog picked that dialog as the project window
+      -- and the lookup returned nothing. The window this wants is the one that has a track rail, so
+      -- every window is tried until one yields it.
+      set out to "none"
+      repeat with cand in (every window)
+        set w to contents of cand
+        try
+          set wp to position of w
+          set ec to entire contents of w
+          repeat with e in ec
+            set el to contents of e
+            try
+              if (role of el as text) is equal to "AXLayoutItem" then
+                set t to (first UI element of el whose role is "AXTextField")
+                set p1 to (value of attribute "AXParent" of el)
+                set rail to (value of attribute "AXParent" of p1)
+                set rp to position of rail
+                set rs to size of rail
+                set relX to ((item 1 of rp) - (item 1 of wp)) as integer
+                set relY to ((item 2 of rp) - (item 2 of wp)) as integer
+                set railW to (item 1 of rs) as integer
+                set railH to (item 2 of rs) as integer
+                set out to (relX as text) & "," & (relY as text) & "," & (railW as text) & "," & (railH as text)
+                exit repeat
+              end if
+            end try
+          end repeat
+        end try
+        if out is not "none" then exit repeat
+      end repeat
+      return out
+    end tell
+    """
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    parts = [p.strip() for p in (r.stdout or "").strip().split(",")]
+    if len(parts) != 4 or not all(p.lstrip("-").isdigit() for p in parts):
+        return None
+    x, y, w, h = (int(p) for p in parts)
+    return (x, y, w, h) if w > 0 and h > 0 else None
 
 
 def _displays():

--- a/Scripts/livekit/live_592_stub_rows_retired.py
+++ b/Scripts/livekit/live_592_stub_rows_retired.py
@@ -60,65 +60,14 @@ def osa(script):
     return (r.stdout or "").strip()
 
 
-_RAIL_FRAME = '''
-tell application "System Events" to tell process "Logic Pro"
-  -- The window is chosen by ELIMINATION rather than by matching its title. `first window whose
-  -- name is …` was measured to answer "invalid index" against a window that `name of every window`
-  -- had just listed, and a lookup that intermittently cannot find what is plainly there is not
-  -- something to build a capture region on.
-  set w to missing value
-  repeat with cand in (every window)
-    set nm to (name of cand as text)
-    if nm does not contain "Choose a Project" and nm does not contain "프로젝트 선택" then
-      set w to contents of cand
-      exit repeat
-    end if
-  end repeat
-  if w is missing value then return "none"
-  set wp to position of w
-  set ec to entire contents of w
-  set out to "none"
-  repeat with e in ec
-    set el to contents of e
-    try
-      if (role of el as text) is equal to "AXLayoutItem" then
-        set t to (first UI element of el whose role is "AXTextField")
-        set p1 to (value of attribute "AXParent" of el)
-        set rail to (value of attribute "AXParent" of p1)
-        set rp to position of rail
-        set rs to size of rail
-        -- `by` is a reserved word in AppleScript; naming a variable that fails to parse.
-        set relX to ((item 1 of rp) - (item 1 of wp)) as integer
-        set relY to ((item 2 of rp) - (item 2 of wp)) as integer
-        set railW to (item 1 of rs) as integer
-        set railH to (item 2 of rs) as integer
-        set out to (relX as text) & "," & (relY as text) & "," & (railW as text) & "," & (railH as text)
-        exit repeat
-      end if
-    end try
-  end repeat
-  return out
-end tell
-'''
-
-
 def header_rail_band():
-    """The track-header rail's own AX frame, in window coordinates, read at run time.
+    """The rail band, derived at run time by the shared recorder.
 
-    NOT a constant. A previous version of this file carried `(603, 162, 325, 406)`, measured once on
-    a 1920x1050 window with the Library closed. The window later changed shape and that rectangle
-    landed on the Step Sequencer, which animates on its own — so a NEGATIVE visual assertion over it
-    reported a change and failed a run in which nothing had been written. A band that is a constant
-    is a band that is right until the user resizes something.
-
-    Returns None when the rail cannot be located, which fails a precondition rather than guessing.
+    Was a local copy of the AppleScript; it now lives in `evidence.py` so the next harness gets it
+    without rediscovering that `by` is a reserved word and that `first window whose name is …` can
+    answer "invalid index" for a window that was just listed.
     """
-    raw = osa(_RAIL_FRAME)
-    parts = [p.strip() for p in raw.split(",")]
-    if len(parts) != 4 or not all(p.lstrip("-").isdigit() for p in parts):
-        return None
-    x, y, w, h = (int(p) for p in parts)
-    return (x, y, w, h) if w > 0 and h > 0 else None
+    return E.track_header_band()
 
 
 def windows():

--- a/Scripts/livekit/live_592_stub_rows_retired.py
+++ b/Scripts/livekit/live_592_stub_rows_retired.py
@@ -52,15 +52,73 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
-# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
-# frame is 603,192 325x406. Every call in this run is a read or a rejected write.
-HEADER_BAND = (603, 162, 325, 406)
 CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
 
 
 def osa(script):
     r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     return (r.stdout or "").strip()
+
+
+_RAIL_FRAME = '''
+tell application "System Events" to tell process "Logic Pro"
+  -- The window is chosen by ELIMINATION rather than by matching its title. `first window whose
+  -- name is …` was measured to answer "invalid index" against a window that `name of every window`
+  -- had just listed, and a lookup that intermittently cannot find what is plainly there is not
+  -- something to build a capture region on.
+  set w to missing value
+  repeat with cand in (every window)
+    set nm to (name of cand as text)
+    if nm does not contain "Choose a Project" and nm does not contain "프로젝트 선택" then
+      set w to contents of cand
+      exit repeat
+    end if
+  end repeat
+  if w is missing value then return "none"
+  set wp to position of w
+  set ec to entire contents of w
+  set out to "none"
+  repeat with e in ec
+    set el to contents of e
+    try
+      if (role of el as text) is equal to "AXLayoutItem" then
+        set t to (first UI element of el whose role is "AXTextField")
+        set p1 to (value of attribute "AXParent" of el)
+        set rail to (value of attribute "AXParent" of p1)
+        set rp to position of rail
+        set rs to size of rail
+        -- `by` is a reserved word in AppleScript; naming a variable that fails to parse.
+        set relX to ((item 1 of rp) - (item 1 of wp)) as integer
+        set relY to ((item 2 of rp) - (item 2 of wp)) as integer
+        set railW to (item 1 of rs) as integer
+        set railH to (item 2 of rs) as integer
+        set out to (relX as text) & "," & (relY as text) & "," & (railW as text) & "," & (railH as text)
+        exit repeat
+      end if
+    end try
+  end repeat
+  return out
+end tell
+'''
+
+
+def header_rail_band():
+    """The track-header rail's own AX frame, in window coordinates, read at run time.
+
+    NOT a constant. A previous version of this file carried `(603, 162, 325, 406)`, measured once on
+    a 1920x1050 window with the Library closed. The window later changed shape and that rectangle
+    landed on the Step Sequencer, which animates on its own — so a NEGATIVE visual assertion over it
+    reported a change and failed a run in which nothing had been written. A band that is a constant
+    is a band that is right until the user resizes something.
+
+    Returns None when the rail cannot be located, which fails a precondition rather than guessing.
+    """
+    raw = osa(_RAIL_FRAME)
+    parts = [p.strip() for p in raw.split(",")]
+    if len(parts) != 4 or not all(p.lstrip("-").isdigit() for p in parts):
+        return None
+    x, y, w, h = (int(p) for p in parts)
+    return (x, y, w, h) if w > 0 and h > 0 else None
 
 
 def windows():
@@ -81,8 +139,19 @@ if not project_windows:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
 arrange_title = project_windows[0]
+band = header_rail_band()
+ev.check("592/precondition-the-track-header-rail-can-be-located",
+         band is not None,
+         "the rail's own AX frame is readable, so the visual assertion below watches the track "
+         "headers rather than a rectangle measured on some earlier window shape",
+         f"band={band!r} window={arrange_title!r}", None)
+
+if band is None:
+    d = None
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
 rec = ev.record_screen(seconds=150)
-before = ev.shot("592/before", settle_region=HEADER_BAND, window_title=arrange_title)
+before = ev.shot("592/before", settle_region=band, window_title=arrange_title)
 
 d = E.Driver()
 time.sleep(4)
@@ -180,9 +249,9 @@ ev.check("592/the-removed-names-did-not-become-reachable",
          # the removal did not BIND them to something rather than free them.
          None)
 
-after = ev.shot("592/after", settle_region=HEADER_BAND, window_title=arrange_title)
+after = ev.shot("592/after", settle_region=band, window_title=arrange_title)
 ev.visual("592/no-project-state-was-touched",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], band, expect_change=False,
           why="every call in this run is a read or a write rejected before it was attempted, so the "
               "track-header rail must be byte-identical across it — a change here would mean one of "
               "those rejected writes was not rejected")

--- a/Scripts/livekit/live_592_stub_rows_retired.py
+++ b/Scripts/livekit/live_592_stub_rows_retired.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Live proof that retiring six more table rows took nothing reachable with it.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_592_stub_rows_retired.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS REMOVED
+----------------
+`mixer.set_input`, `mixer.set_output`, `mixer.toggle_eq`, `mixer.reset_strip`, `plugin.list` and
+`automation.get_mode` had rows in the channel table. None was implemented anywhere: the accessibility
+channel answered all six with a "not yet implemented via AX" string, and for `toggle_eq` and
+`reset_strip` — which named `.mcu` FIRST — the MCU channel had no arm either, so the table promised a
+fallback that did not exist.
+
+Two more that look identical from the accessibility channel were deliberately kept, because they are
+implemented on the channel their chain actually names:
+
+    mixer.set_send        [.mcu]                              MCUChannel
+    automation.set_mode   [.mcu, .midiKeyCommands, .cgEvent]  key command 84
+
+Their accessibility arms were unreachable code — a reader grepping for the operation found a refusal
+that is not what the operation does — so the arms went and the rows stayed.
+
+WHAT THIS RUN CAN AND CANNOT SHOW
+---------------------------------
+None of the six was reachable from a tool, so no live call can demonstrate a behaviour change in
+them. The removed names are probed for completeness, and that check names no mutation because it
+cannot distinguish the two versions: they answered `invalid_params` before this change as well.
+
+The load-bearing evidence is about the NEIGHBOURS. A removal's risk is not in what it deletes but in
+what it takes with it, and `plugin.list` sat beside a `plugin.*` family that is very much alive.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
+# frame is 603,192 325x406. Every call in this run is a read or a rejected write.
+HEADER_BAND = (603, 162, 325, 406)
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def windows():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+titles = windows()
+project_windows = [t for t in titles if not any(c in t for c in CHOOSER_TITLES)]
+ev.check("592/precondition-a-project-is-open",
+         bool(project_windows),
+         "Logic has a project open, so the surviving neighbours have something to answer about and "
+         "an empty answer would mean something",
+         f"windows={titles!r}", None)
+
+if not project_windows:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = project_windows[0]
+rec = ev.record_screen(seconds=150)
+before = ev.shot("592/before", settle_region=HEADER_BAND, window_title=arrange_title)
+
+d = E.Driver()
+time.sleep(4)
+
+# The prefix neighbours, driven with a parameter each one REJECTS. Proving a neighbour survives does
+# not require moving the user's mixer, and the discriminator is the HINT rather than the error code:
+# both a live command and a retired one answer `invalid_params`.
+#
+#   live command    "Unknown parameters: …  Allowed parameters: …"   <- it validated input
+#   retired command "Command '…' is not registered for …"            <- it never existed
+neighbours = {
+    "logic_mixer.set_volume": d.tool("logic_mixer", "set_volume", {"definitely_not_a_param": "1"}),
+    "logic_mixer.set_pan": d.tool("logic_mixer", "set_pan", {"definitely_not_a_param": "1"}),
+    # Probed the same way as the mixer ones: `get_inventory` requires parameters, so calling it
+    # bare answers `invalid_params` for a reason that has nothing to do with this removal. The
+    # rejected-parameter form asks the only question that matters here — does it still resolve.
+    "logic_plugins.get_inventory": d.tool("logic_plugins", "get_inventory",
+                                          {"definitely_not_a_param": "1"}),
+    "logic_tracks.set_automation": d.tool("logic_tracks", "set_automation",
+                                          {"definitely_not_a_param": "1"}),
+}
+ev.note("592/neighbours", {k: str(v)[:200] for k, v in neighbours.items()})
+
+
+def reached_its_dispatcher(body):
+    if not isinstance(body, dict):
+        return False
+    if body.get("error") is None:
+        return True
+    hint = body.get("hint") or ""
+    return "not registered" not in hint
+
+
+unreached = [k for k, v in neighbours.items() if not reached_its_dispatcher(v)]
+ev.check("592/the-prefix-neighbours-still-reach-their-dispatchers",
+         not unreached,
+         "`mixer.set_volume`, `mixer.set_pan`, `plugins.get_inventory` and `tracks.set_automation` "
+         "all still resolve and validate their input — the removal took six named rows and not the "
+         "mixer, plugin or automation families that share their prefixes",
+         f"unreached={unreached} · "
+         f"{ {k: (v.get('hint') or v.get('error') or 'ok')[:60] if isinstance(v, dict) else '?' for k, v in neighbours.items()} }",
+         "remove `mixer.set_volume` alongside them: its hint becomes \"Command 'set_volume' is not "
+         "registered for MCP tool 'logic_mixer'\" and this check goes red")
+
+ev.check("592/the-plugin-family-still-resolves",
+         reached_its_dispatcher(neighbours["logic_plugins.get_inventory"]),
+         "`plugin.get_inventory` still reaches its dispatcher and validates its input — "
+         "`plugin.list` was retired from beside it and the family it belongs to is untouched",
+         f"{str(neighbours['logic_plugins.get_inventory'])[:220]}",
+         "retire `plugin.get_inventory` instead of `plugin.list` — the names differ by a word and "
+         "the live one is the longer")
+
+sweep = {
+    "logic_system.health": d.tool("logic_system", "health", {}),
+    "logic_project.is_running": d.tool("logic_project", "is_running", {}),
+    "logic_project.get_regions": d.tool("logic_project", "get_regions", {}),
+}
+resources = {
+    "logic://tracks": d.resource("logic://tracks"),
+    "logic://mixer": d.resource("logic://mixer"),
+    "logic://transport/state": d.resource("logic://transport/state"),
+}
+broken = {k: v for k, v in sweep.items()
+          if not isinstance(v, dict) or v.get("error") is not None}
+unreadable = [k for k, v in resources.items() if not isinstance(v, dict)]
+ev.check("592/every-reachable-read-only-operation-still-answers",
+         not broken and not unreadable,
+         "health, is_running, get_regions and the three state resources all answer without an "
+         "error, so six rows came out of the shared table without disturbing it",
+         f"broken={list(broken)} unreadable={unreadable}",
+         "remove `system.health` from the table alongside them: the router stops recognising it and "
+         "the dispatcher's answer never reaches the caller")
+
+removed = {
+    "logic_mixer.set_input": d.tool("logic_mixer", "set_input", {}),
+    "logic_mixer.set_output": d.tool("logic_mixer", "set_output", {}),
+    "logic_mixer.toggle_eq": d.tool("logic_mixer", "toggle_eq", {}),
+    "logic_mixer.reset_strip": d.tool("logic_mixer", "reset_strip", {}),
+    "logic_plugins.list": d.tool("logic_plugins", "list", {}),
+    "logic_tracks.get_automation": d.tool("logic_tracks", "get_automation", {}),
+}
+ev.note("592/removed", {k: str(v)[:140] for k, v in removed.items()})
+# Two shapes of refusal, both meaning unreachable, and the difference is the product being MORE
+# specific than this check first assumed. The mixer dispatcher carries an explicit not-exposed list
+# and answers `command_not_exposed`; the others fall through to `invalid_params` as unknown commands.
+# Demanding one shape would have failed the run for the product being clearer.
+UNREACHABLE = ("command_not_exposed", "invalid_params")
+ev.check("592/the-removed-names-did-not-become-reachable",
+         all(isinstance(v, dict) and v.get("error") in UNREACHABLE for v in removed.values()),
+         "none of the six became reachable — each is refused either as an unknown command or by the "
+         "mixer dispatcher's explicit not-exposed list",
+         f"{ {k: (v.get('error') if isinstance(v, dict) else None) for k, v in removed.items()} }",
+         # No mutation: they answered `invalid_params` before this change too, because none was ever
+         # registered for a tool. This check cannot tell the two versions apart, and is here to show
+         # the removal did not BIND them to something rather than free them.
+         None)
+
+after = ev.shot("592/after", settle_region=HEADER_BAND, window_title=arrange_title)
+ev.visual("592/no-project-state-was-touched",
+          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          why="every call in this run is a read or a write rejected before it was attempted, so the "
+              "track-header rail must be byte-identical across it — a change here would mean one of "
+              "those rejected writes was not rejected")
+
+d.close()
+ev.restored("592/nothing-to-restore", True,
+            "this run performs reads and rejected writes only; the negative visual assertion above "
+            "is the evidence for that rather than a claim made here")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -596,14 +596,10 @@ actor AccessibilityChannel: Channel {
             return runtime.setMixerValue(params, .volume)
         case "mixer.set_pan":
             return runtime.setMixerValue(params, .pan)
-        case "mixer.set_send":
-            return .error("Send adjustment not yet implemented via AX")
-        case "mixer.set_input", "mixer.set_output":
-            return .error("I/O routing not yet implemented via AX")
-        case "mixer.toggle_eq":
-            return .error("EQ toggle not yet implemented via AX")
-        case "mixer.reset_strip":
-            return .error("Strip reset not yet implemented via AX")
+        // #592: four unimplemented mixer operations lost their table rows along with the arms that
+        // refused them here, and `mixer.set_send`'s arm went with them — its chain is `[.mcu]`, so
+        // this branch was unreachable and a reader grepping for the operation found a refusal that
+        // is not what it does.
 
         // MARK: - MIDI file import (AX menu navigation)
         case "midi.import_file":
@@ -687,8 +683,6 @@ actor AccessibilityChannel: Channel {
             return await AccessibilityChannel.defaultInsertPlugin(params: params, runtime: runtime.logicRuntime)
         // plugin.bypass / plugin.remove are still intentionally absent from
         // the public contract; no verified AX readback path exists for them.
-        case "plugin.list":
-            return .error("Plugin list reading not yet implemented via AX")
 
         // MARK: - Verified plugin surface (logic_plugins.*)
         // Drift-safe inventory and verified live plugin writes. These route
@@ -702,10 +696,8 @@ actor AccessibilityChannel: Channel {
             return await AccessibilityChannel.defaultInsertVerified(params: params, runtime: runtime.logicRuntime)
 
         // MARK: - Automation
-        case "automation.get_mode":
-            return .error("Automation mode reading not yet implemented via AX")
-        case "automation.set_mode":
-            return .error("Automation mode setting not yet implemented via AX")
+        // #592: `automation.get_mode` was retired; `set_mode`'s arm went too — its chain is
+        // `[.mcu, .midiKeyCommands, .cgEvent]`, so accessibility was never asked.
 
         default:
             return .error("Unsupported AX operation: \(operation)")

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -91,13 +91,16 @@ extension ChannelRouter {
         // named answers `Unsupported AX operation` / `Unknown MCU operation` for them, so a caller
         // who found one would have reached an exhausted chain. That is a stronger case than the two
         // system entries retired earlier, which at least had a channel that would have answered.
+        // #592: `mixer.set_output`, `mixer.set_input`, `mixer.toggle_eq` and `mixer.reset_strip`
+        // were removed. None was implemented anywhere — the accessibility channel answered all four
+        // with a "not yet implemented via AX" string, and for the two that named `.mcu` first the
+        // MCU channel had no arm either, so the table promised a fallback that did not exist.
+        //
+        // `mixer.set_send` stays: it is implemented in `MCUChannel`, which is the only channel its
+        // chain names.
         "mixer.set_send":             [.mcu],
-        "mixer.set_output":           [.accessibility],
-        "mixer.set_input":            [.accessibility],
         "mixer.get_channel_strip":    [.mcu, .accessibility],
         "mixer.set_master_volume":    [.mcu],
-        "mixer.toggle_eq":            [.mcu, .accessibility],
-        "mixer.reset_strip":          [.mcu, .accessibility],
         "mixer.set_plugin_param":     [.scripter],  // public path narrowed to deterministic Scripter flow
         "plugin.insert":              [.accessibility],
 
@@ -254,12 +257,14 @@ extension ChannelRouter {
         // Plugins — bypass/remove intentionally omitted from the routing
         // table: no channel has a deterministic implementation. insert is
         // reintroduced only through an allowlisted AX mixer-slot path.
-        "plugin.list":                [.accessibility],
+        // #592: `plugin.list` was removed — reachable from no tool and implemented by no channel.
         "plugin.set_param":           [.scripter],  // deterministic plugin parameter path
         "plugin.scan_presets":        [.accessibility],  // F2 — AX-only ladder (AXShowMenu→AXPress); ADR-001 removed the CGEvent popup last-resort
 
         // Automation
-        "automation.get_mode":        [.accessibility],
+        //
+        // #592: `automation.get_mode` was removed — no implementation on any channel. `set_mode`
+        // stays: the key-command channel carries it, and accessibility is not in its chain.
         "automation.set_mode":        [.mcu, .midiKeyCommands, .cgEvent],
         "automation.toggle_view":     [.midiKeyCommands, .cgEvent],
 

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -902,11 +902,14 @@ private func makeSetInstrumentFixture() -> (
         // v3.1.2 P2-1: track.set_color now returns a State C envelope with
         // `error:"not_implemented"` instead of a plain free-form string.
         ("track.set_color", "\"error\":\"not_implemented\""),
-        ("mixer.set_send", "Send adjustment not yet implemented via AX"),
-        ("mixer.set_input", "I/O routing not yet implemented via AX"),
-        ("mixer.set_output", "I/O routing not yet implemented via AX"),
-        ("mixer.toggle_eq", "EQ toggle not yet implemented via AX"),
-        ("mixer.reset_strip", "Strip reset not yet implemented via AX"),
+        // #592: four unimplemented mixer operations lost their table rows and their refusal arms,
+        // and `mixer.set_send`'s arm went with them — its chain is `[.mcu]`, where it IS
+        // implemented, so the accessibility refusal was unreachable and misleading to read.
+        ("mixer.set_send", "Unsupported AX operation"),
+        ("mixer.set_input", "Unsupported AX operation"),
+        ("mixer.set_output", "Unsupported AX operation"),
+        ("mixer.toggle_eq", "Unsupported AX operation"),
+        ("mixer.reset_strip", "Unsupported AX operation"),
         // #575: the five unimplemented region operations lost both their routing rows and their
         // channel arm. An operation nothing implements now answers the same way any unknown one
         // does, instead of a sentence that reads as a promise.
@@ -915,9 +918,11 @@ private func makeSetInstrumentFixture() -> (
         ("region.set_name", "Unsupported AX operation"),
         ("region.move", "Unsupported AX operation"),
         ("region.resize", "Unsupported AX operation"),
-        ("plugin.list", "Plugin list reading not yet implemented via AX"),
-        ("automation.get_mode", "Automation mode reading not yet implemented via AX"),
-        ("automation.set_mode", "Automation mode setting not yet implemented via AX"),
+        ("plugin.list", "Unsupported AX operation"),
+        ("automation.get_mode", "Unsupported AX operation"),
+        // `set_mode` is implemented on the key-command channel and accessibility is not in its
+        // chain, so this arm was unreachable too (#592).
+        ("automation.set_mode", "Unsupported AX operation"),
         ("unknown.operation", "Unsupported AX operation"),
     ]
 

--- a/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
+++ b/Tests/LogicProMCPTests/Issue567LocalizedOwnerNameTests.swift
@@ -73,6 +73,15 @@ struct Issue575RetiredUnimplementedRoutesTests {
             "mixer.set_output_volume",
             "mixer.get_bus_routing",
             "automation.get_parameter",
+            // #592 retired six more of the same shape: no implementation on any channel, and for
+            // toggle_eq / reset_strip the `.mcu` they named first had no arm either, so the table
+            // promised a fallback that did not exist.
+            "mixer.set_input",
+            "mixer.set_output",
+            "mixer.toggle_eq",
+            "mixer.reset_strip",
+            "plugin.list",
+            "automation.get_mode",
         ] {
             #expect(ChannelRouter.v2RoutingTable[operation] == nil)
         }
@@ -86,8 +95,11 @@ struct Issue575RetiredUnimplementedRoutesTests {
             "mixer.set_master_volume",
             "mixer.set_send",
             "mixer.get_state",
+            // #592 retired `automation.get_mode`, which used to stand here. It was never a
+            // neighbour in the sense this test means — it had no implementation on any channel,
+            // and it is now in the retired list above. `set_mode` carries the prefix's survival:
+            // the key-command channel implements it.
             "automation.set_mode",
-            "automation.get_mode",
         ] {
             let chain = try #require(ChannelRouter.v2RoutingTable[operation])
             #expect(!chain.isEmpty)


### PR DESCRIPTION
Closes #592. Same shape as #587, which retired five `region.*` rows; these are the rest.

| operation | chain | who implements it |
|---|---|---|
| `mixer.set_input` | `[.accessibility]` | nobody |
| `mixer.set_output` | `[.accessibility]` | nobody |
| `mixer.toggle_eq` | `[.mcu, .accessibility]` | **nobody — MCU has no arm either** |
| `mixer.reset_strip` | `[.mcu, .accessibility]` | **nobody — MCU has no arm either** |
| `plugin.list` | `[.accessibility]` | nobody |
| `automation.get_mode` | `[.accessibility]` | nobody |

A row in the channel table states that an operation is real and declares which surfaces may carry it.
For these six it declared a channel order for a **refusal**, and the sentence it refused with reads as
a promise rather than an answer. The two that name `.mcu` first are worse than empty: the table
advertised a fallback that does not exist.

## Two that look identical and are not — correcting my own claim

I wrote on #575 that *eight* operations shared this shape. Two are implemented:

```
mixer.set_send        [.mcu]                              MCUChannel.swift:259
automation.set_mode   [.mcu, .midiKeyCommands, .cgEvent]  key command 84
```

Neither chain contains `.accessibility`, so the refusal arm I had been reading is **unreachable** for
both. I was looking at a refusal the operation never reaches and calling the operation a stub. Their
rows stay; the dead arms go, because a reader grepping for the operation should not find a sentence
that is not what it does.

## What the live run shows

None of the six was reachable from a tool, so no live call can demonstrate a behaviour change *in
them*. The load-bearing evidence is the **neighbours** — a removal's risk is not in what it deletes
but in what it takes with it, and `plugin.list` sat beside a `plugin.*` family that is very much
alive.

```
6 checks · 6 passed · 3 mutation-backed · negative visual 1/1
```

Neighbours are driven with a parameter each one **rejects**: proving one survives does not require
moving the user's mixer, and the discriminator is the *hint*, because a live command and a retired one
both answer `invalid_params`. A live one says `Unknown parameters: … Allowed parameters: …` — it
validated input. A retired one says `is not registered for MCP tool`.

## Three assumptions the harness gave up, all because the product was clearer than the check

**`plugin.get_inventory` requires parameters**, so calling it bare answers `invalid_params` for a
reason unrelated to this removal. Probed the same way as the mixer neighbours now.

**The retired mixer names answer `command_not_exposed`**, not `invalid_params` — the mixer dispatcher
carries an explicit not-exposed list and says so. Demanding one shape would have failed the run for
the product being *more* specific than the check expected, so it accepts either and records which.

**The visual band was a constant** measured on a window that has since changed shape, and it now
landed on the Step Sequencer, which animates on its own — so a check that exists to show nothing
moved reported movement in a part of the screen the run never touched. It is read from the rail's own
AX frame at run time now: `366,707 235x1182` against this window, nowhere near the `603,162 325x406`
it replaces. Two AppleScript hazards fell out of that — `by` is a reserved word, and
`first window whose name is "…"` answered *invalid index* for a window `name of every window` had just
listed, so the window is chosen by elimination.

## Gate

`lpm-ship.sh` PASS — 3828 tests, preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.