### PR TITLE
fix(#604): the refusal was reporting an absence as an observation

### DIFF
--- a/Scripts/livekit/live_604_refusal_says_what_it_saw.py
+++ b/Scripts/livekit/live_604_refusal_says_what_it_saw.py
@@ -65,6 +65,20 @@ def document_titles():
     return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
 
 
+def save_panels():
+    """Windows AND sheets that are the modal surface a failed Save As leaves behind.
+
+    The first cut of this file compared `len(window_titles())` against `len(document_titles())`,
+    which only ever says "no project chooser is visible" — a leftover window named Save sits in
+    BOTH lists, so the mutation those checks named could not turn them red. This asks the
+    question the checks were written to ask.
+    """
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return (name of every window whose name is "Save") & '
+              '(name of every sheet of every window)')
+    return [t.strip() for t in raw.split(",") if t.strip() == "Save"]
+
+
 def inner(result):
     return result if isinstance(result, dict) else {}
 
@@ -103,6 +117,20 @@ before = ev.shot("604/before", settle_region=band, window_title=arrange_title)
 d = E.Driver()
 time.sleep(5)
 
+# Logic must own the keyboard or the menu press opens NO panel at all — measured four times on
+# 2026-08-19: backgrounded 0/2 panels, frontmost 2/2. Without this the refusal under test would be
+# refusing an absent panel, the dismissal would never run, and the checks below could not tell a
+# working dismissal from a missing one.
+osa('tell application "Logic Pro" to activate')
+time.sleep(2)
+front = osa('tell application "System Events" to return name of first process whose frontmost is true')
+ev.check("604/precondition-logic-owns-the-keyboard",
+         front == "Logic Pro",
+         "the menu press lands in Logic, so a Save panel actually opens and there is something for "
+         "the refusal to describe and the dismissal to clear",
+         f"frontmost={front!r}",
+         None)
+
 saved = inner(d._send("tools/call", {"name": "logic_project", "arguments": {
     "command": "save_as", "params": {"path": TARGET, "confirmed": True}}}))
 text = ((saved.get("result") or {}).get("content") or [{}])[0].get("text", "")
@@ -114,12 +142,21 @@ hint = str(body.get("hint") or body.get("raw") or "")
 ev.note("604/save-as", {"error": body.get("error"), "hint": hint[:400]})
 
 ev.check("604/the-refusal-names-the-shape-it-saw",
-         "filename_fields" in hint and "save_buttons" in hint and "Save" in hint,
-         "the refusal reports each candidate window's observed counts, so the failing clause of a "
-         "seven-conjunct rule is visible in its own output instead of being guessed at",
-         f"hint={hint[:260]!r}",
+         all(k in hint for k in ("filename_fields", "save_buttons", "subrole", "Candidates enumerated:")),
+         "the refusal reports each candidate window's observed counts INCLUDING subrole — one of the "
+         "seven conjuncts — so the failing clause is visible in its own output instead of guessed at",
+         f"hint={hint[:300]!r}",
          "restore the old message: it says only that the panel did not appear within three seconds, "
          "which is a cause that was never measured — the panel is on screen in 0.75s")
+
+ev.check("604/the-refusal-says-whether-logic-owned-the-keyboard",
+         "Logic owned the keyboard when the menu was pressed: true" in hint,
+         "the refusal distinguishes the two worlds it can fail in — panel-absent-because-backgrounded "
+         "versus panel-present-but-unclassified. Measured 2026-08-19: the same menu press opens no "
+         "panel at all when Logic is backgrounded (0/2) and one panel when it is frontmost (2/2), so "
+         "a message that omits this fact points the reader at the classifier for a missing panel",
+         f"hint={hint[:300]!r}",
+         "drop the `logic_owned_the_keyboard` observation from the refusal: this goes red")
 
 ev.check("604/the-refusal-does-not-claim-a-timing-cause-it-never-measured",
          "within 3 seconds" not in hint,
@@ -133,38 +170,50 @@ time.sleep(2)
 after_titles = window_titles()
 ev.note("604/windows-after", after_titles)
 
+panels_left = save_panels()
 ev.check("604/no-panel-is-left-blocking-the-next-operation",
-         len(after_titles) == len(document_titles()),
-         "no modal remains after the refusal — the old timeout path returned before its dismissal "
-         "helper was even defined, and the panel it left up refused every later operation",
-         f"windows={after_titles!r}",
-         "remove the `escapeAnyOpenPanel` call from the timeout path: a 'Save' window stays on "
-         "screen and this check goes red")
+         len(panels_left) == 0,
+         "no Save panel remains after the refusal — the old timeout path returned before its "
+         "dismissal helper was even defined, and the panel it left up refused every later operation",
+         f"save_panels={panels_left!r} all_windows={after_titles!r}",
+         "remove the `escapeAnyOpenPanel` call from the timeout path: the 'Save' window stays on "
+         "screen, `save_panels()` returns it, and this check goes red")
 
 # The decisive one: the NEXT operation must not be refused by something this run left behind.
