### PR TITLE
feat(#628): the mixer fallback is observable, and measured not to fire

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -60,7 +60,14 @@ import sys
 # taken). A census blind to the defect it was built for reported "at budget" while that site shipped.
 #
 # The twenty-two are not new code. They were always there; only the instrument changed.
-BLIND_SITE_BUDGET = 59
+#
+# 59 -> 57 (2026-08-21, #628). Two sites converted, so the ratchet takes the ground:
+# `findVolumeFader` and `findPanControl` no longer take a first match in the long-hand shape — they
+# build the candidate list and can say how many there were. This is the bar FALLING because the
+# defect was fixed, which is the only direction it is allowed to move. The check fails when the
+# count comes in UNDER budget too, on purpose: ground gained and not recorded is ground that the
+# next change can quietly give back.
+BLIND_SITE_BUDGET = 57
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -191,9 +191,14 @@ class Driver:
         self._stderr_file = tempfile.NamedTemporaryFile(
             prefix="lpm-server-stderr-", suffix=".log", delete=False)
         self._stderr_path = self._stderr_file.name
+        # `Log` gates on LOG_LEVEL (`Logger.swift:69`), which the driver would otherwise INHERIT.
+        # At LOG_LEVEL=warn every `Log.info` vanishes while an unrelated warning still fills the
+        # file -- so a harness asserting absence would see a non-empty log and conclude the channel
+        # carried, when the only lines that could have carried were suppressed. Pinned, not inherited.
+        env = dict(os.environ, LOG_LEVEL="info")
         self.proc = subprocess.Popen(
             [self.binary], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=self._stderr_file, text=True, bufsize=1)
+            stderr=self._stderr_file, text=True, bufsize=1, env=env)
         self._send("initialize", {
             "protocolVersion": "2024-11-05", "capabilities": {},
             "clientInfo": {"name": "livekit", "version": "1"}})
@@ -293,14 +298,21 @@ class Driver:
         except Exception:
             return ""
 
-    def server_logged(self, needle):
+    def server_logged(self, needle, since=0):
         """(present, channel_is_live) -- the second value is the control.
 
-        An empty log makes every `needle in log` False, so an absence assertion is vacuous until
-        something has come through. Callers assert on BOTH: absent AND the channel carried.
+        `since` is a byte offset from a previous `len(server_log())`, so a caller can ask about the
+        window AFTER something it did rather than about the whole run. Without it every later read
+        still sees the earlier lines, and "nothing was logged by the write" is indistinguishable
+        from "nothing was logged by the read either" -- the check reads as scoped and is not.
+
+        `channel_is_live` requires an `[INFO]` line, not merely a non-empty file. A log holding only
+        warnings proves the stream is connected and proves nothing about whether an INFO line could
+        have arrived, which is the level every caller of this asserts absence at.
         """
         log = self.server_log()
-        return (needle in log, bool(log.strip()))
+        window = log[since:] if since else log
+        return (needle in window, "[INFO]" in log)
 
     def close(self):
         try:
@@ -309,6 +321,14 @@ class Driver:
         except Exception:
             try:
                 self.proc.kill()
+            except Exception:
+                pass
+        # `delete=False` is required -- the server holds this file open and Python must not remove
+        # it underneath. That makes cleanup THIS function's job: without it every Driver in a run
+        # leaves a descriptor and a file behind, and a long harness accumulates both.
+        for step in (self._stderr_file.close, lambda: os.unlink(self._stderr_path)):
+            try:
+                step()
             except Exception:
                 pass
 

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -57,6 +57,7 @@ import re
 import shutil
 import signal
 import subprocess
+import tempfile
 import sys
 import time
 
@@ -179,9 +180,20 @@ class Driver:
         self.binary = binary or BIN
         self.timeout = timeout
         self._id = 0
+        # The server's diagnostics go to stderr (`Logger.swift:60`). Discarding them made every
+        # `Log.info` in the product unobservable from a live document -- code could say "this
+        # fallback fired" and no harness could assert it fired or did not. Measured 2026-08-21:
+        # that is exactly the state the two #628 branches were in.
+        #
+        # A FILE, not a PIPE. Nothing drains this stream while `_read` blocks on stdout, so a pipe
+        # would deadlock the server once the buffer filled -- silently, and only on the runs that
+        # logged the most.
+        self._stderr_file = tempfile.NamedTemporaryFile(
+            prefix="lpm-server-stderr-", suffix=".log", delete=False)
+        self._stderr_path = self._stderr_file.name
         self.proc = subprocess.Popen(
             [self.binary], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL, text=True, bufsize=1)
+            stderr=self._stderr_file, text=True, bufsize=1)
         self._send("initialize", {
             "protocolVersion": "2024-11-05", "capabilities": {},
             "clientInfo": {"name": "livekit", "version": "1"}})
@@ -266,6 +278,29 @@ class Driver:
 
     def get(self, uri, key, default=None):
         return self.resource(uri).get(key, default)
+
+    def server_log(self):
+        """Everything the server has written to stderr so far.
+
+        Returns "" when the file is unreadable, which is indistinguishable from a server that logged
+        nothing -- so a caller asserting ABSENCE must pair this with a control proving the channel
+        carries at all. `server_logged` returns that control; prefer it over this.
+        """
+        try:
+            self._stderr_file.flush()
+            with open(self._stderr_path, "r", errors="replace") as fh:
+                return fh.read()
+        except Exception:
+            return ""
+
+    def server_logged(self, needle):
+        """(present, channel_is_live) -- the second value is the control.
+
+        An empty log makes every `needle in log` False, so an absence assertion is vacuous until
+        something has come through. Callers assert on BOTH: absent AND the channel carried.
+        """
+        log = self.server_log()
+        return (needle in log, bool(log.strip()))
 
     def close(self):
         try:

