### PR TITLE
fix(#284): two qualification diagnostics that name a cause which is not the cause

### DIFF
--- a/Sources/LogicProMCP/Qualification/PromotionGate.swift
+++ b/Sources/LogicProMCP/Qualification/PromotionGate.swift
@@ -303,7 +303,10 @@ struct PromotionGate {
         }
     }
 
-    private static func isSHA256(_ value: String) -> Bool {
+    /// Internal, not private: `QualificationRunner` compares the PUBLISHED digest against the
+    /// candidate at a second site and needs the same validity test. A copy there would be a second
+    /// definition of "is this a SHA-256" free to drift from this one.
+    static func isSHA256(_ value: String) -> Bool {
         value.count == 64 && value.allSatisfy(\.isHexDigit)
     }
 }

--- a/Sources/LogicProMCP/Qualification/PromotionGate.swift
+++ b/Sources/LogicProMCP/Qualification/PromotionGate.swift
@@ -4,6 +4,8 @@ enum PromotionRejectionReason: Equatable, Sendable {
     case missingArtifact(name: String)
     case requiredArtifactSchemaInvalid(name: String)
     case binarySHAMismatch(expected: String, actual: String)
+    /// One or both values are not a SHA-256. Same reasoning as `releaseVersionUnparseable`.
+    case binarySHAUnparseable(expected: String, actual: String)
     case releaseCommitMismatch(expected: String, actual: String)
     case expiredWaiver(caseID: String)
     case waiverForUnknownCase(caseID: String)
@@ -14,6 +16,11 @@ enum PromotionRejectionReason: Equatable, Sendable {
     case duplicateWaiver(caseID: String)
     case duplicateCaseID(caseID: String)
     case releaseVersionMismatch(expected: String, actual: String)
+    /// Distinct from a mismatch: one or both versions are not a semantic version at all, so there
+    /// was nothing to compare. Folding this into `releaseVersionMismatch` printed
+    /// `expected: "unknown", actual: "unknown"` -- two identical strings reported as disagreeing,
+    /// which sends a reader looking for a difference that does not exist.
+    case releaseVersionUnparseable(expected: String, actual: String)
     case evidenceBindingMismatch(detail: String)
     case requiredOperationNotSatisfied(operationID: String)
     case provenanceSignatureMissing
@@ -37,17 +44,29 @@ struct PromotionGate {
     ) -> PromotionDecision {
         var rejections: [PromotionRejectionReason] = []
 
+        // Three conditions used to share one reason name. A run whose attestation carried
+        // `serverVersion: "unknown"` reported `releaseVersionMismatch` with
+        // `expected: "unknown", actual: "unknown"` -- nothing mismatched; both values were simply
+        // not versions. Naming several causes with one word makes the message point at the wrong
+        // one, and the reader goes looking for a disagreement that is not there.
         if SemanticVersion(attestation.serverVersion) == nil
-            || SemanticVersion(releaseVersion) == nil
-            || attestation.serverVersion != releaseVersion {
+            || SemanticVersion(releaseVersion) == nil {
+            rejections.append(.releaseVersionUnparseable(
+                expected: releaseVersion,
+                actual: attestation.serverVersion
+            ))
+        } else if attestation.serverVersion != releaseVersion {
             rejections.append(.releaseVersionMismatch(
                 expected: releaseVersion,
                 actual: attestation.serverVersion
             ))
         }
-        if !Self.isSHA256(attestation.binarySHA256)
-            || !Self.isSHA256(expectedBinarySHA256)
-            || attestation.binarySHA256 != expectedBinarySHA256 {
+        if !Self.isSHA256(attestation.binarySHA256) || !Self.isSHA256(expectedBinarySHA256) {
+            rejections.append(.binarySHAUnparseable(
+                expected: expectedBinarySHA256,
+                actual: attestation.binarySHA256
+            ))
+        } else if attestation.binarySHA256 != expectedBinarySHA256 {
             rejections.append(.binarySHAMismatch(
                 expected: expectedBinarySHA256,
                 actual: attestation.binarySHA256

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -954,11 +954,23 @@ package struct QualificationRunner: Sendable {
             requiredOperationIDs: requiredOperationIDs
         )
         var rejections = decision.rejections
+        // The SECOND digest comparison: published-vs-candidate, distinct from the gate's
+        // attestation-vs-candidate check. Splitting the unparseable cause in `PromotionGate` and
+        // not here left `--expected-binary-sha256 not-a-sha` still reporting `binarySHAMismatch`
+        // -- the fix applied to one named instance instead of to the property. `--expected-binary-
+        // sha256` is not format-validated when parsed, so a malformed value reaches here intact.
         if let publishedBinarySHA256, publishedBinarySHA256 != candidateSHA256 {
-            rejections.append(.binarySHAMismatch(
-                expected: publishedBinarySHA256,
-                actual: candidateSHA256
-            ))
+            if !PromotionGate.isSHA256(publishedBinarySHA256) {
+                rejections.append(.binarySHAUnparseable(
+                    expected: publishedBinarySHA256,
+                    actual: candidateSHA256
+                ))
+            } else {
+                rejections.append(.binarySHAMismatch(
+                    expected: publishedBinarySHA256,
+                    actual: candidateSHA256
+                ))
+            }
         }
         rejections.append(contentsOf: Self.requiredArtifactSchemaRejections(
             requiredArtifacts: requestedArtifacts,

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -1287,6 +1287,11 @@ package struct QualificationRunner: Sendable {
                 reason: "binarySHAMismatch", caseID: nil, key: nil,
                 name: nil, expected: expected, actual: actual
             )
+        case .binarySHAUnparseable(let expected, let actual):
+            VerificationOutput.Rejection(
+                reason: "binarySHAUnparseable", caseID: nil, key: nil,
+                name: nil, expected: expected, actual: actual
+            )
         case .releaseCommitMismatch(let expected, let actual):
             VerificationOutput.Rejection(
                 reason: "releaseCommitMismatch", caseID: nil, key: nil,
@@ -1335,6 +1340,11 @@ package struct QualificationRunner: Sendable {
         case .releaseVersionMismatch(let expected, let actual):
             VerificationOutput.Rejection(
                 reason: "releaseVersionMismatch", caseID: nil, key: nil,
+                name: nil, expected: expected, actual: actual
+            )
+        case .releaseVersionUnparseable(let expected, let actual):
+            VerificationOutput.Rejection(
+                reason: "releaseVersionUnparseable", caseID: nil, key: nil,
                 name: nil, expected: expected, actual: actual
             )
         case .evidenceBindingMismatch(let detail):

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -248,7 +248,7 @@ struct QualificationOperationResult: Equatable, Sendable {
                 // reason, by design and pending Phase B. Attributing that to the environment sends
                 // whoever reads the attestation to go look at their machine, which is clean.
                 detail: "read-only operation did not return a successful typed response under the "
-                    + "probe's current parameters (see SemanticOracleTable's known-limitations note)"
+                    + "probe's current parameters (see SemanticOracleTable's KNOWN GAPS note)"
             )
         case .protocolSmoke:
             QualificationDeferral(

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -241,7 +241,14 @@ struct QualificationOperationResult: Equatable, Sendable {
         case .notQualified:
             QualificationDeferral(
                 code: .operationUnavailable,
-                detail: "read-only operation did not return a successful typed response on this host"
+                // NOT "on this host". The cause is almost never the machine: the probe sends
+                // `[:]` for every read-only operation not named in `probeParams`, so operations
+                // that require a parameter refuse correctly and are recorded as unavailable.
+                // `SemanticOracleTable.swift` lists six that cannot reach `passed` for exactly this
+                // reason, by design and pending Phase B. Attributing that to the environment sends
+                // whoever reads the attestation to go look at their machine, which is clean.
+                detail: "read-only operation did not return a successful typed response under the "
+                    + "probe's current parameters (see SemanticOracleTable's known-limitations note)"
             )
         case .protocolSmoke:
             QualificationDeferral(

--- a/Tests/LogicProMCPTests/QualificationGateTests.swift
+++ b/Tests/LogicProMCPTests/QualificationGateTests.swift
@@ -265,7 +265,11 @@ struct QualificationGateTests {
         )
 
         #expect(!decision.promotable)
+        // Identical values again: not a mismatch, just not SHA-256s.
         #expect(decision.rejections.contains(
+            .binarySHAUnparseable(expected: "not-a-sha", actual: "not-a-sha")
+        ))
+        #expect(!decision.rejections.contains(
             .binarySHAMismatch(expected: "not-a-sha", actual: "not-a-sha")
         ))
         #expect(QualificationAxis.requiredCombinations.allSatisfy { axis in
@@ -537,9 +541,31 @@ struct QualificationGateTests {
         )
 
         #expect(!decision.promotable)
+        // Two IDENTICAL values. Calling that a "mismatch" reported `expected: "banana",
+        // actual: "banana"` and sent the reader looking for a difference that is not there --
+        // nothing mismatched, the strings are simply not versions.
         #expect(decision.rejections == [
-            .releaseVersionMismatch(expected: "banana", actual: "banana"),
+            .releaseVersionUnparseable(expected: "banana", actual: "banana"),
         ])
+        // The distinction is the point of the split: this must NOT also read as a mismatch.
+        #expect(!decision.rejections.contains(
+            .releaseVersionMismatch(expected: "banana", actual: "banana")))
+    }
+
+    /// The other side of the split: two versions that both PARSE and genuinely differ still report
+    /// a mismatch. Without this, moving every case to `Unparseable` would satisfy the test above.
+    @Test func genuinelyDifferentVersionsStillReportMismatch() {
+        let decision = evaluate(
+            cases: passedRequiredCases(),
+            attestationVersion: "1.2.2",
+            releaseVersion: "1.2.3"
+        )
+
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains(
+            .releaseVersionMismatch(expected: "1.2.3", actual: "1.2.2")))
+        #expect(!decision.rejections.contains(
+            .releaseVersionUnparseable(expected: "1.2.3", actual: "1.2.2")))
     }
 
     @Test func semanticVersionRejectsLeadingZerosAndUnicodeIdentifiers() {

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -2098,6 +2098,46 @@ struct QualificationRunnerTests {
         #expect(Self.rejectionReasons(try Self.resultObject(result)).isEmpty)
     }
 
+    /// The PUBLISHED-vs-candidate digest comparison is a SECOND site, separate from the gate's
+    /// attestation-vs-candidate check. Splitting the unparseable cause in `PromotionGate` and not
+    /// here left `--expected-binary-sha256 not-a-sha` still reporting `binarySHAMismatch` — the fix
+    /// applied to one named instance rather than to the property, and a review caught it.
+    ///
+    /// This drives the real CLI path. The `PromotionGate`-level test cannot reach this site: the
+    /// gate is handed the COMPUTED candidate digest, never the supplied one.
+    @Test func malformedPublishedSHAIsReportedUnparseableNotMismatched() async throws {
+        let fixture = try promotableFixture()
+        defer { fixture.remove() }
+        _ = try await fixture.qualify(waiversURL: fixture.waiversURL)
+
+        let result = await fixture.verify(expectedSHA256: "not-a-sha")
+        let json = try Self.resultObject(result)
+        let reasons = Self.rejectionReasons(json)
+
+        #expect(result.exitCode != 0)
+        #expect(reasons.contains("binarySHAUnparseable"))
+        // The distinction is the whole point: a malformed value is not a disagreement.
+        #expect(!reasons.contains("binarySHAMismatch"))
+    }
+
+    /// The other side, so moving every case to `Unparseable` cannot satisfy the test above: a
+    /// well-formed published digest that genuinely differs must still read as a mismatch.
+    @Test func wellFormedDifferentPublishedSHAStillReportsMismatch() async throws {
+        let fixture = try promotableFixture()
+        defer { fixture.remove() }
+        _ = try await fixture.qualify(waiversURL: fixture.waiversURL)
+
+        let otherDigest = String(repeating: "a", count: 64)
+        #expect(otherDigest != fixture.binarySHA256)
+
+        let result = await fixture.verify(expectedSHA256: otherDigest)
+        let reasons = Self.rejectionReasons(try Self.resultObject(result))
+
+        #expect(result.exitCode != 0)
+        #expect(reasons.contains("binarySHAMismatch"))
+        #expect(!reasons.contains("binarySHAUnparseable"))
+    }
+
     @Test func differentPublishedSHARejects() async throws {
         let fixture = try promotableFixture()
         defer { fixture.remove() }


### PR DESCRIPTION
Two diagnostics in the qualification subsystem that name a cause which is not the cause. Both found by running `--verify-promotion` for the first time (reported on #284).

**This changes what the gate SAYS, not what it measures.** Rejection counts are identical before and after — 106 on the same attestation. `promotable` is `rejections.isEmpty`, so renaming a reason cannot make a rejected attestation promotable or vice versa.

## 1. Three conditions shared one reason name

```json
{"reason": "releaseVersionMismatch", "expected": "unknown", "actual": "unknown"}
```

**Nothing mismatched.** The two values are identical; they are simply not versions. A reader is told the versions disagree and shown two strings that plainly agree, and goes looking for a difference that does not exist. `PromotionGate` folded *attestation unparseable*, *supplied unparseable*, and *the two differ* into one name. Same shape for the SHA check.

Split into `releaseVersionUnparseable` / `binarySHAUnparseable`. Now:

```
releaseVersionUnparseable   expected "unknown"    actual "unknown"        two identical, unparseable
binarySHAMismatch           two valid digests that genuinely differ
binarySHAUnparseable        expected "not-a-sha"  actual <real digest>
```

## 2. "on this host" blamed the machine for the probe's own parameters

The read-only deferral said the operation *"did not return a successful typed response **on this host**"*. The cause is almost never the machine: `probeParams` returns `[:]` for every read-only operation it does not name, so operations requiring a parameter refuse correctly and are recorded as unavailable. `SemanticOracleTable`'s KNOWN GAPS note already lists six that cannot reach `passed` for exactly this reason. Attributing that to the environment sends whoever reads the attestation to inspect a machine that is fine.

## What a review caught, and it is the same shape as the bug

**There are TWO digest comparisons and I split the reason at one.** `PromotionGate` compares attestation-vs-candidate; `QualificationRunner` compares the **published** digest against the candidate at a second site. Fixing the first and not the second left `--expected-binary-sha256 not-a-sha` still claiming a disagreement between a malformed string and a real digest — **the fix applied to one named instance instead of to the property**, which is precisely the defect class this change is about.

`isSHA256` is now internal and **reused, not copied** — a second definition of "is this a SHA-256" is free to drift from the first.

**My test could not have caught it.** It calls `PromotionGate` directly, and the gate is handed the *computed* candidate digest, never the supplied one — so it bypassed the only path where the bug lives. Two tests added on the real CLI path, and the first was watched to fail with the split reverted.

## Tests that encoded the wrong name

`equalInvalidReleaseVersionsReject` and `invalidEqualBinarySHAsReject` — their own names say the values are **equal**, and they asserted a "Mismatch". They now assert the accurate reason **and** that the inaccurate one is absent. Two further cases cover the other side (genuinely differing, well-formed values must still read as mismatches), so moving every case to `Unparseable` cannot satisfy them.

## Gate

```
SHIP GATE PASS @ b956a55d — 3915 tests · live evidence bound to head
```

## Two things stated rather than implied

- **The live evidence on this branch is a binary-level regression check, not proof of this change.** The qualification path has no Logic-UI harness. This change's own verification is the unit tests plus the live `--verify-promotion` runs quoted above.
- **This does not reach the authoritative release workflow, and that is understating it.** A review noted `release.yml` builds a verifier pinned to `67fec5fc…` (enforced by `ProductionReadinessContracts.swift:52` and a contract test). Checking it myself: that step is also **conditional on `vars.ADR001_QUALIFICATION_ENFORCED == 'true'`, and no repository variables are set at all** — so the pinned verifier does not run today. The workflow says so in its own comment: the enforcement steps are *"gated OFF by owner decision (2026-07-21)"* until #284 lands. These names reach the release path only after a pin advance **and** an owner flipping that variable.

