### PR TITLE
feat(#612): name the harnesses a branch must have proved, and check them

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -548,33 +548,51 @@ class Evidence:
         return self._summary(out)
 
     def _summary(self, out):
-        recs = self.records
-        checks = [r for r in recs if r["kind"] == "check"]
-        caps = [r for r in recs if r["kind"] == "capture"]
-        vis = [r for r in recs if r["kind"] == "visual"]
-        return {
-            "file": out,
-            "checks": len(checks),
-            "passed": sum(1 for c in checks if c["passed"]),
-            "mutation_backed": sum(1 for c in checks if c["mutation_flips"]),
-            "captures_unsettled": sum(1 for c in caps if not c["settled"]),
-            "captures_straddling_displays":
-                sum(1 for c in caps if not c.get("display", {}).get("wholly_within")),
-            "restorations_failed":
-                sum(1 for r in recs if r["kind"] == "restoration" and not r["restored"]),
-            "cached_reads_used_as_live":
-                sum(1 for r in recs if r["kind"] == "provenance" and not r["usable_as_live_evidence"]),
-            "captures": len(caps),
-            "visual_assertions": len(vis),
-            "visual_failed": sum(1 for v in vis if not v["passed"]),
-            "recordings": sum(1 for r in recs if r["kind"] == "recording"),
-            "operations_driven": sum(1 for r in recs if r["kind"] == "operation"),
-            # A subject must be a non-empty STRING. `not v.get("subject")` alone accepted True, a
-            # dict, or any other truthy object as a name.
-            "visual_assertions_without_a_subject":
-                sum(1 for v in vis
-                    if not isinstance(v.get("subject"), str) or not v["subject"].strip()),
-        }
+        return summarize(self.records, out)
+
+
+def summarize(recs, out=None):
+    """The counters `is_clean` reads, from a list of records.
+
+    Module-level rather than a method because the records are the whole input: a document read back
+    off disk has records and no Evidence around them, and the alternative — building a throwaway
+    object with a `.records` attribute so a method can be called on it — is a shim standing where an
+    argument belongs. The test file already had to write that shim once.
+
+    Indexed with `.get` rather than `[...]` throughout: a document read back off disk may predate a
+    field or have been truncated, and every missing key here reads as the FAILING value — an absent
+    `passed` is not a pass, an absent `settled` is unsettled. Crashing on a malformed document would
+    turn "this evidence is unreadable" into a stack trace at the gate.
+    """
+    if not isinstance(recs, list):
+        return None
+    recs = [r for r in recs if isinstance(r, dict) and "kind" in r]
+    checks = [r for r in recs if r["kind"] == "check"]
+    caps = [r for r in recs if r["kind"] == "capture"]
+    vis = [r for r in recs if r["kind"] == "visual"]
+    return {
+        "file": out,
+        "checks": len(checks),
+        "passed": sum(1 for c in checks if c.get("passed")),
+        "mutation_backed": sum(1 for c in checks if c.get("mutation_flips")),
+        "captures_unsettled": sum(1 for c in caps if not c.get("settled")),
+        "captures_straddling_displays":
+            sum(1 for c in caps if not c.get("display", {}).get("wholly_within")),
+        "restorations_failed":
+            sum(1 for r in recs if r["kind"] == "restoration" and not r.get("restored")),
+        "cached_reads_used_as_live":
+            sum(1 for r in recs if r["kind"] == "provenance" and not r.get("usable_as_live_evidence")),
+        "captures": len(caps),
+        "visual_assertions": len(vis),
+        "visual_failed": sum(1 for v in vis if not v.get("passed")),
+        "recordings": sum(1 for r in recs if r["kind"] == "recording"),
+        "operations_driven": sum(1 for r in recs if r["kind"] == "operation"),
+        # A subject must be a non-empty STRING. `not v.get("subject")` alone accepted True, a
+        # dict, or any other truthy object as a name.
+        "visual_assertions_without_a_subject":
+            sum(1 for v in vis
+                if not isinstance(v.get("subject"), str) or not v["subject"].strip()),
+    }
 
 
 # Every counter `is_clean` reads. A summary missing any of them is not clean.

--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Which live harnesses a branch changed, and whether each of them proved itself at this head.
+
+Usage:  python3 harness_evidence_coverage.py <worktree> <head-sha> <evidence-root> [base-ref]
+
+#612, item 2. The gate reads ONE document per head — `<root>/<head>/evidence.json`, whichever
+harness wrote it last. On a branch carrying two harnesses that means it can only ever validate the
+last one run, while reporting `ok`. It happened: running #606's harness on the #608 branch to check
+for a regression overwrote #608's own evidence, and the gate then validated #608 against #606's
+proof. Both were clean, so nothing looked wrong.
+
+Items 1 and 3 are already in `evidence.py` — the per-harness filename and the rotation that keeps
+an earlier document instead of replacing it. They make this possible; this is the part that changes
+what the gate can CLAIM.
+
+WHAT "TOUCHED" MEANS HERE, AND WHAT IT DOES NOT
+-----------------------------------------------
+A harness is required to have proved itself when the branch CHANGED it:
+
+    git diff --name-only <base>...HEAD -- Scripts/livekit/live_*.py
+
+That is decidable from the diff, and it is exactly the case that went wrong. What is NOT decidable,
+and is not attempted here: which harnesses a `Sources/` change ought to have been proved against.
+Nothing in the tree records that mapping, and inventing one would put a guess where this check's
+whole value is that it does not guess. A branch that changes only `Sources/` therefore passes this
+check with nothing required — the existing "live evidence for this head" step is what covers it.
+
+So this is a coverage floor, not a coverage proof. Said plainly because a check named `coverage`
+invites being read as more.
+"""
+import glob
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+
+def harness_stems(changed_paths):
+    """The live-harness stems among a list of changed repo paths.
+
+    Takes paths rather than running git, so the rule can be tested without a repository. Deletions
+    are the caller's problem to filter — a path that no longer exists cannot be required to have
+    run, and requiring it would make deleting a harness impossible.
+    """
+    stems = set()
+    for path in changed_paths or []:
+        name = os.path.basename(path)
+        if not name.startswith("live_") or not name.endswith(".py"):
+            continue
+        if os.path.dirname(path).replace("\\", "/").endswith("Scripts/livekit"):
+            stems.add(name[: -len(".py")])
+    return stems
+
+
+def documents_present(head_dir):
+    """`{stem: path}` for every per-harness document in a head directory.
+
+    `evidence.json` is deliberately not counted. It is the legacy single-file name — the last run at
+    this head whatever produced it — and counting it would let one harness's document satisfy the
+    requirement for another, which is the defect.
+    """
+    found = {}
+    for path in sorted(glob.glob(os.path.join(head_dir, "*.evidence.json"))):
+        stem = os.path.basename(path)[: -len(".evidence.json")]
+        found[stem] = path
+    return found
+
+
+def verdict(required, present_paths, read_document=None):
+    """`(missing, unclean)` — harnesses with no document, and ones whose document is not clean.
+
+    `read_document` is injected so the rule can be exercised without files on disk. It takes a path
+    and returns the parsed document, or None when it cannot be read; an unreadable document counts
+    as unclean rather than as absent, because "it ran and produced something unusable" and "it never
+    ran" are different facts and only one of them is a missing run.
+    """
+    read_document = read_document or _read_json
+    missing = sorted(s for s in required if s not in present_paths)
+    unclean = []
+    for stem in sorted(required):
+        if stem not in present_paths:
+            continue
+        doc = read_document(present_paths[stem])
+        summary = E.summarize((doc or {}).get("records"))
+        if not E.is_clean(summary):
+            unclean.append(stem)
+    return missing, unclean
+
+
+def _read_json(path):
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return None
+
+
+def changed_paths(worktree, base):
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"],
+        cwd=worktree, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return None
+    return [p for p in proc.stdout.splitlines() if p.strip()]
+
+
+def main(argv):
+    if len(argv) < 4:
+        print(__doc__)
+        return 2
+    worktree, head, root = argv[1], argv[2], argv[3]
+    base = argv[4] if len(argv) > 4 else "origin/main"
+
+    paths = changed_paths(worktree, base)
+    if paths is None:
+        print(f"-> COVERAGE FAIL: could not diff {base}...HEAD in {worktree}")
+        return 2
+    required = harness_stems(paths)
+    if not required:
+        print("n/a — this branch changes no live harness")
+        return 0
+
+    head_dir = os.path.join(root, head)
+    present = documents_present(head_dir)
+    missing, unclean = verdict(required, present)
+
+    print(f"   harnesses changed by this branch: {len(required)}")
+    for stem in sorted(required):
+        state = "missing" if stem in missing else ("UNCLEAN" if stem in unclean else "ok")
+        print(f"   {state:>7}  {stem}")
+    if missing:
+        print(f"-> COVERAGE FAIL: no evidence at {head_dir} for: {', '.join(missing)}")
+    if unclean:
+        print(f"-> COVERAGE FAIL: evidence present but not clean for: {', '.join(unclean)}")
+    return 1 if (missing or unclean) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Prove the #612 coverage rule against the cases it exists to refuse.
+
+The defect it answers is a quiet one: a branch carrying two harnesses, one document on disk, and a
+gate that reports `ok`. So the cases below are mostly runs where SOMETHING is present — the failure
+never looked like an absence.
+
+    python3 test_harness_evidence_coverage.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import harness_evidence_coverage as C  # noqa: E402
+
+failed = 0
+
+# --- which paths count as a changed harness ----------------------------------------------------
+#
+# `Scripts/livekit/` and nothing else. A `live_*.py` elsewhere in the tree is not a live harness,
+# and `evidence.py` beside them is not one either — the rule is the directory plus the prefix, and
+# both halves are asserted so neither can be dropped without a case going red.
+for paths, expected, why in [
+    (["Scripts/livekit/live_544_output_schema.py"], {"live_544_output_schema"}, "one harness"),
+    (["Scripts/livekit/live_a.py", "Scripts/livekit/live_b.py"], {"live_a", "live_b"}, "two"),
+    (["Scripts/livekit/evidence.py"], set(), "the library beside them is not a harness"),
+    (["Scripts/livekit/session_519_locale_flow.py"], set(), "a session script is not a harness"),
+    (["Tests/live_thing.py"], set(), "live_ prefix outside the directory"),
+    (["Scripts/live_544.py"], set(), "one directory up is not the directory"),
+    (["Sources/LogicProMCP/Server/LogicProTarget.swift"], set(), "product code names no harness"),
+    ([], set(), "nothing changed"),
+    (None, set(), "no diff at all"),
+]:
+    got = C.harness_stems(paths)
+    ok = got == expected
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {str(paths)[:52]:<54} -> {sorted(got)} {why}")
+
+# --- the verdict --------------------------------------------------------------------------------
+#
+# Through the REAL `E.summarize` and `E.is_clean`, not a copy of the predicate: a test that
+# reimplements the rule agrees with itself no matter what the code says.
+CLEAN = {"records": [
+    {"kind": "check", "passed": True, "mutation_flips": True},
+    {"kind": "capture", "settled": True, "display": {"wholly_within": True}},
+    {"kind": "visual", "passed": True, "subject": "Tracks header", "region": [0, 0, 1, 1]},
+    {"kind": "recording"},
+    {"kind": "operation"},
+]}
+# A visual that FAILED, which `is_clean` has always refused. Deliberately not a subject-less one:
+# that clause is newer, and a case here that depends on it would make this file's verdict a
+# statement about which other change has landed rather than about this rule.
+UNCLEAN = {"records": [dict(r) for r in CLEAN["records"]]}
+UNCLEAN["records"][2] = {"kind": "visual", "passed": False, "subject": "Tracks header",
+                         "region": [0, 0, 1, 1]}
+
+DOCS = {
+    "/e/live_a.evidence.json": CLEAN,
+    "/e/live_b.evidence.json": UNCLEAN,
+    "/e/live_broken.evidence.json": None,      # on disk, unreadable
+}
+PRESENT = {
+    "live_a": "/e/live_a.evidence.json",
+    "live_b": "/e/live_b.evidence.json",
+    "live_broken": "/e/live_broken.evidence.json",
+}
+
+for required, present, exp_missing, exp_unclean, why in [
+    ({"live_a"}, PRESENT, [], [], "one harness, its own clean document"),
+    ({"live_a", "live_b"}, PRESENT, [], ["live_b"], "the second document is not clean"),
+    # THE defect: two harnesses changed, one document on disk. Before #612 the gate read a single
+    # file per head and called this covered.
+    ({"live_a", "live_c"}, {"live_a": "/e/live_a.evidence.json"}, ["live_c"], [],
+     "two changed, one proved — the case this check exists for"),
+    ({"live_broken"}, PRESENT, [], ["live_broken"],
+     "unreadable is UNCLEAN, not missing — it ran and produced something unusable"),
+    ({"live_a"}, {}, ["live_a"], [], "nothing on disk at all"),
+    (set(), PRESENT, [], [], "no harness changed, nothing required"),
+]:
+    missing, unclean = C.verdict(required, present, read_document=lambda p: DOCS.get(p))
+    ok = missing == exp_missing and unclean == exp_unclean
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} required={sorted(required)!s:<28} "
+          f"missing={missing} unclean={unclean}  {why}")
+
+# --- `evidence.json` must not satisfy anything --------------------------------------------------
+#
+# The legacy single-file name is the last run at this head whatever wrote it. Counting it would let
+# one harness's document stand in for another's, which is the whole defect wearing a new name.
+#
+# Against a REAL directory. The first version of this block asserted on `documents_present`'s
+# DOCSTRING and then drove `verdict` with a hand-built dict — so widening the glob to `*.json` left
+# the whole suite green, which is the mutation this case exists to catch. A test that never calls
+# the function cannot see what the function does.
+import tempfile
+
+with tempfile.TemporaryDirectory() as head_dir:
+    for name in ["live_a.evidence.json",       # a harness document
+                 "evidence.json",              # the legacy last-run-wins name
+                 "live_a.evidence.1.json",     # a ROTATED earlier run of live_a
+                 "notes.json"]:                # something else entirely
+        open(os.path.join(head_dir, name), "w").write("{}")
+    found = C.documents_present(head_dir)
+    ok = set(found) == {"live_a"}
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} a real directory yields {sorted(found)} "
+          f"— not the legacy name, not a rotated run, not an unrelated file")
+
+got = C.verdict({"live_a"}, {"evidence": "/e/evidence.json"}, read_document=lambda p: CLEAN)
+ok = got == (["live_a"], [])
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} a document named `evidence` satisfies no harness -> {got}")
+
+print()
+print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
Item 2 of #612. Items 1 and 3 are already in `evidence.py` — the per-harness filename and the
rotation that keeps an earlier document rather than replacing it. **Does not close the issue**: the
tool lands here, the flip does not.

## The defect, restated in one line

The gate reads ONE document per head. On a branch carrying two harnesses it can only ever validate
the last one run, **while reporting `ok`**.

It happened, and it is in the issue: running #606's harness on the #608 branch to check for a
regression overwrote #608's own evidence, and the gate validated #608 against #606's proof. Both
were clean, so nothing looked wrong.

## The rule is the diff, so it cannot guess

```
git diff --name-only --diff-filter=d <base>...HEAD -- Scripts/livekit/live_*.py
```

A harness must have proved itself when the branch **changed** it. Deletions are excluded — a path
that no longer exists cannot be required to have run, and requiring it would make deleting a
harness impossible.

What is deliberately **not** attempted: which harnesses a `Sources/` change ought to have run.
Nothing in the tree records that mapping, and inventing one would put a guess exactly where this
check's whole value is that it has none. A branch touching only `Sources/` passes this with nothing
required — the existing "live evidence for this head" step is what covers that case.

**So it is a coverage floor, not a coverage proof.** Said in the docstring too, because a thing
named `coverage` invites being read as more.

`evidence.json` — the legacy last-run-wins name — satisfies nothing. Counting it would let one
harness's document stand in for another's, which is the defect wearing a new name.

## Not wired into the gate, and here is the number

Run against the branch that prompted this work (#640, the #622 subject conversion):

```
harnesses changed by this branch: 24
missing  live_290_shifted_strips_are_refused
missing  live_291_input_slot_is_read
…22 more…
-> COVERAGE FAIL: no evidence at <root>/<head> for: …
```

Twenty-four live runs. Enforcing this in the same change that introduces it would turn the live
suite red in one step, and #622 has just finished demonstrating where that goes: a clause nobody
can satisfy is a clause somebody deletes. So the tool lands and the flip stays a decision — with a
cost that is now a number instead of a guess.

Wiring it is one line in the gate, after the harnesses it would demand have been run.

## `summarize`, extracted

`Evidence._summary` becomes module-level `summarize(records)`. A document read back off disk has
records and no `Evidence` around them, and the alternative is building a throwaway object with a
`.records` attribute so a method can be called on it — a shim standing where an argument belongs.
The test file had already written that shim once.

Every field is read with `.get` rather than `[...]`: a document may predate a field or be
truncated, and every missing key reads as the **failing** value. An absent `passed` is not a pass;
an absent `settled` is unsettled. Crashing on a malformed document would turn "this evidence is
unreadable" into a stack trace at the gate.

## Controlled

Each mutation applied, **counted in the file**, and removed:

| mutation | result |
|---|---|
| any directory counts as `Scripts/livekit` | 2 cases red |
| the legacy `evidence.json` name counts | 1 case red |
| an unclean document passes | 2 cases red |

The middle one is the reason the directory case is driven against a real temporary directory. The
first version of it asserted on a **docstring** and drove the verdict with a hand-built dict — so
widening the glob to `*.json` left the whole file green. A test that never calls the function
cannot see what the function does, and that mutant is what found it.

## What this does NOT establish

- That a harness which ran **proved the change**. It checks that a document exists for that harness
  at that head and that `is_clean` accepts it. Whether the harness asserts anything about the diff
  is a reviewer's job.
- That the harness list is complete for a `Sources/` change — see above; it is not attempted.
- The unclean case in the test uses a **failed** visual rather than a subject-less one on purpose.
  The subject clause is newer, and a case depending on it would make this file's verdict a statement
  about which other change has landed rather than about this rule.
