### PR TITLE
feat(#628): count from the container a call site actually searches, and convert the first one

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -46,7 +46,7 @@ import sys
 # had been blind to. Raising a ratchet for that reason is legitimate and has to be visible, which is
 # why the reason lives here rather than in a commit nobody re-reads. Raising it because something
 # went red is not.
-BLIND_SITE_BUDGET = 38
+BLIND_SITE_BUDGET = 37
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 

--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -88,6 +88,16 @@ def product_census(role, depth=None):
         return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
 
 
+def product_census_from(role, container):
+    """The product's count taken from a NAMED container rather than from the window."""
+    r = subprocess.run([E.BIN, "--probe-locator-census", role, "--probe-locator-from", container],
+                       capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout or "{}")
+    except ValueError:
+        return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
+
+
 def independent_count(role, depth=None):
     args = [COUNTER, role]
     if depth is not None:
@@ -157,6 +167,35 @@ ev.check("628/zero-matches-are-not-identified-either",
          "than assumed live",
          f"candidates={absent.get('candidates')!r} identified={absent.get('identified')!r}",
          "return `candidates: 1` for an empty hit list: this check goes red")
+
+# ---- from a CONTAINER, because no call site searches the whole window ----------------------------
+#
+# The window-wide count answers a question nothing asks. `findTrackNameField` searches a track
+# header; `getControlBar` searches the control bar. Deciding whether a site's candidate set has one
+# member needs the count taken from ITS root, and a count from the wrong root is a confident number
+# about a different question.
+scoped = product_census_from("AXTextField", "Tracks header")
+ev.check("628/a-count-can-be-taken-from-a-named-container",
+         scoped.get("ok") is True and scoped.get("containerCandidates") == 1
+         and isinstance(scoped.get("candidates"), int),
+         "the probe resolves a container by description and counts inside it — the shape a call "
+         "site actually has",
+         f"from={scoped.get('from')!r} containerCandidates={scoped.get('containerCandidates')!r} "
+         f"candidates={scoped.get('candidates')!r} identified={scoped.get('identified')!r}",
+         "search from the window instead of the container: the count becomes the window-wide one "
+         "and no longer describes the site")
+
+# The container is resolved by the SAME counting rule, so an ambiguous container refuses instead of
+# picking one and reporting a confident count taken from whichever it reached first. Measured:
+# `Control Bar` matches two elements in the arrange window.
+ambiguous = product_census_from("AXCheckBox", "Control Bar")
+ev.check("628/an-ambiguous-container-refuses-rather-than-choosing",
+         ambiguous.get("ok") is False and ambiguous.get("containerCandidates", 0) > 1,
+         "a container description matching more than one element produces a refusal naming the "
+         "count, not a count taken from an arbitrary one of them",
+         f"error={ambiguous.get('error')!r} containerCandidates={ambiguous.get('containerCandidates')!r}",
+         "resolve the container with `findDescendant` instead of the census: the first match is "
+         "taken, a count comes back, and this check goes red")
 
 # ---- depth, so that agreeing is not the same as both ignoring the bound ---------------------------
 shallow_p = product_census("AXGroup", depth=1)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -499,8 +499,36 @@ extension AXLogicProElements {
     /// Find the track name text field on a header.
     static func findTrackNameField(trackIndex: Int, runtime: Runtime = .production) -> AXUIElement? {
         guard let header = findTrackHeader(at: trackIndex, runtime: runtime) else { return nil }
-        return AXHelpers.findDescendant(of: header, role: kAXTextFieldRole, maxDepth: 4, runtime: runtime.ax)
-            ?? AXHelpers.findDescendant(of: header, role: kAXStaticTextRole, maxDepth: 4, runtime: runtime.ax)
+        return trackNameField(in: header, runtime: runtime)
+    }
+
+    /// The one text field on a track header, or nil when there is not exactly one.
+    ///
+    /// #628: the caller WRITES to whatever comes back — press, set `AXValue`, confirm. A blind
+    /// first-match here does not merely read the wrong element, it renames it. So the text-field
+    /// lookup counts, and more than one candidate returns nil rather than a guess.
+    ///
+    /// Returning nil is safe and is the reason this site was chosen first: the rename path falls
+    /// through to select-then-menu and verifies either way, so refusing costs a slower route rather
+    /// than the operation.
+    ///
+    /// Measured 2026-08-21 on Logic 12.3 via `--probe-locator-census AXTextField
+    /// --probe-locator-from "Tracks header"`: **one** text field in the whole rail — only the
+    /// selected track renders one — so per header the set is 0 or 1 and this changes no behaviour
+    /// in the state it was measured in. It changes what happens in the state nobody has seen.
+    ///
+    /// The static-text fallback stays and is measured DEAD in that same state: `AXStaticText` from
+    /// `Tracks header` counts **zero**. It is left rather than deleted because zero is a fact about
+    /// one layout, not about every one, and a fallback that has never fired is cheaper to keep than
+    /// a regression to rediscover. It is NOT reached on ambiguity — two text fields refuse outright,
+    /// because falling to a static text there would write the name into a different element again.
+    static func trackNameField(in header: AXUIElement, runtime: Runtime = .production) -> AXUIElement? {
+        let census = AXHelpers.censusDescendant(
+            of: header, role: kAXTextFieldRole, maxDepth: 4, runtime: runtime.ax)
+        if census.candidates > 1 { return nil }
+        if let only = census.element { return only }
+        return AXHelpers.findDescendant(
+            of: header, role: kAXStaticTextRole, maxDepth: 4, runtime: runtime.ax)
     }
 
 }

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -264,11 +264,49 @@ enum MainEntrypoint {
                 writeStdout("{\"ok\":false,\"error\":\"no main window\"}\n")
                 return 1
             }
-            let census = AXHelpers.censusDescendant(of: window, role: role, maxDepth: depth)
+            // `--probe-locator-from <AXDescription>` searches from a named container instead of the
+            // window. Without it the probe can only answer "how many X in the whole window", and no
+            // call site searches the whole window — they search from a rail, a strip, a header. A
+            // count taken from the wrong root is a number about a different question, and the tail
+            // of this issue is exactly the work of deciding call site by call site whether the set
+            // has one member.
+            //
+            // The container itself is resolved by the SAME counting rule, so an ambiguous container
+            // refuses rather than picking one and reporting a confident count taken from whichever
+            // it happened to reach.
+            var root = window
+            var rootDescription: String? = nil
+            var rootCandidates: Int? = nil
+            if let from = arguments.drop(while: { $0 != "--probe-locator-from" }).dropFirst().first {
+                let container = AXLocalePolicy.censusDescendant(
+                    of: window,
+                    role: "AXGroup",
+                    matching: AXLocalePolicy.LabelSet(
+                        canonical: from, variants: [],
+                        rationale: "probe argument, matched verbatim"),
+                    mode: .exactStrict,
+                    maxDepth: depth,
+                    runtime: .production
+                )
+                rootCandidates = container.candidates
+                guard let found = container.element else {
+                    let why = container.candidates == 0
+                        ? "no container with that description"
+                        : "the container description is ambiguous"
+                    writeStdout("{\"ok\":false,\"error\":\"\(why)\",\"from\":\"\(from)\","
+                        + "\"containerCandidates\":\(container.candidates)}\n")
+                    return 1
+                }
+                root = found
+                rootDescription = from
+            }
+            let census = AXHelpers.censusDescendant(of: root, role: role, maxDepth: depth)
             let payload: [String: Any] = [
                 "ok": true,
                 "role": role,
                 "maxDepth": depth,
+                "from": rootDescription as Any,
+                "containerCandidates": rootCandidates as Any,
                 "candidates": census.candidates,
                 // `identified` is the whole point of the count: it is true only at exactly one, and
                 // a reader can tell that from "something was returned" — which the blind lookup
@@ -356,7 +394,7 @@ enum MainEntrypoint {
           LogicProMCP --help, -h               Print this help and exit
           LogicProMCP --version, -V            Print the version and exit
           LogicProMCP --probe-event-list       Read the open Event List note table once and print JSON; exit
-          LogicProMCP --probe-locator-census <AXRole> [--probe-locator-depth N]
+          LogicProMCP --probe-locator-census <AXRole> [--probe-locator-depth N] [--probe-locator-from <AXDescription>]
                                                Count the descendants of the main window with that
                                                role and print JSON; exit. Observation only.
                                                Observation only: it selects nothing and writes nothing.

--- a/Tests/LogicProMCPTests/Issue628TrackNameFieldTests.swift
+++ b/Tests/LogicProMCPTests/Issue628TrackNameFieldTests.swift
@@ -1,0 +1,85 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #628, first converted call site. The caller WRITES to whatever this returns — press, set
+/// `AXValue`, confirm — so a blind first match does not read the wrong element, it renames it.
+///
+/// Chosen first because refusing is cheap here: `AccessibilityChannel+Tracks` falls through to
+/// select-then-menu when this returns nil, and verifies either way. A site where nil breaks the
+/// operation would need its own answer to ambiguity before it could be converted.
+///
+/// Measured 2026-08-21 on Logic 12.3, `--probe-locator-census AXTextField --probe-locator-from
+/// "Tracks header"`: one text field in the whole rail — only the selected track renders one — so
+/// per header the live set is 0 or 1 and this changes nothing in the state it was measured in.
+/// These cases are about the state nobody has seen.
+@Suite("Issue #628 — the track name field is counted, not taken first")
+struct Issue628TrackNameFieldTests {
+
+    private func header(_ b: FakeAXRuntimeBuilder, _ id: Int, children: [(Int, String)]) -> AXUIElement {
+        let node = b.element(id)
+        var kids: [AXUIElement] = []
+        for (childID, role) in children {
+            let child = b.element(childID)
+            b.setAttribute(child, kAXRoleAttribute as String, role)
+            kids.append(child)
+        }
+        b.setChildren(node, kids)
+        return node
+    }
+
+    @Test("one text field is returned")
+    func oneFieldIsReturned() throws {
+        let b = FakeAXRuntimeBuilder()
+        let h = header(b, 7001, children: [(7002, kAXTextFieldRole as String),
+                                           (7003, kAXButtonRole as String)])
+        let found = try #require(AXLogicProElements.trackNameField(
+            in: h, runtime: b.makeLogicRuntime()))
+        #expect(CFEqual(found, b.element(7002)))
+    }
+
+    /// The case this conversion exists for. Two fields used to return whichever the walk reached
+    /// first, and the caller would have typed the track's new name into it.
+    @Test("two text fields return NOTHING rather than the first one")
+    func twoFieldsRefuse() throws {
+        let b = FakeAXRuntimeBuilder()
+        let h = header(b, 7101, children: [(7102, kAXTextFieldRole as String),
+                                           (7103, kAXTextFieldRole as String)])
+        #expect(AXLogicProElements.trackNameField(in: h, runtime: b.makeLogicRuntime()) == nil)
+
+        // The blind form still answers, which is what this site used to do.
+        #expect(AXHelpers.findDescendant(
+            of: h, role: kAXTextFieldRole, maxDepth: 4, runtime: b.makeAXRuntime()) != nil)
+    }
+
+    /// Ambiguity must NOT fall through to the static-text fallback. Doing so would answer a
+    /// "which field" question with a different element and write the name into that instead —
+    /// the same defect wearing the fallback's clothes.
+    @Test("ambiguity does not fall through to the static-text fallback")
+    func ambiguityDoesNotFallThrough() throws {
+        let b = FakeAXRuntimeBuilder()
+        let h = header(b, 7201, children: [(7202, kAXTextFieldRole as String),
+                                           (7203, kAXTextFieldRole as String),
+                                           (7204, kAXStaticTextRole as String)])
+        #expect(AXLogicProElements.trackNameField(in: h, runtime: b.makeLogicRuntime()) == nil)
+    }
+
+    /// Zero text fields still reaches the fallback. It is measured dead on this Logic — zero
+    /// `AXStaticText` under `Tracks header` — and kept because zero is a fact about one layout.
+    @Test("no text field falls back to static text, which is kept though measured dead")
+    func zeroFieldsFallBack() throws {
+        let b = FakeAXRuntimeBuilder()
+        let h = header(b, 7301, children: [(7302, kAXStaticTextRole as String)])
+        let found = try #require(AXLogicProElements.trackNameField(
+            in: h, runtime: b.makeLogicRuntime()))
+        #expect(CFEqual(found, b.element(7302)))
+    }
+
+    @Test("nothing usable on the header returns nil")
+    func nothingReturnsNil() throws {
+        let b = FakeAXRuntimeBuilder()
+        let h = header(b, 7401, children: [(7402, kAXButtonRole as String)])
+        #expect(AXLogicProElements.trackNameField(in: h, runtime: b.makeLogicRuntime()) == nil)
+    }
+}


