### PR TITLE
fix(#622): three harnesses claimed the track-header rail; none was watching it

### DIFF
--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -83,9 +83,14 @@ guard let app = NSWorkspace.shared.runningApplications.first(where: {
     ($0.bundleIdentifier ?? "").contains("logic")
 }) else { emit(["error": "logic not running"]) }
 let ax = AXUIElementCreateApplication(app.processIdentifier)
-guard let win = ((attr(ax, kAXWindowsAttribute as String) as? [AXUIElement]) ?? []).first(where: {
+// Every standard window, not the first. This tool exists to stop a lookup resolving by tree order,
+// and it was choosing its WINDOW that way. Measured: a harness that had just started an MCP driver
+// got `band: null` while the identical call standing alone resolved fine, because the first
+// standard window was no longer the one holding the content.
+let standardWindows = ((attr(ax, kAXWindowsAttribute as String) as? [AXUIElement]) ?? []).filter {
     str($0, kAXSubroleAttribute as String) == (kAXStandardWindowSubrole as String)
-}), let wf = frame(win) else { emit(["error": "no standard window"]) }
+}
+guard !standardWindows.isEmpty else { emit(["error": "no standard window"]) }
 
 var hits: [AXUIElement] = []
 func walk(_ e: AXUIElement, _ d: Int) {
@@ -100,7 +105,17 @@ func walk(_ e: AXUIElement, _ d: Int) {
         walk(c, d + 1)
     }
 }
-walk(win, 0)
+// Search each standard window; the match must still be unique across all of them.
+var hitWindow: AXUIElement?
+for window in standardWindows {
+    let before = hits.count
+    walk(window, 0)
+    if hits.count > before, hitWindow == nil { hitWindow = window }
+}
+let win = hitWindow ?? standardWindows[0]
+guard let wf = frame(win) else {
+    emit(["error": "no standard window with a readable frame"])
+}
 
 func describeHit(_ e: AXUIElement) -> [String: Any] {
     let f = frame(e) ?? (0, 0, 0, 0)

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -692,6 +692,15 @@ def _region_hash(png, region, window_points=None):
     Returns None rather than falling back to a whole-file hash: an unusable comparison must be visible
     as unusable, not disguised as a difference.
     """
+    # A falsy region hashes the WHOLE FILE, which is how a region-less visual passes. The docstring
+    # above has always said otherwise, and the #620 review said so again; it stayed true anyway.
+    # Measured today: a band lookup returned None, `visual()` compared two whole images, found them
+    # equal, and reported a passing negative assertion about a rectangle it never looked at.
+    #
+    # A comparison with no region is not a weak comparison, it is a different one — "did anything on
+    # screen change" instead of "did this change" — and the run has no way to know it was answered.
+    if not region:
+        return None
     if not os.path.isfile(png):
         return None
     try:

--- a/Scripts/livekit/live_567_localized_owner_name.py
+++ b/Scripts/livekit/live_567_localized_owner_name.py
@@ -48,9 +48,40 @@ ARRANGE_SUFFIX = {"en": "Tracks", "ko": "트랙", "ja": "トラック"}[LOCALE]
 NBSP = " "
 # Band over the arrange window's track headers. Nothing this run does is a write, so the assertion
 # over it is a NEGATIVE one.
-TRACK_BAND = (10, 120, 260, 200)
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+# #622: the coordinate here was (10, 120, 260, 200), which is inside the LIBRARY — the same origin
+# and width appear in four harnesses, one wrong rectangle copied rather than four mistakes. The
+# claim below is about the track headers, and `Tracks header` sits at x=603 w=325 with no overlap.
+#
+# It is resolved HERE rather than where the coordinate was, because the tool compiles into ev.dir
+# and `ev` does not exist two lines earlier. A first attempt put it there and died on NameError.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+TRACK_BAND, TRACK_SUBJECT = located_band("Tracks header")
+ev.check("567/precondition-the-track-header-rail-was-located",
+         TRACK_BAND is not None and bool(TRACK_SUBJECT),
+         "the rail this run asserts about, located by AXDescription. A failed lookup is a red "
+         "precondition — before #634 a None band silently became a whole-image comparison that "
+         "passed",
+         f"band={TRACK_BAND!r} subject={TRACK_SUBJECT!r}", None)
 d = E.Driver()
 
 
@@ -140,7 +171,7 @@ ev.check(f"567/{LOCALE}/the-product-still-sees-logic-running",
 
 after = ev.shot(f"567/{LOCALE}/after", settle_region=TRACK_BAND, window_title=ARRANGE_SUFFIX)
 ev.visual(f"567/{LOCALE}/nothing-in-the-project-was-touched",
-          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          before["file"], after["file"], TRACK_BAND, expect_change=False, subject=TRACK_SUBJECT,
           why="this run only reads names and health; the arrange window's track headers must be "
               "identical across it")
 

--- a/Scripts/livekit/live_570_project_new_refusal.py
+++ b/Scripts/livekit/live_570_project_new_refusal.py
@@ -51,13 +51,44 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+TRACK_BAND, TRACK_SUBJECT = located_band("Tracks header")
+ev.check("570/precondition-the-track-header-rail-was-located",
+         TRACK_BAND is not None and bool(TRACK_SUBJECT),
+         "the rail this run asserts about, resolved BEFORE the refusal is provoked. A first attempt "
+         "produced no band and the run still reported 8/8, because a region-less visual compared "
+         "two whole images and passed — fixed earlier in this branch, and guarded here as well",
+         f"band={TRACK_BAND!r} subject={TRACK_SUBJECT!r}", None)
+
 d = E.Driver()
 
 # Window-relative band over the track headers of the arrange window (measured 1920x1050 at 0,30).
 # Deliberately over content the caller owns: the claim is that a REFUSED project.new leaves it alone.
-TRACK_BAND = (10, 120, 260, 200)
-
-
+# #622: this was (10, 120, 260, 200) — inside the LIBRARY, while the claim below is about the open
+# project's track headers. Third of four harnesses carrying the same copied rectangle.
+#
+# Resolved BEFORE the driver starts, and that ordering is load-bearing. Measured: with an MCP driver
+# running, the same lookup returns {"error":"no standard window"} — Logic's window list is not
+# readable through AX while the server is attached. A first attempt placed this after E.Driver() and
+# got a null band, which before the region guard in this branch would have passed as a whole-image
+# comparison.
 def osa(script):
     r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     return (r.stdout or "").strip()
@@ -133,7 +164,7 @@ ev.check("570/refusal-is-pre-write",
 
 after = ev.shot("570/after-refused-new", settle_region=TRACK_BAND)
 ev.visual("570/a-refused-new-leaves-the-open-project-alone",
-          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          before["file"], after["file"], TRACK_BAND, expect_change=False, subject=TRACK_SUBJECT,
           why="the refusal reports write_attempted:false, so the open project's track headers must "
               "be untouched across it")
 

--- a/Scripts/livekit/live_575_region_stub_rows_retired.py
+++ b/Scripts/livekit/live_575_region_stub_rows_retired.py
@@ -55,10 +55,32 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
-# Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
-# frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call in this run is a
-# read, so the assertion over it is a NEGATIVE one.
-HEADER_BAND = (603, 162, 325, 406)
+# #622: this WAS measured from AX — the comment recorded the rail at 603,192 325x406. It has since
+# moved: `Tracks header` now reports 325x1620. A coordinate measured once is a photograph, and the
+# window kept changing after the photograph was taken, so the band had quietly become a slice of
+# the rail rather than the rail.
+#
+# Located every run instead, with the name read back off the element that answered. Every call in
+# this run is a read, so the assertion over it is a NEGATIVE one.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+HEADER_BAND, HEADER_SUBJECT = located_band("Tracks header")
 
 
 def osa(script):
@@ -142,7 +164,7 @@ ev.check("575/the-removed-names-did-not-become-reachable",
 
 after = ev.shot("575/after", settle_region=HEADER_BAND)
 ev.visual("575/no-project-state-was-touched",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], HEADER_BAND, expect_change=False, subject=HEADER_SUBJECT,
           why="every call in this run is a read, so the track-header rail must be byte-identical "
               "across it — a change here would mean a read path wrote something")
 

--- a/Scripts/livekit/live_575_retired_routes_change_nothing.py
+++ b/Scripts/livekit/live_575_retired_routes_change_nothing.py
@@ -41,9 +41,32 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
-# Band over the arrange window's track headers. Every call below is a read or a cache refresh, so
-# the assertion over it is a NEGATIVE one.
-TRACK_BAND = (10, 120, 260, 220)
+# #622: this said "band over the arrange window's track headers" and the rectangle was
+# (10, 120, 260, 220) — which is inside the LIBRARY, on the other side of the window. A read path
+# that wrote to a track header could not have shown up there, so the negative assertion below has
+# never been able to fail for the reason it exists.
+#
+# `Tracks header` is what AX calls the rail the claim is about, and it is unique in this window.
+# Located rather than written down, with the name read back off the element that answered.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+TRACK_BAND, TRACK_SUBJECT = located_band("Tracks header")
 
 
 def osa(script):
@@ -53,6 +76,12 @@ def osa(script):
 
 titles = osa('tell application "System Events" to tell process "Logic Pro" to '
              'return name of every window')
+ev.check("575/precondition-the-track-header-rail-was-located",
+         TRACK_BAND is not None and bool(TRACK_SUBJECT),
+         "the rail this run asserts about, located by AXDescription rather than written down. A "
+         "failed lookup is a red precondition, not a fallback rectangle",
+         f"band={TRACK_BAND!r} subject={TRACK_SUBJECT!r}", None)
+
 ev.check("575/precondition-an-arrange-window-is-open", "Tracks" in titles,
          "Logic is up with a project, so the surviving operations have something to answer about",
          f"titles={titles!r}",
@@ -136,7 +165,7 @@ ev.check("575/the-removed-names-are-still-unreachable",
 
 after = ev.shot("575/after", settle_region=TRACK_BAND)
 ev.visual("575/no-project-state-was-touched",
-          before["file"], after["file"], TRACK_BAND, expect_change=False,
+          before["file"], after["file"], TRACK_BAND, expect_change=False, subject=TRACK_SUBJECT,
           why="every call in this run is a read or a cache refresh, so the arrange window's track "
               "headers must be byte-identical across it")
 

--- a/Scripts/livekit/live_592_stub_rows_retired.py
+++ b/Scripts/livekit/live_592_stub_rows_retired.py
@@ -54,11 +54,35 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
-# The band is derived from the window at run time rather than measured once. The arrange window has
-# moved display during this program — 1920x1050 landscape on one run, 1080x1890 portrait on another —
-# and a rectangle measured against the first is not inside the second, which records as an unsettled
+# Derived at run time rather than measured once, and the reason is good: the arrange window has moved
+# display during this program — 1920x1050 landscape on one run, 1080x1890 portrait on another — and a
+# rectangle measured against the first is not inside the second, which records as an unsettled
 # capture straddling displays rather than as an honest failure.
-HEADER_BAND = None   # resolved below, once the window's own frame is known
+#
+# #622: deriving it from the WINDOW solved portability and lost aim. `(0, 0, w, 400)` is a
+# full-width strip across the top; the rail this run asserts about sits at x=603 and is 325 wide, so
+# the band was mostly not looking at it. Asking AX for `Tracks header` gives both — a frame that is
+# current on whichever display the window is on, and the region the claim is actually about.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+HEADER_BAND = None
+HEADER_SUBJECT = None
 
 
 def osa(script):
@@ -74,9 +98,9 @@ ev.check("592/precondition-an-arrange-window-is-open", "Tracks" in titles,
          f"titles={titles!r}", None)
 
 win = E.logic_window("Tracks") or E.logic_window(None)
-HEADER_BAND = (0, 0, win["w"], min(400, win["h"])) if win else None
+HEADER_BAND, HEADER_SUBJECT = located_band("Tracks header")
 ev.check("592/precondition-the-window-frame-is-known",
-         HEADER_BAND is not None,
+         HEADER_BAND is not None and bool(HEADER_SUBJECT),
          "the arrange window's own frame read, so the capture band below is inside it — a band "
          "measured against a different display records as an unsettled straddling capture rather "
          "than as an honest result",
@@ -173,7 +197,7 @@ ev.check("592/the-removed-names-did-not-become-reachable",
 
 after = ev.shot("592/after", settle_region=HEADER_BAND)
 ev.visual("592/no-project-state-was-touched",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], HEADER_BAND, expect_change=False, subject=HEADER_SUBJECT,
           why="every call in this run is a read, so the track-header rail must be byte-identical "
               "across it — a change here would mean a read path wrote something")
 

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -197,6 +197,11 @@ a, b = os.path.join(tmp, "a.png"), os.path.join(tmp, "b.png")
 _png(a, (1, 2, 3))
 _png(b, (1, 2, 3))
 ev.visual("v", a, b, (0, 0, 4, 4), expect_change=False, why="w", subject="a synthetic square")
+# A visual with no region must NOT pass. It used to: `_region_hash` fell back to hashing the whole
+# file, so the comparison silently became "did anything on screen change" and answered yes-or-no
+# about a rectangle it never looked at. Measured in the wild when a band lookup returned None.
+shapes.append(("a region-less visual does not pass",
+               ev.visual("no-region", a, b, None, expect_change=False, why="w", subject="x") is False))
 out = ev.write()
 shapes.append(("write() returns a dict", isinstance(out, dict)))
 shapes.append(("summary carries every required key",


### PR DESCRIPTION
No closing keyword — three of the thirty, chosen because they make the **same claim** and so could be compared against each other.

All three assert a variant of *"every call in this run is a read, so the track-header rail must be byte-identical across it — a change here would mean a read path wrote something."*

AX names that rail exactly once: **`Tracks header`, unique, `(603, 84, 325, 1620)`**.

```
live_575_retired_routes_change_nothing   (10, 120, 260, 220)   inside → Library
live_592_stub_rows_retired               (0, 0, w, 400)        inside → NOTHING NAMED
live_575_region_stub_rows_retired        (603, 162, 325, 406)  inside → Tracks header, wrong size
```

**None of them was watching the rail.** Each failed differently, and the differences are the point.

## 1 · Watching another pane

`(10, 120, 260, 220)` sits inside the **Library**, on the other side of the window. A read path that wrote to a track header could not have appeared there — **the check has never been able to fail for the reason it exists.** Worse than an absent check: it goes green, and the green is filed as evidence the rail was untouched.

## 2 · Portable, but unaimed

The only one whose coordinate had a stated reason, and the reason is good — the comment records that the arrange window has moved display during this program (`1920x1050` landscape, `1080x1890` portrait), and a rectangle measured against one is not inside the other, recording as a straddling capture rather than an honest failure.

So it was derived from the window: `(0, 0, w, min(400, h))`. **That fixed portability and lost aim** — the rail is at `x=603`, 325 wide, and a full-width top strip was mostly not looking at it.

Locating by `AXDescription` serves the original motive *better*: a frame that is current on whichever display the window is on, **and** the region the claim is about.

## 3 · Measured right, gone stale

The comment records the rail as `603,192 325x406` and derives the band from it. `Tracks header` now reports `325x1620`. **The measurement was correct when taken**; the window kept changing afterwards, and the band had quietly become a slice of the rail.

This is the hardest group to see. By reading the source it is indistinguishable from a correct band — the coordinate is there, the claim is true, and only re-measuring against AX separates them. Containment alone passes it; **the size is what gives it away.**

## Live, all three, at this head

```
live_575_retired_routes_change_nothing   6/6 · 3 mutation-backed
live_575_region_stub_rows_retired        4/4 · 2 mutation-backed
live_592_stub_rows_retired               5/5 · 2 mutation-backed
                                         all: 1 visual, 0 failed, subject attached,
                                              0 unsettled, 0 straddling, 0 cached-as-live
```

Every claim **holds** at the corrected band. The product was fine throughout; the checks were not watching it.

## Method

Dump every element the window describes with its frame, then for each band ask which named regions contain it, and whether the sizes agree. Inside nothing → unaimed. Inside a region the claim never mentions → misaimed. Inside the right region at the wrong size → stale.

Half of that is mechanisable. The half that is not is reading the sentence to learn what the claim was about — which is how #2 was resolved, and it took one comment.