-follow = d.tool("logic_system", "health", {})
+
+
+after = ev.shot("604/after", settle_region=band, window_title=arrange_title)
+# This capture is `screencapture -l <arrange window id>`, so a top-level Save dialog is not in
+# frame and its presence could never move this band. The assertion is therefore the narrower true
+# one — the refusal disturbed nothing behind it. "The panel is gone" is claimed by
+# `604/no-panel-is-left-blocking-the-next-operation`, which can see the panel.
+ev.visual("604/the-arrange-window-behind-is-undisturbed",
+          before["file"], after["file"], band, expect_change=False,
+          why="a refusal that writes nothing must leave the document window exactly as it found it; "
+              "a difference in the title band would mean the failed save renamed or dirtied it")
+
+# `system.health` was the wrong witness: it builds its report from channel health, cache and
+# permissions and never consults `blockingDialogInfo()`, so it cannot report a blocking dialog no
+# matter what is on screen. `list_library` (which routes `library.list`) is read-only AND runs the same preflight the mutating
+# operations do (TrackDispatcher: `blockingLogicDialogResult(operation: "library.list")`), so a
+# leftover panel actually turns this red. It runs AFTER the visual comparison because listing
+# the Library can open Logic's Library panel, which would move the very window the visual guards.
+follow = d.tool("logic_tracks", "list_library", {})
 follow_hint = str((follow or {}).get("hint") or "")
 ev.check("604/the-next-operation-is-not-blocked-by-what-this-one-left",
          isinstance(follow, dict) and "preflight_blocking_dialog" not in str(follow),
-         "an unrelated operation immediately afterwards runs instead of refusing on a blocking "
-         "dialog — which is what a leftover panel does to everything that follows it",
+         "a later operation that fails closed on blocking modals runs instead of refusing — which "
+         "is what a leftover panel does to everything that follows it",
          f"error={(follow or {}).get('error')!r} hint={follow_hint[:160]!r}",
-         "remove the dismissal: this check reports `preflight_blocking_dialog` for `system.health`, "
-         "and would for every later call too")
-
-after = ev.shot("604/after", settle_region=band, window_title=arrange_title)
-ev.visual("604/the-panel-is-gone-from-the-screen",
-          before["file"], after["file"], band, expect_change=False,
-          why="the run opens a Save panel and the refusal dismisses it, so the window behind must "
-              "look exactly as it did before — a difference here would mean the panel is still up or "
-              "something else changed")
+         "remove the dismissal: `list_library` refuses with `preflight_blocking_dialog`, and so "
+         "would every mutating call after it")
 
 d.close()
 ev.restored("604/no-file-was-written-and-no-panel-remains",
-            not os.path.exists(TARGET) and len(window_titles()) == len(document_titles()),
+            not os.path.exists(TARGET) and not save_panels(),
             f"the save did not complete, so no project was written to {TARGET!r} — that is the "
             f"failure under study, not a side effect — and no modal is left on screen. "
-            f"Windows: {window_titles()!r}")
+            f"Save panels: {save_panels()!r} Windows: {window_titles()!r}")
 
 ev.stop_recording(rec)
 out = ev.write()

--- a/Scripts/livekit/live_604_refusal_says_what_it_saw.py
+++ b/Scripts/livekit/live_604_refusal_says_what_it_saw.py
@@ -19,10 +19,18 @@ So the run drives the failing operation on purpose and checks two things about h
 refusal names the shape it actually saw, and that the next operation is not blocked by a leftover
 panel.
 
