### PR TITLE
test(livekit): derive the track-header band from AX instead of writing a rectangle

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -14,6 +14,10 @@ What it refuses to let you record:
   resulting image is not what the user sees. Every capture records which display it fell wholly within.
 - **A whole-window diff as a visual assertion.** A full-window comparison changes when the clock ticks.
   `visual()` requires an explicit region and states what it expected to happen there.
+- **A region measured once and carried as a constant.** A rectangle taken on one window shape silently
+  watches something else after a resize — measured, a stale band landed on the Step Sequencer and made
+  a negative assertion report movement in a part of the screen the run never touched. Derive the band
+  at run time; `track_header_band()` does it for the arrange rail.
 - **A check that cannot fail.** `check()` requires you to name the mutation you applied to the product
   that flipped it. A check nobody has seen fail is not evidence.
 - **A cached read presented as live.** `provenance()` records the source and age of any value that did
@@ -100,6 +104,77 @@ def logic_window(title_contains="Tracks"):
                 "x": int(b["X"]), "y": int(b["Y"]),
                 "w": int(b["Width"]), "h": int(b["Height"])}
     return None
+
+
+
+def track_header_band():
+    """The arrange window's track-header rail, in window coordinates, read from AX at run time.
+
+    Use this instead of writing a rectangle into a harness. Every band in this directory started as a
+    number measured once, and a number measured once is right until someone resizes a window: the
+    #592 harness carried `(603, 162, 325, 406)`, taken on a 1920x1050 window with the Library closed,
+    and after the window changed shape that rectangle landed on the Step Sequencer — which animates
+    on its own. A NEGATIVE visual assertion over it then reported movement in a part of the screen
+    the run had never touched, and failed a run in which nothing was written.
+
+    Measured here on 2026-08-19 against a 1920x1050 arrange window: 366,527 235x522 — the rail, not
+    the top-left block of the window that a hand-written band tends to become. The number moves with
+    the window and the track count, which is the entire point; do not write down whatever it prints.
+
+    Returns None when the rail cannot be located, which a caller should treat as a failed
+    precondition rather than a reason to fall back to a guess.
+
+    Two AppleScript hazards are handled here so a caller does not rediscover them:
+
+    - `by` is a reserved word, so a variable named that fails to PARSE rather than to run.
+    - `first window whose name is "…"` has been measured answering "invalid index" for a window that
+      `name of every window` listed a moment earlier, with a plain-ASCII title that matched exactly.
+      So the window is not chosen by name at all: every window is tried until one yields a rail.
+      Excluding the chooser by title was not enough either — a run that overlapped an "Import" dialog
+      picked that dialog and got nothing.
+    """
+    script = """
+    tell application "System Events" to tell process "Logic Pro"
+      -- Chosen by WHAT IT CONTAINS, not by its name. Excluding the project chooser by title was not
+      -- enough: a run that overlapped an "Import" dialog picked that dialog as the project window
+      -- and the lookup returned nothing. The window this wants is the one that has a track rail, so
+      -- every window is tried until one yields it.
+      set out to "none"
+      repeat with cand in (every window)
+        set w to contents of cand
+        try
+          set wp to position of w
+          set ec to entire contents of w
+          repeat with e in ec
+            set el to contents of e
+            try
+              if (role of el as text) is equal to "AXLayoutItem" then
+                set t to (first UI element of el whose role is "AXTextField")
+                set p1 to (value of attribute "AXParent" of el)
+                set rail to (value of attribute "AXParent" of p1)
+                set rp to position of rail
+                set rs to size of rail
+                set relX to ((item 1 of rp) - (item 1 of wp)) as integer
+                set relY to ((item 2 of rp) - (item 2 of wp)) as integer
+                set railW to (item 1 of rs) as integer
+                set railH to (item 2 of rs) as integer
+                set out to (relX as text) & "," & (relY as text) & "," & (railW as text) & "," & (railH as text)
+                exit repeat
+              end if
+            end try
+          end repeat
+        end try
+        if out is not "none" then exit repeat
+      end repeat
+      return out
+    end tell
+    """
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    parts = [p.strip() for p in (r.stdout or "").strip().split(",")]
+    if len(parts) != 4 or not all(p.lstrip("-").isdigit() for p in parts):
+        return None
+    x, y, w, h = (int(p) for p in parts)
+    return (x, y, w, h) if w > 0 and h > 0 else None
 
 
 def _displays():


### PR DESCRIPTION
Draft until an independent blind review passes — see the convention note at the bottom.

Recovered from the branch behind #597. **#597 itself is superseded**: I re-counted the table on
current `main` and every row it retires is already gone, along with every dead switch arm it removes.

```
mixer.set_output / set_input / toggle_eq / reset_strip
    RoutingTable rows                    0   (removed; the table even carries a #592 comment saying so)
    AccessibilityChannel refusal arms    0   (removed)
    anything routing them                0
    what remains                         an explicit notExposedCommandResult in the dispatcher

plugin.list / automation.get_mode
    absent everywhere outside the table, and absent from the table too
```

Main also carries a **later and more accurate** version of that harness's prose — the correction that
`mixer.set_send` and `automation.set_mode` lost their accessibility arms *without* losing their rows,
because those two operations work on the channels their chains actually name. The branch has the
earlier wording.

So the only thing on it that `main` lacks is this helper, and it is worth keeping.

### What it is for

A band written into a harness is right until someone resizes a window. The #592 harness carried
`(603, 162, 325, 406)`, measured on a 1920x1050 window with the Library closed. After the window
changed shape that rectangle landed on the **Step Sequencer**, which animates on its own — and a
NEGATIVE visual assertion over it then reported movement in a part of the screen the run had never
touched, failing a run in which nothing was written.

`track_header_band()` asks AX for the rail at run time. It returns `None` when the rail cannot be
found, which a caller should treat as a failed precondition rather than a reason to guess.

Two AppleScript hazards are handled inside it so a caller does not rediscover them:

- `by` is a reserved word, so a variable named that fails to **parse** rather than to run.
- `first window whose name is "…"` has been measured answering *invalid index* for a window that
  `name of every window` listed a moment earlier, with a plain-ASCII title that matched exactly. So
  the window is chosen by **what it contains** — a track rail — not by its name. Excluding the
  project chooser by title was not enough either: a run that overlapped an "Import" dialog picked
  that dialog and got nothing.

### One correction to the recovered text

The docstring claimed a specific past measurement — `366,707 235x1182` — that I had no way to
reproduce. Inherited text keeps asserting old facts, so I replaced it with one taken here today
against the window on screen now:

```
track_header_band() -> (366, 527, 235, 522)
logic_window('Tracks') -> 1920x1050 at 0,30
```

`main`'s `live_592` harness is **not** rewired to use it in this PR. Its band is already derived from
the window frame rather than hard-coded, so there is no stale-constant defect left there to fix, and
switching it would change what that harness asserts without a run to show the new assertion still
holds.

### Gate

```
full suite                    3846 tests passed
live evidence                 n/a — no Sources/ change
SHIP GATE PASS                dc736912
```

### Convention

Two of my PRs this week were merged one commit before the blind review's revision existed — not a
race, just me opening them ready before the review had run. From now on mine open as **draft** and
become ready only after a cross-provider blind review passes. A non-draft PR from me means the review
is done.