### PR TITLE
feat(#291): read a channel strip's input source, and refuse the toggle beside it

### DIFF
--- a/Scripts/livekit/live_291_input_slot_is_read.py
+++ b/Scripts/livekit/live_291_input_slot_is_read.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Live proof that a channel strip's INPUT source is read, and its monitoring toggle is not.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_291_output_slot_is_read.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+`ChannelStripState.output` has been on the model since it was written and NOTHING ever set it.
+`defaultGetMixerState` populated `trackIndex`, `volume`, `pan` and `plugins`, and left `input`,
+`output` and `sends` untouched — so `logic://mixer` published an `output` field that was null on every
+strip of every project. A consumer reading it could not tell "not routed" from "never read", because
+the field never carried either.
+
+WHAT IS READ NOW, AND WHAT IS STILL NOT
+---------------------------------------
+Measured on Logic Pro 12.3, English:
+
+    output slot   AXButton, help "Output slot. Click and hold to choose the channel strip output…",
+                  and its AXDescription carries the destination — "Stereo Output"
+    send slot     AXButton, described only as "send button"; an empty one exposes no AXValue, no
+                  AXValueDescription and no AXTitle at all
+
+So an output can be read and a send destination cannot. This change reads outputs and claims nothing
+about sends — which is the asymmetry ADR-008's `complete: false` and `partialReason` exist for, and
+the reason the graph itself is a later slice rather than this one.
+
+The reader is deliberately narrow. It matches the output slot by its help string, so the send button
+sitting beside it — whose help also talks about routing a signal — cannot be mistaken for an output.
+And only the English rendering is measured: on a Logic in another language the reader yields nothing,
+so a caller sees an absent output rather than a wrong one.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    # NOTE: AppleScript joins the list with ", " and a project name containing a comma would
+    # split into two phantom windows. Nothing here acts on a window it did not also find by
+    # its own frame, so the effect is a noisier record rather than a wrong action.
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def document_titles():
+    return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+
+
+def slot_descriptions_by_help():
+    """What Logic's own buttons say, read by a second instrument.
+
+    This walks the arrange window for AXButtons and reports each one's help and description, so the
+    envelope's `output` can be held against the element it claims to come from rather than only
+    against itself.
+    """
+    raw = osa('''
+    tell application "System Events" to tell process "Logic Pro"
+      set w to first window whose name ends with "Tracks"
+      set ec to entire contents of w
+      set out to ""
+      repeat with e in ec
+        set el to contents of e
+        try
+          if (role of el as text) is "AXButton" then
+            set h to (help of el as text)
+            if h starts with "Output slot" or h starts with "Send slot" or h starts with "Input slot" or h starts with "Input Monitoring" then
+              set out to out & (description of el as text) & "\\t" & (text 1 thru 12 of h) & "\\n"
+            end if
+          end if
+        end try
+      end repeat
+      return out
+    end tell
+    ''')
+    rows = []
+    for line in raw.splitlines():
+        if "\t" in line:
+            desc, kind = line.split("\t", 1)
+            rows.append({"description": desc.strip(), "help_prefix": kind.strip()})
+    return rows
+
+
+def mixer_is_open(driver):
+    """Whether the product can read the Mixer — asked of the product, not re-derived.
+
+    This detector has been wrong twice. It first counted any element described "Mixer", which
+    includes the toolbar's AXCheckBox whether the pane is open or shut. It then required a
+    layout area with strips, and matched the INSPECTOR's two-strip area — which `getMixerArea`
+    refuses on purpose, because reading it would silently return only the selected track and the
+    output. Both times the harness concluded the pane was open, read an empty list, and reported
+    the feature as broken.
+
+    The product already answers this question and says so in the envelope: `data_source` reads
+    `mixer_not_visible` when its own landmark rule finds no mixer. Asking it is both simpler and
+    correct by construction — a second implementation of that rule is a second thing to get
+    wrong, and it got it wrong twice.
+    """
+    body = driver.resource("logic://mixer") or {}
+    source = body.get("data_source")
+    # `data_source` is poll FRESHNESS, not pane visibility: `mixer_not_visible` when the
+    # poller found no mixer, `ax_poll` when the last poll is recent, `cache_stale` when it is
+    # not. A closed mixer whose last successful poll is still cached reads `cache_stale`, so
+    # accepting anything but a fresh poll would call a shut pane open. Only `ax_poll` counts.
+    return source == "ax_poll"
+
+
+def toggle_mixer():
+    """Show or hide the Mixer through Logic's own View menu — no coordinates, and reversible."""
+    return osa(
+        'tell application "System Events" to tell process "Logic Pro"\n'
+        'set mi to (first menu item of menu 1 of menu bar item "View" of menu bar 1 '
+        'whose name contains "Mixer")\n'
+        'set nm to (name of mi as text)\n'
+        'click mi\n'
+        'delay 1.5\n'
+        'return nm\n'
+        'end tell')
+
+
+titles = document_titles()
+ev.check("291i/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so its channel strip has an output slot to read",
+         f"windows={window_titles()!r}", None)
+if not titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = titles[0]
+win = E.logic_window(arrange_title)
+# Deliberately the title strip and not the working area: this run asserts that nothing
+# CHANGED, and the control bar's clock and the mixer's level meters move on their own, so
+# a band over them could never stay still and the assertion would fail for reasons that
+# have nothing to do with a read path writing something.
+band = (0, 0, win["w"], 28) if win else None
+ev.check("291i/precondition-the-window-frame-is-known", band is not None,
+         "the arrange window's own frame read, so the capture band is inside it",
+         f"window={win!r} band={band!r}", None)
+if band is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+witness = slot_descriptions_by_help()
+ev.note("291i/slots-seen-by-the-witness", witness)
+outputs = [r for r in witness if r["help_prefix"].startswith("Output")]
+sends = [r for r in witness if r["help_prefix"].startswith("Send")]
+
+ev.check("291i/logic-exposes-an-output-slot-that-names-its-destination",
+         bool(outputs) and all(r["description"] for r in outputs),
+         "an output slot exists on the strip and its description carries a destination name — this "
+         "is the element the reader identifies, read here by a second instrument",
+         f"outputs={outputs!r}", None)
+
+inputs = [r for r in witness if r["help_prefix"].startswith("Input slot")]
+monitors = [r for r in witness if r["help_prefix"].startswith("Input Moni")]
+ev.check("291i/logic-exposes-an-input-slot-that-names-its-source",
+         bool(inputs) and all(r["description"] for r in inputs),
+         "an input slot exists on an audio strip and its description carries a source name — read "
+         "here by a second instrument, not by the code under test",
+         f"inputs={inputs!r}", None)
+
+ev.check("291i/the-monitoring-button-sits-right-beside-it",
+         bool(monitors),
+         "the Input Monitoring button is present on the same strip and its help also begins with "
+         "\"Input\" — this is the neighbour a bare-word match would publish as a source, and the "
+         "run confirms it is really there rather than taking the hazard on faith",
+         f"monitors={monitors!r}", None)
+
+ev.check("291i/the-send-slot-names-no-destination",
+         bool(sends) and all(r["description"] in ("send button", "") for r in sends),
+         "the send slot beside it is described only as \"send button\" — it carries no destination, "
+         "which is why this change reads outputs and claims nothing about sends",
+         f"sends={sends!r}", None)
+
+d = E.Driver()
+time.sleep(5)
+
+# The mixer read needs the Mixer pane on screen. This run opens it if the product cannot see it,
+# records that it did, and puts it back — the same shape as the vertical-zoom actuation in the
+# #576 harness: a view setting changed on purpose, declared, and restored.
+mixer_was_open = mixer_is_open(d)
+toggles = []
+# The View menu entry is a TOGGLE and does not say which way it will go. Measured: with the pane
+# already open, one click closed it — and the earlier, looser detector reported that as success.
+# So the run judges the OUTCOME and tries once more, which is enough because a toggle has two
+# states. Each attempt waits for a fresh poll, since the resource is served from the poller cache
+# and answers `mixer_not_visible` until one lands.
+for _ in range(2):
+    if mixer_is_open(d):
+        break
+    toggles.append(toggle_mixer())
+    for _ in range(6):
+        time.sleep(2)
+        if mixer_is_open(d):
+            break
+ev.check("291i/precondition-the-product-can-see-the-mixer",
+         mixer_is_open(d),
+         "the mixer resource reports a fresh poll rather than `mixer_not_visible`, so the strips "
+         "below are a real read — the product refuses the Inspector's two-strip area on purpose, "
+         "and this asks it rather than re-deriving its landmark rule",
+         f"was_open={mixer_was_open} toggles={toggles!r} now={mixer_is_open(d)}", None)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("291i/before", settle_region=band, window_title=arrange_title)
+# The mixer payload arrives under `strips`, not `data`, and `logic_mixer` exposes no read command at
+# all — the first version of this harness called `logic_mixer.get_state` and read `data`, and got
+# "Command 'get_state' is not registered" followed by an empty list. It reported that as the feature
+# failing. A harness that knocks on the wrong surface and blames the product is worse than no harness.
+body = d.resource("logic://mixer") or {}
+rows = body.get("strips") if isinstance(body.get("strips"), list) else []
+ev.note("291i/mixer-resource", {"rows": len(rows),
+                               "data_source": body.get("data_source"),
+                               "cache_age_sec": body.get("cache_age_sec"),
+                               "first": rows[0] if rows else None})
+
+# `logic://mixer` is served from the state poller's cache, not read at call time. Saying so
+# is the difference between evidence and a screenshot of one: a run that quoted a snapshot
+# taken before the mixer was revealed would be describing the previous state.
+age = body.get("cache_age_sec")
+ev.provenance("291i/mixer-strips",
+              f"state_poller_cache_{body.get('data_source')}",
+              round(age, 2) if isinstance(age, (int, float)) else None,
+              body.get("data_source") == "ax_poll")
+
+with_input = [r for r in rows if isinstance(r, dict) and r.get("input")]
+ev.check("291i/the-mixer-readback-carries-an-input",
+         bool(with_input),
+         "at least one channel strip reports an input source — the field was null on every strip of "
+         "every project before this change, because nothing ever set it",
+         f"strips={len(rows)} with_input={len(with_input)} "
+         f"sample={[r.get('input') for r in with_input][:4]!r}",
+         "revert the `state.input = …` line in `defaultGetMixerState`: every strip reports null "
+         "again, which is the defect")
+
+if with_input and inputs:
+    published_in = {r.get("input") for r in with_input}
+    witnessed_in = {r["description"] for r in inputs}
+    ev.check("291i/every-published-input-is-a-string-logic-put-on-a-slot",
+             published_in.issubset(witnessed_in),
+             "every source the readback publishes appears on an input slot the witness read "
+             "independently — and none of them is the monitoring button's description",
+             f"published={sorted(published_in)!r} witnessed={sorted(witnessed_in)!r} "
+             f"monitor_descriptions={sorted({r['description'] for r in monitors})!r}",
+             "match the slot on the bare word \"input\": the monitoring toggle's description enters "
+             "the published set and stops being a subset of the slot descriptions")
+
+with_output = [r for r in rows if isinstance(r, dict) and r.get("output")]
+ev.check("291i/an-unreadable-mixer-says-so-rather-than-publishing-an-empty-one",
+         bool(rows) or body.get("data_source") == "mixer_not_visible",
+         "either strips were read, or the envelope names `mixer_not_visible` as the reason there "
+         "are none — an empty list with no reason would read as \"this project has no channel "
+         "strips\", which is a different claim entirely",
+         f"rows={len(rows)} data_source={body.get('data_source')!r}", None)
+
+ev.check("291i/the-mixer-readback-carries-an-output",
+         bool(with_output),
+         "at least one channel strip reports an output destination — the field was null on every "
+         "strip of every project before this change, because nothing ever set it",
+         f"strips={len(rows)} with_output={len(with_output)} "
+         f"sample={[r.get('output') for r in with_output][:4]!r}",
+         "revert the `state.output = …` line in `defaultGetMixerState`: every strip reports null "
+         "again, which is the defect")
+
+if outputs and with_output:
+    published = {r.get("output") for r in with_output}
+    witnessed = {r["description"] for r in outputs}
+    ev.check("291i/every-published-output-is-a-string-logic-put-on-a-slot",
+             published.issubset(witnessed),
+             "every destination the readback publishes appears on an output slot the "
+             "witness read independently — checking only the FIRST slot would compare "
+             "against whichever one the window walk saw first, which can be the Inspector's "
+             "strip, and the product refuses that as a mixer on purpose",
+             f"published={sorted(published)!r} witnessed={sorted(witnessed)!r}",
+             "return a fixed string from the reader: the published set stops being a subset "
+             "of what Logic shows, while the not-null check above still passes — that pair "
+             "is what separates a reading from a constant")
+
+ev.check("291i/no-strip-claims-a-send-destination",
+         all(not (isinstance(r, dict) and r.get("sends")) for r in rows),
+         "no strip reports sends: the send slot exposes no destination, so the readback stays "
+         "silent about them rather than inventing an empty list that reads as \"no sends\"",
+         f"strips reporting sends={[r.get('trackIndex') for r in rows if isinstance(r, dict) and r.get('sends')]!r}",
+         None)
+
+after = ev.shot("291i/after", settle_region=band, window_title=arrange_title)
+ev.visual("291i/no-project-state-was-touched",
+          before["file"], after["file"], band, expect_change=False,
+          why="both frames are captured with the Mixer in the SAME state, and every call between "
+              "them is a read, so the window must be byte-identical across it — a change here "
+              "would mean a read path wrote something")
+
+if toggles and not mixer_was_open:
+    toggle_mixer()
+    time.sleep(3)
+# Asked while the driver is still open, so the claim below is a measurement rather than an
+# assertion that cannot fail — a restoration record hard-coded to True is not a record.
+final_state = mixer_is_open(d)
+d.close()
+ev.restored("291i/the-mixer-pane-is-back-where-it-was",
+            final_state == mixer_was_open,
+            f"the mixer was {'readable' if mixer_was_open else 'not readable'} to the product "
+            f"when this run started and is {'readable' if final_state else 'not readable'} now"
+            f"{'; revealed with ' + repr(toggles) + ' and put back' if toggles else ''}. Every "
+            f"other call here is a read; the only thing this run changed is that one view "
+            f"setting, and it says so rather than claiming it left no trace.")
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -969,6 +969,25 @@ enum AXLocalePolicy {
         rationale: "Detects a channel strip's output slot by its AXHelp string; read-only classifier."
     )
 
+    /// Identifies a channel strip's INPUT slot by its AXHelp string (#291).
+    ///
+    /// Measured on Logic Pro 12.3, English, on an audio track: the slot is an `AXButton` whose help
+    /// reads "Input slot. Choose the channel strip input source…" and whose DESCRIPTION carries the
+    /// current source ("Input 1"). A software-instrument strip has no such button at all, so an
+    /// absent input there is the truth rather than a gap.
+    ///
+    /// The keyword is the full phrase "input slot" and not "input", because the same strip carries an
+    /// `AXButton` whose help begins "Input Monitoring button. Hear incoming signal…" — a prefix match
+    /// on the word alone would publish the monitoring toggle as an input source.
+    ///
+    /// Only the English rendering is measured; the empty variants list is the same fail-closed choice
+    /// as `outputSlotHelpKeyword`.
+    static let inputSlotHelpKeyword = LabelSet(
+        canonical: "input slot",
+        variants: [],
+        rationale: "Detects a channel strip's input slot by its AXHelp string; read-only classifier."
+    )
+
     static let regionHelpKeyword = LabelSet(
         canonical: "region",
         variants: ["리전"],

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -232,23 +232,51 @@ extension AXLogicProElements {
         in strip: AXUIElement,
         runtime: AXHelpers.Runtime = .production
     ) -> String? {
+        slotDescription(in: strip, matching: AXLocalePolicy.outputSlotHelpKeyword, runtime: runtime)
+    }
+
+    /// The description of the first slot button whose help matches, or nil.
+    ///
+    /// Shared by the input and output readers so the two cannot drift apart — a second copy of this
+    /// walk is a second place for the "found it but it named nothing" case to be decided differently.
+    private static func slotDescription(
+        in strip: AXUIElement,
+        matching keyword: AXLocalePolicy.LabelSet,
+        runtime: AXHelpers.Runtime
+    ) -> String? {
         let buttons = AXHelpers.findAllDescendants(
             of: strip, role: kAXButtonRole, maxDepth: 4, runtime: runtime
         )
         for button in buttons {
             let help = AXHelpers.getHelp(button, runtime: runtime) ?? ""
-            guard AXLocalePolicy.outputSlotHelpKeyword.containsAny(in: help.lowercased()) else {
-                continue
-            }
+            guard keyword.containsAny(in: help.lowercased()) else { continue }
             guard let description = AXHelpers.getDescription(button, runtime: runtime),
                   !description.isEmpty else {
-                // The slot was found and did not name a destination. That is a gap, not an empty
-                // route, so it reads the same as not finding the slot at all.
+                // The slot was found and did not name anything. That is a gap, not an empty route,
+                // so it reads the same as not finding the slot at all.
                 return nil
             }
             return description
         }
         return nil
+    }
+
+    /// What a channel strip's input slot says its source is (#291).
+    ///
+    /// Same shape as `outputSlotDestination`, and the same refusals: `nil` when no input slot was
+    /// identified, when the slot named nothing, or on a locale whose help string this project has
+    /// not measured. A software-instrument strip has no input slot at all, so `nil` there is the
+    /// truth — but the reader cannot tell that case from the others, and callers are expected to
+    /// treat an absent input as unknown rather than as "no input".
+    ///
+    /// The keyword is the full phrase. Measured on the same strip: an `AXButton` whose help begins
+    /// "Input Monitoring button. Hear incoming signal…" sits beside the input slot, and a match on
+    /// the word "input" alone would publish that toggle as a source.
+    static func inputSlotSource(
+        in strip: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> String? {
+        slotDescription(in: strip, matching: AXLocalePolicy.inputSlotHelpKeyword, runtime: runtime)
     }
 
     static func findVolumeFader(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
@@ -32,6 +32,7 @@ extension AccessibilityChannel {
             // `logic://mixer` published a field that was always null. It is read now; `nil` still
             // means "not identified", never "routed nowhere".
             state.output = AXLogicProElements.outputSlotDestination(in: strip, runtime: runtime.ax)
+            state.input = AXLogicProElements.inputSlotSource(in: strip, runtime: runtime.ax)
             channelStrips.append(state)
         }
         return encodeResult(channelStrips)
@@ -63,6 +64,7 @@ extension AccessibilityChannel {
         state.plugins = AXLogicProElements.pluginSlots(in: strip, runtime: runtime.ax)
         state.pluginsSource = "ax"
         state.output = AXLogicProElements.outputSlotDestination(in: strip, runtime: runtime.ax)
+        state.input = AXLogicProElements.inputSlotSource(in: strip, runtime: runtime.ax)
         return encodeResult(state)
     }
 

--- a/Tests/LogicProMCPTests/Issue291OutputSlotReadTests.swift
+++ b/Tests/LogicProMCPTests/Issue291OutputSlotReadTests.swift
@@ -172,3 +172,91 @@ struct Issue291OutputSlotReadTests {
         #expect(wire.contains("\"output\":\"Bus 3\""))
     }
 }
+
+// MARK: - #291 — the input slot, and the neighbour that would be mistaken for it
+
+@Suite("#291 the input slot is read, and the monitoring toggle is not")
+struct Issue291InputSlotReadTests {
+    private func audioStrip(
+        _ builder: FakeAXRuntimeBuilder,
+        id: Int,
+        inputHelp: String?,
+        inputDescription: String?
+    ) -> AXUIElement {
+        let strip = builder.element(id)
+        builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        var children: [AXUIElement] = []
+        // Measured on the same strip and deliberately included: its help BEGINS with "Input", so a
+        // prefix match on the word alone publishes this toggle as an input source.
+        let monitoring = builder.element(id + 1)
+        builder.setAttribute(monitoring, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(monitoring, kAXHelpAttribute as String,
+                             "Input Monitoring button. Hear incoming signal while recording.")
+        builder.setAttribute(monitoring, kAXDescriptionAttribute as String, "monitoring")
+        children.append(monitoring)
+        if let inputHelp {
+            let slot = builder.element(id + 2)
+            builder.setAttribute(slot, kAXRoleAttribute as String, kAXButtonRole as String)
+            builder.setAttribute(slot, kAXHelpAttribute as String, inputHelp)
+            if let inputDescription {
+                builder.setAttribute(slot, kAXDescriptionAttribute as String, inputDescription)
+            }
+            children.append(slot)
+        }
+        builder.setChildren(strip, children)
+        return strip
+    }
+
+    @Test("the source comes from the input slot's description")
+    func readsTheSource() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let strip = audioStrip(
+            builder, id: 29_800,
+            inputHelp: "Input slot. Choose the channel strip input source.",
+            inputDescription: "Input 1"
+        )
+        let read = AXLogicProElements.inputSlotSource(in: strip, runtime: builder.makeAXRuntime())
+        #expect(try #require(read) == "Input 1")
+    }
+
+    /// The monitoring button is listed FIRST on purpose: a prefix match on "input" would return
+    /// "monitoring" here, and a caller would read a toggle as a signal source.
+    @Test("the input monitoring button is never mistaken for a source")
+    func monitoringIsNotASource() {
+        let builder = FakeAXRuntimeBuilder()
+        let strip = audioStrip(builder, id: 29_900, inputHelp: nil, inputDescription: nil)
+        let read = AXLogicProElements.inputSlotSource(in: strip, runtime: builder.makeAXRuntime())
+        #expect(read == nil)
+    }
+
+    /// A software-instrument strip has no input slot at all. `nil` is the truth there — and it is the
+    /// same `nil` the reader gives when it could not look, which the doc comment states rather than
+    /// papering over.
+    @Test("a strip with no input slot reports nothing")
+    func noInputSlotReportsNothing() {
+        let builder = FakeAXRuntimeBuilder()
+        let strip = builder.element(30_000)
+        builder.setAttribute(strip, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+        builder.setChildren(strip, [])
+        #expect(AXLogicProElements.inputSlotSource(in: strip, runtime: builder.makeAXRuntime()) == nil)
+    }
+
+    @Test("the mixer readback carries the input it read")
+    func mixerStateCarriesInput() throws {
+        let builder = FakeAXRuntimeBuilder()
+        let strip = makeLiveDumpStrip(builder, id: 30_100)
+        let slot = builder.element(30_190)
+        builder.setAttribute(slot, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(slot, kAXHelpAttribute as String,
+                             "Input slot. Choose the channel strip input source.")
+        builder.setAttribute(slot, kAXDescriptionAttribute as String, "Input 2")
+        builder.setChildren(strip, AXHelpers.getChildren(strip, runtime: builder.makeAXRuntime()) + [slot])
+
+        let fixture = make123MixerFixture(stripCount: 2, firstStrip: strip, builder: builder)
+        let result = AccessibilityChannel.defaultGetMixerState(runtime: fixture.runtime)
+        let strips = try #require(
+            try JSONSerialization.jsonObject(with: Data(result.message.utf8)) as? [[String: Any]]
+        )
+        #expect(try #require(strips.first?["input"] as? String) == "Input 2")
+    }
+}


### PR DESCRIPTION
Same shape as the output slice (#601), on the field that was still null.

## The measurement, including the trap

`ChannelStripState.input` had never been set by anything either. Measured on Logic Pro 12.3 with an
audio track present:

```
[Input 1]     help "Input slot. Choose the channel strip input source…"      ← the source
[monitoring]  help "Input Monitoring button. Hear incoming signal…"          ← a toggle
```

**Both begin with the same word, on the same strip.** A match on `input` alone publishes a toggle as
a signal source.

So the keyword is the full phrase `"input slot"`, and the test fixture lists the **monitoring button
first** so a loosened match returns it. Mutation: restoring the bare word gives `read → "monitoring"`
and reddens exactly that test.

A software-instrument strip has no input slot at all — which is why this needed an audio track to
measure, and why `nil` there is the truth. The reader cannot tell that case from *"could not look"*,
and the doc comment says so rather than papering over it: callers treat an absent input as unknown.

Only the English help string is measured; the empty variants list is the same fail-closed choice the
output reader made.

## One walk, not two

The input and output readers now share the walk. A second copy would be a second place for *"found
the slot and it named nothing"* to be decided differently — and that case is the whole reason the
walk returns `nil` rather than an empty string.

## Live

```
13 checks · 13 passed · 4 mutation-backed · visual 1/1 · restoration measured
```

The run reads Logic's own slots with a second instrument and requires every published source to be
one of the strings that instrument saw **on an input slot** — not merely non-null, and not the
monitoring button's description. It also asserts the monitoring button is really present on the same
strip, so the hazard the keyword guards against is confirmed rather than assumed.

## Gate

`lpm-ship.sh` PASS at `83b75171` — preflight clean, `Package.resolved` untouched, branch contains
`origin/main`, live evidence for this head.