### PR TITLE
fix(#622): every visual assertion names its subject, and the clause is switched on

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -1,7 +1,8 @@
 // A NAMED region of the arrange window, in window coordinates, emitted as JSON with the name it
 // matched — so a caller can state what the band IS, not only where it is.
 //
-//   ./ax_control_bar_band "<AXDescription>" [--role R] [--min-width N] [--min-height N]
+//   ./ax_control_bar_band "<AXDescription>" [--role R]
+//                           [--min-width N] [--min-height N] [--max-width N] [--max-height N]
 //
 // An AXDescription is NOT unique. Measured on this window: "Control Bar" matches two elements,
 // "Library" four, "Event" three. The first version walked depth-first and returned whichever it
@@ -78,6 +79,12 @@ func flag(_ name: String) -> String? {
 let wantRole = flag("--role")
 let minWidth = Int(flag("--min-width") ?? "0") ?? 0
 let minHeight = Int(flag("--min-height") ?? "0") ?? 0
+// Upper bounds too, because nesting is the common shape of an ambiguous description: the Marker
+// List window carries "Marker" twice, the outer one the whole pane and the inner one the table
+// alone. A lower bound cannot separate them — every bound that admits the inner admits the outer.
+// Without these the caller's only options are the wrong subject or no subject at all.
+let maxWidth = Int(flag("--max-width") ?? "") ?? Int.max
+let maxHeight = Int(flag("--max-height") ?? "") ?? Int.max
 
 guard let app = NSWorkspace.shared.runningApplications.first(where: {
     ($0.bundleIdentifier ?? "").contains("logic")
@@ -98,7 +105,7 @@ func walk(_ e: AXUIElement, _ d: Int) {
     for c in kids(e) {
         if str(c, kAXDescriptionAttribute as String) == wanted,
            let f = frame(c),
-           f.2 >= minWidth, f.3 >= minHeight,
+           f.2 >= minWidth, f.3 >= minHeight, f.2 <= maxWidth, f.3 <= maxHeight,
            wantRole == nil || str(c, kAXRoleAttribute as String) == wantRole {
             hits.append(c)
         }
@@ -123,7 +130,7 @@ func describeHit(_ e: AXUIElement) -> [String: Any] {
             "band": [f.0 - wf.0, f.1 - wf.1, f.2, f.3]]
 }
 if hits.count > 1 {
-    emit(["error": "AXDescription is ambiguous — add --role / --min-width / --min-height",
+    emit(["error": "AXDescription is ambiguous — add --role / --min-width / --min-height / --max-width / --max-height",
           "wanted": wanted, "matches": hits.map(describeHit),
           "window": str(win, kAXTitleAttribute as String)])
 }

--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -94,10 +94,31 @@ let ax = AXUIElementCreateApplication(app.processIdentifier)
 // and it was choosing its WINDOW that way. Measured: a harness that had just started an MCP driver
 // got `band: null` while the identical call standing alone resolved fine, because the first
 // standard window was no longer the one holding the content.
-let standardWindows = ((attr(ax, kAXWindowsAttribute as String) as? [AXUIElement]) ?? []).filter {
-    str($0, kAXSubroleAttribute as String) == (kAXStandardWindowSubrole as String)
+//
+// Retried, because a single failed AX read is not an answer. Measured 2026-08-20: run from a
+// harness that had just started a screen recording and an MCP driver, `kAXWindowsAttribute` came
+// back EMPTY while Logic was plainly on screen with its window in front — and the identical call
+// a second later returned it. Emitting "no standard window" on the first empty read made a
+// transient look like a fact about the machine, and the caller recorded a refusal for it.
+//
+// The loop only retries EMPTINESS. A window list that comes back populated but without the wanted
+// element is a real answer and is reported as one; retrying that would only make a genuine
+// refusal slow.
+func standardWindowsNow() -> [AXUIElement] {
+    ((attr(ax, kAXWindowsAttribute as String) as? [AXUIElement]) ?? []).filter {
+        str($0, kAXSubroleAttribute as String) == (kAXStandardWindowSubrole as String)
+    }
 }
-guard !standardWindows.isEmpty else { emit(["error": "no standard window"]) }
+var standardWindows = standardWindowsNow()
+var windowAttempts = 1
+while standardWindows.isEmpty && windowAttempts < 12 {
+    usleep(300_000)
+    standardWindows = standardWindowsNow()
+    windowAttempts += 1
+}
+guard !standardWindows.isEmpty else {
+    emit(["error": "no standard window", "attempts": windowAttempts])
+}
 
 var hits: [AXUIElement] = []
 func walk(_ e: AXUIElement, _ d: Int) {
@@ -147,5 +168,9 @@ emit([
     "description": str(r, kAXDescriptionAttribute as String),
     "role": str(r, kAXRoleAttribute as String),
     "candidates": hits.count,
+     // How many reads it took to see a window at all. Anything above 1 means the AX tree was
+     // momentarily empty, which is worth surfacing rather than absorbing: a run that needed six
+     // attempts is telling you something about the machine it ran on.
+     "windowAttempts": windowAttempts,
     "band": [rf.0 - wf.0, rf.1 - wf.1, rf.2, rf.3],
 ])

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -346,18 +346,39 @@ class Evidence:
         if not os.path.exists(tool):
             built = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
             if built.returncode != 0:
+                self.note("located_band/build-failed",
+                          {"selector": list(selector),
+                           "stderr": (built.stderr or b"").decode("utf-8", "replace")[:400]})
                 return None, None
+
+        def refuse(why, r=None):
+            # A refusal that says nothing is a wall. Every one of these has been mistaken for a
+            # different failure at least once: an ambiguous description reads exactly like a
+            # missing element, and both read like the tool not having run at all.
+            self.note("located_band/refused",
+                      {"selector": list(selector), "why": why,
+                       "rc": None if r is None else r.returncode,
+                       "stdout": "" if r is None else (r.stdout or "")[:400],
+                       "stderr": "" if r is None else (r.stderr or "")[:400]})
+            return None, None
+
         r = subprocess.run([tool, *selector], capture_output=True, text=True)
         try:
             payload = json.loads(r.stdout or "{}")
         except ValueError:
-            return None, None
+            return refuse("the tool printed something that is not JSON", r)
         band = payload.get("band")
         if not (isinstance(band, list) and len(band) == 4):
-            return None, None
+            return refuse(payload.get("error") or "no band in the tool's answer", r)
         subject = payload.get("description")
         if not isinstance(subject, str) or not subject.strip():
-            return None, None
+            return refuse("a band with no description cannot be named", r)
+        attempts = payload.get("windowAttempts")
+        if isinstance(attempts, int) and attempts > 1:
+            # Absorbed, not hidden: the lookup succeeded, and it took more than one read of the AX
+            # tree to see a window at all.
+            self.note("located_band/window-list-was-empty-at-first",
+                      {"selector": list(selector), "attempts": attempts})
         return tuple(band), subject
 
     # -- observations -------------------------------------------------------

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -664,13 +664,16 @@ def is_clean(summary):
       * a subject is any non-empty string. That it truthfully names what the rectangle contains is
         not checkable here.
 
-    `visual_assertions_without_a_subject` is COUNTED and deliberately NOT gated on yet. Measured
-    when this was written: thirty harnesses call `visual()` and zero pass `subject=`, so enforcing
-    it here turns the entire live suite red in one step, and the predictable next move is that
-    somebody deletes the clause. Writing truthful subjects means measuring what each band actually
-    contains — thirty times — and inventing them to make a gate go green is the failure this
-    parameter exists to prevent. The counter lands now so adoption is visible; the clause lands
-    when the count reaches zero honestly.
+    `visual_assertions_without_a_subject` is GATED as of #622. It was counted and not enforced for
+    one release, because enforcing it while thirty harnesses passed no subject would have turned
+    the whole live suite red in a step and the predictable next move is that somebody deletes the
+    clause. All thirty-one call sites name a subject now, and the count reached zero by measuring
+    what each band contains rather than by writing a string that would satisfy the counter.
+
+    What the clause still cannot do is check that the name is TRUE. Most bands are resolved from
+    the live tree by `located_band`, so their subject is read back off the element that was found
+    and cannot drift from it; the few that are authored — a window's title bar, a slice offset into
+    a located rail — are the ones a reviewer has to read.
     """
     if not isinstance(summary, dict):
         return False
@@ -691,6 +694,7 @@ def is_clean(summary):
         and summary["captures_straddling_displays"] == 0
         and summary["restorations_failed"] == 0
         and summary["cached_reads_used_as_live"] == 0
+        and summary["visual_assertions_without_a_subject"] == 0
     )
 
 

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -323,6 +323,43 @@ class Evidence:
         self._window_points = None
         Evidence.current = self
 
+    # -- locating a band ----------------------------------------------------
+
+    def located_band(self, *selector):
+        """`(band, subject)` for a region named by AXDescription, or `(None, None)`.
+
+        A rectangle written as four numbers is not defined by its content. The five harnesses that
+        shared `(0, 0.10h, 0.20w, 0.80h)` were all claiming something about the track-header rail,
+        and measured on 2026-08-20 with the Library pane open that rectangle lies 94% inside the
+        LIBRARY: the rail sits at x=603. The band was right in the layout it was written in and
+        wrong in the next one, and nothing in the run could say which.
+
+        So the band is resolved from the live tree and the `subject` comes back off the element
+        that was found, not off the request — which is what makes it evidence rather than a label.
+
+        `(None, None)` on any failure, INCLUDING an ambiguous description, which the tool reports
+        as an error with all its candidates. Callers must treat that as a red precondition; before
+        #634 a `None` band silently became a whole-image comparison that passed.
+        """
+        source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_control_bar_band.swift")
+        tool = os.path.join(self.dir, "ax_control_bar_band")
+        if not os.path.exists(tool):
+            built = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+            if built.returncode != 0:
+                return None, None
+        r = subprocess.run([tool, *selector], capture_output=True, text=True)
+        try:
+            payload = json.loads(r.stdout or "{}")
+        except ValueError:
+            return None, None
+        band = payload.get("band")
+        if not (isinstance(band, list) and len(band) == 4):
+            return None, None
+        subject = payload.get("description")
+        if not isinstance(subject, str) or not subject.strip():
+            return None, None
+        return tuple(band), subject
+
     # -- observations -------------------------------------------------------
 
     def note(self, tag, payload):

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -421,7 +421,8 @@ class Evidence:
         for _ in range(_SETTLE_TRIES):
             _capture_window(win["id"], path)
             frames += 1
-            h = _region_hash(path, settle_region, (win["w"], win["h"]))
+            h = _region_hash(path, _clip_to_window(settle_region, (win["w"], win["h"])),
+                             (win["w"], win["h"]))
             if prev is not None and h == prev:
                 settled = True
                 break
@@ -466,14 +467,17 @@ class Evidence:
         # as absent and `is_clean` refuses the run: each harness's next run tells its owner that this
         # assertion does not say what it watches, and the fix arrives with a measurement attached.
         wp = window_points or self._window_points
-        b = _region_hash(before_file, region, wp)
-        a = _region_hash(after_file, region, wp)
+        # What was HASHED, which is not always what was asked for — see `_clip_to_window`. The
+        # record carries the clipped rectangle, and says so when the two differ.
+        effective = _clip_to_window(region, wp)
+        b = _region_hash(before_file, effective, wp)
+        a = _region_hash(after_file, effective, wp)
         readable = b is not None and a is not None
         changed = readable and b != a
         # An unreadable comparison is not a passing one, whichever way the expectation points.
         passed = readable and (changed == bool(expect_change))
         self.records.append({
-            "kind": "visual", "tag": tag, "region": list(region) if region else None,
+            "kind": "visual", "tag": tag, "region": list(effective) if effective else None,
             "subject": subject,   # None until the harness measures what the region is
 
             "before": before_file, "after": after_file,
@@ -481,6 +485,8 @@ class Evidence:
             "observed": f"before {(b or '?')[:16]} after {(a or '?')[:16]} changed={changed}",
             "passed": passed,
         })
+        if effective is not None and region is not None and tuple(effective) != tuple(region):
+            self.records[-1]["region_requested"] = list(region)
         return passed
 
     # -- recording ----------------------------------------------------------
@@ -716,6 +722,32 @@ def _file_hash(path):
 # visual(), or write(). Each branch was green and the breakage existed only in their merge.
 #
 # The import smoke test beside this file is the part that would have caught it.
+
+def _clip_to_window(region, window_points):
+    """The part of `region` a capture of that window can actually contain, or None if none of it.
+
+    A band can legitimately be larger than the window it is measured in: `Tracks contents` is 6162
+    points wide on a 1920-point window, because the arrange canvas extends past the viewport it is
+    drawn into. `CGImageCreateWithImageInRect` intersects an oversized crop against the image and
+    says nothing, so the record claimed the whole canvas while the hash covered the visible part.
+
+    Clipping here rather than there keeps the two honest: what is recorded as the region is what
+    was hashed. A band lying entirely outside the window returns None, which reads as unreadable
+    rather than as a comparison of two empty crops — those would be equal, and equal is a PASS for
+    every negative assertion.
+    """
+    if not region or not window_points:
+        return tuple(region) if region else None
+    wpts, hpts = window_points
+    if not wpts or not hpts:
+        return tuple(region)
+    x, y, w, h = region
+    x0, y0 = max(0, x), max(0, y)
+    x1, y1 = min(x + w, wpts), min(y + h, hpts)
+    if x1 <= x0 or y1 <= y0:
+        return None
+    return (x0, y0, x1 - x0, y1 - y0)
+
 
 def _region_hash(png, region, window_points=None):
     """Hash one rectangle of a PNG.

--- a/Scripts/livekit/live_290_shifted_strips_are_refused.py
+++ b/Scripts/livekit/live_290_shifted_strips_are_refused.py
@@ -84,10 +84,15 @@ if not titles:
 
 arrange_title = titles[0]
 win = E.logic_window(arrange_title)
+# The window's own title bar, and the subject says so. The band is derived from a frame this run
+# measured — `logic_window` reads it from CoreGraphics — rather than from a layout somebody
+# remembered, and 28 points is the strip that holds the document name.
 band = (0, 0, win["w"], 28) if win else None
-ev.check("290/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+band_subject = f"the title bar of the {arrange_title!r} window" if win else None
+ev.check("290/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject),
+         "the arrange window's own frame read, so the capture band is inside it and can be named",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -162,7 +167,8 @@ ev.check("290/the-write-path-still-validates-its-input",
 
 after = ev.shot("290/after", settle_region=band, window_title=arrange_title)
 ev.visual("290/no-project-state-was-touched",
-          before["file"], after["file"], band, expect_change=False,
+          before["file"], after["file"], band, subject=band_subject,
+          expect_change=False,
           why="every call in this run is a read or a rejected parameter, so the window must be "
               "byte-identical across it — a change here would mean something wrote")
 

--- a/Scripts/livekit/live_291_input_slot_is_read.py
+++ b/Scripts/livekit/live_291_input_slot_is_read.py
@@ -157,10 +157,15 @@ win = E.logic_window(arrange_title)
 # CHANGED, and the control bar's clock and the mixer's level meters move on their own, so
 # a band over them could never stay still and the assertion would fail for reasons that
 # have nothing to do with a read path writing something.
+# The window's own title bar, and the subject says so. The band is derived from a frame this run
+# measured — `logic_window` reads it from CoreGraphics — rather than from a layout somebody
+# remembered, and 28 points is the strip that holds the document name.
 band = (0, 0, win["w"], 28) if win else None
-ev.check("291i/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+band_subject = f"the title bar of the {arrange_title!r} window" if win else None
+ev.check("291i/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject),
+         "the arrange window's own frame read, so the capture band is inside it and can be named",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -308,7 +313,8 @@ ev.check("291i/no-strip-claims-a-send-destination",
 
 after = ev.shot("291i/after", settle_region=band, window_title=arrange_title)
 ev.visual("291i/no-project-state-was-touched",
-          before["file"], after["file"], band, expect_change=False,
+          before["file"], after["file"], band, subject=band_subject,
+          expect_change=False,
           why="both frames are captured with the Mixer in the SAME state, and every call between "
               "them is a read, so the window must be byte-identical across it — a change here "
               "would mean a read path wrote something")

--- a/Scripts/livekit/live_291_output_slot_is_read.py
+++ b/Scripts/livekit/live_291_output_slot_is_read.py
@@ -157,10 +157,15 @@ win = E.logic_window(arrange_title)
 # CHANGED, and the control bar's clock and the mixer's level meters move on their own, so
 # a band over them could never stay still and the assertion would fail for reasons that
 # have nothing to do with a read path writing something.
+# The window's own title bar, and the subject says so. The band is derived from a frame this run
+# measured — `logic_window` reads it from CoreGraphics — rather than from a layout somebody
+# remembered, and 28 points is the strip that holds the document name.
 band = (0, 0, win["w"], 28) if win else None
-ev.check("291/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+band_subject = f"the title bar of the {arrange_title!r} window" if win else None
+ev.check("291/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject),
+         "the arrange window's own frame read, so the capture band is inside it and can be named",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -271,7 +276,8 @@ ev.check("291/no-strip-claims-a-send-destination",
 
 after = ev.shot("291/after", settle_region=band, window_title=arrange_title)
 ev.visual("291/no-project-state-was-touched",
-          before["file"], after["file"], band, expect_change=False,
+          before["file"], after["file"], band, subject=band_subject,
+          expect_change=False,
           why="both frames are captured with the Mixer in the SAME state, and every call between "
               "them is a read, so the window must be byte-identical across it — a change here "
               "would mean a read path wrote something")

--- a/Scripts/livekit/live_448_track_stack_readback.py
+++ b/Scripts/livekit/live_448_track_stack_readback.py
@@ -90,7 +90,19 @@ ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # an assertion that cannot fail. This band is flat grey while the stack is closed and fills with
 # subtrack headers when it opens, so it can stay still — which is what makes its changing mean
 # something.
-QUIET_BAND = (603, 470, 325, 90)
+#
+# So the band is a SLICE of the rail, and the rail is located rather than written down. The whole
+# rail would be the wrong subject here for the reason just given; a fixed rectangle was the wrong
+# subject for a different one — measured 2026-08-20 the rail sits at y=162 h=873, not the 192/406
+# the numbers above were taken from, because it moves with the panes around it. The offset into the
+# rail is what this harness actually knows: 308 points down, past the collapsed headers.
+_RAIL, _RAIL_SUBJECT = ev.located_band("Tracks header")
+QUIET_BAND = (_RAIL[0], _RAIL[1] + 308, _RAIL[2], 90) if _RAIL else None
+QUIET_BAND_SUBJECT = f"{_RAIL_SUBJECT} — the empty area below the collapsed headers" if _RAIL else None
+ev.check("448/precondition-the-track-header-rail-was-located",
+         QUIET_BAND is not None and bool(QUIET_BAND_SUBJECT),
+         "the empty slice of the track-header rail, offset into a rail located by AXDescription",
+         f"rail={_RAIL!r} band={QUIET_BAND!r} subject={QUIET_BAND_SUBJECT!r}", None)
 CACHE_REFRESH_TIMEOUT = 40.0
 POLL = 0.5
 ARROW_TOOL_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_stack_arrow.swift")
@@ -437,7 +449,8 @@ try:
              "would not have caught")
 
     ev.visual("448/the-arrangement-visibly-opened",
-              before_shot["file"], after_shot["file"], QUIET_BAND, expect_change=True,
+              before_shot["file"], after_shot["file"], QUIET_BAND, subject=QUIET_BAND_SUBJECT,
+              expect_change=True,
               why="the subtracks Logic revealed are drawn into the empty part of the track-header "
                   "rail, so a band that was flat grey while the stack was closed must not be flat "
                   "grey now — a flag that flipped while the screen stayed still would be "

--- a/Scripts/livekit/live_519_menu_names_resolve.py
+++ b/Scripts/livekit/live_519_menu_names_resolve.py
@@ -104,8 +104,15 @@ win = E.logic_window()
 # one-pixel line; the arrange lanes are FLAT GREY because this project has one track and no regions, so
 # zoom redraws nothing visible; and a track create does not land on this branch, which still carries #549.
 # The LCD changes whenever the position does, with no dependence on project content.
-LANES = (int(win["w"] * 0.43), int(win["h"] * 0.03),
-         int(win["w"] * 0.15), int(win["h"] * 0.05)) if win else None
+# So it is located rather than estimated. `0.43-0.58 of the width` gives (825, 31, 288, 52) on this
+# window — the readout is 120 wide, so two thirds of that band is the tempo and time-signature
+# fields beside it, and the variable was still called LANES from an earlier subject that did not
+# work. Both are fixed here: the band is the readout, and the name says so.
+LANES, LANES_SUBJECT = ev.located_band("Playhead Position")
+ev.check("519/precondition-the-position-readout-was-located",
+         LANES is not None and bool(LANES_SUBJECT),
+         "the transport's playhead-position readout, located by AXDescription",
+         f"band={LANES!r} subject={LANES_SUBJECT!r}", None)
 # Park the playhead first. Asserting that a move is visible only works if a move happens: a goto to
 # wherever the playhead already sits is a no-op, and the capture would correctly show nothing changing.
 forward()
@@ -158,7 +165,8 @@ ev.check("519/the-guard-passes-this-tree",
          "put one literal back; the guard exited 1 and named the file and line")
 
 ev.visual("519/the-position-readout-changes",
-          pre["file"], post["file"], LANES, expect_change=True,
+          pre["file"], post["file"], LANES, subject=LANES_SUBJECT,
+          expect_change=True,
           why="goto_bar moved the playhead from bar 1 to bar 33, so the transport LCD must read differently")
 
 ev.restored("519/logic-still-usable", True, f"menu_bar={ui_language[:60]}")

--- a/Scripts/livekit/live_519_menu_names_resolve.py
+++ b/Scripts/livekit/live_519_menu_names_resolve.py
@@ -173,4 +173,9 @@ ev.restored("519/logic-still-usable", True, f"menu_bar={ui_language[:60]}")
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
+++ b/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
@@ -301,10 +301,33 @@ ev.check("519/a-region-exists-and-its-korean-help-string-parses",
          "restore the English-only region-help keyword: the enumeration stops recognising the "
          "region and this check goes red before the move is ever attempted")
 
+# #622: this run recorded the screen and took no captures, so `is_clean` refused it for having
+# looked at nothing — a gap that predates the counter and only became visible when the counter
+# landed. The band is the arrange canvas, located by the AXDescription it carries, and it is
+# resolved HERE rather than at the top of the file because a Korean Logic has only just been
+# launched and given a project; before that there is no canvas to find.
+CANVAS, CANVAS_SUBJECT = ev.located_band("Tracks contents")
+ev.check("519/precondition-the-arrange-canvas-was-located",
+         CANVAS is not None and bool(CANVAS_SUBJECT),
+         "the arrange canvas, located by the AXDescription it carries — the same lookup the other "
+         "harnesses use, which does not depend on Logic's language",
+         f"band={CANVAS!r} subject={CANVAS_SUBJECT!r}", None)
+
+arrange_window = next((t for t in windows() if "트랙" in t or "Tracks" in t), None)
+before_move = ev.shot("519/region-before-move", settle_region=CANVAS, window_title=arrange_window)
+
 seek = d.tool("logic_transport", "goto_position", {"bar": str(TARGET_BAR)})
 time.sleep(2)
 moved = d.tool("logic_edit", "move_to_playhead", {})
 time.sleep(2)
+
+after_move = ev.shot("519/region-after-move", settle_region=CANVAS, window_title=arrange_window)
+ev.visual("519/the-region-visibly-moved-on-a-korean-logic",
+          before_move["file"], after_move["file"], CANVAS, subject=CANVAS_SUBJECT,
+          expect_change=True,
+          why=f"the region was dragged to bar {TARGET_BAR} through Logic's Korean menus, so the "
+              "canvas it is drawn on must differ — an envelope reporting State A about a region "
+              "nobody can see moving would leave this band alone")
 ev.note("519/move", {"seek": (seek or {}).get("observed"), "move": moved})
 
 body = moved if isinstance(moved, dict) else {}

--- a/Scripts/livekit/live_523_marker_delete.py
+++ b/Scripts/livekit/live_523_marker_delete.py
@@ -58,12 +58,16 @@ def logic_item_count():
 
 
 def count_band(win):
-    """The witness element's own rectangle, in window points, measured rather than guessed.
+    """`(band, subject)` for the witness element, in window points, measured rather than guessed.
 
     A region picked by eye is a guess about layout that silently stops being true — this one was
     guessed at the top of the window and the node is actually near the bottom, so the assertion
     compared two identical wrong crops and read as "nothing changed" on a run that plainly worked.
     Ask the element where it is.
+
+    The subject comes back off the element that was found, not off the string this walk searched
+    for. The two are the same today; they stop being the same the moment the walk matches
+    something else, and only the read-back one would say so.
     """
     script = ('tell application "System Events" to tell process "Logic Pro"\n'
               'set w to (first window whose name ends with "Marker List")\n'
@@ -74,23 +78,32 @@ def count_band(win):
               'if (description of contents of k) is "Number of Items" then\n'
               'set p to position of contents of k\n'
               'set sz to size of contents of k\n'
-              'return ((item 1 of p) - (item 1 of wp)) & "," & ((item 2 of p) - (item 2 of wp)) '
-              '& "," & (item 1 of sz) & "," & (item 2 of sz)\n'
+              'return (((item 1 of p) - (item 1 of wp)) as text) & "," '
+              '& (((item 2 of p) - (item 2 of wp)) as text) & "," '
+              '& ((item 1 of sz) as text) & "," & ((item 2 of sz) as text) & "," '
+              '& (description of contents of k)\n'
               'end if\n'
               'end try\n'
               'end repeat\n'
               'return "ABSENT"\n'
               'end tell')
+    # `as text` on every number, because `integer & ","` in AppleScript builds a LIST rather than a
+    # string: osascript rendered `298, ,, 716, ,, 146, ,, 25` and the parser below saw ten fields,
+    # not four. It returned None on every run and the caller quietly used its guessed rectangle —
+    # a measurement that never once ran, wearing the shape of one that did.
     r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
-    parts = (r.stdout or "").strip().replace(", ", ",").split(",")
-    if len(parts) != 4:
-        return None
+    parts = (r.stdout or "").strip().split(",")
+    if len(parts) != 5:
+        return None, None
     try:
-        x, y, w, h = (int(v) for v in parts)
+        x, y, w, h = (int(v) for v in parts[:4])
     except ValueError:
-        return None
+        return None, None
+    subject = parts[4].strip()
+    if not subject:
+        return None, None
     # A little margin so anti-aliasing at the edges cannot decide the verdict.
-    return (max(0, x - 4), max(0, y - 4), w + 8, h + 8)
+    return (max(0, x - 4), max(0, y - 4), w + 8, h + 8), subject
 
 
 def count_of(text):
@@ -110,7 +123,17 @@ if not win:
 
 # The witness element's own rectangle, so the visual assertion is about the thing the verdict rests on
 # rather than about the window in general.
-COUNT_BAND = count_band(win) or (0, int(win["h"] * 0.90), win["w"], int(win["h"] * 0.10))
+#
+# The fallback that stood here — the bottom tenth of the window — was the failure mode this
+# function exists to remove, reinstated for the case where the function fails. A rectangle nobody
+# located cannot be named, and an unnamed band is what #622 is about. A failed lookup is red.
+COUNT_BAND, COUNT_SUBJECT = count_band(win)
+ev.check("523/precondition-the-count-readout-was-located",
+         COUNT_BAND is not None and bool(COUNT_SUBJECT),
+         "the Number of Items readout, located by asking the element where it is",
+         f"band={COUNT_BAND!r} subject={COUNT_SUBJECT!r}", None)
+if COUNT_BAND is None:
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
 # ---- precondition: at least two markers, so a delete leaves something behind ----
 while (count_of(logic_item_count()) or 0) < 2:
@@ -162,7 +185,7 @@ ev.check("523/the-product-and-an-independent-read-agree",
          "reported the expected count instead of the observed one; the two reads diverged")
 
 ev.visual("523/the-count-readout-changes",
-          pre["file"], post["file"], COUNT_BAND, expect_change=True,
+          pre["file"], post["file"], COUNT_BAND, subject=COUNT_SUBJECT, expect_change=True,
           why=f"the marker count went {before_text!r} to {after_text!r}, so the readout must repaint")
 
 ev.restored("523/markers-remain-for-the-next-run", (after_n or 0) >= 1,

--- a/Scripts/livekit/live_523_marker_delete.py
+++ b/Scripts/livekit/live_523_marker_delete.py
@@ -193,4 +193,9 @@ ev.restored("523/markers-remain-for-the-next-run", (after_n or 0) >= 1,
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_534_goto_position.py
+++ b/Scripts/livekit/live_534_goto_position.py
@@ -63,7 +63,16 @@ if not win:
 # The transport LCD sits in the control bar along the top of the arrange window. The region is named so
 # the visual assertion is about the readout, not about "some pixel somewhere changed" — Logic repaints
 # meters continuously and a whole-window diff is always true.
-LCD = (int(win["w"] * 0.42), 0, int(win["w"] * 0.34), int(win["h"] * 0.055))
+# The playhead-position readout, located by the AXDescription it carries. What stood here was a
+# fraction of the window — measured 2026-08-20 those fractions give (806, 0, 652, 57), which is a
+# 652-point slab of the control bar starting inside the title bar, while the readout itself is
+# 120x50 at (828, 27). Wide enough to hold the answer, and wide enough to hold the tempo field, the
+# transport buttons and whatever else Logic repaints up there.
+LCD, LCD_SUBJECT = ev.located_band("Playhead Position")
+ev.check("534/precondition-the-position-readout-was-located",
+         LCD is not None and bool(LCD_SUBJECT),
+         "the transport's playhead-position readout, located by AXDescription",
+         f"band={LCD!r} subject={LCD_SUBJECT!r}", None)
 
 # ---- precondition: park the playhead so the measured move is unambiguous ----
 park_body = d.tool("logic_transport", "goto_position", {"position": PARK})
@@ -123,7 +132,8 @@ ev.check("534/the-dialog-does-not-outlive-the-operation",
          "skipped the dismissal; the modal stayed up and the next call refused")
 
 ev.visual("534/the-transport-readout-moves-with-the-operation",
-          pre["file"], post["file"], LCD, expect_change=True,
+          pre["file"], post["file"], LCD, subject=LCD_SUBJECT,
+          expect_change=True,
           why=f"the playhead moved from {PARK} to {TARGET}, so the LCD must repaint")
 
 # ---- restore ----

--- a/Scripts/livekit/live_534_goto_position.py
+++ b/Scripts/livekit/live_534_goto_position.py
@@ -146,4 +146,9 @@ ev.restored("534/playhead-parked-again",
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_538_modal_reconcile.py
+++ b/Scripts/livekit/live_538_modal_reconcile.py
@@ -72,8 +72,11 @@ if not win:
     d.close(); ev.stop_recording(rec)
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
-# The track header rail: the name band of the surviving track lives here.
-RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("538/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 
 # ---- precondition: exactly one track, distinctively named ----
 #
@@ -174,7 +177,7 @@ ev.check("538/logic-agrees-the-sheet-is-gone",
          "left the sheet up by skipping the Create press; this independent read still said 1")
 
 ev.visual("538/the-track-rail-changes",
-          pre["file"], post["file"], RAIL, expect_change=True,
+          pre["file"], post["file"], RAIL, expect_change=True, subject=RAIL_SUBJECT,
           why=f"the distinctively named track {WITNESS_NAME!r} was deleted and replaced")
 
 ev.restored("538/project-has-a-track-again", True,

--- a/Scripts/livekit/live_538_modal_reconcile.py
+++ b/Scripts/livekit/live_538_modal_reconcile.py
@@ -185,4 +185,9 @@ ev.restored("538/project-has-a-track-again", True,
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_542_track_create_retry.py
+++ b/Scripts/livekit/live_542_track_create_retry.py
@@ -155,4 +155,9 @@ ev.restored("542/project-track-count-restored", restored, detail)
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_542_track_create_retry.py
+++ b/Scripts/livekit/live_542_track_create_retry.py
@@ -77,7 +77,11 @@ if not win:
     d.close()
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
-RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("542/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 
 # ---- precondition: no sheet is already up ----
 #
@@ -134,7 +138,7 @@ ev.check("542/exactly-one-track-was-added",
          "the count rose by more than one")
 
 ev.visual("542/a-new-row-appears-in-the-rail",
-          pre["file"], post["file"], RAIL, expect_change=True,
+          pre["file"], post["file"], RAIL, subject=RAIL_SUBJECT, expect_change=True,
           why="a created track has to be visible as a new header row, independent of any AX read")
 
 # ---- restoration: leave the project as it was found ----

--- a/Scripts/livekit/live_543_lookup_names_the_step.py
+++ b/Scripts/livekit/live_543_lookup_names_the_step.py
@@ -77,7 +77,11 @@ if not win:
     d.close()
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
-RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("543/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 
 live_tracks = tracks()
 ev.note("precondition", {"track_count": len(live_tracks),
@@ -156,7 +160,7 @@ ev.restored("543/no-state-was-mutated", len(after_tracks) == len(live_tracks),
             f"track count {len(live_tracks)} -> {len(after_tracks)}; the op is refused before any write")
 
 ev.visual("543/the-rail-is-unchanged", shot["file"], ev.shot("rail-after", settle_region=RAIL)["file"],
-          RAIL, expect_change=False,
+          RAIL, subject=RAIL_SUBJECT, expect_change=False,
           why="a refused lookup must leave the track rail exactly as it was; this is the pixel witness "
               "that the run mutated nothing")
 

--- a/Scripts/livekit/live_544_output_schema.py
+++ b/Scripts/livekit/live_544_output_schema.py
@@ -51,7 +51,11 @@ if not win:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
 # The track rail: a read-only system command has no business repainting it.
-RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("544/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 pre = ev.shot("before-system-reads", settle_region=RAIL)
 
 
@@ -115,7 +119,7 @@ ev.check("544/the-text-the-oracle-grades-is-unchanged",
 
 post = ev.shot("after-system-reads", settle_region=RAIL)
 ev.visual("544/read-only-commands-do-not-disturb-the-session",
-          pre["file"], post["file"], RAIL, expect_change=False,
+          pre["file"], post["file"], RAIL, subject=RAIL_SUBJECT, expect_change=False,
           why="permissions, refresh_cache and health are reads; the track rail must be untouched")
 
 ev.restored("544/no-session-state-was-mutated", True,

--- a/Scripts/livekit/live_544_output_schema.py
+++ b/Scripts/livekit/live_544_output_schema.py
@@ -127,4 +127,9 @@ ev.restored("544/no-session-state-was-mutated", True,
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_545_delete_confirm.py
+++ b/Scripts/livekit/live_545_delete_confirm.py
@@ -125,7 +125,19 @@ if not win:
 # WRONG here: with the Library open that strip is the sound browser, which does not move when a track is
 # deleted, so the visual assertion failed while the delete had plainly worked. Sample where the rows
 # actually are. (This is measurement, not control: nothing is ever clicked by coordinate.)
-RAIL = (int(win["w"] * 0.32), int(win["h"] * 0.16), int(win["w"] * 0.17), int(win["h"] * 0.44))
+# The rows themselves, as a slice of a rail located by AXDescription rather than as a fraction of
+# the window. The fractions happened to land on the rail in the layout they were written in;
+# measured 2026-08-20 the rail sits at x=603 w=325, and the same fractions of the same window give
+# x=614 w=326 only because the panes around it have not moved since. A slice, not the whole rail:
+# the rail carries level meters that repaint on their own, and a positive assertion over those is
+# close to one that cannot fail.
+_RAIL, _RAIL_SUBJECT = ev.located_band("Tracks header")
+RAIL = (_RAIL[0], _RAIL[1] + 6, _RAIL[2], 462) if _RAIL else None
+RAIL_SUBJECT = f"{_RAIL_SUBJECT} — the top of the rail, where the rows stand" if _RAIL else None
+ev.check("545/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "a slice of the track-header rail, offset into a rail located by AXDescription",
+         f"rail={_RAIL!r} band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 
 pre = dialog_count()
 ev.check("545/precondition-no-dialog-is-already-up", pre == 0,
@@ -252,7 +264,8 @@ ev.check("545/the-delete-is-certified-not-abandoned",
 
 shot_after = ev.shot("after-delete", settle_region=RAIL)
 ev.visual("545/the-row-goes-away",
-          shot_before["file"], shot_after["file"], RAIL, expect_change=True,
+          shot_before["file"], shot_after["file"], RAIL, subject=RAIL_SUBJECT,
+          expect_change=True,
           why="the deleted track has to disappear from the rail; pixels witness the removal without "
               "trusting any AX read")
 

--- a/Scripts/livekit/live_549_cell_does_not_veto.py
+++ b/Scripts/livekit/live_549_cell_does_not_veto.py
@@ -280,4 +280,9 @@ ev.restored("549/project-has-tracks-again", len(tracks()) >= 1, f"tracks={len(tr
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_549_cell_does_not_veto.py
+++ b/Scripts/livekit/live_549_cell_does_not_veto.py
@@ -146,7 +146,14 @@ win = E.logic_window()
 osa('tell application "System Events" to tell process "Logic Pro" to '
     'set position of (first window whose name contains "Marker List") to {1200, 640}')
 time.sleep(1.2)
-RAIL = (0, int(win["h"] * 0.12), int(win["w"] * 0.19), int(win["h"] * 0.45)) if win else None
+# The rail itself, located by AXDescription. Those fractions give (0, 126, 364, 472) on this
+# window, which is the LIBRARY browser — the rail begins at x=603 whenever the Library is open. The
+# band was measured with it closed, and nothing in the run could report that it had reopened.
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("549/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 pre = ev.shot("before-create", settle_region=RAIL)
 
 # ---- the defect: create must certify with the failing node present ----
@@ -201,7 +208,8 @@ ev.check("549/the-writes-actually-landed",
 
 post = ev.shot("after-create", settle_region=RAIL)
 if RAIL:
-    ev.visual("549/new-track-name-bands-appear", pre["file"], post["file"], RAIL, expect_change=True,
+    ev.visual("549/new-track-name-bands-appear", pre["file"], post["file"], RAIL,
+              subject=RAIL_SUBJECT, expect_change=True,
               why="three tracks were added, so their name bands must appear in the header rail")
 
 # ---- the dangerous direction: the scan must still see a REAL sheet ----

--- a/Scripts/livekit/live_549_receipt_names_the_node.py
+++ b/Scripts/livekit/live_549_receipt_names_the_node.py
@@ -70,7 +70,11 @@ if not win:
              "no window found", "closed the Tracks window; this check went red")
     d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
-RAIL = (0, int(win["h"] * 0.10), int(win["w"] * 0.20), int(win["h"] * 0.80))
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("549/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
 
 before = tracks()
 ev.note("precondition", {"tracks": len(before), "sheets": sheet_count()})
@@ -166,7 +170,7 @@ ev.check("549/the-node-carries-no-user-content",
          "and the check caught it")
 
 ev.visual("549/the-track-rail-changes",
-          pre["file"], post["file"], RAIL, expect_change=True,
+          pre["file"], post["file"], RAIL, subject=RAIL_SUBJECT, expect_change=True,
           why="one extra track is standing at this point, so the header rail must differ")
 
 # remove the extra track left standing for the visual

--- a/Scripts/livekit/live_549_receipt_names_the_node.py
+++ b/Scripts/livekit/live_549_receipt_names_the_node.py
@@ -188,4 +188,9 @@ ev.restored("549/track-count-returned-to-start", len(after) == len(before),
 
 d.close()
 ev.stop_recording(rec)
-print(json.dumps(ev.write(), indent=1))
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_565_empty_marker_list.py
+++ b/Scripts/livekit/live_565_empty_marker_list.py
@@ -86,11 +86,7 @@ if LOCALE not in LOCALES:
     sys.exit(f"unknown locale {LOCALE!r}; measured locales are {sorted(LOCALES)}")
 L = LOCALES[LOCALE]
 MARKER_WINDOW = L["window"]
-# Window-relative rectangle over the first rows of the Marker List table, derived from a live
-# measurement (window at 452x746, table origin 142 points below the window's own origin). The band
-# stops well short of the table's full height so the assertion is about ROWS appearing, not about
-# the window being repainted.
-ROW_BAND = (4, 145, 420, 60)
+
 
 
 def osa(script):
@@ -176,6 +172,23 @@ if MARKER_WINDOW not in titles:
     open_marker_list()
     titles = osa('tell application "System Events" to tell process "Logic Pro" to '
                  'return name of every window')
+# The table alone, located by the AXDescription it carries rather than written as coordinates.
+# Measured 2026-08-20: the fixed rectangle that stood here did land on the first table rows, so
+# this is not a correction of where it pointed — it is a correction of what could be SAID about
+# it. The window is user-resizable and the rows move with it, and a run had no way to report that
+# it had watched the right thing.
+#
+# "Marker" is ambiguous in this window: the outer group is the whole pane, the inner one the table.
+# The upper bound picks the table, which matters — the outer pane also holds the Number of Items
+# readout, and that repaints for its own reasons, so an assertion over it could go green while the
+# table stayed empty.
+ROW_BAND, ROW_SUBJECT = ev.located_band("Marker", "--role", "AXGroup",
+                                        "--min-height", "300", "--max-height", "650")
+ev.check("565/precondition-the-marker-table-was-located",
+         ROW_BAND is not None and bool(ROW_SUBJECT),
+         "the Marker List table, located by AXDescription with the pane excluded by size",
+         f"band={ROW_BAND!r} subject={ROW_SUBJECT!r}", None)
+
 locale_ok = MARKER_WINDOW in titles
 ev.check(f"565/{LOCALE}/precondition-logic-is-actually-in-this-locale", locale_ok,
          f"a window title carries this locale's Marker List name ({MARKER_WINDOW!r}), so the run "
@@ -272,9 +285,8 @@ ev.check(f"565/{LOCALE}/an-independent-witness-agrees-a-marker-appeared",
 
 after = ev.shot(f"565/{LOCALE}/marker-created", settle_region=ROW_BAND, window_title=MARKER_WINDOW)
 ev.visual(f"565/{LOCALE}/a-row-appears-in-the-marker-table",
-          before["file"], after["file"], ROW_BAND, expect_change=True,
-          why="the first rows of the Marker List table are empty before the create and carry the "
-              "new marker after it")
+          before["file"], after["file"], ROW_BAND, subject=ROW_SUBJECT, expect_change=True,
+          why="the Marker List table holds no rows before the create and one after it")
 
 # ---- restore ----------------------------------------------------------------------------------
 # The run leaves the project with the marker count it found. It cannot restore the specific markers

--- a/Scripts/livekit/live_572_record_sequence_first_call.py
+++ b/Scripts/livekit/live_572_record_sequence_first_call.py
@@ -60,7 +60,17 @@ if missing:
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # Band over the arrange window's track lane area, where an imported region becomes visible.
-REGION_BAND = (280, 120, 700, 220)
+# The arrange canvas, located by AXDescription. The rectangle that stood here spans x 280..980,
+# and measured 2026-08-20 the canvas begins at x=928 — so all but the last fifty points of it lay
+# over the Library, the Inspector and the track headers. An imported region is drawn in the canvas;
+# this band was almost entirely somewhere else.
+_CONTENTS, _CONTENTS_SUBJECT = ev.located_band("Tracks contents")
+REGION_BAND = (_CONTENTS[0], _CONTENTS[1], 700, 220) if _CONTENTS else None
+REGION_BAND_SUBJECT = f"{_CONTENTS_SUBJECT} — the first bars of the top lanes" if _CONTENTS else None
+ev.check("572/precondition-the-arrange-canvas-was-located",
+         REGION_BAND is not None and bool(REGION_BAND_SUBJECT),
+         "a slice of the arrange canvas, offset into a region located by AXDescription",
+         f"contents={_CONTENTS!r} band={REGION_BAND!r} subject={REGION_BAND_SUBJECT!r}", None)
 
 
 def osa(script):
@@ -128,7 +138,8 @@ ev.check("572/a-region-was-actually-created",
 
 after = ev.shot("572/after-first-call", settle_region=REGION_BAND)
 ev.visual("572/the-region-appears-in-the-arrange-window",
-          before["file"], after["file"], REGION_BAND, expect_change=True,
+          before["file"], after["file"], REGION_BAND, subject=REGION_BAND_SUBJECT,
+          expect_change=True,
           why="a new track carrying the imported region is drawn in the arrange area, so this band "
               "must differ across the call")
 

--- a/Scripts/livekit/live_575_move_to_playhead_identity.py
+++ b/Scripts/livekit/live_575_move_to_playhead_identity.py
@@ -57,7 +57,17 @@ if missing:
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # Measured band over the track-header rail: the arrange window sits at 0,30 and the rail's own AX
 # frame is 603,192 325x406, so this is 603,162 in window coordinates. Every call here is a read.
-HEADER_BAND = (603, 162, 325, 406)
+# The top of the track-header rail, located by AXDescription. This assertion is NEGATIVE — the
+# rail must come back byte-identical — so it matters twice over that the band is the rail and not
+# whatever else has moved under those coordinates: a band that drifted onto quiet chrome would
+# pass this while the rail changed completely.
+_RAIL, _RAIL_SUBJECT = ev.located_band("Tracks header")
+HEADER_BAND = (_RAIL[0], _RAIL[1], _RAIL[2], 406) if _RAIL else None
+HEADER_BAND_SUBJECT = f"{_RAIL_SUBJECT} — the top of the rail, where the rows stand" if _RAIL else None
+ev.check("575/precondition-the-track-header-rail-was-located",
+         HEADER_BAND is not None and bool(HEADER_BAND_SUBJECT),
+         "a slice of the track-header rail, offset into a rail located by AXDescription",
+         f"rail={_RAIL!r} band={HEADER_BAND!r} subject={HEADER_BAND_SUBJECT!r}", None)
 
 
 def osa(script):
@@ -134,7 +144,8 @@ ev.check("575/the-reachable-surface-is-unchanged",
 
 after = ev.shot("575/after", settle_region=HEADER_BAND)
 ev.visual("575/no-project-state-was-touched",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], HEADER_BAND, subject=HEADER_BAND_SUBJECT,
+          expect_change=False,
           why="every call in this run is a read, so the track-header rail must be byte-identical "
               "across it — a change here would mean a read path wrote something")
 

--- a/Scripts/livekit/live_575_move_to_playhead_reachable.py
+++ b/Scripts/livekit/live_575_move_to_playhead_reachable.py
@@ -62,7 +62,17 @@ ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # Measured band over the arrange CONTENT area (right of the track-header rail, which ends at
 # x=928): the window sits at 0,30 and the content group starts just past the headers. This is where
 # a region that moved has to leave a mark.
-CONTENT_BAND = (940, 162, 500, 300)
+# The arrange canvas, located by AXDescription. This rectangle was right — measured 2026-08-20
+# the canvas sits at 928,162 and the band began twelve points inside it. It is anchored anyway:
+# the canvas moves whenever the Library or Inspector is opened, and a run had no way to say
+# whether it still watched the canvas or the pane that had slid under it.
+_CONTENTS, _CONTENTS_SUBJECT = ev.located_band("Tracks contents")
+CONTENT_BAND = (_CONTENTS[0] + 12, _CONTENTS[1], 500, 300) if _CONTENTS else None
+CONTENT_BAND_SUBJECT = f"{_CONTENTS_SUBJECT} — the first bars of the top lanes" if _CONTENTS else None
+ev.check("575/precondition-the-arrange-canvas-was-located",
+         CONTENT_BAND is not None and bool(CONTENT_BAND_SUBJECT),
+         "a slice of the arrange canvas, offset into a region located by AXDescription",
+         f"contents={_CONTENTS!r} band={CONTENT_BAND!r} subject={CONTENT_BAND_SUBJECT!r}", None)
 TARGET_BAR = 9
 WITNESS_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_region_select.swift")
 WITNESS = os.path.join(ev.dir, "ax_region_select")
@@ -266,7 +276,8 @@ ev.check("575/an-independent-reader-agrees-the-region-is-there-now",
          "claims the move, and this check — which never reads the envelope — goes red")
 
 ev.visual("575/the-region-visibly-moved",
-          before_shot["file"], after_shot["file"], CONTENT_BAND, expect_change=True,
+          before_shot["file"], after_shot["file"], CONTENT_BAND, subject=CONTENT_BAND_SUBJECT,
+          expect_change=True,
           why="a region that moved from one bar to another is drawn somewhere else in the arrange "
               "content, so the band must differ — an envelope that claimed a move the screen did "
               "not show would be describing something other than what the user sees")

--- a/Scripts/livekit/live_576_completeness_is_measured.py
+++ b/Scripts/livekit/live_576_completeness_is_measured.py
@@ -57,7 +57,17 @@ ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 #     Library    x 0..364     Inspector  x 366..601     arrange content  x 603..1920, y 117..
 #
 # so the header column starts just inside x=603, and y=90 is window-relative for the content's top.
-HEADER_BAND = (610, 95, 190, 420)
+# Anchored to the rail rather than written down. The numbers above are a correct measurement of
+# one layout — and the harness below them proves how little that is worth, since the rectangle it
+# replaced was a correct measurement of a different one. The rail moves with the panes beside it;
+# only asking it where it is survives that.
+_RAIL, _RAIL_SUBJECT = ev.located_band("Tracks header")
+HEADER_BAND = (_RAIL[0] + 7, _RAIL[1], 190, 420) if _RAIL else None
+HEADER_BAND_SUBJECT = f"{_RAIL_SUBJECT} — the name column of the rows" if _RAIL else None
+ev.check("576/precondition-the-track-header-rail-was-located",
+         HEADER_BAND is not None and bool(HEADER_BAND_SUBJECT),
+         "a slice of the track-header rail, offset into a rail located by AXDescription",
+         f"rail={_RAIL!r} band={HEADER_BAND!r} subject={HEADER_BAND_SUBJECT!r}", None)
 ZOOM_TIGHT = 0.0     # every track visible
 ZOOM_LOOSE = 0.6     # tall rows, most tracks pushed out of the viewport
 MIN_TRACKS = 12      # below this the loose zoom may still fit everything
@@ -189,7 +199,8 @@ ev.check("576/completeness-is-not-derived-from-the-regions",
          "with no region, so that derivation reports short of the truth and never reaches complete")
 
 ev.visual("576/the-viewport-actually-moved",
-          loose_shot["file"], tight_shot["file"], HEADER_BAND, expect_change=True,
+          loose_shot["file"], tight_shot["file"], HEADER_BAND, subject=HEADER_BAND_SUBJECT,
+          expect_change=True,
           why="the two readings come from genuinely different viewports, not from two calls against "
               "the same screen — the track-header band must differ between them")
 

--- a/Scripts/livekit/live_576_viewport_limited_region_readback.py
+++ b/Scripts/livekit/live_576_viewport_limited_region_readback.py
@@ -51,9 +51,20 @@ if missing:
     sys.exit(f"cannot run: missing {missing}")
 
 ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
-# Band over the arrange window's track headers. NOT because it changes — measured, it does not: the
-# lane Logic creates is below the visible arrangement. That is the point the visual assertion makes.
-HEADER_BAND = (10, 120, 260, 320)
+# A slice of the arrange window's track headers. NOT because it changes — measured, it does not:
+# the lane Logic creates is below the visible arrangement. That is the point the visual assertion
+# makes, and it is exactly why the rectangle that stood here was dangerous.
+#
+# `(10, 120, 260, 320)` is the LIBRARY browser, not the track headers — `live_576_completeness`
+# says so in its own comment, having found it the hard way when two captures hashed identically
+# across a zoom change that plainly worked. Here the assertion is NEGATIVE, so the wrong rectangle
+# did not fail: the Library does not change when a track is created, so the check passed for a
+# reason that had nothing to do with the claim. Sitting green, saying nothing.
+HEADER_BAND, HEADER_BAND_SUBJECT = ev.located_band("Tracks header")
+ev.check("576/precondition-the-track-header-rail-was-located",
+         HEADER_BAND is not None and bool(HEADER_BAND_SUBJECT),
+         "the track-header rail, located by the AXDescription it carries",
+         f"band={HEADER_BAND!r} subject={HEADER_BAND_SUBJECT!r}", None)
 MAX_ATTEMPTS = 12
 
 
@@ -177,7 +188,8 @@ after = ev.shot("576/after", settle_region=HEADER_BAND)
 # effect leaves no mark inside the viewport, which is why a verification that only reads the viewport
 # cannot certify it — and why an empty region result must not be published as a definite failure.
 ev.visual("576/the-created-track-is-invisible-inside-the-viewport",
-          before["file"], after["file"], HEADER_BAND, expect_change=False,
+          before["file"], after["file"], HEADER_BAND, subject=HEADER_BAND_SUBJECT,
+          expect_change=False,
           why="the envelope reports a track-count delta while the visible track-header band is "
               "byte-identical: the lane Logic created is outside the viewport, so the screenshot "
               "and the AX region reader are blind in the same place and for the same reason")

--- a/Scripts/livekit/live_590_project_new_from_cold_launch.py
+++ b/Scripts/livekit/live_590_project_new_from_cold_launch.py
@@ -264,8 +264,18 @@ ev.check("590/the-operation-does-not-overclaim-what-it-verified",
 
 created_title = next((t for t in after_titles if "Tracks" in t or "트랙" in t), chooser_title)
 after = ev.shot("590/created", settle_region=None, window_title=created_title)
+# The subject here is deliberately not an AX element: the two captures are of DIFFERENT WINDOWS,
+# the chooser before and the arrange window after, so no single element spans them. What the band
+# is, is the top-left corner of whatever window was on screen at each moment — which is exactly the
+# claim, and saying so keeps it from reading as a region of one window that drifted.
+#
+# One limit worth writing down rather than leaving implied: the two windows have different frames,
+# and `visual` scales the crop by the window points of the LAST capture, so the before-crop is
+# scaled by the arrange window's size. It cannot weaken this assertion — the two corners differ
+# either way — but it would matter to any negative assertion built the same way.
 ev.visual("590/the-screen-shows-a-project-where-it-showed-a-chooser",
           before["file"], after["file"], (0, 0, 400, 200), expect_change=True,
+          subject="the top-left corner of the window on screen — the chooser, then the project",
           why="the capture before the call is the chooser window and the one after is the new "
               "arrange window, so the top-left corner of what was captured must differ — an "
               "envelope claiming a project that nobody can see would not move it")

--- a/Scripts/livekit/live_594_first_import_after_project_new.py
+++ b/Scripts/livekit/live_594_first_import_after_project_new.py
@@ -172,11 +172,15 @@ if not document_titles():
 # records as an unsettled capture straddling displays rather than as an honest result.
 arrange_title = document_titles()[0]
 win = E.logic_window(arrange_title)
-band = (0, 0, win["w"], min(500, win["h"])) if win else None
-ev.check("594/precondition-the-window-frame-is-known",
-         band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+# — and located from the tree rather than sized off the window, which answers the same worry more
+# directly. The band that stood here was the top 500 points of the WHOLE window: the title bar, the
+# control bar, the Library, the Inspector and a slice of the canvas. An import that put nothing in
+# the arrange area would still have changed it.
+band, band_subject = ev.located_band("Tracks contents")
+ev.check("594/precondition-the-arrange-canvas-was-located",
+         band is not None and bool(band_subject),
+         "the arrange canvas, located by the AXDescription it carries",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     d.close(); ev.stop_recording(rec)
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
@@ -232,7 +236,8 @@ ev.check("594/the-region-it-made-is-real",
 
 after_shot = ev.shot("594/after-first-import", settle_region=band, window_title=arrange_title)
 ev.visual("594/the-import-put-something-on-screen",
-          before_shot["file"], after_shot["file"], band, expect_change=True,
+          before_shot["file"], after_shot["file"], band, subject=band_subject,
+          expect_change=True,
           why="the project was empty a moment ago and the import creates a track carrying a region, "
               "so the arrangement must look different — an envelope reporting a verified import "
               "that left the screen untouched would be describing something the user cannot see")

--- a/Scripts/livekit/live_606_save_as_writes_the_file.py
+++ b/Scripts/livekit/live_606_save_as_writes_the_file.py
@@ -135,10 +135,17 @@ located = [(t, E.logic_window(t)) for t in titles]
 located = [(t, w) for t, w in located if w]
 located.sort(key=lambda pair: pair[1]["w"] * pair[1]["h"], reverse=True)
 arrange_title, win = located[0] if located else (titles[0], None)
+# The window's own title bar, and the subject says so. The band is derived from a frame this run
+# measured — `logic_window` reads it from CoreGraphics — rather than from a layout somebody
+# remembered, and 28 points is the strip that holds the document name.
 band = (0, 0, win["w"], 28) if win else None
-ev.check("606/precondition-the-window-frame-is-known", band is not None,
-         "the arrange window's own frame read, so the capture band is inside it",
-         f"window={win!r} band={band!r}", None)
+# Not the title it carried before: this run RENAMES the window, so naming the band after the old
+# title would describe the after-capture as something it is not.
+band_subject = "the document window's title bar" if win else None
+ev.check("606/precondition-the-window-frame-is-known",
+         band is not None and bool(band_subject),
+         "the arrange window's own frame read, so the capture band is inside it and can be named",
+         f"window={win!r} band={band!r} subject={band_subject!r}", None)
 if band is None:
     print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
@@ -229,7 +236,8 @@ ev.check("606/the-arrange-window-is-still-locatable-after-the-save",
          f"before_title={arrange_title!r} after_title={after_title!r}", None)
 after = ev.shot("606/after", settle_region=band, window_title=after_title)
 ev.visual("606/the-window-title-changed-to-the-new-project",
-          before["file"], after["file"], band, expect_change=True,
+          before["file"], after["file"], band, subject=band_subject,
+          expect_change=True,
           why="saving under a new name renames the document window, so the title band must differ; "
               "if it does not, the project on screen is still the old one whatever the file system "
               "says")

--- a/Scripts/livekit/live_606_save_as_writes_the_file.py
+++ b/Scripts/livekit/live_606_save_as_writes_the_file.py
@@ -255,5 +255,10 @@ ev.restored("606/the-project-this-run-created-was-removed",
             f"undo without closing the project, and it is stated rather than papered over.")
 
 ev.stop_recording(rec)
+
+# #622: this harness printed its summary and exited 0 whatever the summary said. Twenty-three of
+# its siblings already ended on `is_clean`, and nine did not, for no reason anyone had written
+# down — so a clause added to `is_clean` was enforced for some runs and decorative for others.
 out = ev.write()
 print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -44,10 +44,10 @@ CASES = [
     (False, {**GOOD, "captures_straddling_displays": 1}, "a capture across two displays"),
     (False, {**GOOD, "restorations_failed": 1}, "a restoration that did not happen"),
     (False, {**GOOD, "cached_reads_used_as_live": 1}, "a cached read presented as live"),
-    # Counted, not gated — see is_clean's docstring. This case asserts the CURRENT contract, so it
-    # is the one to flip when the harnesses have adopted `subject=`.
-    (True, {**GOOD, "visual_assertions_without_a_subject": 1},
-     "a visual that names no subject: counted, not yet refused"),
+    # Gated as of #622, once all thirty-one call sites named a subject. Flipped from the deferred
+    # contract this case used to assert.
+    (False, {**GOOD, "visual_assertions_without_a_subject": 1},
+     "a visual that names no subject"),
     (False, None, "not a summary at all"),
 ]
 

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -121,6 +121,31 @@ for raw, why in [
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} name={str(raw)[:28]!r:<32} -> {stem[:28]!r:<30} {why}")
 
+# --- a band larger than its window is CLIPPED, and the record says what was hashed -------------
+#
+# `Tracks contents` is 6162 points wide on a 1920-point window: the arrange canvas extends past the
+# viewport that draws it. `CGImageCreateWithImageInRect` intersects an oversized crop against the
+# image and reports nothing, so the record claimed the whole canvas while the hash covered the
+# visible strip — the number in the evidence was not the number that was measured.
+#
+# The case that matters most is the last one. A band entirely outside the window used to crop to
+# nothing in BOTH captures, and two empty crops are equal, which is a PASS for every
+# `expect_change=False` assertion. Unreadable has to stay unreadable.
+WINDOW = (1920, 1050)
+for region, expected, why in [
+    ((10, 20, 100, 50), (10, 20, 100, 50), "wholly inside — untouched"),
+    ((928, 162, 6162, 873), (928, 162, 992, 873), "wider than the window — clipped to the viewport"),
+    ((0, 0, 1920, 1050), (0, 0, 1920, 1050), "exactly the window — untouched"),
+    ((-40, -10, 200, 100), (0, 0, 160, 90), "starts off the top-left — clipped to the origin"),
+    ((2000, 20, 100, 50), None, "wholly outside — unreadable, not an empty crop"),
+    ((10, 20, 100, 50), (10, 20, 100, 50), "no window points is not a licence to clip"),
+]:
+    wp = None if why.startswith("no window points") else WINDOW
+    got = E._clip_to_window(region, wp)
+    ok = (got is None and expected is None) or (got is not None and tuple(got) == expected)
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {str(region):<26} -> {str(got):<22} {why}")
+
 # --- the API the harnesses actually call must exist -------------------------------------------
 #
 # #620 rewrote evidence.py from a base that predated three functions, and merging it deleted them


### PR DESCRIPTION
Closes #622.

`visual()` takes `subject=`: what the watched rectangle IS, as the UI describes it. The issue
measured thirty call sites passing none. **Thirty-two of thirty-two pass one now**, and
`is_clean` gates on it.

## The count was the easy part; three of the bands were wrong

| harness | the rectangle | what it actually named |
|---|---|---|
| `live_576_viewport` | `(10, 120, 260, 320)` | the **Library browser** |
| `live_572` | `(280, 120, 700, 220)` | Library + Inspector + rail; the canvas starts at x=928 |
| `live_549_cell` | `(0, 0.12h, 0.19w, 0.45h)` | the Library again |
| `live_538/542/543/544/549r` | `(0, 0.10h, 0.20w, 0.80h)` | one rectangle, five harnesses |

`live_576_viewport` is the one worth reading twice. Its sibling `live_576_completeness` names that
exact rectangle in its own comment as a mistake it had already made and fixed — it found it when
two captures hashed identically across a zoom change that plainly worked. There the band was wrong
under `expect_change=True`, so it failed and got corrected. Here the band is wrong under
`expect_change=False`, and the Library does not change when a track is created, **so it passed.**
A wrong band fails loudly under a positive assertion and sits green under a negative one.

Measured in both pane states, because "wrong" needed to mean something exact:

```
Library open    rail at x=603    the shared rectangle is 94% Library
Library closed  rail at x=237    the same rectangle is 61% Inspector, 39% Mixer
```

It was never the rail. So bands are resolved from the live tree by the AXDescription they carry,
and the subject comes back off the element that was found rather than off the request.

## A measurement that had never once run

`live_523`'s `count_band` asks the count readout where it is, so the assertion is about the node
the verdict rests on. It has been returning `None` on every run since it was written.

`integer & ","` in AppleScript builds a **list**, not a string. osascript printed

```
298, ,, 716, ,, 146, ,, 25
```

the parser wanted four fields, got ten, and gave up — and the caller fell back to its guessed
rectangle, the bottom tenth of the window. The fallback is what hid it: with somewhere to fall,
the measurement never had to answer. Every number is coerced `as text` now, the element's
description comes back with it, and there is no fallback.

## Verified live, and it failed

`live_544` on a real Logic, first run: **7/8 checks, visual_failed 1, no subject.** The lookup had
returned `(None, None)`.

Reproduced three times by deleting the compiled tool so the run rebuilds it. The recorded reason —
added because a silent `(None, None)` is a wall — was `no standard window`:
`kAXWindowsAttribute` comes back **empty** for a moment after a harness starts a screen recording
and an MCP driver, while the window is plainly on screen. The identical call a second later
returns it.

```
before the retry, forced rebuild   checks 7/8 · visual_failed 1 · subject missing
after the retry, forced rebuild    checks 8/8 · visual_failed 0 · subject "Tracks header"
```

The tool retries **emptiness only** — a populated window list without the wanted element is a real
answer and stays a fast refusal. `windowAttempts` rides along on the success path, and both
instrumented runs came back **2**. So this is not a rare transient guarded against defensively:
without the retry, nearly every converted harness would have failed, and the shape would have read
as "the new lookup is flaky."

Three full runs, clean:

```
live_534_goto_position   7/7   band [828, 27, 120, 50]    subject "Playhead Position"
live_543_lookup_names    6/6   band [603,162,325,873]     subject "Tracks header"
live_544_output_schema   8/8   band [603,162,325,873]     subject "Tracks header"
```

and every distinct selector the harnesses use resolves against the running application —
`Control Bar`, `Playhead Position`, `Tracks contents`, `Tracks header`, and `Marker`, the last
only with its own window open, which is what its harness arranges.

## Clipping, because a band may be larger than its window

`Tracks contents` is 6162 points wide on a 1920-point window: the canvas extends past the viewport
that draws it. `CGImageCreateWithImageInRect` intersects an oversized crop silently, so the record
named the whole canvas while the hash covered the visible strip. `_clip_to_window` does it
explicitly and records what was hashed.

The case that matters most is the last one in its test: a band entirely outside the window used to
crop to nothing in **both** captures, and two empty crops are equal — a PASS for every negative
assertion. Unreadable stays unreadable now.

## The clause, and nine harnesses that were not consulting it

`is_clean` gates on `visual_assertions_without_a_subject == 0`, and the deferred case in
`test_evidence.py` is flipped. Both were mutation-checked: removing the clause turns that case red
and nothing else.

Twenty-three harnesses ended on `sys.exit(0 if E.is_clean(out) else 1)`; nine did not, for no
reason written down anywhere — so a clause added to `is_clean` would have been enforced for some
runs and decorative for others, between files that look identical. All thirty-two consult it now.
Controlled: a clean run exits 0, the same run with a bogus selector exits 1.

## What this does NOT establish

- **That a subject is TRUE.** The clause checks for a non-empty string. Most subjects are read
  back off the element that was found and cannot drift from it; the authored ones — a window's
  title bar, a slice offset into a located rail — are the ones a reviewer has to read.
- **That every harness still runs.** Three of thirty-two were run against a live Logic. The rest
  are verified as far as their band lookups resolving, which is the part this PR changed.
- `live_590`'s subject is deliberately not an AX element: its two captures are of different
  windows, the chooser and then the project, and no element spans them.

## Where a sub-region was deliberate, it stays one

`live_448` watches the **empty** area below the collapsed headers, so that its changing means
subtracks appeared rather than that a level meter repainted — #636 made exactly this point. It is
still a slice, now offset into a located rail, so it moves with the rail instead of assuming it.

`live_575_move_to_playhead_identity` is resolved in favour of #636's band, which was verified live
there rather than here. #636 has since merged, and this branch carries both that commit directly
and the merge of `main` that contains it — the file on this branch is #636's version, using the
shared `Evidence.located_band` instead of the inline copy.
