### PR TITLE
feat(#291): read a channel strip's output destination, and stop claiming its sends

### DIFF
--- a/Scripts/livekit/live_291_output_slot_is_read.py
+++ b/Scripts/livekit/live_291_output_slot_is_read.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Live proof that a channel strip's output destination is read rather than left null.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_291_output_slot_is_read.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+`ChannelStripState.output` has been on the model since it was written and NOTHING ever set it.
+`defaultGetMixerState` populated `trackIndex`, `volume`, `pan` and `plugins`, and left `input`,
+`output` and `sends` untouched — so `logic://mixer` published an `output` field that was null on every
+strip of every project. A consumer reading it could not tell "not routed" from "never read", because
+the field never carried either.
+
+WHAT IS READ NOW, AND WHAT IS STILL NOT
+---------------------------------------
+Measured on Logic Pro 12.3, English:
+
+    output slot   AXButton, help "Output slot. Click and hold to choose the channel strip output…",
+                  and its AXDescription carries the destination — "Stereo Output"
+    send slot     AXButton, described only as "send button"; an empty one exposes no AXValue, no
+                  AXValueDescription and no AXTitle at all
+
+So an output can be read and a send destination cannot. This change reads outputs and claims nothing
+about sends — which is the asymmetry ADR-008's `complete: false` and `partialReason` exist for, and
+the reason the graph itself is a later slice rather than this one.
+
+The reader is deliberately narrow. It matches the output slot by its help string, so the send button
+sitting beside it — whose help also talks about routing a signal — cannot be mistaken for an output.
+And only the English rendering is measured: on a Logic in another language the reader yields nothing,
+so a caller sees an absent output rather than a wrong one.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    # NOTE: AppleScript joins the list with ", " and a project name containing a comma would
+    # split into two phantom windows. Nothing here acts on a window it did not also find by
+    # its own frame, so the effect is a noisier record rather than a wrong action.
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def document_titles():
+    return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+
+
+def slot_descriptions_by_help():
+    """What Logic's own buttons say, read by a second instrument.
+
+    This walks the arrange window for AXButtons and reports each one's help and description, so the
+    envelope's `output` can be held against the element it claims to come from rather than only
+    against itself.
+    """
+    raw = osa('''
+    tell application "System Events" to tell process "Logic Pro"
+      set w to first window whose name ends with "Tracks"
+      set ec to entire contents of w
+      set out to ""
+      repeat with e in ec
+        set el to contents of e
+        try
+          if (role of el as text) is "AXButton" then
+            set h to (help of el as text)
+            if h starts with "Output slot" or h starts with "Send slot" then
+              set out to out & (description of el as text) & "\\t" & (text 1 thru 10 of h) & "\\n"
+            end if
+          end if
+        end try
+      end repeat
+      return out
+    end tell
+    ''')
+    rows = []
+    for line in raw.splitlines():
+        if "\t" in line:
+            desc, kind = line.split("\t", 1)
+            rows.append({"description": desc.strip(), "help_prefix": kind.strip()})
+    return rows
+
+
+def mixer_is_open(driver):
+    """Whether the product can read the Mixer — asked of the product, not re-derived.
+
+    This detector has been wrong twice. It first counted any element described "Mixer", which
+    includes the toolbar's AXCheckBox whether the pane is open or shut. It then required a
+    layout area with strips, and matched the INSPECTOR's two-strip area — which `getMixerArea`
+    refuses on purpose, because reading it would silently return only the selected track and the
+    output. Both times the harness concluded the pane was open, read an empty list, and reported
+    the feature as broken.
+
+    The product already answers this question and says so in the envelope: `data_source` reads
+    `mixer_not_visible` when its own landmark rule finds no mixer. Asking it is both simpler and
+    correct by construction — a second implementation of that rule is a second thing to get
+    wrong, and it got it wrong twice.
+    """
+    body = driver.resource("logic://mixer") or {}
+    source = body.get("data_source")
+    # `data_source` is poll FRESHNESS, not pane visibility: `mixer_not_visible` when the
+    # poller found no mixer, `ax_poll` when the last poll is recent, `cache_stale` when it is
+    # not. A closed mixer whose last successful poll is still cached reads `cache_stale`, so
+    # accepting anything but a fresh poll would call a shut pane open. Only `ax_poll` counts.
+    return source == "ax_poll"
+
+
+def toggle_mixer():
+    """Show or hide the Mixer through Logic's own View menu — no coordinates, and reversible."""
+    return osa(
+        'tell application "System Events" to tell process "Logic Pro"\n'
+        'set mi to (first menu item of menu 1 of menu bar item "View" of menu bar 1 '
+        'whose name contains "Mixer")\n'
+        'set nm to (name of mi as text)\n'
+        'click mi\n'
+        'delay 1.5\n'
+        'return nm\n'
+        'end tell')
+
+
+titles = document_titles()
+ev.check("291/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so its channel strip has an output slot to read",
+         f"windows={window_titles()!r}", None)
+if not titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = titles[0]
+win = E.logic_window(arrange_title)
+# Deliberately the title strip and not the working area: this run asserts that nothing
+# CHANGED, and the control bar's clock and the mixer's level meters move on their own, so
+# a band over them could never stay still and the assertion would fail for reasons that
+# have nothing to do with a read path writing something.
+band = (0, 0, win["w"], 28) if win else None
+ev.check("291/precondition-the-window-frame-is-known", band is not None,
+         "the arrange window's own frame read, so the capture band is inside it",
+         f"window={win!r} band={band!r}", None)
+if band is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+witness = slot_descriptions_by_help()
+ev.note("291/slots-seen-by-the-witness", witness)
+outputs = [r for r in witness if r["help_prefix"].startswith("Output")]
+sends = [r for r in witness if r["help_prefix"].startswith("Send")]
+
+ev.check("291/logic-exposes-an-output-slot-that-names-its-destination",
+         bool(outputs) and all(r["description"] for r in outputs),
+         "an output slot exists on the strip and its description carries a destination name — this "
+         "is the element the reader identifies, read here by a second instrument",
+         f"outputs={outputs!r}", None)
+
+ev.check("291/the-send-slot-names-no-destination",
+         bool(sends) and all(r["description"] in ("send button", "") for r in sends),
+         "the send slot beside it is described only as \"send button\" — it carries no destination, "
+         "which is why this change reads outputs and claims nothing about sends",
+         f"sends={sends!r}", None)
+
+d = E.Driver()
+time.sleep(5)
+
+# The mixer read needs the Mixer pane on screen. This run opens it if the product cannot see it,
+# records that it did, and puts it back — the same shape as the vertical-zoom actuation in the
+# #576 harness: a view setting changed on purpose, declared, and restored.
+mixer_was_open = mixer_is_open(d)
+toggles = []
+# The View menu entry is a TOGGLE and does not say which way it will go. Measured: with the pane
+# already open, one click closed it — and the earlier, looser detector reported that as success.
+# So the run judges the OUTCOME and tries once more, which is enough because a toggle has two
+# states. Each attempt waits for a fresh poll, since the resource is served from the poller cache
+# and answers `mixer_not_visible` until one lands.
+for _ in range(2):
+    if mixer_is_open(d):
+        break
+    toggles.append(toggle_mixer())
+    for _ in range(6):
+        time.sleep(2)
+        if mixer_is_open(d):
+            break
+ev.check("291/precondition-the-product-can-see-the-mixer",
+         mixer_is_open(d),
+         "the mixer resource reports a fresh poll rather than `mixer_not_visible`, so the strips "
+         "below are a real read — the product refuses the Inspector's two-strip area on purpose, "
+         "and this asks it rather than re-deriving its landmark rule",
+         f"was_open={mixer_was_open} toggles={toggles!r} now={mixer_is_open(d)}", None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("291/before", settle_region=band, window_title=arrange_title)
+# The mixer payload arrives under `strips`, not `data`, and `logic_mixer` exposes no read command at
+# all — the first version of this harness called `logic_mixer.get_state` and read `data`, and got
+# "Command 'get_state' is not registered" followed by an empty list. It reported that as the feature
+# failing. A harness that knocks on the wrong surface and blames the product is worse than no harness.
+body = d.resource("logic://mixer") or {}
+rows = body.get("strips") if isinstance(body.get("strips"), list) else []
+ev.note("291/mixer-resource", {"rows": len(rows),
+                               "data_source": body.get("data_source"),
+                               "cache_age_sec": body.get("cache_age_sec"),
+                               "first": rows[0] if rows else None})
+
+# `logic://mixer` is served from the state poller's cache, not read at call time. Saying so
+# is the difference between evidence and a screenshot of one: a run that quoted a snapshot
+# taken before the mixer was revealed would be describing the previous state.
+age = body.get("cache_age_sec")
+ev.provenance("291/mixer-strips",
+              f"state_poller_cache_{body.get('data_source')}",
+              round(age, 2) if isinstance(age, (int, float)) else None,
+              body.get("data_source") == "ax_poll")
+
+with_output = [r for r in rows if isinstance(r, dict) and r.get("output")]
+ev.check("291/an-unreadable-mixer-says-so-rather-than-publishing-an-empty-one",
+         bool(rows) or body.get("data_source") == "mixer_not_visible",
+         "either strips were read, or the envelope names `mixer_not_visible` as the reason there "
+         "are none — an empty list with no reason would read as \"this project has no channel "
+         "strips\", which is a different claim entirely",
+         f"rows={len(rows)} data_source={body.get('data_source')!r}", None)
+
+ev.check("291/the-mixer-readback-carries-an-output",
+         bool(with_output),
+         "at least one channel strip reports an output destination — the field was null on every "
+         "strip of every project before this change, because nothing ever set it",
+         f"strips={len(rows)} with_output={len(with_output)} "
+         f"sample={[r.get('output') for r in with_output][:4]!r}",
+         "revert the `state.output = …` line in `defaultGetMixerState`: every strip reports null "
+         "again, which is the defect")
+
+if outputs and with_output:
+    published = {r.get("output") for r in with_output}
+    witnessed = {r["description"] for r in outputs}
+    ev.check("291/every-published-output-is-a-string-logic-put-on-a-slot",
+             published.issubset(witnessed),
+             "every destination the readback publishes appears on an output slot the "
+             "witness read independently — checking only the FIRST slot would compare "
+             "against whichever one the window walk saw first, which can be the Inspector's "
+             "strip, and the product refuses that as a mixer on purpose",
+             f"published={sorted(published)!r} witnessed={sorted(witnessed)!r}",
+             "return a fixed string from the reader: the published set stops being a subset "
+             "of what Logic shows, while the not-null check above still passes — that pair "
+             "is what separates a reading from a constant")
+
+ev.check("291/no-strip-claims-a-send-destination",
+         all(not (isinstance(r, dict) and r.get("sends")) for r in rows),
+         "no strip reports sends: the send slot exposes no destination, so the readback stays "
+         "silent about them rather than inventing an empty list that reads as \"no sends\"",
+         f"strips reporting sends={[r.get('trackIndex') for r in rows if isinstance(r, dict) and r.get('sends')]!r}",
+         None)
+
+after = ev.shot("291/after", settle_region=band, window_title=arrange_title)
+ev.visual("291/no-project-state-was-touched",
+          before["file"], after["file"], band, expect_change=False,
+          why="both frames are captured with the Mixer in the SAME state, and every call between "
+              "them is a read, so the window must be byte-identical across it — a change here "
+              "would mean a read path wrote something")
+
+if toggles and not mixer_was_open:
+    toggle_mixer()
+    time.sleep(3)
+# Asked while the driver is still open, so the claim below is a measurement rather than an
+# assertion that cannot fail — a restoration record hard-coded to True is not a record.
+final_state = mixer_is_open(d)
+d.close()
+ev.restored("291/the-mixer-pane-is-back-where-it-was",
+            final_state == mixer_was_open,
+            f"the mixer was {'readable' if mixer_was_open else 'not readable'} to the product "
+            f"when this run started and is {'readable' if final_state else 'not readable'} now"
+            f"{'; revealed with ' + repr(toggles) + ' and put back' if toggles else ''}. Every "
+            f"other call here is a read; the only thing this run changed is that one view "
+            f"setting, and it says so rather than claiming it left no trace.")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -951,6 +951,24 @@ enum AXLocalePolicy {
     )
 
     /// Region detection by AXHelp keyword.
+    /// Identifies a channel strip's OUTPUT slot by its AXHelp string (#291).
+    ///
+    /// Measured on Logic Pro 12.3, English: the slot is an `AXButton` whose help reads "Output slot.
+    /// Click and hold to choose the channel strip output…" and whose DESCRIPTION carries the current
+    /// destination ("Stereo Output"). The send slot beside it is described only as "send button" and,
+    /// when empty, exposes no `AXValue`, `AXValueDescription` or `AXTitle` at all — so an output can
+    /// be read and a send destination cannot.
+    ///
+    /// Only the English rendering is measured. A Logic in another language yields no match, which
+    /// makes the reader report nothing rather than guess — and the caller sees an absent output
+    /// rather than a wrong one. The variants list grows when a locale is actually observed, not when
+    /// one is translated.
+    static let outputSlotHelpKeyword = LabelSet(
+        canonical: "output slot",
+        variants: [],
+        rationale: "Detects a channel strip's output slot by its AXHelp string; read-only classifier."
+    )
+
     static let regionHelpKeyword = LabelSet(
         canonical: "region",
         variants: ["리전"],

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -217,6 +217,40 @@ extension AXLogicProElements {
             : (layoutItems, unreadable)
     }
 
+    /// What a channel strip's output slot says it is routed to (#291).
+    ///
+    /// Returns the slot button's `AXDescription` — measured on Logic Pro 12.3 as "Stereo Output" for
+    /// a track going to the main output. `nil` means no output slot was identified, which is the
+    /// honest answer on a Logic whose help strings this project has not measured, or on a strip whose
+    /// buttons did not read. An absent output is not the same as a track routed nowhere, and callers
+    /// are expected to treat it as unknown.
+    ///
+    /// Sends deliberately have no counterpart here. The send slot is an `AXButton` described only as
+    /// "send button", and an empty one exposes no `AXValue`, `AXValueDescription` or `AXTitle` — so
+    /// there is nothing to read a destination from, and this file does not pretend otherwise.
+    static func outputSlotDestination(
+        in strip: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> String? {
+        let buttons = AXHelpers.findAllDescendants(
+            of: strip, role: kAXButtonRole, maxDepth: 4, runtime: runtime
+        )
+        for button in buttons {
+            let help = AXHelpers.getHelp(button, runtime: runtime) ?? ""
+            guard AXLocalePolicy.outputSlotHelpKeyword.containsAny(in: help.lowercased()) else {
+                continue
+            }
+            guard let description = AXHelpers.getDescription(button, runtime: runtime),
+                  !description.isEmpty else {
+                // The slot was found and did not name a destination. That is a gap, not an empty
+                // route, so it reads the same as not finding the slot at all.
+                return nil
+            }
+            return description
+        }
+        return nil
+    }
+
     static func findVolumeFader(
         in strip: AXUIElement,
         runtime: AXHelpers.Runtime = .production

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
@@ -28,6 +28,10 @@ extension AccessibilityChannel {
             )
             state.plugins = AXLogicProElements.pluginSlots(in: strip, runtime: runtime.ax)
             state.pluginsSource = "ax"
+            // #291: `output` has been on this model since it was written and nothing ever set it, so
+            // `logic://mixer` published a field that was always null. It is read now; `nil` still
+            // means "not identified", never "routed nowhere".
+            state.output = AXLogicProElements.outputSlotDestination(in: strip, runtime: runtime.ax)
             channelStrips.append(state)
         }
         return encodeResult(channelStrips)
@@ -58,6 +62,7 @@ extension AccessibilityChannel {
         var state = ChannelStripState(trackIndex: index, volume: volume, pan: pan)
         state.plugins = AXLogicProElements.pluginSlots(in: strip, runtime: runtime.ax)
         state.pluginsSource = "ax"
+        state.output = AXLogicProElements.outputSlotDestination(in: strip, runtime: runtime.ax)
         return encodeResult(state)
     }
 

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -121,7 +121,17 @@ struct ChannelStripState: Sendable, Codable {
     var trackIndex: Int
     var volume: Double = 0.0
     var pan: Double = 0.0
-    var sends: [SendState] = []
+    /// The strip's sends, when they have been READ (#291).
+    ///
+    /// This was `[SendState] = []`, so every strip of every project serialised `"sends": []` — and
+    /// nothing has ever populated it. A consumer reading that saw "this strip has no sends" when the
+    /// truth was "nobody looked", which is the same absence-as-claim the rest of this model refuses.
+    ///
+    /// It stays absent for now on purpose. Measured on Logic Pro 12.3, an empty send slot is an
+    /// `AXButton` described only as "send button" with no `AXValue`, no `AXValueDescription` and no
+    /// `AXTitle`, so there is nothing to read a destination from — and a send list cannot be
+    /// published until there is.
+    var sends: [SendState]?
     var input: String?
     var output: String?
     var eqEnabled: Bool = false

--- a/Tests/LogicProMCPTests/Issue291OutputSlotReadTests.swift
+++ b/Tests/LogicProMCPTests/Issue291OutputSlotReadTests.swift
@@ -1,0 +1,174 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - #291 — a channel strip's output slot, read rather than left null
+//
+// `ChannelStripState.output` has existed since the model was written and nothing ever set it, so
+// `logic://mixer` published a field that was always null. These pin what the reader does and, more
+// importantly, what it refuses to do.
+//
+// Measured on Logic Pro 12.3: the output slot is an `AXButton` whose help reads "Output slot. Click
+// and hold to choose the channel strip output…" and whose DESCRIPTION carries the destination
+// ("Stereo Output"). The send slot beside it is described only as "send button" and, when empty,
+// exposes no `AXValue`, `AXValueDescription` or `AXTitle` — which is why sends have no counterpart
+// here and this change claims none.
+@Suite("#291 the output slot is read, and nothing else is claimed")
+struct Issue291OutputSlotReadTests {
+    private func strip(
+        _ builder: FakeAXRuntimeBuilder,
+        id: Int,
+        outputHelp: String?,
+        outputDescription: String?,
+        withSendButton: Bool = true
+    ) -> AXUIElement {
+        let strip = builder.element(id)
+        builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        var children: [AXUIElement] = []
+        if let outputHelp {
+            let slot = builder.element(id + 1)
+            builder.setAttribute(slot, kAXRoleAttribute as String, kAXButtonRole as String)
+            builder.setAttribute(slot, kAXHelpAttribute as String, outputHelp)
+            if let outputDescription {
+                builder.setAttribute(slot, kAXDescriptionAttribute as String, outputDescription)
+            }
+            children.append(slot)
+        }
+        if withSendButton {
+            // Deliberately shaped like the real one: a button that names no destination anywhere.
+            let send = builder.element(id + 2)
+            builder.setAttribute(send, kAXRoleAttribute as String, kAXButtonRole as String)
+            builder.setAttribute(send, kAXHelpAttribute as String,
+                                 "Send slot. Route the signal to an aux channel strip.")
+            builder.setAttribute(send, kAXDescriptionAttribute as String, "send button")
+            children.append(send)
+        }
+        builder.setChildren(strip, children)
+        return strip
+    }
+
+    @Test("the destination comes from the output slot's description")
+    func readsTheDestination() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let element = strip(
+            builder, id: 29_100,
+            outputHelp: "Output slot. Click and hold to choose the channel strip output.",
+            outputDescription: "Stereo Output"
+        )
+        let read = AXLogicProElements.outputSlotDestination(
+            in: element, runtime: builder.makeAXRuntime()
+        )
+        #expect(try #require(read) == "Stereo Output")
+    }
+
+    /// The send button sits beside the output slot and its help mentions routing too. If the reader
+    /// matched on anything looser than the output-slot phrase it would return "send button" as a
+    /// destination — a wrong answer, which is worse than no answer.
+    @Test("the send button is never mistaken for an output")
+    func sendButtonIsNotAnOutput() {
+        let builder = FakeAXRuntimeBuilder()
+        let element = strip(builder, id: 29_200, outputHelp: nil, outputDescription: nil)
+        let read = AXLogicProElements.outputSlotDestination(
+            in: element, runtime: builder.makeAXRuntime()
+        )
+        #expect(read == nil)
+    }
+
+    /// A slot that was found but names nothing reads the same as no slot at all. "Found it and it is
+    /// blank" is a gap in the read, not a track routed nowhere, and the two must not collapse.
+    @Test("an output slot with no description reports nothing rather than an empty destination")
+    func blankSlotIsNotAnEmptyRoute() {
+        let builder = FakeAXRuntimeBuilder()
+        let element = strip(
+            builder, id: 29_300,
+            outputHelp: "Output slot. Click and hold to choose the channel strip output.",
+            outputDescription: ""
+        )
+        let read = AXLogicProElements.outputSlotDestination(
+            in: element, runtime: builder.makeAXRuntime()
+        )
+        #expect(read == nil)
+    }
+
+    /// Only the English help string is measured. A Logic in another language must yield nothing —
+    /// the caller then sees an absent output rather than a wrong one, and the variants list grows
+    /// when a locale is observed, not when one is translated.
+    @Test("an unmeasured locale yields no output rather than a guess")
+    func unmeasuredLocaleYieldsNothing() {
+        let builder = FakeAXRuntimeBuilder()
+        let element = strip(
+            builder, id: 29_400,
+            outputHelp: "출력 슬롯. 클릭한 상태를 유지하여 채널 스트립 출력을 선택하십시오.",
+            outputDescription: "스테레오 출력"
+        )
+        let read = AXLogicProElements.outputSlotDestination(
+            in: element, runtime: builder.makeAXRuntime()
+        )
+        #expect(read == nil)
+    }
+
+    /// `sends` was `[SendState] = []`, so every strip of every project serialised `"sends": []` while
+    /// nothing had ever populated it. A consumer read that as "this strip has no sends"; the truth
+    /// was "nobody looked". An absent key is how the two are told apart.
+    @Test("an unread send list is absent from the wire, not empty on it")
+    func unreadSendsAreAbsent() throws {
+        var state = ChannelStripState(trackIndex: 0)
+        state.output = "Stereo Output"
+        let wire = String(data: try JSONEncoder().encode(state), encoding: .utf8) ?? ""
+        #expect(!wire.contains("\"sends\""))
+        #expect(wire.contains("\"output\":\"Stereo Output\""))
+
+        // And when a send list IS read, it must reach the wire — including an empty one, which then
+        // genuinely means "looked, and there are none".
+        var read = ChannelStripState(trackIndex: 1)
+        read.sends = []
+        let readWire = String(data: try JSONEncoder().encode(read), encoding: .utf8) ?? ""
+        #expect(readWire.contains("\"sends\":[]"))
+    }
+
+    /// The wiring line itself, exercised through `defaultGetMixerState`.
+    ///
+    /// The other tests here call the reader directly, so deleting
+    /// `state.output = AXLogicProElements.outputSlotDestination(…)` from the mixer readback left the
+    /// whole suite green — the only thing pinning that line was a live run. Found by a blind review
+    /// of this slice, which is exactly the hole such a review is for.
+    @Test("the mixer readback itself carries the output it read")
+    func defaultGetMixerStatePopulatesOutput() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let strip = makeLiveDumpStrip(builder, id: 29_600)
+        let slot = builder.element(29_690)
+        builder.setAttribute(slot, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(slot, kAXHelpAttribute as String,
+                             "Output slot. Click and hold to choose the channel strip output.")
+        builder.setAttribute(slot, kAXDescriptionAttribute as String, "Stereo Output")
+        builder.setChildren(strip, AXHelpers.getChildren(strip, runtime: builder.makeAXRuntime()) + [slot])
+
+        let fixture = make123MixerFixture(stripCount: 3, firstStrip: strip, builder: builder)
+        let result = AccessibilityChannel.defaultGetMixerState(runtime: fixture.runtime)
+        let json = result.message
+        let strips = try #require(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]]
+        )
+        let first = try #require(strips.first)
+        #expect(try #require(first["output"] as? String) == "Stereo Output")
+    }
+
+    /// The whole point of the change: the field stops being permanently null.
+    @Test("the mixer readback carries the output it read")
+    func mixerStateCarriesOutput() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let element = strip(
+            builder, id: 29_500,
+            outputHelp: "Output slot. Click and hold to choose the channel strip output.",
+            outputDescription: "Bus 3"
+        )
+        var state = ChannelStripState(trackIndex: 0)
+        state.output = AXLogicProElements.outputSlotDestination(
+            in: element, runtime: builder.makeAXRuntime()
+        )
+        let wire = String(data: try JSONEncoder().encode(state), encoding: .utf8) ?? ""
+        #expect(try #require(state.output) == "Bus 3")
+        #expect(wire.contains("\"output\":\"Bus 3\""))
+    }
+}


### PR DESCRIPTION
First shippable slice of ADR-008. Not the graph — see below.

## The field was published as null since the model was written

`ChannelStripState.output` has existed since the model was written and **nothing ever set it**.
`defaultGetMixerState` populated `trackIndex`, `volume`, `pan` and `plugins` and left `input`,
`output` and `sends` untouched, so `logic://mixer` published an `output` field that was null on every
strip of every project. A consumer could not tell *"not routed"* from *"never read"*, because the
field never carried either.

## What is read now, and what still is not

Measured on Logic Pro 12.3, English:

| slot | element | carries a destination? |
|---|---|---|
| output | `AXButton`, help *"Output slot. Click and hold to choose the channel strip output…"* | **yes** — `AXDescription` is `Stereo Output` |
| send | `AXButton`, `AXDescription` `"send button"` | **no** — an empty one has no `AXValue`, no `AXValueDescription`, no `AXTitle` |

An output can be read; a send destination cannot. So outputs are read and sends are not claimed —
the asymmetry ADR-008's `complete` / `partialReason` exist for.

The reader matches the slot by its **help** string, so the send button beside it — whose help also
talks about sending a signal to an aux — cannot be published as a destination. Only the English
rendering is recorded and the variants list is deliberately **empty**: on another locale the reader
yields nothing, so a caller sees an absent output rather than a wrong one. That list grows when a
locale is observed, not when one is translated.

## `sends` was being published as empty, which is a claim

`sends` was `[SendState] = []`, so every strip serialised `"sends": []` while nothing had ever
populated it. That reads as *"this strip has no sends"*; the truth was *"nobody looked"*. It is
optional now and absent until something reads it — and when a send list **is** read, an empty one
then genuinely means "looked, and there are none". Nothing in the tree consumed the field.

## Why not the graph

The ADR-008 graph type is present, tested, behind a default-off flag, and built by nothing. It wants
bus **numbers** and typed edges, and the roadmap's measured obstacle for this issue is that a display
string cannot be a node id — the strip says `Bus 1` where the menu says `Sum 1`. A graph assembled
from this reader would be display strings with no bus numbers and no send edges: the ADR surface
without the ADR.

## A blind review found the hole in my own tests

The unit tests called the reader directly, so deleting the wiring line from `defaultGetMixerState`
left the **entire suite green** — the only thing pinning it was a live run. There is now a test that
goes through the real readback against the 12.3 fixture; removing that line reddens it and nothing
else.

## The harness was wrong four times, each time blaming the product

- called `logic_mixer.get_state` — not a registered command
- read the payload from `data` when it arrives under `strips`
- its "is the mixer open" detector counted the toolbar's `AXCheckBox`, then the Inspector's two-strip
  area — **both of which the product deliberately refuses as a mixer**
- the View menu entry is a toggle that does not say which way it will go: with the pane already open,
  one click closed it, and the looser detector called that success

It now asks the product the question the product already answers (`data_source`), requires a **fresh**
poll rather than accepting a stale cache as "open", judges the toggle by its outcome, records the
cache age as provenance instead of presenting a cached read as live, and compares every published
destination against the **set** of slot descriptions the witness read — not against whichever slot the
window walk saw first, which can be the Inspector's.

```
9 checks · 9 passed · 2 mutation-backed · visual 1/1 · restoration measured · provenance recorded
```

## Gate

`lpm-ship.sh` PASS at `0bc7cace` — 3834 tests, preflight clean, `Package.resolved` untouched, branch
contains `origin/main`, live evidence for this head.