### PR TITLE
feat(#628): a descendant lookup that reports how many it found

### DIFF
--- a/Scripts/livekit/ax_role_count.swift
+++ b/Scripts/livekit/ax_role_count.swift
@@ -1,0 +1,72 @@
+// Count the descendants of Logic's main window carrying a given AXRole, walking the tree from
+// outside the product.
+//
+//   ./ax_role_count <AXRole> [--max-depth N]   ->  {"role":"AXButton","count":50,"maxDepth":10}
+//
+// This exists to be a SECOND opinion on `AXHelpers.censusDescendant`. A unit test can prove the
+// counting rule against a tree the test built; nothing in the product can show the rule surviving
+// Logic's real one, because the only thing that would check it is the code being checked.
+//
+// Deliberately matched on ROLE and nothing else. A LabelSet comparison would have the harness and
+// the product reading the same locale table and agreeing for that reason — which is agreement
+// about a shared input, not corroboration.
+//
+// WHAT IT CANNOT RULE OUT, said here rather than implied: both walkers call the same
+// `AXUIElementCopyAttributeValue`, so a defect in the AX API itself, or in how a subtree answers
+// `AXChildren`, moves both numbers together. What it does rule out is a defect in either walk —
+// depth handling, whether a match is descended into, filtering — which is where the counting rule
+// actually lives.
+import AppKit
+import ApplicationServices
+import Foundation
+
+func attr(_ e: AXUIElement, _ a: String) -> CFTypeRef? {
+    var v: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(e, a as CFString, &v) == .success else { return nil }
+    return v
+}
+func str(_ e: AXUIElement, _ a: String) -> String { (attr(e, a) as? String) ?? "" }
+func kids(_ e: AXUIElement) -> [AXUIElement] {
+    (attr(e, kAXChildrenAttribute as String) as? [AXUIElement]) ?? []
+}
+func emit(_ o: [String: Any]) -> Never {
+    print(String(data: try! JSONSerialization.data(withJSONObject: o, options: [.sortedKeys]),
+                 encoding: .utf8)!)
+    exit(0)
+}
+
+let argv = CommandLine.arguments
+let wantedRole = argv.count > 1 ? argv[1] : "AXButton"
+let maxDepth: Int = {
+    guard let i = argv.firstIndex(of: "--max-depth"), argv.count > i + 1 else { return 10 }
+    return Int(argv[i + 1]) ?? 10
+}()
+
+guard let app = NSWorkspace.shared.runningApplications.first(where: {
+    ($0.bundleIdentifier ?? "").contains("logic")
+}) else { emit(["ok": false, "error": "logic not running"]) }
+
+let ax = AXUIElementCreateApplication(app.processIdentifier)
+// The MAIN window, which is what the product's probe searches. Taking the first standard window
+// instead would compare two different subtrees and the disagreement would say nothing.
+guard let main = attr(ax, kAXMainWindowAttribute as String) else {
+    emit(["ok": false, "error": "no main window"])
+}
+let window = main as! AXUIElement
+
+// Descends into matches, because the lookup this corroborates could have returned either a match or
+// one nested inside it — it stops at the outer one only by virtue of returning it. Counting only
+// the outermost would report a smaller number for the same tree and the comparison would fail for a
+// reason that has nothing to do with the product.
+var count = 0
+func walk(_ e: AXUIElement, _ depth: Int) {
+    guard depth > 0 else { return }
+    for child in kids(e) {
+        if str(child, kAXRoleAttribute as String) == wantedRole { count += 1 }
+        walk(child, depth - 1)
+    }
+}
+walk(window, maxDepth)
+
+emit(["ok": true, "role": wantedRole, "count": count, "maxDepth": maxDepth,
+      "window": str(window, kAXTitleAttribute as String)])

--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Live proof that the counting locator counts Logic's real tree, not one a test built.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_628_counting_locator.py <worktree> <full-40-char-head-sha>
+
+WHAT #628 IS ABOUT
+------------------
+`AXHelpers.findDescendant` returns the first match in traversal order and says nothing about the
+rest. When it is right, nothing records that it was right for a reason rather than by luck — and
+that silence is the defect, not the choosing. `censusDescendant` is the counting form: it returns an
+element only when exactly one matched, and it reports how many there were either way.
+
+WHY A UNIT TEST IS NOT ENOUGH, AND WHY THIS IS NOT SELF-ATTESTATION
+-------------------------------------------------------------------
+The unit tests build their own tree, so they prove the rule and nothing about Logic. The obvious
+live check — run the product's census and assert it returns a number — cannot fail: any number
+satisfies it, and the only thing that could contradict the product is the product.
+
+So the count is checked against `ax_role_count.swift`, a separate walk that shares no code with the
+product. Both are aimed at the SAME subtree (Logic's main window) at the same depth, matched on
+ROLE alone. Role, because it is the one criterion an outside instrument can reproduce without
+reading the product's locale tables — matching on a LabelSet would have the two agreeing about a
+shared input, which is not corroboration.
+
+WHAT THIS CANNOT RULE OUT
+-------------------------
+Both walkers call `AXUIElementCopyAttributeValue`. A defect in the AX API itself, or in how some
+subtree answers `AXChildren`, moves both numbers together and this would not see it. What it does
+rule out is a defect in either walk — depth handling, whether a match is descended into, filtering —
+which is where the counting rule actually lives.
+
+The depth check is the half that makes the agreement mean something. Two walks that both ignored
+`maxDepth` would agree perfectly and be wrong together, so the run also requires the count to CHANGE
+with depth, in the same direction, on both instruments.
+"""
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+# Roles chosen to span the shapes the walk can get wrong: many matches, few, nested containers, and
+# one that is absent. AXToolbar is the absent one and it is not filler — `getTransportBar` looks for
+# a toolbar first, and measuring zero is what says that branch is dead on this Logic rather than
+# merely unexercised.
+ROLES = ["AXButton", "AXTextField", "AXStaticText", "AXGroup", "AXToolbar"]
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+rec = ev.record_screen(seconds=60)
+d = E.Driver()
+
+COUNTER_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_role_count.swift")
+COUNTER = os.path.join(ev.dir, "ax_role_count")
+built = subprocess.run(["swiftc", "-O", COUNTER_SOURCE, "-o", COUNTER], capture_output=True)
+ev.check("628/precondition-the-independent-counter-built",
+         built.returncode == 0,
+         "the second opinion compiles — without it every comparison below is the product agreeing "
+         "with itself",
+         f"rc={built.returncode} stderr={(built.stderr or b'').decode()[:200]!r}", None)
+if built.returncode != 0:
+    d.close(); ev.stop_recording(rec)
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+
+def product_census(role, depth=None):
+    """The product's own count, from the release artifact the gate hashes."""
+    args = [E.BIN, "--probe-locator-census", role]
+    if depth is not None:
+        args += ["--probe-locator-depth", str(depth)]
+    r = subprocess.run(args, capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
+
+
+def independent_count(role, depth=None):
+    args = [COUNTER, role]
+    if depth is not None:
+        args += ["--max-depth", str(depth)]
+    r = subprocess.run(args, capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
+
+
+RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+ev.check("628/precondition-the-track-header-rail-was-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the band this run asserts about, located by the AXDescription it carries",
+         f"band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
+
+before = ev.shot("628/before-counting", settle_region=RAIL)
+
+# One driven read, so the run is on record as having touched the product over the wire rather than
+# only having run its own binary with a flag. `health` writes nothing.
+health = d.tool("logic_system", "health", {})
+ev.check("628/the-server-answers-over-the-wire",
+         isinstance(health, dict) and bool(health),
+         "an ordinary MCP read succeeds, so the artifact under test is the one serving requests",
+         f"keys={sorted(health)[:6] if isinstance(health, dict) else health!r}",
+         None)
+
+# ---- the comparison ------------------------------------------------------------------------------
+agreements = {}
+for role in ROLES:
+    mine = product_census(role)
+    theirs = independent_count(role)
+    ok = (mine.get("ok") and theirs.get("ok")
+          and isinstance(mine.get("candidates"), int)
+          and mine["candidates"] == theirs.get("count"))
+    agreements[role] = {"product": mine.get("candidates"), "independent": theirs.get("count")}
+    ev.check(f"628/{role}-count-agrees-with-an-instrument-that-is-not-the-product",
+             bool(ok),
+             f"`censusDescendant` and a separate walk of the same subtree report the same number of "
+             f"{role} descendants",
+             f"product={mine.get('candidates')!r} independent={theirs.get('count')!r} "
+             f"raw={mine if not ok else ''}",
+             "make `collectMatching` skip descending into a match (add `continue` after the "
+             "append): nested matches stop being counted, the product's number falls below the "
+             "independent walk's, and every role with nesting goes red")
+ev.note("628/counts", agreements)
+
+# `identified` is the fact the blind lookup cannot report. It must be true at exactly one match and
+# false otherwise — including false at 50, where `findDescendant` would happily return something.
+button = product_census("AXButton")
+ev.check("628/many-matches-are-not-identified",
+         button.get("candidates", 0) > 1 and button.get("identified") is False
+         and button.get("returnedElement") is False,
+         "with more than one match the census returns NO element and says so — the blind lookup "
+         "returns one and reports the same thing it reports at a single match",
+         f"candidates={button.get('candidates')!r} identified={button.get('identified')!r} "
+         f"returnedElement={button.get('returnedElement')!r}",
+         "restore `element: hits.first`: an element comes back for an ambiguous lookup and this "
+         "check goes red")
+
+absent = product_census("AXToolbar")
+ev.check("628/zero-matches-are-not-identified-either",
+         absent.get("candidates") == 0 and absent.get("identified") is False,
+         "zero is reported as zero and is not mistaken for one — `getTransportBar` looks for a "
+         "toolbar first and there is none on this Logic, so that branch is measured dead rather "
+         "than assumed live",
+         f"candidates={absent.get('candidates')!r} identified={absent.get('identified')!r}",
+         "return `candidates: 1` for an empty hit list: this check goes red")
+
+# ---- depth, so that agreeing is not the same as both ignoring the bound ---------------------------
+shallow_p = product_census("AXGroup", depth=1)
+shallow_i = independent_count("AXGroup", depth=1)
+deep_p = product_census("AXGroup", depth=10)
+ev.check("628/the-depth-bound-is-honoured-live-by-both-walks",
+         (isinstance(shallow_p.get("candidates"), int)
+          and shallow_p["candidates"] == shallow_i.get("count")
+          and shallow_p["candidates"] < deep_p.get("candidates", 0)),
+         "a shallower search finds strictly fewer, and both instruments report the same shallower "
+         "number — two walks that ignored maxDepth would agree perfectly and be wrong together",
+         f"depth1 product={shallow_p.get('candidates')!r} independent={shallow_i.get('count')!r} "
+         f"depth10 product={deep_p.get('candidates')!r}",
+         "drop the `guard maxDepth > 0` from `collectMatching`: the shallow count stops differing "
+         "from the deep one and this check goes red")
+
+after = ev.shot("628/after-counting", settle_region=RAIL)
+ev.visual("628/counting-changed-nothing-on-screen",
+          before["file"], after["file"], RAIL, subject=RAIL_SUBJECT, expect_change=False,
+          why="every call in this run is a read — a census probe and one MCP health read — so the "
+              "track-header rail must come back byte-identical. A probe that moved the UI would be "
+              "an actuator wearing the word observe")
+
+d.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -489,6 +489,71 @@ enum AXHelpers {
         return nil
     }
 
+    /// One match, and how many there were. The counting form of `findDescendant`.
+    ///
+    /// `findDescendant` returns whatever the traversal reaches first and says nothing about the
+    /// rest. When it is right, nothing records that it was right for a reason rather than by luck,
+    /// and that silence is the defect — not the choosing. `AXLocalePolicy.censusDescendant` is the
+    /// same contract for lookups that match a localized `LabelSet`; this is the one for lookups
+    /// that match `role` / `title` / `identifier` exactly.
+    ///
+    /// They are deliberately NOT one function. A `LabelSet` is a set of human-facing labels in
+    /// whatever language Logic is running in; an `AXIdentifier` is a stable non-localized name.
+    /// Expressing one as the other would put a locale question and an identity question behind the
+    /// same parameter, and the first bug from that would be a lookup that "works in English".
+    ///
+    /// The count includes matches nested inside other matches, because that is the set
+    /// `findDescendant` could have returned. It stops descending into a match only by virtue of
+    /// having returned it; had the outer node not matched, the walk would have gone in. Counting
+    /// only the outermost would report `1` for a tree the original could resolve two ways.
+    struct Census {
+        let element: AXUIElement?
+        let candidates: Int
+
+        /// Exactly one match: the only case where the result is identified rather than merely found.
+        var isUnambiguous: Bool { candidates == 1 }
+    }
+
+    /// Every match, with the count, so a caller can refuse ambiguity instead of inheriting traversal
+    /// order. Additive on purpose: `findDescendant` keeps its behaviour, and adoption is counted by
+    /// `Scripts/check-ax-locator-census.py` rather than forced — flipping every call site at once
+    /// turns a census into a wall of red, and the move after that is somebody deleting the check.
+    static func censusDescendant(
+        of element: AXUIElement,
+        role: String? = nil,
+        title: String? = nil,
+        identifier: String? = nil,
+        maxDepth: Int = 10,
+        runtime: Runtime = .production
+    ) -> Census {
+        var hits: [AXUIElement] = []
+        collectMatching(of: element, role: role, title: title, identifier: identifier,
+                        maxDepth: maxDepth, runtime: runtime, into: &hits)
+        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count)
+    }
+
+    private static func collectMatching(
+        of element: AXUIElement,
+        role: String?,
+        title: String?,
+        identifier: String?,
+        maxDepth: Int,
+        runtime: Runtime,
+        into results: inout [AXUIElement]
+    ) {
+        guard maxDepth > 0 else { return }
+        for child in getChildren(element, runtime: runtime) {
+            let roleMatch = role == nil || getRole(child, runtime: runtime) == role
+            let titleMatch = title == nil || getTitle(child, runtime: runtime) == title
+            let idMatch = identifier == nil || getIdentifier(child, runtime: runtime) == identifier
+            if roleMatch && titleMatch && idMatch {
+                results.append(child)
+            }
+            collectMatching(of: child, role: role, title: title, identifier: identifier,
+                            maxDepth: maxDepth - 1, runtime: runtime, into: &results)
+        }
+    }
+
     /// Collect all descendants matching criteria. Useful for enumerating track headers, etc.
     static func findAllDescendants(
         of element: AXUIElement,

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1101,13 +1101,10 @@ enum AXLocalePolicy {
     /// for any of them returns something plausible either way.
     ///
     /// `candidates` is the whole point. `1` is a fact a later reader can weigh. Absence is not.
-    struct Census {
-        let element: AXUIElement?
-        let candidates: Int
-
-        /// Exactly one match: the only case where the result is identified rather than merely found.
-        var isUnambiguous: Bool { candidates == 1 }
-    }
+    /// The counting contract lives in `AXHelpers`, the layer both census forms sit on. It was
+    /// declared here first, when only the label-matching form existed; giving the identifier form
+    /// its own copy would have produced two structs that mean the same thing and drift apart.
+    typealias Census = AXHelpers.Census
 
     /// Every match, with the count, so a caller can refuse ambiguity instead of inheriting
     /// traversal order. Deliberately additive: `findDescendant` keeps its behaviour, and adoption is

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -243,6 +243,48 @@ enum MainEntrypoint {
             }
         }
 
+        // #628: the counting locator, run against live Logic from the artifact the gate hashes.
+        //
+        // `AXHelpers.censusDescendant` answers "how many matched", which is the fact the blind
+        // `findDescendant` cannot report. A unit test can prove the counting rule against a tree it
+        // built itself; only this can show the rule surviving contact with Logic's real one, and
+        // the count it returns is checkable against an instrument that is not this code.
+        //
+        // Observation only, exactly like `--probe-event-list`: it reads, adds no MCP surface, and
+        // performs no action. `role` is the one criterion an outside instrument can reproduce
+        // without sharing this code's notion of a label, which is what makes the comparison worth
+        // making — matching on a LabelSet would have the harness and the product agreeing because
+        // they read the same table.
+        if arguments.contains("--probe-locator-census") {
+            let role = arguments.drop(while: { $0 != "--probe-locator-census" })
+                .dropFirst().first ?? "AXButton"
+            let depth = Int(arguments.drop(while: { $0 != "--probe-locator-depth" })
+                .dropFirst().first ?? "") ?? 10
+            guard let window = AXLogicProElements.mainWindow() else {
+                writeStdout("{\"ok\":false,\"error\":\"no main window\"}\n")
+                return 1
+            }
+            let census = AXHelpers.censusDescendant(of: window, role: role, maxDepth: depth)
+            let payload: [String: Any] = [
+                "ok": true,
+                "role": role,
+                "maxDepth": depth,
+                "candidates": census.candidates,
+                // `identified` is the whole point of the count: it is true only at exactly one, and
+                // a reader can tell that from "something was returned" — which the blind lookup
+                // reports identically at one match and at nine.
+                "identified": census.isUnambiguous,
+                "returnedElement": census.element != nil,
+            ]
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            guard let data, let text = String(data: data, encoding: .utf8) else {
+                writeStdout("{\"ok\":false,\"error\":\"could not encode the census\"}\n")
+                return 1
+            }
+            writeStdout(text + "\n")
+            return 0
+        }
+
         if arguments.contains("--check-permissions") {
             let status = permissionCheck()
             writeStderr(status.summary + "\n")
@@ -314,6 +356,9 @@ enum MainEntrypoint {
           LogicProMCP --help, -h               Print this help and exit
           LogicProMCP --version, -V            Print the version and exit
           LogicProMCP --probe-event-list       Read the open Event List note table once and print JSON; exit
+          LogicProMCP --probe-locator-census <AXRole> [--probe-locator-depth N]
+                                               Count the descendants of the main window with that
+                                               role and print JSON; exit. Observation only.
                                                Observation only: it selects nothing and writes nothing.
           LogicProMCP doctor [--json] [--verbose|--quiet] [--check-updates] [--strict] [--profile <core|mixer|keycmd|legacy-scripter|full>] [--client <claude-code|claude-desktop|cursor|vscode|terminal|custom>]
                                                Print a diagnostic report and exit

--- a/Tests/LogicProMCPTests/Issue628CountingLocatorTests.swift
+++ b/Tests/LogicProMCPTests/Issue628CountingLocatorTests.swift
@@ -42,7 +42,7 @@ struct Issue628CountingLocatorTests {
         let census = AXHelpers.censusDescendant(of: root, role: kAXButtonRole, runtime: runtime)
         #expect(census.candidates == 2)
         #expect(census.element == nil)
-        #expect(census.isUnambiguous == false)
+        #expect(!census.isUnambiguous)
     }
 
     @Test("exactly one match: identified, and recorded as one")
@@ -75,7 +75,7 @@ struct Issue628CountingLocatorTests {
             of: root, role: kAXButtonRole, runtime: b.makeAXRuntime())
         #expect(census.candidates == 0)
         #expect(census.element == nil)
-        #expect(census.isUnambiguous == false)
+        #expect(!census.isUnambiguous)
     }
 
     /// The case that decides whether the number means anything: a match INSIDE another match.

--- a/Tests/LogicProMCPTests/Issue628CountingLocatorTests.swift
+++ b/Tests/LogicProMCPTests/Issue628CountingLocatorTests.swift
@@ -1,0 +1,177 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #628: `findDescendant` returns the first match in traversal order and nothing records that there
+/// was only one. When it is right, nothing says it was right for a reason rather than by luck — and
+/// that silence is the defect, not the choosing.
+///
+/// `AXLocalePolicy.censusDescendant` (from #633) is the counting form for lookups that match a
+/// localized `LabelSet`. This is the counting form for the other half: `role` / `title` /
+/// `identifier` matched exactly. They stay two functions on purpose — a `LabelSet` is a set of
+/// human-facing labels in whatever language Logic runs in, an `AXIdentifier` is a stable
+/// non-localized name, and putting a locale question and an identity question behind one parameter
+/// invites a lookup that "works in English".
+///
+/// What these tests do NOT establish: that any particular call site is unambiguous live. The count
+/// is a property of the tree the walk ran on. `getControlBar` was a *discriminated* loop that still
+/// had two candidates, so "has a discriminator" and "resolves to one" are different facts and only
+/// the second one is what this returns.
+@Suite("Issue #628 — a descendant lookup that reports how many it found")
+struct Issue628CountingLocatorTests {
+
+    /// Two elements a `role`-only lookup cannot tell apart. `findDescendant` answers with the first
+    /// and no complaint; the census refuses and says two.
+    @Test("two matches: no element, and the count is what says why")
+    func twoMatchesRefuse() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6281)
+        let first = b.element(6282)
+        let second = b.element(6283)
+        b.setAttribute(first, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setAttribute(second, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setChildren(root, [first, second])
+        let runtime = b.makeAXRuntime()
+
+        // The existing lookup is unchanged and still answers — that is the behaviour being
+        // preserved, not a defect being left in place. Adoption is counted, not forced.
+        let blind = AXHelpers.findDescendant(of: root, role: kAXButtonRole, runtime: runtime)
+        #expect(blind != nil)
+
+        let census = AXHelpers.censusDescendant(of: root, role: kAXButtonRole, runtime: runtime)
+        #expect(census.candidates == 2)
+        #expect(census.element == nil)
+        #expect(census.isUnambiguous == false)
+    }
+
+    @Test("exactly one match: identified, and recorded as one")
+    func oneMatchIsIdentified() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6284)
+        let button = b.element(6285)
+        let other = b.element(6286)
+        b.setAttribute(button, kAXRoleAttribute as String, kAXButtonRole as String)
+        b.setAttribute(other, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setChildren(root, [button, other])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXButtonRole, runtime: b.makeAXRuntime())
+        #expect(census.candidates == 1)
+        #expect(census.isUnambiguous)
+        let found = try #require(census.element)
+        #expect(CFEqual(found, button))
+    }
+
+    @Test("no match: zero, and zero is not one")
+    func noMatch() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6287)
+        let text = b.element(6288)
+        b.setAttribute(text, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setChildren(root, [text])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXButtonRole, runtime: b.makeAXRuntime())
+        #expect(census.candidates == 0)
+        #expect(census.element == nil)
+        #expect(census.isUnambiguous == false)
+    }
+
+    /// The case that decides whether the number means anything: a match INSIDE another match.
+    ///
+    /// `findDescendant` stops at the outer one only because it returns it — had the outer node not
+    /// matched, the walk would have descended. So both are things it could have returned under a
+    /// different tree order, and counting only the outermost would report `1` for a tree the
+    /// original can resolve two ways. That is the exact flattery this issue is about.
+    @Test("a match nested inside a match counts, because the blind form could have returned either")
+    func nestedMatchesBothCount() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6289)
+        let outer = b.element(6290)
+        let inner = b.element(6291)
+        b.setAttribute(outer, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(inner, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [outer])
+        b.setChildren(outer, [inner])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole, runtime: b.makeAXRuntime())
+        #expect(census.candidates == 2)
+        #expect(census.element == nil)
+    }
+
+    /// Every criterion narrows, and all three are ANDed — the same rule `findDescendant` applies, so
+    /// the two cannot disagree about what a match is.
+    @Test("title and identifier narrow the same way findDescendant narrows")
+    func criteriaAreAnded() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6292)
+        let wanted = b.element(6293)
+        let wrongTitle = b.element(6294)
+        let wrongIdentifier = b.element(6295)
+        for (node, title, ident) in [(wanted, "Play", "transport.play"),
+                                     (wrongTitle, "Stop", "transport.play"),
+                                     (wrongIdentifier, "Play", "transport.stop")] {
+            b.setAttribute(node, kAXRoleAttribute as String, kAXButtonRole as String)
+            b.setAttribute(node, kAXTitleAttribute as String, title)
+            b.setAttribute(node, kAXIdentifierAttribute as String, ident)
+        }
+        b.setChildren(root, [wanted, wrongTitle, wrongIdentifier])
+        let runtime = b.makeAXRuntime()
+
+        let byRole = AXHelpers.censusDescendant(of: root, role: kAXButtonRole, runtime: runtime)
+        #expect(byRole.candidates == 3)
+
+        let byTitle = AXHelpers.censusDescendant(
+            of: root, role: kAXButtonRole, title: "Play", runtime: runtime)
+        #expect(byTitle.candidates == 2)
+
+        let byBoth = AXHelpers.censusDescendant(
+            of: root, role: kAXButtonRole, title: "Play", identifier: "transport.play",
+            runtime: runtime)
+        #expect(byBoth.candidates == 1)
+        let found = try #require(byBoth.element)
+        #expect(CFEqual(found, wanted))
+
+        // The blind form agrees about WHICH element, and cannot say how many there were. Both
+        // halves matter: if they disagreed, adopting the census would change behaviour rather than
+        // report on it.
+        let blind = try #require(AXHelpers.findDescendant(
+            of: root, role: kAXButtonRole, title: "Play", identifier: "transport.play",
+            runtime: runtime))
+        #expect(CFEqual(blind, wanted))
+    }
+
+    /// `maxDepth` bounds the count as well as the search. A census that quietly searched deeper than
+    /// the lookup it stands in for would report candidates the original could never have returned.
+    @Test("maxDepth bounds the count, so it describes the same search")
+    func depthBoundsTheCount() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6296)
+        let level1 = b.element(6297)
+        let level2 = b.element(6298)
+        b.setAttribute(level1, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(level2, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [level1])
+        b.setChildren(level1, [level2])
+        let runtime = b.makeAXRuntime()
+
+        #expect(AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole, maxDepth: 1, runtime: runtime).candidates == 1)
+        #expect(AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole, maxDepth: 2, runtime: runtime).candidates == 2)
+    }
+
+    /// The label-matching census and this one are the same type now, not two structs that mean the
+    /// same thing. They were declared separately for a while, which is how two copies of one idea
+    /// start.
+    @Test("both census forms return one type")
+    func oneCensusType() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6299)
+        let census: AXLocalePolicy.Census = AXHelpers.censusDescendant(
+            of: root, role: kAXButtonRole, runtime: b.makeAXRuntime())
+        #expect(census.candidates == 0)
+    }
+}