-The classifier is untouched. Its filename-field clause is what fails, and two readers disagree about
-that panel — AppleScript's `entire contents` finds 156 text fields described "text field" while this
-code's own reader finds zero at the same depth. Until that is explained, any replacement rule is a
-guess, and the honest deliverable is a failure that can be read.
+The two readers that disagreed about this panel are now explained, and the explanation is not about
+depth. AppleScript's `entire contents` found 156 text fields because I had activated Logic before
+probing; the product's reader found zero because it never does. Measured 2026-08-19, four trials:
+with Logic backgrounded the same menu press opens NO panel at all (0/2 "Save" windows), and with
+Logic frontmost it opens one (2/2) carrying 157 text fields described "text field", exactly one of
+which is focused — and that focused one is the filename field, value "Untitled".
+
+So the classifier's filename-field clause is wrong twice over: it demands exactly one such field
+when the panel exposes 157, and it was being asked about a panel that, in production conditions, was
+never on screen. Neither is fixed here — this change is about the refusal, and a working save_as is
+its own change with its own proof. What this run adds is that the refusal now says which of those
+two worlds it was in, so the next reader is not sent to the classifier for a missing panel.
 """
 
 import json

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -721,12 +721,57 @@ extension AccessibilityChannel {
             && folderRadioCount == 1
     }
 
-    /// Press Escape so a refusal does not leave a modal behind (#604).
+    /// What the dismissal attempt actually observed (#604).
+    ///
+    /// The first cut of this asserted "the panel, if one opened, has been dismissed" without ever
+    /// looking. That is the defect class this repository cares most about: an absence published as a
+    /// claim. The keystroke can be swallowed — the click that opened the panel is AX, the Escape is
+    /// System Events, and if Automation is denied the panel simply stays — so the caller is told what
+    /// was counted before and after, not what was hoped for.
+    struct PanelDismissal {
+        let panelsBefore: Int
+        let panelsAfter: Int
+        let escapeDelivered: Bool
+
+        var summary: String {
+            guard escapeDelivered else {
+                return "Escape could not be delivered (System Events refused), so \(panelsBefore) "
+                    + "panel-shaped window(s) were left as they were."
+            }
+            if panelsBefore == 0 {
+                return "No panel-shaped window was open before Escape, and none after."
+            }
+            if panelsAfter == 0 {
+                return "Escape cleared the \(panelsBefore) panel-shaped window(s) that were open."
+            }
+            return "Escape was delivered but \(panelsAfter) of \(panelsBefore) panel-shaped "
+                + "window(s) are still open."
+        }
+    }
+
+    /// A window/sheet is "panel-shaped" if it is the modal surface a Save As leaves behind: the
+    /// container role the classifier accepts, carrying the title Logic gives the panel. Deliberately
+    /// looser than `saveAsDialogSelectionIsUnambiguous` — the point is to notice a panel that is
+    /// still up, including the malformed one that could not be driven.
+    static func panelShapedCandidateCount(runtime: AXLogicProElements.Runtime) -> Int {
+        saveAsDialogCandidateShapes(runtime: runtime).filter { shape in
+            let role = (shape["role"] as? String) ?? ""
+            let subrole = (shape["subrole"] as? String) ?? ""
+            let isContainer = role == (kAXSheetRole as String)
+                || (role == (kAXWindowRole as String) && subrole == (kAXDialogSubrole as String))
+            return isContainer && ((shape["title"] as? String) ?? "") == "Save"
+        }.count
+    }
+
+    /// Press Escape so a refusal does not leave a modal behind (#604), and report what that did.
     ///
     /// Logic's Save panel exposes no buttons a caller can reach — `dialog_buttons: []` — so there is
     /// nothing to click and nothing to cancel by name. Escape is what clears it.
-    private static func escapeAnyOpenPanel(runtime: AXLogicProElements.Runtime) async {
-        _ = await AppleScriptChannel.executeAppleScript("""
+    private static func escapeAnyOpenPanel(
+        runtime: AXLogicProElements.Runtime
+    ) async -> PanelDismissal {
+        let before = panelShapedCandidateCount(runtime: runtime)
+        let result = await AppleScriptChannel.executeAppleScript("""
         tell application "System Events"
             tell \(LogicProTarget.appleScriptTarget().systemEventsProcessTarget)
                 set frontmost to true
@@ -736,6 +781,13 @@ extension AccessibilityChannel {
         end tell
         return "escaped"
         """)
+        let delivered = result.isSuccess
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        return PanelDismissal(
+            panelsBefore: before,
+            panelsAfter: panelShapedCandidateCount(runtime: runtime),
+            escapeDelivered: delivered
+        )
     }
 
     /// What each candidate window looked like to the classifier (#604).