### PR DESCRIPTION
Two things #628 needs before its tail can be worked honestly: a way to **measure** a call site, and
a first site converted **because** the measurement said so. Does not close the issue — the ratio is
7 of 109 and this moves it by one.

## The window-wide count answers a question nothing asks

`findTrackNameField` searches a track header. `getControlBar` searches the control bar. Nothing
searches the whole window, so the census added in #644 could not tell anyone whether a *site's*
candidate set has one member — and a count taken from the wrong root is a confident number about a
different question.

`--probe-locator-from <AXDescription>` resolves a container and counts inside it. The container is
resolved by the **same** counting rule, so an ambiguous one refuses instead of picking one and
reporting a count taken from whichever it reached first:

```
--probe-locator-census AXCheckBox --probe-locator-from "Control Bar"
  {"ok":false,"error":"the container description is ambiguous","containerCandidates":2}
```

That refusal is a live check in the harness, not a claim here.

## The first site, chosen by measurement rather than by position in a file

Measured on Logic 12.3:

```
AXTextField   from "Tracks header"   1   identified
AXStaticText  from "Tracks header"   0   dead
AXSlider      from "Tracks header"   2   ambiguous
```

`findTrackNameField` is the first row. Its caller **writes** to whatever comes back — press, set
`AXValue`, confirm — so a blind first match there does not read the wrong element, **it renames it.**

