### PR TITLE
fix(#622): delete the whole-image fallback instead of leaving it unreachable

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -701,6 +701,16 @@ def _region_hash(png, region, window_points=None):
     # screen change" instead of "did this change" — and the run has no way to know it was answered.
     if not region:
         return None
+    # The whole-image fallback that used to live further down is DELETED, not merely bypassed. It
+    # said the opposite of this guard, in the same function, and this guard won only by running
+    # first — so deleting it would have restored the defect silently, and anyone reading that
+    # branch had every reason to think whole-image hashing was supported.
+    #
+    # With the fallback gone this guard is no longer individually load-bearing: `x, y, w, h = region`
+    # raises on None and the broad `except` below returns None anyway. Measured — removing this line
+    # leaves the shape test green. It stays because being correct by way of an exception handler is
+    # not the same as being correct on purpose, and that handler also swallows real failures. Said
+    # plainly so nobody reads a passing suite as proof this line is doing the work.
     if not os.path.isfile(png):
         return None
     try:
@@ -715,9 +725,6 @@ def _region_hash(png, region, window_points=None):
         img = CGImageSourceCreateImageAtIndex(src, 0, None)
         if img is None:
             return None
-        if not region:
-            data = CGDataProviderCopyData(CGImageGetDataProvider(img))
-            return hashlib.sha256(bytes(data)).hexdigest()
         pw, ph = CGImageGetWidth(img), CGImageGetHeight(img)
         sx = sy = 1.0
         if window_points:


### PR DESCRIPTION
No closing keyword. Small, and the reasoning is the point.

## Two opposite intents in one function

#634 added an early guard so a region-less visual could not pass. The original whole-image fallback **stayed below it** — alive in the file, dead only because the guard runs first.

```python
if not region:
    return None                                  # ← #634's guard

... later, in the same function ...

if not region:
    return hashlib.sha256(whole_image).hexdigest()   # ← the discarded intent
```

**A guard that wins by ordering is not a guard.** Delete the guard and the defect returns silently — and whoever deletes it believes they are tidying dead code. Meanwhile anyone reading the lower branch has every reason to think whole-image hashing is a supported mode.

The fallback is gone. The function says one thing.

## Measured while doing it, and written beside the code

With the fallback removed, **the guard is no longer individually load-bearing**. `x, y, w, h = region` raises on `None`, and the broad `except` returns `None` anyway — so deleting the guard leaves the shape test green.

It stays. Being correct *by way of an exception handler* is not the same as being correct on purpose, and that handler also swallows real failures. But claiming the line is doing work it isn't would be its own small lie, so the file says so.

## Second redundant pair today

The first was `_safe_name`, where `os.path.basename` and the character class each fully covered the other — neither individually detectable by mutation. Same honest report both times: **no test can attribute the property to either line**, and that belongs next to the code rather than in a commit message nobody re-reads.

Worth noticing that both pairs formed the same way: a new guard added in front of an old one, with the old one left in place. The second expression is always the one that looks harmless.

## Still open, recorded on #622 and not fixed here

A band larger than the window is silently **clipped** — `CGImageCreateWithImageInRect` intersects rather than fails — so `Tracks contents` at `6162` wide is compared as the visible crop while the document records the full rectangle. That affects `live_608`, merged in #627: a true result with a receipt that claims more area than was examined. Deciding between clip-and-record-the-clip versus refuse-and-require-a-fitting-target is the next question, and it is a design choice rather than a defect fix.