### PR TITLE
fix(#668): refresh_cache moves to the medium deadline class

### DIFF
--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -645,7 +645,18 @@ enum OperationRegistry {
     } + ([
         (.systemHealth, "health", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, []),
         (.systemPermissions, "permissions", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, []),
-        (.systemRefreshCache, "refresh_cache", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, []),
+        // #668 — `.short` (25s) was wrong for this one. `refresh_cache` drives a full poll cycle,
+        // whose cost grows with project size: measured median 12.6s on a 74-track project, with
+        // roughly 1 call in 5 hitting the 25s ceiling and returning `operation_timeout`.
+        //
+        // `.medium` (90s) is NOT a computed headroom figure. The 74-track maximum is CENSORED —
+        // every sample at ~26.67s was cut by the old deadline, so the true maximum is unknown and
+        // any multiple of the median would be arithmetic on a truncated distribution. This is a
+        // deliberately generous class chosen so the operation can finish, not a measurement.
+        //
+        // This is mitigation, not a fix: the cycle still costs what it costs, and a large enough
+        // project will exhaust 90s too. Splitting the poll cycle per section closes #668.
+        (.systemRefreshCache, "refresh_cache", Mutability.readOnly, DeadlineClass.medium, VerificationPolicy.none, []),
         (.systemListRecentTraces, "list_recent_traces", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, ["limit"]),
         (.systemGetTrace, "get_trace", Mutability.readOnly, DeadlineClass.short, VerificationPolicy.none, ["trace_id"]),
         // WHY: trace deletion destroys internal evidence, not Logic state, so it stays readOnly and bypasses the Logic-write gate.

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -354,7 +354,7 @@ struct OperationRegistryTests {
         ("logic_audio", "audio.recommend_eq", "recommend_eq", .readOnly, .short, .none),
         ("logic_system", "system.health", "health", .readOnly, .short, .none),
         ("logic_system", "system.permissions", "permissions", .readOnly, .short, .none),
-        ("logic_system", "system.refresh_cache", "refresh_cache", .readOnly, .short, .none),
+        ("logic_system", "system.refresh_cache", "refresh_cache", .readOnly, .medium, .none),   // #668
         ("logic_system", "system.list_recent_traces", "list_recent_traces", .readOnly, .short, .none),
         ("logic_system", "system.get_trace", "get_trace", .readOnly, .short, .none),
         ("logic_system", "system.clear_traces", "clear_traces", .readOnly, .short, .none),


### PR DESCRIPTION
Mitigates #668. **One functional line: `refresh_cache` moves `DeadlineClass.short` (25s) → `.medium` (90s).**

## Why

`refresh_cache` drives a full poll cycle. On a 74-track project that cycle costs a **median of 12.6s**, and roughly **1 call in 5 hits the 25s ceiling** and returns `operation_timeout`. It is a read-only operation on the public surface; leaving it failing one time in five while the cause is investigated is not the right trade.

## 90s is a choice, not computed headroom — and the code says so

Every 74-track sample at ~26.67s was **censored** by the old deadline: `26674 / 26676 / 26689` recur across different operations, which is a ceiling, not load. The true maximum is unknown, so `median × N` would be arithmetic on a truncated distribution.

I could not measure an uncensored maximum — the fixture had already been removed from the owner's project, and rebuilding it costs ~11 minutes and alters a real Logic document. So the class is deliberately generous and labelled as a choice, both in the registry comment and in the commit message.

## This does not close #668

The cycle still costs what it costs; a large enough project exhausts 90s too. **What closes the issue is splitting the poll cycle per section**, sequenced after the #289 coordinator decision because the two overlap. Stated here explicitly so the issue is not closed on the deadline bump.

## Verification

```
registry test pins the deadline class per operation, so both moved together
reverting the source alone           -> 5 assertions fail
ship gate @ 57be38fb                 -> 8/8, full suite 3922 tests
live evidence @ 57be38fb             -> 11/11, zero failure counters
```

## Two things the gate caught that I had missed

```
C1a  the commit message contained "session" — a token the public-surface filter rejects.
     I meant a Logic session; the filter is right that it reads as internal process
     metadata on a public commit. Reworded to "a real Logic document".
C3a  Package.resolved had drifted back in during branch switching.
```

Amending for C1a moved the head, which invalidated the live evidence bound to the previous one — the gate then failed with `no passing live evidence bound to 57be38fb` and pushed nothing. Correct behaviour; evidence regenerated at the new head.
