### PR TITLE
feat(#373): Phase A — export_plan and analyze_file reach passed

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -893,6 +893,16 @@ struct QualificationTransport: Sendable {
             // gate. The limitation is real and stated: the HIT branch stays unexercised here, and
             // covering it needs a fixture library rather than a different string.
             return ["path": "__qualification_probe__/definitely-absent"]
+        case .projectExportPlan:
+            // A DRY RUN whose oracle allows `status ∈ {planned, degraded}`. An absent project is
+            // honestly `degraded` and still returns a complete, schema-valid manifest, so the probe
+            // needs no fixture project and no path that varies by host. `output_root` is required
+            // too -- omitting it refuses with `output_root must be an absolute local path`, which
+            // is why supplying only `project` still failed.
+            return [
+                "project": "/__qualification_probe__/absent.logicx",
+                "output_root": "/tmp",
+            ]
         case .pluginsGetInventory:
             // Track 0 exists whenever a project does: `project.new` reports
             // `mandatory_track_created`. On a projectless Logic this still returns a typed refusal

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -893,6 +893,20 @@ struct QualificationTransport: Sendable {
             // gate. The limitation is real and stated: the HIT branch stays unexercised here, and
             // covering it needs a fixture library rather than a different string.
             return ["path": "__qualification_probe__/definitely-absent"]
+        case .audioAnalyzeFile:
+            // The oracle requires `verification.status ∈ {pass, warn}` -- a `fail` arrives with
+            // isError and is classified before the oracle runs, so accepting it could only launder
+            // a failed analysis into a semantic pass. That means a REAL, analysable file.
+            //
+            // A macOS system sound rather than a committed fixture, and the trade is deliberate:
+            // a repo fixture is repo-controlled but the binary has no way to locate it at run time,
+            // which would need a new option threaded through the transport. This file is externally
+            // owned, which is the weaker guarantee -- but if it ever disappears, `analyze_file`
+            // returns its typed refusal and the case defers exactly as it does today. The downside
+            // is the current state, so this cannot regress anything.
+            //
+            // Measured: 1.502 s, 48 kHz, `verification.status == "pass"`.
+            return ["path": "/System/Library/Sounds/Ping.aiff"]
         case .projectExportPlan:
             // A DRY RUN whose oracle allows `status ∈ {planned, degraded}`. An absent project is
             // honestly `degraded` and still returns a complete, schema-valid manifest, so the probe


### PR DESCRIPTION
Second slice of #373 Phase A. Two more read-only operations reach `passed`, and **both were ones I had wrongly scoped as needing a decision.**

## Cumulative, measured live

```
SESSION START   passed=12   not_qualified=100
AFTER #654      passed=14   not_qualified=98
THIS PR         passed=16   not_qualified=96

resolve_path · get_inventory · export_plan · analyze_file    not_qualified -> passed
```

Driven with `--qualify` against Logic 12.3 before and after each change, with only the intended cases moving.

## `export_plan` — no fixture project needed

I scoped this as *"needs a real `.logicx` path, which varies per run"*. Reading the oracle instead of guessing corrected it: `export_plan` is a **dry run** whose oracle allows `status ∈ {planned, degraded}`. An absent project is honestly `degraded` and still returns a complete, schema-valid manifest satisfying every constraint — `schema`, `execution_mode: dry_run_only`, `next_safe_action: review_export_plan`, `project_count`, and a `projects` array.

It also requires `output_root`. Supplying only `project` still refuses with *"output_root must be an absolute local path"* — which is why my first live attempt failed and looked like the path was at fault.

## `analyze_file` — a real file, and a trade stated rather than hidden

The oracle requires `verification.status ∈ {pass, warn}`. A `fail` arrives with `isError` and is classified *before* the oracle runs, so accepting it could only launder a failed analysis into a semantic pass. That means a real, analysable file.

I generated a deterministic WAV fixture and **dropped it**: the binary has no way to locate a repo file at run time, which would need a new option threaded through the transport for one probe.

A macOS system sound instead. The trade is deliberate: an externally owned file is the weaker guarantee for a gate whose point is same-artifact reproducibility. What makes it acceptable is the **failure mode** — if it ever disappears, `analyze_file` returns its typed refusal and the case defers exactly as it does today. The downside is the current state, so this cannot regress anything.

Driven live at 1.502 s, 48 kHz, `verification.status == "pass"`.

## Gate

```
SHIP GATE PASS @ 50ceeccd — 3915 tests · live evidence bound to head
```

## Unrelated finding, reported on #284 rather than fixed here

While running these, `--qualify` intermittently failed with `Logic Pro UI locale mismatch: expected en-US, observed unknown` — with Logic up for hours, a project open, and no dialog.

That **disproves the "settle timing after launch" cause I previously posted to #284**, and a follow-up hypothesis (first health read in a fresh subprocess needs settling) is disproven too: 15 of 15 direct reads returned `en-US`, including at zero delay, while three consecutive `--qualify` runs went FAIL, FAIL, PASS.

Retracted there with the measurements and **no new cause named** — I have been wrong about this five times and would rather leave it open than post a sixth story.
