### PR TITLE
feat(#628): measure what a site's own discriminator leaves, and one leaves four

### DIFF
--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -212,6 +212,52 @@ ev.check("628/the-depth-bound-is-honoured-live-by-both-walks",
          "drop the `guard maxDepth > 0` from `collectMatching`: the shallow count stops differing "
          "from the deep one and this check goes red")
 
+# ---- the survivor count of a real site's own predicate --------------------------------------------
+#
+# Counting by role answers "how many carry this role". The tail asks something else: how many
+# survive the DISCRIMINATOR a call site applies. A site that gathers thirty-seven groups, narrows to
+# four, and then takes the first has narrowed and still inherited tree order — which is this issue,
+# at a real site, rather than in the abstract.
+#
+# The predicates are called by the product, not reimplemented here. A measurement that rewrites the
+# rule can disagree with the code for a reason that has nothing to do with the tree.
+selection = subprocess.run([E.BIN, "--probe-selection-census"], capture_output=True, text=True)
+try:
+    sites = json.loads(selection.stdout or "{}")
+except ValueError:
+    sites = {"ok": False, "raw": (selection.stdout or selection.stderr)[:200]}
+ev.note("628/selection-census", sites)
+
+rows = sites.get("sites") or []
+ev.check("628/a-site-predicate-reports-how-many-it-left",
+         sites.get("ok") is True and len(rows) >= 2
+         and all(isinstance(r.get("gathered"), int) and isinstance(r.get("survivors"), int)
+                 for r in rows),
+         "each site reports what it gathered and what its own discriminator left — the number the "
+         "blind form never had",
+         "; ".join(f"{r.get('site','?').split()[-1]}: {r.get('gathered')}->{r.get('survivors')}"
+                   for r in rows),
+         "have the probe report only the gathered count: `survivors` disappears and this goes red")
+
+# A property of the REPORT, not of Logic: whatever the tree holds, `identified` has to mean exactly
+# one. Asserting a specific survivor count would be asserting today's project, and it would go red
+# when someone adds a track rather than when the code breaks.
+ev.check("628/identified-means-exactly-one-whatever-the-tree-holds",
+         bool(rows) and all(r.get("identified") == (r.get("survivors") == 1) for r in rows),
+         "`identified` is true for a site if and only if its predicate left one candidate",
+         "; ".join(f"{r.get('survivors')}->{r.get('identified')}" for r in rows),
+         "report `identified: survivors > 0`: a site that narrowed to four claims identity and this "
+         "check goes red")
+
+# The narrowing itself has to be visible. A predicate that leaves everything it gathered is not a
+# discriminator, and a run where that happened should say so rather than look the same as a good one.
+ev.check("628/at-least-one-predicate-actually-narrows",
+         any(r.get("survivors", 0) < r.get("gathered", 0) for r in rows),
+         "at least one site's discriminator rejected something — otherwise the census is measuring "
+         "a filter that filters nothing",
+         "; ".join(f"{r.get('gathered')}->{r.get('survivors')}" for r in rows),
+         "make both predicates return true for every element: nothing narrows and this goes red")
+
 after = ev.shot("628/after-counting", settle_region=RAIL)
 ev.visual("628/counting-changed-nothing-on-screen",
           before["file"], after["file"], RAIL, subject=RAIL_SUBJECT, expect_change=False,

--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -228,7 +228,25 @@ except ValueError:
     sites = {"ok": False, "raw": (selection.stdout or selection.stderr)[:200]}
 ev.note("628/selection-census", sites)
 
-rows = sites.get("sites") or []
+all_rows = sites.get("sites") or []
+# `unreachable` is a THIRD outcome, not a count of zero. A site whose input is not on screen has not
+# been measured, and folding it in with the measured ones is how "we did not look" becomes "we
+# looked and found none" — the failure this whole harness is built around. The first version of
+# these checks did exactly that and went red the moment a site reported it, which is the check
+# catching its own author.
+rows = [r for r in all_rows if "survivors" in r]
+unreachable = [r for r in all_rows if "unreachable" in r]
+ev.note("628/unreachable-sites", unreachable)
+
+ev.check("628/an-unmeasurable-site-says-so-instead-of-reporting-zero",
+         all("gathered" not in r and "survivors" not in r and bool(r.get("unreachable"))
+             for r in unreachable),
+         "a site whose input is absent from this UI state carries a reason and NO counts — "
+         "'no strip on screen' and 'the predicate left none' are different facts",
+         f"unreachable={[r.get('unreachable') for r in unreachable]!r} measured={len(rows)}",
+         "report `survivors: 0` for an unreachable site: it becomes indistinguishable from a "
+         "discriminator that matched nothing, and this check goes red")
+
 ev.check("628/a-site-predicate-reports-how-many-it-left",
          sites.get("ok") is True and len(rows) >= 2
          and all(isinstance(r.get("gathered"), int) and isinstance(r.get("survivors"), int)

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -323,6 +323,60 @@ enum MainEntrypoint {
             return 0
         }
 
+        // #628: the survivor count of a real call site's own predicate.
+        //
+        // `--probe-locator-census` answers "how many carry this role". It cannot answer the question
+        // the tail actually asks, which is how many survive the DISCRIMINATOR a site applies —
+        // `isTrackHeadersGroup`, `looksLikeTransportContainer`. Those are the sites this issue is
+        // about: they gather many and select one with a predicate, and nothing records whether the
+        // predicate left one or several.
+        //
+        // The predicates are called HERE rather than reimplemented. A measurement that rewrites the
+        // rule can disagree with the code for a reason that has nothing to do with the tree, which
+        // is the failure this whole issue is a census of.
+        //
+        // Observation only: it gathers, filters, counts, and returns. It selects nothing.
+        if arguments.contains("--probe-selection-census") {
+            guard let window = AXLogicProElements.mainWindow() else {
+                writeStdout("{\"ok\":false,\"error\":\"no main window\"}\n")
+                return 1
+            }
+            let ax = AXLogicProElements.Runtime.production.ax
+            var results: [[String: Any]] = []
+
+            func record(_ site: String, _ gathered: Int, _ survivors: Int) {
+                results.append([
+                    "site": site,
+                    "gathered": gathered,
+                    "survivors": survivors,
+                    // The whole point: a predicate that leaves one has identified something. One
+                    // that leaves several has narrowed and then still taken tree order.
+                    "identified": survivors == 1,
+                ])
+            }
+
+            let groups8 = AXHelpers.findAllDescendants(
+                of: window, role: "AXGroup", maxDepth: 8, runtime: ax)
+            record("AXLogicProElements+Tracks.swift:54 isTrackHeadersGroup",
+                   groups8.count,
+                   groups8.filter { AXLogicProElements.isTrackHeadersGroup($0, runtime: ax) }.count)
+
+            let groups6 = AXHelpers.findAllDescendants(
+                of: window, role: "AXGroup", maxDepth: 6, runtime: ax)
+            record("AXLogicProElements+Transport.swift:24 looksLikeTransportContainer",
+                   groups6.count,
+                   groups6.filter { AXLogicProElements.looksLikeTransportContainer($0, runtime: ax) }.count)
+
+            let payload: [String: Any] = ["ok": true, "sites": results]
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            guard let data, let text = String(data: data, encoding: .utf8) else {
+                writeStdout("{\"ok\":false,\"error\":\"could not encode the census\"}\n")
+                return 1
+            }
+            writeStdout(text + "\n")
+            return 0
+        }
+
         if arguments.contains("--check-permissions") {
             let status = permissionCheck()
             writeStderr(status.summary + "\n")

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -406,6 +406,29 @@ enum MainEntrypoint {
                                 "unreachable": "no track header at index 0 in this UI state"])
             }
 
+            // The mixer strip pair. Both have an UNCONDITIONAL positional fallback when their
+            // discriminator finds nothing — `sliders.first` and `sliders[1]` — so what matters here
+            // is not only how many survive the predicate but whether the predicate finds anything
+            // at all. A survivor count of zero means the site is selecting by index, which is this
+            // issue's sentence written literally.
+            let mixerArea = AXLogicProElements.getMixerArea()
+            let strips = mixerArea.map {
+                AXLogicProElements.mixerChannelStrips(in: $0, runtime: ax)
+            } ?? []
+            if let strip = strips.first {
+                let sliders = AXHelpers.findAllDescendants(
+                    of: strip, role: "AXSlider", maxDepth: 4, runtime: ax)
+                record("AXLogicProElements+Mixer.swift:309 findVolumeFader (falls back to sliders.first)",
+                       sliders.count,
+                       sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isVolumeFader }.count)
+                record("AXLogicProElements+Mixer.swift:322 findPanControl (falls back to sliders[1])",
+                       sliders.count,
+                       sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isPanControl }.count)
+            } else {
+                results.append(["site": "AXLogicProElements+Mixer.swift:309/:322",
+                                "unreachable": "no mixer channel strip in this UI state"])
+            }
+
             let payload: [String: Any] = ["ok": true, "sites": results]
             let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
             guard let data, let text = String(data: data, encoding: .utf8) else {

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -367,6 +367,45 @@ enum MainEntrypoint {
                    groups6.count,
                    groups6.filter { AXLogicProElements.looksLikeTransportContainer($0, runtime: ax) }.count)
 
+            // Sites whose collection is gathered from something other than the window. The input is
+            // resolved through the product's own accessor, so a site that cannot be reached in this
+            // UI state is reported as unreachable rather than as zero — those are different facts
+            // and only one of them is about the code.
+            if let controlBar = AXLogicProElements.getControlBar() {
+                let barGroups = AXHelpers.findAllDescendants(
+                    of: controlBar, role: "AXGroup", maxDepth: 8, runtime: ax)
+                record("AXLogicProElements+Transport.swift:165 playheadPositionGroupLabel",
+                       barGroups.count,
+                       barGroups.filter {
+                           AXLocalePolicy.playheadPositionGroupLabel.matches(
+                               AXHelpers.getDescription($0, runtime: ax), mode: .exactStrict)
+                       }.count)
+            } else {
+                results.append(["site": "AXLogicProElements+Transport.swift:165 playheadPositionGroupLabel",
+                                "unreachable": "no control bar in this UI state"])
+            }
+
+            // `Tracks.swift:443` is deliberately absent. Its predicate closes over a `labels:
+            // [String]` PARAMETER, so its survivor count is a function of the caller's argument and
+            // not of the tree alone — measuring it with one label set would report a number that
+            // says as much about the arguments I chose as about Logic. Parameterised sites need
+            // their callers enumerated first, which is separate work.
+            if let header = AXLogicProElements.findTrackHeader(at: 0) {
+                let sliders = AXHelpers.findAllDescendants(
+                    of: header, role: "AXSlider", maxDepth: 4, runtime: ax)
+                record("AXLogicProElements+Mixer.swift:63 header pan slider",
+                       sliders.count,
+                       sliders.filter { slider in
+                           AXHelpers.getChildren(slider, runtime: ax).contains { child in
+                               let desc = (AXHelpers.getDescription(child, runtime: ax) ?? "").lowercased()
+                               return AXLocalePolicy.headerPanHint.containsAny(in: desc)
+                           }
+                       }.count)
+            } else {
+                results.append(["site": "AXLogicProElements+Mixer.swift:63 header pan slider",
+                                "unreachable": "no track header at index 0 in this UI state"])
+            }
+
             let payload: [String: Any] = ["ok": true, "sites": results]
             let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
             guard let data, let text = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
**Stacked on #648** — base is `work/628-probe-from-parent`, not `main`. Merge #648 first; this
retargets to `main` cleanly afterwards.

## The first live ambiguous site with a number

Counting by role answers *"how many carry this role"*. The tail asks something else: **how many
survive the discriminator a call site applies.** A site that gathers many, narrows, and then takes
the first of what is left has narrowed and *still* inherited tree order — this issue at a real site
rather than in the abstract.

`--probe-selection-census` calls the product's own predicates and reports gathered vs survivors.
Measured on Logic 12.3, one project, one track:

```
AXLogicProElements+Tracks.swift:54     isTrackHeadersGroup           38 -> 1   identified
AXLogicProElements+Transport.swift:24  looksLikeTransportContainer   37 -> 4   tree order
AXLogicProElements+Transport.swift:165 playheadPositionGroupLabel     2 -> 1   identified
AXLogicProElements+Mixer.swift:63      header pan slider              2 -> 1   identified
AXLogicProElements+Mixer.swift:309     findVolumeFader                2 -> 1   identified
AXLogicProElements+Mixer.swift:322     findPanControl                 2 -> 1   identified
```

Five of six discriminate to one. `getTransportBar` is the outlier.

### The two mixer sites are worth a second look, and the measurement says the opposite of the shape

```swift
findVolumeFader   …first(where: isVolumeFader) ?? sliders.first
findPanControl    …first(where: isPanControl)  ?? (sliders.count > 1 ? sliders[1] : nil)
```

Both take an element by **position** when their discriminator finds nothing. `sliders[1]` is this
issue's sentence written literally. Measured with the Mixer open, both discriminators resolve to one
and **neither fallback is reached** — the difference between a fallback existing and a fallback
firing, and only the second is a live defect.

With the Mixer closed they report `unreachable`, not zero. "No strip on screen" and "the predicate
left none" are different facts, and a zero there would have read as a broken discriminator.

**`getTransportBar` narrows thirty-seven groups to four and then takes whichever the walk reaches
first.** Every previous finding in this issue was a *dead* lookup — thirteen of sixteen first-match
sites match nothing at all. This is the first one that is live, discriminated, and still ambiguous,
which is precisely the shape the issue is named after.

It is **measured here and not fixed.** Choosing among the four needs a discriminator nobody has yet,
and inventing one for the transport container is design work with its own blast radius — the same
reason `getControlBar` got a "holds a checkbox" discriminator in #633 rather than a rename.

## The predicates are called, not reimplemented

A measurement that rewrites the rule can disagree with the code for a reason that has nothing to do
with the tree — which is the failure this whole issue is a census of. So the probe imports
`isTrackHeadersGroup` and `looksLikeTransportContainer` and runs them.

## The live checks assert the report, not the tree

```
identified is true  ⟺  survivors == 1        a property of the report, whatever Logic holds
at least one predicate rejects something     otherwise the census measures a filter that filters nothing
each site reports gathered AND survivors     the number the blind form never had
```

Asserting `survivors == 4` would be asserting **today's project**: it would go red when someone adds
a track rather than when the code breaks. That distinction is why the numbers live in a note and the
checks live on the invariants.

Harness: **16/16, 13 mutation-backed**, evidence bound to this head.

## What this does NOT establish

- **That four is the count in every state.** One project, one track, arrange window, Mixer closed,
  en. More tracks or an open Mixer can change what looks like a transport container.
- **That the other eleven AX-collection selections are fine.** Six of seventeen are measured.
- **`Tracks.swift:443` is deliberately absent, not overlooked.** Its predicate closes over a
  `labels: [String]` PARAMETER, so its survivor count is a function of the caller's argument and not
  of the tree alone. Measuring it with one label set would report a number that says as much about
  the arguments I picked as about Logic. Parameterised sites need their callers enumerated first.
- **A site that cannot be reached reports `unreachable`, not a count.** "The control bar is not on
  screen" and "the predicate left zero" are different facts, and only one of them is about the code.
- **That `identified: true` means the discriminator is good.** It means one survived in the state
  the walk ran in.


## The harness caught its own author

Adding a site that reports `unreachable` turned two checks red, and they were right to. The checks
assumed every row carries `gathered` and `survivors`, so a row saying "no mixer strip in this UI
state" arrived as `None -> None` and failed an invariant about counts.

**`unreachable` is a third outcome, not a count of zero.** Folding it in with the measured rows is
exactly how "we did not look" becomes "we looked and found none" — the failure this file exists to
make visible, reproduced in the file itself. The rows are partitioned now and the distinction is
asserted rather than assumed.

Final: **17/17, 14 mutation-backed.**