@@ -775,12 +827,18 @@ extension AccessibilityChannel {
             let enabled: Bool? = saveButtons.first.flatMap {
                 AXHelpers.getAttribute($0, kAXEnabledAttribute as String, runtime: runtime.ax)
             }
+            // #604 follow-up: `subrole` is one of the classifier's seven conjuncts, so omitting it
+            // hides a failing clause from the very message meant to diagnose it. And `enabled ?? false`
+            // reported an unread button as a *disabled* one — two different facts, one of them made up.
             return [
                 "title": AXHelpers.getTitle(candidate, runtime: runtime.ax) ?? "",
                 "role": AXHelpers.getRole(candidate, runtime: runtime.ax) ?? "",
+                "subrole": AXHelpers.getAttribute(
+                    candidate, kAXSubroleAttribute as String, runtime: runtime.ax
+                ) as String? ?? "",
                 "filename_fields": filenameFields.count,
                 "save_buttons": saveButtons.count,
-                "save_enabled": enabled ?? false,
+                "save_enabled": enabled.map { $0 as Any } ?? "unread",
                 "cancel_buttons": buttons.filter {
                     AXLocalePolicy.elementMatches($0, AXLocalePolicy.cancelButton, runtime: runtime.ax)
                 }.count,
@@ -887,16 +945,36 @@ extension AccessibilityChannel {
             // `preflight_blocking_dialog` on a "Save" window that exposes no buttons a caller could
             // answer with. Escape is the only thing that clears it.
             let shapes = saveAsDialogCandidateShapes(runtime: runtime)
-            await escapeAnyOpenPanel(runtime: runtime)
-            let described = shapes
-                .filter { !(($0["title"] as? String) ?? "").isEmpty }
-                .map { "\($0)" }
-                .joined(separator: " | ")
-            return .error(
-                "Save As panel was not recognised. Candidates seen: "
-                + (described.isEmpty ? "none" : described)
-                + ". The panel, if one opened, has been dismissed."
-            )
+            let dismissal = await escapeAnyOpenPanel(runtime: runtime)
+            // Every candidate is described, including one whose title would not read. Dropping those
+            // and then printing "none" was the same defect the message exists to cure: an absence
+            // published as an observation.
+            let described = shapes.map { "\($0)" }.joined(separator: " | ")
+            // A bare sentence is not a State C envelope, so `ChannelRouter` could not surface it and
+            // relabelled this deliberate refusal `channels_exhausted` — the one channel ran and
+            // declined on purpose. Say that in the code the wire actually reads.
+            // Measured 2026-08-19, four trials: with Logic backgrounded the very same menu press
+            // opens NO panel at all (0 "Save" windows, 2/2), and with Logic frontmost it opens one
+            // carrying 157 text fields (2/2). A refusal that omits which of those two worlds it was
+            // in sends the next reader to the classifier when the panel was never there.
+            let ownedKeyboard = ProcessUtils.logicOwnsTheKeyboard()
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Save As panel was not recognised by the structural classifier. "
+                    + "Candidates enumerated: \(shapes.count). "
+                    + (shapes.isEmpty ? "" : "Shapes: \(described). ")
+                    + "Logic owned the keyboard when the menu was pressed: \(ownedKeyboard). "
+                    + dismissal.summary,
+                extras: [
+                    "write_attempted": false,
+                    "logic_owned_the_keyboard": ownedKeyboard,
+                    "candidates_enumerated": shapes.count,
+                    "candidate_shapes": shapes,
+                    "panels_before_dismissal": dismissal.panelsBefore,
+                    "panels_after_dismissal": dismissal.panelsAfter,
+                    "escape_delivered": dismissal.escapeDelivered,
+                ]
+            ))
         }
 
         // Helper: dismiss dialog on failure (press Escape to avoid blocking UI)

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -4365,3 +4365,35 @@ private final class AXPressLog: @unchecked Sendable {
     // and it still reaches a control that could legitimately select
     #expect(recorder.ids.contains(builder.elementID(name)))
 }
