### PR TITLE
test(#622): 608 claimed the document was unchanged while watching the title bar

### DIFF
--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -1,9 +1,14 @@
 // A NAMED region of the arrange window, in window coordinates, emitted as JSON with the name it
 // matched — so a caller can state what the band IS, not only where it is.
 //
-//   ./ax_control_bar_band                 -> the Control Bar (the default; #614 depends on it)
-//   ./ax_control_bar_band "Control Bar"   -> the same, named explicitly
-//   ./ax_control_bar_band "<AXDescription>" -> any region Logic describes by that exact string
+//   ./ax_control_bar_band "<AXDescription>" [--role R] [--min-width N] [--min-height N]
+//
+// An AXDescription is NOT unique. Measured on this window: "Control Bar" matches two elements,
+// "Library" four, "Event" three. The first version walked depth-first and returned whichever it
+// reached first, which is first-match dressed as identity — the same defect this file exists to
+// remove from the harnesses. It now REFUSES when more than one element survives the filters and
+// prints all of them, so the caller adds a discriminator it can state out loud rather than
+// inheriting one from tree order.
 //
 // A band written as coordinates is not defined by its content: the top-left 240x28 of the arrange
 // window is the track-name column with the Mixer closed and a column of mixer strips with it open,
@@ -64,8 +69,15 @@ func emit(_ o: [String: Any]) -> Never {
 // The claim a refusal that writes nothing CAN keep is that it did not touch the transport. The
 // control bar is chrome rather than document, so it does not scroll with the arrange, and its clock
 // only advances while the transport is running — which the quiet probe checks before this is used.
-let wanted = CommandLine.arguments.count > 1 && !CommandLine.arguments[1].isEmpty
-    ? CommandLine.arguments[1] : "Control Bar"
+let argv = CommandLine.arguments
+let wanted = argv.count > 1 && !argv[1].isEmpty ? argv[1] : "Control Bar"
+func flag(_ name: String) -> String? {
+    guard let i = argv.firstIndex(of: name), argv.count > i + 1 else { return nil }
+    return argv[i + 1]
+}
+let wantRole = flag("--role")
+let minWidth = Int(flag("--min-width") ?? "0") ?? 0
+let minHeight = Int(flag("--min-height") ?? "0") ?? 0
 
 guard let app = NSWorkspace.shared.runningApplications.first(where: {
     ($0.bundleIdentifier ?? "").contains("logic")
@@ -75,18 +87,32 @@ guard let win = ((attr(ax, kAXWindowsAttribute as String) as? [AXUIElement]) ?? 
     str($0, kAXSubroleAttribute as String) == (kAXStandardWindowSubrole as String)
 }), let wf = frame(win) else { emit(["error": "no standard window"]) }
 
-var rail: AXUIElement?
+var hits: [AXUIElement] = []
 func walk(_ e: AXUIElement, _ d: Int) {
-    guard d <= 18, rail == nil else { return }
+    guard d <= 18 else { return }
     for c in kids(e) {
-        if str(c, kAXDescriptionAttribute as String) == wanted { rail = c; return }
+        if str(c, kAXDescriptionAttribute as String) == wanted,
+           let f = frame(c),
+           f.2 >= minWidth, f.3 >= minHeight,
+           wantRole == nil || str(c, kAXRoleAttribute as String) == wantRole {
+            hits.append(c)
+        }
         walk(c, d + 1)
-        if rail != nil { return }
     }
 }
 walk(win, 0)
 
-guard let r = rail, let rf = frame(r) else {
+func describeHit(_ e: AXUIElement) -> [String: Any] {
+    let f = frame(e) ?? (0, 0, 0, 0)
+    return ["role": str(e, kAXRoleAttribute as String),
+            "band": [f.0 - wf.0, f.1 - wf.1, f.2, f.3]]
+}
+if hits.count > 1 {
+    emit(["error": "AXDescription is ambiguous — add --role / --min-width / --min-height",
+          "wanted": wanted, "matches": hits.map(describeHit),
+          "window": str(win, kAXTitleAttribute as String)])
+}
+guard let r = hits.first, let rf = frame(r) else {
     emit(["error": "no element with that exact AXDescription",
           "wanted": wanted,
           "window": str(win, kAXTitleAttribute as String)])
@@ -94,5 +120,6 @@ guard let r = rail, let rf = frame(r) else {
 emit([
     "window": str(win, kAXTitleAttribute as String),
     "description": str(r, kAXDescriptionAttribute as String),
+    "role": str(r, kAXRoleAttribute as String),
     "band": [rf.0 - wf.0, rf.1 - wf.1, rf.2, rf.3],
 ])

--- a/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
+++ b/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
@@ -109,13 +109,13 @@ BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
 subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
 
 
-def located_band(description="Control Bar"):
+def located_band(*selector):
     """(band, subject) for a named region, or (None, None) — never a fallback rectangle.
 
     Falling back to coordinates when the lookup fails would put the run back on the footing this
     replaces, and it would do it silently, on the runs where AX is least trustworthy.
     """
-    r = subprocess.run([BAND_TOOL, description], capture_output=True, text=True)
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
     try:
         payload = json.loads(r.stdout or "{}")
     except ValueError:
@@ -126,7 +126,10 @@ def located_band(description="Control Bar"):
     return tuple(b), payload.get("description")
 
 
-band, band_subject = located_band()
+# "Control Bar" matches TWO elements in this window — the strip and a smaller group inside it — so
+# the lookup refuses without a discriminator rather than returning whichever the tree walk reached
+# first. The width is the discriminator, stated here instead of inherited from walk order.
+band, band_subject = located_band("Control Bar", "--min-width", "1000")
 ev.check("293/precondition-the-window-frame-is-known", band is not None and bool(band_subject),
          "the arrange window's frame read AND the Control Bar located by AXDescription, so the "
          "capture band is inside the window and can say what it watches. No fallback rectangle: a "

--- a/Scripts/livekit/live_608_first_call_is_not_refused.py
+++ b/Scripts/livekit/live_608_first_call_is_not_refused.py
@@ -93,10 +93,35 @@ located = [(t, E.logic_window(t)) for t in titles]
 located = [(t, w) for t, w in located if w]
 located.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
 arrange_title, win = located[0] if located else (titles[0], None)
-band = (0, 0, win["w"], 28) if win else None
-ev.check("608/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+# #622: the claim below is that the DOCUMENT is unchanged, and this band used to be a 28px strip
+# at the very top of the window — chrome, above the Control Bar, and not the document at all. It
+# also named nothing: of the described elements in this window, none sits at those coordinates.
+# `Tracks contents` is the arrange document area, located by AXDescription, so the band watches what
+# the claim is about and can say what it watched.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(description):
+    """(band, subject) for a named region, or (None, None). No fallback rectangle: falling back to
+    coordinates would silently restore what this replaces, on the runs where AX is least reliable."""
+    r = subprocess.run([BAND_TOOL, description], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+band, band_subject = located_band("Tracks contents")
+ev.check("608/precondition-the-window-frame-is-known", band is not None and bool(band_subject),
+         "the arrange document area located by AXDescription, so the band watches the thing the "
+         "visual below claims about. A failed lookup is a red precondition, not a guess",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -169,7 +194,7 @@ time.sleep(2)
 
 after = ev.shot("608/after", settle_region=band, window_title=arrange_title)
 ev.visual("608/the-guard-changed-nothing-on-screen",
-          before["file"], after["file"], band, expect_change=False,
+          before["file"], after["file"], band, expect_change=False, subject=band_subject,
           why="this whole change is to a read-only preflight, so the document window must look "
               "exactly as it did — a difference would mean something in the run wrote to the project")
 

--- a/Scripts/livekit/live_614_the_refusal_it_can_still_reach.py
+++ b/Scripts/livekit/live_614_the_refusal_it_can_still_reach.py
@@ -84,7 +84,7 @@ def document_titles():
 
 
 def _control_bar_band():
-    """The window's control bar, in window coordinates, or None.
+    """(band, subject) for the control bar in window coordinates, or (None, None).
 
     Located by AXDescription through a raw-AX witness rather than System Events: twice this week a
     rule prototyped through System Events failed to hold through the API the product uses.
@@ -93,14 +93,19 @@ def _control_bar_band():
     out = os.path.join(os.path.dirname(src), ".ax_control_bar_band.bin")
     if subprocess.run(["swiftc", "-O", src, "-o", out],
                       capture_output=True, text=True).returncode != 0:
-        return None
-    r = subprocess.run([out], capture_output=True, text=True)
+        return None, None
+    # "Control Bar" is not a unique AXDescription in this window; the tool refuses ambiguity, so
+    # the width discriminator is passed explicitly rather than relying on tree order.
+    r = subprocess.run([out, "Control Bar", "--min-width", "1000"], capture_output=True, text=True)
     try:
         payload = json.loads(r.stdout or "{}")
     except ValueError:
-        return None
+        return None, None
     b = payload.get("band")
-    return tuple(b) if isinstance(b, list) and len(b) == 4 else None
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    # The name comes back off the element that answered, so `subject` cannot drift from the band.
+    return tuple(b), payload.get("description")
 
 
 def save_panels():
@@ -152,9 +157,9 @@ arrange_title, win = located[0] if located else (titles[0], None)
 #
 # The locator emits nothing when the description is not found, which is a failed precondition rather
 # than a licence to fall back to a rectangle.
-band = _control_bar_band()
+band, band_subject = _control_bar_band()
 ev.check("614/precondition-the-control-bar-was-located",
-         band is not None,
+         band is not None and bool(band_subject),
          "the visual band is the control bar found by its AXDescription, so it watches the same thing "
          "whatever pane is open and wherever the arrange has scrolled to",
          f"band={band!r}", None)
@@ -313,7 +318,7 @@ after = ev.shot("604/after", settle_region=band, window_title=after_title)
 # `expect_change` to match whatever happened would make the check pass by agreeing with the result,
 # which is the defect this whole directory exists to refuse.
 ev.visual("614/the-transport-is-undisturbed",
-          before["file"], after["file"], band, expect_change=False,
+          before["file"], after["file"], band, expect_change=False, subject=band_subject,
           why="a refusal that writes nothing must leave the transport exactly as it found it. Aimed "
               "at the control bar on purpose: no region of the DOCUMENT is invariant across a "
               "refusal — the arrange scrolls when a modal takes and returns focus — and a control "


### PR DESCRIPTION
Third of thirty-one. **No closing keyword** — #622 is not finished by this.

## The defect this exposes

`live_608`'s visual said:

> *"the document window must look exactly as it did — a difference would mean something in the run wrote to the project"*

and the band it watched was `(0, 0, win["w"], 28)`: a strip at the very top of the window, **above** the Control Bar. That is chrome, not the document. A write to the project could not have shown up there.

So the claim and the watched region were about different things, and the check would have stayed green through the exact failure it exists to catch.

## Why `subject=` could not simply be filled in

This is the finding that re-scoped #622. I dumped every element the arrange window describes — **478 of them, with frames** — and joined them against the harness bands:

```
literal / window-derived bands evaluable against the live window   18
of those, matching a described element                              0
```

Zero. The bands are not under-documented; **they are pointed at places the UI does not name**, and in 608's case at a place its own claim was not about. Annotating them would have written a caption onto the wrong picture.

## The change

`Tracks contents` — the arrange document area — located by AXDescription, with the name read back off the element that answered. A failed lookup is a red precondition, not a fallback rectangle: falling back to coordinates would silently restore what this replaces, on exactly the runs where AX is least reliable.

The claim got **more** honest, not narrower — the band now watches the document the sentence is about.

## Live, at this head

```
checks 7/7 · mutation-backed 2 · captures 2 · visual 1 (0 failed)
recordings 1 · operations_driven 5 · restorations_failed 0 · cached-as-live 0
visual_assertions_without_a_subject 0
```

## What remains, and why it is not a sweep

Twenty-eight harnesses still write their band down. Each needs the same judgement — *what is this claim actually about, and which named region can carry it* — and a live re-run to show it still holds.

Two of the five sharing this title-strip band are **not** convertible the same way, checked rather than assumed: `live_606`'s claim is genuinely about the window title (`expect_change=True` on a rename), and macOS does not expose the title bar as a described element; the two `live_291` harnesses claim about the Mixer, whose named region has to be located with the Mixer actually open. Those are separate pieces of work, not a search-and-replace.