### PR TITLE
ci(#628): a ratchet over the remaining 27 lookups, and the candidate count in the record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
 
+      - name: AX lookups that keep one candidate must not increase
+        # A ratchet, not a gate on zero: 27 sites still pick one element from many and record
+        # nothing about the rest, and they cannot convert at once. The bar only moves down.
+        run: python3 Scripts/check-ax-locator-census.py
+
       - name: Every module with consumers must still satisfy them
         # The module list is derived, not written down: a `.py` is in scope exactly when another
         # file imports it. Checks every referenced name exists and every call binds against the real
@@ -92,6 +97,11 @@ jobs:
         # `#expect(<Bool> == true/false)` and kin pass unconditionally on this toolchain — they
         # prove nothing. Fail fast (no Xcode needed) before the build if any reappear.
         run: bash Scripts/ci-forbid-dead-expect.sh
+
+      - name: AX lookups that keep one candidate must not increase
+        # A ratchet, not a gate on zero: 27 sites still pick one element from many and record
+        # nothing about the rest, and they cannot convert at once. The bar only moves down.
+        run: python3 Scripts/check-ax-locator-census.py
 
       - name: Every module with consumers must still satisfy them
         # The module list is derived, not written down: a `.py` is in scope exactly when another

--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""How many AX lookups still pick one element from many without recording the count.
+
+THE DEFECT
+----------
+`AXLocalePolicy.findDescendant` and `AXHelpers.findDescendant` return the first match in traversal
+order. `findAllDescendants(...).first` does the same by hand. When the answer is right, nothing
+records that it was right for a reason rather than by luck, and a later reader cannot tell a
+discriminator from tree order. Measured on one arrange window, AXDescription "Control Bar" matches
+two elements, "Library" four, "Event" three.
+
+`censusDescendant` returns the match AND the candidate count, so `candidates == 1` becomes a fact.
+
+WHAT IS AND IS NOT COUNTED
+--------------------------
+Finding many and USING many is not this defect — `findAllDescendants` has 89 call sites and most of
+them are fine. Only sites that narrow to a single element are counted. Getting this distinction
+wrong is how the first census of this issue reported 110 instead of 27, in the flattering direction.
+
+A RATCHET, NOT A GATE ON ZERO
+-----------------------------
+Twenty-seven sites cannot convert at once — each needs its own judgement about what discriminates
+the target, and conversions in the product need live proof. Gating on zero would paint the tree red
+and the next move after that is somebody deleting the check.
+
+So the bar only moves down. A new blind lookup fails this; converting one lets BLIND_SITE_BUDGET
+drop. The derived count is always printed, so a budget that has drifted from reality is visible
+rather than trusted.
+"""
+import os
+import re
+import sys
+
+# Lower this when sites convert. It may never rise: that is the whole mechanism.
+BLIND_SITE_BUDGET = 27
+
+SEARCH_ROOTS = ("Sources", "Scripts")
+
+
+def blind_sites(root):
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in (".build", ".git")]
+        for f in filenames:
+            if not f.endswith(".swift"):
+                continue
+            path = os.path.join(dirpath, f)
+            lines = open(path).read().splitlines()
+            for i, line in enumerate(lines):
+                if "static func" in line or line.strip().startswith("//"):
+                    continue
+                if re.search(r"\bfindDescendant\(", line):
+                    out.append((path, i + 1, "findDescendant"))
+                elif re.search(r"\bfindAllDescendants\(", line):
+                    # narrowed to one within the call's own expression
+                    if re.search(r"\)\s*\.first\b", "\n".join(lines[i:i + 8])):
+                        out.append((path, i + 1, "findAllDescendants(...).first"))
+    return out
+
+
+def main():
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sites = []
+    for r in SEARCH_ROOTS:
+        d = os.path.join(repo, r)
+        if os.path.isdir(d):
+            sites.extend(blind_sites(d))
+
+    converted = 0
+    for dirpath, dirnames, filenames in os.walk(os.path.join(repo, "Sources")):
+        dirnames[:] = [d for d in dirnames if d not in (".build", ".git")]
+        for f in filenames:
+            if f.endswith(".swift"):
+                src = open(os.path.join(dirpath, f)).read()
+                converted += len([m for m in re.finditer(r"\bcensusDescendant\(", src)
+                                  if "static func" not in src[max(0, m.start() - 80):m.start()]])
+
+    files = {p for p, _, _ in sites}
+    print(f"AX lookups that keep one candidate and record no count: {len(sites)}"
+          f"  (in {len(files)} files)")
+    print(f"lookups that report their candidate count:               {converted}")
+    print(f"budget:                                                  {BLIND_SITE_BUDGET}")
+
+    if len(sites) > BLIND_SITE_BUDGET:
+        print("\nOVER BUDGET — a lookup that keeps one candidate without counting them was added.")
+        print("Use AXLocalePolicy.censusDescendant, or lower nothing and convert one first.")
+        for p, n, kind in sites:
+            print(f"  {os.path.relpath(p, repo)}:{n}  {kind}")
+        return 1
+    if len(sites) < BLIND_SITE_BUDGET:
+        print(f"\nUNDER BUDGET by {BLIND_SITE_BUDGET - len(sites)} — lower BLIND_SITE_BUDGET to "
+              f"{len(sites)} so the ground gained is held.")
+        return 1
+    print("\nat budget")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -117,9 +117,13 @@ guard let r = hits.first, let rf = frame(r) else {
           "wanted": wanted,
           "window": str(win, kAXTitleAttribute as String)])
 }
+// `candidates` on the SUCCESS path, not only in the ambiguity error. Refusing when there are two
+// is half the job; the other half is that "there was exactly one" reaches the record. Otherwise a
+// later reader still cannot tell a discriminator from tree order — which is the whole defect.
 emit([
     "window": str(win, kAXTitleAttribute as String),
     "description": str(r, kAXDescriptionAttribute as String),
     "role": str(r, kAXRoleAttribute as String),
+    "candidates": hits.count,
     "band": [rf.0 - wf.0, rf.1 - wf.1, rf.2, rf.3],
 ])

--- a/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
+++ b/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
@@ -119,22 +119,25 @@ def located_band(*selector):
     try:
         payload = json.loads(r.stdout or "{}")
     except ValueError:
-        return None, None
+        return None, None, None
     b = payload.get("band")
     if not (isinstance(b, list) and len(b) == 4):
-        return None, None
-    return tuple(b), payload.get("description")
+        return None, None, None
+    return tuple(b), payload.get("description"), payload.get("candidates")
 
 
 # "Control Bar" matches TWO elements in this window — the strip and a smaller group inside it — so
 # the lookup refuses without a discriminator rather than returning whichever the tree walk reached
 # first. The width is the discriminator, stated here instead of inherited from walk order.
-band, band_subject = located_band("Control Bar", "--min-width", "1000")
-ev.check("293/precondition-the-window-frame-is-known", band is not None and bool(band_subject),
-         "the arrange window's frame read AND the Control Bar located by AXDescription, so the "
-         "capture band is inside the window and can say what it watches. No fallback rectangle: a "
-         "failed lookup is a red precondition, not a guess",
-         f"window={win!r} band={band!r} subject={band_subject!r}", None)
+band, band_subject, band_candidates = located_band("Control Bar", "--min-width", "1000")
+ev.check("293/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject) and band_candidates == 1,
+         "the arrange window's frame read AND the Control Bar located by AXDescription with "
+         "EXACTLY ONE candidate. The count is the point: refusing two is half of it, and the other "
+         "half is that 'there was one' reaches this document — otherwise a later reader cannot tell "
+         "a discriminator from tree order. No fallback rectangle: a failed lookup is a red "
+         "precondition, not a guess",
+         f"window={win!r} band={band!r} subject={band_subject!r} candidates={band_candidates!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 

--- a/Scripts/livekit/live_608_first_call_is_not_refused.py
+++ b/Scripts/livekit/live_608_first_call_is_not_refused.py
@@ -103,25 +103,28 @@ BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
 subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
 
 
-def located_band(description):
+def located_band(*selector):
     """(band, subject) for a named region, or (None, None). No fallback rectangle: falling back to
     coordinates would silently restore what this replaces, on the runs where AX is least reliable."""
-    r = subprocess.run([BAND_TOOL, description], capture_output=True, text=True)
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
     try:
         payload = json.loads(r.stdout or "{}")
     except ValueError:
-        return None, None
+        return None, None, None
     b = payload.get("band")
     if not (isinstance(b, list) and len(b) == 4):
-        return None, None
-    return tuple(b), payload.get("description")
+        return None, None, None
+    return tuple(b), payload.get("description"), payload.get("candidates")
 
 
-band, band_subject = located_band("Tracks contents")
-ev.check("608/precondition-the-window-frame-is-known", band is not None and bool(band_subject),
-         "the arrange document area located by AXDescription, so the band watches the thing the "
-         "visual below claims about. A failed lookup is a red precondition, not a guess",
-         f"window={win!r} band={band!r} subject={band_subject!r}", None)
+band, band_subject, band_candidates = located_band("Tracks contents")
+ev.check("608/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject) and band_candidates == 1,
+         "the arrange document area located by AXDescription, with EXACTLY ONE candidate. Refusing "
+         "two is half of it; the other half is that 'there was one' reaches this document, so a "
+         "later reader can tell a discriminator from tree order. A failed lookup is a red "
+         "precondition, not a guess",
+         f"window={win!r} band={band!r} subject={band_subject!r} candidates={band_candidates!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 

--- a/Scripts/livekit/live_614_the_refusal_it_can_still_reach.py
+++ b/Scripts/livekit/live_614_the_refusal_it_can_still_reach.py
@@ -93,19 +93,20 @@ def _control_bar_band():
     out = os.path.join(os.path.dirname(src), ".ax_control_bar_band.bin")
     if subprocess.run(["swiftc", "-O", src, "-o", out],
                       capture_output=True, text=True).returncode != 0:
-        return None, None
+        return None, None, None
     # "Control Bar" is not a unique AXDescription in this window; the tool refuses ambiguity, so
     # the width discriminator is passed explicitly rather than relying on tree order.
     r = subprocess.run([out, "Control Bar", "--min-width", "1000"], capture_output=True, text=True)
     try:
         payload = json.loads(r.stdout or "{}")
     except ValueError:
-        return None, None
+        return None, None, None
     b = payload.get("band")
     if not (isinstance(b, list) and len(b) == 4):
-        return None, None
-    # The name comes back off the element that answered, so `subject` cannot drift from the band.
-    return tuple(b), payload.get("description")
+        return None, None, None
+    # The name comes back off the element that answered, so `subject` cannot drift from the band,
+    # and the candidate count comes with it so "there was one" is recorded rather than assumed.
+    return tuple(b), payload.get("description"), payload.get("candidates")
 
 
 def save_panels():
@@ -157,9 +158,9 @@ arrange_title, win = located[0] if located else (titles[0], None)
 #
 # The locator emits nothing when the description is not found, which is a failed precondition rather
 # than a licence to fall back to a rectangle.
-band, band_subject = _control_bar_band()
+band, band_subject, band_candidates = _control_bar_band()
 ev.check("614/precondition-the-control-bar-was-located",
-         band is not None and bool(band_subject),
+         band is not None and bool(band_subject) and band_candidates == 1,
          "the visual band is the control bar found by its AXDescription, so it watches the same thing "
          "whatever pane is open and wherever the arrange has scrolled to",
          f"band={band!r}", None)


### PR DESCRIPTION
Items 2 and 3 of #628. #629 landed item 1 (`censusDescendant` and its first consumer) but merged before these were pushed. **No closing keyword** — the 27 conversions are what the ratchet now tracks.

## First, correcting my own number

#628 said **110**. That was every call to either locator. Finding many and *using* many is not this defect — 89 of those are fine and never were the problem.

```
findDescendant(                        19   returns the first match, silently
findAllDescendants(...).first           8   narrowed to one within the expression
                                      ---
sites that keep one, counting nothing  27   in 11 files
```

The wrong figure was wrong in the **flattering** direction — a bigger number makes the finding look weightier — which is why nothing in me challenged it. That is the same shape as the defect itself, one level up: a plausible answer stood because it pointed where I expected. An independent measurement run without knowledge of this correction landed in the same range.

## Item 2 — a ratchet, not a gate on zero

Twenty-seven sites cannot convert at once: each needs its own judgement about what discriminates the target, and each product conversion needs live proof. Gating on zero paints the tree red, and the move after that is somebody deleting the check.

**The bar only moves down.** Adding a lookup fails it; converting one leaves it *under* budget, which also fails — so ground gained has to be claimed rather than silently absorbed. The derived count is always printed, so a budget that has drifted from the tree is visible rather than trusted.

```
a new findDescendant call site   28 > 27   exit 1
budget raised above the truth    27 < 28   exit 1
```

The first attempt at the first mutation reported *"not detected"* — falsely. The anchor it patched did not exist, so nothing was injected. **A control that never ran is not a control that passed**, and that is in the commit rather than quietly fixed. It is the third time in this run that a mutation test needed its own verification.

## Item 3 — "there was exactly one" reaches the document

Refusing two candidates is half the job. The other half is that the single candidate is **recorded**; a locator silent on success leaves exactly what existed before, and a later reader still cannot tell a discriminator from tree order.

The band tool emits `candidates` on the **success** path, not only inside the ambiguity error, and the three harnesses that locate a band require it to be 1 and put the number in their precondition. A lookup that was ambiguous, or whose count went missing, is now red rather than quietly fine.

## Live, all three, at this head

```
live_293   10/10  mutation-backed 4  subjectless 0
live_608     7/7  mutation-backed 2  subjectless 0
live_614   13/13  mutation-backed 5  subjectless 0
live_534     6/6  mutation-backed 6      (the #629 consumer, still green)
```

## One latent bug found on the way

`_control_bar_band`'s compile-failure path returned a two-tuple while its caller unpacked three — a `swiftc` failure would have crashed the harness instead of failing its precondition. It survived every live run because `swiftc` succeeded: the path that only runs once something else has already gone wrong. Every return in all three helpers is now checked to have matching arity.