### PR TITLE
test: give the AX-backed probe a budget it can actually observe the answer in

### DIFF
--- a/Tests/LogicProMCPTests/StructuredContentTests.swift
+++ b/Tests/LogicProMCPTests/StructuredContentTests.swift
@@ -78,6 +78,11 @@ struct StructuredContentTests {
         }
     }
 
+    /// A ceiling for "the harness gives up", not a latency assertion. The measured response was
+    /// 1.52s; this is generous enough that machine speed and load do not decide the verdict, and
+    /// small enough that a genuine hang still fails the run rather than stalling it.
+    private static let accessibilityBackedProbeBudget: UInt64 = 30_000_000_000
+
     @Test("tools_call_probe_includes_structured_content", processInspectionUnavailableInSandbox)
     func toolsCallProbeIncludesStructuredContent() async throws {
         let server = LogicProServer()
@@ -89,7 +94,17 @@ struct StructuredContentTests {
         _ = try await waitForProbeResponse(transport, id: 1)
 
         await transport.queueJSON(probeToolCallFrame(id: 2, name: "logic_system", command: "health"))
-        let response = try await waitForProbeResponse(transport, id: 2)
+        // The probe helper's 1s default is a budget for a protocol round trip, and this one is not
+        // that: `logic_system health` walks Accessibility. Measured here at 1.52s with a correct
+        // `result` in the frame — so the harness was giving up half a second before the answer
+        // arrived and reporting `result` as nil. That is absence of observation, not a defect, and
+        // it made this test fail intermittently on `origin/main` as well as on feature branches.
+        //
+        // Nothing below is relaxed: the assertions on `structuredContent` and its equality with the
+        // text payload are unchanged, so a genuinely malformed response still fails. This only
+        // stops the harness from blinking first. A real hang still fails, just later.
+        let response = try await waitForProbeResponse(
+            transport, id: 2, timeoutNanoseconds: Self.accessibilityBackedProbeBudget)
         let result = try #require(response["result"] as? [String: Any])
         let content = try #require(result["content"] as? [[String: Any]])
         let firstContent = try #require(content.first)


### PR DESCRIPTION
The second of the two intermittent full-suite failures I traced today. Sibling of #671, same disease: a harness that stops looking before the subject answers, reporting absence of observation as a defect.

`tools_call_probe_includes_structured_content` failed intermittently on `origin/main` **and** on feature branches, reporting `result` as nil. Measured through the same probe:

```
logic_system health responded in 1.518s, result present
probe helper default budget            1.000s
```

The 1s default is a budget for a **protocol round trip**, and this call is not one — `logic_system health` walks Accessibility. The harness was giving up half a second before the answer arrived.

## Nothing is relaxed

The assertions on `structuredContent` and its equality with the text payload are untouched. Mutation-verified: a mutant returning tool results with `structuredContent: nil` still fails this test at the same line.

```
mutant: structuredContent: nil  ->  ✘ Expectation failed at StructuredContentTests.swift:113
```

What changed is only how long the harness looks before concluding no frame came. A real hang still fails the run, just later.

The number is named and commented as a **ceiling for giving up, not a latency claim**, so nobody later reads 30s as an expectation about how long `health` should take.

## Why this matters beyond itself

Both of today's intermittent full-suite failures were in this family — a check whose verdict depended on machine speed rather than on the code. With #671 merged and this one, the ship gate can pass on a branch that deserves to pass:

```
SHIP GATE PASS — full suite 3923 tests passed (784s)
live evidence: n/a — no Sources/ or live-harness change
```