### PR TITLE
fix(#373): the recommend_eq oracle pinned one of two success branches

### DIFF
--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -538,7 +538,7 @@ enum SemanticOracleTable {
     ///
     /// The root cause is a gap in the constraint data model, not laziness: a
     /// constraint binds to ONE payload and has no cross-check case, and there is
-    /// no implication case. For these eight the only honest checks ARE
+    /// no implication case. For these nine the only honest checks ARE
     /// cross-checks and conditionals. Forcing them under a numeric cap would
     /// have produced tautological oracles (`enumMember` over a field a
     /// `typedField` already types) — checkbox oracles of exactly the kind this
@@ -566,6 +566,8 @@ enum SemanticOracleTable {
         // Expressing it as an enum over both scopes would accept a response claiming
         // `complete: true` while naming the viewport scope -- weaker than what it replaces.
         .projectGetRegions,
+        // Same shape as projectGetRegions: two success branches, and a flat list can only pin one.
+        .audioRecommendEQ,
     ]
 
     static var customOracles: [OperationOracle] { all.filter { $0.strength == .custom } }
@@ -964,16 +966,46 @@ enum SemanticOracleTable {
     // directly. The default six-bands-per-octave grid keeps a detected
     // resonance's Q at or below 10; recommendEQ makes gainDb non-positive.
     static let audioRecommendEQ = OperationOracle(
-        .audioRecommendEQ,
-        strength: .shapeAndDomain,
-        constraints: [
-            .nonEmptyArray(key: "bands"),
-            .numericRange(key: "bands.0.centerHz", min: 20, max: 20_000),
-            .typedField(key: "bands.0.gainDb", type: .number),
-            .numericRange(key: "bands.0.q", min: 0, max: 10),
-            .valueEquals(key: "bands.0.reason", expected: .string("resonance_cut")),
-        ]
-    )
+        custom: .audioRecommendEQ,
+        reason: """
+            `EQRecommendationOutcome` has TWO success branches and the handler \
+            returns both without `isError`: a recommendation, or a safe refusal \
+            carrying a reason. `recommendEQ` declines on analysis_incomplete, \
+            confidence_below_minimum, and source_classification_unknown -- it \
+            measured, then judged the measurement insufficient to cut safely. \
+            Declining IS the contract there, which is why it is not an error. \
+            A `nonEmptyArray` constraint pins only the recommending branch and \
+            fails the operation for behaving correctly; the constraint model \
+            has no implication case, so the branch lives in the closure.
+            """
+    ) { responseData, _ in
+        guard let response = JSONInspector.parse(responseData) as? [String: Any],
+              let bands = response["bands"] as? [Any] else {
+            return false
+        }
+        guard let first = bands.first else {
+            // The refusal branch. It must NAME why it declined, and only with a reason the engine
+            // can actually produce -- an empty band list with an invented excuse is not a safe
+            // refusal, it is an unexplained one.
+            let known = ["analysis_incomplete", "confidence_below_minimum", "source_classification_unknown"]
+            guard let reason = response["reason"] as? String, known.contains(reason) else {
+                return false
+            }
+            return true
+        }
+        // The recommending branch keeps every obligation the constraint list carried.
+        guard let band = first as? [String: Any],
+              let centerHz = JSONInspector.number(of: band["centerHz"] ?? NSNull()),
+              centerHz >= 20, centerHz <= 20_000,
+              JSONInspector.number(of: band["gainDb"] ?? NSNull()) != nil,
+              let q = JSONInspector.number(of: band["q"] ?? NSNull()),
+              q >= 0, q <= 10,
+              band["reason"] as? String == "resonance_cut" else {
+            return false
+        }
+        // A recommendation that also claims it could not recommend is contradicting itself.
+        return response["reason"] == nil || response["reason"] is NSNull
+    }
 
     // MARK: - midi
 

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -378,7 +378,39 @@ enum SemanticOracleFixtures {
                 {"bands":[{"centerHz":5001.953125,"gainDb":-36.0,"q":8.6,\
                 "reason":"resonance_cut"}]}
                 """,
-            readback: health
+            readback: health,
+            customMutants: [
+                .init(.malformed, "not json"),
+                .init(.malformed, "{}"),
+                // An empty band list is the REFUSAL branch, and a refusal that will not say why
+                // is not a safe refusal -- it is an unexplained one.
+                .init(.wellFormedButWrong, "{\"bands\":[]}"),
+                // Declining for a reason the engine cannot produce.
+                .init(.wellFormedButWrong, "{\"bands\":[],\"reason\":\"because_i_said_so\"}"),
+                // Recommending AND claiming it could not recommend.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"bands\":[{\"centerHz\":5000,\"gainDb\":-36.0,\"q\":8.6,"
+                        + "\"reason\":\"resonance_cut\"}],\"reason\":\"confidence_below_minimum\"}"
+                ),
+                // A cut outside the audible range the old constraint pinned.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"bands\":[{\"centerHz\":19,\"gainDb\":-36.0,\"q\":8.6,\"reason\":\"resonance_cut\"}]}"
+                ),
+                // A band that is not a resonance cut.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"bands\":[{\"centerHz\":5000,\"gainDb\":-36.0,\"q\":8.6,\"reason\":\"guesswork\"}]}"
+                ),
+                // CFBoolean where a number belongs -- the hole a review found in get_regions.
+                .init(
+                    .wellFormedButWrong,
+                    "{\"bands\":[{\"centerHz\":false,\"gainDb\":-36.0,\"q\":8.6,\"reason\":\"resonance_cut\"}]}"
+                ),
+                // A scalar where a band object belongs.
+                .init(.wellFormedButWrong, "{\"bands\":[5000]}"),
+            ]
         ),
         .midiListPorts: SemanticOracleFixture(
             response: """

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -759,6 +759,29 @@ struct SemanticOracleMutationTests {
     /// the target position removed. The envelope must bind that equality:
     /// otherwise stable reads, typed counts, and echoed target metadata can
     /// falsely certify a no-op or the deletion of a marker at another position.
+    /// `recommend_eq`'s refusal branch, asserted positively — the same omission a review caught in
+    /// the get_regions change, where ten negative mutants shipped without one positive case.
+    ///
+    /// `recommendEQ` declines on analysis_incomplete, confidence_below_minimum, and
+    /// source_classification_unknown. It measured and judged the measurement insufficient to cut
+    /// safely; declining IS the contract, which is why the handler returns it without `isError`.
+    @Test func recommendEQOracleAcceptsASafeRefusalThatNamesItsReason() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.audioRecommendEQ])
+        let fixture = try #require(SemanticOracleFixtures.byOperationID[.audioRecommendEQ])
+
+        for reason in ["analysis_incomplete", "confidence_below_minimum", "source_classification_unknown"] {
+            let refusal = "{\"bands\":[],\"reason\":\"\(reason)\"}"
+            let accepted = try #require(oracle.evaluate(
+                responseData: Data(refusal.utf8), readbackData: fixture.readbackData))
+            #expect(accepted, "safe refusal \(reason) must qualify — declining is the contract")
+        }
+
+        // And the recommending branch still qualifies, so widening did not trade one for the other.
+        let stillHonest = try #require(oracle.evaluate(
+            responseData: fixture.responseData, readbackData: fixture.readbackData))
+        #expect(stillHonest, "the recommending branch stopped qualifying")
+    }
+
     /// The branch this oracle was widened FOR, asserted positively.
     ///
     /// A review pointed out that the change shipped seven negative mutants and never once showed


