### PR TITLE
fix(#519): the last two menu drives that carried their spellings as literals

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
+  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
       }
     },
     {
@@ -56,57 +20,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
       }
     },
     {
@@ -128,75 +47,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -255,6 +255,16 @@ enum AXLocalePolicy {
     /// `AccessibilityChannel+Project.swift`, where it shipped as one half of a Korean-then-English
     /// pair. I did not re-measure it on a Korean Logic, so its provenance is "already trusted in
     /// shipped code", not "measured by me" — recorded here so nobody reads it as a fresh observation.
+    ///
+    /// **There is NO Japanese variant, and `save_as` therefore does not resolve on a Japanese Logic.**
+    /// The File menu BAR has a measured `ファイル`, and an early draft of this change let that fact
+    /// stand in for the item — "Japanese works without a third literal" — which it does not: the bar
+    /// resolving is worthless if the item does not. The item's Japanese label has never been read off
+    /// a live Japanese Logic, and this repository does not translate labels into a LabelSet. So the
+    /// gap is recorded rather than papered over, and `Issue519SaveAsMenuLocaleTests` asserts the
+    /// absence so it cannot quietly become an assumption.
+    ///
+    /// This is not a regression: the two hard-coded literals it replaces had exactly the same gap.
     static let saveAsMenuItem = LabelSet(
         canonical: "Save As…",
         variants: ["다른 이름으로 저장…"],

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -231,6 +231,23 @@ enum AXLocalePolicy {
         rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
     )
 
+    /// #519: File > Save As…
+    ///
+    /// The English label was MEASURED on 2026-08-19 by enumerating the File menu on a live Logic
+    /// 12.3 — the trailing character is a real ellipsis, not three dots, and matching on "Save As"
+    /// alone would also hit "Save A Copy As…" and "Save as Template…", both of which sit two rows
+    /// away in the same menu.
+    ///
+    /// The Korean variant is carried over from the literal it replaces in
+    /// `AccessibilityChannel+Project.swift`, where it shipped as one half of a Korean-then-English
+    /// pair. I did not re-measure it on a Korean Logic, so its provenance is "already trusted in
+    /// shipped code", not "measured by me" — recorded here so nobody reads it as a fresh observation.
+    static let saveAsMenuItem = LabelSet(
+        canonical: "Save As…",
+        variants: ["다른 이름으로 저장…"],
+        rationale: "File menu entry that opens the Save panel; the panel is the only path to save_as."
+    )
+
     /// #519: File > Bounce.
     static let bounceMenuItem = LabelSet(
         canonical: "Bounce",

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -231,6 +231,19 @@ enum AXLocalePolicy {
         rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
     )
 
+    /// #519: the Track menu bar item.
+    ///
+    /// All three labels were already in the tree, as three hard-coded strings inside
+    /// `clickTrackMenu` — `"트랙"`, `"Track"` and `"トラック"`, the last carrying its own comment that it
+    /// was measured on Logic 12.3 with `AppleLanguages=ja` and is a third spelling rather than a
+    /// variant. Moving them here does not add a measurement; it puts them where the next measured
+    /// language can join them instead of becoming a fourth element in a literal array.
+    static let trackMenuBar = LabelSet(
+        canonical: "Track",
+        variants: ["트랙", "トラック"],
+        rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
+    )
+
     /// #519: File > Save As…
     ///
     /// The English label was MEASURED on 2026-08-19 by enumerating the File menu on a live Logic

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Menu.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Menu.swift
@@ -31,6 +31,38 @@ extension AXLogicProElements {
     }
 
     /// Navigate menu: e.g. menuItem(path: ["File", "New..."]).
+    /// Locale-resolved menu lookup (#519): each step matches ANY measured label for that item.
+    ///
+    /// The literal-string overload below is fine when the caller already knows the exact title, and
+    /// wrong the moment Logic is running in another language. `save_as` used to work around that by
+    /// trying a Korean literal and then an English one, which covers exactly two of the languages
+    /// Logic ships and fails silently in the rest — the shape #519 is about.
+    static func menuItem(
+        labelPath: [AXLocalePolicy.LabelSet],
+        runtime: Runtime = .production
+    ) -> AXUIElement? {
+        guard var current = getMenuBar(runtime: runtime) else { return nil }
+        for labels in labelPath {
+            var found = false
+            for child in AXHelpers.getChildren(current, runtime: runtime.ax) {
+                if labels.matches(AXHelpers.getTitle(child, runtime: runtime.ax)) {
+                    current = child
+                    found = true
+                    break
+                }
+                for sub in AXHelpers.getChildren(child, runtime: runtime.ax)
+                where labels.matches(AXHelpers.getTitle(sub, runtime: runtime.ax)) {
+                    current = sub
+                    found = true
+                    break
+                }
+                if found { break }
+            }
+            guard found else { return nil }
+        }
+        return current
+    }
+
     static func menuItem(path: [String], runtime: Runtime = .production) -> AXUIElement? {
         guard var current = getMenuBar(runtime: runtime) else { return nil }
         for title in path {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -1021,8 +1021,14 @@ extension AccessibilityChannel {
         //
         // #519: this used to try a Korean literal and then an English one, which covers exactly two
         // of the languages Logic ships and fails silently in every other. Resolved through
-        // AXLocalePolicy instead, so the Japanese `ファイル` already measured for this menu bar works
-        // without a third literal, and a new measured label is added in one place.
+        // AXLocalePolicy instead, so a newly measured label is added in one place rather than as
+        // another literal here.
+        //
+        // It does NOT yet reach Japanese. The File menu bar has a measured `ファイル`, but the ITEM's
+        // Japanese label has never been read off a live Japanese Logic, so `saveAsMenuItem` has no
+        // Japanese variant and this refusal is what a Japanese user gets. An earlier draft of this
+        // comment claimed otherwise on the strength of the bar alone, which is the same over-claim
+        // this change deliberately refused to make about `logicUILocaleIdentifier`.
         let trigger = clickMenuItem(
             AXLocalePolicy.saveAsMenuItem, in: AXLocalePolicy.fileMenuBar, runtime: runtime
         )

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift
@@ -1017,13 +1017,28 @@ extension AccessibilityChannel {
             ))
         }
 
-        // Step 1: Trigger Save As via menu click
-        let koreanResult = clickMenuItem("다른 이름으로 저장…", menuName: "파일", runtime: runtime)
-        let triggered = koreanResult.isSuccess
-            || clickMenuItem("Save As…", menuName: "File", runtime: runtime).isSuccess
-
-        guard triggered else {
-            return .error("Failed to open Save As dialog via menu")
+        // Step 1: Trigger Save As via menu click.
+        //
+        // #519: this used to try a Korean literal and then an English one, which covers exactly two
+        // of the languages Logic ships and fails silently in every other. Resolved through
+        // AXLocalePolicy instead, so the Japanese `ファイル` already measured for this menu bar works
+        // without a third literal, and a new measured label is added in one place.
+        let trigger = clickMenuItem(
+            AXLocalePolicy.saveAsMenuItem, in: AXLocalePolicy.fileMenuBar, runtime: runtime
+        )
+        guard trigger.isSuccess else {
+            let ownedKeyboard = ProcessUtils.logicOwnsTheKeyboard()
+            return .error(HonestContract.encodeStateC(
+                error: .elementNotFound,
+                hint: "Could not open the Save As panel: \(trigger.message)",
+                extras: [
+                    "write_attempted": false,
+                    "frontmost_preparation": preparation.rawValue,
+                    "logic_owned_the_keyboard": ownedKeyboard,
+                    "menu_labels_tried": AXLocalePolicy.saveAsMenuItem.labels,
+                    "menu_bar_labels_tried": AXLocalePolicy.fileMenuBar.labels,
+                ]
+            ))
         }
 
         // Creator Studio 12.3 exposes this panel as a top-level AXDialog rather
@@ -1387,6 +1402,39 @@ extension AccessibilityChannel {
                 "safe_to_retry": true,
             ]
         ))
+    }
+
+    /// Locale-resolved menu click (#519). Same gate as the literal overload: an item whose
+    /// `AXEnabled` does not read `true` is refused rather than pressed, because a press on a disabled
+    /// item reports success.
+    private static func clickMenuItem(
+        _ item: AXLocalePolicy.LabelSet,
+        in menuBar: AXLocalePolicy.LabelSet,
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ChannelResult {
+        guard let element = AXLogicProElements.menuItem(
+            labelPath: [menuBar, item], runtime: runtime
+        ) else {
+            return .error(
+                "Cannot find menu item: any of \(menuBar.labels) > any of \(item.labels)"
+            )
+        }
+        let enabled: Bool? = AXHelpers.getAttribute(
+            element, kAXEnabledAttribute as String, runtime: runtime.ax
+        )
+        guard enabled == true else {
+            let observed = enabled.map(String.init) ?? "unreadable"
+            return .error(
+                "Refusing to press menu item \(item.canonical): AXEnabled is \(observed). "
+                + "Logic disables its document-modifying File items while it is a background "
+                + "application, and pressing a disabled item reports success without doing anything, "
+                + "so an unreadable answer is refused for the same reason a false one is."
+            )
+        }
+        guard AXHelpers.performAction(element, kAXPressAction, runtime: runtime.ax) else {
+            return .error("Failed to click: \(item.canonical)")
+        }
+        return .success("{\"menu_clicked\":\"\(item.canonical)\"}")
     }
 
     private static func clickMenuItem(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -1871,10 +1871,20 @@ extension AccessibilityChannel {
         englishMenuName: String = "Track",
         runtime: AXLogicProElements.Runtime = .production
     ) -> ChannelResult {
-        // #519: the Japanese menu bar is a third spelling, not a variant of either of the other two.
-        // Measured 2026-08-17 on Logic 12.3 with AppleLanguages=ja: the menu is `トラック`. Without it
-        // every menu-driven track operation returned `element_not_found` on a Japanese Logic.
-        for menuTitle in [menuName, englishMenuName, "トラック"] {
+        // #519: the menu-bar spellings live in AXLocalePolicy now rather than in this array. The
+        // Japanese `トラック` was measured on Logic 12.3 with `AppleLanguages=ja` and is a third
+        // spelling, not a variant of either of the others; without it every menu-driven track
+        // operation returned `element_not_found` on a Japanese Logic. That measurement is preserved
+        // in `AXLocalePolicy.trackMenuBar`, where a fourth measured language can join it instead of
+        // becoming a fourth element in a literal here.
+        //
+        // The caller-supplied names still come first so an explicit override wins, and the policy's
+        // labels are appended rather than replacing them.
+        var barCandidates = [menuName, englishMenuName]
+        for label in AXLocalePolicy.trackMenuBar.labels where !barCandidates.contains(label) {
+            barCandidates.append(label)
+        }
+        for menuTitle in barCandidates {
             for itemTitle in menuItemTitles {
                 guard let item = AXLogicProElements.menuItem(path: [menuTitle, itemTitle], runtime: runtime) else {
                     continue

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -191,3 +191,33 @@ struct Issue519SaveAsMenuLocaleTests {
         #expect(!usesEnglishLiteral)
     }
 }
+
+/// #519: the Track menu bar's three measured spellings moved out of a literal array in
+/// `clickTrackMenu` and into `AXLocalePolicy`. The move must not lose any of them — the Japanese form
+/// in particular was measured on a Japanese Logic and its absence made every menu-driven track
+/// operation return `element_not_found` there.
+extension Issue519SaveAsMenuLocaleTests {
+    @Test("issue519_the_track_menu_bar_keeps_all_three_measured_spellings")
+    func trackMenuBarKeepsAllSpellings() {
+        let labels = AXLocalePolicy.trackMenuBar.labels
+        #expect(labels.contains("Track"))
+        #expect(labels.contains("트랙"))
+        #expect(labels.contains("トラック"))
+    }
+
+    /// The literal array must not have grown back. A fourth language belongs in the label set.
+    @Test("issue519_the_track_menu_drive_does_not_hard_code_a_spelling")
+    func trackMenuDriveHasNoLiteralSpelling() throws {
+        let source = try String(
+            contentsOfFile: #filePath.replacingOccurrences(
+                of: "Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift",
+                with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift"
+            ),
+            encoding: .utf8
+        )
+        let usesPolicy = source.contains("AXLocalePolicy.trackMenuBar.labels")
+        let hardCodesJapanese = source.contains("[menuName, englishMenuName, \"トラック\"]")
+        #expect(usesPolicy)
+        #expect(!hardCodesJapanese)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -134,3 +134,60 @@ struct Issue606MenuEnabledGateTests {
         #expect(!usesLenientForm)
     }
 }
+
+/// #519: the Save As menu drive must resolve through AXLocalePolicy, not through two hard-coded
+/// literals. The pair it replaced covered exactly two of the languages Logic ships.
+@Suite(.serialized)
+struct Issue519SaveAsMenuLocaleTests {
+    @Test("issue519_save_as_labels_cover_the_measured_forms")
+    func labelsCoverMeasuredForms() {
+        let labels = AXLocalePolicy.saveAsMenuItem.labels
+        #expect(labels.contains("Save As…"))
+        #expect(labels.contains("다른 이름으로 저장…"))
+        // The trailing character is a real ellipsis. Three dots is a different string and would not
+        // match the live menu.
+        #expect(!labels.contains("Save As..."))
+    }
+
+    /// The item is picked by exact label, so the two neighbours in the same File menu — measured on a
+    /// live Logic 12.3 two rows away — must not match.
+    @Test("issue519_save_as_does_not_match_its_neighbours_in_the_same_menu")
+    func doesNotMatchNeighbours() {
+        let item = AXLocalePolicy.saveAsMenuItem
+        #expect(item.matches("Save As…"))
+        #expect(!item.matches("Save A Copy As…"))
+        #expect(!item.matches("Save as Template…"))
+        #expect(!item.matches("Save"))
+    }
+
+    /// The bar it hangs off already carries a Japanese form that the old literal pair could not reach.
+    @Test("issue519_the_file_menu_bar_reaches_beyond_the_two_old_literals")
+    func fileMenuBarReachesFurther() {
+        let bar = AXLocalePolicy.fileMenuBar.labels
+        #expect(bar.contains("File"))
+        #expect(bar.contains("파일"))
+        // The label the replaced pair could never have matched.
+        #expect(bar.contains("ファイル"))
+    }
+
+    /// The shipped call site must not have drifted back to literals — the defect #519 is about is a
+    /// literal in a call site, not a missing label set.
+    @Test("issue519_the_shipped_call_site_uses_the_label_sets")
+    func shippedCallSiteIsLocaleResolved() throws {
+        let source = try String(
+            contentsOfFile: #filePath.replacingOccurrences(
+                of: "Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift",
+                with: "Sources/LogicProMCP/Channels/AccessibilityChannel+Project.swift"
+            ),
+            encoding: .utf8
+        )
+        let usesLabelSets = source.contains(
+            "clickMenuItem(\n            AXLocalePolicy.saveAsMenuItem, in: AXLocalePolicy.fileMenuBar"
+        )
+        let usesKoreanLiteral = source.contains("menuName: \"파일\"")
+        let usesEnglishLiteral = source.contains("menuName: \"File\"")
+        #expect(usesLabelSets)
+        #expect(!usesKoreanLiteral)
+        #expect(!usesEnglishLiteral)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue606SaveAsFieldIdentityTests.swift
@@ -160,14 +160,30 @@ struct Issue519SaveAsMenuLocaleTests {
         #expect(!item.matches("Save"))
     }
 
-    /// The bar it hangs off already carries a Japanese form that the old literal pair could not reach.
-    @Test("issue519_the_file_menu_bar_reaches_beyond_the_two_old_literals")
-    func fileMenuBarReachesFurther() {
+    /// The bar it hangs off already carries a Japanese form. The ITEM does not — and that gap is
+    /// asserted here rather than left to be assumed away.
+    ///
+    /// A review caught an earlier draft claiming `save_as` "works on Japanese without a third
+    /// literal" because the BAR has `ファイル`. A resolved bar is worthless if the item under it does
+    /// not resolve, and the item's Japanese label has never been measured on a live Japanese Logic.
+    /// If someone measures it, they add it to `saveAsMenuItem.variants` and this test's last
+    /// expectation is what tells them to.
+    @Test("issue519_the_bar_reaches_japanese_and_the_item_does_not_yet")
+    func fileMenuBarReachesFurtherThanTheItem() {
         let bar = AXLocalePolicy.fileMenuBar.labels
         #expect(bar.contains("File"))
         #expect(bar.contains("파일"))
-        // The label the replaced pair could never have matched.
         #expect(bar.contains("ファイル"))
+
+        // The honest state of the item: two measured labels, no Japanese. Flip this the day someone
+        // reads the real label off a Japanese Logic — not before.
+        let item = AXLocalePolicy.saveAsMenuItem.labels
+        #expect(item.contains("Save As…"))
+        #expect(item.contains("다른 이름으로 저장…"))
+        let itemHasAnyJapanese = item.contains { label in
+            label.unicodeScalars.contains { (0x3040...0x30FF).contains(Int($0.value)) }
+        }
+        #expect(!itemHasAnyJapanese)
     }
 
     /// The shipped call site must not have drifted back to literals — the defect #519 is about is a


### PR DESCRIPTION
**Blind-reviewed.** One finding, and it was the sharpest kind: this change stepped over a line it had
just drawn for itself. Fixed below.

Two call sites, the same shape, one of them the last row of the census #519 opened with.

### `save_as` covered exactly two languages

```swift
let koreanResult = clickMenuItem("다른 이름으로 저장…", menuName: "파일", runtime: runtime)
let triggered = koreanResult.isSuccess
    || clickMenuItem("Save As…", menuName: "File", runtime: runtime).isSuccess
```

Two of the languages Logic ships, and silent failure in the rest — including **Japanese, whose
`ファイル` was already measured and sitting in `AXLocalePolicy.fileMenuBar`**, where this call could not
reach it. The label existed; the call site could not use it.

`AXLogicProElements.menuItem(labelPath:)` now resolves each step against any measured label, and
`AXLocalePolicy.saveAsMenuItem` carries the item's forms.

The English label was measured today by enumerating the live File menu, and it has to match exactly:

```
Save        Save As…        Save A Copy As…        Save as Template…
```

Four entries, three starting "Save A"/"Save as". A substring rule reaches the wrong one, so tests pin
that the set matches `"Save As…"`, rejects all three neighbours, and does not accept `"Save As..."`
with three dots.

The Korean variant is **carried over from the literal it replaces, not re-measured**. The label set
says so — its provenance is "already trusted in shipped code", and inherited text that keeps
asserting an old observation is its own failure mode.

### The Track menu carried three spellings in an array

```swift
for menuTitle in [menuName, englishMenuName, "トラック"] {
```

Fixing only the site I happened to open would leave an identical one two files away. All three move to
`AXLocalePolicy.trackMenuBar`. This adds no measurement — the Japanese form was already measured on
Logic 12.3 with `AppleLanguages=ja`, and its note that it is a *third spelling rather than a variant*
moves with it. Caller-supplied names still come first, so an explicit override wins.

### Two things kept

The locale-resolved click keeps the `AXEnabled` pre-gate `save_as` grew for #606: an item whose
enabled state does not read `true` is refused rather than pressed, because Logic disables its
document-modifying File items while backgrounded and a press on a disabled one reports success.

And the refusal now names what it tried — `menu_labels_tried`, `menu_bar_labels_tried`. The old
message was "Failed to open Save As dialog via menu", which named neither, and that is why finding
these took a census.

### Checked and deliberately not changed

`AXLogicProElements.logicUILocaleIdentifier` detects the UI locale from English or Korean top-level
titles and returns `nil` for anything else. That looks like the same defect and is not:
`QualificationLocale` has exactly `en-US` and `ko-KR`, so a Japanese Logic reporting `"unknown"` is
the honest answer rather than a mislabelled one. Widening it would claim qualification coverage that
does not exist.

### What the review found

The commit that introduced `saveAsMenuItem` said resolving through `AXLocalePolicy` means "the
Japanese `ファイル` already measured for this menu bar works without a third literal". The **bar** does
have a measured Japanese label. The **item** does not — English and Korean and nothing else — and a
resolved bar is worthless if the item under it cannot be found.

That is exactly the over-claim this same PR refused to make one level up, where it left
`logicUILocaleIdentifier` covering two locales because widening it would "claim qualification coverage
that does not exist". The principle was stated and then not applied one layer down, in the same diff.

The label set now records the gap and why it is not filled — nobody has read the item's Japanese label
off a live Japanese Logic, and this repository does not translate labels into a LabelSet. The call
site says a Japanese user gets the refusal. And a test asserts the **absence**: the item carries no
Japanese-script label at all, so the gap cannot quietly become an assumption.

Not a regression — the two literals this replaces had the same gap. What changed is that it is written
down instead of implied away.

### Gate

```
unit   6 new tests — label coverage, neighbour rejection, the Japanese form the old pair
       could not reach, and two checks that the shipped call sites have not drifted back to literals
live   live_606_save_as_writes_the_file.py — 9 checks, 9 passed, 4 mutation-backed
       save_as still writes a project at the exact requested path through the locale-resolved drive
full suite      3854 tests passed
SHIP GATE PASS  ef6d59e5
```

### Why #519 stays open

The census in that issue lists ten hard-coded menu-bar occurrences; all ten are now resolved, and this
PR adds one the table did not cover. But the issue's subject is Logic being unusable outside English
and Korean, and **`save_as` is still unusable on a Japanese Logic** — the File menu BAR resolves
`ファイル`, and the ITEM has no measured Japanese label, so the drive refuses. The table is finished;
the condition the table was a symptom of is not.

That issue closes when someone reads the item's real label off a live Japanese Logic and adds it. The
test added here asserts the absence, so that person has something telling them where it goes.


