### PR TITLE
feat(#628): an ambiguous census names its candidates, not just counts them

### DIFF
--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -171,15 +171,28 @@ ev.check("628/an-ambiguous-census-names-its-candidates",
          f"candidates={button.get('candidates')!r} names={len(named)} sample={named[:4]!r}",
          "drop `matches: hits` from the Census constructor: the list empties and this goes red")
 
-# Emptiness is the failure mode this placeholder exists for. An element with nothing to call itself
-# would otherwise print "", and a refusal reading ["", "", ""] looks like a broken reporter rather
-# than a fact about the tree — so the run requires every entry to carry something.
+# Emptiness is the failure mode the placeholder exists for. Aimed at GROUPS, not buttons: measured
+# on Logic 12.3 the group census contains elements with no description at all, and the button one
+# may not. A no-blank assertion over candidates that all happen to be named passes with the
+# placeholder completely broken — it would be a check that cannot see its own subject.
+group_census = product_census("AXGroup", depth=3)
+group_named = group_census.get("candidateNames") or []
+placeholder_fired = sum(1 for n in group_named if isinstance(n, str) and n.startswith("<unnamed"))
+
+ev.check("628/the-unnamed-placeholder-is-exercised-on-this-tree",
+         placeholder_fired > 0,
+         "at least one live candidate has nothing to call itself, so the no-blank check below has a "
+         "subject — without this it would pass on a tree where every element is named and say "
+         "nothing about the fallback",
+         f"candidates={group_census.get('candidates')!r} named={len(group_named)} "
+         f"unnamed={placeholder_fired}", None)
+
 ev.check("628/no-candidate-is-named-with-an-empty-string",
-         bool(named) and all(isinstance(n, str) and n.strip() for n in named),
-         "no name is blank: an unnamed element reports `<unnamed ROLE>` instead, which says what "
-         "was found rather than looking like the reporter failed",
-         f"blank={[i for i, n in enumerate(named) if not (isinstance(n, str) and n.strip())]!r} "
-         f"unnamed_count={sum(1 for n in named if isinstance(n, str) and n.startswith('<unnamed'))}",
+         bool(group_named) and all(isinstance(n, str) and n.strip() for n in group_named),
+         "no name is blank on a census proven to contain unnamed elements: they report "
+         "`<unnamed ROLE>`, which says what was found rather than looking like the reporter failed",
+         f"blank={[i for i, n in enumerate(group_named) if not (isinstance(n, str) and n.strip())]!r} "
+         f"unnamed={placeholder_fired} sample={group_named[:4]!r}",
          "return the raw description instead of the placeholder: unnamed elements become \"\" and "
          "this goes red")
 
@@ -220,6 +233,21 @@ ev.check("628/an-ambiguous-container-refuses-rather-than-choosing",
          f"error={ambiguous.get('error')!r} containerCandidates={ambiguous.get('containerCandidates')!r}",
          "resolve the container with `findDescendant` instead of the census: the first match is "
          "taken, a count comes back, and this check goes red")
+
+# `AXLocalePolicy.censusDescendant` is a SECOND producer of `Census` and nothing here covered its
+# names. Dropping `matches: hits` from that function alone left every other check on this branch
+# green — a second implementation of the same contract, uncovered.
+container_named = ambiguous.get("containerCandidateNames") or []
+ev.check("628/the-ambiguous-container-refusal-names-its-candidates",
+         isinstance(container_named, list)
+         and len(container_named) == ambiguous.get("containerCandidates")
+         and all(isinstance(n, str) and n.strip() for n in container_named),
+         "the container refusal says WHICH elements answered to that description, one name per "
+         "candidate — the count alone cannot separate an ambiguous tree from too broad a selector",
+         f"containerCandidates={ambiguous.get('containerCandidates')!r} "
+         f"names={container_named!r}",
+         "drop `matches: hits` from AXLocalePolicy.censusDescendant: the list empties and this "
+         "goes red while every unit test stays green")
 
 # ---- depth, so that agreeing is not the same as both ignoring the bound ---------------------------
 shallow_p = product_census("AXGroup", depth=1)

--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -159,6 +159,30 @@ ev.check("628/many-matches-are-not-identified",
          "restore `element: hits.first`: an element comes back for an ambiguous lookup and this "
          "check goes red")
 
+# #628 states the refusal must NAME its candidates, not only count them. A count refuses; a name
+# tells the person holding the refusal whether the tree is genuinely ambiguous or the selector is one
+# word too broad. Measured on Logic 12.3: this is exactly where the issue started — TWO elements
+# describe themselves "Control Bar", and until now nothing could say that from the outside.
+named = button.get("candidateNames") or []
+ev.check("628/an-ambiguous-census-names-its-candidates",
+         isinstance(named, list) and len(named) == button.get("candidates"),
+         "every candidate of the ambiguous lookup is named, so the refusal can be acted on — one "
+         "name per candidate, counted against the census's own count rather than a fixed number",
+         f"candidates={button.get('candidates')!r} names={len(named)} sample={named[:4]!r}",
+         "drop `matches: hits` from the Census constructor: the list empties and this goes red")
+
+# Emptiness is the failure mode this placeholder exists for. An element with nothing to call itself
+# would otherwise print "", and a refusal reading ["", "", ""] looks like a broken reporter rather
+# than a fact about the tree — so the run requires every entry to carry something.
+ev.check("628/no-candidate-is-named-with-an-empty-string",
+         bool(named) and all(isinstance(n, str) and n.strip() for n in named),
+         "no name is blank: an unnamed element reports `<unnamed ROLE>` instead, which says what "
+         "was found rather than looking like the reporter failed",
+         f"blank={[i for i, n in enumerate(named) if not (isinstance(n, str) and n.strip())]!r} "
+         f"unnamed_count={sum(1 for n in named if isinstance(n, str) and n.startswith('<unnamed'))}",
+         "return the raw description instead of the placeholder: unnamed elements become \"\" and "
+         "this goes red")
+
 absent = product_census("AXToolbar")
 ev.check("628/zero-matches-are-not-identified-either",
          absent.get("candidates") == 0 and absent.get("identified") is False,

--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -541,10 +541,20 @@ enum AXHelpers {
         /// reads as a bug in this function rather than as a fact about the tree.
         func names(runtime: Runtime = .production) -> [String] {
             matches.map { element in
-                let described = AXHelpers.getDescription(element, runtime: runtime)
-                    ?? AXHelpers.getTitle(element, runtime: runtime)
-                    ?? AXHelpers.getIdentifier(element, runtime: runtime)
-                if let described, !described.isEmpty { return described }
+                // `??` falls through on NIL ONLY, and AX hands back present-but-empty strings all
+                // the time. Written as a `??` chain, an element with `description == ""` and
+                // `title == "Mixer"` stopped at the empty description and reported
+                // `<unnamed AXGroup>` -- the fallback existed and could not be reached. A
+                // whitespace-only description was worse: it passed `!isEmpty` and became the name,
+                // which is the blank this placeholder exists to prevent.
+                //
+                // So each attribute is tested for CONTENT, not for presence.
+                for attribute in [kAXDescriptionAttribute, kAXTitleAttribute, kAXIdentifierAttribute] {
+                    let value = AXHelpers.getAttribute(element, attribute, runtime: runtime) ?? ""
+                    if !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        return value
+                    }
+                }
                 return "<unnamed \(AXHelpers.getRole(element, runtime: runtime) ?? "element")>"
             }
         }

--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -509,9 +509,42 @@ enum AXHelpers {
     struct Census {
         let element: AXUIElement?
         let candidates: Int
+        /// Every element that matched, in traversal order.
+        ///
+        /// #628 asks for two things when a lookup is ambiguous: that it REFUSE, and that the
+        /// candidates be NAMED. The count alone delivers the first and not the second -- "2
+        /// matched" tells the person holding the failure nothing about which two, so they cannot
+        /// tell a genuinely ambiguous tree from a selector that is one word too broad.
+        ///
+        /// The matches were already computed and then thrown away. Keeping the references costs
+        /// nothing; READING them costs an AX round trip each, which is why `names(runtime:)` is a
+        /// method and not a stored property -- the ambiguous path can afford it and the
+        /// overwhelmingly common one-match path never pays.
+        let matches: [AXUIElement]
+
+        init(element: AXUIElement?, candidates: Int, matches: [AXUIElement] = []) {
+            self.element = element
+            self.candidates = candidates
+            self.matches = matches
+        }
 
         /// Exactly one match: the only case where the result is identified rather than merely found.
         var isUnambiguous: Bool { candidates == 1 }
+
+        /// What each candidate calls itself, for a refusal that a reader can act on.
+        ///
+        /// An element with no description, title, or identifier yields `"<unnamed \(role)>"` rather
+        /// than an empty string: three anonymous groups must not print as `["", "", ""]`, which
+        /// reads as a bug in this function rather than as a fact about the tree.
+        func names(runtime: Runtime = .production) -> [String] {
+            matches.map { element in
+                let described = AXHelpers.getDescription(element, runtime: runtime)
+                    ?? AXHelpers.getTitle(element, runtime: runtime)
+                    ?? AXHelpers.getIdentifier(element, runtime: runtime)
+                if let described, !described.isEmpty { return described }
+                return "<unnamed \(AXHelpers.getRole(element, runtime: runtime) ?? "element")>"
+            }
+        }
     }
 
     /// Every match, with the count, so a caller can refuse ambiguity instead of inheriting traversal
@@ -529,7 +562,7 @@ enum AXHelpers {
         var hits: [AXUIElement] = []
         collectMatching(of: element, role: role, title: title, identifier: identifier,
                         maxDepth: maxDepth, runtime: runtime, into: &hits)
-        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count)
+        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count, matches: hits)
     }
 
     private static func collectMatching(

--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -522,7 +522,10 @@ enum AXHelpers {
         /// overwhelmingly common one-match path never pays.
         let matches: [AXUIElement]
 
-        init(element: AXUIElement?, candidates: Int, matches: [AXUIElement] = []) {
+        /// `matches` is deliberately NOT defaulted. A future construction site that forgot it would
+        /// compile and then report zero names for a real ambiguity — a silent downgrade back to
+        /// exactly the count-only refusal this issue exists to remove. Let it fail to build instead.
+        init(element: AXUIElement?, candidates: Int, matches: [AXUIElement]) {
             self.element = element
             self.candidates = candidates
             self.matches = matches

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1159,6 +1159,6 @@ enum AXLocalePolicy {
         let hits = AXHelpers.findAllDescendants(
             of: element, role: role, maxDepth: maxDepth, runtime: runtime
         ).filter { elementMatches($0, labels, mode: mode, runtime: runtime) }
-        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count)
+        return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count, matches: hits)
     }
 }

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -293,8 +293,15 @@ enum MainEntrypoint {
                     let why = container.candidates == 0
                         ? "no container with that description"
                         : "the container description is ambiguous"
+                    // #628: the count refuses, the NAMES make the refusal actionable. "2 matched"
+                    // cannot distinguish a genuinely ambiguous tree from a selector one word too
+                    // broad; the two descriptions can.
+                    let named = container.names(runtime: .production)
+                    let namesJSON = (try? JSONSerialization.data(withJSONObject: named))
+                        .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
                     writeStdout("{\"ok\":false,\"error\":\"\(why)\",\"from\":\"\(from)\","
-                        + "\"containerCandidates\":\(container.candidates)}\n")
+                        + "\"containerCandidates\":\(container.candidates),"
+                        + "\"containerCandidateNames\":\(namesJSON)}\n")
                     return 1
                 }
                 root = found
@@ -308,6 +315,9 @@ enum MainEntrypoint {
                 "from": rootDescription as Any,
                 "containerCandidates": rootCandidates as Any,
                 "candidates": census.candidates,
+                // Named only when the answer is ambiguous: at one match the name adds nothing the
+                // caller did not already ask for, and each name costs an AX round trip.
+                "candidateNames": census.candidates > 1 ? census.names(runtime: .production) : [],
                 // `identified` is the whole point of the count: it is true only at exactly one, and
                 // a reader can tell that from "something was returned" — which the blind lookup
                 // reports identically at one match and at nine.

--- a/Tests/LogicProMCPTests/Issue628CensusNamesTests.swift
+++ b/Tests/LogicProMCPTests/Issue628CensusNamesTests.swift
@@ -78,6 +78,83 @@ struct Issue628CensusNamesTests {
         #expect(!names.contains(""))
     }
 
+    /// **These five exist because the first version of `names()` was a `??` chain**, which falls
+    /// through on nil ONLY. AX returns present-but-empty strings routinely, so an element with
+    /// `description == ""` and `title == "Mixer"` stopped at the empty description and reported
+    /// `<unnamed AXGroup>`: the fallback was written, shipped, and unreachable. The original tests
+    /// covered "description present" and "everything absent" and missed the entire middle.
+    @Test("an empty description falls through to the title")
+    func emptyDescriptionFallsThroughToTitle() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6550)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        let g = group(b, 6551, description: "")
+        b.setAttribute(g, kAXTitleAttribute as String, "Mixer")
+        b.setChildren(root, [g])
+
+        let names = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime()
+        ).names(runtime: b.makeAXRuntime())
+        #expect(names == ["Mixer"])
+    }
+
+    @Test("an empty description and empty title fall through to the identifier")
+    func emptyPairFallsThroughToIdentifier() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6560)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        let g = group(b, 6561, description: "")
+        b.setAttribute(g, kAXTitleAttribute as String, "")
+        b.setAttribute(g, kAXIdentifierAttribute as String, "transport-rail")
+        b.setChildren(root, [g])
+
+        let names = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime()
+        ).names(runtime: b.makeAXRuntime())
+        #expect(names == ["transport-rail"])
+    }
+
+    /// A whitespace-only description passed `!isEmpty` and became the name — producing exactly the
+    /// blank entry the placeholder exists to prevent, while looking like a successful read.
+    @Test("a whitespace-only description is not a name")
+    func whitespaceIsNotAName() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6570)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        let g = group(b, 6571, description: "   ")
+        b.setChildren(root, [g])
+
+        let names = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime()
+        ).names(runtime: b.makeAXRuntime())
+        #expect(names == ["<unnamed AXGroup>"])
+        #expect(!names.contains { $0.trimmingCharacters(in: .whitespaces).isEmpty })
+    }
+
+    /// The LabelSet census is a SECOND producer of `Census`. Dropping `matches:` from it alone left
+    /// every other case here green — nothing covered it, which is how a second implementation of
+    /// the same contract goes uncovered.
+    @Test("the LabelSet census names its candidates too")
+    func labelSetCensusNamesCandidates() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6580)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [group(b, 6581, description: "Control Bar"),
+                             group(b, 6582, description: "Control Bar")])
+
+        let census = AXLocalePolicy.censusDescendant(
+            of: root,
+            role: kAXGroupRole as String,
+            matching: AXLocalePolicy.LabelSet(canonical: "Control Bar", variants: [],
+                                              rationale: "test"),
+            mode: .exactStrict,
+            maxDepth: 4,
+            runtime: b.makeAXRuntime())
+        #expect(census.candidates == 2)
+        #expect(census.element == nil)
+        #expect(census.names(runtime: b.makeAXRuntime()) == ["Control Bar", "Control Bar"])
+    }
+
     /// The one-match path must not start paying for names it does not need, and must still report
     /// the match itself.
     @Test("a single match is identified and its match list holds exactly it")

