### PR TITLE
feat(#628): a press form that reports what changed, recovered after it was lost

### DIFF
--- a/Scripts/livekit/ax_event_tab.swift
+++ b/Scripts/livekit/ax_event_tab.swift
@@ -9,8 +9,13 @@
 // was open and the probe was reading its rows.
 //
 //   swiftc -O ax_event_tab.swift -o ax_event_tab
-//   ./ax_event_tab                 -> {"tabs":[{"description":"Event","selected":true}, …]}
-//   ./ax_event_tab select Event    -> the same, plus "pressed", AFTER re-reading
+//   ./ax_event_tab                      -> {"tabs":[{"description":"Event","selected":true}, …]}
+//   ./ax_event_tab select Event         -> the same, plus "pressed", AFTER re-reading
+//   ./ax_event_tab press <Role> <Desc>  -> press any control by role + AXDescription
+//
+// The `press` form exists because System Events cannot see these controls either. Opening the
+// Mixer through `click checkbox "Mixer" of window 1` returns -1728 while raw AX finds that exact
+// checkbox in the Control Bar. Same wall as the tabs, same way through it.
 //
 // The reported `selected` is always a fresh read taken after any press, never the press's return
 // code. `ax_region_select.swift` records why: on this build an AXSelected write returned .success
@@ -47,6 +52,20 @@ func isSelected(_ element: AXUIElement) -> Bool {
 /// Every radio button under `root`, by AXDescription. Depth-bounded rather than unbounded: the
 /// tabs sit several groups deep and an unbounded walk of Logic's arrange window is slow enough
 /// to change what it is measuring.
+/// Every element of `role` carrying `description`, depth-bounded. Reports ALL matches so the caller
+/// can refuse ambiguity rather than inherit tree order — an AXDescription is not unique.
+func matching(_ root: AXUIElement, role wantRole: String, description wantDesc: String,
+              depth: Int = 0) -> [AXUIElement] {
+    guard depth < 16 else { return [] }
+    var found: [AXUIElement] = []
+    for child in children(root) {
+        if role(child) == wantRole, describe(child) == wantDesc { found.append(child) }
+        found.append(contentsOf: matching(child, role: wantRole, description: wantDesc,
+                                          depth: depth + 1))
+    }
+    return found
+}
+
 func radioButtons(_ root: AXUIElement, depth: Int = 0) -> [AXUIElement] {
     guard depth < 16 else { return [] }
     var found: [AXUIElement] = []
@@ -78,6 +97,25 @@ let mainWindow = window as! AXUIElement
 
 var tabs = radioButtons(mainWindow)
 var pressed: String? = nil
+
+if CommandLine.arguments.count >= 4, CommandLine.arguments[1] == "press" {
+    let wantRole = CommandLine.arguments[2]
+    let wantDesc = CommandLine.arguments[3]
+    let hits = matching(mainWindow, role: wantRole, description: wantDesc)
+    if hits.count != 1 {
+        emit(["error": hits.isEmpty ? "no such control" : "ambiguous", "role": wantRole,
+              "description": wantDesc, "candidates": hits.count])
+    }
+    let before = isSelected(hits[0])
+    _ = AXUIElementPerformAction(hits[0], kAXPressAction as CFString)
+    Thread.sleep(forTimeInterval: 1.5)
+    // Re-read rather than trust the return code: a press that reports success and changes nothing
+    // is the norm on this surface, not the exception.
+    let after = matching(mainWindow, role: wantRole, description: wantDesc)
+    emit(["pressed": wantDesc, "candidates": hits.count, "valueBefore": before,
+          "valueAfter": after.first.map { isSelected($0) } ?? false,
+          "changed": after.first.map { isSelected($0) != before } ?? false])
+}
 
 if CommandLine.arguments.count >= 3, CommandLine.arguments[1] == "select" {
     let wanted = CommandLine.arguments[2]


### PR DESCRIPTION
This commit existed once, passed a gate, and **never reached the remote**. Independent of #634 — merge in either order.

## What was lost, and how I noticed

I told the peer and this issue's readers that `ax_event_tab.swift` had gained a `press` form and that the Mixer conversions were therefore unblocked. Then I checked:

```
dee767db  "a press form that reports what changed"
  ancestor of origin/main?               NO
  on the remote branch it was built on?  NO   ← never pushed at all
main's ax_event_tab.swift                5 "press" hits — all the pre-existing select form
```

A gate had reported `SHIP GATE PASS` for it. The commit survived locally and is recovered here unchanged.

**The near-miss is worth more than the recovery.** My first grep returned `0`, which made me suspect the pattern. My second returned `5` — and *that* is where I could have stopped and declared the tool present. Only reading the five lines showed they were all old code.

A count moving from **0 to 5 read as confirmation.** Zero makes you doubt the instrument; a positive number does not make you check the object.

## What the tool does

`press <Role> <Description>` — find by role and `AXDescription`, press, then **re-read and report `changed`**.

```
press AXCheckBox Mixer  →  {"candidates":1,"valueBefore":false,"valueAfter":true,"changed":true}
press AXCheckBox Mixer  →  {"candidates":1,"valueBefore":true,"valueAfter":false,"changed":true}
```

`changed` is the point. *"Pressed"* is not an observation on this surface — a press that returns success and does nothing is the norm, which is why System Events reporting no error told us nothing. `candidates` comes with it, so "there was exactly one thing to press" is recorded rather than assumed.

It exists because **System Events cannot reach these controls**: `click checkbox "Mixer" of window 1` returns `-1728` while raw AX finds that checkbox in the Control Bar immediately. Same wall as the List Editors tabs.

## Why it matters for #628

The Mixer lookups read zero **because the Mixer is closed**, and a zero measured in the wrong state is how #302 stayed stuck for weeks — an accident of state recorded as a property. With this tool the state can be created, measured, and restored.

That measurement is already recorded on #628 and it stands — I ran it with a local build:

```
                                  closed    OPEN
AXGroup identifier="Mixer"           0        0     ← dead either way
AXScrollArea identifier="Mixer"      0        0     ← dead either way
AXGroup desc="Mixer"                 0        2
```

What was missing until now is any way for someone else to reproduce it. **A measurement nobody can repeat is a claim.**

## Verified from this branch

Compiled from the branch, pressed the Mixer open, pressed it closed, `changed: true` both ways, state left as found. And unlike last time, the push was confirmed against the remote rather than inferred from the gate's exit code.