### PR TITLE
fix(#628): the Control Bar is chosen by what it holds, not by what the walk reached first

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -46,7 +46,7 @@ import sys
 # had been blind to. Raising a ratchet for that reason is legitimate and has to be visible, which is
 # why the reason lives here rather than in a commit nobody re-reads. Raising it because something
 # went red is not.
-BLIND_SITE_BUDGET = 39
+BLIND_SITE_BUDGET = 38
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -53,13 +53,33 @@ extension AXLogicProElements {
     static func getControlBar(runtime: Runtime = .production) -> AXUIElement? {
         guard let window = mainWindow(runtime: runtime) else { return nil }
 
-        let groups = AXHelpers.findAllDescendants(of: window, role: kAXGroupRole, maxDepth: 8, runtime: runtime.ax)
-        for group in groups {
-            let desc = AXHelpers.getDescription(group, runtime: runtime.ax) ?? ""
-            if AXLocalePolicy.controlBarGroupLabel.matches(desc, mode: .exactStrict) {
-                return group
+        // #628: "Control Bar" is not a unique AXDescription. Measured on one arrange window, two
+        // groups carry it — (10, 54, 1900, 58) with twenty direct checkboxes, and
+        // (828, 58, 264, 48) with none. The loop that used to be here returned whichever the walk
+        // reached first, which is the right one today and says nothing about why.
+        //
+        // The discriminator is the property callers actually depend on: this is the bar you can
+        // find a transport control in. `findControlBarCheckbox` and its siblings all immediately
+        // search it for a checkbox, so a candidate holding none cannot be what they meant, whatever
+        // it is called.
+        let labelled = AXHelpers.findAllDescendants(
+            of: window, role: kAXGroupRole, maxDepth: 8, runtime: runtime.ax
+        ).filter { group in
+            AXLocalePolicy.controlBarGroupLabel.matches(
+                AXHelpers.getDescription(group, runtime: runtime.ax) ?? "", mode: .exactStrict
+            )
+        }
+        let withControls = labelled.filter { group in
+            AXHelpers.getChildren(group, runtime: runtime.ax).contains { child in
+                AXHelpers.getRole(child, runtime: runtime.ax) == kAXCheckBoxRole as String
             }
         }
+        // Exactly one, or nothing. Two bars that both hold transport controls is a tree this code
+        // has never seen and must not guess about; the callers all fail closed on nil.
+        if withControls.count == 1 { return withControls[0] }
+        // No labelled candidate holds a control: fall back to a lone labelled group rather than
+        // regressing to first-of-many, so a Logic that renders the bar differently still resolves.
+        if withControls.isEmpty, labelled.count == 1 { return labelled[0] }
         return nil
     }
 

--- a/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
@@ -294,6 +294,67 @@ import Testing
     #expect(AXLogicProElements.findControlBarBeatSlider(runtime: runtime) == beatSlider)
 }
 
+/// #628: two groups labelled "Control Bar" must not resolve by tree order either.
+///
+/// Measured on one arrange window: (10, 54, 1900, 58) with twenty direct checkboxes and
+/// (828, 58, 264, 48) with none. The walk reaches the real one first today, which is why nothing
+/// ever went wrong and why nothing ever recorded that it was luck. The discriminator is the
+/// property callers depend on — this is the bar you can find a transport control in.
+@Test func testControlBarPrefersTheLabelledGroupThatHoldsControls() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(910)
+    let window = builder.element(911)
+    let decoyBar = builder.element(912)
+    let realBar = builder.element(913)
+    let cycle = builder.element(914)
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window])
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    // The empty one FIRST, so passing by traversal order is not enough.
+    builder.setChildren(window, [decoyBar, realBar])
+    for bar in [decoyBar, realBar] {
+        builder.setAttribute(bar, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(bar, kAXDescriptionAttribute as String, "Control Bar")
+    }
+    builder.setChildren(realBar, [cycle])
+    builder.setAttribute(cycle, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    builder.setAttribute(cycle, kAXTitleAttribute as String, "Cycle")
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.getControlBar(runtime: runtime) == realBar)
+    #expect(AXLogicProElements.findControlBarCheckbox(
+        matching: AXLocalePolicy.transportCycleControl,
+        runtime: runtime
+    ) == cycle)
+}
+
+/// Two labelled bars that BOTH hold controls is a tree this code has never seen. It refuses rather
+/// than guessing, and every caller fails closed on nil.
+@Test func testControlBarRefusesTwoBarsThatBothHoldControls() {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(920)
+    let window = builder.element(921)
+    let firstBar = builder.element(922)
+    let secondBar = builder.element(923)
+
+    builder.setAttribute(app, kAXWindowsAttribute as String, [window])
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    builder.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    builder.setChildren(window, [firstBar, secondBar])
+    for (index, bar) in [firstBar, secondBar].enumerated() {
+        builder.setAttribute(bar, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(bar, kAXDescriptionAttribute as String, "Control Bar")
+        let box = builder.element(930 + index)
+        builder.setAttribute(box, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+        builder.setAttribute(box, kAXTitleAttribute as String, "Cycle")
+        builder.setChildren(bar, [box])
+    }
+
+    let runtime = builder.makeLogicRuntime(appElement: app)
+    #expect(AXLogicProElements.getControlBar(runtime: runtime) == nil)
+}
+
 /// #628: two checkboxes in the Control Bar carrying the same label must not resolve by tree order.
 ///
 /// Measured on one arrange window, "Solo" matches TWENTY checkboxes — one in the Control Bar and


### PR DESCRIPTION
**Merge after #632.** Both PRs target `main` — this branch was *cut from* #632's head so the ratchet arithmetic lines up, but GitHub-wise there is no base relationship and deleting #632's branch cannot close this one. Merging out of order just means a rebase.

No closing keyword; this is one more conversion on #628's ratchet.

## The scope that made the last conversion sound was itself a first-match

#632 converts `findControlBarCheckbox` because `"Solo"` matches **twenty** checkboxes window-wide — one in the Control Bar, nineteen track buttons — and scoping to the bar makes it unique. So: is the bar unique?

```
AXGroup desc="Control Bar", depth ≤ 8   →  2 candidates

candidate 0   (10, 54, 1900, 58)   direct checkboxes: 20   ← the walk reaches this first
candidate 1   (828, 58, 264, 48)   direct checkboxes:  0
```

**No.** `getControlBar` looped and returned the first. It returns the right one today, and nothing recorded that this was luck. Same defect, one level up, in the same file — and one of the thirteen loop-form spellings the census could not see until #632 taught it that shape.

## The two are not equally dangerous, and the fix order followed that

| | failure | how it shows |
| --- | --- | --- |
| widened `"Solo"` scope | presses a **track's** solo instead of the transport's | wrong target, **silent** |
| flipped Control Bar order | empty candidate → no checkbox → `nil` | no target, **loud** — every caller fails closed |

The quiet one was fixed first. Saying this plainly matters more than making both sound urgent: only one of them can act on the wrong object.

## The discriminator is the property callers depend on

This is *the bar you can find a transport control in*. A labelled group holding no checkbox cannot be what `findControlBarCheckbox` and its siblings meant, whatever it is called — they all immediately search it for one.

- Exactly one labelled group holding a control → that one.
- **Two** that both hold controls → `nil`. A tree this code has never seen is not one to guess about, and every caller fails closed.
- None holding a control, but exactly one labelled → that one, so a Logic rendering the bar differently still resolves rather than regressing to first-of-many.

## Mutations

```
reverted to first-of-labelled     3 issues
the checkbox filter removed       2 issues
```

The fixture puts the **empty** bar first, so passing by traversal order is not enough to satisfy it.

## Live

```
live_534_goto_position:  6/6 checks · 6 of 6 mutation-backed
```

Run against real Logic on the head that carries this change — the transport path still resolves its bar.

## Ratchet

39 → 38, and the budget is lowered in the same change, because leaving it high is how a ratchet quietly becomes a ceiling.

## Not done here

`getTransportBar` tries a toolbar, a descendant toolbar, then a group identified `Transport`. Measured on this Logic: **all three match zero.** Converting a lookup that never matches would lower the ratchet without changing anything — the number would move and the defect would not. Recorded on #628 so the next conversion starts from that measurement.
