### PR TITLE
test: stop the qualification summary from stating a count it never counted

### DIFF
--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -1222,11 +1222,28 @@ struct QualificationRunnerTests {
         #expect(readOnly.allSatisfy {
             $0.status == .passed || $0.status == .notQualified || $0.status == .protocolSmoke
         })
-        print(
-            "qualification operation classification: "
-                + "qualified=\(qualified.count), protocol_smoke=\(smoke.count), "
-                + "deferred=\(deferred.count), failed=0"
-        )
+        // `failed` used to be a literal `0` inside this format string, so the line reported
+        // "failed=0" on runs where the `status != .failed` assertion had just failed. Believing it
+        // cost real time: the only way to see that one operation had failed was to notice that
+        // qualified + protocol_smoke + deferred summed to 110 against 111 specs and do the
+        // subtraction by hand. A diagnostic that states a count it never counted is worse than none,
+        // because it is believed.
+        //
+        // Counted by grouping rather than by naming three buckets: `QualificationStatus` has six
+        // cases, and a summary that names a subset of them is the same defect in a slower form —
+        // my first attempt at this fix hand-listed four and would have reported `waived` and
+        // `skipped` operations as unaccounted, turning a legitimate status into a test failure.
+        let byStatus = Dictionary(grouping: operationResults, by: \.status)
+            .mapValues(\.count)
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { "\($0.key.rawValue)=\($0.value)" }
+            .joined(separator: ", ")
+        print("qualification operation classification: \(byStatus) of \(operationResults.count)")
+
+        let failed = operationResults.filter { $0.status == .failed }
+        if !failed.isEmpty {
+            print("failed operations: \(failed.map(\.operationID).sorted().joined(separator: ", "))")
+        }
     }
 
     /// #399 (CEO audit P0) — INVERTED. This test used to prove the runner CAUGHT


### PR DESCRIPTION
Third of today's "the diagnostic lied to me" fixes, and this one cost the most time.

`failed` was a **literal `0` inside the format string**:

```swift
+ "deferred=\(deferred.count), failed=0"
```

So the line printed `failed=0` on runs where the `status != .failed` assertion had just failed. I believed it. The only way to see that one operation had failed was to notice that `qualified + protocol_smoke + deferred` summed to **110 against 111 specs** and do the subtraction by hand.

## After

Counts are grouped by status, and the total is printed so the sum is checkable at a glance:

```
qualification operation classification: not_qualified=96, passed=15 of 111
```

Any operation that fails now appears in the line **by construction**, and its operation IDs are printed beneath it.

## Why grouping, and not a hand-written list

My first attempt at this fix hand-listed four statuses and computed an "unaccounted" remainder from them — then asserted that remainder was zero.

`QualificationStatus` has **six** cases: `passed`, `failed`, `waived`, `skipped`, `notQualified`, `protocolSmoke`. So `waived` and `skipped` operations would have been reported as unaccounted and, worse, would have tripped the assertion I had just added. **A legitimate status turned into a test failure — the same defect as the original literal, in a slower form.**

I caught it by reading the enum before running, not by the test telling me. Grouping cannot go stale when a case is added.

## Gate

```
SHIP GATE PASS — full suite 3923 tests passed (784s)
live evidence: n/a — no Sources/ or live-harness change
```