### PR TITLE
feat(#628): the candidate count reaches the document, not just the tool's stdout

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -379,6 +379,20 @@ class Evidence:
             # tree to see a window at all.
             self.note("located_band/window-list-was-empty-at-first",
                       {"selector": list(selector), "attempts": attempts})
+        # #628, item 3: the candidate count reaches the DOCUMENT, not just the tool's stdout.
+        #
+        # Refusing when a name is ambiguous is half the job. The other half is that "there was
+        # exactly one" survives into the record — a lookup that stays silent on success leaves a
+        # result with no way to tell a discriminator from tree order, which is the whole issue.
+        #
+        # Recorded on EVERY success, including `candidates: 1`, and including the case where the
+        # tool did not report a count at all. A note written only when the number is interesting
+        # cannot be distinguished from a run of an older tool that never counted: both are silence,
+        # and one of them is a lookup nobody has checked.
+        self.note("located_band/candidates",
+                  {"selector": list(selector), "subject": subject,
+                   "candidates": payload.get("candidates"),
+                   "counted": isinstance(payload.get("candidates"), int)})
         return tuple(band), subject
 
     # -- observations -------------------------------------------------------

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -146,6 +146,53 @@ for region, expected, why in [
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} {str(region):<26} -> {str(got):<22} {why}")
 
+# --- what `located_band` puts in the DOCUMENT --------------------------------------------------
+#
+# #628: refusing an ambiguous name is half the job; the other half is that "there was exactly one"
+# survives into the record. A lookup silent on success leaves a result with no way to tell a
+# discriminator from tree order.
+#
+# Driven through the REAL `located_band` against a STUB tool placed where it would compile one.
+# Nothing here calls swiftc, and nothing reimplements the parsing — a test that rewrites the rule
+# agrees with itself no matter what the code does.
+import json as _json
+import stat
+import tempfile as _tempfile
+
+def _with_stub_tool(stdout, selector=("Tracks header",)):
+    """Run `located_band` with a tool that prints `stdout`. Returns (result, records)."""
+    root = _tempfile.mkdtemp()
+    ev = E.Evidence("b" * 40, root)
+    tool = os.path.join(ev.dir, "ax_control_bar_band")
+    with open(tool, "w") as fh:
+        fh.write("#!/bin/sh\ncat <<'JSON'\n" + stdout + "\nJSON\n")
+    os.chmod(tool, os.stat(tool).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return ev.located_band(*selector), ev.records
+
+BAND = '{"band":[603,162,325,873],"description":"Tracks header","candidates":1}'
+NO_COUNT = '{"band":[603,162,325,873],"description":"Tracks header"}'
+AMBIGUOUS = '{"error":"AXDescription is ambiguous","matches":[{"role":"AXGroup"},{"role":"AXGroup"}]}'
+
+for stdout, want_result, want_tag, want_payload, why in [
+    (BAND, ((603, 162, 325, 873), "Tracks header"), "located_band/candidates",
+     {"candidates": 1, "counted": True}, "one candidate is RECORDED as one"),
+    (NO_COUNT, ((603, 162, 325, 873), "Tracks header"), "located_band/candidates",
+     {"candidates": None, "counted": False},
+     "an older tool that never counted is not silence — it says so"),
+    (AMBIGUOUS, (None, None), "located_band/refused",
+     {"why": "AXDescription is ambiguous"}, "ambiguity is refused and the reason recorded"),
+    ("not json at all", (None, None), "located_band/refused",
+     {"why": "the tool printed something that is not JSON"}, "unparseable output is a refusal"),
+]:
+    (result, records) = _with_stub_tool(stdout)
+    notes = [r for r in records if r.get("kind") == "observation" and r.get("tag") == want_tag]
+    payload = notes[0]["payload"] if notes else {}
+    ok = (result == want_result
+          and len(notes) == 1
+          and all(payload.get(k) == v for k, v in want_payload.items()))
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {why:<52} -> {result} {payload if not ok else ''}")
+
 # --- the API the harnesses actually call must exist -------------------------------------------
 #
 # #620 rewrote evidence.py from a base that predated three functions, and merging it deleted them


### PR DESCRIPTION
Item 3 of #628: *"the count carried into live evidence, so a harness's document says how many
candidates each lookup had."* Does not close the issue — item 1 (an ambiguity-aware locator in the
AX layer) is separate and is a `Sources/` change.

## Half the job was already done, and nothing read it

Refusing when a name is ambiguous is half. #627 did that for the livekit tool, and
`ax_control_bar_band` has emitted `candidates` on its **success** path since #629 — precisely so a
later reader can tell *"there was exactly one"* from *"the first one was taken."*

`located_band` parsed the band and the description and dropped the count on the floor. So the
document said what the band was and nothing about whether the name identified it.

## Why the note is unconditional

The obvious form is to record it only when the number is interesting — `candidates > 1`. That
cannot be told apart from a run of an older tool that never counted at all:

```
candidates: 1        recorded — the lookup was checked and there was one
candidates: absent   recorded with counted: false — the tool did not answer
neither recorded     silence, and the two above are not the same fact
```

Both would be silence, and one of them is a lookup nobody has checked. So every success writes a
note, carrying `counted: false` rather than nothing when the tool reported no count.

## Controlled

Driven through the real `located_band` against a **stub tool** dropped where it would otherwise
compile one — no `swiftc`, and no reimplementation of the parsing, because a test that rewrites the
rule agrees with itself no matter what the code does.

Mutating the note to fire only when `candidates > 1`:

```
FAIL  one candidate is RECORDED as one
FAIL  an older tool that never counted is not silence — it says so
```

The two cases red are exactly the two the unconditional form exists for. The ambiguity and
unparseable-output cases stay green under that mutant, which is correct — they go down the refusal
path and are unaffected.

## What this does NOT establish

- **That any product lookup counts its candidates.** This is the livekit path only. The AX layer's
  `AXHelpers.findDescendant` still returns the first match silently; `AXLocalePolicy.censusDescendant`
  (from #633) is the counting form and has two call sites. Item 1 is that work.
- **That a count of 1 means the discriminator is good.** It means the search found one thing in the
  state it ran in. `getControlBar` was a discriminated loop that still had two candidates — a
  discriminator that does not narrow to one leaves exactly the defect this issue is about.
