### PR TITLE
feat(#628): a locator that counts its candidates, its first consumer, and a ratchet over the rest

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1091,4 +1091,39 @@ enum AXLocalePolicy {
             elementMatches($0, labels, mode: mode, runtime: runtime)
         }
     }
+
+    /// What a lookup found AND how many candidates it had to choose between.
+    ///
+    /// `findDescendant` above returns the first match in traversal order and says nothing about the
+    /// rest. When it is right, nothing records that it was right for a reason rather than by luck —
+    /// and that silence is the defect, not the choosing. Measured on one arrange window,
+    /// `AXDescription` "Control Bar" matches two elements, "Library" four, "Event" three; a lookup
+    /// for any of them returns something plausible either way.
+    ///
+    /// `candidates` is the whole point. `1` is a fact a later reader can weigh. Absence is not.
+    struct Census {
+        let element: AXUIElement?
+        let candidates: Int
+
+        /// Exactly one match: the only case where the result is identified rather than merely found.
+        var isUnambiguous: Bool { candidates == 1 }
+    }
+
+    /// Every match, with the count, so a caller can refuse ambiguity instead of inheriting
+    /// traversal order. Deliberately additive: `findDescendant` keeps its behaviour, and adoption is
+    /// counted rather than forced, because flipping every call site at once would turn a census into
+    /// a wall of red and the next move after that is somebody deleting the check.
+    static func censusDescendant(
+        of element: AXUIElement,
+        role: String,
+        matching labels: LabelSet,
+        mode: MatchMode = .exact,
+        maxDepth: Int = 5,
+        runtime: AXHelpers.Runtime
+    ) -> Census {
+        let hits = AXHelpers.findAllDescendants(
+            of: element, role: role, maxDepth: maxDepth, runtime: runtime
+        ).filter { elementMatches($0, labels, mode: mode, runtime: runtime) }
+        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count)
+    }
 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -3072,13 +3072,21 @@ extension AccessibilityChannel {
                 continue
             }
             found = true