--- a/Tests/LogicProMCPTests/Issue628CensusNamesTests.swift
+++ b/Tests/LogicProMCPTests/Issue628CensusNamesTests.swift
@@ -1,0 +1,112 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #628 states two things that must be demonstrable:
+///
+///     two candidates exist   ->  refused, and both are named
+///     one candidate exists   ->  recorded as one, not merely accepted
+///
+/// The second was already met — `Census.isUnambiguous`, carried into the probe payload and asserted
+/// in live evidence. The first was met only HALFWAY: `censusDescendant` computed every match, kept
+/// the count, and threw the matches away. So it refused without saying which two, and "2 matched"
+/// cannot distinguish a genuinely ambiguous tree from a selector one word too broad.
+///
+/// These cases pin the naming, including the case that would otherwise print as `["", "", ""]`.
+@Suite("Issue #628 — an ambiguous census names its candidates")
+struct Issue628CensusNamesTests {
+
+    private func group(_ b: FakeAXRuntimeBuilder, _ id: Int, description: String?) -> AXUIElement {
+        let g = b.element(id)
+        b.setAttribute(g, kAXRoleAttribute as String, kAXGroupRole as String)
+        if let description {
+            b.setAttribute(g, kAXDescriptionAttribute as String, description)
+        }
+        b.setChildren(g, [])
+        return g
+    }
+
+    @Test("two matches are refused AND both are named")
+    func twoMatchesAreNamed() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6500)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [group(b, 6501, description: "Control Bar"),
+                             group(b, 6502, description: "Control Bar")])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime())
+
+        #expect(census.candidates == 2)
+        #expect(census.element == nil)          // refused
+        #expect(!census.isUnambiguous)
+        // ...and it can say WHICH two. This is the half that was missing.
+        #expect(census.names(runtime: b.makeAXRuntime()) == ["Control Bar", "Control Bar"])
+    }
+
+    /// The names must come off the ELEMENTS, not be re-derived from the query — two candidates that
+    /// matched a role-only lookup can be called different things, and a refusal that flattened them
+    /// to one label would hide exactly the case worth seeing.
+    @Test("candidates that call themselves different things are reported separately")
+    func distinctNamesSurvive() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6510)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [group(b, 6511, description: "Tracks header"),
+                             group(b, 6512, description: "Tracks contents")])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime())
+        #expect(census.names(runtime: b.makeAXRuntime()) == ["Tracks header", "Tracks contents"])
+    }
+
+    /// An element with nothing to call itself must not print as `""`. Three anonymous groups
+    /// reported as `["", "", ""]` read as a bug in the reporter rather than a fact about the tree,
+    /// and the person holding that refusal learns nothing at all.
+    @Test("an unnamed candidate reports its role rather than an empty string")
+    func unnamedCandidatesSaySo() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6520)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [group(b, 6521, description: nil), group(b, 6522, description: nil)])
+
+        let names = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime()
+        ).names(runtime: b.makeAXRuntime())
+        #expect(names == ["<unnamed AXGroup>", "<unnamed AXGroup>"])
+        #expect(!names.contains(""))
+    }
+
+    /// The one-match path must not start paying for names it does not need, and must still report
+    /// the match itself.
+    @Test("a single match is identified and its match list holds exactly it")
+    func oneMatchStillIdentifies() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6530)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        let only = group(b, 6531, description: "Mixer")
+        b.setChildren(root, [only])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXGroupRole as String, maxDepth: 4, runtime: b.makeAXRuntime())
+        #expect(census.isUnambiguous)
+        #expect(census.matches.count == 1)
+        let found = try #require(census.element)
+        #expect(CFEqual(found, only))
+    }
+
+    @Test("no match names nothing, and does not fabricate an entry")
+    func noMatchNamesNothing() throws {
+        let b = FakeAXRuntimeBuilder()
+        let root = b.element(6540)
+        b.setAttribute(root, kAXRoleAttribute as String, kAXGroupRole as String)
+        b.setChildren(root, [])
+
+        let census = AXHelpers.censusDescendant(
+            of: root, role: kAXSliderRole as String, maxDepth: 4, runtime: b.makeAXRuntime())
+        #expect(census.candidates == 0)
+        #expect(census.matches.isEmpty)
+        #expect(census.names(runtime: b.makeAXRuntime()).isEmpty)
+    }
+}


