### PR TITLE
test(#289): pin the postPoll coupling — a slow subscriber holds the poller

### DIFF
--- a/Tests/LogicProMCPTests/Issue289PostPollCouplingTests.swift
+++ b/Tests/LogicProMCPTests/Issue289PostPollCouplingTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// ADR-006 asks for bounded per-client subscription queues. There are no queues at all:
+/// `ResourceSubscriptions.publishChangedResources` awaits `notify(uri)` inline, and that publish
+/// runs as `StatePoller`'s `postPoll` callback (`LogicProServer.swift:387`), reached from
+/// `finishPoll` — a private method, so it executes **inside the poller actor**.
+///
+/// The consequence is not the unbounded-queue growth the ADR anticipates. It is the opposite
+/// shape: a slow subscriber holds the actor, and the poller cannot start its next cycle. No test
+/// covered `postPoll` at all before this one, so the coupling was load-bearing and unpinned.
+@Suite("Issue289PostPollCoupling")
+struct Issue289PostPollCouplingTests {
+
+    @Test("a slow postPoll delays the poll that follows it — the subscriber is in the poller's path")
+    func aSlowPostPollBlocksTheNextPoll() async {
+        let cache = StateCache()
+        // The AX side is irrelevant here: what is measured is whether the poller's own actor is
+        // held by postPoll, which happens whether or not the poll reads anything.
+        let channel = AccessibilityChannel()
+
+        let delay = Duration.milliseconds(300)
+        let poller = StatePoller(
+            axChannel: channel,
+            cache: cache,
+            runtime: .init(hasVisibleWindow: { true }),
+            postPoll: { _ in try? await Task.sleep(for: delay) }
+        )
+
+        // A bare threshold on the slow run is not evidence: the poll itself costs time on this
+        // machine (measured ~1.1s with an empty postPoll), so `elapsed >= 300ms` passes whether or
+        // not postPoll contributes anything. The difference between the two runs is what isolates
+        // it, so both are measured here and compared.
+        let slowStart = ContinuousClock().now
+        await poller.refreshNow()
+        let slow = slowStart.duration(to: ContinuousClock().now)
+
+        let fastPoller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { true }),
+            postPoll: { _ in }
+        )
+        let fastStart = ContinuousClock().now
+        await fastPoller.refreshNow()
+        let fast = fastStart.duration(to: ContinuousClock().now)
+
+        // postPoll is awaited inside the actor-isolated finishPoll, so its cost lands on the
+        // refresh. A design that handed the notification off would show no such difference.
+        #expect(slow - fast >= delay / 2,
+                "slow=\(slow) fast=\(fast) — postPoll should add ~\(delay) to the refresh")
+    }
+
+}


### PR DESCRIPTION
Pins a coupling ADR-006 (#289) cares about, which no test touched. **No production code.**

## The finding

ADR-006 asks for **bounded per-client subscription queues**. There are no queues at all:

```
ResourceSubscriptions.publishChangedResources   awaits notify(uri) inline, in the loop
LogicProServer.swift:387                        that publish IS StatePoller's postPoll callback
StatePoller.finishPoll                          private -> actor-isolated
```

So the hazard is not the unbounded-queue growth the ADR anticipates — it is the opposite shape. **A slow subscriber holds the poller actor and the next poll cannot start.** Having no queue is not the same as being safe.

`grep -rln postPoll Tests/` returned nothing before this PR: the coupling was load-bearing and entirely unpinned.

## The first version of this test was wrong, and its control caught it

I asserted `elapsed >= 300ms` on a refresh with a 300ms `postPoll`. The control — the same refresh with an empty `postPoll` — **failed**: the poll itself costs ~1.1s on this machine, so the threshold was satisfied whether or not the callback contributed anything.

That is a check an unrelated cost can satisfy. It now measures both runs and asserts on the **difference**, which is the only part attributable to `postPoll`.

## Mutation-tested

```
postPoll handed off with Task.detached   3 assertions fail
```

If someone later decouples the notification — which is what the ADR is reaching for — this test fails loudly and says why, instead of the coupling quietly disappearing or quietly staying.

## What this does not claim

It does not show a slow subscriber exists in practice, or that the delay matters to any real client. It shows the path is coupled and that the coupling is now measurable. The ADR's benchmark matrix remains **unmeasured** — the fixtures it names (128/256, synthetic 1,000 tracks, 50 subscriptions) do not exist.

Gate: `SHIP GATE PASS` at `c04993d7`, full suite 3922 tests.
