### PR TITLE
fix(#622): one stale band converted, and one that must not be

### DIFF
--- a/Scripts/livekit/live_575_move_to_playhead_identity.py
+++ b/Scripts/livekit/live_575_move_to_playhead_identity.py
@@ -57,7 +57,33 @@ if missing:
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
 # frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call here is a read.
-HEADER_BAND = (603, 162, 325, 406)
+# #622: measured from AX when it was written — the comment beside its sibling recorded the rail at
+# 325x406 — and the rail now reports 325x1620. A coordinate measured once is a photograph; the
+# window kept changing after it was taken, so this had become a slice of the rail rather than the
+# rail. Located every run instead.
+BAND_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+BAND_TOOL = os.path.join(ev.dir, "ax_control_bar_band")
+subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, capture_output=True)
+
+
+def located_band(*selector):
+    """(band, subject) for a named region, or (None, None) — never a fallback rectangle."""
+    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
+    try:
+        payload = json.loads(r.stdout or "{}")
+    except ValueError:
+        return None, None
+    b = payload.get("band")
+    if not (isinstance(b, list) and len(b) == 4):
+        return None, None
+    return tuple(b), payload.get("description")
+
+
+HEADER_BAND, HEADER_SUBJECT = located_band("Tracks header")
+ev.check("575/precondition-the-track-header-rail-was-located",
+         HEADER_BAND is not None and bool(HEADER_SUBJECT),
+         "the rail this run asserts about, located by AXDescription rather than written down",
+         f"band={HEADER_BAND!r} subject={HEADER_SUBJECT!r}", None)
 
 
 def osa(script):
@@ -134,7 +160,7 @@ ev.check("575/the-reachable-surface-is-unchanged",
 
 after = ev.shot("575/after", settle_region=HEADER_BAND)
 ev.visual("575/no-project-state-was-touched",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], HEADER_BAND, expect_change=False, subject=HEADER_SUBJECT,
           why="every call in this run is a read, so the track-header rail must be byte-identical "
               "across it — a change here would mean a read path wrote something")
 


### PR DESCRIPTION
No closing keyword. Two harnesses that look identical by geometry, and only one should change.

## Converted

`live_575_move_to_playhead_identity` claimed the track-header rail and watched `(603, 162, 325, 406)`. The rail now reports `325x1620` — **measured correctly when written**, and the window kept changing afterwards, so it had become a slice. Located every run now, with a precondition guarding the lookup.

Verified live: the visual passes with its subject attached.

Two other checks in that harness fail on `regions=0` — this project has none — and they fail identically **without** this change: 3/5 before, 4/6 after, the extra pass being the new precondition. Said plainly so nobody attributes them here.

## NOT converted, and this is the finding

`live_448_track_stack_readback` watches `(603, 470, 325, 90)`. By geometry it is the same shape as the one above — inside `Tracks header`, much smaller than it. By claim it is a different thing entirely:

> *"the subtracks Logic revealed are drawn into the **empty part** of the track-header rail, so a band that was flat grey while the stack was closed must not be flat"* — with `expect_change: true`

**The sub-region is the point.** Naming the whole rail would break it: the rail is not flat grey, so the before-state the assertion rests on would not hold. Converting it would turn a working check into a broken one while looking like progress on this issue.

## So the triage needs a fifth category

The four groups so far all describe a band that is **wrong**:

```
aimed right, unnamed        metadata
measured right, gone stale  only AX re-measurement separates it
aimed at nothing named      the claim must be settled first
aimed at another pane       the check could never fail
deliberately a sub-region   ← the claim DEPENDS on it being smaller
```

The fifth is indistinguishable from the second by geometry alone — both are *"inside the right region at a smaller size"*. Only reading the sentence separates them.

That is the **second** time the mechanical half of this method could not finish the job. The first was `live_592`, where a coordinate had a stated and correct reason. Both times the remainder was reading what the check says about itself, and both times the mechanical pass would have produced a confident wrong answer.

Worth carrying into the remaining conversions: a band being smaller than its named region is a **question**, not a verdict.