### PR TITLE
fix(#290): an ordinal write refuses a strip list that was not read whole

### DIFF
--- a/Scripts/livekit/live_290_shifted_strips_are_refused.py
+++ b/Scripts/livekit/live_290_shifted_strips_are_refused.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Live proof that the ordinal-write guard did not break the path it guards.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_290_shifted_strips_are_refused.py <worktree> <full-40-char-head-sha>
+
+WHAT CHANGED
+------------
+`stripEnumeration` has always counted the mixer children whose role would not read, and every caller
+threw that count away. Its own comment says what the count is for:
+
+    A child whose role is unreadable is dropped by the filter, and every later strip then moves down
+    one. Callers address strips by ORDINAL, so a request for track 0 would act on physical strip 1 —
+    a wrong-target write that no downstream readback can catch, because the readback reads the same
+    shifted list.
+
+`mixer.insert_plugin` is such a caller and it is a WRITE. It now refuses, State C with
+`write_attempted: false`, when any mixer child would not report a role. That is ADR-007's rule at the
+one place it is already measurable: resolve exactly, or refuse.
+
+WHAT THIS RUN CAN AND CANNOT SHOW
+---------------------------------
+The refusal branch cannot be reached live. It fires when Logic's Accessibility tree fails to report a
+role for a mixer child — a transient the run cannot induce without corrupting the very tree it is
+measuring, and inducing it would prove the fake, not the guard. That branch is covered by unit tests
+with an injected AX failure, and by a mutation that removes the guard and reddens only its own test.
+
+What this run shows is the half a unit test cannot: that on a mixer Logic reads completely, the guard
+lets everything through. A guard is only as good as its false-positive rate, and the cheapest way for
+this one to be wrong is to refuse a mixer that is perfectly fine.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def document_titles():
+    return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+
+
+def toggle_mixer():
+    return osa('tell application "System Events" to tell process "Logic Pro" to '
+               'click (first menu item of menu 1 of menu bar item "View" of menu bar 1 '
+               'whose name contains "Mixer")')
+
+
+titles = document_titles()
+ev.check("290/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so there is a mixer to read",
+         f"windows={window_titles()!r}", None)
+if not titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = titles[0]
+win = E.logic_window(arrange_title)
+band = (0, 0, win["w"], 28) if win else None
+ev.check("290/precondition-the-window-frame-is-known", band is not None,
+         "the arrange window's own frame read, so the capture band is inside it",
+         f"window={win!r} band={band!r}", None)
+if band is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+d = E.Driver()
+time.sleep(5)
+
+
+def mixer_readable():
+    """Asked of the product: `data_source` is `mixer_not_visible` when its landmark finds no mixer,
+    and only a FRESH poll (`ax_poll`) means the strips below are a real read."""
+    return ((d.resource("logic://mixer") or {}).get("data_source")) == "ax_poll"
+
+
+toggles = []
+for _ in range(2):
+    if mixer_readable():
+        break
+    toggles.append(toggle_mixer())
+    for _ in range(6):
+        time.sleep(2)
+        if mixer_readable():
+            break
+
+was_readable_at_start = not toggles
+ev.check("290/precondition-the-product-can-read-the-mixer",
+         mixer_readable(),
+         "the mixer resource reports a fresh poll, so a strip list exists for the guard to pass or "
+         "refuse — asked of the product rather than re-derived from its landmark rule",
+         f"toggles={toggles!r} readable={mixer_readable()}", None)
+
+rec = ev.record_screen(seconds=150)
+before = ev.shot("290/before", settle_region=band, window_title=arrange_title)
+
+body = d.resource("logic://mixer") or {}
+strips = body.get("strips") if isinstance(body.get("strips"), list) else []
+age = body.get("cache_age_sec")
+ev.provenance("290/mixer-strips", f"state_poller_cache_{body.get('data_source')}",
+              round(age, 2) if isinstance(age, (int, float)) else None,
+              body.get("data_source") == "ax_poll")
+ev.note("290/strips", {"count": len(strips), "data_source": body.get("data_source")})
+
+ev.check("290/the-mixer-reads-completely-on-this-host",
+         bool(strips),
+         "Logic reports every mixer child's role here, so this run exercises the guard's PASS side — "
+         "the refusal side cannot be induced live without corrupting the tree being measured, and is "
+         "covered by unit tests with an injected AX failure",
+         f"strips={len(strips)} data_source={body.get('data_source')!r}", None)
+
+# The guard sits in front of a write. Probe it with a parameter it rejects rather than actually
+# inserting a plugin into the operator's project: what matters is that the call still reaches its
+# validation instead of being refused by the new guard.
+probe = d.tool("logic_mixer", "insert_plugin", {"nope": "1"})
+hint = (probe.get("hint") or "") if isinstance(probe, dict) else ""
+ev.note("290/insert-probe", probe if isinstance(probe, dict) else {"raw": str(probe)[:200]})
+
+ev.check("290/the-guard-does-not-refuse-a-mixer-that-reads-fine",
+         "unreadable_mixer_children" not in str(probe),
+         "the new refusal does not fire on a healthy mixer — a guard's cheapest way to be wrong is "
+         "to reject something that was never broken, and that is the half a unit test cannot show",
+         f"hint={hint[:160]!r}",
+         "invert the guard to refuse when the count is ZERO: this check goes red on every healthy "
+         "mixer, which is the false-positive direction that matters")
+
+ev.check("290/the-write-path-still-validates-its-input",
+         isinstance(probe, dict)
+         and ("Allowed parameters" in hint or "Unknown parameters" in hint
+              or probe.get("error") == "invalid_params"),
+         "insert_plugin still reaches its own parameter validation, so the guard was added in front "
+         "of the path rather than in place of it",
+         f"error={probe.get('error') if isinstance(probe, dict) else None!r} hint={hint[:140]!r}",
+         None)
+
+after = ev.shot("290/after", settle_region=band, window_title=arrange_title)
+ev.visual("290/no-project-state-was-touched",
+          before["file"], after["file"], band, expect_change=False,
+          why="every call in this run is a read or a rejected parameter, so the window must be "
+              "byte-identical across it — a change here would mean something wrote")
+
+if toggles and not was_readable_at_start:
+    toggle_mixer()
+    # The resource is served from the poller's cache, so closing the pane does not change the answer
+    # until a poll lands on the new state. Measuring immediately reads the world as it was and
+    # reports a restore that did happen as one that did not.
+    for _ in range(8):
+        time.sleep(2)
+        if not mixer_readable():
+            break
+final_readable = mixer_readable()
+d.close()
+ev.restored("290/the-mixer-pane-is-back-where-it-was",
+            final_readable == was_readable_at_start,
+            f"the mixer was {'readable' if was_readable_at_start else 'not readable'} to the product "
+            f"when this run started and is {'readable' if final_readable else 'not readable'} now"
+            f"{'; revealed with ' + repr(toggles) + ' and put back' if toggles else ''}.")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -191,6 +191,26 @@ extension AXLogicProElements {
         stripEnumeration(in: mixer, runtime: runtime).strips
     }
 
+    /// The strips, but only when the enumeration read EVERY child (#290).
+    ///
+    /// `stripEnumeration` has always counted the children whose role would not read, and every
+    /// caller threw that count away. The comment on it says what the count is for: a dropped child
+    /// moves every later strip down one, and callers address strips by ORDINAL — so a request for
+    /// track 0 acts on physical strip 1, and no readback catches it, because the readback reads the
+    /// same shifted list.
+    ///
+    /// This is ADR-007's rule applied to the one place it is already measurable: resolve exactly, or
+    /// refuse. A caller that indexes the result of this function is indexing a list that was read
+    /// whole.
+    static func mixerChannelStripsIfCompletelyRead(
+        in mixer: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> (strips: [AXUIElement], unreadableChildren: Int)? {
+        let enumeration = stripEnumeration(in: mixer, runtime: runtime)
+        guard enumeration.unreadableChildren == 0 else { return nil }
+        return enumeration
+    }
+
     /// The strips, plus whether any child's role could not be read.
     ///
     /// A child whose role is unreadable is dropped by the filter, and every later strip then moves

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Plugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Plugins.swift
@@ -87,7 +87,28 @@ extension AccessibilityChannel {
                 hint: "Cannot locate visible mixer for insert_plugin"
             ))
         }
