### PR TITLE
fix(#608): a read that did not happen was being reported as a dialog on screen

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
+  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
       }
     },
     {
@@ -56,57 +20,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
       }
     },
     {
@@ -128,75 +47,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Scripts/livekit/live_608_first_call_is_not_refused.py
+++ b/Scripts/livekit/live_608_first_call_is_not_refused.py
@@ -1,0 +1,179 @@
+"""Live proof that a fresh process's first call is not refused for a dialog that is not there.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_608_first_call_is_not_refused.py <worktree> <full-40-char-head-sha>
+
+WHAT THIS RUN IS ABOUT
+----------------------
+Every mutating operation consults a fail-closed blocking-dialog guard. In a FRESH process that guard
+refused the first call, on a screen holding one ordinary window and nothing else. Measured before the
+fix, four trials out of four, with the refusal's own instrumentation:
+
+    last_dialog_presence_reason   windows_read_failed
+    windows_read_ax_error         -25204   (kAXErrorCannotComplete)
+    dialog_present_recheck        false    (the same read, milliseconds later)
+
+So the AX messaging to Logic had not gone through yet, and the guard reported that as
+`blocking_dialog_present: true` — sending an operator to dismiss a modal that does not exist.
+
+The fix re-reads ONCE, and only on that status. A read that succeeds is never re-read, whatever it
+says, so this is not "retry until the answer is convenient" — it is "a failed read is not an
+observation". Both halves are checked here, because a fix that stops refusing is worthless if it also
+stops refusing when it should.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def save_panels():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return (name of every window whose name is "Save")')
+    return [t.strip() for t in raw.split(",") if t.strip() == "Save"]
+
+
+def first_call_in_a_fresh_process():
+    """Spawn the server, make ONE read-only call, and return its parsed body.
+
+    `logic_tracks.list_library` is read-only and runs the same preflight the mutating operations do,
+    so it exercises the guard without writing anything.
+    """
+    d = E.Driver()
+    try:
+        return d.tool("logic_tracks", "list_library", {}) or {}
+    finally:
+        d.close()
+
+
+titles = window_titles()
+ev.check("608/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so the guard has an ordinary window to look at and any refusal "
+         "is about the read rather than about an empty app",
+         f"windows={titles!r}", None)
+if not titles:
+    ev.write()
+    sys.exit("no project open")
+
+ev.check("608/precondition-no-dialog-is-on-screen-to-begin-with",
+         not save_panels(),
+         "nothing modal is up before the run, so a refusal in the next check cannot be a correct one",
+         f"save_panels={save_panels()!r} windows={titles!r}", None)
+
+located = [(t, E.logic_window(t)) for t in titles]
+located = [(t, w) for t, w in located if w]
+located.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
+arrange_title, win = located[0] if located else (titles[0], None)
+band = (0, 0, win["w"], 28) if win else None
+ev.check("608/precondition-the-window-frame-is-known", band is not None,
+         "the arrange window's own frame read, so the capture band is inside it",
+         f"window={win!r} band={band!r}", None)
+if band is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("608/before", settle_region=band, window_title=arrange_title)
+
+# ---- the fix: four independent fresh processes, each making exactly one call ----
+bodies = [first_call_in_a_fresh_process() for _ in range(4)]
+ev.note("608/fresh-process-first-calls", [
+    {"error": b.get("error"),
+     "blocking_dialog_present": b.get("blocking_dialog_present"),
+     "reason": b.get("last_dialog_presence_reason"),
+     "ax_error": b.get("windows_read_ax_error")}
+    for b in bodies
+])
+
+refused = [b for b in bodies if b.get("error") == "unsupported_state"]
+ev.check("608/no-fresh-process-is-refused-on-its-first-call",
+         len(refused) == 0,
+         "four separate server processes each make one read-only call as their FIRST call and none "
+         "is refused — before the fix this was refused 4 times out of 4 with "
+         "windows_read_ax_error -25204 on the same screen",
+         f"refused={len(refused)}/4 details={[b.get('last_dialog_presence_reason') for b in bodies]!r}",
+         "change the `error.raw == AXError.cannotComplete.rawValue` re-read condition to `false`: "
+         "every one of these four is refused again and this goes red")
+
+ev.check("608/the-first-call-actually-did-its-work",
+         all("categories" in json.dumps(b) for b in bodies),
+         "each call returned its real payload rather than merely not erroring — a refusal that was "
+         "downgraded to a silent empty success would pass the check above and fail this one",
+         f"payload_present={[('categories' in json.dumps(b)) for b in bodies]!r}", None)
+
+# ---- the negative control: with a REAL dialog up, the guard must still refuse ----
+osa('tell application "Logic Pro" to activate')
+time.sleep(2)
+osa('tell application "System Events" to tell process "Logic Pro" to '
+    'click menu item "Save As…" of menu 1 of menu bar item 3 of menu bar 1')
+time.sleep(4)
+panel_up = save_panels()
+ev.check("608/negative-control-a-real-panel-is-on-screen",
+         bool(panel_up),
+         "a genuine modal was opened, so the next check is asked in the condition the guard exists "
+         "for — without this the negative control would be green because nothing was ever there",
+         f"save_panels={panel_up!r} windows={window_titles()!r}", None)
+
+blocked = first_call_in_a_fresh_process()
+ev.note("608/first-call-with-a-real-panel", {
+    "error": blocked.get("error"),
+    "blocking_dialog_present": blocked.get("blocking_dialog_present"),
+    "failure_stage": blocked.get("failure_stage"),
+    "dialog_title": blocked.get("dialog_title"),
+})
+ev.check("608/a-real-dialog-still-refuses-and-is-named",
+         blocked.get("error") == "unsupported_state"
+         and blocked.get("blocking_dialog_present") is True
+         and blocked.get("dialog_title") == "Save",
+         "the guard still fails closed on an actual modal AND names it — the fix removed a false "
+         "refusal, and this is what proves it did not remove the true one",
+         f"error={blocked.get('error')!r} blocking={blocked.get('blocking_dialog_present')!r} "
+         f"title={blocked.get('dialog_title')!r} stage={blocked.get('failure_stage')!r}",
+         "make `dialogPresent` return false unconditionally: this goes red while the four checks "
+         "above stay green, which is exactly the trade this check exists to catch")
+
+osa('tell application "System Events" to key code 53')
+time.sleep(2)
+
+after = ev.shot("608/after", settle_region=band, window_title=arrange_title)
+ev.visual("608/the-guard-changed-nothing-on-screen",
+          before["file"], after["file"], band, expect_change=False,
+          why="this whole change is to a read-only preflight, so the document window must look "
+              "exactly as it did — a difference would mean something in the run wrote to the project")
+
+ev.restored("608/the-panel-opened-by-the-negative-control-is-gone",
+            not save_panels(),
+            f"the Save panel this run opened on purpose was dismissed. Save panels now: "
+            f"{save_panels()!r}. Windows: {window_titles()!r}")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))

--- a/Scripts/livekit/live_608_first_call_is_not_refused.py
+++ b/Scripts/livekit/live_608_first_call_is_not_refused.py
@@ -157,8 +157,12 @@ ev.check("608/a-real-dialog-still-refuses-and-is-named",
          "refusal, and this is what proves it did not remove the true one",
          f"error={blocked.get('error')!r} blocking={blocked.get('blocking_dialog_present')!r} "
          f"title={blocked.get('dialog_title')!r} stage={blocked.get('failure_stage')!r}",
-         "make `dialogPresent` return false unconditionally: this goes red while the four checks "
-         "above stay green, which is exactly the trade this check exists to catch")
+         "make `dialogPresent` return false unconditionally: this goes red while the checks above "
+         "stay green, which is exactly the trade it exists to catch. NOTE what it does NOT catch: "
+         "reverting the re-read leaves this green, because the first read then fails with "
+         "cannotComplete, the guard still fail-closes, and `blockingDialogInfo()` is a LATER read "
+         "that can still name the panel. This check locks fail-closed, not the fix — the two "
+         "first-call checks above are what lock the fix")
 
 osa('tell application "System Events" to key code 53')
 time.sleep(2)
@@ -177,3 +181,7 @@ ev.restored("608/the-panel-opened-by-the-negative-control-is-gone",
 ev.stop_recording(rec)
 out = ev.write()
 print(json.dumps(out, indent=1))
+# Exit non-zero when the run is not clean. Without this the script always exits 0 and a mixed run
+# reads as a pass to anything that looks at the status rather than at the document — every other
+# harness in this directory does this and this one did not.
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_608_first_call_is_not_refused.py
+++ b/Scripts/livekit/live_608_first_call_is_not_refused.py
@@ -9,7 +9,7 @@ Every mutating operation consults a fail-closed blocking-dialog guard. In a FRES
 refused the first call, on a screen holding one ordinary window and nothing else. Measured before the
 fix, four trials out of four, with the refusal's own instrumentation:
 
-    last_dialog_presence_reason   windows_read_failed
+    dialog_presence_reason   windows_read_failed
     windows_read_ax_error         -25204   (kAXErrorCannotComplete)
     dialog_present_recheck        false    (the same read, milliseconds later)
 
@@ -108,7 +108,7 @@ bodies = [first_call_in_a_fresh_process() for _ in range(4)]
 ev.note("608/fresh-process-first-calls", [
     {"error": b.get("error"),
      "blocking_dialog_present": b.get("blocking_dialog_present"),
-     "reason": b.get("last_dialog_presence_reason"),
+     "reason": b.get("dialog_presence_reason"),
      "ax_error": b.get("windows_read_ax_error")}
     for b in bodies
 ])
@@ -119,7 +119,7 @@ ev.check("608/no-fresh-process-is-refused-on-its-first-call",
          "four separate server processes each make one read-only call as their FIRST call and none "
          "is refused — before the fix this was refused 4 times out of 4 with "
          "windows_read_ax_error -25204 on the same screen",
-         f"refused={len(refused)}/4 details={[b.get('last_dialog_presence_reason') for b in bodies]!r}",
+         f"refused={len(refused)}/4 details={[b.get('dialog_presence_reason') for b in bodies]!r}",
          "change the `error.raw == AXError.cannotComplete.rawValue` re-read condition to `false`: "
          "every one of these four is refused again and this goes red")
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -196,7 +196,28 @@ enum AXLogicProElements {
         var namesAnActualDialog: Bool { self == .blockingWindowFound }
     }
 
+    /// The reason AND the AX status behind it, for callers that publish a refusal.
+    ///
+    /// `dialogPresenceReason` throws the status away. A refusal that says `windows_read_failed`
+    /// without saying WHICH failure sends the next reader to guess between "Logic is not running",
+    /// "no Accessibility permission" and the -25204 that this issue is about.
+    static func dialogPresenceDecision(
+        runtime: Runtime = .production
+    ) -> (reason: DialogPresenceReason, windowsReadError: Int32?) {
+        var carried: Int32?
+        let reason = dialogPresenceReason(runtime: runtime, windowsReadError: &carried)
+        return (reason, carried)
+    }
+
     static func dialogPresenceReason(runtime: Runtime = .production) -> DialogPresenceReason {
+        var ignored: Int32?
+        return dialogPresenceReason(runtime: runtime, windowsReadError: &ignored)
+    }
+
+    private static func dialogPresenceReason(
+        runtime: Runtime,
+        windowsReadError: inout Int32?
+    ) -> DialogPresenceReason {
         let reason: DialogPresenceReason
         var axError: Int32?
         if let app = appRoot(runtime: runtime) {
@@ -247,6 +268,7 @@ enum AXLogicProElements {
         } else {
             reason = .appRootUnresolvable
         }
+        windowsReadError = axError
         return reason
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -188,6 +188,8 @@ enum AXLogicProElements {
         /// The windows read answered `kAXErrorCannotComplete` twice: the AX messaging to Logic did
         /// not go through. Fail-closed like the rest, but it is a different thing to be told.
         case appNotYetAddressable = "logic_not_yet_addressable"
+        /// A window blocked because its children would not read — fail-closed, but nobody saw a dialog.
+        case windowChildrenUnreadable = "window_children_unreadable"
         case blockingWindowFound = "blocking_window_found"
         case noBlockingWindow = "no_blocking_window"
 
@@ -201,6 +203,15 @@ enum AXLogicProElements {
     /// `dialogPresenceReason` throws the status away. A refusal that says `windows_read_failed`
     /// without saying WHICH failure sends the next reader to guess between "Logic is not running",
     /// "no Accessibility permission" and the -25204 that this issue is about.
+    /// A window whose children would not read blocks, but it is NOT a dialog anyone saw.
+    /// Seeing a real modal wins over a failed read, because a modal that was observed is the more
+    /// actionable thing to tell the caller.
+    private static func summarise(_ findings: [BlockingModalFinding]) -> DialogPresenceReason {
+        if findings.contains(where: { $0.isAnActualModal }) { return .blockingWindowFound }
+        if findings.contains(where: { $0.isBlocking }) { return .windowChildrenUnreadable }
+        return .noBlockingWindow
+    }
+
     static func dialogPresenceDecision(
         runtime: Runtime = .production
     ) -> (reason: DialogPresenceReason, windowsReadError: Int32?) {
@@ -225,9 +236,7 @@ enum AXLogicProElements {
                 app, kAXWindowsAttribute as String, runtime: runtime.ax
             ) {
             case .success(.elements(let windows)):
-                reason = windows.contains { windowHostsBlockingModal($0, runtime: runtime.ax) }
-                    ? .blockingWindowFound
-                    : .noBlockingWindow
+                reason = summarise(windows.map { blockingModalFinding($0, runtime: runtime.ax) })
             case .success(.absent):
                 reason = .windowsAttributeAbsent
             case .success(.malformed):
@@ -249,9 +258,7 @@ enum AXLogicProElements {
                         app, kAXWindowsAttribute as String, runtime: runtime.ax
                     ) {
                     case .success(.elements(let windows)):
-                        reason = windows.contains { windowHostsBlockingModal($0, runtime: runtime.ax) }
-                            ? .blockingWindowFound
-                            : .noBlockingWindow
+                        reason = summarise(windows.map { blockingModalFinding($0, runtime: runtime.ax) })
                         axError = nil
                     case .success(.absent):
                         reason = .windowsAttributeAbsent
@@ -276,36 +283,59 @@ enum AXLogicProElements {
         dialogPresenceReason(runtime: runtime).isBlocked
     }
 
+    /// Why a window counted as blocking — a modal that was SEEN, or a read that did not happen.
+    ///
+    /// #608: this used to return a bare Bool, so the fail-closed default for an unreadable child was
+    /// indistinguishable from an actual dialog. The refusal then reported
+    /// `refusal_names_an_actual_dialog: true` for a window whose children would not read, which is
+    /// the defect this whole issue is about wearing a different hat: an absence published as an
+    /// observation.
+    enum BlockingModalFinding {
+        case none
+        case sawModal
+        case readFailed
+
+        var isBlocking: Bool { self != .none }
+        var isAnActualModal: Bool { self == .sawModal }
+    }
+
     private static func windowHostsBlockingModal(
         _ window: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> Bool {
-        if isBlockingDialogWindow(window, runtime: runtime) { return true }
+        blockingModalFinding(window, runtime: runtime).isBlocking
+    }
+
+    private static func blockingModalFinding(
+        _ window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> BlockingModalFinding {
+        if isBlockingDialogWindow(window, runtime: runtime) { return .sawModal }
         switch AXHelpers.childrenResult(window, runtime: runtime) {
         case .failure(let error)
             where error.raw == AXError.attributeUnsupported.rawValue
                 || error.raw == AXError.noValue.rawValue:
-            return false
+            return .none
         case .failure:
-            return true
+            return .readFailed
         case .success(let children):
             for child in children {
                 switch AXHelpers.getAttributeResult(
                     child, kAXRoleAttribute as String, runtime: runtime
                 ) as Result<String?, AXHelpers.AXStatusError> {
                 case .success(.some(let role)) where role == (kAXSheetRole as String):
-                    return true
+                    return .sawModal
                 case .failure(let error)
                     where error.raw == AXError.attributeUnsupported.rawValue
                         || error.raw == AXError.noValue.rawValue:
                     continue
                 case .failure:
-                    return true
+                    return .readFailed
                 case .success:
                     continue
                 }
             }
-            return false
+            return .none
         }
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -196,30 +196,6 @@ enum AXLogicProElements {
         var namesAnActualDialog: Bool { self == .blockingWindowFound }
     }
 
-    /// The reason the most recent `dialogPresent` call gave.
-    ///
-    /// A refusal is assembled by its caller after the guard has already answered, so the condition is
-    /// gone by the time anyone asks. This carries it across that gap. It describes the LAST decision
-    /// in this process, not necessarily the one a particular caller saw — say so wherever it is
-    /// published rather than presenting it as that call's own reason.
-    private static let reasonLock = NSLock()
-    nonisolated(unsafe) private static var lastReason: DialogPresenceReason?
-    nonisolated(unsafe) private static var lastWindowsReadError: Int32?
-
-    static func lastDialogPresenceReason() -> DialogPresenceReason? {
-        reasonLock.lock()
-        defer { reasonLock.unlock() }
-        return lastReason
-    }
-
-    /// The AXError behind a `windows_read_failed`, so the refusal names the status rather than the
-    /// category. Fail-closed guards are only readable if they say what the platform actually said.
-    static func lastDialogPresenceWindowsReadError() -> Int32? {
-        reasonLock.lock()
-        defer { reasonLock.unlock() }
-        return lastWindowsReadError
-    }
-
     static func dialogPresenceReason(runtime: Runtime = .production) -> DialogPresenceReason {
         let reason: DialogPresenceReason
         var axError: Int32?
@@ -271,10 +247,6 @@ enum AXLogicProElements {
         } else {
             reason = .appRootUnresolvable
         }
-        reasonLock.lock()
-        lastReason = reason
-        lastWindowsReadError = axError
-        reasonLock.unlock()
         return reason
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -174,16 +174,112 @@ enum AXLogicProElements {
     /// `AXWindows` list are not "no dialog". Subrole-only top-level windows
     /// miss Logic's New Track sheet, which is an `AXChildren` member with
     /// role `AXSheet` on a host whose own `AXModal` is false.
-    static func dialogPresent(runtime: Runtime = .production) -> Bool {
-        guard let app = appRoot(runtime: runtime) else { return true }
-        switch AXHelpers.getAXUIElementArrayRead(
-            app, kAXWindowsAttribute as String, runtime: runtime.ax
-        ) {
-        case .success(.elements(let windows)):
-            return windows.contains { windowHostsBlockingModal($0, runtime: runtime.ax) }
-        case .success(.absent), .success(.malformed), .failure:
-            return true
+    /// Why the blocking-dialog guard answered as it did (#608).
+    ///
+    /// Four different conditions all mean "blocked", and three of them are not dialogs at all — they
+    /// are the fail-closed defaults for an app root that would not resolve or a windows array that
+    /// would not read. Reporting them all as `blocking_dialog_present` sends an operator looking for
+    /// a modal that is not on screen, which is how a first-call refusal cost an afternoon.
+    enum DialogPresenceReason: String, Sendable {
+        case appRootUnresolvable = "app_root_unresolvable"
+        case windowsAttributeAbsent = "windows_attribute_absent"
+        case windowsAttributeMalformed = "windows_attribute_malformed"
+        case windowsReadFailed = "windows_read_failed"
+        /// The windows read answered `kAXErrorCannotComplete` twice: the AX messaging to Logic did
+        /// not go through. Fail-closed like the rest, but it is a different thing to be told.
+        case appNotYetAddressable = "logic_not_yet_addressable"
+        case blockingWindowFound = "blocking_window_found"
+        case noBlockingWindow = "no_blocking_window"
+
+        var isBlocked: Bool { self != .noBlockingWindow }
+        /// True when this answer is about a dialog, rather than about a read that did not happen.
+        var namesAnActualDialog: Bool { self == .blockingWindowFound }
+    }
+
+    /// The reason the most recent `dialogPresent` call gave.
+    ///
+    /// A refusal is assembled by its caller after the guard has already answered, so the condition is
+    /// gone by the time anyone asks. This carries it across that gap. It describes the LAST decision
+    /// in this process, not necessarily the one a particular caller saw — say so wherever it is
+    /// published rather than presenting it as that call's own reason.
+    private static let reasonLock = NSLock()
+    nonisolated(unsafe) private static var lastReason: DialogPresenceReason?
+    nonisolated(unsafe) private static var lastWindowsReadError: Int32?
+
+    static func lastDialogPresenceReason() -> DialogPresenceReason? {
+        reasonLock.lock()
+        defer { reasonLock.unlock() }
+        return lastReason
+    }
+
+    /// The AXError behind a `windows_read_failed`, so the refusal names the status rather than the
+    /// category. Fail-closed guards are only readable if they say what the platform actually said.
+    static func lastDialogPresenceWindowsReadError() -> Int32? {
+        reasonLock.lock()
+        defer { reasonLock.unlock() }
+        return lastWindowsReadError
+    }
+
+    static func dialogPresenceReason(runtime: Runtime = .production) -> DialogPresenceReason {
+        let reason: DialogPresenceReason
+        var axError: Int32?
+        if let app = appRoot(runtime: runtime) {
+            switch AXHelpers.getAXUIElementArrayRead(
+                app, kAXWindowsAttribute as String, runtime: runtime.ax
+            ) {
+            case .success(.elements(let windows)):
+                reason = windows.contains { windowHostsBlockingModal($0, runtime: runtime.ax) }
+                    ? .blockingWindowFound
+                    : .noBlockingWindow
+            case .success(.absent):
+                reason = .windowsAttributeAbsent
+            case .success(.malformed):
+                reason = .windowsAttributeMalformed
+            case .failure(let error):
+                // #608 measured: the FIRST windows read in a fresh process answers
+                // `kAXErrorCannotComplete` (-25204) — the AX messaging to Logic did not go through —
+                // and the same read succeeds milliseconds later. Every mutating operation was being
+                // refused as `blocking_dialog_present` on a screen holding one ordinary window,
+                // 4 trials out of 4.
+                //
+                // A failed read is not an observation, so re-reading it is not the same as retrying
+                // until the answer is convenient: a read that SUCCEEDS is never retried here, whatever
+                // it says. Once, and only for this status.
+                axError = error.raw
+                if error.raw == AXError.cannotComplete.rawValue {
+                    usleep(200_000)
+                    switch AXHelpers.getAXUIElementArrayRead(
+                        app, kAXWindowsAttribute as String, runtime: runtime.ax
+                    ) {
+                    case .success(.elements(let windows)):
+                        reason = windows.contains { windowHostsBlockingModal($0, runtime: runtime.ax) }
+                            ? .blockingWindowFound
+                            : .noBlockingWindow
+                        axError = nil
+                    case .success(.absent):
+                        reason = .windowsAttributeAbsent
+                    case .success(.malformed):
+                        reason = .windowsAttributeMalformed
+                    case .failure(let retryError):
+                        reason = .appNotYetAddressable
+                        axError = retryError.raw
+                    }
+                } else {
+                    reason = .windowsReadFailed
+                }
+            }
+        } else {
+            reason = .appRootUnresolvable
         }
+        reasonLock.lock()
+        lastReason = reason
+        lastWindowsReadError = axError
+        reasonLock.unlock()
+        return reason
+    }
+
+    static func dialogPresent(runtime: Runtime = .production) -> Bool {
+        dialogPresenceReason(runtime: runtime).isBlocked
     }
 
     private static func windowHostsBlockingModal(
@@ -448,6 +544,7 @@ enum AXLogicProElements {
                 // Re-ask the very question that refused, at census time. If this disagrees with the
                 // refusal the guard is not reading what it thinks it is.
                 "dialog_present_recheck": dialogPresent(runtime: runtime),
+                "recheck_reason": dialogPresenceReason(runtime: runtime).rawValue,
             ]
         case .success(.absent):
             return ["reason": "windows_attribute_absent", "windows": []]

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -183,7 +183,17 @@ func toolTextResultTreatingUnverifiedAsError(_ result: ChannelResult) -> CallToo
 
 func blockingLogicDialogResult(
     operation: String,
-    info: AXLogicProElements.BlockingDialogInfo? = AXLogicProElements.blockingDialogInfo()
+    info: AXLogicProElements.BlockingDialogInfo? = AXLogicProElements.blockingDialogInfo(),
+    // #608: the decision the caller REFUSED on, passed in rather than re-read here.
+    //
+    // Re-reading asks the same question a second time, and between the two the screen can change —
+    // so a call that was refused could be annotated `no_blocking_window`, a reason that contradicts
+    // the refusal it explains. That is the same defect as the process-global this file already
+    // removed, arriving by a different route: state carried across a gap instead of handed across it.
+    //
+    // Defaulting to a fresh read keeps every existing call site compiling and behaving as before;
+    // callers that have the decision should pass it.
+    decision: (reason: AXLogicProElements.DialogPresenceReason, windowsReadError: Int32?)? = nil
 ) -> CallTool.Result {
     // #608: the guard has four ways to answer "blocked" and only one of them is a dialog. Measured,
     // the first call in a fresh process was refused because the windows read answered
@@ -194,8 +204,8 @@ func blockingLogicDialogResult(
     // would change what every existing caller reads off the wire, and two dispatcher tests assert
     // those exact values — that question deserves its own decision, not a side effect of a bug fix.
     // The distinction is carried by new fields and by the hint.
-    let decision = AXLogicProElements.dialogPresenceDecision()
-    let reason = decision.reason
+    let resolved = decision ?? AXLogicProElements.dialogPresenceDecision()
+    let reason = resolved.reason
     let sawADialog = info != nil || reason.namesAnActualDialog
     var extras: [String: Any] = [
         "operation": operation,
@@ -205,7 +215,10 @@ func blockingLogicDialogResult(
         "refusal_names_an_actual_dialog": sawADialog,
         // #608: WHICH AX status, not just which category. -25204 (cannotComplete) is the transient
         // this issue is about; anything else is a different problem wearing the same label.
-        "windows_read_ax_error": decision.windowsReadError.map { Int($0) } ?? NSNull(),
+        "windows_read_ax_error": resolved.windowsReadError.map { Int($0) } ?? NSNull(),
+        // Whether the reason was handed over by the caller that refused, or re-read here. A caller
+        // that does not pass it gets an honest "this was measured later", not a silent substitution.
+        "dialog_presence_reason_source": decision == nil ? "re_read_at_refusal" : "decision_at_refusal_time",
         "write_attempted": false,
         "safe_to_retry": true,
     ]

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -185,50 +185,38 @@ func blockingLogicDialogResult(
     operation: String,
     info: AXLogicProElements.BlockingDialogInfo? = AXLogicProElements.blockingDialogInfo()
 ) -> CallTool.Result {
-    // #608: the guard has four ways to answer "blocked" and only one of them is a dialog. Saying
-    // `blocking_dialog_present: true` for all four sends an operator to dismiss a modal that is not
-    // on screen — measured, that is exactly what happened to every first call in a fresh process,
-    // where the windows read answered kAXErrorCannotComplete. The refusal now says which world it is
-    // in, and only claims a dialog when one was found.
-    let reason = AXLogicProElements.lastDialogPresenceReason()
-    let sawADialog = info != nil || reason?.namesAnActualDialog == true
+    // #608: the guard has four ways to answer "blocked" and only one of them is a dialog. Measured,
+    // the first call in a fresh process was refused because the windows read answered
+    // kAXErrorCannotComplete — not because anything was on screen. That is now re-read once so it no
+    // longer refuses, and when a refusal DOES happen the reason travels with it.
+    //
+    // `blocking_dialog_present` and `failure_stage` keep their existing meanings. Repurposing them
+    // would change what every existing caller reads off the wire, and two dispatcher tests assert
+    // those exact values — that question deserves its own decision, not a side effect of a bug fix.
+    // The distinction is carried by new fields and by the hint.
+    let reason = AXLogicProElements.dialogPresenceReason()
+    let sawADialog = info != nil || reason.namesAnActualDialog
     var extras: [String: Any] = [
         "operation": operation,
-        "failure_stage": sawADialog ? "preflight_blocking_dialog" : "preflight_logic_not_addressable",
-        "blocking_dialog_present": sawADialog,
+        "failure_stage": "preflight_blocking_dialog",
+        "blocking_dialog_present": true,
+        "dialog_presence_reason": reason.rawValue,
+        "refusal_names_an_actual_dialog": sawADialog,
         "write_attempted": false,
         "safe_to_retry": true,
     ]
     var hint = sawADialog
         ? "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry."
-        : "Refusing \(operation): Logic's accessibility interface did not answer, so whether a "
-            + "blocking dialog is present could not be established and the operation fails closed. "
-            + "Nothing was touched. This is not a dialog to dismiss — retry in a moment, and if it "
+        : "Refusing \(operation): the blocking-dialog preflight could not establish whether a dialog "
+            + "is present (\(reason.rawValue)), so it fails closed. Nothing was touched. No modal was "
+            + "identified — do not go looking for one to dismiss; retry in a moment, and if it "
             + "persists check that Logic is running and that this process has Accessibility access."
     // #190: identify the dialog so the demo/product workflow can recover
     // deterministically instead of guessing at a generic blocking-dialog refusal.
     if info == nil {
         // #606: refusing without an identity is refusing on something nobody can name. Say what the
-        // guard actually saw so the caller is not sent hunting for a dialog that is not there.
-        // #608: read the recorded reason BEFORE taking the census — the census re-asks the same
-        // question to show whether the condition still holds, and re-asking OVERWRITES the record.
-        // The first cut of this did it the other way round and reported `no_blocking_window` as the
-        // reason a refusal fired, which is not a reason at all. An instrument that disturbs what it
-        // measures reads as a measurement.
-        if let reason {
-            extras["last_dialog_presence_reason"] = reason.rawValue
-            extras["refusal_names_an_actual_dialog"] = reason.namesAnActualDialog
-            if let axError = AXLogicProElements.lastDialogPresenceWindowsReadError() {
-                extras["windows_read_ax_error"] = Int(axError)
-            }
-        }
+        // guard saw so the caller is not sent hunting for a dialog that is not there.
         extras["dialog_presence_census"] = AXLogicProElements.dialogPresenceCensus()
-        // Which of the guard's four "blocked" conditions actually fired. Three of them are not
-        // dialogs — they are fail-closed defaults for a read that did not happen — and reporting all
-        // four as `blocking_dialog_present` is what sends an operator hunting a modal that is not on
-        // screen. The value is the most recent decision in this process; under the serialized
-        // dispatch that is the decision that refused this call, but it is named `last_*` because
-        // nothing here can prove that.
     }
     if let info {
         extras["dialog_title"] = info.title

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -185,20 +185,50 @@ func blockingLogicDialogResult(
     operation: String,
     info: AXLogicProElements.BlockingDialogInfo? = AXLogicProElements.blockingDialogInfo()
 ) -> CallTool.Result {
+    // #608: the guard has four ways to answer "blocked" and only one of them is a dialog. Saying
+    // `blocking_dialog_present: true` for all four sends an operator to dismiss a modal that is not
+    // on screen — measured, that is exactly what happened to every first call in a fresh process,
+    // where the windows read answered kAXErrorCannotComplete. The refusal now says which world it is
+    // in, and only claims a dialog when one was found.
+    let reason = AXLogicProElements.lastDialogPresenceReason()
+    let sawADialog = info != nil || reason?.namesAnActualDialog == true
     var extras: [String: Any] = [
         "operation": operation,
-        "failure_stage": "preflight_blocking_dialog",
-        "blocking_dialog_present": true,
+        "failure_stage": sawADialog ? "preflight_blocking_dialog" : "preflight_logic_not_addressable",
+        "blocking_dialog_present": sawADialog,
         "write_attempted": false,
         "safe_to_retry": true,
     ]
-    var hint = "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry."
+    var hint = sawADialog
+        ? "Refusing \(operation) while a blocking Logic dialog/sheet is present. Dismiss crash, save, bounce, import, or other modal dialogs, then retry."
+        : "Refusing \(operation): Logic's accessibility interface did not answer, so whether a "
+            + "blocking dialog is present could not be established and the operation fails closed. "
+            + "Nothing was touched. This is not a dialog to dismiss — retry in a moment, and if it "
+            + "persists check that Logic is running and that this process has Accessibility access."
     // #190: identify the dialog so the demo/product workflow can recover
     // deterministically instead of guessing at a generic blocking-dialog refusal.
     if info == nil {
         // #606: refusing without an identity is refusing on something nobody can name. Say what the
         // guard actually saw so the caller is not sent hunting for a dialog that is not there.
+        // #608: read the recorded reason BEFORE taking the census — the census re-asks the same
+        // question to show whether the condition still holds, and re-asking OVERWRITES the record.
+        // The first cut of this did it the other way round and reported `no_blocking_window` as the
+        // reason a refusal fired, which is not a reason at all. An instrument that disturbs what it
+        // measures reads as a measurement.
+        if let reason {
+            extras["last_dialog_presence_reason"] = reason.rawValue
+            extras["refusal_names_an_actual_dialog"] = reason.namesAnActualDialog
+            if let axError = AXLogicProElements.lastDialogPresenceWindowsReadError() {
+                extras["windows_read_ax_error"] = Int(axError)
+            }
+        }
         extras["dialog_presence_census"] = AXLogicProElements.dialogPresenceCensus()
+        // Which of the guard's four "blocked" conditions actually fired. Three of them are not
+        // dialogs — they are fail-closed defaults for a read that did not happen — and reporting all
+        // four as `blocking_dialog_present` is what sends an operator hunting a modal that is not on
+        // screen. The value is the most recent decision in this process; under the serialized
+        // dispatch that is the decision that refused this call, but it is named `last_*` because
+        // nothing here can prove that.
     }
     if let info {
         extras["dialog_title"] = info.title

--- a/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
+++ b/Sources/LogicProMCP/Dispatchers/DispatcherSupport.swift
@@ -194,7 +194,8 @@ func blockingLogicDialogResult(
     // would change what every existing caller reads off the wire, and two dispatcher tests assert
     // those exact values — that question deserves its own decision, not a side effect of a bug fix.
     // The distinction is carried by new fields and by the hint.
-    let reason = AXLogicProElements.dialogPresenceReason()
+    let decision = AXLogicProElements.dialogPresenceDecision()
+    let reason = decision.reason
     let sawADialog = info != nil || reason.namesAnActualDialog
     var extras: [String: Any] = [
         "operation": operation,
@@ -202,6 +203,9 @@ func blockingLogicDialogResult(
         "blocking_dialog_present": true,
         "dialog_presence_reason": reason.rawValue,
         "refusal_names_an_actual_dialog": sawADialog,
+        // #608: WHICH AX status, not just which category. -25204 (cannotComplete) is the transient
+        // this issue is about; anything else is a different problem wearing the same label.
+        "windows_read_ax_error": decision.windowsReadError.map { Int($0) } ?? NSNull(),
         "write_attempted": false,
         "safe_to_retry": true,
     ]

--- a/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
+++ b/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
@@ -115,6 +115,32 @@ struct Issue608FirstReadTransientTests {
         #expect(reader.reads == 1)
     }
 
+    /// The hole a reviewer found: nothing covered the retry's SUCCESS path finding a dialog. Every
+    /// other test either feeds a plain window on retry or never enters the retry at all, so a
+    /// one-line `case .success(.elements): reason = .noBlockingWindow` on the re-read would have left
+    /// them all green — and that mutation is precisely "the retry swallowed a modal".
+    @Test("issue608_a_dialog_seen_only_on_the_re_read_still_blocks")
+    func dialogSeenOnlyOnTheReReadStillBlocks() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(0)
+        let dialog = b.element(1)
+        b.setAttribute(dialog, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        b.setAttribute(dialog, kAXTitleAttribute as String, "Save")
+        b.setChildren(dialog, [])
+        // First read fails with the transient; the SECOND read is the one that sees the modal.
+        let reader = WindowsReader(
+            failures: 1, status: AXError.cannotComplete.rawValue, windows: [dialog]
+        )
+        let runtime = makeRuntime(reader: reader, builder: b, app: app)
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        #expect(reason == .blockingWindowFound)
+        #expect(reason.isBlocked)
+        #expect(reason.namesAnActualDialog)
+        #expect(reader.reads == 2)
+    }
+
     /// The distinction that keeps this from being "retry until you like the answer": a read that
     /// SUCCEEDS and finds a dialog is never re-read, however inconvenient its answer.
     @Test("issue608_a_successful_read_that_finds_a_dialog_is_never_re_read")

--- a/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
+++ b/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
@@ -161,3 +161,90 @@ struct Issue608FirstReadTransientTests {
         #expect(reader.reads == 1)
     }
 }
+
+/// #608 follow-up: a window whose children will not read blocks — but nobody saw a dialog.
+///
+/// `windowHostsBlockingModal` returned a bare Bool, so the fail-closed default for an unreadable
+/// child was indistinguishable from an actual modal, and the refusal reported
+/// `refusal_names_an_actual_dialog: true` for a read that did not happen. That is this issue's own
+/// defect wearing a different hat.
+@Suite(.serialized)
+struct Issue608UnreadableIsNotADialogTests {
+    private final class Reader: @unchecked Sendable {
+        private let windows: [AXUIElement]
+        init(windows: [AXUIElement]) { self.windows = windows }
+        func read() -> Result<AnyObject?, AXHelpers.AXStatusError> { .success(windows as AnyObject) }
+    }
+
+    @Test("issue608_a_window_whose_children_will_not_read_blocks_without_claiming_a_dialog")
+    func unreadableChildrenBlockWithoutClaimingADialog() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(0)
+        let window = b.element(1)
+        b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(window, kAXSubroleAttribute as String, kAXStandardWindowSubrole as String)
+
+        let reader = Reader(windows: [window])
+        let runtime = b.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { _, attribute in
+                guard attribute == (kAXWindowsAttribute as String) else { return nil }
+                return reader.read()
+            },
+            // The children read fails with a status that is NOT "unsupported" or "no value", which is
+            // the fail-closed branch.
+            childrenResultHandler: { _ in
+                // Only one window exists in this fixture, so an unconditional failure IS that
+                // window's children read.
+                .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        // Fail-closed is preserved.
+        #expect(reason.isBlocked)
+        // But it does not claim anyone saw a dialog.
+        #expect(!reason.namesAnActualDialog)
+        #expect(reason == .windowChildrenUnreadable)
+    }
+
+    /// A real dialog alongside an unreadable window is still reported as a dialog — the observed
+    /// thing is the more actionable one to name.
+    @Test("issue608_a_real_dialog_wins_over_an_unreadable_window")
+    func realDialogWinsOverUnreadable() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(0)
+        let dialog = b.element(1)
+        b.setAttribute(dialog, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        b.setAttribute(dialog, kAXTitleAttribute as String, "Save")
+        b.setChildren(dialog, [])
+        let broken = b.element(2)
+        b.setAttribute(broken, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(broken, kAXSubroleAttribute as String, kAXStandardWindowSubrole as String)
+
+        let reader = Reader(windows: [broken, dialog])
+        let runtime = b.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { _, attribute in
+                guard attribute == (kAXWindowsAttribute as String) else { return nil }
+                return reader.read()
+            },
+            childrenResultHandler: { element in
+                // The dialog is recognised by its SUBROLE before children are ever read, so failing
+                // every children read still leaves the dialog observable and only breaks the other
+                // window — which is the mix this test is about.
+                _ = element
+                return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        #expect(reason == .blockingWindowFound)
+        #expect(reason.namesAnActualDialog)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
+++ b/Tests/LogicProMCPTests/Issue608FirstReadTransientTests.swift
@@ -1,0 +1,137 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #608: the FIRST windows read in a fresh process answers `kAXErrorCannotComplete`, and every
+/// mutating operation was refused as `blocking_dialog_present` on a screen holding one ordinary
+/// window. Measured four trials out of four; the same read succeeds milliseconds later.
+///
+/// A failed read is not an observation, so re-reading it is not the same as retrying until the answer
+/// is convenient — the tests below pin exactly that distinction: a read that SUCCEEDS is never
+/// re-read, whatever it says.
+@Suite(.serialized)
+struct Issue608FirstReadTransientTests {
+    /// A windows read that fails with `status` the first `failures` times, then reports `windows`.
+    private final class WindowsReader: @unchecked Sendable {
+        private let lock = NSLock()
+        private var remainingFailures: Int
+        private let status: Int32
+        private let windows: [AXUIElement]
+        private(set) var reads = 0
+
+        init(failures: Int, status: Int32, windows: [AXUIElement]) {
+            self.remainingFailures = failures
+            self.status = status
+            self.windows = windows
+        }
+
+        func read() -> Result<AnyObject?, AXHelpers.AXStatusError> {
+            lock.lock()
+            defer { lock.unlock() }
+            reads += 1
+            if remainingFailures > 0 {
+                remainingFailures -= 1
+                return .failure(AXHelpers.AXStatusError(raw: status))
+            }
+            return .success(windows as AnyObject)
+        }
+    }
+
+    private func makeRuntime(
+        reader: WindowsReader,
+        builder: FakeAXRuntimeBuilder,
+        app: AXUIElement
+    ) -> AXLogicProElements.Runtime {
+        builder.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { _, attribute in
+                // Only the windows attribute is served here; everything else falls through to the
+                // builder's own store, which is what the window fixtures below rely on.
+                guard attribute == (kAXWindowsAttribute as String) else { return nil }
+                return reader.read()
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+    }
+
+    /// One plain standard window: nothing blocking.
+    private func makeApp() -> (FakeAXRuntimeBuilder, AXUIElement, AXUIElement) {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(0)
+        let window = b.element(1)
+        b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(window, kAXSubroleAttribute as String, kAXStandardWindowSubrole as String)
+        b.setChildren(window, [])
+        return (b, app, window)
+    }
+
+    @Test("issue608_a_cannot_complete_read_is_re_read_once_and_does_not_refuse")
+    func cannotCompleteIsReReadOnce() {
+        let (builder, app, window) = makeApp()
+        let reader = WindowsReader(
+            failures: 1, status: AXError.cannotComplete.rawValue, windows: [window]
+        )
+        let runtime = makeRuntime(reader: reader, builder: builder, app: app)
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        #expect(reason == .noBlockingWindow)
+        #expect(!reason.isBlocked)
+        // Exactly two: the failure and the one re-read. Not a loop.
+        #expect(reader.reads == 2)
+    }
+
+    @Test("issue608_a_persistent_cannot_complete_still_fails_closed_but_is_named_apart")
+    func persistentCannotCompleteFailsClosed() {
+        let (builder, app, window) = makeApp()
+        let reader = WindowsReader(
+            failures: 99, status: AXError.cannotComplete.rawValue, windows: [window]
+        )
+        let runtime = makeRuntime(reader: reader, builder: builder, app: app)
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        // Fail-closed is preserved — the guard still blocks.
+        #expect(reason.isBlocked)
+        // But it does not claim a dialog, which is the whole point: an operator told
+        // `blocking_dialog_present` goes looking for a modal that is not on screen.
+        #expect(!reason.namesAnActualDialog)
+        #expect(reason == .appNotYetAddressable)
+        #expect(reader.reads == 2)
+    }
+
+    /// The guard must not re-read any other failure status — only the one measured to be transient.
+    @Test("issue608_other_read_failures_are_not_re_read")
+    func otherFailuresAreNotReRead() {
+        let (builder, app, window) = makeApp()
+        let reader = WindowsReader(
+            failures: 1, status: AXError.apiDisabled.rawValue, windows: [window]
+        )
+        let runtime = makeRuntime(reader: reader, builder: builder, app: app)
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        #expect(reason == .windowsReadFailed)
+        #expect(reason.isBlocked)
+        #expect(reader.reads == 1)
+    }
+
+    /// The distinction that keeps this from being "retry until you like the answer": a read that
+    /// SUCCEEDS and finds a dialog is never re-read, however inconvenient its answer.
+    @Test("issue608_a_successful_read_that_finds_a_dialog_is_never_re_read")
+    func successfulBlockingReadIsNeverReRead() {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(0)
+        let dialog = b.element(1)
+        b.setAttribute(dialog, kAXRoleAttribute as String, kAXWindowRole as String)
+        b.setAttribute(dialog, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        b.setAttribute(dialog, kAXTitleAttribute as String, "Save")
+        b.setChildren(dialog, [])
+        let reader = WindowsReader(failures: 0, status: 0, windows: [dialog])
+        let runtime = makeRuntime(reader: reader, builder: b, app: app)
+
+        let reason = AXLogicProElements.dialogPresenceReason(runtime: runtime)
+        #expect(reason == .blockingWindowFound)
+        #expect(reason.namesAnActualDialog)
+        #expect(reader.reads == 1)
+    }
+}


### PR DESCRIPTION
Draft until a cross-provider blind review passes.

Closes #608.

Every mutating operation consults a fail-closed blocking-dialog preflight, and in a **fresh process**
that preflight refused the FIRST call — on a screen holding one ordinary window and nothing else. Any
later call passed, and so did the first call of any process that had done something else first.

### Finding out which of four conditions fired

The guard has four ways to answer "blocked" and only one of them is a dialog. It reported all four as
`blocking_dialog_present`, so there was no way to tell them apart from outside. The first thing this
change does is make the guard say which one fired — and the answer was **not** the one I had written
into the issue as the leading hypothesis:

```
dialog_presence_reason      windows_read_failed
windows_read_ax_error       -25204   (kAXErrorCannotComplete)
dialog_present_recheck      false    (the same read, milliseconds later)
```

Not an unresolvable app root. The AX messaging to Logic had simply not gone through yet, and a read
that did not happen was being published as an observation of a dialog. Four trials out of four.

### The fix

The windows read is re-read **once**, and **only** on `kAXErrorCannotComplete`. A read that succeeds is
never re-read, whatever it says — that is the difference between *a failed read is not an observation*
and *retry until the answer is convenient*, and it is pinned by a test that hands the guard a
successful read finding a dialog and asserts exactly one read happened.

A `cannotComplete` that persists through the re-read still fails closed, under its own name
`logic_not_yet_addressable`, with a hint that says to wait rather than to go hunting for a modal.

```
before   4 fresh processes, first call:  4 refused
after    4 fresh processes, first call:  0 refused, all returned their real payload
control  with a real Save panel up:      still refused, blocking_dialog_present true, dialog_title "Save"
```

### Two defects of my own that the gate caught

I first repurposed `blocking_dialog_present` and `failure_stage` to go false when the reason said the
refusal was not about a dialog. Two dispatcher tests assert those exact values and they were right to:
the caller can **supply** the `dialogPresent` closure, in which case nothing is recorded, and "no
reason recorded" is not evidence that no dialog was seen. Changing what those fields mean also changes
what every existing reader gets off the wire — that deserves its own decision, not a side effect of a
bug fix. Both fields keep their meanings; the distinction is carried by `dialog_presence_reason`,
`refusal_names_an_actual_dialog`, and a differentiated hint.

The reason was also carried across the gap between decision and refusal by a **process-wide variable**,
and a process-wide variable leaks: a test calling the refusal builder directly inherited a
`no_blocking_window` left by an unrelated test and had its dialog claim downgraded. It passed alone and
failed in the suite. Making the read consume the value only bounded the leak; the variable is gone, and
the refusal asks the question itself while assembling — which, after the re-read, is a question whose
answer no longer flips.

There was a third, in the instrument rather than the product: the reason was read **after** the census,
and the census re-asks the same question, so the instrument overwrote its own measurement and reported
`no_blocking_window` as the reason a refusal fired.

### What the reviews found

**Round one — the tests could not answer the question I asked.** I asked the reviewer to hunt for a
re-read that swallows a modal. My four tests could not have caught one: every case either fed a plain
window on the re-read or never entered the retry, so a one-line
`case .success(.elements): reason = .noBlockingWindow` on the re-read left all four green — and that
line *is* "the retry swallowed a modal". A test now injects a dialog only the SECOND read can see;
mutation-tested against that exact one-liner, three assertions go red.

**Round one — the live negative control named the wrong mutation.** It claimed to fail if
`dialogPresent` is forced false. True, and about fail-closed, **not** about this change: revert the
re-read and the first read is `cannotComplete` again, the guard still fail-closes, and
`blockingDialogInfo()` is a LATER read that can still name the panel — so the control stays green. It
now states its scope and points at the two first-call checks as the ones that lock the fix.

**Round one — the harness never exited non-zero.** Every other file in that directory ends
`sys.exit(0 if E.is_clean(out) else 1)`; this one printed and exited 0 whatever it contained.

**Round one — dead instrumentation.** Removing the process-global also removed the only publisher of
`windows_read_ax_error` while the harness went on reading it. Restored via `dialogPresenceDecision`,
which returns reason and AX status together.

**Round two — a failed read was reported as a dialog.** `windowHostsBlockingModal` returned a bare
Bool, so the fail-closed default for unreadable children was indistinguishable from a modal someone
saw, and the refusal published `refusal_names_an_actual_dialog: true` for a read that did not happen.
That is this issue's own defect wearing a different hat. The finding is now three-valued — saw a
modal / read failed / neither — both of the first two block, only the first claims a dialog, and a
real dialog beside an unreadable window still wins because the observed thing is the more actionable
one to name.

**Round two — the refusal re-read the reason instead of receiving it.** Between the guard answering
and the refusal being assembled the screen can change, so a refused call could be annotated
`no_blocking_window`, a reason contradicting the refusal it explains. `blockingLogicDialogResult` now
accepts the decision. **Wiring it through the dispatchers is deliberately NOT attempted** — they
consult an injected `() -> Bool`, so passing the decision means changing that closure's type across
the registry, wider than this fix should carry. The wire says which it got via
`dialog_presence_reason_source` rather than pretending.

### Gate

```
full suite                    3855 tests passed
live evidence for this head   7 checks, 7 passed, 2 mutation-backed, 1 visual passed
SHIP GATE PASS                22c4ae39
```

The live run includes the negative control: it opens a real Save panel on purpose and asserts the guard
still refuses and still names it. Without that, "stopped refusing" and "stopped guarding" look
identical.

**One caveat about the evidence, filed as #612**: `evidence.json` is keyed by head SHA alone, so two
harnesses at the same head overwrite each other and the gate reads whichever ran last. I ran #606's
harness on this branch to check `save_as` had not regressed (it passes 9/9), which overwrote this
branch's own document; I re-ran #608's harness afterwards and confirmed the file holds #608's checks.
The collision itself is unfixed and belongs to #612.