-            if let cancel = AXLocalePolicy.findDescendant(
+            // #628: identified, not merely found. `findDescendant` returns the first match in
+            // traversal order, so with two Cancel-labelled buttons it presses one and nothing
+            // records that there was a choice. Measured on the real dialog there is exactly one
+            // (its children are Cancel and OK), so the census returns that one and the behaviour is
+            // unchanged — the difference is that the single candidate is now a checked fact rather
+            // than an assumption. A second one falls through to the close-button and Escape paths
+            // below, which is the existing fail-open-to-a-safer-route behaviour, not a new refusal.
+            let cancelCensus = AXLocalePolicy.censusDescendant(
                 of: window,
                 role: kAXButtonRole as String,
                 matching: AXLocalePolicy.cancelButton,
                 maxDepth: 4,
                 runtime: runtime.ax
-            ) {
+            )
+            if let cancel = cancelCensus.element {
                 // ADR-001 coordinate ban: dismiss via AXPress only (Escape remains
                 // the terminal non-coordinate fallback below).
                 if AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax) {

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -466,6 +466,59 @@ struct AXLocalePolicyTests {
         #expect(shallow == nil)
     }
 
+    // MARK: - censusDescendant (#628: identity from a discriminator, not tree order)
+
+    /// `findDescendant` returns the first match in traversal order and says nothing about the rest.
+    /// When it is right, nothing records that it was right for a reason — and that silence is the
+    /// defect, not the choosing. These two pin BOTH halves: a second candidate must be refused, and
+    /// a single candidate must be REPORTED as single. The second is the one easy to leave out.
+    @Test("censusDescendant refuses two candidates and names how many there were")
+    func censusRefusesAmbiguity() {
+        let builder = FakeAXRuntimeBuilder()
+        let first = addPolicyElement(builder, 90, role: kAXButtonRole as String, title: "취소")
+        let second = addPolicyElement(builder, 91, role: kAXButtonRole as String, title: "취소")
+        let window = addPolicyElement(
+            builder, 92, role: kAXWindowRole as String, children: [first, second]
+        )
+        let runtime = builder.makeAXRuntime()
+
+        let census = AXLocalePolicy.censusDescendant(
+            of: window, role: kAXButtonRole as String,
+            matching: AXLocalePolicy.cancelButton, maxDepth: 4, runtime: runtime
+        )
+        #expect(census.candidates == 2)
+        #expect(census.element == nil)
+        #expect(!census.isUnambiguous)
+
+        // What the old helper does with the same tree: returns one, silently.
+        let blind = AXLocalePolicy.findDescendant(
+            of: window, role: kAXButtonRole as String,
+            matching: AXLocalePolicy.cancelButton, maxDepth: 4, runtime: runtime
+        )
+        #expect(blind == first, "the defect this exists to expose: a plausible answer, chosen by order")
+    }
+
+    @Test("censusDescendant records that a single candidate WAS single")
+    func censusRecordsUniqueness() {
+        let builder = FakeAXRuntimeBuilder()
+        let decoy = addPolicyElement(builder, 93, role: kAXStaticTextRole as String, title: "취소")
+        let only = addPolicyElement(builder, 94, role: kAXButtonRole as String, title: "취소")
+        let window = addPolicyElement(
+            builder, 95, role: kAXWindowRole as String, children: [decoy, only]
+        )
+        let runtime = builder.makeAXRuntime()
+
+        let census = AXLocalePolicy.censusDescendant(
+            of: window, role: kAXButtonRole as String,
+            matching: AXLocalePolicy.cancelButton, maxDepth: 4, runtime: runtime
+        )
+        // `element == only` alone would pass just as well against the blind helper. The count is
+        // what makes this an identification rather than a find.
+        #expect(census.candidates == 1)
+        #expect(census.element == only)
+        #expect(census.isUnambiguous)
+    }
+
     // MARK: - Phase 2 (#60) read-only locator label sets
 
     /// `.exactStrict` mode preserves verbatim (no-trim) equality used by the

--- a/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
+++ b/Tests/LogicProMCPTests/Issue498GoToDialogClassifierTests.swift
@@ -5,7 +5,8 @@ import Testing
 private func makeIssue498Fixture(
     title: String,
     subrole: String,
-    isModal: Bool
+    isModal: Bool,
+    secondCancel: Bool = false
 ) -> (
     builder: FakeAXRuntimeBuilder,
     runtime: AXLogicProElements.Runtime,
@@ -25,7 +26,16 @@ private func makeIssue498Fixture(
     builder.setAttribute(cancel, kAXTitleAttribute as String, "Cancel")
     builder.setAttribute(ok, kAXRoleAttribute as String, kAXButtonRole as String)
     builder.setAttribute(ok, kAXTitleAttribute as String, "OK")
-    builder.setChildren(window, [cancel, ok])
+    // #628: a second button carrying the same label. The real dialog has exactly one — measured,
+    // its children are Cancel and OK — so this is the case the census exists to notice.
+    if secondCancel {
+        let decoy = builder.element(498_005)
+        builder.setAttribute(decoy, kAXRoleAttribute as String, kAXButtonRole as String)
+        builder.setAttribute(decoy, kAXTitleAttribute as String, "Cancel")
+        builder.setChildren(window, [cancel, decoy, ok])
+    } else {
+        builder.setChildren(window, [cancel, ok])
+    }
 
     return (builder, builder.makeLogicRuntime(appElement: app), cancel)
 }
@@ -42,6 +52,26 @@ func issue498DismissesExactFloatingModalDialog() {
     #expect(fixture.builder.actionCalls.count == 1)
     #expect(fixture.builder.actionCalls.first?.elementID == fixture.builder.elementID(fixture.cancel))
     #expect(fixture.builder.actionCalls.first?.action == kAXPressAction as String)
+}
+
+@Test("Issue628: two same-labelled Cancels are not pressed on a guess")
+func issue628AmbiguousCancelIsNotPressedByTreeOrder() {
+    let fixture = makeIssue498Fixture(
+        title: "Go To Position",
+        subrole: kAXFloatingWindowSubrole as String,
+        isModal: true,
+        secondCancel: true
+    )
+    // Still dismissed — the close-button and Escape routes are unchanged. What must NOT happen is
+    // pressing whichever Cancel the traversal reached first, which is what the old lookup did
+    // while recording nothing about there having been a choice.
+    _ = AccessibilityChannel.closeGoToPositionDialog(runtime: fixture.runtime)
+    let pressedTheFirstCancel = fixture.builder.actionCalls.contains {
+        $0.elementID == fixture.builder.elementID(fixture.cancel)
+            && $0.action == kAXPressAction as String
+    }
+    #expect(!pressedTheFirstCancel,
+            "identity came from tree order: with two candidates neither is identified")
 }
 
 @Test("Issue498: standard non-modal project window is not touched")


### PR DESCRIPTION
Items 1 and 2 of #628. **No closing keyword** — item 3 (carrying the count into live evidence) remains.

## The defect

```swift
// AXLocalePolicy.swift:1090      findAllDescendants(…).first { elementMatches(…) }
// AXHelpers.swift:479-481        if roleMatch && titleMatch && idMatch { return child }
```

Both return the first match in traversal order and say nothing about the rest. **When the answer is right, nothing records that it was right for a reason rather than by luck.** Measured on one arrange window: `"Control Bar"` matches two elements, `"Library"` four, `"Event"` three.

## First, correcting my own number

#628 said **110**. That was every call to either locator. Finding many and *using* many is not this defect — 89 of those 110 are fine and never were the problem.

```
findDescendant(                        19   returns the first match, silently
findAllDescendants(...).first           8   narrowed to one within the expression
                                      ---
sites that keep one, counting nothing  27   in 11 files
```

The wrong figure was wrong in the **flattering** direction, which is why it went unchallenged — the same shape as the defect itself, one level up: a plausible answer stood because it pointed where I expected.

## `censusDescendant`

Returns the match **and the count**. `candidates == 1` is a fact a later reader can weigh; its absence is what exists today. Additive — `findDescendant` keeps its behaviour.

Both halves pinned, **the second being the one easy to leave out**:

```
census takes the first match instead of refusing   red
census always reports candidates: 1                red   ← the point
```

A test asserting only `element == only` passes against the blind helper too. The count is what makes it an identification rather than a find.

## It ships with a consumer, not alone

A function with no callers cannot be shown to work against the running application — a live run goes green and says nothing about it. That is what the gate refused on #616 this morning, correctly.

`closeGoToPositionDialog`'s Cancel lookup adopts it. The real dialog has exactly one Cancel (children are Cancel and OK, measured under #498), so **behaviour is unchanged**; what changes is that the single candidate is a checked fact. Two candidates fall through to the close-button and Escape routes — existing fail-open-to-a-safer-path behaviour, not a new refusal. The #498 fixture grows a second same-labelled button, and reverting the call site turns it red.

## A ratchet over the remaining 27

Not a gate on zero: they cannot convert at once, each needs its own judgement about what discriminates the target, and each product conversion needs live proof. Gating on zero paints the tree red, and the move after that is somebody deleting the check.

**The bar only moves down.** Adding a lookup fails it; converting one leaves it *under* budget, which also fails — so ground gained has to be claimed. The derived count is always printed, so a budget that has drifted is visible rather than trusted.

```
a new findDescendant call site   28 > 27   exit 1
budget raised above the truth    27 < 28   exit 1
```

The first attempt at the first mutation reported *"not detected"* — falsely. The anchor it patched did not exist, so nothing was injected. **A control that never ran is not a control that passed**, and that is recorded in the commit rather than quietly fixed.

Runs in `compile` and `test`, which `build` fans in over.

## Live, at this head

```
live_534_goto_position:  6/6 checks · 6 of 6 mutation-backed · 2 captures
                         1 visual (0 failed) · 1 recording · 3 operations · 0 cached-as-live
```

It drives the dialog this change touches, and every check in it is mutation-backed.