-        let strips = AXLogicProElements.mixerChannelStrips(in: mixer, runtime: runtime.ax)
+        // #290: this operation indexes the strip list by ORDINAL, so it may only do so when that
+        // list was read whole. A child whose role would not read is dropped by the filter and every
+        // later strip moves down one — a request for track 0 then inserts into physical strip 1, and
+        // no readback catches it because the readback reads the same shifted list. Resolve exactly,
+        // or refuse.
+        let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime.ax)
+        guard enumeration.unreadableChildren == 0 else {
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "refusing insert_plugin: \(enumeration.unreadableChildren) mixer child(ren) "
+                    + "would not report a role, so the strip at index \(track) cannot be trusted to "
+                    + "be the strip for that track — a dropped child shifts every later ordinal and "
+                    + "no readback can catch the wrong target.",
+                extras: [
+                    "track": track,
+                    "visible_strips": enumeration.strips.count,
+                    "unreadable_mixer_children": enumeration.unreadableChildren,
+                    "write_attempted": false,
+                ]
+            ))
+        }
+        let strips = enumeration.strips
         guard track < strips.count else {
             return .error(HonestContract.encodeStateC(
                 error: .elementNotFound,

--- a/Tests/LogicProMCPTests/Issue290ShiftedOrdinalRefusalTests.swift
+++ b/Tests/LogicProMCPTests/Issue290ShiftedOrdinalRefusalTests.swift
@@ -1,0 +1,89 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+// MARK: - #290 — an ordinal write refuses a list that was not read whole
+//
+// `stripEnumeration` has always counted the mixer children whose role would not read, and every
+// caller threw that count away. Its own comment says what the count is for:
+//
+//     A child whose role is unreadable is dropped by the filter, and every later strip then moves
+//     down one. Callers address strips by ORDINAL, so a request for track 0 would act on physical
+//     strip 1 — a wrong-target write that no downstream readback can catch, because the readback
+//     reads the same shifted list.
+//
+// `mixer.insert_plugin` is such a caller and it is a WRITE. This is ADR-007's rule at the one place
+// it is already measurable: resolve exactly, or refuse.
+@Suite("#290 a shifted strip list is refused rather than indexed")
+struct Issue290ShiftedOrdinalRefusalTests {
+    /// A mixer whose children include one element whose role will not read.
+    private func mixerWithUnreadableChild(
+        _ builder: FakeAXRuntimeBuilder,
+        id: Int,
+        readableStrips: Int
+    ) -> (mixer: AXUIElement, runtime: AXHelpers.Runtime) {
+        let mixer = builder.element(id)
+        builder.setAttribute(mixer, kAXRoleAttribute as String, kAXGroupRole as String)
+        var children: [AXUIElement] = []
+        for offset in 0..<readableStrips {
+            let strip = builder.element(id + 10 + offset)
+            builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            children.append(strip)
+        }
+        let mystery = builder.element(id + 99)
+        children.append(mystery)
+        builder.setChildren(mixer, children)
+        let mysteryID = builder.elementID(mystery)
+
+        let runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                guard builder.elementID(element) == mysteryID,
+                      attribute == (kAXRoleAttribute as String) else { return nil }
+                return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+        return (mixer, runtime)
+    }
+
+    @Test("the enumeration reports the child it could not read")
+    func enumerationCountsTheUnreadableChild() {
+        let builder = FakeAXRuntimeBuilder()
+        let (mixer, runtime) = mixerWithUnreadableChild(builder, id: 29_000, readableStrips: 3)
+        let enumeration = AXLogicProElements.stripEnumeration(in: mixer, runtime: runtime)
+        #expect(enumeration.strips.count == 3)
+        #expect(enumeration.unreadableChildren == 1)
+    }
+
+    /// The strict accessor is the whole point: a caller that indexes its result is indexing a list
+    /// that was read whole, and it has no way to opt out of that by accident.
+    @Test("the strict accessor yields nothing when a child would not read")
+    func strictAccessorRefusesAnIncompleteRead() {
+        let builder = FakeAXRuntimeBuilder()
+        let (mixer, runtime) = mixerWithUnreadableChild(builder, id: 29_100, readableStrips: 4)
+        #expect(AXLogicProElements.mixerChannelStripsIfCompletelyRead(
+            in: mixer, runtime: runtime
+        ) == nil)
+    }
+
+    @Test("a fully readable mixer still yields its strips")
+    func strictAccessorPassesACompleteRead() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let mixer = builder.element(29_200)
+        builder.setAttribute(mixer, kAXRoleAttribute as String, kAXGroupRole as String)
+        let strips = (0..<3).map { offset -> AXUIElement in
+            let strip = builder.element(29_210 + offset)
+            builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            return strip
+        }
+        builder.setChildren(mixer, strips)
+
+        let result = try #require(AXLogicProElements.mixerChannelStripsIfCompletelyRead(
+            in: mixer, runtime: builder.makeAXRuntime()
+        ))
+        #expect(result.strips.count == 3)
+        #expect(result.unreadableChildren == 0)
+    }
+}


