### PR TITLE
fix(#606): the blind review found a wedge, a lenient gate, and three checks that could not fail

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
+  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
       }
     },
     {
@@ -56,57 +20,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
       }
     },
     {
@@ -128,75 +47,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Scripts/livekit/live_606_save_as_writes_the_file.py
+++ b/Scripts/livekit/live_606_save_as_writes_the_file.py
@@ -63,10 +63,28 @@ if missing:
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 DIRECTORY = "/Users/isaac/Music/Logic"
-NAME = "lpm-606-live-proof"
+# Unique per run. The first cut used a fixed name and left Logic open under it, so on the SECOND run
+# the window title already matched before save_as was called and `logic-says-it-is-now-that-project`
+# was satisfied by the previous run rather than by this one. A check a prior run can satisfy is not
+# a check.
+NAME = f"lpm-606-live-proof-{HEAD[:8]}-{os.getpid()}"
 TARGET = f"{DIRECTORY}/{NAME}.logicx"
 # What the OLD code produced instead: the path itself as a filename, with "/" shown as ":".
 PATH_AS_NAME = f"{DIRECTORY}/{TARGET.replace('/', ':')}"
+
+
+def colon_named_bundles():
+    """Every project in the target folder whose name is a mangled path.
+
+    Probing one guessed path was not enough: the old failure wrote into whatever folder the panel
+    happened to have open, so a single `os.path.exists` on a name built from DIRECTORY could be
+    green while the artifact sat elsewhere. This at least sees the whole target folder, and the
+    check below compares BEFORE against AFTER so absence-by-default cannot pass for evidence.
+    """
+    try:
+        return sorted(n for n in os.listdir(DIRECTORY) if ":" in n)
+    except OSError:
+        return []
 
 
 def osa(script):
@@ -78,6 +96,12 @@ def window_titles():
     raw = osa('tell application "System Events" to tell process "Logic Pro" to '
               'return name of every window')
     return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def any_sheets():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return (count of sheets of every window)')
+    return [n for n in raw.split(",") if n.strip() not in ("", "0")]
 
 
 def save_panels():
@@ -98,6 +122,7 @@ if not titles:
     ev.write()
     sys.exit("no project open")
 
+colon_before = colon_named_bundles()
 ev.check("606/precondition-target-path-is-clear",
          not os.path.exists(TARGET) and not os.path.exists(PATH_AS_NAME),
          "neither the requested path nor the path-as-a-name variant exists before the run, so "
@@ -132,6 +157,7 @@ ev.note("606/warmup-first-call-is-refused-see-608", {
     "blocking_dialog_present": (warm or {}).get("blocking_dialog_present"),
 })
 
+titles_before_save = window_titles()
 saved = d.tool("logic_project", "save_as", {"path": TARGET, "confirmed": True})
 ev.note("606/save-as", {k: saved.get(k) for k in
                         ("state", "success", "error", "hint", "requested", "observed", "via")
@@ -147,13 +173,15 @@ ev.check("606/a-project-exists-at-the-exact-requested-path",
          "remove the Go-to-Folder step from `saveAsViaAXDialog`: the panel stays in whatever folder "
          "it opened in, nothing is written here, and this goes red")
 
+colon_after = colon_named_bundles()
 ev.check("606/no-project-was-created-with-the-path-as-its-name",
-         not os.path.exists(PATH_AS_NAME),
-         "the old failure produced a project literally NAMED after the requested path, in the wrong "
-         "folder, while reporting success — so its absence is the specific thing being proven",
-         f"path_as_name_exists={os.path.exists(PATH_AS_NAME)} probe={PATH_AS_NAME!r}",
-         "revert step 3b to setting the full path into the filename field: this folder appears and "
-         "this goes red")
+         colon_after == colon_before and not os.path.exists(PATH_AS_NAME),
+         "the old failure produced a project literally NAMED after the requested path — so what is "
+         "proven is that the set of path-named projects in the target folder is UNCHANGED across "
+         "the run, not merely that one guessed name is absent",
+         f"before={colon_before!r} after={colon_after!r} probe_exists={os.path.exists(PATH_AS_NAME)}",
+         "revert step 3b to setting the full path into the filename field: a ':Users:…' bundle "
+         "appears in this folder, the two censuses differ, and this goes red")
 
 ev.check("606/the-operation-reported-state-A",
          isinstance(saved, dict) and saved.get("state") == "A" and saved.get("success") is True,
@@ -165,18 +193,26 @@ ev.check("606/the-operation-reported-state-A",
          "reports success, no panel opens, and this reports element_not_found instead")
 
 title_after = window_titles()
-ev.check("606/logic-says-it-is-now-that-project",
-         any(t.startswith(NAME) for t in title_after),
-         "Logic's own window title names the saved project — a readback through the UI rather than "
-         "through the file system, so a stale directory listing cannot carry this check",
-         f"windows={title_after!r}",
-         "revert the Go-to-Folder step: the title becomes the colon-mangled path and this goes red")
+ev.check("606/logic-changed-its-title-to-this-runs-project",
+         any(t.startswith(NAME) for t in title_after)
+         and not any(t.startswith(NAME) for t in titles_before_save),
+         "Logic's own window title now names this run's project and did NOT before the call — a "
+         "readback through the UI, and one that a previous run cannot pre-satisfy because the name "
+         "carries this run's head and pid",
+         f"before={titles_before_save!r} after={title_after!r} name={NAME!r}",
+         "revert the Go-to-Folder step: the title becomes the colon-mangled path, so the 'after' "
+         "half fails and this goes red")
 
-ev.check("606/no-panel-was-left-behind",
-         not save_panels(),
-         "the Save panel is gone — a successful save must not leave its own modal up any more than a "
-         "refusal may",
-         f"save_panels={save_panels()!r}", None)
+# `save_panels()` only asked for windows named "Save", so a leftover Go-to-Folder SHEET — which the
+# new step 3a can open — would not have tripped it. And on a run where no panel ever opened this is
+# green for the wrong reason, so it is recorded as a guard rather than as proof of the dismissal.
+ev.check("606/no-panel-or-sheet-was-left-behind",
+         not save_panels() and not any_sheets(),
+         "neither the Save panel nor its Go-to-Folder sheet is on screen — a successful save must "
+         "not leave a modal up any more than a refusal may. This is a guard, not a proof of the "
+         "dismissal code: on a run where the panel never opened it is green for the wrong reason, "
+         "and the run that exercises the dismissal is the refusal harness for #604",
+         f"save_panels={save_panels()!r} sheets={any_sheets()!r}", None)
 
 # The operation RENAMES the window, so capturing "after" by the title captured "before" can only
 # ever miss — the first cut of this file did exactly that and recorded "no Logic window on screen",

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -836,7 +836,13 @@ extension AccessibilityChannel {
                 "subrole": AXHelpers.getAttribute(
                     candidate, kAXSubroleAttribute as String, runtime: runtime.ax
                 ) as String? ?? "",
-                "filename_fields": filenameFields.count,
+                // #606: this dump used the retired `AXDescription == "text field"` rule, which the
+                // unit tests prove matches nothing on the measured panel — so a refusal kept telling
+                // its reader the panel had no filename field while the classifier had already moved
+                // to focus. Report BOTH: the count the classifier judges by, and the old one, which
+                // is now only useful as evidence of the attribute gap.
+                "filename_fields": filenameFieldCandidates(in: candidate, runtime: runtime).count,
+                "text_fields_matching_retired_description_rule": filenameFields.count,
                 "save_buttons": saveButtons.count,
                 "save_enabled": enabled.map { $0 as Any } ?? "unread",
                 "cancel_buttons": buttons.filter {
@@ -1070,14 +1076,52 @@ extension AccessibilityChannel {
         }
 
         // Helper: dismiss dialog on failure (press Escape to avoid blocking UI)
-        func dismissDialog() {
-            let cancelButtons = AXHelpers.findAllDescendants(of: saveDialog, role: "AXButton", runtime: runtime.ax)
-            for btn in cancelButtons {
-                if AXLocalePolicy.elementMatches(btn, AXLocalePolicy.cancelButton, runtime: runtime.ax) {
-                    AXHelpers.performAction(btn, kAXPressAction, runtime: runtime.ax)
-                    return
+        // One dismissal for every failure path, and it must actually clear what is on screen.
+        //
+        // The previous helper pressed the FIRST Cancel-matching button it found at the default depth
+        // and returned, ignoring the result. Once step 3a can open a Go-to-Folder sheet there are two
+        // surfaces and two Cancels, so one press closes at most one of them — and a Save panel left
+        // behind is what `dialogPresent()` then reports as `blocking_dialog_present` for every later
+        // operation. So: press Cancel, then Escape, then look, and repeat while anything remains.
+        func dismissEverything() async -> PanelDismissal {
+            let before = panelShapedCandidateCount(runtime: runtime)
+            var delivered = true
+            for _ in 0..<3 {
+                let buttons = AXHelpers.findAllDescendants(
+                    of: saveDialog, role: kAXButtonRole as String, maxDepth: 12, runtime: runtime.ax
+                )
+                if let cancel = buttons.first(where: {
+                    AXLocalePolicy.elementMatches($0, AXLocalePolicy.cancelButton, runtime: runtime.ax)
+                }) {
+                    _ = AXHelpers.performAction(cancel, kAXPressAction, runtime: runtime.ax)
+                    try? await Task.sleep(nanoseconds: 300_000_000)
                 }
+                let escaped = await escapeAnyOpenPanel(runtime: runtime)
+                delivered = delivered && escaped.escapeDelivered
+                if escaped.panelsAfter == 0 { break }
             }
+            return PanelDismissal(
+                panelsBefore: before,
+                panelsAfter: panelShapedCandidateCount(runtime: runtime),
+                escapeDelivered: delivered
+            )
+        }
+
+        /// Every failure after the panel is up returns through here, so no path can forget to clean up.
+        func refuse(
+            _ error: HonestContract.FailureError,
+            _ hint: String,
+            _ extras: [String: Any] = [:]
+        ) async -> ChannelResult {
+            let dismissal = await dismissEverything()
+            var all = extras
+            all["write_attempted"] = extras["write_attempted"] ?? false
+            all["panels_before_dismissal"] = dismissal.panelsBefore
+            all["panels_after_dismissal"] = dismissal.panelsAfter
+            all["escape_delivered"] = dismissal.escapeDelivered
+            return .error(HonestContract.encodeStateC(
+                error: error, hint: hint + " " + dismissal.summary, extras: all
+            ))
         }
 
         // Step 3a: put the panel in the target DIRECTORY (#606).
@@ -1093,27 +1137,45 @@ extension AccessibilityChannel {
         // AX attribute on the panel that sets its directory.
         let directory = (path as NSString).deletingLastPathComponent
         guard let goToFolder = await openGoToFolderSheet(in: saveDialog, runtime: runtime) else {
-            dismissDialog()
-            return .error(HonestContract.encodeStateC(
-                error: .elementNotFound,
-                hint: "The Save panel's \"Go to Folder\" sheet did not appear, so the panel could not "
-                    + "be moved to \(directory). Nothing was saved: this panel writes a project NAMED "
+            return await refuse(
+                .elementNotFound,
+                "The Save panel's \"Go to Folder\" sheet did not appear, so the panel could not be "
+                    + "moved to \(directory). Nothing was saved: this panel writes a project NAMED "
                     + "after the path if the path is typed into the filename field instead.",
-                extras: ["write_attempted": false, "directory": directory]
-            ))
+                ["directory": directory]
+            )
         }
         guard AXHelpers.setAttribute(
             goToFolder, kAXValueAttribute, (directory + "/") as CFTypeRef, runtime: runtime.ax
         ) else {
-            dismissDialog()
-            return .error(HonestContract.encodeStateC(
-                error: .axWriteFailed,
-                hint: "Could not type \(directory) into the Save panel's \"Go to Folder\" sheet.",
-                extras: ["write_attempted": false, "directory": directory]
-            ))
+            return await refuse(
+                .axWriteFailed,
+                "Could not type \(directory) into the Save panel's \"Go to Folder\" sheet.",
+                ["directory": directory]
+            )
         }
         await pressReturn()
-        try? await Task.sleep(nanoseconds: 800_000_000)
+
+        // The sheet must be GONE before the filename field is resolved. `filenameFieldCandidates`
+        // searches the panel's descendants, and a still-open sheet has a focused text field of its
+        // own — so without this wait the base name can be typed into the Go-to-Folder box.
+        var sheetCleared = false
+        for _ in 0..<15 {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            let sheets = AXHelpers.getChildren(saveDialog, runtime: runtime.ax).filter {
+                AXHelpers.getRole($0, runtime: runtime.ax) == (kAXSheetRole as String)
+            }
+            if sheets.isEmpty { sheetCleared = true; break }
+        }
+        guard sheetCleared else {
+            return await refuse(
+                .axWriteFailed,
+                "The Save panel's \"Go to Folder\" sheet stayed open after \(directory) was entered, "
+                    + "so the panel's directory is unknown and the filename field cannot be told "
+                    + "apart from the sheet's own field.",
+                ["directory": directory]
+            )
+        }
 
         // Step 3b: the filename field takes the BASE NAME only. Logic appends the extension itself.
         let baseName: String = {
@@ -1124,20 +1186,22 @@ extension AccessibilityChannel {
         // than reused from the classification pass.
         let filenameFields = filenameFieldCandidates(in: saveDialog, runtime: runtime)
         guard filenameFields.count == 1, let filenameField = filenameFields.first else {
-            dismissDialog()
-            return .error(HonestContract.encodeStateC(
-                error: .elementNotFound,
-                hint: "Cannot resolve the filename field in the Save As panel: expected exactly one "
-                    + "focused text field, found \(filenameFields.count).",
-                extras: ["write_attempted": false, "focused_text_fields": filenameFields.count]
-            ))
+            return await refuse(
+                .elementNotFound,
+                "Cannot resolve the filename field in the Save As panel: expected exactly one focused "
+                    + "text field, found \(filenameFields.count).",
+                ["focused_text_fields": filenameFields.count]
+            )
         }
 
         guard AXHelpers.setAttribute(
             filenameField, kAXValueAttribute, baseName as CFTypeRef, runtime: runtime.ax
         ) else {
-            dismissDialog()
-            return .error("Cannot set the exact Save As filename field")
+            return await refuse(
+                .axWriteFailed,
+                "Could not type the base name \(baseName) into the Save As filename field.",
+                ["base_name": baseName]
+            )
         }
         // Confirm the text entry so the save panel updates its internal path state
         AXHelpers.performAction(filenameField, kAXConfirmAction, runtime: runtime.ax)
@@ -1152,8 +1216,11 @@ extension AccessibilityChannel {
         guard saveButtons.count == 1,
               let saveButton = saveButtons.first,
               AXHelpers.performAction(saveButton, kAXPressAction, runtime: runtime.ax) else {
-            dismissDialog()
-            return .error("Cannot press the exact Save button in Save As dialog")
+            return await refuse(
+                .axWriteFailed,
+                "Could not press the Save button: expected exactly one, found \(saveButtons.count).",
+                ["save_buttons": saveButtons.count]
+            )
         }
 
         // Step 5: Verify file exists (up to 5s)
@@ -1173,11 +1240,14 @@ extension AccessibilityChannel {
             ))
         }
 
-        return .error(HonestContract.encodeStateC(
-            error: .axWriteFailed,
-            hint: "Save As dialog completed but no file appeared at requested path within 5s",
-            extras: ["requested": path]
-        ))
+        // This used to dismiss nothing, so a panel that never accepted the save stayed on screen and
+        // refused every later operation. It also blamed a timeout for what was, every time it was
+        // investigated, a panel still waiting on something.
+        return await refuse(
+            .axWriteFailed,
+            "The Save panel was driven to completion but no project appeared at \(path) within 5s.",
+            ["requested": path, "base_name": baseName, "directory": directory]
+        )
     }
 
     static func openBounceDialogViaMenu(
@@ -1333,14 +1403,20 @@ extension AccessibilityChannel {
         // property of the item, not of AX menu presses in general. The press then returned true, the
         // caller inferred the panel was coming, and fifteen polls later reported a panel it had never
         // caused. An AX return code is not evidence of an effect; `AXEnabled` is the pre-gate.
+        // Strict, matching this tree's other actuation gate (`menuItemEnabledForActuation`):
+        // ENABLED means the attribute read and said true. An unreadable attribute is not evidence
+        // that the item is pressable — treating it as permission would leave exactly the hole this
+        // gate exists to close, since the press then reports success either way.
         let enabled: Bool? = AXHelpers.getAttribute(
             item, kAXEnabledAttribute as String, runtime: runtime.ax
         )
-        guard enabled != false else {
+        guard enabled == true else {
+            let observed = enabled.map(String.init) ?? "unreadable"
             return .error(
-                "Refusing to press disabled menu item: \(menuName) > \(itemTitle). "
+                "Refusing to press menu item \(menuName) > \(itemTitle): AXEnabled is \(observed). "
                 + "Logic disables its document-modifying File items while it is a background "
-                + "application, and pressing one reports success without doing anything."
+                + "application, and pressing a disabled item reports success without doing anything, "
+                + "so an unreadable answer is refused for the same reason a false one is."
             )
         }
         guard AXHelpers.performAction(item, kAXPressAction, runtime: runtime.ax) else {

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -93,3 +93,42 @@ struct Issue606SaveAsFieldIdentityTests {
         #expect(AccessibilityChannel.filenameFieldCandidates(in: panel, runtime: runtime).count == 2)
     }
 }
+
+/// #606 follow-up: the menu gate must refuse an UNREADABLE `AXEnabled`, not only a false one.
+///
+/// The first cut used `enabled != false`, so a missing read was treated as permission to press. That
+/// is the opposite of this tree's other actuation gate (`menuItemEnabledForActuation` is
+/// `enabled == true`), and it leaves open exactly the hole the gate exists to close: `AXPress` on a
+/// disabled item returns true, so an unreadable answer followed by a press is indistinguishable from
+/// success on a disabled item.
+@Suite(.serialized)
+struct Issue606MenuEnabledGateTests {
+    private func gateAccepts(enabled: Bool?) -> Bool {
+        // The predicate under test, stated the way the call site states it.
+        enabled == true
+    }
+
+    @Test("issue606_menu_gate_accepts_only_a_read_true")
+    func gateAcceptsOnlyReadTrue() {
+        #expect(gateAccepts(enabled: true))
+        #expect(!gateAccepts(enabled: false))
+        // The case the first cut got wrong.
+        #expect(!gateAccepts(enabled: nil))
+    }
+
+    /// The same predicate, read out of the shipped source, so this test fails if the call site drifts
+    /// back to the lenient form while the helper above stays strict.
+    @Test("issue606_the_shipped_call_site_uses_the_strict_form")
+    func shippedCallSiteIsStrict() throws {
+        let source = try String(
+            contentsOfFile: #filePath
+                .replacingOccurrences(
+                    of: "Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift",
+                    with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift"
+                ),
+            encoding: .utf8
+        )
+        #expect(source.contains("guard enabled == true else {"))
+        #expect(!source.contains("guard enabled != false else {"))
+    }
+}

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -128,7 +128,9 @@ struct Issue606MenuEnabledGateTests {
                 ),
             encoding: .utf8
         )
-        #expect(source.contains("guard enabled == true else {"))
-        #expect(!source.contains("guard enabled != false else {"))
+        let usesStrictForm = source.contains("guard enabled == true else {")
+        let usesLenientForm = source.contains("guard enabled != false else {")
+        #expect(usesStrictForm)
+        #expect(usesLenientForm == false)
     }
 }

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -131,6 +131,6 @@ struct Issue606MenuEnabledGateTests {
         let usesStrictForm = source.contains("guard enabled == true else {")
         let usesLenientForm = source.contains("guard enabled != false else {")
         #expect(usesStrictForm)
-        #expect(usesLenientForm == false)
+        #expect(!usesLenientForm)
     }
 }


### PR DESCRIPTION
#609 merged at `bc1d3a6c`. The revision an independent blind review produced landed **after** that
merge and is not on `main`. This is the same one-commit-behind merge that already happened once with
#605/#607, so the branch is unchanged and this PR carries only what the review found.

All four findings hold against the source, and two I could confirm from my own run history.

### BLOCKER — every failure path after the Go-to-Folder sheet could leave a modal up

`dismissDialog` pressed the **first** Cancel it found at the default depth of 5 and returned, ignoring
the result. Once step 3a can open a sheet there are two surfaces and two Cancels, so one press clears
at most one of them — and a Save panel left behind is exactly what `dialogPresent()` reports as
`blocking_dialog_present` for every later operation.

Worse: nothing waited for the sheet to close before resolving the filename field. That resolution
walks the panel's descendants for a **focused** text field, and an open Go-to-Folder sheet has one of
its own — so the base name could be typed into the Go-to-Folder box.

Now `dismissEverything` presses Cancel, presses Escape, looks, and repeats while anything remains;
every failure returns through one `refuse` helper that runs it and reports what it counted before and
after; and the sheet must be **observed gone** before the filename field is resolved, with its own
refusal if it is not. The five-second timeout path dismissed nothing at all and now goes through the
same helper.

### MAJOR — the AXEnabled gate treated "unreadable" as permission to press

`enabled != false` continues when the read returns nil. That is the opposite of this tree's other
actuation gate — `menuItemEnabledForActuation` is `enabled == true` — and it leaves open the exact
hole the gate exists to close, since `AXPress` on a disabled item returns true either way. Now
strict, and the refusal says whether it read `false` or could not read at all.

Pinned two ways: a predicate test that feeds `nil`, and a test that reads the **shipped source** for
the strict form, so the call site cannot drift back while the predicate test stays green.

### MAJOR — three live checks could not fail

| check | why it could not go red |
|---|---|
| `no-project-was-created-with-the-path-as-its-name` | absence was the passing state, so **any** full revert kept it green — nothing gets created, nothing to find. It also probed one guessed path, while the old failure wrote into whatever folder the panel had open. Now it compares a census of path-named projects in the folder taken **before and after**. |
| `no-panel-was-left-behind` | asked only for windows named `Save`, so a leftover Go-to-Folder **sheet** — which the new step 3a can open — did not trip it. Now asks about sheets too, and states plainly that it is a guard rather than proof of the dismissal. |
| `logic-says-it-is-now-that-project` | used a **fixed** project name that the harness leaves Logic open under. From the second run onward the title already matched before `save_as` was called — I ran it three times, so runs two and three were satisfied by run one. The name now carries this run's head and pid, and the check asserts the title did **not** match before the call and does after. |

### MINOR — the refusal's own diagnostic still used the retired rule

`saveAsDialogCandidateShapes` counted filename fields with `AXDescription == "text field"` — the
filter the unit tests prove matches nothing on the measured panel. A future refusal would have gone
on telling its reader that a panel with a filename field has none. It now reports the count the
classifier judges by, and keeps the old one under a name that says what it is.

### Gate

```
full suite                    3848 tests passed
live evidence for this head   9 checks, 9 passed, 4 mutation-backed, 1 visual passed,
                              0 unsettled, 0 straddling displays, 0 restorations failed
SHIP GATE PASS                43aab616
```

Mutation-tested: reverting the call site to `enabled != false` turns the source-drift test red;
reverting turns it green.