### PR TITLE
ci: the class, not just the instance — every module with consumers is checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: Every module with consumers must still satisfy them
+        # The module list is derived, not written down: a `.py` is in scope exactly when another
+        # file imports it. Checks every referenced name exists and every call binds against the real
+        # signature. Return SHAPE is not static — the evidence self-test below drives that.
+        run: python3 Scripts/check-python-contracts.py
+
       - name: Self-test the live-evidence library (#622 harness API)
         # is_clean, the document-name constraint, and — the reason this is here — that every
         # `E.<name>` / `ev.<name>` a harness references still exists. Two individually-green
@@ -86,6 +92,12 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: Every module with consumers must still satisfy them
+        # The module list is derived, not written down: a `.py` is in scope exactly when another
+        # file imports it. Checks every referenced name exists and every call binds against the real
+        # signature. Return SHAPE is not static — the evidence self-test below drives that.
+        run: python3 Scripts/check-python-contracts.py
 
       - name: Self-test the live-evidence library (#622 harness API)
         # is_clean, the document-name constraint, and — the reason this is here — that every

--- a/Scripts/check-python-contracts.py
+++ b/Scripts/check-python-contracts.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Every Python module in this repo that has consumers must still satisfy them.
+
+THE CLASS OF DEFECT
+-------------------
+A module can be changed so that every caller breaks while nothing in the repository notices,
+because the checks that exist look at the MODULE and the callers live somewhere else. It happened
+here: `evidence.py` was rewritten from a stale base, three functions vanished, thirty-four
+consumers kept calling them, and both branches were green — the Swift suite does not import Python,
+and the module's own tests exercised what had changed rather than what depended on it.
+
+Deleting a name is only the cheapest version. The same hole is open when a signature gains a
+required argument, or when a return value changes shape, since the name is still there.
+
+WHAT THIS CHECKS, AND HOW IT AVOIDS GOING STALE
+-----------------------------------------------
+The module list is DERIVED, never written down: every `.py` in the tree is a candidate, and a
+module is in scope exactly when another file imports it. A hand-kept list is a second copy that
+goes stale at the moment a new module acquires its first consumer — which is precisely when it
+starts mattering.
+
+For each consumer, under the alias it actually imported:
+
+  * every `M.name` referenced must exist
+  * every `M.name(...)` call must BIND against the real signature — this is what catches a new
+    required parameter, which a name check cannot see
+  * a variable assigned from `M.Class(...)` carries that class, so `var.attr` is checked too
+
+WHAT IT DOES NOT CHECK, STATED SO NOBODY READS IT AS MORE
+---------------------------------------------------------
+Return SHAPE. `f()` changing from a list to a dict keeps its name and its signature, and no static
+pass can see it in untyped Python. That gap is covered separately, by driving the API and asserting
+what comes back — for `evidence.py` that is `Scripts/livekit/test_evidence.py`, which runs the
+whole non-capture surface headlessly. Any module without such a drive has this square open, and
+this script says which.
+"""
+import ast
+import importlib
+import inspect
+import os
+import sys
+
+SKIP_DIRS = {".git", ".build", "node_modules", ".venv", "venv"}
+
+
+def local_modules(root):
+    out = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for f in filenames:
+            if f.endswith(".py"):
+                out.setdefault(f[:-3], os.path.join(dirpath, f))
+    return out
+
+
+def aliases(tree, known, selfname):
+    """{alias: module} for every local module this file imports, under the name it uses."""
+    found = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name in known and a.name != selfname:
+                    found[a.asname or a.name] = a.name
+    return found
+
+
+def from_imports(tree, known, selfname):
+    """[(module, name)] for `from M import name` — the name is bound directly, with no alias to
+    hang attribute checks on, so it is verified at the import itself."""
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in known and node.module != selfname:
+            for a in node.names:
+                if a.name != "*":
+                    out.append((node.module, a.name))
+    return out
+
+
+def declared_attrs(cls):
+    """Attribute names a class assigns to `self`. `hasattr(Cls, "dir")` is False for a name plainly
+    set in __init__, so reading them statically is the difference between a real finding and noise —
+    and it beats constructing the class, which for Evidence would create directories."""
+    try:
+        src = inspect.getsource(cls)
+    except (OSError, TypeError):
+        return set()
+    names = set()
+    for node in ast.walk(ast.parse(src.lstrip())):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) \
+                and node.value.id == "self" and isinstance(node.ctx, ast.Store):
+            names.add(node.attr)
+    return names
+
+
+def instance_vars(tree, alias_map):
+    """{var: (module, ClassName)} for `var = M.Class(...)`."""
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            fn = node.value.func
+            if (isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name)
+                    and fn.value.id in alias_map and fn.attr[:1].isupper()):
+                for t in node.targets:
+                    if isinstance(t, ast.Name):
+                        out[t.id] = (alias_map[fn.value.id], fn.attr)
+    return out
+
+
+def call_arity_ok(func, node):
+    """Whether this call site binds against the real signature. (ok, message)."""
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True, ""            # builtins and C functions expose none; not a finding
+    if any(isinstance(a, ast.Starred) for a in node.args) or any(k.arg is None for k in node.keywords):
+        return True, ""            # *args / **kwargs at the call site: arity is not decidable here
+    args = [None] * len(node.args)
+    kwargs = {k.arg: None for k in node.keywords}
+    try:
+        sig.bind(*args, **kwargs)
+        return True, ""
+    except TypeError as exc:
+        return False, f"{exc} — signature is {sig}"
+
+
+def main():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    known = local_modules(root)
+    loaded, offenders, checked, unimportable = {}, [], 0, []
+    covered_by_a_drive = {"evidence": "Scripts/livekit/test_evidence.py"}
+    consumed = {}
+
+    for path in sorted(known.values()):
+        try:
+            tree = ast.parse(open(path).read())
+        except SyntaxError as exc:
+            offenders.append(f"{os.path.relpath(path, root)}: will not parse ({exc})")
+            continue
+        selfname = os.path.basename(path)[:-3]
+        alias_map = aliases(tree, known, selfname)
+        pulled = from_imports(tree, known, selfname)
+        if not alias_map and not pulled:
+            continue
+        for mod, _ in pulled:
+            consumed.setdefault(mod, set()).add(path)
+            if mod not in loaded:
+                sys.path.insert(0, os.path.dirname(known[mod]))
+                try:
+                    loaded[mod] = importlib.import_module(mod)
+                except Exception as exc:                       # noqa: BLE001
+                    loaded[mod] = None
+                    unimportable.append(f"{mod}: {type(exc).__name__}: {exc}")
+                finally:
+                    sys.path.pop(0)
+        for mod, name in pulled:
+            if loaded.get(mod) is not None:
+                checked += 1
+                if not hasattr(loaded[mod], name):
+                    offenders.append(
+                        f"{os.path.relpath(path, root)}: `from {mod} import {name}` — no such name")
+        for mod in alias_map.values():
+            consumed.setdefault(mod, set()).add(path)
+        for alias, mod in alias_map.items():
+            if mod not in loaded:
+                sys.path.insert(0, os.path.dirname(known[mod]))
+                try:
+                    loaded[mod] = importlib.import_module(mod)
+                except Exception as exc:                       # noqa: BLE001
+                    loaded[mod] = None
+                    unimportable.append(f"{mod}: {type(exc).__name__}: {exc}")
+                finally:
+                    sys.path.pop(0)
+        ivars = instance_vars(tree, alias_map)
+        rel = os.path.relpath(path, root)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name):
+                continue
+            base = node.value.id
+            if base in alias_map:
+                owner = loaded.get(alias_map[base])
+                label = f"{alias_map[base]}.{node.attr}"
+            elif base in ivars:
+                mod, cls = ivars[base]
+                owner = getattr(loaded.get(mod), cls, None)
+                label = f"{mod}.{cls}.{node.attr}"
+            else:
+                continue
+            if owner is None:
+                continue
+            checked += 1
+            if inspect.isclass(owner) and node.attr in declared_attrs(owner):
+                continue
+            if not hasattr(owner, node.attr):
+                offenders.append(f"{rel}: calls {label}, which does not exist")
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            fn = node.func
+            if not isinstance(fn.value, ast.Name):
+                continue
+            base = fn.value.id
+            if base in alias_map:
+                owner, label = loaded.get(alias_map[base]), f"{alias_map[base]}.{fn.attr}"
+                bound = False
+            elif base in ivars:
+                mod, cls = ivars[base]
+                owner, label = getattr(loaded.get(mod), cls, None), f"{mod}.{cls}.{fn.attr}"
+                bound = True                                   # `self` is already supplied
+            else:
+                continue
+            target = getattr(owner, fn.attr, None) if owner is not None else None
+            if target is None or not callable(target):
+                continue
+            call = node
+            if bound and inspect.isfunction(target):
+                args = [None] + [None] * len(call.args)
+                try:
+                    inspect.signature(target).bind(*args, **{k.arg: None for k in call.keywords
+                                                             if k.arg is not None})
+                    continue
+                except TypeError as exc:
+                    offenders.append(f"{rel}: {label}(...) does not bind — {exc}")
+                    continue
+            ok, why = call_arity_ok(target, call)
+            if not ok:
+                offenders.append(f"{rel}: {label}(...) does not bind — {why}")
+
+    print(f"modules with consumers: {len(consumed)}   references checked: {checked}")
+    for mod in sorted(consumed):
+        drive = covered_by_a_drive.get(mod)
+        note = f"return shapes driven by {drive}" if drive else "NO return-shape drive"
+        print(f"  {mod:30} {len(consumed[mod]):3} consumers   {note}")
+    for u in unimportable:
+        print(f"  could not import {u}")
+    if unimportable:
+        offenders.append(f"{len(unimportable)} module(s) with consumers would not import")
+    if offenders:
+        print("\nOFFENDERS")
+        for o in offenders:
+            print("  " + o)
+        return 1
+    print("\nevery consumer's references and call arities bind")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -157,5 +157,58 @@ for name in sorted(instance_calls):
         print(f"FAIL Evidence.{name} is called by a harness and does not exist")
 print(f"ok   harness API present: {len(module_calls)} module + {len(instance_calls)} instance names")
 
+# --- the return SHAPES, driven ------------------------------------------------------------------
+#
+# The static contract check beside this (Scripts/check-python-contracts.py) proves every name a
+# consumer references exists and every call binds. It cannot see a function that keeps its name and
+# its signature and starts returning something else — nothing static can, in untyped Python. This
+# drives the whole non-capture surface headlessly and asserts what comes back.
+#
+# Everything except shot() and record_screen() runs without Logic and without a display; visual()
+# is fed two synthetic PNGs. That is what makes this runnable in CI, which is the only place it
+# stops a merge.
+import struct
+import tempfile
+import zlib
+
+
+def _png(path, colour):
+    raw = b"".join(b"\x00" + bytes(colour) * 4 for _ in range(4))
+
+    def chunk(tag, data):
+        body = tag + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body))
+
+    open(path, "wb").write(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b""))
+
+
+tmp = tempfile.mkdtemp()
+ev = E.Evidence(head="0" * 40, root=tmp, name="contract-drive")
+shapes = []
+shapes.append(("Evidence.dir is a str", isinstance(ev.dir, str)))
+ev.check("t", True, "expected", "observed", "a mutation")
+ev.note("n", {"a": 1})
+ev.restored("r", True, "why")
+a, b = os.path.join(tmp, "a.png"), os.path.join(tmp, "b.png")
+_png(a, (1, 2, 3))
+_png(b, (1, 2, 3))
+ev.visual("v", a, b, (0, 0, 4, 4), expect_change=False, why="w", subject="a synthetic square")
+out = ev.write()
+shapes.append(("write() returns a dict", isinstance(out, dict)))
+shapes.append(("summary carries every required key",
+               all(k in out for k in E._REQUIRED_SUMMARY_KEYS)))
+shapes.append(("counters are ints", all(isinstance(out[k], int) for k in E._REQUIRED_SUMMARY_KEYS)))
+shapes.append(("is_clean() returns a bool", isinstance(E.is_clean(out), bool)))
+shapes.append(("the driven visual named a subject", out["visual_assertions_without_a_subject"] == 0))
+shapes.append(("have_tools() returns a list", isinstance(E.have_tools(), list)))
+shapes.append(("_safe_name() returns a str", isinstance(E._safe_name("x"), str)))
+for why, ok in shapes:
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} shape: {why}")
+
 print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
 sys.exit(1 if failed else 0)


### PR DESCRIPTION
#624 fixed the module that broke. This is the class it belongs to, at the owner's direction.

## The class, in one sentence

> **A module can be changed so that every caller breaks while nothing notices, because the checks that exist look at the module and the callers live somewhere else.**

Deleting a name — what actually happened — is the cheapest version. The same hole is open when a signature gains a required argument, or when a return value changes shape. **The name is still there in both.**

## Scope is derived, and the measurement widened it

`Scripts/check-python-contracts.py` writes no list. Every `.py` is a candidate; a module is in scope exactly when another file imports it.

```
local python modules      66
modules with consumers    12      ← not the one that broke
references checked      1187
```

A hand-kept list goes stale the moment a new module gets its first consumer, which is precisely when it starts mattering. Worth saying plainly: the honest answer to *"is anything outside `Scripts/livekit/` affected"* was not "no" — it was **"eleven more"**.

For each consumer, under the alias it really imported: every referenced name must exist; every call must **bind against the real signature**; and a variable assigned from `M.Class(...)` carries that class, so its attributes are checked too. Names assigned to `self` are read statically — `hasattr(Evidence, "dir")` is False for a name plainly set in `__init__`, and constructing the class would create directories as a side effect of a check.

## What it cannot do, said rather than implied

Return **shape** is not static. `f()` going from a list to a dict keeps its name and its signature, and no static pass sees it in untyped Python.

So the report **names the modules with no return-shape drive** — eleven of twelve — rather than reporting a clean bill it has not earned. A check that states what it did not look at cannot lie about its own coverage. Tracked in #625.

The covered one is driven instead: `test_evidence.py` now runs the whole non-capture surface headlessly — construct, `check`, `note`, `restored`, `visual` against two 4×4 PNGs it generates, `write`, `is_clean` — and asserts what comes back. This is possible because everything except `shot()` and `record_screen()` needs neither Logic nor a display, which had to be measured to be believed.

Two more places it declines to guess: a call site spreading `*args`/`**kwargs` has undecidable arity and is passed, and only `var = M.Class(...)` is followed for instance types. Guessing there would produce false reds, and a check that cries wolf gets switched off.

## Four ways to break a consumer, each mutated

```
                          static   drive
name deleted                 1       1
signature gains an arg       1       1
return list -> dict          0       1     ← only the drive sees it
rewritten to a stub          1       1
baseline / restored          0       0
```

The third is the point. It is also the most likely to appear next, and it is the one a name check would have waved through.

## Where it runs

In `compile` and `test`, beside the existing fail-fast guards. `build` fans in over both, so a red blocks the merge. No new required context, so the ruleset needs no edit — a check that names a defect but never runs is not a control.