**Refusing is cheap at this site, which is why it went first.**
`AccessibilityChannel+Tracks:1096` falls through to select-then-menu when the lookup returns nil,
and verifies either way. So ambiguity costs a slower route rather than the operation. A site where
nil breaks the operation needs its own answer to ambiguity before it can be converted, and nothing
here pretends otherwise.

### Ambiguity does not fall through to the fallback

Two text fields return **nil**, not the static text. Falling through would answer a "which field"
question with a different element and write the name into that instead — the same defect wearing
the fallback's clothes. It has its own test, and the mutation that removes the refusal turns exactly
that case red and no other.

### The dead fallback is kept

`AXStaticText` from the rail counts **zero**, so the fallback has never fired here. It stays: zero
is a fact about one layout, not about every one, and a fallback that has never fired is cheaper to
keep than a regression to rediscover. What changed is that it is now documented as measured-dead
rather than assumed-live.

## Ratchet 38 → 37

The census asked for it:

```
UNDER BUDGET by 1 — lower BLIND_SITE_BUDGET to 37 so the ground gained is held.
```

Ground gained has to be claimed or it leaks back — that is the whole point of a budget that fails in
both directions.

## Live

`live_628_counting_locator` gains the two container checks. **13/13, 10 mutation-backed**, evidence
bound to this head.

## What this does NOT establish

- **That the other 101 sites are convertible.** Three were measured; one was convertible, one was
  dead, one was ambiguous. That distribution is the argument for measuring each rather than sweeping.
- **That `identified: true` means the discriminator is good.** It means the set had one member in
  the state the walk ran in. `getControlBar` was a discriminated loop that still had two candidates.
- **That refusing is safe elsewhere.** It is safe *here*, for a reason specific to this caller.