--- a/Scripts/livekit/live_628_mixer_fallback_is_visible.py
+++ b/Scripts/livekit/live_628_mixer_fallback_is_visible.py
@@ -63,8 +63,9 @@ PAN_FALLBACK = "findPanControl: no slider described as a pan control"
 
 # Named where it is used rather than left as a bare string in the check: this is the mutation that
 # was applied to the product, rebuilt, and watched to make the absent line appear.
-MUTATION = ("AXLogicProElements+Mixer.swift: `isVolumeFader` forced to false so the description "
-            "matches nothing and the positional fallback becomes the only path")
+MUTATION = ("AXLogicProElements+PluginSlots.swift `sliderText`: BOTH `isVolume` and `isPan` "
+            "forced false, so no description matches and the positional fallback becomes the only "
+            "path for either locator")
 
 
 def osa(script):
@@ -138,11 +139,17 @@ ev.note("628/mixer-resource", {"rows": len(rows),
                                "data_source": body.get("data_source"),
                                "first": rows[0] if rows else None})
 
-ev.check("628/the-locator-ran-against-real-strips", len(rows) > 0,
-         "the mixer read returned at least one strip, so `findVolumeFader` and `findPanControl` "
-         "were each called on a live element -- an empty list would make the absence below "
-         "meaningless, because a locator that never ran cannot log",
-         f"rows={len(rows)}", None)
+# A row alone is too weak. `findVolumeFader` returning nil yields `volume: 0.0` via `?? 0.0`, and
+# a strip with NO sliders logs nothing at all (`AXLogicProElements+Mixer.swift:323`) -- so "rows > 0"
+# is satisfied by exactly the state that would make the absence assertions vacuous. A non-default
+# volume means the locator returned an element AND the extractor read it.
+located = [r for r in rows if isinstance(r.get("volume"), (int, float)) and r["volume"] > 0.0]
+ev.check("628/the-locator-found-a-described-slider", len(located) > 0,
+         "at least one strip reports a non-default volume, so `findVolumeFader` returned a real "
+         "slider rather than nil -- a strip with no sliders logs nothing and would satisfy the "
+         "absence checks below without the locator ever having had anything to choose between",
+         f"rows={len(rows)} with_located_fader={len(located)} "
+         f"volumes={[r.get('volume') for r in rows][:5]}", None)
 
 # THE CONTROL. Absence of a line in an empty file is not evidence of anything, so the run proves the
 # stream carries before it reads anything into the silence.
