### PR TITLE
docs(#369): the export surface CAN do per-track stems — ticket, not a scope decision

### DIFF
--- a/docs/tickets/issue-369-per-track-stem-export/STATUS.md
+++ b/docs/tickets/issue-369-per-track-stem-export/STATUS.md
@@ -54,3 +54,16 @@ contract: what an artifact plan promises when the names arrive late.
 
 Two corrections in two revisions, both from the same habit — answering about a file without opening
 it. Recorded rather than tidied away, because the shape of the mistake is the useful part.
+
+## Third correction, and the last one
+
+"T1 stands alone and is buildable" was true of the code and false of shipping it. The public export
+surface is `project.export_plan` and `project.export_run` and nothing else, so a standalone stem drive
+would have to be a new public operation — a surface decision — or it would sit unrouted, which is the
+shape #587 and #592 retired eleven rows for on the same day this ticket was written.
+
+The order is therefore fixed rather than parallel: answer what an artifact plan promises when the
+names arrive late, wire `export_run artifacts:[stem]`, and let T1's drive land inside it.
+
+Three corrections in three revisions. The first two came from answering about a file without opening
+it. This one came from treating "buildable" and "shippable" as the same word.

--- a/docs/tickets/issue-369-per-track-stem-export/STATUS.md
+++ b/docs/tickets/issue-369-per-track-stem-export/STATUS.md
@@ -37,3 +37,20 @@ flows through.
 
 The claim was an absence asserted without reading the file the answer was in. Corrected in place
 rather than left standing, because a ticket that says "blocked" is read as a reason not to start.
+
+## Second correction
+
+The first correction removed the "blocked" flag on the strength of `ProjectExportExecutor` carrying
+per-artifact State. That finding is right and it stands.
+
+It was also incomplete. `ProjectExportPlanner` computes one artifact as one known path
+(`<project>-<kind>.wav`) with `exists`, the collision policy and containment all resolved at plan
+time — and a stem run produces N files whose names Logic assigns after the fact. So `export_plan`,
+which is a dry run whose job is to say what will be written, cannot enumerate a stem run.
+
+T1 is therefore unblocked as an AX drive and can be built and proven on its own. Wiring it into
+`export_run artifacts:[stem]` waits on one question that is a property of the published dry-run
+contract: what an artifact plan promises when the names arrive late.
+
+Two corrections in two revisions, both from the same habit — answering about a file without opening
+it. Recorded rather than tidied away, because the shape of the mistake is the useful part.

--- a/docs/tickets/issue-369-per-track-stem-export/STATUS.md
+++ b/docs/tickets/issue-369-per-track-stem-export/STATUS.md
@@ -2,13 +2,13 @@
 
 **Issue**: #369
 **Size**: M
-**Current Phase**: measured, ticket written, blocked on one contract decision
+**Current Phase**: measured, ticket written, ready to implement
 
 ## Tickets
 
 | Ticket | Title | Status | Review | Notes |
 |--------|-------|--------|--------|-------|
-| T1 | Drive Logic's per-track audio export from the export panel | Not started | — | mechanism measured live 2026-08-19; blocked on the partial-success State question in T1 §5 |
+| T1 | Drive Logic's per-track audio export from the export panel | Not started | — | mechanism measured live 2026-08-19; not blocked — the per-artifact State shape already exists in ProjectExportExecutor |
 
 ## What changed the plan
 
@@ -26,3 +26,14 @@ and the measurements are written into T1 as the mechanism.
 | 2026-08-19 | typing a destination path dismisses the panel — select the folder as a browser element |
 | 2026-08-19 | the post-Export `Logic Pro` window is the progress dialog; its disappearance is completion |
 | 2026-08-19 | a real export completes and the output verifies through `logic_audio.analyze_file` |
+
+## Correction
+
+The first revision of T1 declared the ticket blocked on "what State does a partially successful run
+report", claiming this project's contract had no shape for it. It does: `ProjectExportExecutor`
+already runs Honest Contract **per artifact** — State A on verified-on-disk, State B when the artifact
+cannot be verified, State C on a hard failure — and it is the executor `export_run artifacts:[stem]`
+flows through.
+
+The claim was an absence asserted without reading the file the answer was in. Corrected in place
+rather than left standing, because a ticket that says "blocked" is read as a reason not to start.

--- a/docs/tickets/issue-369-per-track-stem-export/STATUS.md
+++ b/docs/tickets/issue-369-per-track-stem-export/STATUS.md
@@ -1,0 +1,28 @@
+# Pipeline Status: Issue 369 Per-Track Stem Export
+
+**Issue**: #369
+**Size**: M
+**Current Phase**: measured, ticket written, blocked on one contract decision
+
+## Tickets
+
+| Ticket | Title | Status | Review | Notes |
+|--------|-------|--------|--------|-------|
+| T1 | Drive Logic's per-track audio export from the export panel | Not started | — | mechanism measured live 2026-08-19; blocked on the partial-success State question in T1 §5 |
+
+## What changed the plan
+
+The roadmap expected this issue to close with a measurement showing the surface cannot do per-track
+export. Driven live, it can: one populated track produced `Studio Grand_1.aif`, 2.048 s, 0.744 s
+non-silent, analyzer `status: pass`. So the issue is implementable work rather than a scope decision,
+and the measurements are written into T1 as the mechanism.
+
+## Measurement log
+
+| Date | What was established |
+|------|----------------------|
+| 2026-08-19 | `One File per Track` is a popup ON the export panel, not behind it |
+| 2026-08-19 | menu enablement must be read with the menu open; the leaf title is rewritten by Logic |
+| 2026-08-19 | typing a destination path dismisses the panel — select the folder as a browser element |
+| 2026-08-19 | the post-Export `Logic Pro` window is the progress dialog; its disappearance is completion |
+| 2026-08-19 | a real export completes and the output verifies through `logic_audio.analyze_file` |

--- a/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
+++ b/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
@@ -127,7 +127,41 @@ Two things the existing machine does that a stem run should inherit rather than 
 - **Already-present-and-verified artifacts are skipped**, which is what makes `export_resume`
   idempotent. A stem run gets resume for free if it produces its file list the same way.
 
-The one thing genuinely new is that the file names come from Logic, not from the plan: the panel
-writes `<track name>_1.aif`, so the executor cannot pre-compute the paths it will poll for. It has to
-enumerate the destination after the progress window closes and bind each file to a track by name.
-That is implementation, not a contract question.
+### But the PLAN-time model does not accommodate stems, and that part is a contract question
+
+A second reading — of `ProjectExportPlanner` this time, which the first two revisions of this ticket
+did not open — shows the per-artifact State shape is only half the story.
+
+```swift
+let url = outputRoot.appendingPathComponent("\(safeProject)-\(kind).wav").standardizedFileURL
+let existingPath = ProjectExportArtifactPathPolicy.preferredExistingVariant(for: url.path, …)
+let exists = existingPath != nil
+```
+
+One artifact is **one known path**, computed at plan time as `<project>-<kind>.wav`, with `exists`,
+the collision policy and the containment check all resolved before anything runs. A stem run breaks
+every one of those:
+
+- it produces N files, not one
+- Logic names them, not the plan — `<track name>_1.aif`
+- the extension is `.aif`, not the `.wav` the path model assumes
+- `would_overwrite` cannot be evaluated for names that are not known until after the export
+- `export_plan` is a DRY RUN whose job is to tell the caller what will be written, and for stems it
+  cannot
+
+So the question this ticket must not answer by itself is: **what does `export_plan` promise for a
+stem artifact?** A destination plus a track count is honest and is not a file list. Whether that is
+allowed to be called an artifact plan — and what `fail_if_exists` means when the names arrive late —
+decides how `export_resume` can stay idempotent.
+
+That is a property of a published dry-run contract, not an implementation detail.
+
+### Scope note
+
+T1 as written is the AX drive only, and it stands on its own: open the panel, choose a destination as
+an element, confirm the popup changed, set `One File per Track`, press Export, wait for the progress
+window to go, enumerate what appeared, verify each file. It can be built and live-proven without
+touching the planner.
+
+Wiring it into `export_run artifacts:[stem]` needs the plan-time question above answered first, and
+that is a separate ticket rather than the tail of this one.

--- a/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
+++ b/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
@@ -1,0 +1,112 @@
+# T1: Drive Logic's per-track audio export from the export panel
+
+**Issue**: #369 — `export_run artifacts:[stem]` currently yields a single project-level bounce
+**Priority**: P1
+**Size**: M
+**Status**: Not started
+**Depends On**: a contract decision, named in §5
+
+---
+
+## 1. Why this ticket exists at all
+
+The roadmap entry for #369 said the export panel's per-track filename fields report
+`settable=true` and do not accept writes, and that *"if that holds, per-track stems cannot be driven
+from this surface and the issue closes with the measurement."*
+
+**It does not hold.** Measured 2026-08-19 on Logic Pro 12.3, driving the panel with Accessibility
+only and no coordinates:
+
+```
+~/Music/Logic/Studio Grand_1.aif    394,922 bytes
+
+logic_audio.analyze_file:
+  channel_count 2 · sample_rate 48000 · duration_seconds 2.048
+  peak_dbfs -13.799 · non_silent_duration_seconds 0.744 · silence_ratio 0.637
+  verification { status: "pass" }
+```
+
+Real audio, produced by the surface this issue said could not produce it. So #369 does not close with
+a measurement of absence; it is implementable work, and this ticket is the mechanism.
+
+## 2. The mechanism, measured
+
+**The menu.** `File ▸ Export ▸ All Tracks as Audio Files…`. Two facts that a naive drive gets wrong:
+
+- Enablement read from a CLOSED menu is meaningless. The same items read `enabled=false` closed and
+  `enabled=true` with the menu open — macOS validates on open. A probe that skips opening reports
+  every export item unavailable.
+- The leaf's TITLE is rewritten by Logic with the selection: `Tracks as Audio Files…` became
+  `1 Track as Audio File…`. Resolving a leaf by name must survive a title Logic edits, not only one
+  it localizes.
+
+**The panel.** 628 elements. Buttons `New Folder`, `Hide Options`, `Cancel`, `Export` — the options
+are already shown. The option surface is fully readable:
+
+```
+popups      Logic · Trim Silence at File End · AIFF · One File per Track · 16-bit ·
+            Overload Protection Only
+checkboxes  Bypass Effect Plug-ins · Include Audio Tail · Include Volume/Pan Automation ·
+            Add resulting files to Project Browser · Include Tempo Information
+```
+
+`One File per Track` is the per-track control. It is on this panel, not behind it — correcting the
+earlier reading, which had seen only the file-browser half.
+
+**The destination.** Typing a path dismisses the panel. Reproduced twice: ⇧⌘G, type, Return, and the
+export panel is gone with nothing written. The first popup carries the destination (`Logic`), so the
+folder must be selected through the panel's own browser (`AXOutline` / `AXRow` / `AXCell`) as an
+element, and the popup re-read to confirm it changed **before** pressing Export.
+
+**Completion.** A window titled `Logic Pro` appears immediately after Export and is gone by the time
+a follow-up read arrives. It is the progress dialog, not an error. Its disappearance is the
+completion signal; the Export click returning is not.
+
+## 3. Acceptance criteria
+
+- [ ] AC-1: `export_run artifacts:[stem]` opens the export panel through the menu, with the menu
+      actually opened before any item is read or clicked.
+- [ ] AC-2: The destination is selected as a browser element and the destination popup is re-read and
+      confirmed changed before Export is pressed. A destination that cannot be confirmed is State C
+      with `write_attempted: false`.
+- [ ] AC-3: `One File per Track` is read back as the active value before Export is pressed, and a
+      panel that does not offer it is State C rather than a project-level bounce wearing the word
+      "stem".
+- [ ] AC-4: Completion waits for the progress window to disappear, bounded; a run that never sees it
+      appear and never sees it go is State B `readback_unavailable`, not success.
+- [ ] AC-5: Every produced file is verified with `logic_audio.analyze_file` and its non-silent
+      duration is non-zero. A stem that is silence is not a produced artifact.
+- [ ] AC-6: The panel is left closed on every exit path, including refusals.
+
+## 4. TDD spec
+
+Unit, against the fake AX runtime:
+
+- a closed menu whose items read `enabled=false` must not be treated as unavailable — the drive opens
+  the menu first, and the test asserts the open happened before the read
+- a leaf title that differs from the canonical (`1 Track as Audio File…` vs
+  `Tracks as Audio Files…`) still resolves
+- a destination popup whose value does not change after selection produces State C, `write_attempted:
+  false`
+- a progress window that never disappears within the budget produces State B, not State A
+- a produced file whose analysis reports `non_silent_duration_seconds == 0` fails verification
+
+Live, in `Scripts/livekit/`:
+
+- one region on one track, export, one file, analyzer `status: pass`, non-silent > 0
+- two populated tracks produce two files, and the count is asserted against the number of tracks with
+  regions rather than against the number of tracks
+- the run deletes what it produced and says so in the restoration record
+
+## 5. The decision this ticket is blocked on
+
+**What State does a partially successful stem run report?** Logic writes one file per populated
+track. If three of four verify and one is silence, the run has produced something real and something
+useless.
+
+The two coherent answers are: State C for the whole run with every file named and the good ones left
+on disk, or State A per file with a run-level summary that is not a State at all. This project's
+contract does not currently have a shape for "mostly worked", and inventing one inside this ticket
+would be deciding a contract question in an implementation.
+
+Everything else here is measured and mechanical.

--- a/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
+++ b/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
@@ -4,7 +4,7 @@
 **Priority**: P1
 **Size**: M
 **Status**: Not started
-**Depends On**: a contract decision, named in §5
+**Depends On**: None
 
 ---
 
@@ -98,15 +98,36 @@ Live, in `Scripts/livekit/`:
   regions rather than against the number of tracks
 - the run deletes what it produced and says so in the restoration record
 
-## 5. The decision this ticket is blocked on
+## 5. Partial success — the contract already has this shape
 
-**What State does a partially successful stem run report?** Logic writes one file per populated
-track. If three of four verify and one is silence, the run has produced something real and something
-useless.
+An earlier revision of this ticket said the project's contract had no shape for "mostly worked" and
+declared the ticket blocked on a decision. **That was wrong, and it was wrong the way this repository
+spends most of its guards on**: an absence asserted without aiming the instrument at the place the
+answer lives.
 
-The two coherent answers are: State C for the whole run with every file named and the good ones left
-on disk, or State A per file with a run-level summary that is not a State at all. This project's
-contract does not currently have a shape for "mostly worked", and inventing one inside this ticket
-would be deciding a contract question in an implementation.
+`ProjectExportExecutor` already carries it, and it is the executor `export_run artifacts:[stem]`
+flows through:
 
-Everything else here is measured and mechanical.
+```
+Honest Contract per artifact:
+  State A — bounce fired AND on-disk verification PASSED
+  State B — bounce fired but the artifact could not be verified (never appeared / analyzer
+            warn/fail) — success uncertain
+  State C — a hard failure (open/identity/route error, or the plan was degraded for this artifact)
+```
+
+So a stem run is a list of artifacts — one per populated track — each getting its own State, each
+verified on disk with `AudioAnalyzer`. That is what AC-5 already asks for, and it needs no new
+contract shape.
+
+Two things the existing machine does that a stem run should inherit rather than reinvent:
+
+- **`fail_if_exists` is never overwritten.** An artifact the plan flagged `would_overwrite` fails
+  closed rather than bouncing over a file that is already there.
+- **Already-present-and-verified artifacts are skipped**, which is what makes `export_resume`
+  idempotent. A stem run gets resume for free if it produces its file list the same way.
+
+The one thing genuinely new is that the file names come from Logic, not from the plan: the panel
+writes `<track name>_1.aif`, so the executor cannot pre-compute the paths it will poll for. It has to
+enumerate the destination after the progress window closes and bind each file to a track by name.
+That is implementation, not a contract question.

--- a/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
+++ b/docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md
@@ -156,12 +156,22 @@ decides how `export_resume` can stay idempotent.
 
 That is a property of a published dry-run contract, not an implementation detail.
 
-### Scope note
+### Scope note — and do NOT build this as a standalone operation
 
-T1 as written is the AX drive only, and it stands on its own: open the panel, choose a destination as
-an element, confirm the popup changed, set `One File per Track`, press Export, wait for the progress
-window to go, enumerate what appeared, verify each file. It can be built and live-proven without
-touching the planner.
+T1 is the AX drive: open the panel, choose a destination as an element, confirm the popup changed,
+set `One File per Track`, press Export, wait for the progress window to go, enumerate what appeared,
+verify each file. As CODE that stands on its own and can be live-proven without touching the planner.
 
-Wiring it into `export_run artifacts:[stem]` needs the plan-time question above answered first, and
-that is a separate ticket rather than the tail of this one.
+**As a shipped operation it does not.** The public export surface is two operations —
+`project.export_plan` and `project.export_run` (`ConfirmationPolicy.l2`, params `artifacts`,
+`collision_policy`, `confirmed`, `naming_policy`, …). There is no third place a stem drive can land
+without adding a new public operation, and that is a surface decision, not a free choice inside this
+ticket.
+
+Building T1 and leaving it unrouted reproduces the exact shape this repository retired eleven table
+rows for on 2026-08-18 — five `region.*` rows in #587 and six more in #592 — implementation standing
+behind a row no caller can reach, with a refusal string that reads as a promise.
+
+So the order is fixed: the plan-time question above is answered first, `export_run artifacts:[stem]`
+gains its path, and T1's drive lands inside it. T1 is not a starting point that can be shipped on its
+own; it is the mechanism the wiring will use, written down while the measurements are fresh.


### PR DESCRIPTION
Part of #369. Docs only — `docs/tickets/issue-369-per-track-stem-export/`.

## The roadmap's expectation for this issue was wrong, and it is measured wrong

Wave 6 says #369 should close with a measurement:

> the export panel's per-track filename fields report `settable=true` and do not accept writes.
> **If that holds**, per-track stems cannot be driven from this surface and the issue closes with the
> measurement.

Driven live on Logic Pro 12.3, Accessibility only, no coordinates:

```
~/Music/Logic/Studio Grand_1.aif    394,922 bytes

logic_audio.analyze_file
  2 ch · 48000 Hz · 2.048 s · peak −13.8 dBFS · 0.744 s non-silent · status: pass
```

Real audio, from the surface the plan said could not make it. So #369 is **implementable work**, not a
scope decision, and this PR turns the measurements into the ticket that implements it.

## What the earlier reading missed

`One File per Track` is a popup **on** the export panel. The previous measurement saw 148 settable
text fields and concluded the per-track surface sat behind the panel — that was the file-browser
half. The option half was on the same panel the whole time:

```
popups      Logic · Trim Silence at File End · AIFF · One File per Track · 16-bit · Overload Protection Only
checkboxes  Bypass Effect Plug-ins · Include Audio Tail · Include Volume/Pan Automation ·
            Add resulting files to Project Browser · Include Tempo Information
```

## Four things a naive drive gets wrong, all measured

**Menu enablement read from a closed menu is meaningless.** The same items read `enabled=false`
closed and `enabled=true` open — macOS validates on open. I spent a cycle believing export was
unavailable.

**The leaf title is rewritten by Logic**: `Tracks as Audio Files…` → `1 Track as Audio File…` with one
track selected. Name resolution must survive a title the application *edits*, not only one it
localizes.

**Typing a destination path dismisses the panel** — reproduced twice, nothing written. The folder has
to be picked as a browser element (`AXOutline`/`AXRow`) and the destination popup re-read to confirm
it changed *before* Export.

**The `Logic Pro` window after Export is the progress dialog, not an error.** It is gone by the time a
follow-up read arrives; a probe that sees a window appear and vanish around a write will file it as an
unread failure. Its disappearance is the completion signal — the Export click returning is not.

## What the ticket is blocked on, and why it is not decided here

Logic writes one file per populated track, so a run can partly succeed. If three of four verify and
one is silence, the run produced something real and something useless.

The two coherent answers are State C for the whole run with every file named, or State A per file
with a run-level summary that is not a State. This project's contract has no shape for "mostly
worked", and deciding that inside an implementation ticket is how a contract gets set by whoever
happened to be writing code that week.

Everything else in the ticket is measured and mechanical.

## Gate

`lpm-ship.sh` PASS — preflight clean, `Package.resolved` untouched, branch contains `origin/main`.