### PR TITLE
fix(#612): coverage was computed for whatever commit the tree sat on

### DIFF
--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -98,9 +98,22 @@ def _read_json(path):
         return None
 
 
-def changed_paths(worktree, base):
+def changed_paths(worktree, base, head="HEAD"):
+    """Paths the branch changed, excluding deletions.
+
+    `head` is the commit the caller is asking ABOUT, not the worktree's current one. The first
+    version hard-coded `HEAD` and took the head sha only to look up an evidence directory, so a
+    gate invoked for one commit computed coverage from whatever the tree happened to be sitting on.
+    In a pre-push hook those are the same and it would never have shown; anywhere else they are
+    not, and the failure is a coverage verdict about the wrong commit reported as a verdict about
+    this one.
+
+    `--diff-filter=d` drops deletions. A harness that no longer exists cannot be required to have
+    run, and requiring it would make deleting a harness impossible — the branch could never
+    produce the evidence, because there is nothing left to produce it.
+    """
     proc = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"],
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}...{head}"],
         cwd=worktree, capture_output=True, text=True)
     if proc.returncode != 0:
         return None
@@ -114,7 +127,7 @@ def main(argv):
     worktree, head, root = argv[1], argv[2], argv[3]
     base = argv[4] if len(argv) > 4 else "origin/main"
 
-    paths = changed_paths(worktree, base)
+    paths = changed_paths(worktree, base, head)
     if paths is None:
         print(f"-> COVERAGE FAIL: could not diff {base}...HEAD in {worktree}")
         return 2

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -111,6 +111,64 @@ ok = got == (["live_a"], [])
 failed += 0 if ok else 1
 print(f"{'ok  ' if ok else 'FAIL'} a document named `evidence` satisfies no harness -> {got}")
 
+# --- `changed_paths` against a REAL repository -------------------------------------------------
+#
+# Two contracts were written in a docstring and tested nowhere, which is the same shape as the
+# defect this whole file is about — a rule named in one place and enforced in another.
+#
+#   1. deletions are excluded. A harness that no longer exists cannot be required to have run, and
+#      requiring it would make deleting a harness impossible: the branch can never produce the
+#      evidence, because there is nothing left to produce it.
+#   2. the commit asked about is the `head` ARGUMENT, not the worktree's HEAD. The first version
+#      hard-coded HEAD and took the sha only to find an evidence directory. In a pre-push hook the
+#      two agree and it would never have shown.
+import subprocess
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True)
+
+with tempfile.TemporaryDirectory() as repo:
+    os.makedirs(os.path.join(repo, "Scripts", "livekit"))
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+
+    def write(rel, text):
+        with open(os.path.join(repo, rel), "w") as fh:
+            fh.write(text)
+
+    write("Scripts/livekit/live_kept.py", "# kept\n")
+    write("Scripts/livekit/live_doomed.py", "# doomed\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    write("Scripts/livekit/live_added.py", "# added\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add one harness")
+    mid_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    os.remove(os.path.join(repo, "Scripts/livekit/live_doomed.py"))
+    write("Scripts/livekit/live_kept.py", "# kept, edited\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "delete one harness, edit another")
+    tip_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    at_tip = C.harness_stems(C.changed_paths(repo, base_sha, tip_sha))
+    ok = at_tip == {"live_added", "live_kept"}
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} a deleted harness is not required to have run -> {sorted(at_tip)}")
+
+    # The worktree is sitting on `tip`. Asking about `mid` must answer about `mid`.
+    at_mid = C.harness_stems(C.changed_paths(repo, base_sha, mid_sha))
+    ok = at_mid == {"live_added"}
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} the head ARGUMENT decides, not the worktree's HEAD -> {sorted(at_mid)}")
+
+    ok = C.changed_paths(repo, "no/such/ref", tip_sha) is None
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} an unreadable base is None, not an empty change set")
+
 print()
 print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")
 sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #612.

Follow-up to #641, found in review rather than by the tests.

## The defect

`changed_paths` hard-coded `HEAD` and took the head sha only to look up an evidence directory:

```python
["git", "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD"]
```

In a pre-push hook the worktree's `HEAD` and the head being gated are the same commit, so this
would never have shown. Anywhere else — a gate invoked for an older commit, a tree left on another
branch — it computes coverage from one commit and reports the verdict as being about another.

That is the shape #612 is about, one level up. The original defect was *evidence* attributed to the
wrong harness; this would have been *coverage* attributed to the wrong commit.

## Two contracts that were written down and tested nowhere

The docstring said *"deletions are the caller's problem to filter."* Nothing tested it. Every
earlier fixture added or modified a harness, so the deletion case had no case — which is the same
failure this file exists to catch: **a rule named in one place and enforced in another.**

Both are now driven against a real git repository built in a temp directory — three commits, one
harness added, one deleted, one edited:

```
a deleted harness is not required to have run     -> {live_added, live_kept}
the head ARGUMENT decides, not the worktree HEAD  -> {live_added}
an unreadable base is None, not an empty change set
```

The deletion contract matters more than it looks: without it, a PR that removes a harness can never
pass, because the branch is asked to produce evidence from something it just deleted.

## Controlled

Each mutation applied, counted in the file, and removed:

| mutation | result |
|---|---|
| `{base}...HEAD` restored | the head-argument case goes red |
| `--diff-filter=d` dropped | the deletion case goes red |

## The rule is now the enforced one

With #641 merged, the live gate extracts `harness_evidence_coverage.py` **and** `evidence.py` from
`origin/main` and runs them from a temp directory, so a branch cannot edit its own judge. Verified
end to end on a scratch branch that changes one harness and has evidence only for a *different*
one — the exact #612 scenario, where #606's document stood in for #608's:

```
== live gate for 3948c904 ==
   harnesses changed by this branch: 1
   missing  live_534_goto_position
-> COVERAGE FAIL: no evidence at <root>/3948c904 for: live_534_goto_position
   documents bound to this build: 1

LIVE GATE FAIL — do not push, do not open a PR, do not merge
```

Note the last line before the verdict: a clean document **was** present and bound to the build. The
old check read `<head>/evidence.json` — which that document also writes — so the same branch would
have passed it. That is reasoning about code I read rather than a re-run of it; the old path is
gone.

## What this does NOT establish

- **That the right harnesses were run for a `Sources/` change.** Nothing in the tree records which
  harness covers which product code, and the rule deliberately does not guess. A branch touching
  only `Sources/` still requires nothing here.
- **That a harness which ran proved the change.** Coverage checks that a document exists for that
  harness at that head and that `is_clean` accepts it. Whether its assertions bear on the diff is a
  reviewer's job.
