### PR TITLE
Point server.json websiteUrl at logicpromcp.com

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MongLong0214/logic-pro-mcp",
   "title": "Logic Pro MCP",
   "description": "Logic Pro MCP server for stateful DAW control, live readback, MIDI, plugins, and safety gates.",
-  "websiteUrl": "https://github.com/MongLong0214/logic-pro-mcp#readme",
+  "websiteUrl": "https://logicpromcp.com",
   "repository": {
     "url": "https://github.com/MongLong0214/logic-pro-mcp",
     "source": "github"


### PR DESCRIPTION
## Problem

`server.json` sets `websiteUrl` to `https://github.com/MongLong0214/logic-pro-mcp#readme`.

MCP registries and directories treat `websiteUrl` as the canonical project link. The `registryFit` note in this same file already states the record "intentionally relies on websiteUrl plus publisher metadata," so this field is the primary discovery surface.

Verified today: PulseMCP, LobeHub, Metatext, and Glama all list this server, and **none of them link to logicpromcp.com**. Google Search Console reports **0 external backlinks** for the docs site, which is a direct consequence.

## Change

```diff
- "websiteUrl": "https://github.com/MongLong0214/logic-pro-mcp#readme",
+ "websiteUrl": "https://logicpromcp.com",
```

One line. No functional impact on the server, packaging, or install path. The `repository` field still points at this repo, so registries keep the source link.

## Why it matters

logicpromcp.com currently averages position 17.1 in Google with 4.8% CTR on relevant queries (`logic pro mcp`, `logic pro mcp server`, `mcp for logic pro`). Intent is right, authority is the bottleneck. Directory links flowing to the docs site instead of GitHub is the cheapest available fix.

GitHub repo About → Website was set to logicpromcp.com separately.