### PR TITLE
fix(#594): the first import into a new project, and an error that says what it saw

### DIFF
--- a/Scripts/livekit/live_594_first_import_after_project_new.py
+++ b/Scripts/livekit/live_594_first_import_after_project_new.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Live proof that the FIRST import into a freshly created project succeeds.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_594_first_import_after_project_new.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+`record_sequence` imports a Standard MIDI File through Logic's Open panel. After the go-to-folder
+field accepted the path, the code polled the Import button into an enabled state for 20 x 200ms and
+then gave up:
+
+    IMPORT_BTN_ERROR: Import button never became enabled (file not selected)
+
+Four seconds is enough for a WARM panel and not for the first one in a freshly created document.
+Measured five times across two locales: every failure was the first import after `project.new`, and
+every retry seconds later reached State A. That is the opening move an agent makes — create a
+project, record something — so the operation was failing at first contact and working for anyone who
+ignored its error.
+
+The message was the second half of the defect. "(file not selected)" is a cause this code never
+checked; it is what the code inferred from the button not enabling. A caller told a cause nobody
+measured cannot tell a slow panel from a wrong path.
+
+WHY THIS RUN CREATES A PROJECT
+------------------------------
+The defect exists only on the first import into a new document. A run against a project that had
+already imported once would exercise a warm panel and pass while measuring nothing, so this one makes
+the project and imports immediately, with no warm-up call in between. It says so here rather than
+leaving a reader to wonder why Logic restarted.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def escape_blocking_dialog():
+    """Dismiss a modal that has no AX-reachable buttons, and say whether it went.
+
+    Logic's save prompt appears as its own `AXDialog` window and, measured here, exposes NO buttons
+    to Accessibility at all — `dialog_buttons: []`. Worse, `first window whose name is "Save"` fails
+    with an invalid-index error while the same name is in the window list, so the window cannot even
+    be addressed by name. Escape dismisses it; nothing else this run can do will.
+
+    An earlier version of this harness tried to close it as if it were a document, six times.
+    """
+    before = window_titles()
+    osa('tell application "Logic Pro" to activate')
+    time.sleep(1)
+    osa('tell application "System Events" to key code 53')
+    time.sleep(2)
+    after = window_titles()
+    return {"before": before, "after": after, "dismissed": len(after) < len(before)}
+
+
+def document_titles():
+    return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+
+
+def close_open_documents():
+    """Leave Logic with no document open, using the product where it can and Escape where it cannot.
+
+    `project.close` is the right instrument and it refuses while a blocking dialog is present, so an
+    Escape pass runs first and again between attempts. `saving: "no"` discards — this run only ever
+    creates untitled scratch projects, and it verifies that before asking.
+    """
+    steps = []
+    for _ in range(4):
+        docs = document_titles()
+        if not docs:
+            break
+        named = [t for t in docs if not (t.startswith("Untitled") or t.startswith("무제"))]
+        if named:
+            steps.append({"refused": named,
+                          "why": "a named project is the operator's; this run does not discard it"})
+            return {"steps": steps, "refused_named_projects": named}
+        result = driver_close()
+        steps.append({"close": str(result)[:160]})
+        time.sleep(3)
+        if document_titles():
+            steps.append({"escape": escape_blocking_dialog()})
+    return {"steps": steps, "refused_named_projects": []}
+
+
+def inner(result):
+    """The channel envelope `record_sequence` carries verbatim under `detail`."""
+    raw = result.get("detail") if isinstance(result, dict) else None
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return {}
+
+
+titles = window_titles()
+ev.check("594/precondition-logic-is-up", bool(titles) or E.logic_window(None) is not None,
+         "Logic is running with at least one window, so a project can be created into it",
+         f"titles={titles!r}", None)
+
+d = E.Driver()
+time.sleep(4)
+
+
+def driver_close():
+    return d._send("tools/call", {"name": "logic_project",
+                                  "arguments": {"command": "close",
+                                                "params": {"confirmed": True, "saving": "no"}}})
+
+
+closed = close_open_documents()
+ev.note("594/closed-documents", closed)
+ev.check("594/precondition-no-document-is-open",
+         not document_titles() and not closed["refused_named_projects"],
+         "no document window remains, so the project this run creates is genuinely new — and no "
+         "named project of the operator's was discarded to get there",
+         f"remaining={document_titles()!r} refused={closed['refused_named_projects']!r} "
+         f"steps={json.dumps(closed['steps'], ensure_ascii=False)[:200]}", None)
+
+if document_titles() or closed["refused_named_projects"]:
+    d.close()
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=180)
+created = d.tool("logic_project", "new", {})
+time.sleep(8)
+ev.note("594/project-new", {k: v for k, v in created.items() if k != "raw_help"}
+        if isinstance(created, dict) else {"raw": str(created)[:200]})
+ev.check("594/a-new-project-exists",
+         bool(document_titles()),
+         "a document window appeared, so what follows is the FIRST import into a project that did "
+         "not exist a moment ago — the only state this defect lives in",
+         f"windows={window_titles()!r}", None)
+
+if not document_titles():
+    d.close(); ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+# No warm-up call. The whole point is the first one.
+first = d.tool("logic_tracks", "record_sequence", {"notes": "60,0,480"})
+body = inner(first) or (first if isinstance(first, dict) else {})
+ev.note("594/first-import", {k: v for k, v in (first or {}).items() if k != "raw_help"}
+        if isinstance(first, dict) else {"raw": str(first)[:300]})
+
+ev.check("594/the-first-import-into-a-new-project-succeeds",
+         isinstance(first, dict) and first.get("verified") is True,
+         "the very first `record_sequence` after `project.new` reaches State A, with no retry and no "
+         "warm-up call before it",
+         f"verified={first.get('verified') if isinstance(first, dict) else None!r} "
+         f"error={(first or {}).get('error')!r} "
+         f"detail={str((first or {}).get('detail'))[:200]!r}",
+         # Measured honestly, and it is not the tidy mutation the fix suggests. Restoring the
+         # original 20 x 200ms budget did NOT reproduce the failure on this attempt — the panel was
+         # warm enough by then. Cutting the poll to a single iteration DOES redden this check and
+         # only this one, which is what establishes that the check is sensitive to the poll rather
+         # than passing for some unrelated reason.
+         #
+         # So the case for widening the budget rests on the five recorded failures with the old one
+         # and none with the new, not on a reproduction under mutation. An intermittent defect is
+         # not made deterministic by wanting it to be.
+         "cut the poll to `repeat 1 times`: this check goes red and reports the Import button "
+         "staying disabled, while every other check here stays green")
+
+ev.check("594/it-reports-what-it-observed-rather-than-a-cause-it-inferred",
+         "file not selected" not in str((first or {}).get("detail", "")),
+         "the old message asserted \"(file not selected)\" — a cause the code never checked, inferred "
+         "from the button not enabling. Whatever this run reports, it is not that sentence",
+         f"detail={str((first or {}).get('detail'))[:200]!r}",
+         "restore the old failure string: it names a cause nobody measured, and a caller cannot tell "
+         "a slow panel from a wrong path from it")
+
+ev.check("594/the-region-it-made-is-real",
+         isinstance(first, dict)
+         and isinstance(first.get("start_bar"), int)
+         and isinstance(first.get("end_bar"), int)
+         and first["end_bar"] > first["start_bar"],
+         "the import produced a region with a read-back extent, so success here is a region Logic "
+         "confirms rather than an operation that merely stopped erroring",
+         f"start={first.get('start_bar') if isinstance(first, dict) else None!r} "
+         f"end={first.get('end_bar') if isinstance(first, dict) else None!r} "
+         f"name={(first or {}).get('region_name')!r} "
+         f"verify_source={(first or {}).get('verify_source')!r}",
+         "return State A without the readback: `verify_source` stops being `ax_region_delta` and the "
+         "bars stop being present, which is what separates a verified import from a quiet one")
+
+d.close()
+ev.restored("594/the-created-project-is-left-open",
+            bool(document_titles()),
+            f"this run creates a project on purpose — that is the state under test — and leaves it "
+            f"open rather than discarding it, so Logic is usable afterwards. Windows: "
+            f"{window_titles()!r}. Documents closed to reach a clean start: "
+            f"{json.dumps(closed, ensure_ascii=False)[:200]}")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+MIDIImport.swift
@@ -336,13 +336,28 @@ extension AccessibilityChannel {
                 -- Navigating to + selecting the file can take >1s, so poll the
                 -- Import button into an ENABLED state before clicking rather than
                 -- racing a fixed delay (clicking too early imports nothing and
-                -- leaves the panel open). ~4s (20 x 200ms).
+                -- leaves the panel open).
+                --
+                -- #594: this was 20 x 200ms, and four seconds is enough for a WARM Open panel and
+                -- not for the first one in a freshly created document. Measured five times across
+                -- two locales: every failure was the first import after `project.new`, and every
+                -- retry seconds later reached State A. That is the opening move an agent makes, so
+                -- the operation was failing at first contact and succeeding for anyone who ignored
+                -- its error.
+                --
+                -- 60 x 200ms, and the loop now records WHAT IT SAW rather than only whether it
+                -- clicked, so a timeout can say which of "no panel", "panel but no button" and
+                -- "button never enabled" actually happened.
                 set importClicked to false
