### PR TITLE
feat(#373): a flag-gated operation is not an unavailable one either

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -1904,7 +1904,7 @@ package struct QualificationRunner: Sendable {
             // the operation returned a typed refusal. What differs is why the probe asked in a way
             // that would be refused, and that distinction is in the code, not in the evidence.
             case .some(.liveMutationNotRun), .some(.operationUnavailable),
-                 .some(.deliberateZeroWriteProbe):
+                 .some(.deliberateZeroWriteProbe), .some(.notExposedInProductionContract):
                 return evidence.operationIsError == true
             case .some(.semanticMismatch), .some(.semanticValidatorUnavailable):
                 return evidence.operationIsError == false

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -238,6 +238,16 @@ struct QualificationOperationResult: Equatable, Sendable {
                 code: .semanticMismatch,
                 detail: "read-only response did not match its operation-specific independent readback"
             )
+        // DERIVED from what the operation answered, not from a list. `clear_traces` needs a set
+        // because nothing in its refusal distinguishes "declined on purpose" from "called wrong";
+        // this one announces itself, and a list here would be a second place to keep in step with
+        // the feature flags.
+        case .notQualified where error == HonestContract.FailureError.commandNotExposed.rawValue:
+            QualificationDeferral(
+                code: .notExposedInProductionContract,
+                detail: "the production MCP contract does not expose this operation; no probe "
+                    + "parameter can qualify it while its feature flag is off"
+            )
         case .notQualified where QualificationTransport.declinesItsSuccessPathByDesign
             .contains(operationID):
             QualificationDeferral(

--- a/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
+++ b/Sources/LogicProMCP/Qualification/ReleaseQualificationAttestation.swift
@@ -57,6 +57,15 @@ enum QualificationDeferralCode: String, Codable, Sendable {
     /// never do. Reporting both with one code tells a reader that a deliberate abstention is an
     /// oversight.
     case deliberateZeroWriteProbe = "deliberate_zero_write_probe"
+    /// The production MCP contract does not expose this operation, so no parameter can make it
+    /// reach `passed` -- it answers `command_not_exposed` by design until a feature flag is set.
+    ///
+    /// Distinct from `operationUnavailable` for the same reason `deliberateZeroWriteProbe` is: that
+    /// code says the call did not succeed under the probe's current parameters, which is an
+    /// invitation to change them. Here the parameters are irrelevant. Qualifying it at all would
+    /// mean running the gate with a non-production flag set, at which point it is no longer
+    /// qualifying the production contract.
+    case notExposedInProductionContract = "not_exposed_in_production_contract"
 }
 
 struct QualificationDeferral: Codable, Equatable, Sendable {


### PR DESCRIPTION
Fourth slice of #373 Phase A. Like #656, no operation changes status — this fixes what the attestation *says* about two that cannot.

## Flag-gated is not unavailable

`audio.analyze_spectrum` and `audio.recommend_eq` answer `command_not_exposed` unless `LOGIC_MCP_ADR012_SPECTRAL_EQ=1`. In a production-contract run they **cannot** reach `passed` regardless of host or parameters — the only way to qualify them is to run the gate with a non-production flag set, at which point it is not qualifying the production contract.

They sat in `operation_unavailable`, whose detail says the call did not succeed *"under the probe's current parameters"* — the same misdirection `clear_traces` had. The parameters are irrelevant, and changing them is wasted effort.

```
analyze_spectrum  ->  not_exposed_in_production_contract
recommend_eq      ->  not_exposed_in_production_contract

operation_unavailable:  6 -> 3
```

## Derived, not listed

This is the improvement over #656. `clear_traces` needs a hardcoded set because nothing in its refusal distinguishes *"declined on purpose"* from *"called wrong"*. These announce themselves with a typed `command_not_exposed`, so the classification matches on **what the operation answered**. That keeps it correct when a flag moves, and avoids a second place that has to be kept in step with the feature flags.

The exhaustive switch in `QualificationRunner` broke again, which is the third time today that missing `default` has caught a consumer.

## Gate

```
SHIP GATE PASS @ 78c0bfd1 — 3915 tests · live evidence bound to head
```

## The residue is one problem, not four — and I had it wrong

I have described `scan_plugin_presets` as a *"measured menu-wedge hazard"* in three PR bodies. **Measured, it is not.** Driven once against live Logic:

```
elapsed 3.1s   error='channels_exhausted'
hint: "No plugin window with Setting dropdown found. Open an instrument plugin window first."
Logic after: same windows · no modal · alive
```

A clean typed refusal in three seconds. I had carried a wedge memory from a different code path and applied it here without checking — the same mistake as calling `export_plan` and `analyze_file` blocked when they were not.

With that corrected, everything left in Phase A is the **same** question:

```
scan_plugin_presets   needs a plugin window open
get_regions           needs an arrange viewport
list_library          needs the Library panel open
saga_status           needs a real saga record to exist
```

None is a parameter problem. Every one is *"the qualification must arrange Logic's state first"* — which is a single scoping decision (does Phase A drive setup, or does that belong to Phase B/C-live), not four separate judgement calls. `SemanticOracleTable` already anticipated three of them as environment-conditional.