### PR DESCRIPTION
Third and last piece of #628, and the one that closes the half of its acceptance criterion that was still open.

## What was missing

#628 states two things that must be demonstrable:

```
two candidates exist  ->  refused, and both are named
one candidate exists  ->  recorded as one, not merely accepted
```

The second was met. The first was met **halfway**: `censusDescendant` computed every match, kept the count, and threw the matches away. So it refused without saying *which* two — and **"2 matched" cannot distinguish a genuinely ambiguous tree from a selector one word too broad.** The person holding that refusal learns they are stuck and nothing about how to get unstuck.

`Census` now carries `matches`, with a `names(runtime:)` method. The matches were already computed; keeping the references costs nothing, and *reading* them costs an AX round trip each — so it is a method, and the one-match path never pays.

## Driven live

```
candidates: 24  identified: false
<unnamed AXGroup>, <unnamed AXGroup>, Control Bar, Control Bar, Playhead Position, Inspector, ...
```

**Two elements described "Control Bar"** — the original observation in this issue, now visible by name instead of only as a count.

## Three defects the review found, all real

A pre-merge review at high effort returned **BLOCK**. The first was a bug in the fix itself:

**`names()` was a `??` chain, which falls through on NIL only.** AX returns present-but-empty strings routinely, so an element with `description == ""` and `title == "Mixer"` stopped at the empty description and reported `<unnamed AXGroup>` — the fallback was written, shipped, and unreachable. Whitespace-only was worse: it passed `!isEmpty` and *became* the name, producing exactly the blank the placeholder exists to prevent while looking like a successful read. Each attribute is tested for **content** now.