### PR DESCRIPTION
Item 1 of #628. Does not close the issue — no call site is converted, and the reason is measured
below rather than deferred.

## What was missing, and what was already there

`AXHelpers.findDescendant` returns the first match in traversal order and says nothing about the
rest. When it is right, nothing records that it was right for a reason rather than by luck, and
that silence is the defect — not the choosing.

`AXLocalePolicy.censusDescendant` (#633) was **already** the counting form for lookups matching a
localized `LabelSet`. So this is not "build the locator"; it is "build the other half and do not
end up with two that disagree." The other half is `role` / `title` / `identifier`, matched exactly.

They stay two functions on purpose. A `LabelSet` is a set of human-facing labels in whatever
language Logic is running in; an `AXIdentifier` is a stable non-localized name. Putting a locale
question and an identity question behind one parameter is how you get a lookup that "works in
English."

They do **not** stay two types. `Census` moves down to `AXHelpers` — the layer both forms sit on —
with a `typealias` where it was declared. Two structs meaning the same thing is how one idea
becomes two that drift.

### The count includes nested matches, and that decision is the whole number

`findDescendant` stops at an outer match only by virtue of returning it: had that node not matched,
the walk would have descended into it. Both are therefore things it could have returned. Counting
only the outermost would report `1` for a tree the original can resolve two ways — the exact
flattery this issue is about.

## Proved against Logic, not only against a tree the test built

A unit test proves the counting rule and nothing about Logic. The obvious live check — run the
census, assert a number comes back — **cannot fail**: any number satisfies it, and the only thing
that could contradict the product is the product.

So `--probe-locator-census` runs it from the artifact the gate hashes (observation only, no MCP
surface, no action), and `ax_role_count.swift` walks the same subtree sharing no code with it.
Measured on Logic 12.3, five roles, both instruments:

```
AXButton 50 · AXTextField 23 · AXStaticText 227 · AXGroup 38 · AXToolbar 0
```

Matched on **role** alone — the one criterion an outside instrument can reproduce without reading
the product's locale tables. A `LabelSet` comparison would have the two agreeing about a shared
input, which is not corroboration.

`AXToolbar` being zero is not filler. `getTransportBar` looks for a toolbar first, so that branch is
now **measured dead** rather than assumed live.

**Agreement alone is not enough**, because two walks that both ignored `maxDepth` would agree
perfectly and be wrong together. So the run also requires the count to fall with depth on both
instruments: `AXGroup` at depth 1 vs depth 10, same number from each.

## The live check can fail — demonstrated, not asserted

Mutation applied to the product, release rebuilt, harness re-run:

```
skip descending into a match (`continue` after the append)

  AXButton     product 50  independent 50    agree — buttons do not nest
  AXTextField  product 23  independent 23    agree
  AXStaticText product 227 independent 227   agree
  AXGroup      product  5  independent 38    RED
  AXToolbar    product  0  independent  0    agree

  harness exit 1, checks 10/11
```

Worth reading twice: **only the nesting role caught it.** Four of the five roles agreed under a
mutant that halves the answer. Had `AXGroup` not been in the set, this harness would have gone
green against broken code — so the sensitivity comes from one deliberate choice in `ROLES`, not
from having five of them.

Unit mutations, each applied, counted in the file, and removed:

| mutation | result |
|---|---|
| `element: hits.first` instead of exactly-one | 2 cases red |
| skip descending into a match | 1 case red |

## No call site converted, and that is a measurement rather than a deferral

Adoption is counted by `check-ax-locator-census.py`, not forced — flipping call sites at once turns
a census into a wall of red, and the move after that is somebody deleting the check.

Looking for a first site, the two obvious ones are **dead lookups**:

```
getTransportBar     findDescendant(role: kAXToolbarRole)     0 AXToolbar in the arrange window
findTrackNameField  findDescendant(role: kAXStaticTextRole)  0 AXStaticText inside the rail
```

Converting a dead lookup changes nothing and moves the census number for no reason. This
corroborates the "six measured dead" note already in the census output — the code's own comments
were right, and the cheapest order really is comment → call site → live measurement.

## What this does NOT establish

- **That any product lookup is unambiguous live.** The count is a property of the tree the walk ran
  on. `getControlBar` was a *discriminated* loop that still had two candidates — "has a
  discriminator" and "resolves to one" are different facts, and only the second is what `identified`
  reports.
- **That the AX API is honest.** Both walkers call `AXUIElementCopyAttributeValue`, so a defect
  there, or in how a subtree answers `AXChildren`, moves both numbers together. Written in the
  harness docstring too. What it rules out is a defect in either *walk* — depth handling, descent
  into matches, filtering — which is where the counting rule lives.