### PR DESCRIPTION
The instance I missed. A review found it after I had audited this defect class and cleared `analyze_spectrum` — correctly, as it turns out, but I stopped one oracle short.

## Two success branches, one pinned

`EQRecommendationOutcome` has two success branches and the handler returns **both** without `isError`:

```swift
case .recommendation(let bands):        toolTextResult(EQRecommendationResponse(bands: bands))
case .noSafeRecommendation(let reason): toolTextResult(EQRecommendationResponse(bands: [], reason: reason))
```

`recommendEQ` declines on `analysis_incomplete`, `confidence_below_minimum`, and `source_classification_unknown`. It **measured**, then judged the measurement insufficient to cut safely. Declining *is* the contract, which is why it is not an error.

The oracle required `.nonEmptyArray(key: "bands")` — so it failed the operation for behaving correctly.

## Why `analyze_spectrum` was right to leave alone

I checked this distinction because I have had it wrong in both directions today:

```
analyze_spectrum   complete:false  <- failClosed(), zero confidence, no bands   oracle CORRECT to reject
recommend_eq       bands:[] + reason <- measured, then safely declined          oracle WRONG to reject
```

Two fields that look alike and mean different things. Accepting `analyze_spectrum`'s false branch would launder a failed analysis into a semantic pass; accepting this one records that the product declined for a reason it can actually produce.

## This does not move the counts

The spectral commands are flag-gated, so this oracle is unreachable in a production-contract run. That is exactly why the bug survived: **a grader nothing runs is a grader nobody has watched.** It would mis-grade the moment `LOGIC_MCP_ADR012_SPECTRAL_EQ` is set.

## Nine mutants and a positive test, both watched to fail

The refusal branch must **name** a reason the engine can actually produce — an empty band list with an invented excuse is an unexplained refusal, not a safe one. A recommendation must not also claim it could not recommend. And `centerHz` must reject a **CFBoolean**, which is the hole the same review found in the `get_regions` closure — closed here before it could be repeated in a second closure.

The positive test was verified to fail against the old single-branch behaviour, so it is load-bearing rather than decorative.

## Gate

```
SHIP GATE PASS @ 57ba4237 — 3917 tests · live evidence bound to head
```

Custom-oracle count corrected to nine, and `audioRecommendEQ` entered in `sanctionedCustomOperationIDs` with its reason — the two ratchets that refused the `get_regions` change, satisfied up front this time rather than after being caught.
