### PR TITLE
fix(#606): save_as pressed a disabled item, asked for the wrong attribute, and typed a path where a name goes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
+  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
       }
     },
     {
@@ -56,57 +20,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
       }
     },
     {
@@ -128,75 +47,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Scripts/livekit/live_606_save_as_writes_the_file.py
+++ b/Scripts/livekit/live_606_save_as_writes_the_file.py
@@ -178,7 +178,20 @@ ev.check("606/no-panel-was-left-behind",
          "refusal may",
          f"save_panels={save_panels()!r}", None)
 
-after = ev.shot("606/after", settle_region=band, window_title=arrange_title)
+# The operation RENAMES the window, so capturing "after" by the title captured "before" can only
+# ever miss — the first cut of this file did exactly that and recorded "no Logic window on screen",
+# which then made the visual compare a real image against nothing and call it unchanged. Re-resolve
+# the arrange window by area, the same way the "before" side chose it.
+relocated = [(t, E.logic_window(t)) for t in window_titles()]
+relocated = [(t, w) for t, w in relocated if w]
+relocated.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
+after_title = relocated[0][0] if relocated else arrange_title
+ev.check("606/the-arrange-window-is-still-locatable-after-the-save",
+         bool(relocated),
+         "the document window can still be found by frame after the save, so the visual below "
+         "compares two real captures rather than one capture against a failed lookup",
+         f"before_title={arrange_title!r} after_title={after_title!r}", None)
+after = ev.shot("606/after", settle_region=band, window_title=after_title)
 ev.visual("606/the-window-title-changed-to-the-new-project",
           before["file"], after["file"], band, expect_change=True,
           why="saving under a new name renames the document window, so the title band must differ; "

--- a/Scripts/livekit/live_606_save_as_writes_the_file.py
+++ b/Scripts/livekit/live_606_save_as_writes_the_file.py
@@ -1,0 +1,202 @@
+"""Live proof that `project.save_as` writes a project at the path it was asked for.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_606_save_as_writes_the_file.py <worktree> <full-40-char-head-sha>
+
+WHAT THIS RUN IS ABOUT
+----------------------
+`save_as` did not work, and the reasons were three separate lies the code told itself.
+
+1. It pressed `File ▸ Save As…` without bringing Logic forward. Logic DISABLES its
+   document-modifying File items while it is a background application — and an `AXPress` on a
+   disabled item reports SUCCESS. Measured 2026-08-19, four trials: backgrounded, the press opens
+   zero panels (0/2); frontmost, it opens one (2/2). `Open…` stays enabled either way, so this is a
+   property of the item, not of AX menu presses.
+
+2. It looked for the filename field by `AXDescription == "text field"` and found NOTHING. The rule
+   came from an AppleScript probe, and System Events *synthesises* `description` from
+   `AXRoleDescription` when `AXDescription` is nil. Through the API this code uses:
+
+       field        SysEv description     AXDescription   AXRoleDescription     AXFocused
+       search       "search text field"   nil             "search text field"   false
+       FILENAME     "text field"          nil             "text field"          true
+       tag editor   "tag editor"          "tag editor"    "text field"          false
+
+   Focus selects exactly one, is not localised, and is the field a person types into.
+
+3. It typed the whole POSIX path into that field. This panel does not navigate on a typed path —
+   measured twice, by `AXConfirm` and by a real Return, and both times Logic saved a project
+   literally NAMED `:Users:isaac:Music:Logic:x` into whatever folder the panel had open. It reported
+   success. The old "no file appeared at the requested path" was therefore true and useless: the
+   file existed, under a name made out of the path. The panel's own "Go to Folder" sheet is what
+   moves it.
+
+So this run does not check that `save_as` returns success — the broken version could do that. It
+checks that a project exists at the exact path, that no path-named project was created, and that
+Logic's own window title says it is that project.
+
+The first call in a fresh process is separately refused as `blocking_dialog_present` on a screen
+with no dialog (#608, filed, not fixed here). The run performs one read-only call first and records
+that it had to.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+DIRECTORY = "/Users/isaac/Music/Logic"
+NAME = "lpm-606-live-proof"
+TARGET = f"{DIRECTORY}/{NAME}.logicx"
+# What the OLD code produced instead: the path itself as a filename, with "/" shown as ":".
+PATH_AS_NAME = f"{DIRECTORY}/{TARGET.replace('/', ':')}"
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def save_panels():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return (name of every window whose name is "Save")')
+    return [t.strip() for t in raw.split(",") if t.strip() == "Save"]
+
+
+for stale in (TARGET, PATH_AS_NAME):
+    if os.path.isdir(stale):
+        shutil.rmtree(stale)
+
+titles = window_titles()
+ev.check("606/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so File > Save As has something to save",
+         f"windows={titles!r}", None)
+if not titles:
+    ev.write()
+    sys.exit("no project open")
+
+ev.check("606/precondition-target-path-is-clear",
+         not os.path.exists(TARGET) and not os.path.exists(PATH_AS_NAME),
+         "neither the requested path nor the path-as-a-name variant exists before the run, so "
+         "anything found afterwards was written by this run",
+         f"target={os.path.exists(TARGET)} path_as_name={os.path.exists(PATH_AS_NAME)}", None)
+
+# Pick the arrange window by AREA rather than by a title suffix: the title is localised and a
+# plugin window can end in the same word. The band is the top strip of that window's own frame.
+located = [(t, E.logic_window(t)) for t in titles]
+located = [(t, w) for t, w in located if w]
+located.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
+arrange_title, win = located[0] if located else (titles[0], None)
+band = (0, 0, win["w"], 28) if win else None
+ev.check("606/precondition-the-window-frame-is-known", band is not None,
+         "the arrange window's own frame read, so the capture band is inside it",
+         f"window={win!r} band={band!r}", None)
+if band is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=150)
+before = ev.shot("606/before", settle_region=band, window_title=arrange_title)
+
+d = E.Driver()
+time.sleep(3)
+
+# #608: the first call in a fresh process is refused on a dialog that is not there. This one is
+# read-only and is here to absorb that, not to prove anything — it is recorded so the receipt shows
+# the run had to do it.
+warm = d.tool("logic_tracks", "list_library", {})
+ev.note("606/warmup-first-call-is-refused-see-608", {
+    "error": (warm or {}).get("error"),
+    "blocking_dialog_present": (warm or {}).get("blocking_dialog_present"),
+})
+
+saved = d.tool("logic_project", "save_as", {"path": TARGET, "confirmed": True})
+ev.note("606/save-as", {k: saved.get(k) for k in
+                        ("state", "success", "error", "hint", "requested", "observed", "via")
+                        if isinstance(saved, dict)})
+
+time.sleep(3)
+
+ev.check("606/a-project-exists-at-the-exact-requested-path",
+         os.path.isdir(TARGET),
+         "the operation wrote a project bundle at the path it was given — the thing the operation is "
+         "for, and the thing that never happened before this change",
+         f"exists={os.path.isdir(TARGET)} path={TARGET!r}",
+         "remove the Go-to-Folder step from `saveAsViaAXDialog`: the panel stays in whatever folder "
+         "it opened in, nothing is written here, and this goes red")
+
+ev.check("606/no-project-was-created-with-the-path-as-its-name",
+         not os.path.exists(PATH_AS_NAME),
+         "the old failure produced a project literally NAMED after the requested path, in the wrong "
+         "folder, while reporting success — so its absence is the specific thing being proven",
+         f"path_as_name_exists={os.path.exists(PATH_AS_NAME)} probe={PATH_AS_NAME!r}",
+         "revert step 3b to setting the full path into the filename field: this folder appears and "
+         "this goes red")
+
+ev.check("606/the-operation-reported-state-A",
+         isinstance(saved, dict) and saved.get("state") == "A" and saved.get("success") is True,
+         "the response claims a verified write, and the two checks above are what independently "
+         "corroborate that claim rather than taking it",
+         f"state={(saved or {}).get('state')!r} success={(saved or {}).get('success')!r} "
+         f"error={(saved or {}).get('error')!r}",
+         "revert the frontmost gate: the menu item is disabled from the background, the press "
+         "reports success, no panel opens, and this reports element_not_found instead")
+
+title_after = window_titles()
+ev.check("606/logic-says-it-is-now-that-project",
+         any(t.startswith(NAME) for t in title_after),
+         "Logic's own window title names the saved project — a readback through the UI rather than "
+         "through the file system, so a stale directory listing cannot carry this check",
+         f"windows={title_after!r}",
+         "revert the Go-to-Folder step: the title becomes the colon-mangled path and this goes red")
+
+ev.check("606/no-panel-was-left-behind",
+         not save_panels(),
+         "the Save panel is gone — a successful save must not leave its own modal up any more than a "
+         "refusal may",
+         f"save_panels={save_panels()!r}", None)
+
+after = ev.shot("606/after", settle_region=band, window_title=arrange_title)
+ev.visual("606/the-window-title-changed-to-the-new-project",
+          before["file"], after["file"], band, expect_change=True,
+          why="saving under a new name renames the document window, so the title band must differ; "
+              "if it does not, the project on screen is still the old one whatever the file system "
+              "says")
+
+d.close()
+
+removed = False
+if os.path.isdir(TARGET):
+    shutil.rmtree(TARGET)
+    removed = not os.path.exists(TARGET)
+ev.restored("606/the-project-this-run-created-was-removed",
+            removed and not os.path.exists(PATH_AS_NAME),
+            f"the run's own artifact at {TARGET!r} was deleted, and no path-named artifact remains. "
+            f"Logic still has it open under that name — that is a live-session fact this run cannot "
+            f"undo without closing the project, and it is stated rather than papered over.")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -402,6 +402,62 @@ enum AXLogicProElements {
         return .buttons(buttons)
     }
 
+    /// Why `dialogPresent()` answered the way it did (#606).
+    ///
+    /// This guard is fail-closed: an unreadable windows array, an unreadable child role, or a missing
+    /// app root all answer "blocked". That is the right default and a terrible thing to report on its
+    /// own — a caller told only `blocking_dialog_present: true` when `blockingDialogInfo()` returns
+    /// nil has been refused on the strength of something nobody can name, and is sent looking for a
+    /// dialog that may not exist. Measured on 2026-08-19: `project.save_as` refused this way with a
+    /// single `AXStandardWindow` on screen and every attribute reading cleanly.
+    static func dialogPresenceCensus(runtime: Runtime = .production) -> [String: Any] {
+        guard let app = appRoot(runtime: runtime) else {
+            return ["reason": "no_app_root", "windows": []]
+        }
+        switch AXHelpers.getAXUIElementArrayRead(
+            app, kAXWindowsAttribute as String, runtime: runtime.ax
+        ) {
+        case .success(.elements(let windows)):
+            var rows: [[String: Any]] = []
+            for window in windows {
+                let subrole: String? = AXHelpers.getAttribute(
+                    window, kAXSubroleAttribute as String, runtime: runtime.ax
+                )
+                var row: [String: Any] = [
+                    "title": AXHelpers.getTitle(window, runtime: runtime.ax) ?? "",
+                    "subrole": subrole ?? "<unread>",
+                    "is_blocking_dialog": isBlockingDialogWindow(window, runtime: runtime.ax),
+                ]
+                switch AXHelpers.childrenResult(window, runtime: runtime.ax) {
+                case .success(let children):
+                    row["children"] = children.count
+                    row["sheet_children"] = children.filter {
+                        AXHelpers.getRole($0, runtime: runtime.ax) == (kAXSheetRole as String)
+                    }.count
+                    row["children_with_unreadable_role"] = children.filter {
+                        AXHelpers.getRole($0, runtime: runtime.ax) == nil
+                    }.count
+                case .failure(let error):
+                    row["children"] = "<unread: \(error.raw)>"
+                }
+                rows.append(row)
+            }
+            return [
+                "reason": "windows_read",
+                "windows": rows,
+                // Re-ask the very question that refused, at census time. If this disagrees with the
+                // refusal the guard is not reading what it thinks it is.
+                "dialog_present_recheck": dialogPresent(runtime: runtime),
+            ]
+        case .success(.absent):
+            return ["reason": "windows_attribute_absent", "windows": []]
+        case .success(.malformed):
+            return ["reason": "windows_attribute_malformed", "windows": []]
+        case .failure(let error):
+            return ["reason": "windows_read_failed", "ax_error": error.raw, "windows": []]
+        }
+    }
+
     static func blockingDialogInfo(runtime: Runtime = .production) -> BlockingDialogInfo? {
         blockingDialogTarget(runtime: runtime)?.info
     }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -852,6 +852,34 @@ extension AccessibilityChannel {
         }
     }
 
+    /// The Save panel's filename field, identified by focus (#606).
+    ///
+    /// The old rule asked for `AXDescription == "text field"` and matched **nothing**, which read as
+    /// "the panel has no filename field" and sent three separate investigations at the wrong target.
+    /// The rule had been written from an AppleScript probe, and System Events *synthesises*
+    /// `description` from `AXRoleDescription` when `AXDescription` is nil. Measured through the API
+    /// this code actually uses:
+    ///
+    /// ```
+    ///                   System Events `description`   raw AXDescription   AXRoleDescription   AXFocused
+    ///   search field    "search text field"           nil                 "search text field" false
+    ///   FILENAME field  "text field"                  nil                 "text field"        true
+    ///   tag editor      "tag editor"                  "tag editor"        "text field"        false
+    /// ```
+    ///
+    /// `AXRoleDescription` picks two of the three and is localised, which #519 makes expensive.
+    /// Focus picks exactly one, is not localised, and is the field a person would type into.
+    static func filenameFieldCandidates(
+        in container: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) -> [AXUIElement] {
+        AXHelpers.findAllDescendants(
+            of: container, role: kAXTextFieldRole as String, maxDepth: 12, runtime: runtime.ax
+        ).filter {
+            (AXHelpers.getAttribute($0, kAXFocusedAttribute as String, runtime: runtime.ax) as Bool?) == true
+        }
+    }
+
     private static func exactSaveAsDialog(
         runtime: AXLogicProElements.Runtime
     ) -> AXUIElement? {
@@ -872,9 +900,7 @@ extension AccessibilityChannel {
         }
 
         let matches = candidates.filter { candidate in
-            let filenameFields = AXHelpers.findAllDescendants(
-                of: candidate, role: kAXTextFieldRole as String, maxDepth: 12, runtime: runtime.ax
-            ).filter { AXHelpers.getDescription($0, runtime: runtime.ax) == "text field" }
+            let filenameFields = filenameFieldCandidates(in: candidate, runtime: runtime)
             let buttons = AXHelpers.findAllDescendants(
                 of: candidate, role: kAXButtonRole as String, maxDepth: 12, runtime: runtime.ax
             )
@@ -911,13 +937,78 @@ extension AccessibilityChannel {
         return matches.count == 1 ? matches[0] : nil
     }
 
+    /// Open the Save panel's "Go to Folder" sheet and return its one text field (#606).
+    ///
+    /// There is no AX attribute on this panel that sets its directory, and typing a POSIX path into
+    /// the filename field does not navigate — it becomes the file's name. This sheet is the only
+    /// coordinate-free way in, and reaching it is a keystroke.
+    private static func openGoToFolderSheet(
+        in panel: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) async -> AXUIElement? {
+        _ = await AppleScriptChannel.executeAppleScript("""
+        tell application "System Events"
+            keystroke "g" using {command down, shift down}
+        end tell
+        return "sent"
+        """)
+        for _ in 0..<15 {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            let sheets = AXHelpers.getChildren(panel, runtime: runtime.ax).filter {
+                AXHelpers.getRole($0, runtime: runtime.ax) == (kAXSheetRole as String)
+            }
+            for sheet in sheets {
+                let fields = AXHelpers.findAllDescendants(
+                    of: sheet, role: kAXTextFieldRole as String, maxDepth: 8, runtime: runtime.ax
+                )
+                if fields.count == 1 { return fields[0] }
+            }
+        }
+        return nil
+    }
+
+    private static func pressReturn() async {
+        _ = await AppleScriptChannel.executeAppleScript("""
+        tell application "System Events"
+            key code 36
+        end tell
+        return "sent"
+        """)
+    }
+
     static func saveAsViaAXDialog(
         path: String,
-        runtime: AXLogicProElements.Runtime = .production
+        runtime: AXLogicProElements.Runtime = .production,
+        isFrontmost: @Sendable () -> Bool = ProcessUtils.Runtime.production.logicIsFrontmost,
+        activateLogic: @Sendable () -> Bool = ProcessUtils.Runtime.production.activateLogicPro,
+        sleepMicros: @Sendable (UInt32) -> Void = { usleep($0) }
     ) async -> ChannelResult {
         // Validate path before setting it into the AX dialog
         guard AppleScriptSafety.isValidProjectPath(path, requireExisting: false) else {
             return .error("save_as requires an absolute .logicx project path")
+        }
+
+        // #606: Logic disables its document-modifying File items while it is a background
+        // application, so from an MCP client — which IS the frontmost app when it calls this — the
+        // `Save As…` item is `AXEnabled=false` and pressing it does nothing while reporting success.
+        // Refuse before touching anything if Logic cannot be brought forward: a non-ready result here
+        // means no menu was pressed and no panel was opened.
+        let preparation = FrontmostGate.prepare(
+            isFrontmost: isFrontmost, activate: activateLogic, sleepMicros: sleepMicros
+        )
+        guard preparation.isReady else {
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "save_as drives Logic's own File menu, and Logic disables Save As while it is "
+                    + "in the background — the press would report success and open nothing. Nothing "
+                    + "was touched. Bring Logic Pro to the front and retry.",
+                extras: [
+                    "operation": "project.save_as",
+                    "frontmost_preparation": preparation.rawValue,
+                    "write_attempted": false,
+                    "safe_to_retry": true,
+                ]
+            ))
         }
 
         // Step 1: Trigger Save As via menu click
@@ -967,6 +1058,7 @@ extension AccessibilityChannel {
                     + dismissal.summary,
                 extras: [
                     "write_attempted": false,
+                    "frontmost_preparation": preparation.rawValue,
                     "logic_owned_the_keyboard": ownedKeyboard,
                     "candidates_enumerated": shapes.count,
                     "candidate_shapes": shapes,
@@ -988,17 +1080,61 @@ extension AccessibilityChannel {
             }
         }
 
-        // Step 3: Find filename text field and set full path
-        let filenameFields = AXHelpers.findAllDescendants(
-            of: saveDialog, role: kAXTextFieldRole as String, maxDepth: 12, runtime: runtime.ax
-        ).filter { AXHelpers.getDescription($0, runtime: runtime.ax) == "text field" }
+        // Step 3a: put the panel in the target DIRECTORY (#606).
+        //
+        // This panel does not navigate on a POSIX path typed into its filename field. Measured twice:
+        // set the field to "/Users/isaac/Music/Logic/x.logicx" and confirm — by `AXConfirm` and by a
+        // real Return — and both times Logic saved a project literally NAMED
+        // ":Users:isaac:Music:Logic:x" into whatever folder the panel already had open. It reported
+        // success, so the old code's "no file appeared at the requested path" was true and told you
+        // nothing: the file existed, under a name made from the path.
+        //
+        // The panel's own "Go to Folder" sheet is what moves it, and that is a keystroke — there is no
+        // AX attribute on the panel that sets its directory.
+        let directory = (path as NSString).deletingLastPathComponent
+        guard let goToFolder = await openGoToFolderSheet(in: saveDialog, runtime: runtime) else {
+            dismissDialog()
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "The Save panel's \"Go to Folder\" sheet did not appear, so the panel could not "
+                    + "be moved to \(directory). Nothing was saved: this panel writes a project NAMED "
+                    + "after the path if the path is typed into the filename field instead.",
+                extras: ["write_attempted": false, "directory": directory]
+            ))
+        }
+        guard AXHelpers.setAttribute(
+            goToFolder, kAXValueAttribute, (directory + "/") as CFTypeRef, runtime: runtime.ax
+        ) else {
+            dismissDialog()
+            return .error(HonestContract.encodeStateC(
+                error: .axWriteFailed,
+                hint: "Could not type \(directory) into the Save panel's \"Go to Folder\" sheet.",
+                extras: ["write_attempted": false, "directory": directory]
+            ))
+        }
+        await pressReturn()
+        try? await Task.sleep(nanoseconds: 800_000_000)
+
+        // Step 3b: the filename field takes the BASE NAME only. Logic appends the extension itself.
+        let baseName: String = {
+            let last = (path as NSString).lastPathComponent
+            return last.hasSuffix(".logicx") ? String(last.dropLast(".logicx".count)) : last
+        }()
+        // Focus can move while the sheet comes and goes, so the field is resolved again here rather
+        // than reused from the classification pass.
+        let filenameFields = filenameFieldCandidates(in: saveDialog, runtime: runtime)
         guard filenameFields.count == 1, let filenameField = filenameFields.first else {
             dismissDialog()
-            return .error("Cannot resolve the exact filename field in Save As dialog")
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Cannot resolve the filename field in the Save As panel: expected exactly one "
+                    + "focused text field, found \(filenameFields.count).",
+                extras: ["write_attempted": false, "focused_text_fields": filenameFields.count]
+            ))
         }
 
         guard AXHelpers.setAttribute(
-            filenameField, kAXValueAttribute, path as CFTypeRef, runtime: runtime.ax
+            filenameField, kAXValueAttribute, baseName as CFTypeRef, runtime: runtime.ax
         ) else {
             dismissDialog()
             return .error("Cannot set the exact Save As filename field")
@@ -1190,6 +1326,22 @@ extension AccessibilityChannel {
     ) -> ChannelResult {
         guard let item = AXLogicProElements.menuItem(path: [menuName, itemTitle], runtime: runtime) else {
             return .error("Cannot find menu item: \(menuName) > \(itemTitle)")
+        }
+        // #606: pressing a DISABLED menu item reports success and does nothing. Logic disables its
+        // document-modifying File items while it is a background application — measured: with another
+        // app frontmost `Save As…` is `AXEnabled=false` (2/2) while `Open…` stays true, so this is a
+        // property of the item, not of AX menu presses in general. The press then returned true, the
+        // caller inferred the panel was coming, and fifteen polls later reported a panel it had never
+        // caused. An AX return code is not evidence of an effect; `AXEnabled` is the pre-gate.
+        let enabled: Bool? = AXHelpers.getAttribute(
+            item, kAXEnabledAttribute as String, runtime: runtime.ax
+        )
+        guard enabled != false else {
+            return .error(
+                "Refusing to press disabled menu item: \(menuName) > \(itemTitle). "
+                + "Logic disables its document-modifying File items while it is a background "
+                + "application, and pressing one reports success without doing anything."
+            )
         }
         guard AXHelpers.performAction(item, kAXPressAction, runtime: runtime.ax) else {
             return .error("Failed to click: \(menuName) > \(itemTitle)")

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -195,6 +195,11 @@ func blockingLogicDialogResult(
     var hint = "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry."
     // #190: identify the dialog so the demo/product workflow can recover
     // deterministically instead of guessing at a generic blocking-dialog refusal.
+    if info == nil {
+        // #606: refusing without an identity is refusing on something nobody can name. Say what the
+        // guard actually saw so the caller is not sent hunting for a dialog that is not there.
+        extras["dialog_presence_census"] = AXLogicProElements.dialogPresenceCensus()
+    }
     if let info {
         extras["dialog_title"] = info.title
         extras["dialog_role"] = info.role

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -1,0 +1,95 @@
+import ApplicationServices
+import Testing
+@testable import LogicProMCP
+
+/// #606: the Save panel's filename field is identified by FOCUS, not by `AXDescription`.
+///
+/// The shipped rule asked for `AXDescription == "text field"` and matched nothing on the live panel,
+/// which read as "this panel has no filename field" and sent three investigations at the classifier.
+/// The rule had been written from an AppleScript probe: System Events *synthesises* `description`
+/// from `AXRoleDescription` when `AXDescription` is nil, and the raw API this code uses does not.
+/// Measured on the live panel:
+///
+///     field           SysEv description     AXDescription   AXRoleDescription     AXFocused
+///     search          "search text field"   nil             "search text field"   false
+///     FILENAME        "text field"          nil             "text field"          true
+///     tag editor      "tag editor"          "tag editor"    "text field"          false
+@Suite(.serialized)
+struct Issue606SaveAsFieldIdentityTests {
+    /// Builds the measured shape of Logic's Save panel: a split group holding the three text fields
+    /// exactly as the live panel exposes them.
+    private func makeLivePanelShape() -> (FakeAXRuntimeBuilder, AXUIElement) {
+        let b = FakeAXRuntimeBuilder()
+        let panel = b.element(1)
+        let splitGroup = b.element(2)
+        let search = b.element(3)
+        let filename = b.element(4)
+        let tagEditor = b.element(5)
+
+        b.setAttribute(panel, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        b.setAttribute(panel, kAXTitleAttribute as String, "Save")
+        b.setChildren(panel, [splitGroup])
+        b.setAttribute(splitGroup, kAXRoleAttribute as String, kAXSplitGroupRole as String)
+        b.setChildren(splitGroup, [search, filename, tagEditor])
+
+        for field in [search, filename, tagEditor] {
+            b.setAttribute(field, kAXRoleAttribute as String, kAXTextFieldRole as String)
+            b.setChildren(field, [])
+        }
+        // Exactly as measured: AXDescription is nil on the two the old rule needed to tell apart,
+        // and present on the one it did not.
+        b.setAttribute(search, kAXFocusedAttribute as String, false)
+        b.setAttribute(filename, kAXFocusedAttribute as String, true)
+        b.setAttribute(filename, kAXValueAttribute as String, "Untitled")
+        b.setAttribute(tagEditor, kAXDescriptionAttribute as String, "tag editor")
+        b.setAttribute(tagEditor, kAXFocusedAttribute as String, false)
+        return (b, panel)
+    }
+
+    @Test("issue606_the_filename_field_is_the_focused_one")
+    func filenameFieldIsTheFocusedOne() throws {
+        let (builder, panel) = makeLivePanelShape()
+        let runtime = builder.makeLogicRuntime()
+
+        let fields = AccessibilityChannel.filenameFieldCandidates(in: panel, runtime: runtime)
+        #expect(fields.count == 1)
+
+        let field = try #require(fields.first)
+        let value: String? = AXHelpers.getAttribute(
+            field, kAXValueAttribute as String, runtime: runtime.ax
+        )
+        let readBack = try #require(value)
+        #expect(readBack == "Untitled")
+    }
+
+    /// The old rule, run against the same shape, to pin WHY it failed rather than only that it did.
+    @Test("issue606_the_old_description_rule_matches_nothing_on_this_shape")
+    func oldDescriptionRuleMatchesNothing() {
+        let (builder, panel) = makeLivePanelShape()
+        let runtime = builder.makeLogicRuntime()
+
+        let byDescription = AXHelpers.findAllDescendants(
+            of: panel, role: kAXTextFieldRole as String, maxDepth: 12, runtime: runtime.ax
+        ).filter { AXHelpers.getDescription($0, runtime: runtime.ax) == "text field" }
+
+        // Zero — not one. This is the whole failure: a panel with a perfectly readable filename field
+        // reported as having none, because the attribute the filter reads is empty on that element.
+        #expect(byDescription.isEmpty)
+    }
+
+    /// Focus must select, not merely exist: a panel where nothing is focused resolves nothing, and a
+    /// panel where two fields claim focus is ambiguous and must not be typed into.
+    @Test("issue606_focus_rule_refuses_when_it_does_not_select_exactly_one")
+    func focusRuleRefusesAmbiguity() {
+        let (builder, panel) = makeLivePanelShape()
+        let runtime = builder.makeLogicRuntime()
+
+        builder.setAttribute(builder.element(4), kAXFocusedAttribute as String, false)
+        #expect(AccessibilityChannel.filenameFieldCandidates(in: panel, runtime: runtime).isEmpty)
+
+        builder.setAttribute(builder.element(4), kAXFocusedAttribute as String, true)
+        builder.setAttribute(builder.element(3), kAXFocusedAttribute as String, true)
+        #expect(AccessibilityChannel.filenameFieldCandidates(in: panel, runtime: runtime).count == 2)
+    }
+}


### PR DESCRIPTION
Closes #606.

`project.save_as` now writes a project at the path it is given. Three independent defects, each
measured live before it was touched, each of which alone made the operation impossible.

### 1. The menu press never brought Logic forward — and pressing a disabled item reports success

Logic **disables** its document-modifying File items while it is a background application. An MCP
client is the frontmost app when it calls this, so the item was disabled every time, and `AXPress`
on a disabled item returns true. `triggered` was therefore true, and the code polled fifteen times
for a panel it had never caused.

```
front app        gesture              windows named "Save"     Save As… AXEnabled   Open… AXEnabled
Google Chrome    File ▸ Save As…      0     (2/2)              false               true
Logic Pro        File ▸ Save As…      1     (2/2)              true                true
```

`Open…` is unaffected in both columns, so this is a property of the item, not of AX menu presses.
Two changes follow: `clickMenuItem` reads `kAXEnabledAttribute` and refuses a disabled item **by
name** at every call site, and `save_as` establishes frontmost through the existing `FrontmostGate`
before pressing anything.

### 2. The filename field was looked up by an attribute it does not carry

The rule was `AXDescription == "text field"`, and it matched **nothing** on a panel that plainly has
a filename field — which read as "this panel has no filename field" and sent three investigations at
the classifier. It had been written from an AppleScript probe, and System Events **synthesises**
`description` from `AXRoleDescription` when `AXDescription` is nil. Measured through the API this
code actually uses:

```
field         SysEv `description`   AXDescription   AXRoleDescription     AXFocused   AXValue
search        "search text field"   nil             "search text field"   false       nil
FILENAME      "text field"          nil             "text field"          true        "Untitled"
tag editor    "tag editor"          "tag editor"    "text field"          false       ""
```

`AXRoleDescription` picks two of the three and is localised — expensive given #519. **Focus picks
exactly one**, is neither localised nor synthesised, and is the field a person types into. That is
the identifier now, at both the classification site and the typing site.

### 3. The full POSIX path was typed where a name goes

This panel does not navigate on a typed path. Measured twice — by `AXConfirm` and by a real Return —
Logic saved a project literally named `:Users:isaac:Music:Logic:x` into whatever folder the panel had
open, **and reported success**. So the old `"no file appeared at the requested path within 5s"` was
true and told you nothing: the file existed, under a name made out of the path.

The panel's own Go-to-Folder sheet is the only coordinate-free way to move it, so the directory goes
there and the base name goes in the field.

### Also: a fail-closed guard that cannot name what it saw

`blockingLogicDialogResult` reports `dialog_title`/`dialog_role` only when `blockingDialogInfo()`
returns an identity. When it does not, the caller was told `blocking_dialog_present: true` with
nothing named. It now carries a census — the window list with subroles, sheet counts and
unreadable-role counts, plus a recheck of the very question that refused.

That census is what exposed **#608**: the first call in a fresh process is refused as
`blocking_dialog_present` on a screen holding one `AXStandardWindow`, with `dialog_present_recheck`
answering **false** milliseconds later. Filed, not fixed here. The live harness performs one
read-only call first to absorb it and records that it had to.

### Proof

```
full suite                    3846 tests passed
live evidence for this head   9 checks, 9 passed, 4 mutation-backed, 1 visual passed,
                              0 unsettled, 0 straddling displays, 0 restorations failed
SHIP GATE PASS                0d419d18
```

The live run asserts a project exists at the **exact** path, that **no** path-named project was
created, that Logic's own window title names the saved project, and that the title band changed. It
does not assert that the operation returned success — the broken version could do that.

Unit tests build the panel's measured shape and pin the focus rule, including one that runs the OLD
rule against the same shape to record that it matches zero. Mutation-tested: restoring the
description filter turns two of the three red.

One harness self-defect was caught and fixed on the way: the "after" capture looked for the window by
the title the save had just changed, found nothing, and the visual then compared a real image against
a failed lookup and called it unchanged.