### PR TITLE
fix(#284): retry the health read when the UI locale is unreadable, not when it disagrees

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -544,7 +544,27 @@ struct QualificationTransport: Sendable {
 
         do {
             let handshake = try initialize(session)
-            let healthBefore = try health(session, id: 2, phase: "health_before")
+            // The UI locale comes from a MENU-BAR read (`AXLogicProElements+Menu.swift:25`): the
+            // observed top-level titles must contain one language's full set. That read is
+            // TRANSIENTLY EMPTY -- measured, three consecutive fresh processes reported `unknown`
+            // and two reads seconds later reported `en-US`, with Logic untouched between them.
+            //
+            // Sampling it once meant a single unreadable read aborted the entire run, and the guard
+            // downstream reported it as a locale MISMATCH for a locale that was correct. That
+            // message cost eight wrong explanations before the mechanism was found.
+            //
+            // Retried ONLY while the value is unrecognised. A recognised locale -- en-US or ko-KR --
+            // stops immediately even when it is the WRONG one, because that is a real mismatch and
+            // must still fail closed. Retrying an unrecognised value cannot convert a genuine
+            // ko-KR run into an en-US pass: ko-KR is recognised and exits the loop on the first read.
+            var healthBefore = try health(session, id: 2, phase: "health_before")
+            var localeRetryID = 900
+            while QualificationLocale(rawValue: healthBefore.value.logicProUILocale) == nil,
+                  localeRetryID < 906 {
+                Thread.sleep(forTimeInterval: 1.5)
+                healthBefore = try health(session, id: localeRetryID, phase: "health_before_retry")
+                localeRetryID += 1
+            }
             let catalogBefore = try catalog(session, id: 3, phase: "catalog_before")
             let baselineTraceList = try traces(session, id: 4)
             let baselineTraceIDs = Set(baselineTraceList.traces.map(\.traceID))


### PR DESCRIPTION
A single unreadable menu-bar sample was discarding entire qualification runs, and the guard reported it as a **locale mismatch for a locale that was correct**.

## The failure

```
--qualify: "Logic Pro UI locale mismatch: expected en-US, observed unknown"   15+ consecutive
direct health read:  en-US, throughout
```

**I was wrong about the cause eight times** — TCC inheritance, an intervening shell, process depth, environment stripping, launch settle, first-read settle, Logic not being frontmost, accumulated AX state. A fresh Logic relaunch with a fully readable menu bar still failed.

## The mechanism, measured

The locale is derived from a **menu-bar read** (`AXLogicProElements+Menu.swift:25`): one language's full set of top-level titles must be a subset of what AX observes, or the result is `nil` → `unknown`.

**That read is transiently empty.** Three consecutive fresh processes reported `unknown`; two reads seconds later reported `en-US`, with Logic untouched between them.

The qualification sampled it exactly once, so one unreadable sample threw away the run — and `unknown` collapses *"could not read"* with *"read, matched nothing"*, so the guard downstream named a cause that was not the cause. That message is precisely what cost eight wrong explanations.

## The fix, and its limit

Retried **only while the value is unrecognised**. A recognised locale stops the loop immediately **even when it is the wrong one**, because that is a real mismatch and must still fail closed.

This cannot turn a genuine ko-KR run into an en-US pass: ko-KR is recognised and exits on the first read. An independent review confirmed it — *"I found no current path turning a genuine ko-KR observation into an en-US pass"* — and flagged that the predicate is broader than its original comment claimed, which is now corrected in the comment rather than narrowed in the code (any unrecognised value deserves the retry).

Bounded at 6 attempts, 1.5 s apart: at most 9 s added, and only on a run that would otherwise have aborted.

## Measured

```
3 of 3 consecutive runs completed   (15+ in a row had failed)
passed 18 · failed 1                 operation counts unchanged
SHIP GATE PASS @ 5cdaf9dd — 3917 tests · live evidence bound to head
```

Reliability only — no operation changes status.