My tests covered *"description present"* and *"everything absent"* and missed the entire middle, which is where the bug lived.

**`AXLocalePolicy.censusDescendant` is a second producer of `Census`** and nothing covered its names. Dropping `matches: hits` from it alone left all five unit tests and both live checks green. Verified after the fix: that mutation now flips one live check and one unit test.

**The live no-blank check ran against `AXButton`** with nothing requiring an unnamed button, so it would pass with the placeholder completely broken whenever every live button happened to be named — a check that cannot see its own subject. Re-aimed at groups, where unnamed elements are measured to exist, with a precondition asserting the placeholder actually fired. Mutation confirms it: without the placeholder, **12 of 24** candidates print as empty strings.

## `matches` is deliberately not defaulted

A future construction site that forgot it would compile and report zero names for a real ambiguity — a silent downgrade back to exactly the count-only refusal this issue exists to remove. Let it fail to build instead.

## Gate

```
SHIP GATE PASS @ 98898d7c — 3912 tests · live evidence bound to head
live_628_counting_locator: 21/21 checks, 17 mutation-backed, all failure counters zero
```

## Residual

Naming a very large census performs up to four synchronous AX reads per candidate, and the probe has no timeout — raised by the review, accepted, and bounded by the fact that names are only read when a lookup is ambiguous. A real description equal to `"<unnamed AXGroup>"` would collide with the placeholder; that loses provenance but affects neither refusal nor cardinality.