@@ -195,11 +202,15 @@ ev.check("628/precondition-a-track-is-addressable-by-reference",
 
 wrote = None
 restored_write = None
+# Defined before the branch: the post-write check below reads it unconditionally, and a skipped
+# write would otherwise raise NameError inside the harness rather than fail a check.
+log_mark = len(d.server_log())
 if band is not None and target_ref and original_volume is not None:
     before = ev.shot("628/before-the-write", settle_region=band, window_title=arrange_title)
     # Far enough from the current value that a detented fader must visibly move: the fader snaps in
     # raw steps of 10, about 0.053 normalized, so a smaller delta could round to a no-op.
     target_volume = 0.25 if original_volume > 0.5 else 0.85
+    log_mark = len(d.server_log())
     wrote = d.tool("logic_mixer", "set_volume", {"target_ref": target_ref, "value": target_volume})
     time.sleep(2)
     after = ev.shot("628/after-the-write", settle_region=band, window_title=arrange_title)
@@ -207,13 +218,20 @@ if band is not None and target_ref and original_volume is not None:
     # The write must have LANDED. Without this the visual assertion below is vacuous -- a refused
     # write disturbs nothing, and "the arrangement did not move" would pass because nothing
     # happened at all. Measured: the first version of this harness passed exactly that way.
-    moved = (isinstance(wrote, dict) and wrote.get("success") is not False
-             and wrote.get("observed_after") is not None
-             and abs(float(wrote["observed_after"]) - float(original_volume)) > 0.05)
+    # Compared against the operation's OWN `observed_before`, not against the cached mixer value:
+    # `logic://mixer` is served from the poller and can be seconds stale, so a no-op write can look
+    # like a move purely because the cache had not caught up. The response carries both endpoints.
+    ob = (wrote or {}).get("observed_before")
+    oa = (wrote or {}).get("observed_after")
+    moved = (isinstance(wrote, dict) and not wrote.get("error")
+             and ob is not None and oa is not None
+             and abs(float(oa) - float(ob)) > 0.05)
     ev.check("628/the-write-actually-moved-the-fader", moved,
-             "the volume write was accepted and the readback shows the fader at a new value -- a "
-             "refused write would make the visual assertion below true for no reason",
-             f"wrote={json.dumps(wrote)[:300] if wrote else None}", None)
+             "the operation's own before/after readback shows the fader at a new value -- a refused "
+             "or zero-step write would make the visual assertion below true for no reason",
+             f"observed_before={ob!r} observed_after={oa!r} "
+             f"nudge_steps={(wrote or {}).get('nudge_steps')!r} error={(wrote or {}).get('error')!r}",
+             None)
 
     ev.visual("628/a-mixer-write-does-not-disturb-the-arrangement",
               before["file"], after["file"], band, False,
@@ -233,15 +251,21 @@ if band is not None and target_ref and original_volume is not None:
 
 ev.note("628/the-write", {"target_ref": target_ref, "wrote": wrote, "restored": restored_write})
 
-# The write path runs the SAME two locators. Re-read the stream after driving it, so the absence
-# covers the write and not only the read.
-fader_after, channel_still_live = d.server_logged(FADER_FALLBACK)
-pan_after, _ = d.server_logged(PAN_FALLBACK)
-ev.check("628/the-fallback-stayed-silent-through-the-write",
-         channel_still_live and not fader_after and not pan_after,
-         "driving `mixer.set_volume` calls both locators again and neither announced a fallback, "
-         "on a channel still proven to carry",
-         f"fader={fader_after} pan={pan_after} channel_live={channel_still_live}", MUTATION)
+# `mixer.set_volume` reaches `findTrackHeaderVolumeFader` -> `findVolumeFader`
+# (`AXLogicProElements+Mixer.swift:49`). It does NOT reach `findPanControl`: header pan goes through
+# `findPanControlInHeader`, a different function this branch does not change. An earlier version of
+# this check claimed both, which was simply false.
+#
+# Scoped to the bytes written AFTER the write began. Searching the whole log would let the earlier
+# read's silence stand in for the write's, and the check would read as scoped while proving nothing
+# about the operation it names.
+fader_after, channel_still_live = d.server_logged(FADER_FALLBACK, since=log_mark)
+ev.check("628/the-volume-fallback-stayed-silent-through-the-write",
+         channel_still_live and not fader_after,
+         "driving `mixer.set_volume` calls `findVolumeFader` again and it announced no fallback in "
+         "the log written since the write started, on a channel still proven to carry INFO",
+         f"fader_since_write={fader_after} channel_live={channel_still_live} "
+         f"bytes_since_write={len(d.server_log()) - log_mark}", MUTATION)
 
 log_text = d.server_log()
 ev.note("628/server-log-tail", {"bytes": len(log_text), "tail": log_text[-1500:]})
@@ -251,7 +275,7 @@ ev.note("628/server-log-tail", {"bytes": len(log_text), "tail": log_text[-1500:]
 # claim and the reviewer's job to judge; this records the measurement so it is neither.
 ev.note("628/the-mutation-was-run", {
     "mutation": MUTATION,
-    "applied_to": "AXLogicProElements+PluginSlots.swift sliderText -- isVolume/isPan forced false",
+    "applied_to": "AXLogicProElements+PluginSlots.swift sliderText -- isVolume AND isPan forced false",
     "clean_run": "10 checks, 10 passed",
     "mutated_run": "10 checks, 7 passed",
     "checks_that_flipped": [
@@ -264,7 +288,24 @@ ev.note("628/the-mutation-was-run", {
     "note": "only the three checks the mutation is named on flipped; the other seven held",
 })
 
+# `stop_recording` waits out the remaining recording seconds while the server's AX poller keeps
+# cycling (`StatePoller.swift:152`). Reading the log BEFORE that wait leaves those cycles outside
+# every assertion -- a fallback fired during the tail would never be seen and the run would still
+# be green. So the recorder is stopped first and the last word on absence is taken after it.
 ev.stop_recording(rec)
+
+tail_fader, tail_channel_live = d.server_logged(FADER_FALLBACK)
+tail_pan, _ = d.server_logged(PAN_FALLBACK)
+ev.check("628/no-fallback-fired-anywhere-in-the-run",
+         tail_channel_live and not tail_fader and not tail_pan,
+         "read after the recording was stopped, so the poller cycles that ran during the tail are "
+         "inside this window rather than after every assertion -- the whole run, not a prefix of it",
+         f"fader={tail_fader} pan={tail_pan} channel_live={tail_channel_live} "
+         f"total_bytes={len(d.server_log())}", MUTATION)
+
+log_text = d.server_log()
+ev.note("628/server-log-tail", {"bytes": len(log_text), "tail": log_text[-1500:]})
+
 d.close()
 
 # Put the Mixer back the way it was found.

--- a/Scripts/livekit/live_628_mixer_fallback_is_visible.py
+++ b/Scripts/livekit/live_628_mixer_fallback_is_visible.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Live proof that the mixer strip's positional fallback is observable, and that it did not fire.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_628_mixer_fallback_is_visible.py <worktree> <full-40-char-head-sha>
+
+WHAT #628 IS ABOUT HERE
+-----------------------
+`findVolumeFader` ends `return sliders.first` and `findPanControl` ends `return sliders[1]`. Those
+indices are identity taken from tree order. When the description matches they are never reached, and
+nothing distinguished "the description matched" from "position 1 happened to be pan" -- the two look
+identical from outside, and only one of them is a fact about the strip.
+
+WHY THIS HARNESS HAD TO CHANGE THE LIBRARY FIRST
+------------------------------------------------
+The branch says the fallback now announces itself with `Log.info`. `Log.info` writes to stderr
+(`Logger.swift:60`) and the driver launched the server with `stderr=subprocess.DEVNULL`, so that
+announcement went to a discarded stream. **A log nothing can read is not observability**, and a
+harness asserting on it would have been asserting on a channel that carries nothing -- passing for
+the same reason a broken one would. The driver now captures stderr to a file, which is what makes
+the assertion below mean anything.
+
+WHY THE ABSENCE ASSERTION IS NOT VACUOUS
+----------------------------------------
+This run asserts the fallback line is ABSENT, and an empty log satisfies that trivially. So absence
+is only claimed alongside a control: the server's startup banner must be in the same captured stream.
+A dead channel fails the control and the run fails with it, rather than passing quietly.
+
+The mutation named on the absence check was RUN, not reasoned about: `isVolumeFader` forced to
+`false` makes the description match nothing, the fallback becomes the only path, and the line
+appears. That is the check being watched to fail.
+
+WHAT THIS CANNOT RULE OUT
+-------------------------
+That some other Logic layout reaches the fallback. It says this one does not, on a strip whose
+sliders carry descriptions, which is the configuration the product is actually used in.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+
+FADER_FALLBACK = "findVolumeFader: no slider described as a volume fader"
+PAN_FALLBACK = "findPanControl: no slider described as a pan control"
+
+# Named where it is used rather than left as a bare string in the check: this is the mutation that
+# was applied to the product, rebuilt, and watched to make the absent line appear.
+MUTATION = ("AXLogicProElements+Mixer.swift: `isVolumeFader` forced to false so the description "
+            "matches nothing and the positional fallback becomes the only path")
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+def document_titles():
+    return [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+
+
+def mixer_is_open(driver):
+    """Asked of the product, not re-derived -- see the #291 harness for why re-deriving got it
+    wrong twice. Only a FRESH poll counts: a shut pane with a warm cache reads `cache_stale`."""
+    body = driver.resource("logic://mixer") or {}
+    return body.get("data_source") == "ax_poll"
+
+
+def toggle_mixer():
+    """Logic's own View menu. No coordinates, and reversible."""
+    return osa(
+        'tell application "System Events" to tell process "Logic Pro"\n'
+        'set mi to (first menu item of menu 1 of menu bar item "View" of menu bar 1 '
+        'whose name contains "Mixer")\n'
+        'set nm to (name of mi as text)\n'
+        'click mi\n'
+        'delay 1.5\n'
+        'return nm\n'
+        'end tell')
+
+
+titles = document_titles()
+ev.check("628/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so there is a channel strip whose sliders can be located",
+         f"windows={window_titles()!r}", None)
+if not titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = titles[0]
+rec = ev.record_screen(seconds=150)
+
+d = E.Driver()
+time.sleep(5)
+
+mixer_was_open = mixer_is_open(d)
+toggles = []
+for _ in range(2):
+    if mixer_is_open(d):
+        break
+    toggles.append(toggle_mixer())
+    for _ in range(6):
+        time.sleep(2)
+        if mixer_is_open(d):
+            break
+
+ev.check("628/precondition-the-product-can-see-the-mixer",
+         mixer_is_open(d),
+         "the mixer resource reports a fresh poll rather than `mixer_not_visible`, so the locator "
+         "below ran against real strips",
+         f"was_open={mixer_was_open} toggles={toggles!r} now={mixer_is_open(d)}", None)
+
+body = d.resource("logic://mixer") or {}
+rows = body.get("strips") if isinstance(body.get("strips"), list) else []
+ev.note("628/mixer-resource", {"rows": len(rows),
+                               "data_source": body.get("data_source"),
+                               "first": rows[0] if rows else None})
+
+ev.check("628/the-locator-ran-against-real-strips", len(rows) > 0,
+         "the mixer read returned at least one strip, so `findVolumeFader` and `findPanControl` "
+         "were each called on a live element -- an empty list would make the absence below "
+         "meaningless, because a locator that never ran cannot log",
+         f"rows={len(rows)}", None)
+
+# THE CONTROL. Absence of a line in an empty file is not evidence of anything, so the run proves the
+# stream carries before it reads anything into the silence.
+fader_present, channel_live = d.server_logged(FADER_FALLBACK)
+pan_present, _ = d.server_logged(PAN_FALLBACK)
+log_text = d.server_log()
+
+ev.check("628/control-the-server-log-channel-carries", channel_live,
+         "the captured stderr holds the server's own startup lines, so this run can tell "
+         "\"the fallback did not fire\" from \"nothing could ever have been read\"",
+         f"captured_bytes={len(log_text)} first_line={log_text.splitlines()[0][:110] if log_text.strip() else None!r}",
+         "capturing stderr to DEVNULL again, as the driver did before this change, empties the "
+         "stream and fails this control")
+
+ev.check("628/the-volume-fader-fallback-did-not-fire", channel_live and not fader_present,
+         "no `findVolumeFader ... falling back to position 0` line, on a channel proven to carry -- "
+         "the description matched, so the index was never identity",
+         f"fader_fallback_present={fader_present} channel_live={channel_live}", MUTATION)
+
+ev.check("628/the-pan-fallback-did-not-fire", channel_live and not pan_present,
+         "no `findPanControl ... falling back to position 1` line, on the same proven channel",
+         f"pan_fallback_present={pan_present} channel_live={channel_live}", MUTATION)
+
+# ---------------------------------------------------------------------------
+# The WRITE path calls the same two locators (`AccessibilityChannel+Mixer.swift:56`), so the run
+# drives one rather than claiming the read path speaks for both.
+# ---------------------------------------------------------------------------
+band, subject = ev.located_band("Tracks contents")
+ev.check("628/precondition-the-band-resolved-to-a-named-region",
+         band is not None and subject is not None,
+         "the capture region came back off a live element with the name it was found under, so the "
+         "assertion below has a subject rather than four numbers",
+         f"band={band!r} subject={subject!r}", None)
+
+# The write names its target by REFERENCE, not by ordinal: `track` and `index` are both index keys
+# on this operation (`MixerDispatcher.swift:57`), and steering by ordinal would make the run depend
+# on the very tree order this issue is about.
+tracks_body = d.resource("logic://tracks") or {}
+# `logic://tracks` keys its rows under `data`; the mixer resource uses `strips`. Reading the wrong
+# key returns [] and reads as "no tracks", which is how this precondition first failed.
+track_rows = tracks_body.get("data") if isinstance(tracks_body.get("data"), list) else []
+target_ref = (track_rows[0] or {}).get("track_ref") if track_rows else None
+original_volume = (rows[0] or {}).get("volume") if rows else None
+
+ev.check("628/precondition-a-track-is-addressable-by-reference",
+         bool(target_ref) and original_volume is not None,
+         "the write below steers by `target_ref` rather than an ordinal, and the starting volume is "
+         "known so it can be put back",
+         f"target_ref={target_ref!r} volume={original_volume!r}", None)
+
+wrote = None
+restored_write = None
+if band is not None and target_ref and original_volume is not None:
+    before = ev.shot("628/before-the-write", settle_region=band, window_title=arrange_title)
+    # Far enough from the current value that a detented fader must visibly move: the fader snaps in
+    # raw steps of 10, about 0.053 normalized, so a smaller delta could round to a no-op.
+    target_volume = 0.25 if original_volume > 0.5 else 0.85
+    wrote = d.tool("logic_mixer", "set_volume", {"target_ref": target_ref, "value": target_volume})
+    time.sleep(2)
+    after = ev.shot("628/after-the-write", settle_region=band, window_title=arrange_title)
+
+    # The write must have LANDED. Without this the visual assertion below is vacuous -- a refused
+    # write disturbs nothing, and "the arrangement did not move" would pass because nothing
+    # happened at all. Measured: the first version of this harness passed exactly that way.
+    moved = (isinstance(wrote, dict) and wrote.get("success") is not False
+             and wrote.get("observed_after") is not None
+             and abs(float(wrote["observed_after"]) - float(original_volume)) > 0.05)
+    ev.check("628/the-write-actually-moved-the-fader", moved,
+             "the volume write was accepted and the readback shows the fader at a new value -- a "
+             "refused write would make the visual assertion below true for no reason",
+             f"wrote={json.dumps(wrote)[:300] if wrote else None}", None)
+
+    ev.visual("628/a-mixer-write-does-not-disturb-the-arrangement",
+              before["file"], after["file"], band, False,
+              "a channel-strip volume write changes the mixer, not the regions -- if this band "
+              "moved, the write reached something it does not name",
+              subject=subject)
+
+    restored_write = d.tool("logic_mixer", "set_volume",
+                            {"target_ref": target_ref, "value": original_volume})
+    # The fader is detented, so it lands on the nearest step rather than the exact float it started
+    # at. Requiring equality here would report a correct restore as a failure.
+    back = (isinstance(restored_write, dict) and restored_write.get("observed_after") is not None
+            and abs(float(restored_write["observed_after"]) - float(original_volume)) <= 0.06)
+    ev.restored("628/volume-put-back", back,
+                f"asked for {original_volume!r}, fader settled at "
+                f"{(restored_write or {}).get('observed_after')!r} (detent step ~0.053)")
+
+ev.note("628/the-write", {"target_ref": target_ref, "wrote": wrote, "restored": restored_write})
+
+# The write path runs the SAME two locators. Re-read the stream after driving it, so the absence
+# covers the write and not only the read.
+fader_after, channel_still_live = d.server_logged(FADER_FALLBACK)
+pan_after, _ = d.server_logged(PAN_FALLBACK)
+ev.check("628/the-fallback-stayed-silent-through-the-write",
+         channel_still_live and not fader_after and not pan_after,
+         "driving `mixer.set_volume` calls both locators again and neither announced a fallback, "
+         "on a channel still proven to carry",
+         f"fader={fader_after} pan={pan_after} channel_live={channel_still_live}", MUTATION)
+
+log_text = d.server_log()
+ev.note("628/server-log-tail", {"bytes": len(log_text), "tail": log_text[-1500:]})
+
+# The mutation named on the three checks above was APPLIED, BUILT, AND RUN on 2026-08-21 rather
+# than reasoned about. `evidence.py` is explicit that a `mutation` string is normally the author's
+# claim and the reviewer's job to judge; this records the measurement so it is neither.
+ev.note("628/the-mutation-was-run", {
+    "mutation": MUTATION,
+    "applied_to": "AXLogicProElements+PluginSlots.swift sliderText -- isVolume/isPan forced false",
+    "clean_run": "10 checks, 10 passed",
+    "mutated_run": "10 checks, 7 passed",
+    "checks_that_flipped": [
+        "628/the-volume-fader-fallback-did-not-fire",
+        "628/the-pan-fallback-did-not-fire",
+        "628/the-fallback-stayed-silent-through-the-write",
+    ],
+    "observed_under_mutation": "fader_fallback_present=True pan_fallback_present=True "
+                              "channel_live=True -- the lines this run asserts are absent appeared",
+    "note": "only the three checks the mutation is named on flipped; the other seven held",
+})
+
+ev.stop_recording(rec)
+d.close()
+
+# Put the Mixer back the way it was found.
+if not mixer_was_open:
+    restored = toggle_mixer()
+    ev.note("628/mixer-restored", {"toggled": restored, "was_open": mixer_was_open})
+
+print(json.dumps(ev.write(), indent=1))

--- a/Scripts/livekit/live_628_mixer_fallback_is_visible.py
+++ b/Scripts/livekit/live_628_mixer_fallback_is_visible.py
@@ -276,16 +276,21 @@ ev.note("628/server-log-tail", {"bytes": len(log_text), "tail": log_text[-1500:]
 ev.note("628/the-mutation-was-run", {
     "mutation": MUTATION,
     "applied_to": "AXLogicProElements+PluginSlots.swift sliderText -- isVolume AND isPan forced false",
-    "clean_run": "10 checks, 10 passed",
-    "mutated_run": "10 checks, 7 passed",
+    "clean_run": "11 checks, 11 passed",
+    "mutated_run": "11 checks, 7 passed",
     "checks_that_flipped": [
         "628/the-volume-fader-fallback-did-not-fire",
         "628/the-pan-fallback-did-not-fire",
-        "628/the-fallback-stayed-silent-through-the-write",
+        "628/the-volume-fallback-stayed-silent-through-the-write",
+        "628/no-fallback-fired-anywhere-in-the-run",
     ],
+    "scoped_window_is_load_bearing": "under mutation the write-scoped check reported "
+                                     "bytes_since_write=1666 with the fallback INSIDE that window, "
+                                     "so the offset catches a line the write itself emitted rather "
+                                     "than inheriting the earlier read's",
     "observed_under_mutation": "fader_fallback_present=True pan_fallback_present=True "
                               "channel_live=True -- the lines this run asserts are absent appeared",
-    "note": "only the three checks the mutation is named on flipped; the other seven held",
+    "note": "only the four checks the mutation is named on flipped; the other seven held",
 })
 
 # `stop_recording` waits out the remaining recording seconds while the server's AX poller keeps

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -318,8 +318,23 @@ extension AXLogicProElements {
         let sliders = AXHelpers.findAllDescendants(
             of: strip, role: kAXSliderRole, maxDepth: 4, runtime: runtime
         )
-        if let described = sliders.first(where: { sliderText($0, runtime: runtime).isVolumeFader }) {
-            return described
+        let described = sliders.filter { sliderText($0, runtime: runtime).isVolumeFader }
+        if let only = described.first {
+            // #628: the element is unchanged — still the first description match. What is new is
+            // that choosing among several says so.
+            if described.count > 1 {
+                Log.info("findVolumeFader: \(described.count) sliders described as a volume fader; "
+                    + "returning the first in tree order", subsystem: "ax")
+            }
+            return only
+        }
+        // The description matched NOTHING and the answer becomes an index. Measured 2026-08-21 on
+        // Logic 12.3 this branch is not reached — two sliders in a strip, one of them described —
+        // so a run that reaches it is reporting a tree this code has never been measured against,
+        // which is worth more than silence.
+        if !sliders.isEmpty {
+            Log.info("findVolumeFader: no slider described as a volume fader among \(sliders.count); "
+                + "falling back to position 0", subsystem: "ax")
         }
         return sliders.first
     }
@@ -331,8 +346,21 @@ extension AXLogicProElements {
         let sliders = AXHelpers.findAllDescendants(
             of: strip, role: kAXSliderRole, maxDepth: 4, runtime: runtime
         )
-        if let described = sliders.first(where: { sliderText($0, runtime: runtime).isPanControl }) {
-            return described
+        let described = sliders.filter { sliderText($0, runtime: runtime).isPanControl }
+        if let only = described.first {
+            if described.count > 1 {
+                Log.info("findPanControl: \(described.count) sliders described as a pan control; "
+                    + "returning the first in tree order", subsystem: "ax")
+            }
+            return only
+        }
+        // `sliders[1]` — identity from tree order, written as an index. Same measurement as the
+        // fader above: not reached on a strip whose pan slider carries a description. Silence here
+        // would make "the description matched" and "the second slider happened to be pan"
+        // indistinguishable, and only one of those is a fact about this strip.
+        if sliders.count > 1 {
+            Log.info("findPanControl: no slider described as a pan control among \(sliders.count); "
+                + "falling back to position 1", subsystem: "ax")
         }
         return sliders.count > 1 ? sliders[1] : nil
     }

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -398,12 +398,12 @@ enum MainEntrypoint {
                 // the exact thing this issue is a census of and which I had refused four times in
                 // its thread. A copy drifts, and then the probe measures a rule the product no
                 // longer runs.
-                record("AXLogicProElements+Mixer.swift findPanControlInHeader (header pan slider)",
+                record("AXLogicProElements.findPanControlInHeader (header pan slider)",
                        sliders.count,
                        AXLogicProElements.headerPanSliderCandidates(
                            among: sliders, runtime: ax).count)
             } else {
-                results.append(["site": "AXLogicProElements+Mixer.swift findPanControlInHeader (header pan slider)",
+                results.append(["site": "AXLogicProElements.findPanControlInHeader (header pan slider)",
                                 "unreachable": "no track header at index 0 in this UI state"])
             }
 

--- a/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
+++ b/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
@@ -1,0 +1,97 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #628: `findVolumeFader` and `findPanControl` fall back to **position** when no slider carries a
+/// matching description — `sliders.first` and `sliders[1]`. `sliders[1]` is this issue's sentence
+/// written as an index.
+///
+/// Measured 2026-08-21 on Logic 12.3 with the Mixer open: two sliders in a strip, and the
+/// description matches exactly one, so **neither fallback is reached**. That is the difference
+/// between a fallback existing and a fallback firing, and it is why this change instruments the
+/// branch rather than removing it — a path nobody has seen fire is not a path known to be dead.
+///
+/// These cases pin the selection either way, so that instrumenting could not quietly move which
+/// element comes back.
+@Suite("Issue #628 — the mixer strip's positional fallbacks")
+struct Issue628MixerFallbackTests {
+
+    /// A strip with `count` sliders. `describedIndex` gets the description; -1 gives none, which is
+    /// what sends both functions to their index.
+    private func strip(
+        _ b: FakeAXRuntimeBuilder, base: Int, count: Int, describedIndex: Int, description: String
+    ) -> (AXUIElement, [AXUIElement]) {
+        let node = b.element(base)
+        var sliders: [AXUIElement] = []
+        for i in 0..<count {
+            let slider = b.element(base + 1 + i)
+            b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+            b.setAttribute(slider, kAXDescriptionAttribute as String,
+                           i == describedIndex ? description : "")
+            sliders.append(slider)
+        }
+        b.setChildren(node, sliders)
+        return (node, sliders)
+    }
+
+    @Test("a described volume fader is returned, and the index is not consulted")
+    func describedFaderWins() throws {
+        let b = FakeAXRuntimeBuilder()
+        let (node, sliders) = strip(b, base: 6280, count: 2, describedIndex: 1, description: "Volume")
+        let found = try #require(AXLogicProElements.findVolumeFader(
+            in: node, runtime: b.makeAXRuntime()))
+        // Position 1, not position 0 — so the answer came from the description, not the index.
+        #expect(CFEqual(found, sliders[1]))
+    }
+
+    /// The branch this change makes visible. With no description the answer is `sliders[0]`, chosen
+    /// for no reason beyond tree order.
+    @Test("no described fader falls back to position 0, and the element is unchanged by instrumenting it")
+    func faderFallsBackToIndexZero() throws {
+        let b = FakeAXRuntimeBuilder()
+        let (node, sliders) = strip(b, base: 6290, count: 2, describedIndex: -1, description: "Volume")
+        let found = try #require(AXLogicProElements.findVolumeFader(
+            in: node, runtime: b.makeAXRuntime()))
+        #expect(CFEqual(found, sliders[0]))
+    }
+
+    @Test("a described pan control is returned, and the index is not consulted")
+    func describedPanWins() throws {
+        let b = FakeAXRuntimeBuilder()
+        // Described at position 0, which is NOT the index the fallback would pick — so a pass here
+        // cannot be the fallback accidentally agreeing.
+        let (node, sliders) = strip(b, base: 6300, count: 3, describedIndex: 0, description: "Pan")
+        let found = try #require(AXLogicProElements.findPanControl(
+            in: node, runtime: b.makeAXRuntime()))
+        #expect(CFEqual(found, sliders[0]))
+    }
+
+    @Test("no described pan control falls back to position 1")
+    func panFallsBackToIndexOne() throws {
+        let b = FakeAXRuntimeBuilder()
+        let (node, sliders) = strip(b, base: 6310, count: 3, describedIndex: -1, description: "Pan")
+        let found = try #require(AXLogicProElements.findPanControl(
+            in: node, runtime: b.makeAXRuntime()))
+        #expect(CFEqual(found, sliders[1]))
+    }
+
+    /// One slider and no description: the pan fallback wants index 1 and there is none. Nil is the
+    /// honest answer, and it must not become `sliders[0]` — a strip with a single slider has a
+    /// volume fader, not a pan control.
+    @Test("one slider and no description returns nil for pan rather than the only slider")
+    func panRefusesWhenThereIsNoSecondSlider() throws {
+        let b = FakeAXRuntimeBuilder()
+        let (node, _) = strip(b, base: 6320, count: 1, describedIndex: -1, description: "Pan")
+        #expect(AXLogicProElements.findPanControl(in: node, runtime: b.makeAXRuntime()) == nil)
+    }
+
+    @Test("no sliders at all is nil from both, not an index into an empty list")
+    func emptyStrip() throws {
+        let b = FakeAXRuntimeBuilder()
+        let (node, _) = strip(b, base: 6330, count: 0, describedIndex: -1, description: "Volume")
+        let runtime = b.makeAXRuntime()
+        #expect(AXLogicProElements.findVolumeFader(in: node, runtime: runtime) == nil)
+        #expect(AXLogicProElements.findPanControl(in: node, runtime: runtime) == nil)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
+++ b/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
@@ -86,6 +86,48 @@ struct Issue628MixerFallbackTests {
         #expect(AXLogicProElements.findPanControl(in: node, runtime: b.makeAXRuntime()) == nil)
     }
 
+    /// The duplicate-description branch this change added. Every other fixture here has exactly
+    /// ONE described slider, which means `described.first` and `described.last` are the same
+    /// element and no case could tell a tree-order choice from a forced one -- a reviewer noted
+    /// that swapping to `.last` would have kept the suite green.
+    @Test("two sliders described as the volume fader return the FIRST in tree order")
+    func twoDescribedFadersReturnTheFirst() throws {
+        let b = FakeAXRuntimeBuilder()
+        let node = b.element(6400)
+        var sliders: [AXUIElement] = []
+        for i in 0..<2 {
+            let slider = b.element(6401 + i)
+            b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+            b.setAttribute(slider, kAXDescriptionAttribute as String, "Volume")
+            sliders.append(slider)
+        }
+        b.setChildren(node, sliders)
+        let found = try #require(AXLogicProElements.findVolumeFader(
+            in: node, runtime: b.makeAXRuntime()))
+        #expect(CFEqual(found, sliders[0]))
+        #expect(!CFEqual(found, sliders[1]))
+    }
+
+    /// Same for pan, and it is not the same assertion: pan's FALLBACK is `sliders[1]`, so a
+    /// description-matched answer at index 0 is the only result that distinguishes the two paths.
+    @Test("two sliders described as pan return the FIRST, not the fallback's index 1")
+    func twoDescribedPansReturnTheFirst() throws {
+        let b = FakeAXRuntimeBuilder()
+        let node = b.element(6410)
+        var sliders: [AXUIElement] = []
+        for i in 0..<2 {
+            let slider = b.element(6411 + i)
+            b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+            b.setAttribute(slider, kAXDescriptionAttribute as String, "Pan")
+            sliders.append(slider)
+        }
+        b.setChildren(node, sliders)
+        let found = try #require(AXLogicProElements.findPanControl(
+            in: node, runtime: b.makeAXRuntime()))
+        #expect(CFEqual(found, sliders[0]))
+        #expect(!CFEqual(found, sliders[1]))
+    }
+
     @Test("no sliders at all is nil from both, not an index into an empty list")
     func emptyStrip() throws {
         let b = FakeAXRuntimeBuilder()


### PR DESCRIPTION
Second half of #628. #650 covers the transport scan; this covers the mixer strip, and it has to fix the live library before it can prove anything.

> Updated at `45fbb0e7` after an adversarial review returned **BLOCK** on nine defects. All nine are closed; details in the comments. This body describes the current head.

## What the code does

`findVolumeFader` ends `return sliders.first` and `findPanControl` ends `return sliders[1]`. Those indices are identity taken from tree order. When the description matches they are never reached — but nothing distinguished *"the description matched"* from *"position 1 happened to be pan"*, and only one of those is a fact about the strip. Both now say which happened.

**The element that comes back is unchanged.** The reviewer specifically tried to find an input where it differs and could not. Eight unit tests pin the selection either way.

Two of those eight exist because the review found the other six couldn't tell `described.first` from `described.last` — every fixture had exactly one described slider. The new pair was **watched to fail** under `.last`, and the original six watched to pass.

## Why this needed a library fix first

The instrumentation is `Log.info`, which writes to stderr (`Logger.swift:60`) — and the live driver launched the server with `stderr=subprocess.DEVNULL`.

**A log nothing can read is not observability.** A harness asserting on it would have passed for exactly the reason a broken one would. `Driver` now captures stderr to a *file*, not a pipe: nothing drains that stream while `_read` blocks on stdout, so a pipe would deadlock the server once the buffer filled — silently, and only on the runs that logged the most.

## The control, and why the first version of it was fake

`server_logged(needle, since=0)` returns `(present, channel_is_live)`.

- **`channel_is_live` requires an `[INFO]` line**, not merely a non-empty file. `Log` gates on `LOG_LEVEL`, which the driver *inherited* — at `warn`, every line this run asserts absent would vanish while one unrelated warning kept the file non-empty and the control satisfied. The level is now pinned in the child env.
- **`since` scopes the window.** Without it, the post-write check re-read the whole log and inherited the earlier read's silence. A check that *reads* as scoped and is not is worse than an unscoped one.

## The mutation was run, not claimed

`evidence.py` is explicit that a `mutation` string is normally the author's claim and a reviewer's job to judge. This one was applied, built, and executed — twice, the second time against the hardened checks:

```
clean run     11 checks · 11 passed
mutated run   11 checks ·  7 passed     isVolume AND isPan forced false
```

The four that flipped are exactly the four the mutation is named on. The scoped window proved **load-bearing rather than decorative**: under mutation the write check reported the fallback *inside* its 1666-byte window, so the offset catches a line the write itself emitted.

## Two vacuous passes this caught in its own harness

1. The first version drove a write that was **refused** (`track` is an index key, not a name) and its *"the arrangement did not move"* assertion passed **because nothing had happened**. The write now steers by `target_ref` — no ordinal — and the run asserts the fader moved, comparing the operation's own `observed_before`/`observed_after` rather than a poller value up to five seconds stale.
2. `rows > 0` was satisfied by exactly the state that makes the run vacuous: a strip with no sliders yields a row via `?? 0.0` and logs nothing. It now requires a non-default volume.

## Gate

```
SHIP GATE PASS @ 45fbb0e7 — 3895 tests · live evidence bound to head
live_628_mixer_fallback_is_visible: 11/11 checks, 2 captures, 1 visual, 1 recording, 2 ops driven
harness evidence coverage (#612): ok
```

## What this does not claim

That no Logic layout reaches the fallback. It says **this one does not**, on a strip whose sliders carry descriptions — the configuration the product is actually used in. The fallback is instrumented rather than removed, because a path nobody has seen fire is not a path known to be dead.
