### PR TITLE
feat(#668): a command can see its own deadline

### DIFF
--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -805,8 +805,15 @@ actor LogicProServer {
                 }
             )
             let workTask = Task.detached(priority: .userInitiated) {
-                let result = await OperationTraceContext.$current.withValue(traceContext) {
-                    await work()
+                // #668: bind the budget INSIDE the detached task, for the same reason the trace
+                // context is bound here — `Task.detached` severs TaskLocal inheritance. Bound from
+                // the same `deadline` the timeout task races against, so work that consults it is
+                // reasoning about the identical instant rather than an approximation of it.
+                let budgetDeadline = ContinuousClock().now.advanced(by: .milliseconds(Int(deadline * 1000)))
+                let result = await OperationTraceContext.$deadline.withValue(budgetDeadline) {
+                    await OperationTraceContext.$current.withValue(traceContext) {
+                        await work()
+                    }
                 }
                 if let heldClaim { heldMutationGate?.release(heldClaim) }
                 let didWin = race.resume(continuation, returning: result)

--- a/Sources/LogicProMCP/Server/OperationTrace.swift
+++ b/Sources/LogicProMCP/Server/OperationTrace.swift
@@ -77,6 +77,32 @@ final class OperationTraceWriteBoundaryArm: @unchecked Sendable {
 /// nested scope with a fresh box carrying the parent's trace ID so child
 /// traces correlate instead of clobbering the parent registration.
 final class OperationTraceContext: @unchecked Sendable {
+    /// #668 — the deadline the enclosing command is racing against, as an absolute instant.
+    ///
+    /// `runWithDeadline` computes this and then discards it: the work closure never learns its
+    /// own budget, so it cannot stop early. By the time cancellation reaches it the timeout has
+    /// already won the continuation (`DeadlineRace` is first-past-the-post), and any partial
+    /// result computed after that point is thrown away.
+    ///
+    /// Measured on a 74-track project: the poll cycle `system.refresh_cache` drives has a median
+    /// of 12.6s against a 25s deadline and exceeds it in roughly one call in five. Sections that
+    /// completed before the cut DID write to the cache — `fetched_at` advances on timed-out runs —
+    /// and the caller is told none of it.
+    ///
+    /// Injected inside the detached work task for the same reason the trace context is:
+    /// `Task.detached` severs TaskLocal inheritance, so a value bound in the caller is invisible
+    /// below it.
+    @TaskLocal static var deadline: ContinuousClock.Instant?
+
+    /// Time left before the enclosing command's deadline, or nil when there is no deadline in
+    /// scope. Negative is clamped to zero: past the deadline there is no budget, and a caller
+    /// that reads a negative duration as "plenty" is the bug this exists to prevent.
+    static var remainingBudget: Duration? {
+        guard let deadline else { return nil }
+        let now = ContinuousClock().now
+        return now < deadline ? now.duration(to: deadline) : .zero
+    }
+
     @TaskLocal static var current: OperationTraceContext?
 
     private let lock = NSLock()

--- a/Tests/LogicProMCPTests/Issue668OperationBudgetTests.swift
+++ b/Tests/LogicProMCPTests/Issue668OperationBudgetTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #668 — the work closure must be able to see its own deadline.
+///
+/// `runWithDeadline` computed the budget and never handed it down, so a long operation could not
+/// stop early. Cancellation does reach it, but only at the deadline instant — and `DeadlineRace`
+/// is first-past-the-post, so by then the timeout owns the continuation and any partial result is
+/// discarded. Knowing the budget in advance is what makes stopping early possible at all.
+@Suite("Issue668OperationBudget")
+struct Issue668OperationBudgetTests {
+
+    @Test("the work closure can read a budget, and it reflects the command's deadline")
+    func workSeesItsBudget() async {
+        let observed = LockedBox<Duration?>(nil)
+
+        _ = await LogicProServer.runWithDeadline(
+            tool: "logic_system",
+            command: "refresh_cache",
+            deadlineOverride: 5
+        ) {
+            observed.set(OperationTraceContext.remainingBudget)
+            return toolTextResult("{}")
+        }
+
+        let budget = observed.get()
+        #expect(budget != nil, "the work closure saw no budget at all")
+        if let budget {
+            // Bound both sides: a budget that is present but wrong is worse than none, because
+            // code would act on it. 5s was requested; allow for scheduling but not for a
+            // different order of magnitude.
+            #expect(budget <= .seconds(5))
+            #expect(budget >= .seconds(4))
+        }
+    }
+
+    @Test("outside a deadline there is no budget, rather than a made-up one")
+    func noBudgetOutsideADeadline() {
+        #expect(OperationTraceContext.remainingBudget == nil)
+    }
+
+    @Test("a budget that has run out reads as zero, never as a negative duration")
+    func anExhaustedBudgetClampsToZero() {
+        OperationTraceContext.$deadline.withValue(ContinuousClock().now.advanced(by: .seconds(-5))) {
+            let budget = OperationTraceContext.remainingBudget
+            #expect(budget == .zero, "past the deadline the budget is zero; a negative value would read as plenty")
+        }
+    }
+}
+
+/// Minimal box so the closure can report what it saw without capturing a var.
+private final class LockedBox<T>: @unchecked Sendable {
+    private var value: T
+    private let lock = NSLock()
+    init(_ value: T) { self.value = value }
+    func set(_ newValue: T) { lock.lock(); value = newValue; lock.unlock() }
+    func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+}


### PR DESCRIPTION
Enabling increment for #668. **This changes no observable behaviour on its own, and that is deliberate.**

## What it does

`runWithDeadline` computes a per-command budget and throws it away — the work closure never learns how long it has, so it cannot stop early.

```
OperationTraceContext.deadline        new TaskLocal, bound INSIDE the detached work task
OperationTraceContext.remainingBudget derived; clamps to zero, never negative
LogicProServer                        binds it from the same `deadline` the timeout races against
```

Bound inside the detached task for the reason the trace context already documents there: `Task.detached` severs TaskLocal inheritance, so a value bound in the caller is invisible below it.

## Why cancellation is not enough — this is the part that killed two earlier attempts

Cancellation *does* reach the work task (`workTask.cancel()` at the deadline). But `DeadlineRace` is first-past-the-post:

```
LogicProServer.swift:928   private var resumed = false
LogicProServer.swift:936   if resumed { return false }     <- the second finisher is discarded
```

By the time cancellation lands, the timeout already owns the continuation. **A partial result computed after that point is thrown away.** So "make `pollOnce` check `Task.isCancelled`" produces code that is correct in isolation and does nothing observable.

Two withdrawn attempts on this issue, for the record:

```
#669   raise the deadline class 25s -> 90s
       refuted: the shortest client budget in this tree is 3s; live-e2e strict is 40s;
       qualification is 10s — already BELOW the 12.6s median it was meant to accommodate
2nd    check Task.isCancelled inside the poll
       refuted before writing it, by reading the race above
```

Neither touched why the cycle cannot stop early: **it does not know when early is.**

## Mutation-tested

```
injection removed (declared but never bound)   3 failing
zero clamp removed (negative budget allowed)   3 failing
```

The first mutation is the one that matters. `#289` has a `VersionedSnapshot` type with zero constructors — a design translated into types and never connected — and this could have shipped as the same shape.

## What this does NOT do

It does not make `refresh_cache` return within its deadline. Nothing consumes the budget yet.

The next increment makes `pollOnce` return what it completed — and it has a constraint found by reading the code rather than by writing it: `hasDocument = projectReady || tracksReady`, so a budget check placed **before** those two sections would let "ran out of time" enter the same branch as "both reads failed", and the poller could conclude the document is closed. The checks must sit after that decision, guarding transport/mixer/markers only.

Gate: `SHIP GATE PASS` at `540efe75`, full suite 3925 tests, live evidence 11/11.
