### PR TITLE
fix(#612): evidence documents were keyed by head alone, so two harnesses overwrote each other

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -72,16 +72,34 @@ _SETTLE_GAP = 0.35
 # Window geometry
 # ---------------------------------------------------------------------------
 
+_NAME_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _safe_name(raw):
+    """A document name that can only ever be a single file inside the head directory.
+
+    `name` used to live only inside the JSON. It is now a PATH COMPONENT, so an unconstrained value
+    escapes: `Evidence(..., name="../escaped")` wrote `escaped.evidence.json` in the evidence ROOT,
+    outside the head directory, where the gate would never look for it and nothing would notice.
+    """
+    stem = os.path.basename(str(raw)).strip() or "livekit"
+    stem = _NAME_SAFE.sub("_", stem).lstrip(".") or "livekit"
+    return stem[:80]
+
+
 def _running_harness_name():
     """The stem of the script that is running, e.g. `live_608_first_call_is_not_refused`.
 
-    Falls back to the worktree name only when the entry point cannot be determined, which is the old
-    behaviour and is ambiguous by construction.
+    When the entry point cannot be determined — `python3 -c`, a REPL, a wrapper that execs without
+    setting `__file__` — this used to fall back to the WORKTREE basename, which is exactly the
+    ambiguity #612 is about: two harnesses under one worktree share it and overwrite each other
+    again. The fallback now carries the pid, so two such runs cannot collide, and it says in the name
+    that it could not identify itself.
     """
     path = getattr(sys.modules.get("__main__"), "__file__", None)
     if path:
-        return os.path.splitext(os.path.basename(path))[0]
-    return os.path.basename(REPO or "livekit")
+        return _safe_name(os.path.splitext(os.path.basename(path))[0])
+    return _safe_name(f"unidentified-harness-pid{os.getpid()}")
 
 
 def logic_window(title_contains="Tracks"):
@@ -263,7 +281,7 @@ class Evidence:
         # head both called themselves `lpm-wt-608` and there was no field saying which script wrote
         # it. Name it after the running script instead, and key the file by that name too — see
         # `write()`.
-        self.name = name or _running_harness_name()
+        self.name = _safe_name(name) if name else _running_harness_name()
         self.records = []
         self._window_points = None
 
@@ -311,7 +329,11 @@ class Evidence:
         region alone: Logic repaints level meters and clocks continuously, so a whole-window settle
         never converges and would silently record `settled: false` on a perfectly good run.
         """
-        path = os.path.join(self.dir, f"{tag.replace('/', '_')}.png")
+        # Keyed by harness as well as tag (#612 follow-up). Tags collide across harnesses —
+        # `575/before` is used by three different files, `before-create` by two — so a document
+        # rotated aside for later comparison used to name PNGs a later run had already replaced.
+        # Archiving a document whose pixels are gone is the opposite of keeping a flake visible.
+        path = os.path.join(self.dir, f"{self.name}__{tag.replace('/', '_')}.png")
         win = logic_window(window_title)
         if not win:
             self.records.append({"kind": "capture", "tag": tag, "file": path,
@@ -377,7 +399,7 @@ class Evidence:
         The file name never begins with a dot: `screencapture` rejects dotfiles while still exiting 0,
         which produces a silent absence rather than an error.
         """
-        path = os.path.join(self.dir, "run.mov")
+        path = os.path.join(self.dir, f"{self.name}__run.mov")
         proc = subprocess.Popen(
             ["/usr/sbin/screencapture", "-v", "-V", str(seconds), path],
             stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -439,17 +461,21 @@ class Evidence:
         # A re-run against the SAME binary is a re-measurement of the same thing. Replacing the
         # earlier document silently would hide a flake — two runs disagreeing is exactly what you
         # want to see — so the previous one is kept beside it rather than dropped.
+        # Rotate ANY existing document, not only one from the same binary.
+        #
+        # The first cut rotated only when the artifact sha256 matched, on the theory that a different
+        # binary is a new measurement and may replace cleanly. That erases the case the rotation
+        # exists for: the normal loop is edit → rebuild → re-run, so the second run almost always has
+        # a DIFFERENT hash, and the flake it was meant to preserve was the thing overwritten.
+        # Unreadable or pre-schema JSON took the same overwrite path for the same reason.
+        #
+        # Keeping every document costs a few kilobytes and is the only way "two runs disagreeing" is
+        # something anyone can see afterwards.
         if os.path.exists(out):
-            try:
-                with open(out) as fh:
-                    previous = json.load(fh)
-            except (OSError, ValueError):
-                previous = None
-            if previous and previous.get("artifact", {}).get("sha256") == doc["artifact"]["sha256"]:
-                n = 1
-                while os.path.exists(os.path.join(self.dir, f"{self.name}.evidence.{n}.json")):
-                    n += 1
-                os.replace(out, os.path.join(self.dir, f"{self.name}.evidence.{n}.json"))
+            n = 1
+            while os.path.exists(os.path.join(self.dir, f"{self.name}.evidence.{n}.json")):
+                n += 1
+            os.replace(out, os.path.join(self.dir, f"{self.name}.evidence.{n}.json"))
         with open(out, "w") as fh:
             json.dump(doc, fh, indent=1)
         # The old single-file name is still written, because the gate reads it. It is the LAST run at

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -57,6 +57,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import time
 
 # Set by the harness before use.
@@ -70,6 +71,18 @@ _SETTLE_GAP = 0.35
 # ---------------------------------------------------------------------------
 # Window geometry
 # ---------------------------------------------------------------------------
+
+def _running_harness_name():
+    """The stem of the script that is running, e.g. `live_608_first_call_is_not_refused`.
+
+    Falls back to the worktree name only when the entry point cannot be determined, which is the old
+    behaviour and is ambiguous by construction.
+    """
+    path = getattr(sys.modules.get("__main__"), "__file__", None)
+    if path:
+        return os.path.splitext(os.path.basename(path))[0]
+    return os.path.basename(REPO or "livekit")
+
 
 def logic_window(title_contains="Tracks"):
     """The on-screen bounds of a Logic window, via CoreGraphics rather than AX.
@@ -246,7 +259,11 @@ class Evidence:
         self.head = head
         self.dir = os.path.join(root, head)
         os.makedirs(self.dir, exist_ok=True)
-        self.name = name or os.path.basename(REPO or "livekit")
+        # #612: the document used to be named after the WORKTREE, so two harnesses run at the same
+        # head both called themselves `lpm-wt-608` and there was no field saying which script wrote
+        # it. Name it after the running script instead, and key the file by that name too — see
+        # `write()`.
+        self.name = name or _running_harness_name()
         self.records = []
         self._window_points = None
 
@@ -412,8 +429,34 @@ class Evidence:
             },
             "records": self.records,
         }
-        out = os.path.join(self.dir, "evidence.json")
+        # #612: one file per HARNESS per head, not one per head. `evidence.json` was keyed by the
+        # head SHA alone, so the last harness to run at a given head silently replaced every earlier
+        # one's document — measured: running #606's harness on the #608 branch to check for a
+        # regression overwrote #608's own evidence, and the gate then validated #608 against #606's
+        # proof and reported ok. A check whose subject can be swapped without the check noticing is
+        # not a check.
+        out = os.path.join(self.dir, f"{self.name}.evidence.json")
+        # A re-run against the SAME binary is a re-measurement of the same thing. Replacing the
+        # earlier document silently would hide a flake — two runs disagreeing is exactly what you
+        # want to see — so the previous one is kept beside it rather than dropped.
+        if os.path.exists(out):
+            try:
+                with open(out) as fh:
+                    previous = json.load(fh)
+            except (OSError, ValueError):
+                previous = None
+            if previous and previous.get("artifact", {}).get("sha256") == doc["artifact"]["sha256"]:
+                n = 1
+                while os.path.exists(os.path.join(self.dir, f"{self.name}.evidence.{n}.json")):
+                    n += 1
+                os.replace(out, os.path.join(self.dir, f"{self.name}.evidence.{n}.json"))
         with open(out, "w") as fh:
+            json.dump(doc, fh, indent=1)
+        # The old single-file name is still written, because the gate reads it. It is the LAST run at
+        # this head whatever produced it, which is the very ambiguity #612 is about — the per-harness
+        # file above is the one to trust, and the gate should move to requiring one per harness.
+        legacy = os.path.join(self.dir, "evidence.json")
+        with open(legacy, "w") as fh:
             json.dump(doc, fh, indent=1)
         return self._summary(out)
 


### PR DESCRIPTION
**Blind-reviewed twice, independently.** Both rounds returned BLOCK on the same point — #612 is
not resolved by this PR — and one round added four more findings, each reproduced rather than argued. All are fixed
below.

**#612 is deliberately left open by this PR.** A review caught that an earlier draft of this body
carried a closing keyword for it while the body itself explains that the gate change is not attempted here — `lpm-live-gate.sh` still opens the single `evidence.json`, so the last-writer-wins document the issue is about is still the one the gate reads. #612 is closable only once the gate requires a document per harness. This PR makes that possible and stops there.

(Every issue number in this body is kept away from a closing keyword on purpose. GitHub's parser does
not read negation — `does not close #NNN` is parsed as `close #NNN` — so a sentence saying an issue is
deliberately left open would have closed it on merge. Caught in review before that happened, and the
placeholder above is deliberate too: a real number beside the keyword would demonstrate the bug by
committing it.)

`Evidence.write()` wrote `<root>/<head>/evidence.json` with mode `"w"`. The path depends only on the
head SHA, so every harness run at a given head wrote the same file and the last one won. The captures
survived, because their names carry the check tag; the document did not. `doc["name"]` was the
**worktree** directory, not the harness, so two runs both labelled themselves the same thing and
nothing recorded which script had produced the file.

This is not hypothetical. Running #606's harness on the #608 branch — to check that a guard change had
not regressed `save_as` — overwrote #608's own evidence, after which the ship gate validated #608
against #606's document and reported `ok`. Both were clean, so nothing looked wrong.

### Proof, with two real harnesses at one head

```
live_606_save_as_writes_the_file.evidence.json     9 checks, 9 passed
live_604_refusal_says_what_it_saw.evidence.json    9 checks, 7 passed
```

Both documents survive. Before this change the second run erased the first. Re-running the same
harness against the same artifact sha256 moves the previous document to `.1.json` rather than
replacing it, because two runs disagreeing is exactly what you want to be able to see; a run against a
different binary is a new measurement and replaces cleanly.

### What is deliberately NOT changed

The single `evidence.json` is still written, because that is what `lpm-ship.sh` reads. It remains the
last run at this head whatever produced it — which is the ambiguity this issue is about. **Requiring
one document per harness the branch touches is a gate-side change and is not attempted here**, because
changing the gate contract inside a fix for the library it reads would make the fix unreviewable
against its own subject.

Until the gate moves, `SHIP GATE PASS`'s "live evidence for this head ok" should be read as *something
passed at this head*, not as *this change was verified*.

### What the reviews found, and what changed

**Rotation was gated on the artifact sha256 matching**, so only a re-run against the SAME binary moved
the previous document aside. The normal loop is edit → rebuild → re-run, which changes the hash — so
the second run overwrote exactly the document the rotation exists to preserve. Unreadable or
pre-schema JSON took the same path. Every existing document now rotates: three runs across two
binaries leave `.json`, `.1.json`, `.2.json`, nothing lost.

**The JSON became per-harness while the files it NAMES stayed keyed by head alone**, and tags collide
across harnesses — `575/before` belongs to three different files, `before-create` to two. A document
rotated aside for comparison pointed at PNGs a later run had already replaced; the reviewer reproduced
it by hash (document `aeaf6c6b…`, disk `c687acd6…`). Captures and the recording are now keyed by
harness too. The separation had been done by half.

**`_running_harness_name` fell back to the worktree basename** when `__main__.__file__` is missing —
`python3 -c`, a REPL, any wrapper that execs without setting it. That is the original ambiguity
restored on a side path. The fallback now carries the pid and says in the name that it could not
identify itself.

### Also filed separately

**#619** — `name` became a path component while still accepting anything, so
`Evidence(name: "../escaped")` wrote outside the head directory. The constraint is in this branch; the
issue exists because the danger is not today's value (a script stem, safe) but that a field which was
documentation is now filesystem authority, and nothing in the type says so. A future editor who wires
the name to a CLI argument or a branch name needs that reasoning, and it must not live only in this
diff.

### Discovered while proving it, filed separately

`live_604_refusal_says_what_it_saw.py` **can no longer reach its subject** — #606 made `save_as`
succeed, so the refusal it asserts does not happen and it now fails 2 of 9 for that reason. Filed as
#614, with a measured reachable refusal to repoint it at (a path under a directory that does not
exist), which as a bonus exercises the dismissal code the current harness could only ever see skipped.

### Gate

```
full suite      3848 tests passed
live evidence   n/a — no Sources/ change in this branch
SHIP GATE PASS  e0369f76
```





