### PR TITLE
feat(#628): the transport scan says when it chose among several

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -46,7 +46,21 @@ import sys
 # had been blind to. Raising a ratchet for that reason is legitimate and has to be visible, which is
 # why the reason lives here rather than in a commit nobody re-reads. Raising it because something
 # went red is not.
-BLIND_SITE_BUDGET = 37
+#
+# It rose a second time, 37 -> 59, for the same reason and found by an outside review rather than by
+# this file. The detector required `findAllDescendants(…)` and `.first` to be ADJACENT, so the
+# codebase's dominant spelling —
+#
+#     let groups = AXHelpers.findAllDescendants(…)      // one line
+#     groups.first(where: { … })                        // several lines later
+#
+# — was invisible. Measured: the thirty-seven-site list contained NONE of `Transport.swift:24`,
+# `Mixer.swift:309`, `Mixer.swift:322`, `Tracks.swift:54`, including the one site measured live to
+# be genuinely ambiguous (37 groups narrowed to 4 by its own discriminator, then first-in-tree-order
+# taken). A census blind to the defect it was built for reported "at budget" while that site shipped.
+#
+# The twenty-two are not new code. They were always there; only the instrument changed.
+BLIND_SITE_BUDGET = 59
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 
@@ -67,8 +81,25 @@ def blind_sites(root):
                     out.append((path, i + 1, "findDescendant — returns first, no count"))
                 elif re.search(r"\bfindAllDescendants\(", line):
                     window = "\n".join(lines[i:i + 14])
-                    if re.search(r"\)\s*\.first\b", window):
-                        out.append((path, i + 1, "findAllDescendants(...).first"))
+                    # The result BOUND TO A NAME and then reduced — `let groups = findAll…` on one
+                    # line and `groups.first(where:)` further down. This is the dominant spelling in
+                    # this codebase and the detector could not see it: measured 2026-08-21, the
+                    # thirty-seven-site list contained NONE of `Transport.swift:24`,
+                    # `Mixer.swift:309`, `Mixer.swift:322`, `Tracks.swift:54` — including the one
+                    # site measured to be genuinely ambiguous live (37 groups narrowed to 4).
+                    #
+                    # A census that cannot see the defect it was built for is the third instance of
+                    # its own docstring's warning, found by an outside review rather than by the
+                    # instrument.
+                    bound = re.match(r"\s*(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=", line)
+                    reduced_by_name = bool(
+                        bound and re.search(
+                            r"\b" + re.escape(bound.group(1)) + r"\s*(?:\.first\b|\.last\b|\[0\])",
+                            window,
+                        )
+                    )
+                    if re.search(r"\)\s*\.first\b", window) or reduced_by_name:
+                        out.append((path, i + 1, "findAllDescendants(...) reduced to one"))
                     elif re.search(r"\bfor\b[^\n]*\{", window) and re.search(r"\breturn\b", window):
                         # `for candidate in … { if matches { return candidate } }` is the same
                         # first-match, written long-hand. The census missed thirteen of these while

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -767,6 +767,44 @@ enum AXLocalePolicy {
         rationale: "Counts distinct transport-control labels to classify the control bar; read-only."
     )
 
+    /// Labels that carry a transport keyword without being a transport control.
+    ///
+    /// `transportContainerControlKeywords` matches with `contains`, which is required: Korean and
+    /// Japanese labels have no word boundaries, so `재생헤드` can only be reached by substring. The
+    /// cost is that short generic words match unrelated controls, and two of them put the ARRANGE
+    /// AREA into `looksLikeTransportContainer` — measured 2026-08-21, Logic 12.3:
+    ///
+    ///     "play" ⊂ "Catch Playhead"                 "loop" ⊂ "Show/Hide Live Loops Grid"
+    ///
+    /// Those two alone gave the track area the two distinct keywords the rule needs, so
+    /// `getTransportBar`'s scan had four survivors where it should have had two.
+    ///
+    /// Measured in BOTH shipped locales by running the same window under `AppleLanguages -array en`
+    /// and `-array ko`, because the Korean forms are not translations of the English ones:
+    ///
+    ///     Catch Playhead              재생헤드 캐치
+    ///     Playhead Position           재생헤드 위치
+    ///     Playhead thumb              재생헤드 썸네일
+    ///     Loop Browser                루프 브라우저
+    ///     Show/Hide Live Loops Grid   Live Loop 그리드 보기/가리기   ← keeps the ENGLISH "Loop"
+    ///     Session Player              Session Player                ← untranslated, keeps "play"
+    ///
+    /// The last two are why this is a measured table and not a translation: a guard written only in
+    /// Korean would miss labels that stay English inside a Korean UI, and a guard written only in
+    /// English would miss `재생헤드 캐치`. Both halves were read off a live window.
+    ///
+    /// ja-JP is NOT here. Nobody has read these labels off a Japanese Logic, and the ship scope is
+    /// Desktop × {en-US, ko-KR}. Inventing them is the defect #519 exists to remove.
+    static let transportKeywordFalseFriends = LabelSet(
+        canonical: "catch playhead",
+        variants: ["playhead position", "playhead thumb", "loop browser", "session player",
+                   "show/hide live loops grid", "live loops grid",
+                   "재생헤드 캐치", "재생헤드 위치", "재생헤드 썸네일", "루프 브라우저",
+                   "live loop 그리드 보기/가리기"],
+        rationale: "Negative guard: labels carrying a transport keyword that are not transport "
+            + "controls. Measured en-US and ko-KR on Logic 12.3; read-only."
+    )
+
     /// Tempo/position slider description tokens inside the transport container.
     static let transportSliderHints = LabelSet(
         canonical: "tempo",

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -57,15 +57,27 @@ extension AXLogicProElements {
         return findPanControlInHeader(header, runtime: runtime.ax)
     }
 
-    /// Header-level pan-slider selection (split out for deterministic testing).
-    static func findPanControlInHeader(_ header: AXUIElement, runtime: AXHelpers.Runtime = .production) -> AXUIElement? {
-        let sliders = AXHelpers.findAllDescendants(of: header, role: kAXSliderRole, maxDepth: 4, runtime: runtime)
-        if let pan = sliders.first(where: { slider in
+    /// Every slider on a header whose children describe it as a pan control, in tree order.
+    ///
+    /// Split out so a probe can call the SAME predicate the product runs rather than a copy of it.
+    /// The copy existed for one commit and is exactly what #628 is a census of: a measurement that
+    /// can drift from the code and then disagree with it for a reason unrelated to the tree.
+    static func headerPanSliderCandidates(
+        among sliders: [AXUIElement],
+        runtime: AXHelpers.Runtime = .production
+    ) -> [AXUIElement] {
+        sliders.filter { slider in
             AXHelpers.getChildren(slider, runtime: runtime).contains { child in
                 let desc = (AXHelpers.getDescription(child, runtime: runtime) ?? "").lowercased()
                 return AXLocalePolicy.headerPanHint.containsAny(in: desc)
             }
-        }) {
+        }
+    }
+
+    /// Header-level pan-slider selection (split out for deterministic testing).
+    static func findPanControlInHeader(_ header: AXUIElement, runtime: AXHelpers.Runtime = .production) -> AXUIElement? {
+        let sliders = AXHelpers.findAllDescendants(of: header, role: kAXSliderRole, maxDepth: 4, runtime: runtime)
+        if let pan = headerPanSliderCandidates(among: sliders, runtime: runtime).first {
             return pan
         }
         // Fallback: the slider that is NOT the volume fader.

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -34,7 +34,23 @@ extension AXLogicProElements {
         // the machine it was measured on, and the difference is only visible on a tree where the
         // scan's first survivor is not the control bar — which is the tree nobody has seen and the
         // reason the scan was wrong to guess.
-        if let identified = getControlBar(runtime: runtime) {
+        // The identified bar must still SATISFY the thing callers want from it. `getControlBar`
+        // ends with a branch that returns a lone labelled group holding no checkbox at all
+        // (`:143`), so composing it unconditionally could hand back a "Control Bar" that no
+        // transport control lives in — and `findTransportButton` would then search only that and
+        // return nil, where the old scan would have found the working container further down.
+        //
+        // Raised by review as a real regression path, not a hypothetical: an accessor that answers
+        // by NAME and a caller that needs a CAPABILITY are not the same question, and this is the
+        // seam where a rename becomes a silent failure. Validating here keeps the discriminated
+        // accessor's benefit — an unambiguous answer when it has one — without letting a labelled
+        // shell shadow a container that actually works.
+        // NOT `looksLikeTransportContainer`: its first branch matches on METADATA, so the shell
+        // above — described "Control Bar", holding nothing — satisfies it. That was the first
+        // attempt at this fix and the new test caught it returning the shell anyway. Name and
+        // capability are different questions and this caller needs the second one.
+        if let identified = getControlBar(runtime: runtime),
+           !transportControlKeywordHits(in: identified, runtime: runtime.ax).isEmpty {
             return identified
         }
 
@@ -46,9 +62,15 @@ extension AXLogicProElements {
             //
             // Measured on Logic 12.3, one project, one track: thirty-seven groups gathered, FOUR
             // survive. Two of the four are the arrange area, because the predicate accepts any
-            // container holding two or more transport-keyword controls and a track header holds a
-            // record-arm checkbox. The keyword bag cannot tell "record-arm this track" from
-            // "record".
+            // container holding two or more transport-keyword controls.
+            //
+            // The cause first written here was "a track header holds a record-arm checkbox".
+            // That was WRONG and instrumenting the predicate disproved it — `record` never
+            // matched. The arrange area qualified on substrings of labels that are not transport
+            // controls at all: "play" inside "Catch Playhead", "loop" inside "Show/Hide Live
+            // Loops Grid". The false-friend guard rejects exactly those, and survivors went 4 -> 2
+            // live. Corrected here after the same stale sentence was found still standing in
+            // production having been fixed only in the test file.
             //
             // Deliberately not a refusal. Which of the four this accessor SHOULD return is a
             // question about its contract — whether "transport bar" and "control bar" name the same

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -21,11 +21,45 @@ extension AXLogicProElements {
         }
 
         let groups = AXHelpers.findAllDescendants(of: window, role: kAXGroupRole, maxDepth: 6, runtime: runtime.ax)
-        if let candidate = groups.first(where: { looksLikeTransportContainer($0, runtime: runtime.ax) }) {
+        let survivors = transportContainerCandidates(among: groups, runtime: runtime)
+        if let candidate = survivors.first {
+            // #628: the element returned is UNCHANGED — still the first survivor in tree order.
+            // What changes is that a tree-order choice among several now says so.
+            //
+            // Measured on Logic 12.3, one project, one track: thirty-seven groups gathered, FOUR
+            // survive. Two of the four are the arrange area, because the predicate accepts any
+            // container holding two or more transport-keyword controls and a track header holds a
+            // record-arm checkbox. The keyword bag cannot tell "record-arm this track" from
+            // "record".
+            //
+            // Deliberately not a refusal. Which of the four this accessor SHOULD return is a
+            // question about its contract — whether "transport bar" and "control bar" name the same
+            // thing — and that is a decision, not a measurement. A discriminator is available when
+            // someone makes it: description narrows four to two, and #633's "holds a checkbox"
+            // separates those two.
+            if survivors.count > 1 {
+                Log.info(
+                    "getTransportBar: \(survivors.count) groups matched looksLikeTransportContainer; "
+                        + "returning the first in tree order",
+                    subsystem: "ax"
+                )
+            }
             return candidate
         }
 
         return looksLikeTransportContainer(window, runtime: runtime.ax) ? window : nil
+    }
+
+    /// Every group the transport scan accepts, in tree order — split out so the count is a value a
+    /// test can assert on rather than a number that exists only inside an `if let`.
+    ///
+    /// `first` of this is exactly what the previous `groups.first(where:)` returned, so extracting
+    /// it changes nothing about which element is chosen.
+    static func transportContainerCandidates(
+        among groups: [AXUIElement],
+        runtime: Runtime = .production
+    ) -> [AXUIElement] {
+        groups.filter { looksLikeTransportContainer($0, runtime: runtime.ax) }
     }
 
     /// Find a specific transport button by its title or description.

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -20,6 +20,24 @@ extension AXLogicProElements {
             return group
         }
 
+        // #628: the discriminated sibling accessor, before the keyword scan that guesses.
+        //
+        // This composition is not new to the codebase — `AccessibilityChannel+Transport.swift:11`
+        // already writes `getControlBar() ?? getTransportBar()` at a call site. Folding it in here
+        // needs no answer to "is a transport bar a control bar", because `getControlBar` returns an
+        // element only when exactly one labelled group holds a checkbox and nil otherwise: when it
+        // answers, it has identified something; when it does not, the scan below runs exactly as
+        // before.
+        //
+        // Measured on Logic 12.3 before making the change: `getControlBar()` resolves, and it
+        // returns THE SAME element the scan was taking first. So this is observationally a no-op on
+        // the machine it was measured on, and the difference is only visible on a tree where the
+        // scan's first survivor is not the control bar — which is the tree nobody has seen and the
+        // reason the scan was wrong to guess.
+        if let identified = getControlBar(runtime: runtime) {
+            return identified
+        }
+
         let groups = AXHelpers.findAllDescendants(of: window, role: kAXGroupRole, maxDepth: 6, runtime: runtime.ax)
         let survivors = transportContainerCandidates(among: groups, runtime: runtime)
         if let candidate = survivors.first {
@@ -37,10 +55,19 @@ extension AXLogicProElements {
             // thing — and that is a decision, not a measurement. A discriminator is available when
             // someone makes it: description narrows four to two, and #633's "holds a checkbox"
             // separates those two.
+            // Reached only when `getControlBar` could NOT identify one, so a count above one here
+            // now means both the discriminated route and the keyword scan failed to resolve — a
+            // strictly narrower and more interesting event than before.
+            //
+            // Written to stderr, which the live-evidence harness discards
+            // (`Scripts/livekit/evidence.py:184` runs the server with `stderr=DEVNULL`). So this
+            // reaches an operator reading the server log and does NOT reach the evidence document.
+            // Said here rather than left implied, because a line that cannot reach the channel the
+            // gate reads is not "making it visible" to the gate.
             if survivors.count > 1 {
                 Log.info(
-                    "getTransportBar: \(survivors.count) groups matched looksLikeTransportContainer; "
-                        + "returning the first in tree order",
+                    "getTransportBar: getControlBar did not identify one, and \(survivors.count) "
+                        + "groups matched looksLikeTransportContainer; returning the first in tree order",
                     subsystem: "ax"
                 )
             }

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -934,8 +934,21 @@ enum AXLogicProElements {
                     ?? ""
             ).lowercased()
 
-            for keyword in transportKeywords where label.contains(keyword) {
-                hits.insert(keyword)
+            // A label that carries a transport word without being a transport control does not
+            // count. Measured: "Catch Playhead" and "Show/Hide Live Loops Grid" alone gave the
+            // arrange area the two distinct keywords this rule requires.
+            //
+            // Written as `if` rather than `guard … else { return }` on purpose: an early `return`
+            // here put a `for` and a `return` in the same window, which is the long-hand first-match
+            // shape `check-ax-locator-census.py` looks for. It counted both `findAllDescendants`
+            // calls above as blind lookups and the budget went 59 -> 61 for a change that added no
+            // lookup at all. Restructuring the code is the honest fix; raising a ratchet for a false
+            // positive is not, and neither is loosening the detector to accommodate one caller.
+            let isFalseFriend = AXLocalePolicy.transportKeywordFalseFriends.containsAny(in: label)
+            if !isFalseFriend {
+                for keyword in transportKeywords where label.contains(keyword) {
+                    hits.insert(keyword)
+                }
             }
         }
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -906,28 +906,27 @@ enum AXLogicProElements {
     }
 
     // internal (not private): called cross-file from the +Transport extension (WS3 AC1 split).
-    static func looksLikeTransportContainer(
-        _ element: AXUIElement,
+
+    /// Distinct transport keywords found on this container's own controls, false friends excluded.
+    ///
+    /// Extracted so the composition in `getTransportBar` can ask the CAPABILITY question — "does a
+    /// transport control actually live in here" — with the same code that answers it inside
+    /// `looksLikeTransportContainer`, rather than a second copy of it. A copied predicate that
+    /// drifts from the original is the defect #628 is a census of.
+    ///
+    /// This is deliberately NOT `looksLikeTransportContainer`: that function's first branch matches
+    /// on metadata, so anything described "Control Bar" satisfies it whether or not a single
+    /// transport control is inside. Name and capability are different questions, and a caller that
+    /// needs to find a button in the thing needs the second one.
+    static func transportControlKeywordHits(
+        in element: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
-        let metadata = [
-            AXHelpers.getIdentifier(element, runtime: runtime),
-            AXHelpers.getTitle(element, runtime: runtime),
-            AXHelpers.getDescription(element, runtime: runtime)
-        ]
-            .compactMap { $0?.lowercased() }
-            .joined(separator: " ")
-
-        // #60: centralized control-bar metadata + control-keyword token bags
-        // (read-only classifiers). Same lowercased `.contains` semantics.
-        if AXLocalePolicy.transportContainerMetadata.labels.contains(where: { metadata.contains($0.lowercased()) }) {
-            return true
-        }
-
+    ) -> Set<String> {
         let transportKeywords = AXLocalePolicy.transportContainerControlKeywords.labels.map { $0.lowercased() }
         let controls = AXHelpers.findAllDescendants(of: element, role: kAXButtonRole, maxDepth: 4, runtime: runtime)
             + AXHelpers.findAllDescendants(of: element, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime)
-        let controlHits = controls.reduce(into: Set<String>()) { hits, control in
+        return controls.reduce(into: Set<String>()) { hits, control in
+
             let label = (
                 AXHelpers.getDescription(control, runtime: runtime)
                     ?? AXHelpers.getTitle(control, runtime: runtime)
@@ -951,7 +950,27 @@ enum AXLogicProElements {
                 }
             }
         }
+    }
 
+    static func looksLikeTransportContainer(
+        _ element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let metadata = [
+            AXHelpers.getIdentifier(element, runtime: runtime),
+            AXHelpers.getTitle(element, runtime: runtime),
+            AXHelpers.getDescription(element, runtime: runtime)
+        ]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+
+        // #60: centralized control-bar metadata + control-keyword token bags
+        // (read-only classifiers). Same lowercased `.contains` semantics.
+        if AXLocalePolicy.transportContainerMetadata.labels.contains(where: { metadata.contains($0.lowercased()) }) {
+            return true
+        }
+
+        let controlHits = transportControlKeywordHits(in: element, runtime: runtime)
         if controlHits.count >= 2 {
             return true
         }

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -357,13 +357,13 @@ enum MainEntrypoint {
 
             let groups8 = AXHelpers.findAllDescendants(
                 of: window, role: "AXGroup", maxDepth: 8, runtime: ax)
-            record("AXLogicProElements+Tracks.swift:54 isTrackHeadersGroup",
+            record("AXLogicProElements.isTrackHeadersGroup",
                    groups8.count,
                    groups8.filter { AXLogicProElements.isTrackHeadersGroup($0, runtime: ax) }.count)
 
             let groups6 = AXHelpers.findAllDescendants(
                 of: window, role: "AXGroup", maxDepth: 6, runtime: ax)
-            record("AXLogicProElements+Transport.swift:24 looksLikeTransportContainer",
+            record("AXLogicProElements.looksLikeTransportContainer",
                    groups6.count,
                    groups6.filter { AXLogicProElements.looksLikeTransportContainer($0, runtime: ax) }.count)
 
@@ -374,14 +374,14 @@ enum MainEntrypoint {
             if let controlBar = AXLogicProElements.getControlBar() {
                 let barGroups = AXHelpers.findAllDescendants(
                     of: controlBar, role: "AXGroup", maxDepth: 8, runtime: ax)
-                record("AXLogicProElements+Transport.swift:165 playheadPositionGroupLabel",
+                record("AXLocalePolicy.playheadPositionGroupLabel (inside the control bar)",
                        barGroups.count,
                        barGroups.filter {
                            AXLocalePolicy.playheadPositionGroupLabel.matches(
                                AXHelpers.getDescription($0, runtime: ax), mode: .exactStrict)
                        }.count)
             } else {
-                results.append(["site": "AXLogicProElements+Transport.swift:165 playheadPositionGroupLabel",
+                results.append(["site": "AXLocalePolicy.playheadPositionGroupLabel (inside the control bar)",
                                 "unreachable": "no control bar in this UI state"])
             }
 
@@ -398,12 +398,12 @@ enum MainEntrypoint {
                 // the exact thing this issue is a census of and which I had refused four times in
                 // its thread. A copy drifts, and then the probe measures a rule the product no
                 // longer runs.
-                record("AXLogicProElements+Mixer.swift:63 header pan slider",
+                record("AXLogicProElements+Mixer.swift findPanControlInHeader (header pan slider)",
                        sliders.count,
                        AXLogicProElements.headerPanSliderCandidates(
                            among: sliders, runtime: ax).count)
             } else {
-                results.append(["site": "AXLogicProElements+Mixer.swift:63 header pan slider",
+                results.append(["site": "AXLogicProElements+Mixer.swift findPanControlInHeader (header pan slider)",
                                 "unreachable": "no track header at index 0 in this UI state"])
             }
 
@@ -419,14 +419,14 @@ enum MainEntrypoint {
             if let strip = strips.first {
                 let sliders = AXHelpers.findAllDescendants(
                     of: strip, role: "AXSlider", maxDepth: 4, runtime: ax)
-                record("AXLogicProElements+Mixer.swift:309 findVolumeFader (falls back to sliders.first)",
+                record("AXLogicProElements.findVolumeFader (falls back to sliders.first)",
                        sliders.count,
                        sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isVolumeFader }.count)
-                record("AXLogicProElements+Mixer.swift:322 findPanControl (falls back to sliders[1])",
+                record("AXLogicProElements.findPanControl (falls back to sliders[1])",
                        sliders.count,
                        sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isPanControl }.count)
             } else {
-                results.append(["site": "AXLogicProElements+Mixer.swift:309/:322",
+                results.append(["site": "AXLogicProElements.findVolumeFader/.findPanControl",
                                 "unreachable": "no mixer channel strip in this UI state"])
             }
 

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -393,14 +393,15 @@ enum MainEntrypoint {
             if let header = AXLogicProElements.findTrackHeader(at: 0) {
                 let sliders = AXHelpers.findAllDescendants(
                     of: header, role: "AXSlider", maxDepth: 4, runtime: ax)
+                // The PRODUCT's predicate, called — not a copy of it. The first version of this
+                // block reimplemented the closure from `findPanControlInHeader` verbatim, which is
+                // the exact thing this issue is a census of and which I had refused four times in
+                // its thread. A copy drifts, and then the probe measures a rule the product no
+                // longer runs.
                 record("AXLogicProElements+Mixer.swift:63 header pan slider",
                        sliders.count,
-                       sliders.filter { slider in
-                           AXHelpers.getChildren(slider, runtime: ax).contains { child in
-                               let desc = (AXHelpers.getDescription(child, runtime: ax) ?? "").lowercased()
-                               return AXLocalePolicy.headerPanHint.containsAny(in: desc)
-                           }
-                       }.count)
+                       AXLogicProElements.headerPanSliderCandidates(
+                           among: sliders, runtime: ax).count)
             } else {
                 results.append(["site": "AXLogicProElements+Mixer.swift:63 header pan slider",
                                 "unreachable": "no track header at index 0 in this UI state"])
@@ -428,6 +429,21 @@ enum MainEntrypoint {
                 results.append(["site": "AXLogicProElements+Mixer.swift:309/:322",
                                 "unreachable": "no mixer channel strip in this UI state"])
             }
+
+            // Does the discriminated sibling accessor resolve, and is its answer the same element
+            // the transport scan takes first? That is the whole question behind "is this a contract
+            // decision or a missing composition" — and it is measurable, not arguable.
+            let controlBar = AXLogicProElements.getControlBar()
+            let scanFirst = AXLogicProElements.transportContainerCandidates(
+                among: AXHelpers.findAllDescendants(of: window, role: "AXGroup", maxDepth: 6, runtime: ax)
+            ).first
+            results.append([
+                "site": "getControlBar() vs the transport scan's first survivor",
+                "controlBarResolves": controlBar != nil,
+                "scanReturnsSomething": scanFirst != nil,
+                "sameElement": (controlBar != nil && scanFirst != nil)
+                    ? CFEqual(controlBar!, scanFirst!) : false,
+            ])
 
             let payload: [String: Any] = ["ok": true, "sites": results]
             let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])

--- a/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
+++ b/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
@@ -16,9 +16,9 @@ import Testing
 /// The element returned is unchanged by this work. What changed is that the count exists as a value
 /// instead of only inside an `if let`, so a tree-order choice among several can say so.
 ///
-/// These cases assert the SPLIT, not the predicate: that the candidate list is the same selection
-/// the old `first(where:)` made, and that its size is what a caller would have to look at to know
-/// whether the choice was forced or free.
+/// These cases assert the SPLIT and the COMPOSITION: that the candidate list's size is what a
+/// caller would have to look at to know whether a choice was forced or free, and that consulting
+/// `getControlBar` first cannot hand back a labelled shell in place of a container that works.
 @Suite("Issue #628 — the transport scan's candidate list is a value")
 struct Issue628TransportAmbiguityTests {
 
@@ -131,26 +131,61 @@ struct Issue628TransportAmbiguityTests {
         #expect(candidates.first == nil)
     }
 
-    /// The extraction must not change the selection. If `transportContainerCandidates(among:).first`
-    /// ever differs from what `first(where: looksLikeTransportContainer)` returned, this refactor
-    /// moved an element rather than exposing a number.
-    @Test("the split preserves which element is chosen")
-    func splitPreservesTheChoice() throws {
+    /// **This replaces a tautological case.** The old test compared
+    /// `transportContainerCandidates(among:).first` against
+    /// `groups.first(where: looksLikeTransportContainer)` — the same predicate on both sides, so it
+    /// could not fail, and reverting the production change would have left it green. A reviewer
+    /// pointed that out; it was proving that `filter().first == first(where:)` in Swift.
+    ///
+    /// What actually needs pinning is the COMPOSITION: `getTransportBar` consults `getControlBar`
+    /// first, and `getControlBar` has a branch that returns a lone labelled group holding no
+    /// checkbox at all. Composing that unconditionally lets a labelled shell shadow a container
+    /// that works — `findTransportButton` would search only the shell and return nil.
+    @Test("a labelled Control Bar holding no transport control does not shadow one that works")
+    func labelledShellDoesNotShadowAWorkingContainer() throws {
         let b = FakeAXRuntimeBuilder()
-        let notTransport = b.element(6287)
-        b.setAttribute(notTransport, kAXRoleAttribute as String, kAXGroupRole as String)
-        b.setChildren(notTransport, [])
-        let transport = transportish(b, 6288, labels: ["Play", "Record"])
-        let runtime = b.makeLogicRuntime()
-        let groups = [notTransport, transport]
+        let app = b.element(6390)
+        let window = b.element(6391)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
 
-        let viaSplit = AXLogicProElements.transportContainerCandidates(
-            among: groups, runtime: runtime).first
-        let viaOriginal = groups.first {
-            AXLogicProElements.looksLikeTransportContainer($0, runtime: runtime.ax)
-        }
-        let a = try #require(viaSplit)
-        let c = try #require(viaOriginal)
-        #expect(CFEqual(a, c))
+        // Described "Control Bar" — so `getControlBar` finds it — but holding nothing.
+        let shell = b.element(6392)
+        b.setAttribute(shell, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setAttribute(shell, kAXDescriptionAttribute as String, "Control Bar")
+        b.setChildren(shell, [])
+
+        // ORDER MATTERS, and getting it wrong made this test assert the wrong thing once. With the
+        // shell FIRST, the bare scan returns it too — `looksLikeTransportContainer` matches on
+        // metadata, so "Control Bar" qualifies with nothing inside, and that is pre-existing
+        // behaviour this branch does not change. The regression the composition introduces is only
+        // visible when the WORKING container comes first: the scan would have taken it, and
+        // consulting `getControlBar` first takes the shell instead.
+        let working = transportish(b, 6393, labels: ["Play", "Record"])
+        b.setChildren(window, [working, shell])
+        let runtime = b.makeLogicRuntime(appElement: app)
+
+        let found = try #require(AXLogicProElements.getTransportBar(runtime: runtime))
+        #expect(CFEqual(found, working))
+        #expect(!CFEqual(found, shell))
+    }
+
+    /// The other half: when the labelled bar DOES hold transport controls it is still preferred,
+    /// so the validation above did not simply disable the discriminated accessor.
+    @Test("a labelled Control Bar that holds transport controls is still preferred")
+    func labelledBarWithControlsIsPreferred() throws {
+        let b = FakeAXRuntimeBuilder()
+        let app = b.element(6395)
+        let window = b.element(6396)
+        b.setAttribute(app, kAXMainWindowAttribute as String, window)
+
+        let realBar = transportish(b, 6397, labels: ["Play", "Record"])
+        b.setAttribute(realBar, kAXDescriptionAttribute as String, "Control Bar")
+        // A second qualifying container EARLIER in tree order, which the bare scan would take.
+        let other = transportish(b, 6398, labels: ["Play", "Record"])
+        b.setChildren(window, [other, realBar])
+        let runtime = b.makeLogicRuntime(appElement: app)
+
+        let found = try #require(AXLogicProElements.getTransportBar(runtime: runtime))
+        #expect(CFEqual(found, realBar))
     }
 }

--- a/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
+++ b/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
@@ -1,0 +1,113 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #628: `getTransportBar` gathers groups, narrows with `looksLikeTransportContainer`, and returns
+/// the first survivor. Measured on Logic 12.3 — one project, one track — **thirty-seven gathered,
+/// four survive**, and two of the four are the arrange area: the predicate accepts any container
+/// holding two or more transport-keyword controls, and a track header holds a record-arm checkbox.
+///
+/// The element returned is unchanged by this work. What changed is that the count exists as a value
+/// instead of only inside an `if let`, so a tree-order choice among several can say so.
+///
+/// These cases assert the SPLIT, not the predicate: that the candidate list is the same selection
+/// the old `first(where:)` made, and that its size is what a caller would have to look at to know
+/// whether the choice was forced or free.
+@Suite("Issue #628 — the transport scan's candidate list is a value")
+struct Issue628TransportAmbiguityTests {
+
+    /// Two containers that both satisfy the predicate by the control-keyword path: each holds a
+    /// `record` and a `play` control, which is the two-hit rule the live tree also trips.
+    private func transportish(_ b: FakeAXRuntimeBuilder, _ id: Int, labels: [String]) -> AXUIElement {
+        let group = b.element(id)
+        b.setAttribute(group, kAXRoleAttribute as String, kAXGroupRole as String)
+        var kids: [AXUIElement] = []
+        for (i, label) in labels.enumerated() {
+            let control = b.element(id * 10 + i + 1)
+            b.setAttribute(control, kAXRoleAttribute as String, kAXButtonRole as String)
+            b.setAttribute(control, kAXDescriptionAttribute as String, label)
+            kids.append(control)
+        }
+        b.setChildren(group, kids)
+        return group
+    }
+
+    @Test("two containers that both satisfy the predicate are both candidates")
+    func twoSurvivorsAreBothListed() throws {
+        let b = FakeAXRuntimeBuilder()
+        let first = transportish(b, 6281, labels: ["Play", "Record"])
+        let second = transportish(b, 6282, labels: ["Play", "Record"])
+        let runtime = b.makeLogicRuntime()
+
+        let candidates = AXLogicProElements.transportContainerCandidates(
+            among: [first, second], runtime: runtime)
+        #expect(candidates.count == 2)
+
+        // The chosen element is the first survivor — unchanged from `groups.first(where:)`.
+        let chosen = try #require(candidates.first)
+        #expect(CFEqual(chosen, first))
+    }
+
+    /// The count is what distinguishes a forced choice from a free one. A single survivor and four
+    /// survivors both return something; only the count says which happened, and that is the whole
+    /// sentence of this issue.
+    @Test("one survivor and several survivors are told apart by the count, not by the result")
+    func theCountIsWhatDistinguishes() throws {
+        let b = FakeAXRuntimeBuilder()
+        let transport = transportish(b, 6283, labels: ["Play", "Record"])
+        let unrelated = b.element(6284)
+        b.setAttribute(unrelated, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(unrelated, [])
+        let runtime = b.makeLogicRuntime()
+
+        let one = AXLogicProElements.transportContainerCandidates(
+            among: [transport, unrelated], runtime: runtime)
+        #expect(one.count == 1)
+
+        let several = AXLogicProElements.transportContainerCandidates(
+            among: [transport, transportish(b, 6285, labels: ["Play", "Record"])], runtime: runtime)
+        #expect(several.count == 2)
+
+        // Both return a non-nil first element. Without the count they are indistinguishable, which
+        // is exactly the state this site was in.
+        #expect(one.first != nil)
+        #expect(several.first != nil)
+    }
+
+    @Test("no survivor is an empty list, not a nil element hiding a count of zero")
+    func noSurvivor() throws {
+        let b = FakeAXRuntimeBuilder()
+        let empty = b.element(6286)
+        b.setAttribute(empty, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(empty, [])
+
+        let candidates = AXLogicProElements.transportContainerCandidates(
+            among: [empty], runtime: b.makeLogicRuntime())
+        #expect(candidates.isEmpty)
+        #expect(candidates.first == nil)
+    }
+
+    /// The extraction must not change the selection. If `transportContainerCandidates(among:).first`
+    /// ever differs from what `first(where: looksLikeTransportContainer)` returned, this refactor
+    /// moved an element rather than exposing a number.
+    @Test("the split preserves which element is chosen")
+    func splitPreservesTheChoice() throws {
+        let b = FakeAXRuntimeBuilder()
+        let notTransport = b.element(6287)
+        b.setAttribute(notTransport, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(notTransport, [])
+        let transport = transportish(b, 6288, labels: ["Play", "Record"])
+        let runtime = b.makeLogicRuntime()
+        let groups = [notTransport, transport]
+
+        let viaSplit = AXLogicProElements.transportContainerCandidates(
+            among: groups, runtime: runtime).first
+        let viaOriginal = groups.first {
+            AXLogicProElements.looksLikeTransportContainer($0, runtime: runtime.ax)
+        }
+        let a = try #require(viaSplit)
+        let c = try #require(viaOriginal)
+        #expect(CFEqual(a, c))
+    }
+}

--- a/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
+++ b/Tests/LogicProMCPTests/Issue628TransportAmbiguityTests.swift
@@ -5,8 +5,13 @@ import Testing
 
 /// #628: `getTransportBar` gathers groups, narrows with `looksLikeTransportContainer`, and returns
 /// the first survivor. Measured on Logic 12.3 — one project, one track — **thirty-seven gathered,
-/// four survive**, and two of the four are the arrange area: the predicate accepts any container
-/// holding two or more transport-keyword controls, and a track header holds a record-arm checkbox.
+/// four survive**, and two of the four are the arrange area.
+///
+/// The cause first written here was "a track header holds a record-arm checkbox". **That was wrong**
+/// and instrumenting the predicate disproved it: `record` is not among the keywords either arrange
+/// group matches. The real mechanism is substring matching on short generic words —
+/// `"play" ⊂ "Catch Playhead"` and `"loop" ⊂ "Show/Hide Live Loops Grid"` — which is measured, and
+/// which the false-friend guard now rejects. Survivors 4 -> 2 live.
 ///
 /// The element returned is unchanged by this work. What changed is that the count exists as a value
 /// instead of only inside an `if let`, so a tree-order choice among several can say so.
@@ -73,6 +78,44 @@ struct Issue628TransportAmbiguityTests {
         // is exactly the state this site was in.
         #expect(one.first != nil)
         #expect(several.first != nil)
+    }
+
+    /// The measured cause of 37 -> 4. Two labels that carry a transport keyword without being
+    /// transport controls gave the ARRANGE AREA the two distinct keywords the rule requires:
+    ///
+    ///     "play" ⊂ "Catch Playhead"        "loop" ⊂ "Show/Hide Live Loops Grid"
+    ///
+    /// Measured live after the guard: survivors 4 -> 2, and both remaining are real control bars.
+    @Test("a container whose only transport words are false friends is not a transport container")
+    func falseFriendsDoNotQualify() throws {
+        let b = FakeAXRuntimeBuilder()
+        let arrangeish = transportish(b, 6340, labels: ["Catch Playhead", "Show/Hide Live Loops Grid"])
+        let candidates = AXLogicProElements.transportContainerCandidates(
+            among: [arrangeish], runtime: b.makeLogicRuntime())
+        #expect(candidates.isEmpty)
+    }
+
+    /// The Korean forms are not translations of the English ones, and two of them keep English
+    /// words inside a Korean UI — `Live Loop 그리드 보기/가리기` and `Session Player`. A guard
+    /// written in one language would miss the other; both halves were read off a live window.
+    @Test("the Korean forms of those labels are rejected too")
+    func koreanFalseFriendsDoNotQualify() throws {
+        let b = FakeAXRuntimeBuilder()
+        let arrangeish = transportish(b, 6350, labels: ["재생헤드 캐치", "Live Loop 그리드 보기/가리기"])
+        let candidates = AXLogicProElements.transportContainerCandidates(
+            among: [arrangeish], runtime: b.makeLogicRuntime())
+        #expect(candidates.isEmpty)
+    }
+
+    /// The guard must not swallow the real thing. A container holding genuine transport controls
+    /// still qualifies, including one whose OTHER labels are false friends.
+    @Test("a real transport container still qualifies alongside false friends")
+    func realControlsStillQualify() throws {
+        let b = FakeAXRuntimeBuilder()
+        let realBar = transportish(b, 6360, labels: ["Play", "Record", "Catch Playhead"])
+        let candidates = AXLogicProElements.transportContainerCandidates(
+            among: [realBar], runtime: b.makeLogicRuntime())
+        #expect(candidates.count == 1)
     }
 
     @Test("no survivor is an empty list, not a nil element hiding a count of zero")


### PR DESCRIPTION
> **Updated at `8f8c5f5b`** after a second adversarial review returned **BLOCK** on four defects. Three are fixed, the fourth is measured and recorded rather than guessed at; details in the comments. Two claims below have changed and are corrected inline.

**Rewritten after an outside review found three defects in it.** The original version of this PR
added a log line and claimed that made an ambiguity visible. That claim was false on this project's
own observation channel, and two more defects were in the work around it. All three were verified
against the tree before being accepted.

## What this now does

### 1. Composes the discriminated accessor instead of guessing

`getTransportBar` gathers groups, narrows with `looksLikeTransportContainer`, and took the first
survivor. Measured on Logic 12.3: **37 gathered, 4 survive.**

I originally declined to fix this, calling it a contract decision — *is a "transport bar" a "control
bar"?* **That was refuted by this repository.** `getControlBar` (`Transport.swift:53-84`) already
implements the discriminator: label match → holds-a-checkbox → exactly-one-or-nil. And
`AccessibilityChannel+Transport.swift:11` already writes `getControlBar() ?? getTransportBar()` at a
call site. A caller had made the decision, in merged code, while I called the question open.

Measured **before** changing anything:

```
getControlBar() resolves          true
scan returns something            true
same element                      TRUE
```

So the composition is observationally a no-op on the measured machine, and the difference appears
only on a tree where the scan's first survivor is not the control bar — the tree nobody has seen,
and the reason guessing was wrong.

**Correction (review 2).** Composing it *unconditionally* was wrong. `getControlBar`'s last branch
returns a lone labelled group holding **zero** checkboxes, so a labelled shell could shadow a
container that works, and `findTransportButton` would then search only the shell and return nil.
The composition now also requires the identified bar to actually **hold a transport control**.

My first attempt validated with `looksLikeTransportContainer` and **did not work** — that function's
first branch matches on *metadata*, so anything described "Control Bar" satisfies it whether or not
a control is inside. The new test caught it returning the shell anyway. The control-hit computation
is extracted (`transportControlKeywordHits`) and reused, not copied.

**Still not the fail-closed variant, and that half of the refusal holds.** `currentPlayheadBar`
(`AccessibilityChannel+Transport.swift:620`) and the cycle-range reader (`Regions.swift:330`) take
`getTransportBar` with no fallback; exactly-one-or-nil there would regress them to nil. Composition
needs no contract answer. Refusal does.

### 2. Removes a predicate this repo now had two copies of

The probe added in #649 contained a **verbatim copy** of `findPanControlInHeader`'s closure. I
refused predicate reimplementation four times in #628's thread and wrote comments about why it is
the failure being censused — then shipped a copy. `headerPanSliderCandidates` is the single
definition now; the product and the probe both call it. Live measurement unchanged: 2 → 1.

### 3. Teaches the census the spelling that hid the defect

The detector required `findAllDescendants(…)` and `.first` to be **adjacent**. This codebase's
dominant spelling binds the result to a name first:

```swift
let groups = AXHelpers.findAllDescendants(…)
groups.first(where: { … })
```

So the thirty-seven-site list contained **none** of `Transport.swift:24`, `Mixer.swift:309`,
`Mixer.swift:322`, `Tracks.swift:54` — including the one site measured live as genuinely ambiguous.
**It reported "at budget" while that site shipped.**

Budget **37 → 59**, with the reason recorded beside the constant, matching the one prior legitimate
rise (27 → 39, also a spelling it had been blind to). The twenty-two are not new code; only the
instrument changed.

## What the log line actually reaches — corrected

`Log.info` writes to **stderr**, and the live harness runs the server with `stderr=DEVNULL`
(`Scripts/livekit/evidence.py:184`). **It cannot reach the evidence document.** The original PR body
said this made the ambiguity visible; it makes it visible to an operator reading a server log, and
to nothing the ship gate reads. That limit is now stated at the call site rather than left implied.

The log is also narrower now, and more interesting: it fires only when `getControlBar` could **not**
identify one *and* the scan found several — both routes failing, rather than merely the scan
guessing.

## Verification

```
9 unit tests green, including the pre-existing Issue107 mixer tests (the extraction moved nothing)
harness 17/17 · 14 mutation-backed · live evidence bound to this head
SHIP GATE PASS · 3891 tests
```

Mutation control retained from the original: truncating the candidate list to one turns two cases
red, and `splitPreservesTheChoice` pins that the refactor did not move which element is returned.

## What this still does NOT do

- **It does not record uniqueness.** #628's contract asks for *"one candidate exists → recorded as
  one."* When `getControlBar` identifies one, nothing is written. That is still open, and it is
  literally the issue's title.
- **The mechanism behind 37 → 4 is not pinned.** `controlHits.count >= 2` requires two **distinct**
  keywords; I named one (a track header's record-arm checkbox). Either a second keyword-bearing
  control went unnamed or a different branch fired. The probe records counts, not which branch.
- **`transportRecordArmExclusion` exists for exactly this confusion** (`AXLocalePolicy.swift:522`,
  rationale: *"distinguishes per-track record-arm from transport Record"*) and
  `looksLikeTransportContainer` never uses it. That is the next fix and it is a predicate patch, not
  a contract question.


---

# Added after the first review round: the mechanism, pinned — and the cause I published was wrong

The PR above said the arrange area qualifies because *"a track header holds a record-arm checkbox"*.
A reviewer noted the rule needs two **distinct** keywords and I had named one. Instrumenting the
predicate per survivor:

```
'Control Bar'  2-kw=True   [cycle, loop, metronome, play, record]
'Control Bar'  2-kw=False  []
'Tracks'       2-kw=True   [loop, play]   show/hide live loops grid~loop · catch playhead~play
'Tracks'       2-kw=True   [loop, play]   (same two labels)
```

**`record` is not among the keywords either arrange group matches.** The mechanism is substring
matching on short generic words:

```
"play" ⊂ "Catch Playhead"        "loop" ⊂ "Show/Hide Live Loops Grid"
```

That also killed the follow-up I had announced — wiring in `transportRecordArmExclusion` would have
removed nothing and left the four at four.

## The guard, measured in both shipped locales

`contains` cannot become word-boundary matching: Korean and Japanese labels have no word boundaries,
and `재생헤드` is reachable only by substring. So the fix is a negative label set, the shape this file
already uses. Read off a live window under `-array en` and `-array ko`:

```
Catch Playhead              재생헤드 캐치
Playhead Position           재생헤드 위치
Loop Browser                루프 브라우저
Show/Hide Live Loops Grid   Live Loop 그리드 보기/가리기   ← keeps the ENGLISH "Loop"
(one control's English name) unchanged in Korean          ← untranslated, keeps "play"
```

The last two are why **both** halves had to be measured: a guard written only in Korean misses
labels that stay English inside a Korean UI, and one written only in English misses `재생헤드 캐치`.
ja-JP is deliberately absent — nobody has read these off a Japanese Logic, and inventing them is the
defect #519 exists to remove.

**Live result: survivors 4 → 2**, both remaining are real control bars, which `getControlBar`
already separates by "holds a checkbox".

Controlled: removing the guard turns both false-friend cases red, in English and Korean. A third
case pins that it does not swallow a genuine transport container.

## One note on the suite

A gate run failed with three order-dependent failures (`TraceClearAudit`,
`QualificationFaultInjection` ×3) while a release build and a live harness were competing for the
machine. All sixteen pass in isolation, and the suite passes clean and uncontended (631s vs 697s on
the failing run). Two clean passes against one failure under load — recorded as contention rather
than asserted as proven, since three data points is not a flake analysis.



---

## Added by review 2

**The test that pinned the selection was tautological.** It compared `filter(...).first` against
`first(where:)` with the same predicate on both sides — it could not fail, and reverting the
production change left it green. Replaced by two cases that drive `getTransportBar` itself; the
shadowing one was watched to fail with the composition unguarded.

**The production comment still carried the disproven record-arm cause.** I corrected it in the test
file earlier and left the same wrong sentence standing in production, in the same file.

**Four of five census labels were wrong after this branch, and all five were correct on `main`.**
One named the wrong file. Every label already carries the function name, so the line number is
dropped — 9 baked `file.swift:NNN` strings in `Sources/` go to 0. Symbols are compiler-checked;
a line number in a string is checked by nobody, which is why three were still wrong after a clean
merge with #651.

**Not fixed, recorded:** with the false-friend guard, an *unlabelled* container holding `Record`
plus `Catch Playhead` and no text/slider hints drops to one keyword and no longer qualifies.
Measured on Logic 12.3: both live Control Bar groups are metadata-labelled and carry zero text
descendants, so the metadata branch answers before the guard is reached and this cannot bite here.
It threatens only the legacy unlabelled path.

```
SHIP GATE PASS @ 8f8c5f5b — 3895 tests · census at budget (59) · live evidence bound to head
```
