### PR TITLE
fix(#519): an AXDescription is localized, and a comment of mine said otherwise

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -295,6 +295,33 @@ def _body(raw):
 # Evidence document
 # ---------------------------------------------------------------------------
 
+# An AXDescription is LOCALIZED, and not uniformly. Measured on Logic 12.3, 2026-08-21, by running
+# the same window under `AppleLanguages -array en` and `-array ko`:
+#
+#     Tracks contents  ->  트랙 콘텐츠          Library    ->  라이브러리
+#     Tracks header    ->  트랙 헤더            Mixer      ->  믹서
+#     Tracks           ->  트랙                 Inspector  ->  인스펙터
+#     Step Sequencer   ->  Step Sequencer      <- NOT translated
+#
+# That last row is why this is a measured table and not a rule. Some descriptions translate and
+# some do not, so neither "they are stable identifiers" nor "they are all localized" is safe — and
+# the first of those is exactly what a comment in `live_519_region_op_on_a_localized_logic` used to
+# claim. A Korean run disproved it: the canvas lookup found nothing and the harness could not take
+# a capture, on the one run where the locale was the entire point.
+#
+# ONLY measured pairs belong here. An unmeasured locale must fail to resolve, loudly, rather than
+# be guessed at — guessing localized labels is the defect #519 exists to remove from the product,
+# and a harness is not exempt from it.
+AX_REGION_LABELS = {
+    "Tracks contents": ["트랙 콘텐츠"],
+    "Tracks header": ["트랙 헤더"],
+    "Tracks": ["트랙"],
+    "Library": ["라이브러리"],
+    "Mixer": ["믹서"],
+    "Inspector": ["인스펙터"],
+}
+
+
 class Evidence:
     """Accumulates records and writes `<root>/<head>/evidence.json`.
 
@@ -362,14 +389,35 @@ class Evidence:
                        "stderr": "" if r is None else (r.stderr or "")[:400]})
             return None, None
 
-        r = subprocess.run([tool, *selector], capture_output=True, text=True)
-        try:
-            payload = json.loads(r.stdout or "{}")
-        except ValueError:
-            return refuse("the tool printed something that is not JSON", r)
+        # The requested name first, then the measured translations of it. Not a fallback in the
+        # sense this file spends so much effort removing — each candidate is an exact match against
+        # a description read off a live window, and a name nobody has measured is simply absent
+        # from the table and cannot be tried.
+        wanted = selector[0] if selector else ""
+        candidates = [wanted] + [alt for alt in AX_REGION_LABELS.get(wanted, []) if alt != wanted]
+        r = None
+        payload = {}
+        for candidate in candidates:
+            r = subprocess.run([tool, candidate, *selector[1:]], capture_output=True, text=True)
+            try:
+                payload = json.loads(r.stdout or "{}")
+            except ValueError:
+                return refuse("the tool printed something that is not JSON", r)
+            if isinstance(payload.get("band"), list):
+                break
+            # An AMBIGUOUS name is an answer, not a miss: trying the next language's word for it
+            # would be answering a different question than the one that just failed.
+            if payload.get("matches"):
+                break
         band = payload.get("band")
         if not (isinstance(band, list) and len(band) == 4):
             return refuse(payload.get("error") or "no band in the tool's answer", r)
+        if payload.get("description") and payload["description"] != wanted:
+            # Which language's label actually matched. Silence here would let a run claim it
+            # watched `Tracks header` when what it found was `트랙 헤더` — the same region, but the
+            # record should say which word was on screen.
+            self.note("located_band/matched-a-localized-label",
+                      {"requested": wanted, "matched": payload["description"]})
         subject = payload.get("description")
         if not isinstance(subject, str) or not subject.strip():
             return refuse("a band with no description cannot be named", r)

--- a/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
+++ b/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
@@ -306,11 +306,18 @@ ev.check("519/a-region-exists-and-its-korean-help-string-parses",
 # landed. The band is the arrange canvas, located by the AXDescription it carries, and it is
 # resolved HERE rather than at the top of the file because a Korean Logic has only just been
 # launched and given a project; before that there is no canvas to find.
+#
+# This comment used to say the lookup "does not depend on Logic's language — the one property this
+# harness needs above all others." That was WRONG, and this run is what disproved it: measured
+# 2026-08-21, the canvas answers to `트랙 콘텐츠` on a Korean Logic and the English name finds
+# nothing, so the capture could not be taken on the single run where the locale was the point.
+# `located_band` now tries the measured translations; an unmeasured locale still finds nothing, and
+# that is deliberate.
 CANVAS, CANVAS_SUBJECT = ev.located_band("Tracks contents")
 ev.check("519/precondition-the-arrange-canvas-was-located",
          CANVAS is not None and bool(CANVAS_SUBJECT),
-         "the arrange canvas, located by the AXDescription it carries — the same lookup the other "
-         "harnesses use, which does not depend on Logic's language",
+         "the arrange canvas, located by the AXDescription it carries — through the measured "
+         "translation table, because that description IS localized",
          f"band={CANVAS!r} subject={CANVAS_SUBJECT!r}", None)
 
 arrange_window = next((t for t in windows() if "트랙" in t or "Tracks" in t), None)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -193,6 +193,48 @@ for stdout, want_result, want_tag, want_payload, why in [
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} {why:<52} -> {result} {payload if not ok else ''}")
 
+# --- a localized AXDescription still resolves, and the record says which word matched ----------
+#
+# #519: `Tracks contents` is `트랙 콘텐츠` on a Korean Logic, so a lookup for the English name finds
+# nothing — measured on the one run where the locale was the entire point. `Step Sequencer` is NOT
+# translated, which is why the table is measured pairs rather than a rule.
+#
+# The stub answers only for the KOREAN name, so a version that tries the requested name alone fails
+# these cases and a version that tries the table's entries passes them.
+def _with_locale_stub(answers_for, selector=("Tracks contents",)):
+    root = _tempfile.mkdtemp()
+    ev = E.Evidence("c" * 40, root)
+    tool = os.path.join(ev.dir, "ax_control_bar_band")
+    with open(tool, "w") as fh:
+        fh.write("#!/bin/sh\n"
+                 f'if [ "$1" = "{answers_for}" ]; then\n'
+                 f'  echo \'{{"band":[928,162,6162,391],"description":"{answers_for}","candidates":1}}\'\n'
+                 "else\n"
+                 "  echo '{\"error\":\"no element with that exact AXDescription\"}'\n"
+                 "fi\n")
+    os.chmod(tool, os.stat(tool).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return ev.located_band(*selector), ev.records
+
+(result, records) = _with_locale_stub("트랙 콘텐츠")
+matched = [r for r in records if r.get("tag") == "located_band/matched-a-localized-label"]
+ok = (result[0] == (928, 162, 6162, 391) and result[1] == "트랙 콘텐츠"
+      and len(matched) == 1 and matched[0]["payload"]["requested"] == "Tracks contents")
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} a Korean window resolves through the measured table -> {result}")
+
+# The English name still wins when it is the one on screen, and nothing is noted.
+(result, records) = _with_locale_stub("Tracks contents")
+noted = [r for r in records if r.get("tag") == "located_band/matched-a-localized-label"]
+ok = result[1] == "Tracks contents" and not noted
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} an English window needs no translation and notes none -> {result}")
+
+# A name with no measured translation fails closed rather than being guessed at.
+(result, records) = _with_locale_stub("트랙 콘텐츠", selector=("Step Sequencer",))
+ok = result == (None, None)
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} an unmeasured name is refused, not guessed -> {result}")
+
 # --- the API the harnesses actually call must exist -------------------------------------------
 #
 # #620 rewrote evidence.py from a base that predated three functions, and merging it deleted them


### PR DESCRIPTION
Closes #519.

Two things, and the second is the reason the first could be recorded honestly.

## The acceptance criterion, proven live on a Korean Logic

#519's outstanding criterion was that a **region operation** be shown to succeed on a Logic running
in another language. Measured on Logic 12.3 with `AppleLanguages -array ko`, from a cold launch:

```
519/precondition-logic-is-running-in-korean
  menu bar  ['Apple','Logic Pro','파일','편집','트랙','탐색','녹음','Mix','보기','윈도우','1','도움말']

519/a-project-can-be-created-on-a-korean-logic-from-a-cold-launch
  windows   ['무제 30 - 트랙', '프로젝트 선택']

519/the-region-operation-reaches-state-a-on-a-korean-logic
  state='A' verified=True 'MIDI 리전' track 1 bar 1 -> 9 (playhead 9)
```

State A, verified against the **same** region it started with, driven entirely through Korean menus.
The machine's language is restored and the restore is checked by reading Logic's menu bar back, not
by trusting the setting this run wrote.

## A comment I wrote in #640 was false, and this run is what disproved it

That harness takes captures because #622 required every run to look at something. I added them with
this beside the lookup:

> *"The lookup is by AXDescription, which does not change with Logic's language — the one property
> this harness needs above all others."*

**It does change.** On the Korean run the canvas lookup found nothing, so the one run where the
locale was the entire point could not take its capture. Measured by putting the same window under
`en` and then `ko`:

```
Tracks contents  ->  트랙 콘텐츠          Library    ->  라이브러리
Tracks header    ->  트랙 헤더            Mixer      ->  믹서
Tracks           ->  트랙                 Inspector  ->  인스펙터
Step Sequencer   ->  Step Sequencer      <- NOT translated
```

**The last row is the whole point.** One exception makes *both* generalisations false — "they are
stable identifiers" and "they are all localized" are equally unusable. So `AX_REGION_LABELS` is a
table of measured pairs, not a rule.

#640 is merged and its body is left alone: it was true as far as anyone had measured when it was
written, and deleting it would take the reason it changed with it. This is the correction it points
to.

## Only measured pairs, and an unmeasured locale fails

`located_band` tries the requested name, then its measured translations. A name nobody has read off
a live window in that language is **absent from the table and cannot be tried** — guessing localized
labels is the defect #519 exists to remove from the product, and a harness is not exempt from it. If
the table is short, the run fails and the next person lengthens it.

An **ambiguous** answer stops the search rather than continuing to the next language. Ambiguity is an
answer; trying another language's word for it would be answering a different question.

The record names which word matched:

```
located_band/matched-a-localized-label  {requested: "Tracks contents", matched: "트랙 콘텐츠"}
```

Silence there would let a run claim it watched `Tracks header` when what was on screen said
`트랙 헤더` — the same region, but not the same statement.

## Scale

Six harnesses share this lookup, and every one of them has only ever run in English:

```
live_448 · live_538 · live_542 · live_543 · live_544 · live_545 · live_549 ×2 · live_567
live_570 · live_572 · live_575 ×3 · live_576 ×2 · live_592 · live_608 · live_519
```

It was one Korean run away from being found, and had not been found.

## Controlled

```
drop the translations from the candidate list
  Korean case   RED
  English case  GREEN     <- the asymmetry that kept this invisible
```

Re-run after the fix, same head, Korean Logic: **8/8 checks, visual passed, subject present,
`captures_unsettled: 0`, language restored.**

## What this does NOT establish

- **That other locales work.** `ja` is in the harness's menu tables and is **not** in the region
  table — nobody has run a Japanese Logic here. That lookup will fail there, loudly, which is the
  intended behaviour and not a claim that Japanese is supported.
- **That `Step Sequencer` is the only untranslated description.** It is the only one measured to be.
