### PR TITLE
fix(livekit): a merge deleted three functions and left every call site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Self-test the live-evidence library (#622 harness API)
+        # is_clean, the document-name constraint, and — the reason this is here — that every
+        # `E.<name>` / `ev.<name>` a harness references still exists. Two individually-green
+        # branches once merged into a main where three functions had been deleted and every call
+        # site remained, and nothing in this file could see it: the Swift suite does not import
+        # evidence.py. Pure Python, no Xcode, no Logic.
+        run: python3 Scripts/livekit/test_evidence.py
+
       - name: Self-test the preflight stamp gate (#552)
         # The stamp only helps if it actually refuses. This asserts NOT-STAMPED is 1, stamped is 0, an
         # unresolvable tree-ish is 2, and the hook refuses an unstamped commit while allowing a deletion.
@@ -78,6 +86,14 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Self-test the live-evidence library (#622 harness API)
+        # is_clean, the document-name constraint, and — the reason this is here — that every
+        # `E.<name>` / `ev.<name>` a harness references still exists. Two individually-green
+        # branches once merged into a main where three functions had been deleted and every call
+        # site remained, and nothing in this file could see it: the Swift suite does not import
+        # evidence.py. Pure Python, no Xcode, no Logic.
+        run: python3 Scripts/livekit/test_evidence.py
 
       - name: Self-test the preflight stamp gate (#552)
         # The stamp only helps if it actually refuses. This asserts NOT-STAMPED is 1, stamped is 0, an

--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -1,4 +1,9 @@
-// The arrange window's track-header rail, in window coordinates, emitted as JSON.
+// A NAMED region of the arrange window, in window coordinates, emitted as JSON with the name it
+// matched — so a caller can state what the band IS, not only where it is.
+//
+//   ./ax_control_bar_band                 -> the Control Bar (the default; #614 depends on it)
+//   ./ax_control_bar_band "Control Bar"   -> the same, named explicitly
+//   ./ax_control_bar_band "<AXDescription>" -> any region Logic describes by that exact string
 //
 // A band written as coordinates is not defined by its content: the top-left 240x28 of the arrange
 // window is the track-name column with the Mixer closed and a column of mixer strips with it open,
@@ -45,9 +50,10 @@ func emit(_ o: [String: Any]) -> Never {
     exit(0)
 }
 
-// Every measured AXDescription for the rail. Add by MEASUREMENT only — widening this to a substring
-// or a structural guess is what made the earlier attempt return the Inspector.
-// The CONTROL BAR, not the track rail.
+// The default region. An argument overrides it, and the match is always the EXACT AXDescription —
+// widening to a substring or a structural guess is what made the earlier attempt return the
+// Inspector. Whatever is passed, the emitted `description` is read back off the element that was
+// found, so the caller names what was measured rather than what was requested.
 //
 // Three different regions of the document view were tried as a negative control and all three
 // failed the same way: quiet at rest, different after the run. Bisected, the last one differed in
@@ -58,7 +64,8 @@ func emit(_ o: [String: Any]) -> Never {
 // The claim a refusal that writes nothing CAN keep is that it did not touch the transport. The
 // control bar is chrome rather than document, so it does not scroll with the arrange, and its clock
 // only advances while the transport is running — which the quiet probe checks before this is used.
-let railDescriptions: Set<String> = ["Control Bar"]
+let wanted = CommandLine.arguments.count > 1 && !CommandLine.arguments[1].isEmpty
+    ? CommandLine.arguments[1] : "Control Bar"
 
 guard let app = NSWorkspace.shared.runningApplications.first(where: {
     ($0.bundleIdentifier ?? "").contains("logic")
@@ -72,7 +79,7 @@ var rail: AXUIElement?
 func walk(_ e: AXUIElement, _ d: Int) {
     guard d <= 18, rail == nil else { return }
     for c in kids(e) {
-        if railDescriptions.contains(str(c, kAXDescriptionAttribute as String)) { rail = c; return }
+        if str(c, kAXDescriptionAttribute as String) == wanted { rail = c; return }
         walk(c, d + 1)
         if rail != nil { return }
     }
@@ -80,7 +87,8 @@ func walk(_ e: AXUIElement, _ d: Int) {
 walk(win, 0)
 
 guard let r = rail, let rf = frame(r) else {
-    emit(["error": "no element described as the track-header rail",
+    emit(["error": "no element with that exact AXDescription",
+          "wanted": wanted,
           "window": str(win, kAXTitleAttribute as String)])
 }
 emit([

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -668,3 +668,94 @@ def _file_hash(path):
         return None
 
 
+# --- Restored after a merge dropped them -------------------------------------------------------
+#
+# #620 rewrote this file from a base that predated these three, so merging it deleted them while
+# every CALL SITE stayed: `_region_hash` at shot()/visual(), `_worktree_head` at write(), and
+# `have_tools` in thirty-two harnesses. Main could not run a single live harness.
+#
+# Neither gate could see it. The ship gate runs the Swift suite, and #620 changed no Sources/ so it
+# needed no live evidence; #620's own test exercises is_clean and _safe_name and never calls shot(),
+# visual(), or write(). Each branch was green and the breakage existed only in their merge.
+#
+# The import smoke test beside this file is the part that would have caught it.
+
+def _region_hash(png, region, window_points=None):
+    """Hash one rectangle of a PNG.
+
+    `region` is in WINDOW POINTS, the same units `logic_window()` reports. The capture is in backing
+    PIXELS — measured 3840x2100 for a 1920x1050 window on this hardware — so the rectangle is scaled by
+    the ratio the image itself reveals. Without that scaling the crop lands somewhere else entirely and
+    the assertion compares two identical wrong regions, which reads as "nothing changed" on a run where
+    the feature plainly worked.
+
+    Returns None rather than falling back to a whole-file hash: an unusable comparison must be visible
+    as unusable, not disguised as a difference.
+    """
+    if not os.path.isfile(png):
+        return None
+    try:
+        from Quartz import (CGImageSourceCreateWithURL, CGImageSourceCreateImageAtIndex,
+                            CGImageCreateWithImageInRect, CGRectMake, CGDataProviderCopyData,
+                            CGImageGetDataProvider, CGImageGetWidth, CGImageGetHeight)
+        from Foundation import NSURL
+        url = NSURL.fileURLWithPath_(png)
+        src = CGImageSourceCreateWithURL(url, None)
+        if src is None:
+            return None
+        img = CGImageSourceCreateImageAtIndex(src, 0, None)
+        if img is None:
+            return None
+        if not region:
+            data = CGDataProviderCopyData(CGImageGetDataProvider(img))
+            return hashlib.sha256(bytes(data)).hexdigest()
+        pw, ph = CGImageGetWidth(img), CGImageGetHeight(img)
+        sx = sy = 1.0
+        if window_points:
+            wpts, hpts = window_points
+            if wpts:
+                sx = pw / float(wpts)
+            if hpts:
+                sy = ph / float(hpts)
+        x, y, w, h = region
+        sub = CGImageCreateWithImageInRect(
+            img, CGRectMake(x * sx, y * sy, w * sx, h * sy))
+        if sub is None:
+            return None
+        data = CGDataProviderCopyData(CGImageGetDataProvider(sub))
+        return hashlib.sha256(bytes(data)).hexdigest()
+    except Exception:
+        return None
+
+
+def _worktree_head(repo):
+    """(HEAD sha, dirty) for the worktree the binary was built in.
+
+    `dirty` counts tracked-file modifications under Sources/ and Tests/ only: an untracked scratch file
+    does not change what was compiled, but an edited source does, and a binary built from an edited tree
+    is not evidence about the commit it is filed under.
+    """
+    if not repo:
+        return None, False
+    try:
+        head = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
+                              capture_output=True, text=True, check=False).stdout.strip()
+        st = subprocess.run(["git", "-C", repo, "status", "--porcelain", "--", "Sources", "Tests"],
+                            capture_output=True, text=True, check=False).stdout.strip()
+        return (head or None), bool(st)
+    except Exception:
+        return None, False
+
+
+def have_tools():
+    """Everything the recorder needs, checked before a run rather than mid-run."""
+    missing = []
+    if not shutil.which("screencapture") and not os.path.exists("/usr/sbin/screencapture"):
+        missing.append("screencapture")
+    try:
+        import Quartz  # noqa: F401
+    except ImportError:
+        missing.append("pyobjc (Quartz)")
+    if BIN and not os.access(BIN, os.X_OK):
+        missing.append(f"built binary at {BIN}")
+    return missing

--- a/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
+++ b/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
@@ -98,10 +98,40 @@ located = [(t, E.logic_window(t)) for t in titles]
 located = [(t, w) for t, w in located if w]
 located.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
 arrange_title, win = located[0] if located else (titles[0], None)
-band = (10, 24, min(1900, win["w"] - 20), 58) if win else None
-ev.check("293/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+# The band is LOCATED, not written down. `#622`: a rectangle chosen by coordinates cannot show that
+# it drifted onto different content — three bands did exactly that this week, keeping their numbers
+# while the pane beneath them changed. This asks Logic where the Control Bar is and takes the name
+# back off the element that answered, so `subject=` names what was measured rather than what was
+# hoped for. (The hand-picked numbers here were in fact right — AX reports the same
+# [10, 24, 1900, 58] — but they were right by luck and could not have said so.)
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(description="Control Bar"):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle.
+
+    Falling back to coordinates when the lookup fails would put the run back on the footing this
+    replaces, and it would do it silently, on the runs where AX is least trustworthy.
+    """
+    r = subprocess.run([BAND_TOOL, description], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+band, band_subject = located_band()
+ev.check("293/precondition-the-window-frame-is-known", band is not None and bool(band_subject),
+         "the arrange window's frame read AND the Control Bar located by AXDescription, so the "
+         "capture band is inside the window and can say what it watches. No fallback rectangle: a "
+         "failed lookup is a red precondition, not a guess",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -283,13 +313,11 @@ relocated = [(t, w) for t, w in relocated if w]
 relocated.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
 after_title = relocated[0][0] if relocated else arrange_title
 after = ev.shot("293/after", settle_region=band, window_title=after_title)
-# OWED once #620 lands: `subject=` — what this band IS, not only where. It is the control bar strip
-# at the top of the arrange window: chrome, so it does not scroll with the document. That matters
+# `subject` is the Control Bar: chrome, so it does not scroll with the document. That matters
 # because no region of the DOCUMENT is invariant across this run — recording a region changes it on
-# purpose. The parameter does not exist on this branch's evidence.py yet, and passing it would break
-# the run rather than document it.
+# purpose. The string comes from the element AX matched, not from this file.
 ev.visual("293/the-transport-is-undisturbed-by-the-probe",
-          before_probe["file"], after["file"], band, expect_change=False,
+          before_probe["file"], after["file"], band, expect_change=False, subject=band_subject,
           why="bracketed around the PROBE, not around the whole run: `record_sequence` resets the "
               "playhead to bar 1, so a before/after spanning it could not tell a still transport "
               "from one that moved and came back. Between these two frames the only product call is "

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -121,5 +121,41 @@ for raw, why in [
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} name={str(raw)[:28]!r:<32} -> {stem[:28]!r:<30} {why}")
 
+# --- the API the harnesses actually call must exist -------------------------------------------
+#
+# #620 rewrote evidence.py from a base that predated three functions, and merging it deleted them
+# while every call site stayed. Main could not run a single live harness. Both branches were green:
+# the ship gate runs the Swift suite, #620 touched no Sources/ so it needed no live evidence, and
+# the tests above never call shot(), visual(), or write().
+#
+# The required names are SCANNED from the harnesses rather than listed here. A hand-written list is
+# a second copy that goes stale exactly when a harness starts using something new.
+import glob
+import inspect
+import re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+module_calls, instance_calls = set(), set()
+for path in sorted(glob.glob(os.path.join(HERE, "live_*.py")) + glob.glob(os.path.join(HERE, "session_*.py"))):
+    src = open(path).read()
+    module_calls |= set(re.findall(r"\bE\.([A-Za-z_]\w*)", src))
+    instance_calls |= set(re.findall(r"\bev\.([A-Za-z_]\w*)", src))
+
+for name in sorted(module_calls):
+    ok = hasattr(E, name)
+    failed += 0 if ok else 1
+    if not ok:
+        print(f"FAIL evidence.{name} is called by a harness and does not exist")
+# Attributes assigned in __init__ are not class attributes, so `hasattr(Evidence, "dir")` is False
+# for a name that plainly exists. Read those statically rather than constructing an Evidence, which
+# would create directories as a side effect of a unit test.
+init_attrs = set(re.findall(r"self\.([A-Za-z_]\w*)\s*=", inspect.getsource(E.Evidence)))
+for name in sorted(instance_calls):
+    ok = hasattr(E.Evidence, name) or name in init_attrs
+    failed += 0 if ok else 1
+    if not ok:
+        print(f"FAIL Evidence.{name} is called by a harness and does not exist")
+print(f"ok   harness API present: {len(module_calls)} module + {len(instance_calls)} instance names")
+
 print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
 sys.exit(1 if failed else 0)


### PR DESCRIPTION
**Main cannot run a single live harness right now.** This restores it, adds the check that would have caught it, and runs that check where merges are gated.

## What broke

```
evidence.py:387,432,433   _region_hash      called by shot() and visual()   — not defined
evidence.py:495           _worktree_head    called by write()               — not defined
33 harnesses              E.have_tools()                                    — not defined
```

#620 rewrote `evidence.py` from a base that predated all three. Merging it deleted the definitions while **every call site stayed**.

## Why both gates were green

This is the part worth keeping:

- the ship gate runs the **Swift** suite, which never imports `evidence.py`
- #620 changed no `Sources/`, so it needed no live evidence
- #620's own test exercises `is_clean` and `_safe_name` and never calls `shot()`, `visual()`, or `write()`

Each branch was green on its own. **The breakage existed only in their merge**, and nothing in the repository looked at the surface that broke.

## The check

Scans every harness beside it for the `E.<name>` and `ev.<name>` it references and requires each to exist. The list is **scanned, not written down** — a hand-kept list is a second copy that goes stale exactly when a harness starts using something new. Names assigned in `__init__` are read statically rather than by constructing an `Evidence`, which would create directories as a side effect of a unit test.

Deleting `have_tools` again turns it red.

And it now runs in `compile` and `test`. It was a standalone script, so nothing executed it — a check that names a defect but never runs is not a control. Both jobs are required and `build` is a fan-in over them, so a red here blocks the merge. Verified it exits 0 with `PATH` restricted to `/usr/bin:/bin`: `have_tools()` is only checked for existence, never called.

## #622: the first band that says what it watches

`visual()` takes `subject=` — what the watched rectangle **is**, as the UI describes it. Thirty-one harnesses call `visual()` and none passed one, because thirty-one truthful subjects means thirty-one measurements, and inventing them is the failure the parameter exists to prevent.

So one is measured, and the tool that measures it is now general. `ax_control_bar_band.swift` was hardcoded to the Control Bar — and its prose still described the track-header rail it had stopped looking for, down to the error message. It takes the AXDescription as an argument now, defaulting to Control Bar so #614 is unaffected, and **reads the name back off the element it found**, so a caller states what was measured rather than what was requested. An unmatched name emits an error, not a rectangle.

Worth recording: #293's hardcoded numbers were **right** — AX reports the same `[10, 24, 1900, 58]` — but they were right by luck and could not have said so. Three bands this week kept their coordinates while the content beneath them changed.

There is no fallback rectangle. A failed lookup is a red precondition, because falling back to coordinates would restore exactly what this replaces, silently, on the runs where AX is least trustworthy.

## Live

```
checks 10/10 · mutation-backed 4 · captures 3 · visual 1 (0 failed)
recordings 1 · operations_driven 2 · restorations_failed 0 · cached-as-live 0
visual_assertions_without_a_subject 0        ← the first run that can say this
```

One of thirty-one. The rest need the same measurement each — #622 stays open.