### PR TITLE
feat(#373): a deliberate abstention is not an unavailable operation

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -1900,7 +1900,11 @@ package struct QualificationRunner: Sendable {
                 return false
             }
             switch evidence.deferral?.code {
-            case .some(.liveMutationNotRun), .some(.operationUnavailable):
+            // `deliberateZeroWriteProbe` sits with these two because it is the same OBSERVATION --
+            // the operation returned a typed refusal. What differs is why the probe asked in a way
+            // that would be refused, and that distinction is in the code, not in the evidence.
+            case .some(.liveMutationNotRun), .some(.operationUnavailable),
+                 .some(.deliberateZeroWriteProbe):
                 return evidence.operationIsError == true
             case .some(.semanticMismatch), .some(.semanticValidatorUnavailable):
                 return evidence.operationIsError == false

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -238,6 +238,13 @@ struct QualificationOperationResult: Equatable, Sendable {
                 code: .semanticMismatch,
                 detail: "read-only response did not match its operation-specific independent readback"
             )
+        case .notQualified where QualificationTransport.declinesItsSuccessPathByDesign
+            .contains(operationID):
+            QualificationDeferral(
+                code: .deliberateZeroWriteProbe,
+                detail: "the probe declines this operation's success path by design; reaching it "
+                    + "would destroy or mutate state the qualification must not touch"
+            )
         case .notQualified:
             QualificationDeferral(
                 code: .operationUnavailable,
@@ -862,6 +869,18 @@ struct QualificationTransport: Sendable {
             result.isError == true
         )
     }
+
+    /// Operations whose probe parameters are chosen to REFUSE, not to succeed.
+    ///
+    /// Kept beside `probeParams` on purpose: the reason an operation is here is a value that
+    /// function sends, and separating the two is how a list stops matching the code it describes.
+    /// `system.clear_traces` is probed `confirmed: false` so qualification never destroys the
+    /// diagnostic evidence it is producing -- its oracle pins the real success contract
+    /// (`success == true`, a `receipt_path`, a cleared count), and that contract can only be
+    /// satisfied by actually clearing traces.
+    static let declinesItsSuccessPathByDesign: Set<String> = [
+        OperationID.systemClearTraces.rawValue,
+    ]
 
     private static func probeParams(for spec: OperationSpec, traceID: String) -> [String: Any] {
         if spec.mutability == .mutating {

--- a/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
+++ b/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
@@ -48,6 +48,15 @@ enum QualificationDeferralCode: String, Codable, Sendable {
     case operationUnavailable = "operation_unavailable"
     case semanticMismatch = "semantic_mismatch"
     case semanticValidatorUnavailable = "semantic_validator_unavailable"
+    /// The probe declines this operation's success path ON PURPOSE, because reaching it would
+    /// destroy or mutate something the qualification must not touch.
+    ///
+    /// Distinct from `operationUnavailable`, which says the call did not succeed under the probe's
+    /// current parameters and therefore invites someone to go fix the parameters. For these there
+    /// is nothing to fix: sending the value that would succeed is the one thing the probe must
+    /// never do. Reporting both with one code tells a reader that a deliberate abstention is an
+    /// oversight.
+    case deliberateZeroWriteProbe = "deliberate_zero_write_probe"
 }
 
 struct QualificationDeferral: Codable, Equatable, Sendable {


### PR DESCRIPTION
Third slice of #373 Phase A. No operation changes status — this fixes what the attestation *says* about one that cannot change status.

## `clear_traces` cannot pass, and that is correct

Its oracle pins the real success contract:

```swift
.valueEquals(key: "success", expected: .bool(true)),
.typedField(key: "receipt_path", type: .string),
.numericRange(key: "cleared_trace_count", min: 0, max: 100_000),
```

That contract is satisfiable **only by actually clearing traces**. The probe sends `confirmed: false` on purpose so qualification never destroys the diagnostic evidence it is producing. So the refusal is correct and permanent — I verified that before reclassifying, rather than assuming the deferral was a gap to close.

## But it was described as if the parameters were wrong

It landed in `operation_unavailable`, whose detail reads *"did not return a successful typed response **under the probe's current parameters**"*.

For every other operation in that bucket the parameters are exactly what needs fixing — that is what #654 and #655 did for four of them. Here there is **nothing to fix**: sending the value that would succeed is the one thing the probe must never do. One code for both tells a reader that a deliberate abstention is an oversight, and sends them looking for a parameter change that must not happen.

```
BEFORE   clear_traces -> operation_unavailable
AFTER    clear_traces -> deliberate_zero_write_probe

deferral codes, live:  live_mutation_not_run 88 · operation_unavailable 6 -> 5
                       semantic_mismatch 2 · deliberate_zero_write_probe 1
```

Same defect class as the two diagnostics corrected in #653: **a message naming a cause that is not the cause.**

## Two implementation notes

**The set lives beside `probeParams`.** The reason an operation belongs to it is a value that function sends, and separating the two is how a list stops matching the code it describes.

**Adding the case broke an exhaustive switch** in `QualificationRunner`. That is the compiler catching a consumer — the same absent `default` I checked was still absent when reviewing #653's encoder. `deliberateZeroWriteProbe` groups with `liveMutationNotRun` and `operationUnavailable` there because it is the same *observation* (a typed refusal); what differs is why the probe asked in a way that would be refused, and that belongs in the code rather than in the evidence.

## Gate

```
SHIP GATE PASS @ cf24420a — 3915 tests · live evidence bound to head
```

## Still open, and named rather than closed over

`analyze_spectrum` and `recommend_eq` are arguably this same class — gated behind `LOGIC_MCP_ADR012_SPECTRAL_EQ=1` and therefore unable to reach `passed` in any production-contract run, yet sitting in `operation_unavailable` as though a parameter would help. Left for a separate change, since whether the fix is a new code or excluding them from the set is a scoping call, not a mechanical one.