### PR DESCRIPTION
## The hazard was measured, counted, and thrown away

`stripEnumeration` has always returned the count of mixer children whose role would not read. Every
caller discarded it:

```swift
static func mixerChannelStrips(…) -> [AXUIElement] {
    stripEnumeration(in: mixer, runtime: runtime).strips   // the count goes here to die
}
```

Its own comment says what the count is for:

> A child whose role is unreadable is dropped by the filter, and every later strip then moves down
> one. Callers address strips by **ordinal**, so a request for track 0 would act on physical strip 1
> — a wrong-target write that no downstream readback can catch, because the readback reads the same
> shifted list.

`mixer.insert_plugin` is such a caller, it is **registered**, and it is a **write**:

```swift
let strips = mixerChannelStrips(in: mixer, …)
let strip  = strips[track]
```

## The change

It refuses with State C and `write_attempted: false` when any mixer child would not report a role,
and the envelope carries `unreadable_mixer_children` so the refusal can be acted on rather than
merely suffered.

This is ADR-007's rule at the one place it is already measurable: **resolve exactly, or refuse.** The
selector resolver that rule belongs to is in the tree, tested, behind a default-off flag, and called
by nothing — that stays true, and this change does not pretend to have wired it. It stops one
operation indexing a list it cannot trust while the mechanism to do that properly is built.

