### PR TITLE
feat(#373): Phase A — qualifying parameters for two read-only probes

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -880,6 +880,25 @@ struct QualificationTransport: Sendable {
             return ["idempotency_key": "qualification-read-probe", "steps": []]
         case .systemSagaStatus:
             return ["idempotency_key": "qualification-read-probe"]
+
+        // #373 Phase A. `default: [:]` sends NO parameters, so every read-only operation that
+        // requires one refuses correctly and is recorded as unavailable -- the product working,
+        // scored as a failure. `SemanticOracleTable`'s KNOWN GAPS note lists six in that state.
+        // These two are the ones a qualifying parameter can fix without a fixture or a side effect.
+        case .tracksResolvePath:
+            // A LIBRARY path classifier, not a filesystem one. Its oracle accepts either contract:
+            // a hit must name `matchedPath` and classify the node, a miss must say why. This path
+            // is a deterministic MISS, chosen on purpose -- a hit depends on what patches the
+            // machine happens to have installed, and a gate whose result varies by host is not a
+            // gate. The limitation is real and stated: the HIT branch stays unexercised here, and
+            // covering it needs a fixture library rather than a different string.
+            return ["path": "__qualification_probe__/definitely-absent"]
+        case .pluginsGetInventory:
+            // Track 0 exists whenever a project does: `project.new` reports
+            // `mandatory_track_created`. On a projectless Logic this still returns a typed refusal
+            // rather than the bare `invalid_params` an absent parameter produced.
+            return ["track": 0]
+
         default:
             return [:]
         }


### PR DESCRIPTION
First slice of #373 Phase A, which the roadmap places in the current wave: *"#373 is the evidence engine and #284 is the gate that consumes it, so they run together in that order."*

## The blocker was one line

```swift
// QualificationTransport.probeParams(for:traceID:)
default:
    return [:]
```

Every read-only operation not named in that switch is invoked with **no parameters at all**. The ones that require a parameter refuse — correctly, with a typed envelope — and the refusal is recorded as `operation_unavailable`. **That is the product working and being scored as a failure.**

`SemanticOracleTable`'s KNOWN GAPS note lists six in that state and prescribes exactly this fix: *"give these probes qualifying params … rather than weaken the oracles."* The readback plumbing was already complete — every operation reads an independent resource via `readbackSource(for:)` — so nothing else was missing.

## Measured live, not inferred

`--qualify` driven against Logic 12.3, same binary, before and after:

```
BEFORE   total=113  passed=12  not_qualified=100
AFTER    total=113  passed=14  not_qualified=98

  resolve_path     not_qualified -> passed
  get_inventory    not_qualified -> passed
```

Exactly those two cases changed. Nothing else moved.

## A limitation written into the code, not hidden

`resolve_path` is a **library** path classifier, and its oracle accepts either contract — a hit must name `matchedPath` and classify the node; a miss must say why. The path supplied is a **deterministic miss on purpose**: a hit depends on which patches the host happens to have installed, and *a gate whose result varies by machine is not a gate*.

So the **hit branch stays unexercised**, and covering it needs a fixture library rather than a different string. That is stated in the source beside the parameter.

## Why only two

The other four documented cases each need a decision, not a parameter:

| operation | what it needs |
|---|---|
| `export_plan` | an absolute `.logicx` path; oracle likely wants a real project |
| `analyze_file` | a real audio fixture |
| `scan_plugin_presets` | `submenuOpenDelayMs`, but it opens Logic menus — known wedge risk on this host |
| `saga_status` | a seeded saga record, not just a key |
| `clear_traces` | **nothing.** It is probed `confirmed:false` deliberately so qualification never destroys diagnostic evidence. The refusal is correct and it should not be made to pass — it needs a different classification, not a parameter. |

Bundling those into one change is how the last three PRs got blocked.

## Gate

```
SHIP GATE PASS @ 85800ba0 — 3915 tests · live evidence bound to head
```

An earlier gate run failed with 3 issues at **848s**. The same commit then passed **3915/3915 at 657s** running alone, and passed the gate again at 716s. The cause was load contention from a concurrent `codex` review in another worktree on this machine, not this change — a deterministic defect would have failed every time.