+
+/// #604: the dismissal must report what it observed, never assert an outcome it did not look at.
+///
+/// The first cut said "The panel, if one opened, has been dismissed." unconditionally — the
+/// keystroke goes out through System Events while the panel was opened through AX, so a denied
+/// Automation permission leaves the panel up and the sentence still claimed it was gone.
+@Test("issue604_dismissal_summary_reports_the_observation_not_the_hope")
+func issue604DismissalSummaryReportsTheObservation() {
+    let denied = AccessibilityChannel.PanelDismissal(
+        panelsBefore: 1, panelsAfter: 1, escapeDelivered: false
+    )
+    #expect(denied.summary.contains("Escape could not be delivered"))
+    #expect(!denied.summary.contains("cleared"))
+
+    let cleared = AccessibilityChannel.PanelDismissal(
+        panelsBefore: 1, panelsAfter: 0, escapeDelivered: true
+    )
+    #expect(cleared.summary.contains("Escape cleared the 1 panel-shaped window(s)"))
+
+    let stubborn = AccessibilityChannel.PanelDismissal(
+        panelsBefore: 2, panelsAfter: 1, escapeDelivered: true
+    )
+    #expect(stubborn.summary.contains("still open"))
+    #expect(!stubborn.summary.contains("cleared"))
+
+    let nothingThere = AccessibilityChannel.PanelDismissal(
+        panelsBefore: 0, panelsAfter: 0, escapeDelivered: true
+    )
+    #expect(nothingThere.summary.contains("No panel-shaped window was open"))
+    // The one thing it must never say when nothing was there: that it cleared something.
+    #expect(!nothingThere.summary.contains("cleared"))
+}


### PR DESCRIPTION
#605 merged at `6ad01599`, one commit behind the branch head — the review fixes pushed to
`work/604-save-panel` as `f70b4e40` never reached `main`. `main` currently carries the *first* cut of
#604, which an independent blind review blocked. This PR lands what that review produced.

Everything below was confirmed against the source before acting on it, and the live claims measured.

### Three live checks could not fail

| check | why it could not go red |
|---|---|
| `no-panel-is-left-blocking-the-next-operation` | compared `len(after_titles)` to `len(document_titles())`, which only drops project-chooser titles. A leftover window named `Save` sits in **both**, so the comparison only said "no chooser is visible". |
| the check the file calls decisive | used `system.health`, which builds its report from channel health, cache, permissions and process metrics and never consults `blockingDialogInfo()`. It cannot report a blocking dialog whatever is on screen. |
| the visual | `screencapture -l <arrange window id>` cannot see a top-level `Save` AXDialog, so `expect_change=False` held either way — it claimed "the panel is gone" while blind to the panel. |

Now: a `save_panels()` predicate that asks for Save windows and sheets directly; `list_library`, which
is read-only **and** runs the same preflight the mutating operations do; and a visual that claims only
what it can see. The harness also activates Logic first, because otherwise no panel opens and the
dismissal under test never runs.

### Four places the product published an absence

- The dismissal asserted *"The panel, if one opened, has been dismissed."* without looking. The click
  that opens the panel is AX and the Escape is System Events — deny Automation and the panel stays
  while the sentence still says it is gone. It now counts panel-shaped windows before and after and
  reports whether the keystroke was delivered.
- The candidate dump dropped every window whose title would not read, then printed
  `Candidates seen: none`.
- `subrole` was omitted although it is one of the classifier's seven conjuncts, and `enabled ?? false`
  reported an *unread* Save button as a *disabled* one.
- The refusal was a bare sentence, not a State C envelope, so a single-channel chain relabelled this
  deliberate refusal `channels_exhausted`. It is now a real State C with `write_attempted: false`.

### With the panel present it now reads

```
error: element_not_found
hint:  Save As panel was not recognised by the structural classifier. Candidates enumerated: 3.
       Shapes: [title: "Save", role: AXWindow, subrole: AXDialog, filename_fields: 0,
                save_buttons: 1, save_enabled: true, cancel_buttons: 1,
                package_radios: 1, folder_radios: 1] | …
       Logic owned the keyboard when the menu was pressed: true.
       Escape cleared the 1 panel-shaped window(s) that were open.
```

Six of seven conjuncts pass and the message names the one that fails. Chasing that led to the actual
root cause, now filed as #606 with its measurements: `Save As…` is `AXEnabled=false` while Logic is a
background app and `AXPress` on it still reports success, and `filename_fields: 0` is a filter reading
`AXDescription` where the datum lives in `AXRoleDescription`.

### Gate

```
full suite                    3843 tests passed
live evidence for this head   9 checks, 9 passed, 5 mutation-backed, 1 visual, 0 failed
SHIP GATE PASS                f70b4e40
```

The new unit test was mutation-tested: forcing `summary` to always claim the panel was cleared turns
it red with 6 issues; reverting turns it green.