`mixer.set_volume` and `set_pan` are **not** affected and did not need to be: they target the
per-track header fader, which belongs to exactly one track by construction (#107), and never index
the strip list.

## What the live run can and cannot show

The refusal branch **cannot be reached live**. It fires when Logic's Accessibility tree fails to
report a role for a mixer child — a transient the run cannot induce without corrupting the very tree
it is measuring, and inducing it would prove the fake rather than the guard. That branch is covered
by unit tests with an injected AX failure, and by a mutation that removes the guard and reddens only
its own test.

What the run shows is the half a unit test cannot: **on a mixer Logic reads completely, the guard
lets everything through.** A guard's cheapest way to be wrong is to reject something that was never
broken, and the mutation named on that check inverts it to refuse when the count is zero — which
reddens on every healthy mixer.

```
6 checks · 6 passed · visual 1/1 (negative) · restoration measured · provenance recorded
```

## What the harness learned

Closing the mixer pane and immediately asking whether it was closed reported a restore that **had**
happened as one that had not: the resource is served from the poller's cache, so the answer lags the
world by a poll. It now waits for the cache to catch up before judging its own restoration.

## Gate

`lpm-ship.sh` PASS at `3edbb497` — 3831 tests, preflight clean, `Package.resolved` untouched, branch
contains `origin/main`, live evidence for this head.