### PR TITLE
feat(#289): source priority in the cache commit rule

### DIFF
--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -31,6 +31,13 @@ actor StateCache {
     private var projectEpoch: UInt64 = 0
     private var sectionRevisions: [CacheSectionID: UInt64] = [:]
     private var droppedStaleWriteCounts: [CacheSectionID: UInt64] = [:]
+    /// Which source produced each committed revision, per section. ADR-006's commit rule has to
+    /// answer "was everything committed since my observation lower-priority than me?", and that is
+    /// a question about the commits in the GAP, not about the newest one alone: a background poll
+    /// landing on top of an explicit read would otherwise let a subscription refresh erase the read
+    /// it never outranked. Bounded — entries at or below the observable window are pruned.
+    private var revisionSources: [CacheSectionID: [UInt64: RefreshSource]] = [:]
+    private static let revisionSourceWindow: UInt64 = 64
 
     /// Whether Logic Pro has an open document with a visible window.
     /// Defaults to true (optimistic) — StatePoller sets to false when no document detected.
@@ -266,8 +273,35 @@ actor StateCache {
         }
     }
 
-    private func advanceSectionRevision(_ section: CacheSectionID) {
-        sectionRevisions[section, default: 0] += 1
+    private func advanceSectionRevision(_ section: CacheSectionID, source: RefreshSource = .explicitRead) {
+        let next = sectionRevisions[section, default: 0] + 1
+        sectionRevisions[section] = next
+        var history = revisionSources[section, default: [:]]
+        history[next] = source
+        if next > Self.revisionSourceWindow {
+            let floor = next - Self.revisionSourceWindow
+            history = history.filter { $0.key >= floor }
+        }
+        revisionSources[section] = history
+    }
+
+    /// True when every revision committed after `observed` came from a source this write strictly
+    /// outranks. An unknown revision (pruned, or written before sources were recorded) is treated
+    /// as NOT displaceable: forgetting who wrote something is not evidence that it was unimportant.
+    private func everyCommitInGapIsOutrankedBy(
+        _ source: RefreshSource,
+        section: CacheSectionID,
+        observed: SectionVersion
+    ) -> Bool {
+        let current = sectionRevisions[section, default: 0]
+        guard current > observed.sectionRevision else { return false }
+        let history = revisionSources[section, default: [:]]
+        var revision = observed.sectionRevision + 1
+        while revision <= current {
+            guard let committed = history[revision], committed.rank < source.rank else { return false }
+            revision += 1
+        }
+        return true
     }
 
     /// Advances the cache's project epoch without changing section content.
@@ -284,8 +318,23 @@ actor StateCache {
     /// per-section diagnostic counter records the drop.
     private func accepts(
         _ observed: SectionVersion,
-        for section: CacheSectionID
+        for section: CacheSectionID,
+        source: RefreshSource = .explicitRead
     ) -> Bool {
+        // A stale revision is not automatically a stale VALUE. When everything committed since the
+        // observation came from sources this write strictly outranks, the refusal would be the
+        // inversion ADR-006 forbids — a slow background poll burying a mutation verification that
+        // read the same generation. A stale project epoch is never displaceable: the value is about
+        // a different project, and no amount of authority makes it true here.
+        if projectEpoch == observed.projectEpoch,
+           everyCommitInGapIsOutrankedBy(source, section: section, observed: observed) {
+            Log.debug(
+                "priority displacement for \(section.rawValue): \(source.rawValue) overrides "
+                + "rev \(observed.sectionRevision)..\(sectionRevisions[section, default: 0])",
+                subsystem: "cache"
+            )
+            return true
+        }
         guard projectEpoch == observed.projectEpoch,
               sectionRevisions[section, default: 0] == observed.sectionRevision else {
             droppedStaleWriteCounts[section, default: 0] += 1
@@ -309,8 +358,17 @@ actor StateCache {
     /// was captured before the read that produced it.
     @discardableResult
     func updateTransport(_ state: TransportState, ifCurrent observed: SectionVersion) -> Bool {
-        guard accepts(observed, for: .transport) else { return false }
-        updateTransport(state)
+        updateTransport(state, ifCurrent: observed, source: .explicitRead)
+    }
+
+    func updateTransport(
+        _ state: TransportState,
+        ifCurrent observed: SectionVersion,
+        source: RefreshSource
+    ) -> Bool {
+        guard accepts(observed, for: .transport, source: source) else { return false }
+        transport = state
+        advanceSectionRevision(.transport, source: source)
         return true
     }
 

--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -273,7 +273,7 @@ actor StateCache {
         }
     }
 
-    private func advanceSectionRevision(_ section: CacheSectionID, source: RefreshSource = .explicitRead) {
+    private func advanceSectionRevision(_ section: CacheSectionID, source: RefreshSource = .backgroundPoll) {
         let next = sectionRevisions[section, default: 0] + 1
         sectionRevisions[section] = next
         var history = revisionSources[section, default: [:]]
@@ -319,7 +319,7 @@ actor StateCache {
     private func accepts(
         _ observed: SectionVersion,
         for section: CacheSectionID,
-        source: RefreshSource = .explicitRead
+        source: RefreshSource = .backgroundPoll
     ) -> Bool {
         // A stale revision is not automatically a stale VALUE. When everything committed since the
         // observation came from sources this write strictly outranks, the refusal would be the
@@ -357,8 +357,13 @@ actor StateCache {
     /// Applies `state` only if the transport has not changed since `observed`
     /// was captured before the read that produced it.
     @discardableResult
+    /// Source-less overload. It defaults to `.backgroundPoll`, the LOWEST rank, because every
+    /// caller of the conditional writes today is `StatePoller` — a background loop. Defaulting to
+    /// anything higher would label a background poll authoritative, which is the exact mislabelling
+    /// ADR-006's priority rule exists to prevent, and it would do so silently at every call site
+    /// that has not been converted yet. A caller that really is authoritative has to say so.
     func updateTransport(_ state: TransportState, ifCurrent observed: SectionVersion) -> Bool {
-        updateTransport(state, ifCurrent: observed, source: .explicitRead)
+        updateTransport(state, ifCurrent: observed, source: .backgroundPoll)
     }
 
     func updateTransport(

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -281,7 +281,7 @@ actor StatePoller {
             section: .transport,
             axChannel: axChannel, cache: cache, as: TransportState.self
         ) { cache, state, observed in
-            await cache.updateTransport(state, ifCurrent: observed)
+            await cache.updateTransport(state, ifCurrent: observed, source: .backgroundPoll)
         }
         if transportReady { cacheKeys.append(.transport) }
         let mixerReady = await poll(

--- a/Sources/LogicProMCP/State/VersionedSnapshot.swift
+++ b/Sources/LogicProMCP/State/VersionedSnapshot.swift
@@ -35,6 +35,31 @@ struct VersionedSnapshot<Value: Sendable>: Sendable {
     }
 }
 
+/// Who produced a cache write, ranked. ADR-006's commit rule needs this because a bare
+/// compare-and-swap is first-writer-wins: two refreshes that capture the same section revision
+/// race, and the loser's value is discarded no matter which one is authoritative. When the winner
+/// is a slow background poll and the loser is a mutation verification, the cache keeps the older,
+/// less trustworthy read — the inversion the ADR names in "slow background polls must not
+/// overwrite mutation verification".
+///
+/// `rank` is the comparison; the case order is not load-bearing.
+enum RefreshSource: String, Sendable, CaseIterable {
+    case mutationVerification
+    case explicitRead
+    case subscription
+    case backgroundPoll
+
+    /// Higher outranks lower. Only a STRICTLY higher rank may displace an already-committed write.
+    var rank: Int {
+        switch self {
+        case .mutationVerification: return 3
+        case .explicitRead: return 2
+        case .subscription: return 1
+        case .backgroundPoll: return 0
+        }
+    }
+}
+
 enum CacheSectionID: String, Sendable, CaseIterable {
     case transport
     case tracks

--- a/Tests/LogicProMCPTests/Issue289RefreshPriorityTests.swift
+++ b/Tests/LogicProMCPTests/Issue289RefreshPriorityTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// ADR-006's commit rule has four conditions; `StateCache.accepts` implemented two of them
+/// (project epoch, section revision). These cover the third: **source priority**.
+///
+/// The race the ADR names is not hypothetical. Two refreshes capture the same version and both
+/// try to commit; the compare-and-swap lets whichever arrives first win, regardless of which one
+/// is authoritative. `Issue289StaleRefreshTests.concurrentWritesFromSameObservationAllowOnlyOne`
+/// asserted exactly that with `tempo == 101 || tempo == 202`. When the winner is a slow background
+/// poll, a mutation verification's fresher read is thrown away — the ADR's
+/// *"slow background polls must not overwrite mutation verification"*, inverted.
+@Suite("Issue289RefreshPriority")
+struct Issue289RefreshPriorityTests {
+
+    @Test("a background poll cannot bury a mutation verification that observed the same revision")
+    func mutationVerificationDisplacesABackgroundPollFromTheSameObservation() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        // The background poll wins the race to the actor and commits first.
+        let pollApplied = await cache.updateTransport(
+            transport(tempo: 90),
+            ifCurrent: observed,
+            source: .backgroundPoll
+        )
+        #expect(pollApplied)
+
+        // The mutation verification started from the SAME observation and is strictly more
+        // authoritative. Under a bare CAS it is refused and its value is lost.
+        let verifyApplied = await cache.updateTransport(
+            transport(tempo: 140),
+            ifCurrent: observed,
+            source: .mutationVerification
+        )
+
+        #expect(verifyApplied)
+        #expect((await cache.getTransport()).tempo == 140)
+    }
+
+    @Test("the displacement is one-directional — a poll cannot overwrite a verification")
+    func backgroundPollCannotDisplaceAMutationVerification() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        #expect(await cache.updateTransport(
+            transport(tempo: 140), ifCurrent: observed, source: .mutationVerification
+        ))
+
+        let pollApplied = await cache.updateTransport(
+            transport(tempo: 90), ifCurrent: observed, source: .backgroundPoll
+        )
+
+        #expect(!pollApplied)
+        #expect((await cache.getTransport()).tempo == 140)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+    }
+
+    @Test("equal priority keeps first-writer-wins — displacement needs a strictly higher rank")
+    func equalPriorityDoesNotDisplace() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        #expect(await cache.updateTransport(
+            transport(tempo: 90), ifCurrent: observed, source: .backgroundPoll
+        ))
+        let second = await cache.updateTransport(
+            transport(tempo: 91), ifCurrent: observed, source: .backgroundPoll
+        )
+
+        #expect(!second)
+        #expect((await cache.getTransport()).tempo == 90)
+    }
+
+    @Test("a higher-priority commit in the gap blocks displacement, even behind a lower one")
+    func aHigherPriorityCommitInTheGapIsNotDiscarded() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        // Explicit read commits first, then a background poll lands on top of it.
+        #expect(await cache.updateTransport(
+            transport(tempo: 120), ifCurrent: observed, source: .explicitRead
+        ))
+        let afterRead = await cache.currentVersion(for: .transport)
+        #expect(await cache.updateTransport(
+            transport(tempo: 90), ifCurrent: afterRead, source: .backgroundPoll
+        ))
+
+        // A subscription refresh outranks the poll but NOT the explicit read it would erase.
+        let applied = await cache.updateTransport(
+            transport(tempo: 70), ifCurrent: observed, source: .subscription
+        )
+
+        #expect(!applied)
+        #expect((await cache.getTransport()).tempo == 90)
+    }
+
+    @Test("a stale project epoch still refuses, priority cannot override it")
+    func priorityDoesNotOverrideAStaleProjectEpoch() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+        await cache.advanceProjectEpoch()
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 140), ifCurrent: observed, source: .mutationVerification
+        )
+
+        #expect(!applied)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+    }
+
+    /// The previous epoch test never reached the displacement branch: it advanced the epoch
+    /// without advancing the section revision, so the gap was empty and the branch returned early.
+    /// Deleting the epoch guard from that branch changed nothing and no test noticed. This one
+    /// puts a genuinely displaceable commit in the gap AND moves the epoch, so the epoch guard is
+    /// the only thing standing between the write and the cache.
+    @Test("a displaceable gap does not let a write from a previous project epoch through")
+    func epochGuardHoldsInsideTheDisplacementBranch() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        let afterPoll = await cache.updateTransport(
+            transport(tempo: 90), ifCurrent: observed, source: .backgroundPoll
+        )
+        #expect(afterPoll)
+        await cache.advanceProjectEpoch()
+
+        // Outranks everything in the gap, but describes a project that is no longer open.
+        let applied = await cache.updateTransport(
+            transport(tempo: 140), ifCurrent: observed, source: .mutationVerification
+        )
+
+        #expect(!applied)
+        #expect((await cache.getTransport()).tempo == 90)
+    }
+
+    /// The revision→source history is pruned to a bounded window. A revision whose author has been
+    /// forgotten must not be assumed unimportant — treating an unknown as low-priority would let a
+    /// late write erase an arbitrarily authoritative commit just because the cache aged past it.
+    @Test("a commit whose source has been pruned from history is not displaceable")
+    func prunedHistoryIsNotTreatedAsLowPriority() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        // Push the observed revision out of the retained window.
+        for tempo in 0..<70 {
+            _ = await cache.updateTransport(
+                transport(tempo: Double(60 + tempo)),
+                ifCurrent: await cache.currentVersion(for: .transport),
+                source: .backgroundPoll
+            )
+        }
+        let surviving = (await cache.getTransport()).tempo
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 140), ifCurrent: observed, source: .mutationVerification
+        )
+
+        #expect(!applied)
+        #expect((await cache.getTransport()).tempo == surviving)
+    }
+
+    private func transport(tempo: Double) -> TransportState {
+        var state = TransportState()
+        state.tempo = tempo
+        state.lastUpdated = Date()
+        return state
+    }
+}