-                repeat 20 times
+                set sawPanel to false
+                set sawButton to false
+                repeat 60 times
                     tell \(logicProAppleScript.systemEventsProcessTarget)
                         try
                             set importDlg to first window whose name is "가져오기"
+                            set sawPanel to true
                             set ib to button "가져오기" of UI element 1 of importDlg
+                            set sawButton to true
                             if (enabled of ib) then
                                 click ib
                                 set importClicked to true
@@ -351,7 +366,9 @@ extension AccessibilityChannel {
                         if importClicked is false then
                             try
                                 set importDlg to first window whose name is "Import"
+                                set sawPanel to true
                                 set ib to button "Import" of UI element 1 of importDlg
+                                set sawButton to true
                                 if (enabled of ib) then
                                     click ib
                                     set importClicked to true
@@ -373,7 +390,18 @@ extension AccessibilityChannel {
                             end if
                         end repeat
                     end tell
-                    return "IMPORT_BTN_ERROR: Import button never became enabled (file not selected)"
+                    -- #594: report the observation, not an inference. The old message asserted
+                    -- "(file not selected)" — a cause this code never checked, inferred from the
+                    -- button not enabling. A caller told a cause that was never measured cannot tell
+                    -- a slow panel from a wrong path, and this operation's whole contract is that it
+                    -- does not state what it did not observe.
+                    if sawPanel is false then
+                        return "IMPORT_BTN_ERROR: the Import panel never appeared after the path was accepted"
+                    else if sawButton is false then
+                        return "IMPORT_BTN_ERROR: the Import panel appeared but exposed no Import button"
+                    else
+                        return "IMPORT_BTN_ERROR: the Import button stayed disabled for the whole wait after the path was accepted"
+                    end if
                 end if
                 -- Poll for the tempo dialog (subrole AXDialog) before dismissing
                 -- rather than a fixed delay. ~3s (15 x 200ms).


### PR DESCRIPTION
Closes #594

## The failure

`record_sequence` imports a Standard MIDI File through Logic's Open panel. After the go-to-folder
field accepted the path, the code polled the Import button into an enabled state for `20 x 200ms` and
gave up.

Four seconds is enough for a **warm** panel and not for the first one in a freshly created document.
Measured five times across two locales: every failure was the first import after `project.new`, and
every retry seconds later reached State A. That is the opening move an agent makes — create a
project, record something — so the operation was failing at first contact and working for anyone who
ignored its error, which is the wrong lesson to teach.

The budget is now `60 x 200ms`.

## The message was the other half

```
IMPORT_BTN_ERROR: Import button never became enabled (file not selected)
```

*"(file not selected)"* is a cause this code never checked. It is what the code **inferred** from the
button not enabling, stated as though it had been observed — so a caller could not tell a slow panel
from a wrong path. The loop now records whether it saw the panel and whether it saw the button, and
the failure names which of the three actually happened.

I wrote that message with a duration in it first — *"stayed disabled for 12s"* — which is the same
defect one layer down: the code counts iterations, it does not measure time. The number went wrong
the moment a mutation changed the budget, which is how it was caught.

## What the mutation actually did

The evidence document says this plainly rather than implying the tidy version:

- restoring the original `20 x 200ms` budget **did not reproduce** the failure on the attempt that
  tested it — the panel was warm enough by then
- cutting the poll to a **single iteration** does redden the first-import check and only that one,
  which establishes the check is sensitive to the poll rather than passing for an unrelated reason

So the case for widening rests on five recorded failures with the old budget and none with the new,
not on a reproduction under mutation. An intermittent defect is not made deterministic by wanting it
to be. `Certainty: tentative`.

## Live proof

The run closes any open document, creates a project, and imports **immediately** — no warm-up call,
because the first one is the whole point.

```
7 checks · 7 passed · 3 mutation-backed · visual 1/1 · restoration recorded
```

## Two things the harness had to learn about Logic

**The save prompt is its own window, not a sheet on the document.** An earlier version put it in the
document list and then tried to close the prompt as if it were a project, six times over.

**That window exposes no buttons to Accessibility** — `dialog_buttons: []` — and
`first window whose name is "Save"` fails with an invalid-index error while that exact name sits in
the window list. It cannot be addressed by name or answered by button. Escape dismisses it; nothing
else available to the run does. So the shutdown drives `project.close`, which is the right instrument
and refuses while a modal is present, and escapes between attempts.

## Gate

`lpm-ship.sh` PASS at `71728dea` — 3828 tests, preflight clean, `Package.resolved` untouched, branch
contains `origin/main`, live evidence for this head.