### PR TITLE
release: sync Formula sha256 to v3.14.0 tarball

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -15,7 +15,7 @@ class LogicProMcp < Formula
   # LogicProMCP-macOS-universal.tar.gz release artifact.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "83d3f3ffc1651917da077da24fa43c8490c9e32a0c6d29aa8663a0085007c2b9"
+    sha256 "0a0e221cadb7f61b28b77c97ade70650d41ef09cee47394914030c2a66a1a45e"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
Closes the window opened by the v3.14.0 release commit.

The hash cannot be known before the tag exists, because the tag is what triggers the build that produces the artifact. Taken from the published `SHA256SUMS.txt`:

```
0a0e221cadb7f61b28b77c97ade70650d41ef09cee47394914030c2a66a1a45e  LogicProMCP-macOS-universal.tar.gz
```

Verified against the published release rather than asserted — the file was fetched from the v3.14.0 release and the binary inside it checked: `Mach-O universal binary with 2 architectures [x86_64] [arm64]`.

Until this lands, `brew install` is **fail-closed**: Homebrew verifies the downloaded tarball against the formula hash, so an install during the window is refused rather than served a wrong binary.