--- a/Tests/LogicProMCPTests/Issue289RefreshPriorityTests.swift
+++ b/Tests/LogicProMCPTests/Issue289RefreshPriorityTests.swift
@@ -161,6 +161,25 @@ struct Issue289RefreshPriorityTests {
         #expect((await cache.getTransport()).tempo == surviving)
     }
 
+    /// Every caller of the conditional writes today is `StatePoller`, a background loop. If the
+    /// source-less overload defaulted to anything above the bottom rank, those writes would be
+    /// labelled authoritative and could not be displaced by a real mutation verification — the
+    /// mislabelling this rule exists to prevent, applied silently to every unconverted call site.
+    @Test("the source-less overload is the lowest rank, so unconverted callers stay displaceable")
+    func sourcelessWritesAreNotTreatedAsAuthoritative() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+
+        #expect(await cache.updateTransport(transport(tempo: 90), ifCurrent: observed))
+
+        let applied = await cache.updateTransport(
+            transport(tempo: 140), ifCurrent: observed, source: .mutationVerification
+        )
+
+        #expect(applied)
+        #expect((await cache.getTransport()).tempo == 140)
+    }
+
     private func transport(tempo: Double) -> TransportState {
         var state = TransportState()
         state.tempo = tempo


### PR DESCRIPTION
First increment of ADR-006 (#289): the cache commit rule learns **who is asking**.

## The gap, and why it was not hypothetical

`StateCache.accepts` implemented two of the ADR's four commit conditions — project epoch and section revision. A bare compare-and-swap is first-writer-wins, so two refreshes that capture the same revision race and the loser is discarded regardless of authority. When the winner is a slow background poll and the loser is a mutation verification, the cache keeps the older, less trustworthy read. That is the ADR's *"slow background polls must not overwrite mutation verification"*, inverted.

It was already written down as accepted behaviour: `Issue289StaleRefreshTests.concurrentWritesFromSameObservationAllowOnlyOne` asserts `surviving.tempo == 101 || surviving.tempo == 202`. **That test still passes unchanged.** This adds an ordering it never constrained rather than rewriting what it claimed.

## The rule

`RefreshSource` ranks the four sources the ADR names. A write may displace already-committed revisions only when **every commit in the gap** is strictly outranked — the question is about the gap, not the newest commit alone, or a background poll landing on top of an explicit read would let a subscription refresh erase a read it never outranked. Two clauses hold the edges:

- a revision whose author has been pruned from the bounded history is **not** displaceable — forgetting who wrote something is not evidence it was unimportant;
- a stale project epoch is never displaceable at any rank — that value describes a different project.

## A defect I introduced and caught before review

I defaulted the source-less overload to `.explicitRead`, then checked who actually calls these. Every caller today is `StatePoller` — a background loop by its own file comment. That default would have labelled every poll second-highest, so a poll could not be displaced by anything below a mutation verification: the exact mislabelling this rule exists to prevent, applied silently at every unconverted call site. The default is now `.backgroundPoll`, the bottom rank.

## Mutation-tested, and the first pass found two dead guards of mine

```
unknown revision is displaceable        0 -> 4 failing
epoch guard removed from the branch     0 -> 4 failing
equal rank displaces                         16 failing
source-less defaults to explicitRead          5 failing
```

The epoch one is the instructive failure: I had written a test for it, believed it covered the branch, and it never entered the branch at all — it advanced the epoch without advancing the revision, so the gap was empty and the function returned early. A test aimed at the wrong place looks identical to a test that passes.

## Scope — counted, not estimated

```
conditional-write overloads on StateCache   11
overloads taking an explicit source          4   (transport)
call sites still on the source-less form     4   (project, tracks x2, channelStrips)
```

The half-converted state fails safe: unconverted callers take the bottom rank and stay displaceable. But priority distinguishes nothing in those sections yet.

**Not done, and not measured:** `RefreshCoordinator` (single-flight, coalescing, deadlines, backpressure) does not exist; subscription backpressure is untouched; the benchmark matrix the ADR names (128/256, synthetic 1,000 tracks, 50 subscriptions) needs fixtures that do not exist.

Behaviour is unchanged when `FeatureFlags.adr006VersionedCache` is off — this path is the conditional write itself, not the flag-gated envelope.
