### PR TITLE
fix(#638): the runtime could select a Logic variant this release does not ship for

### DIFF
--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LogicChecks.swift
@@ -48,6 +48,20 @@ extension SetupDoctor {
                 remediationType: .docs
             )
         }
+        if Self.unshippedVariantOnly(supported) {
+            // Not "unreadable": the bundle read fine and is a Logic this release does not ship for.
+            // Reporting it as unreadable sent the reader looking for a permissions problem.
+            return check(
+                id: "logic.installation",
+                domain: "logic",
+                status: .fail,
+                summary: "Only Logic Pro Creator Studio was found. This release ships for desktop "
+                    + "Logic Pro only; Creator Studio is recognised so it is not driven by mistake.",
+                evidence: ["reason": "unshipped_variant_only",
+                           "path": supported.map(\.path).joined(separator: ",")],
+                remediationType: .docs
+            )
+        }
         guard let primary = preferredReadableLogicApp(supported), let version = primary.version else {
             return check(
                 id: "logic.installation",

--- a/Sources/LogicProMCP/Utilities/SetupDoctor+LogicSupport.swift
+++ b/Sources/LogicProMCP/Utilities/SetupDoctor+LogicSupport.swift
@@ -30,6 +30,17 @@ extension SetupDoctor {
     }
 
 
+    /// The app this server will drive, or nil when none of the shipped variants is installed.
+    ///
+    /// The last two fallbacks used to be `creatorStudio` and then ANY app. `shipVariants` is
+    /// `[.desktop]` and the ADR records Creator Studio as permanently out of scope — so returning
+    /// it here made the runtime select a variant the release matrix does not cover, and the
+    /// catch-all could return something that is not Logic at all. Recognising a bundle id is not
+    /// claiming support for it, which is the same correction the README needed.
+    ///
+    /// Callers must distinguish "nothing shipped is installed" from "a bundle would not read":
+    /// `unshippedVariantOnly` answers that, so the doctor does not report an out-of-scope install
+    /// as an unreadable one.
     static func preferredLogicApp(_ apps: [LogicAppInfo]) -> LogicAppInfo? {
         apps.first {
             $0.path == LogicProVariant.desktop.defaultInstallPath
@@ -37,8 +48,13 @@ extension SetupDoctor {
         }
             ?? apps.first { $0.bundleID == LogicProVariant.desktop.bundleID }
             ?? apps.first { $0.path == LogicProVariant.desktop.defaultInstallPath }
-            ?? apps.first { $0.bundleID == LogicProVariant.creatorStudio.bundleID }
-            ?? apps.first
+    }
+
+    /// Whether the only Logic present is one this release does not ship for. Distinguishes an
+    /// out-of-scope install from an unreadable bundle, which otherwise report identically.
+    static func unshippedVariantOnly(_ apps: [LogicAppInfo]) -> Bool {
+        preferredLogicApp(apps) == nil
+            && apps.contains { $0.bundleID == LogicProVariant.creatorStudio.bundleID }
     }
 
 

--- a/Tests/LogicProMCPTests/CreatorRuntimeScopeTests.swift
+++ b/Tests/LogicProMCPTests/CreatorRuntimeScopeTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import LogicProMCP
+
+/// The runtime must not select a variant the release matrix does not cover.
+///
+/// `QualificationAxis.shipVariants` is `[.desktop]` and the ADR records Creator Studio as
+/// permanently out of scope. #631 corrected the README's claim of supporting both; this is the
+/// other half — the code path that could still hand back Creator as the app to drive.
+@Suite struct CreatorRuntimeScopeTests {
+    private static func app(_ path: String, _ bundleID: String?) -> SetupDoctor.LogicAppInfo {
+        SetupDoctor.LogicAppInfo(
+            path: path,
+            version: LogicProSupport.latestValidatedLogicVersion,
+            bundleID: bundleID,
+            readable: true
+        )
+    }
+
+    @Test("Creator Studio alone is not selected as the app to drive")
+    func creatorAloneIsNotPreferred() {
+        let apps = [Self.app("/Applications/Logic Pro Creator Studio.app",
+                             LogicProVariant.creatorStudio.bundleID)]
+        // Before: fell through to the creatorStudio branch and returned it, so the doctor reported
+        // a version and the server proceeded against a variant nothing has qualified.
+        #expect(SetupDoctor.preferredLogicApp(apps) == nil)
+        #expect(SetupDoctor.unshippedVariantOnly(apps))
+    }
+
+    @Test("an unrelated app is not selected either")
+    func unrelatedAppIsNotPreferred() {
+        // The old catch-all was `?? apps.first`, which could return something that is not Logic.
+        let apps = [Self.app("/Applications/Not Logic.app", "com.example.other")]
+        #expect(SetupDoctor.preferredLogicApp(apps) == nil)
+        #expect(!SetupDoctor.unshippedVariantOnly(apps),
+                "no Creator present, so this is not the out-of-scope case")
+    }
+
+    @Test("desktop is still selected, and preferred over Creator when both are installed")
+    func desktopIsSelected() {
+        let desktop = Self.app("/Applications/Logic Pro.app", LogicProVariant.desktop.bundleID)
+        let creator = Self.app("/Applications/Logic Pro Creator Studio.app",
+                               LogicProVariant.creatorStudio.bundleID)
+        #expect(SetupDoctor.preferredLogicApp([desktop]) == desktop)
+        // Creator FIRST in the list: passing by array order is not enough.
+        #expect(SetupDoctor.preferredLogicApp([creator, desktop]) == desktop)
+        #expect(!SetupDoctor.unshippedVariantOnly([creator, desktop]))
+    }
+
+    @Test("nothing installed is not the out-of-scope case")
+    func emptyIsNotUnshipped() {
+        #expect(SetupDoctor.preferredLogicApp([]) == nil)
+        #expect(!SetupDoctor.unshippedVariantOnly([]))
+    }
+
+    @Test("the ship scope this rests on is desktop only")
+    func shipScopeIsDesktopOnly() {
+        // If this ever changes, the checks above are the ones to revisit rather than delete.
+        #expect(QualificationAxis.shipVariants == [.desktop])
+    }
+}

--- a/Tests/LogicProMCPTests/LogicProTargetTests.swift
+++ b/Tests/LogicProMCPTests/LogicProTargetTests.swift
@@ -168,7 +168,15 @@ import Testing
     #expect(supported[0].bundleID == "com.apple.mobilelogic")
 }
 
-@Test func setupDoctorInstallationCheckReportsCreatorStudioVariant() {
+/// This test used to assert the opposite: a Creator-Studio-only machine reported `.pass` with
+/// `variant: creator_studio`, which is how the runtime came to select a variant this release does
+/// not ship for. `shipVariants` is `[.desktop]`, so a pass there was the doctor certifying a
+/// configuration the release matrix does not cover.
+///
+/// The distinction the evidence must keep is between "nothing shipped is installed" and "a bundle
+/// would not read" — they used to report identically, and the reader went looking for a
+/// permissions problem that was not there.
+@Test func setupDoctorInstallationCheckFailsWhenOnlyCreatorStudioIsInstalled() {
     let apps = [
         SetupDoctor.LogicAppInfo(
             path: "/Applications/Logic Pro Creator Studio.app",
@@ -178,9 +186,10 @@ import Testing
         ),
     ]
     let check = SetupDoctor.logicInstallationCheck(logicApps: apps)
-    #expect(check.status == SetupDoctor.CheckStatus.pass)
-    #expect(check.evidence["variant"] == "creator_studio")
-    #expect(check.evidence["bundle_id"] == "com.apple.mobilelogic")
+    #expect(check.status == SetupDoctor.CheckStatus.fail)
+    #expect(check.evidence["reason"] == "unshipped_variant_only")
+    #expect(check.evidence["path"] == "/Applications/Logic Pro Creator Studio.app")
+    #expect(check.evidence["variant"] == nil)
 }
 
 @Test func setupDoctorTCCRedactsMobileLogicAppleEvents() {


### PR DESCRIPTION
Closes #638.

**This branch was pushed past the local pre-push stamp hook, once, with the owner's explicit
approval.** That is recorded here rather than left to be discovered. Everything the server checks —
`build`, `compile`, `test` — applies unchanged; the hook that was bypassed is local, and
`lpm-ship.sh` is not run by CI.

## The defect

`SetupDoctor.preferredLogicApp` fell through to Creator Studio and then to anything at all:

```swift
?? apps.first { $0.bundleID == LogicProVariant.creatorStudio.bundleID }
?? apps.first
```

`QualificationAxis.shipVariants` is `[.desktop]` and `docs/adr/README.md:96` records Creator Studio
as permanently out of scope. So on a Creator-only machine the doctor reported a version and the
server proceeded against a variant nothing has qualified, and the final catch-all could return an
application that is not Logic at all. #631 corrected the README's claim of controlling both
variants; this is the runtime half of the same disagreement.

`unshippedVariantOnly` comes with it, because removing the fallbacks alone makes the doctor say
*"Logic Pro.app exists but its version could not be read"* — which is false, and sends the reader
after a permissions problem that is not there. The bundle read fine and is simply out of scope, and
the check now says so.

## The issue body's evidence claim was wrong, and this fixes it

#638 says *"Existing doctor tests (22) still pass."* That came from a **filtered** run. The full
suite was RED:

```
✘ setupDoctorInstallationCheckReportsCreatorStudioVariant()
  (check.status → .fail) == .pass
  (check.evidence["variant"] → nil) == "creator_studio"
```

That test pinned the old contract — a Creator-only machine reporting `.pass` with
`variant: creator_studio` — which is exactly the certification this change withdraws. It lives in
`LogicProTargetTests`, which the doctor filter never reached. **A filtered run answers a narrower
question than the one being claimed.** The test is moved to the new contract here, and the full
suite passes.

## The gate, at this exact head

```
== ship gate: work/creator-runtime @ 12d42e0e ==
Package.resolved matches origin/main          ok
test target compiles                          ok
dead swift-testing assertions                 ok
pre-push stamp hook installed                 ok
public-surface preflight                      ok
full suite                                    ok — ✔ Test run with 3875 tests passed after 381.731 seconds.
branch contains origin/main                   ok
Package.resolved still clean after all checks ok
live evidence for this head                   FAIL — no passing live evidence bound to 12d42e0e

SHIP GATE FAIL — nothing was pushed
```

Eight of nine. **The block names the head it came from**, on its first line, so a later merge can
be seen to have moved past it rather than silently replacing what it describes.

It has already been re-run once for exactly that reason: the branch was pushed at `a0d6cc00`, #641
landed on `main`, the branch was updated to `12d42e0e`, and the block above is from the second run
at the new head. Nothing in the branch's own content changed between them — the merge brought only
`main` — and the numbers are re-measured rather than carried over, because the issue body already
demonstrates what happens when a claim is left pointing at a commit that has moved.

## Why no live evidence can exist for this

Desktop Logic is installed on the only available machine, and `SetupDoctor+LogicSupport.swift:34-39`
prefers desktop before ever reaching the fallback this change removes. Old code and new code return
the **same app**. The behaviour differs only where Creator Studio is the *only* Logic present.

The issue names a second door — `resolve_bundle_id` with `forced_bundle_id` — and I expected that
one to be observable here. **It is not.** Measured against the release binary:

```
LOGIC_PRO_BUNDLE_ID=com.apple.logic10       → bundle_id com.apple.logic10, variant desktop, resolved true
LOGIC_PRO_BUNDLE_ID=com.apple.mobilelogic   → bundle_id unknown,           variant unknown, resolved false
LOGIC_PRO_BUNDLE_ID=com.example.not.logic   → bundle_id unknown,           variant unknown, resolved false
```

Forcing Creator and forcing a bundle that does not exist are **indistinguishable** on a machine
without Creator installed. That door also only opens where Creator is present.

## A waiver was designed for this, and specifying it honestly deleted it

Written truthfully, the precondition is `desktop ABSENT && Creator PRESENT`:

| the precondition is… | what follows |
|---|---|
| **true** here | the live run *can* discriminate — no waiver needed |
| **false** here | this change's behaviour cannot be observed at all |

**A waiver whose precondition is honest can never open.** The only machine that satisfies it is one
that does not need it. Three lesser defects in the same design — an env var not bound to a commit,
no re-evaluation, and CI being able to set env vars too — are all fixable; that one is not. The
full analysis is in #638.

## So the exception, and the three conditions it rests on

1. **Undiscriminatable** — unobservable on *every available* machine, in the principled sense, not
   the "hard to measure" sense.
2. **Unit evidence complete** — 5 new tests, 2 mutations, and the full suite green **after** the
   contract test above was corrected. The fixture places Creator **first**, so passing by array
   order is not enough:
   ```
   creatorStudio fallback restored     2 tests fail
   `?? apps.first` catch-all restored  3 tests fail
   ```
3. **Environment is the cause** — hardware, not effort. Owner-confirmed: there is no machine to
   install the other variant on, now or later.

Miss any one and the question gets asked again. Condition 1 is the load-bearing one.

## What this does NOT close

The forced-bundle door is **still open**: `LogicProVariantPolicy.resolveBundleID` returns the forced
string verbatim, and on a machine where Creator is installed `targetFromInstalledBundle` would bind
it. This PR changes the doctor's selection only. Left deliberately rather than widened, and the
measurement above is the reason it cannot be proved either way here.
