### PR TITLE
fix(#373): the get_regions oracle pinned one of two documented branches

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -793,16 +793,38 @@ enum SemanticOracleTable {
     // complete/scope/reason are hardcoded honesty disclaimers: this read only
     // ever sees the visible arrange viewport, and it must never claim otherwise.
     static let projectGetRegions = OperationOracle(
-        .projectGetRegions,
-        strength: .shapeAndDomain,
-        constraints: [
-            .valueEquals(key: "complete", expected: .bool(false)),
-            .valueEquals(key: "scope", expected: .string("visible_arrange_area")),
-            .valueEquals(key: "reason", expected: .string("logic_ax_viewport_only")),
-            .numericRange(key: "returned_count", min: 0, max: 100_000),
-            .typedField(key: "regions", type: .array),
-        ]
-    )
+        custom: .projectGetRegions,
+        reason: """
+            `complete` is CONDITIONAL, not invariant. The product emits \
+            `scope: complete ? "whole_arrangement" : "visible_arrange_area"` \
+            (`AccessibilityChannel+Regions.swift:53`) -- both branches are its \
+            documented contract. The previous constraint list pinned only the \
+            viewport-limited one, so a project whose regions all fit in view \
+            failed the oracle for answering correctly. That includes the EMPTY \
+            fixture this gate runs against, which is why the case could never \
+            reach passed. Measured live: complete=true, \
+            scope="whole_arrangement", reason absent, returned_count=0.
+            """
+    ) { responseData, _ in
+        guard let response = JSONInspector.parse(responseData) as? [String: Any],
+              let complete = response["complete"], JSONInspector.isBoolean(complete),
+              let regions = response["regions"] as? [Any],
+              let count = response["returned_count"] as? Int,
+              count >= 0, count <= 100_000 else {
+            return false
+        }
+        // Stronger than the list it replaces: the advertised count must match the array it
+        // describes. A reader that says "3" and ships 1 is not answering correctly in either
+        // branch, and no `valueEquals` could express that.
+        guard count == regions.count else { return false }
+        if (complete as? NSNumber)?.boolValue == true {
+            // A complete read covers the arrangement and has no limitation to explain.
+            return response["scope"] as? String == "whole_arrangement"
+        }
+        // An incomplete read must name its scope AND say why it is limited.
+        return response["scope"] as? String == "visible_arrange_area"
+            && response["reason"] as? String == "logic_ax_viewport_only"
+    }
 
     // ProjectExportPlannerModels `ProjectExportPlan` CodingKeys.
     // NOTE: unreachable under the current probe (empty params; the planner

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -560,6 +560,12 @@ enum SemanticOracleTable {
         .midiListPorts,
         .tracksListLibrary,
         .tracksResolvePath,
+        // Entered deliberately, not to get past the guard that stopped this change. A flat
+        // constraint list cannot express what this oracle has to check: `complete` decides which
+        // scope is legal and whether `reason` is required, and the model has no implication case.
+        // Expressing it as an enum over both scopes would accept a response claiming
+        // `complete: true` while naming the viewport scope -- weaker than what it replaces.
+        .projectGetRegions,
     ]
 
     static var customOracles: [OperationOracle] { all.filter { $0.strength == .custom } }

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -538,7 +538,7 @@ enum SemanticOracleTable {
     ///
     /// The root cause is a gap in the constraint data model, not laziness: a
     /// constraint binds to ONE payload and has no cross-check case, and there is
-    /// no implication case. For these seven the only honest checks ARE
+    /// no implication case. For these eight the only honest checks ARE
     /// cross-checks and conditionals. Forcing them under a numeric cap would
     /// have produced tautological oracles (`enumMember` over a field a
     /// `typedField` already types) — checkbox oracles of exactly the kind this
@@ -801,7 +801,9 @@ enum SemanticOracleTable {
     static let projectGetRegions = OperationOracle(
         custom: .projectGetRegions,
         reason: """
-            `complete` is CONDITIONAL, not invariant. The product emits \
+            `complete` is CONDITIONAL, not invariant -- an earlier note here \
+            said this read only ever sees the visible viewport, which is not \
+            what the product does. The product emits \
             `scope: complete ? "whole_arrangement" : "visible_arrange_area"` \
             (`AccessibilityChannel+Regions.swift:53`) -- both branches are its \
             documented contract. The previous constraint list pinned only the \
@@ -814,22 +816,36 @@ enum SemanticOracleTable {
     ) { responseData, _ in
         guard let response = JSONInspector.parse(responseData) as? [String: Any],
               let complete = response["complete"], JSONInspector.isBoolean(complete),
-              let regions = response["regions"] as? [Any],
-              let count = response["returned_count"] as? Int,
-              count >= 0, count <= 100_000 else {
+              let regions = response["regions"] as? [Any] else {
             return false
         }
-        // Stronger than the list it replaces: the advertised count must match the array it
-        // describes. A reader that says "3" and ships 1 is not answering correctly in either
-        // branch, and no `valueEquals` could express that.
-        guard count == regions.count else { return false }
+        // `JSONInspector.number`, NOT `as? Int`. A review found the counterexample: on Darwin a
+        // JSON boolean is a CFBoolean-backed NSNumber, so `as? Int` bridges `false` to 0 and
+        // `returned_count: false` would agree with an empty array. The `.numericRange` constraint
+        // this closure replaced went through `JSONInspector.number`, which rejects CFBooleans
+        // outright -- so that payload was an old-reject/new-accept case, and the claim that this
+        // change only tightened the grader was wrong until this line.
+        guard let countValue = response["returned_count"],
+              let count = JSONInspector.number(of: countValue),
+              count >= 0, count <= 100_000,
+              count == Double(regions.count) else {
+            return false
+        }
+        // The product emits `[RegionInfo]`. An array carrying nulls or scalars is not a region
+        // list, and "is an array" was the whole of the old check.
+        guard regions.allSatisfy({ $0 is [String: Any] }) else { return false }
+
+        let reason = response["reason"]
         if (complete as? NSNumber)?.boolValue == true {
-            // A complete read covers the arrangement and has no limitation to explain.
+            // A complete read covers the arrangement and has NO limitation to explain. The product
+            // encodes `reason: nil`, which JSON omits, so a complete response that names one is
+            // describing a limitation it also claims not to have.
+            guard reason == nil || reason is NSNull else { return false }
             return response["scope"] as? String == "whole_arrangement"
         }
         // An incomplete read must name its scope AND say why it is limited.
         return response["scope"] as? String == "visible_arrange_area"
-            && response["reason"] as? String == "logic_ax_viewport_only"
+            && reason as? String == "logic_ax_viewport_only"
     }
 
     // ProjectExportPlannerModels `ProjectExportPlan` CodingKeys.

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -237,7 +237,40 @@ enum SemanticOracleFixtures {
                 "returned_count":1,"_debug":{"layoutItems":1,"nonRegion":0}}
                 """,
             readback: "{\"cache_age_sec\":1.0,\"fetched_at\":null,\"ax_occluded\":false,"
-                + "\"source\":\"ax_live\",\"data\":[]}"
+                + "\"source\":\"ax_live\",\"data\":[]}",
+            customMutants: [
+                .init(.malformed, "not json"),
+                .init(.malformed, "{}"),
+                // The contradiction a flat enum over both scopes would have let through: a read
+                // claiming it covered everything while naming the viewport-limited scope.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":true,\"scope\":\"visible_arrange_area\",\"regions\":[],\"returned_count\":0}"
+                ),
+                // The mirror: limited, but naming the whole-arrangement scope.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":false,\"scope\":\"whole_arrangement\",\"regions\":[],\"returned_count\":0,"
+                        + "\"reason\":\"logic_ax_viewport_only\"}"
+                ),
+                // Limited, correct scope, but declining to say WHY it is limited.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":false,\"scope\":\"visible_arrange_area\",\"regions\":[],\"returned_count\":0}"
+                ),
+                // A reader that advertises three and ships one. The constraint list this oracle
+                // replaced could not express this at all, in either branch.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":true,\"scope\":\"whole_arrangement\",\"returned_count\":3,"
+                        + "\"regions\":[{\"name\":\"Audio 1\"}]}"
+                ),
+                // `complete` stringified -- NSNumber/String confusion must not pass.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":\"true\",\"scope\":\"whole_arrangement\",\"regions\":[],\"returned_count\":0}"
+                ),
+            ]
         ),
         .projectExportPlan: SemanticOracleFixture(
             response: """

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -270,6 +270,26 @@ enum SemanticOracleFixtures {
                     .wellFormedButWrong,
                     "{\"complete\":\"true\",\"scope\":\"whole_arrangement\",\"regions\":[],\"returned_count\":0}"
                 ),
+                // A review's counterexample: on Darwin a JSON boolean is a CFBoolean-backed
+                // NSNumber, so `as? Int` bridged this to 0 and it agreed with an empty array.
+                // The constraint list this closure replaced rejected it.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":false,\"scope\":\"visible_arrange_area\","
+                        + "\"reason\":\"logic_ax_viewport_only\",\"regions\":[],\"returned_count\":false}"
+                ),
+                // Complete, yet naming a limitation it also claims not to have.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":true,\"scope\":\"whole_arrangement\",\"regions\":[],"
+                        + "\"returned_count\":0,\"reason\":\"bogus_limitation\"}"
+                ),
+                // "is an array" was the whole of the old check; nulls are not regions.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"complete\":true,\"scope\":\"whole_arrangement\",\"regions\":[null],"
+                        + "\"returned_count\":1}"
+                ),
             ]
         ),
         .projectExportPlan: SemanticOracleFixture(

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -759,6 +759,33 @@ struct SemanticOracleMutationTests {
     /// the target position removed. The envelope must bind that equality:
     /// otherwise stable reads, typed counts, and echoed target metadata can
     /// falsely certify a no-op or the deletion of a marker at another position.
+    /// The branch this oracle was widened FOR, asserted positively.
+    ///
+    /// A review pointed out that the change shipped seven negative mutants and never once showed
+    /// that the response it exists to accept actually passes. Negatives alone are satisfied by an
+    /// oracle that rejects everything, which is the opposite failure from the one being fixed.
+    ///
+    /// This payload is the shape measured live on Logic 12.3 against the empty fixture project:
+    /// every region visible, so the read is complete, names the whole arrangement, and has no
+    /// limitation to explain.
+    @Test func getRegionsOracleAcceptsTheCompleteWholeArrangementBranch() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.projectGetRegions])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[.projectGetRegions])
+
+        let complete = """
+            {"complete":true,"scope":"whole_arrangement","regions":[],"returned_count":0,\
+            "_debug":{"layoutItems":0,"nonRegion":0,"track_headers":1,"track_headers_in_viewport":1}}
+            """
+        let accepted = try #require(oracle.evaluate(
+            responseData: Data(complete.utf8), readbackData: fixture.readbackData))
+        #expect(accepted, "the complete/whole_arrangement branch must qualify — it is why this oracle changed")
+
+        // And the branch that already worked still does, so widening did not trade one for the other.
+        let stillHonest = try #require(oracle.evaluate(
+            responseData: fixture.responseData, readbackData: fixture.readbackData))
+        #expect(stillHonest, "the viewport-limited branch stopped qualifying")
+    }
+
     @Test func deleteMarkerOracleRequiresTheExactSettledPositionMultiset() throws {
         let oracle = try #require(SemanticOracleTable.byOperationID[.navigateDeleteMarker])
         let fixture = try #require(SemanticOracleFixtures.byOperationID[.navigateDeleteMarker])


### PR DESCRIPTION
Fifth slice of #373 Phase A, and the only one that edits a **grader**. It took three gate refusals and a review BLOCK to get right, each catching something my own care missed.

## The bug

```
oracle expected                      live actual
complete == false                 →  true
scope == visible_arrange_area     →  "whole_arrangement"
reason == logic_ax_viewport_only  →  absent
```

The product emits `scope: complete ? "whole_arrangement" : "visible_arrange_area"` (`AccessibilityChannel+Regions.swift:53`) — **both branches are its contract.** The oracle pinned only the viewport-limited one, so a project whose regions all fit in view failed *for answering correctly*. That includes the `empty` fixture this gate runs against, which is why the case could never pass no matter what the probe sent.

```
get_regions   not_qualified -> passed
passed  16 -> 17 · semantic_mismatch 2 -> 1
```

## What the controls caught

**Gate 1 — `sanctionedCustomOperationIDs`.** I converted a declarative constraint list into an arbitrary closure without declaring it. That ratchet exists so the conversion is a conscious, documented act. It isn't avoidable here: `complete` decides which scope is legal and whether `reason` is required, and the constraint model has no implication case.

**Gate 2 — the mutation-kind requirement.** I sanctioned a closure without ever showing it can fail. *"An escape hatch with no failing mutant is unfalsifiable."*

**Review — my central claim was false.** I argued this only *tightened* the grader. The counterexample:

```json
{"complete":false,"scope":"visible_arrange_area",
 "reason":"logic_ax_viewport_only","regions":[],"returned_count":false}
```

On Darwin a JSON boolean is a CFBoolean-backed `NSNumber`, so `as? Int` bridged `false` to `0` and the count agreed with an empty array. The `.numericRange` constraint I replaced went through `JSONInspector.number`, which rejects CFBooleans outright — **an old-reject/new-accept case, inside a change whose whole argument was that no such case existed.**

Verified both ways rather than taken on faith: with `as? Int` restored the oracle **survives** the mutant and the suite goes red; with the guarded read it rejects it.

Three more from the same review, all real:

- the complete branch ignored `reason`, so a response could claim it covered everything while naming a limitation it also claimed not to have
- `regions` was only checked to *be* an array, so `[null]` passed; the product emits `[RegionInfo]`
- **ten negative mutants and not one positive test.** Negatives alone are satisfied by an oracle that rejects everything — the opposite failure from the one being fixed. The complete branch is now asserted to PASS, alongside the viewport branch.

## Net effect on strictness

Now genuinely stronger than what it replaced, in ways the constraint model could not express:

```
returned_count must EQUAL regions.count      (new; old checked them independently)
returned_count must not be a CFBoolean       (parity with the old .numericRange)
regions elements must be objects             (old: "is an array")
complete:true must carry no reason           (old: unchecked)
complete/scope coupling enforced both ways   (old: single branch only)
```

## Gate

```
SHIP GATE PASS @ b53f5919 — 3916 tests · live evidence bound to head
```

## Reported, not bundled

`audio.recommend_eq` has the same one-branch shape: its `noSafeRecommendation` path returns empty bands without `isError` while the oracle demands a non-empty array. I had audited `analyze_spectrum` for this and correctly cleared it — its `complete:false` comes from `failClosed()` with zero confidence — but missed this one. Its own change, its own mutants.
