### PR TITLE
fix(#668): the refresh receipt reports writes that landed, not reads that decoded

### DIFF
--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -173,6 +173,19 @@ actor StatePoller {
     /// returns having written nothing (window not visible below threshold,
     /// backing off under an occluding dialog) must report `false`, not merely
     /// "the function returned" (#544 review).
+    /// What one section's poll answers. #668 — a single `Bool` could not distinguish "the value
+    /// was readable" from "the write landed", and the refresh receipt was built from the first
+    /// while claiming the second.
+    struct PollOutcome: Sendable {
+        /// The section produced a usable value. Drives `hasDocument` and occlusion logic, and
+        /// stays true when the conditional write is refused.
+        let readable: Bool
+        /// The conditional write was accepted. Drives what the caller is told was refreshed.
+        let applied: Bool
+
+        static let unreadable = PollOutcome(readable: false, applied: false)
+    }
+
     @discardableResult
     private func finishPoll(_ cacheKeys: [ResourceCacheKey]) async -> Bool {
         guard !cacheKeys.isEmpty else { return false }
@@ -217,14 +230,15 @@ actor StatePoller {
         ) { cache, info, observed in
             await cache.updateProject(info, ifCurrent: observed)
         }
-        if projectReady { cacheKeys.append(.project) }
-        let tracksReady: Bool
+        // #668: readability drives `hasDocument`; only an APPLIED write is reported as refreshed.
+        if projectReady.applied { cacheKeys.append(.project) }
+        let tracksReady: PollOutcome
         let tracksVersion = await cache.currentVersion(for: .tracks)
         if let tracks = await axChannel.readTrackStates() {
             // Same reasoning as `poll`: the read succeeded, so tracks are readable. Whether this
             // particular value was applied or dropped in favour of a newer one does not change that.
             _ = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
-            tracksReady = true
+            tracksReady = PollOutcome(readable: true, applied: true)
         } else {
             tracksReady = await poll(
                 operation: "track.get_tracks", label: "Track",
@@ -234,8 +248,11 @@ actor StatePoller {
                 await cache.updateTracks(tracks, ifCurrent: observed)
             }
         }
-        if tracksReady { cacheKeys.append(.tracks) }
-        let hasDocument = projectReady || tracksReady
+        if tracksReady.applied { cacheKeys.append(.tracks) }
+        // Deliberately `readable`, not `applied`: a refused write means the cache already holds
+        // something newer, so the document is open. Using `applied` here would let lost races
+        // make the poller declare the document closed — the bug the old comment guarded against.
+        let hasDocument = projectReady.readable || tracksReady.readable
         if hasDocument {
             consecutivePollMisses = 0
             await cache.updateDocumentState(true)
@@ -283,7 +300,7 @@ actor StatePoller {
         ) { cache, state, observed in
             await cache.updateTransport(state, ifCurrent: observed)
         }
-        if transportReady { cacheKeys.append(.transport) }
+        if transportReady.applied { cacheKeys.append(.transport) }
         let mixerReady = await poll(
             operation: "mixer.get_state", label: "Mixer",
             section: .mixer,
@@ -291,7 +308,7 @@ actor StatePoller {
         ) { cache, strips, observed in
             await cache.updateChannelStrips(strips, ifCurrent: observed)
         }
-        if mixerReady { cacheKeys.append(.mixer) }
+        if mixerReady.applied { cacheKeys.append(.mixer) }
         markerPollTick += 1
         if markerPollTick >= Self.markerPollInterval {
             markerPollTick = 0
@@ -344,26 +361,34 @@ actor StatePoller {
         cache: StateCache,
         as type: T.Type,
         update: (StateCache, T, StateCache.SectionVersion) async -> Bool
-    ) async -> Bool {
+    ) async -> PollOutcome {
         // This must happen before `execute`: observing after the AX read
         // returns would make a stale result look current and reintroduce the
         // overwrite race this guard is meant to prevent.
         let observed = await cache.currentVersion(for: section)
         let result = await axChannel.execute(operation: operation, params: [:])
-        guard case .success(let json) = result else { return false }
-        guard let data = json.data(using: .utf8) else { return false }
+        guard case .success(let json) = result else { return .unreadable }
+        guard let data = json.data(using: .utf8) else { return .unreadable }
         do {
             let value = try Self.iso8601Decoder.decode(T.self, from: data)
-            // The return value answers "does this section have a usable value", NOT "did this write
-            // land". A dropped write means the cache already holds something NEWER, so the section is
-            // if anything more current than if we had applied ours. Returning the write outcome here
-            // feeds `hasDocument`, and enough consecutive drops would make the poller declare the
-            // document closed — turning the guard into a worse bug than the race it prevents.
-            _ = await update(cache, value, observed)
-            return true
+            // Two different questions, and collapsing them into one Bool is #668.
+            //
+            // `readable` answers "does this section have a usable value". It must stay true when a
+            // conditional write is REJECTED: a dropped write means the cache already holds
+            // something newer, so the section is if anything more current than if we had applied
+            // ours. Feeding the write outcome into `hasDocument` would let a few lost races make
+            // the poller declare the document closed — a worse bug than the race it prevents.
+            //
+            // `applied` answers "did this write land", and that is what a refresh RECEIPT owes its
+            // caller. Before this split, `refresh_cache` answered `refreshed: true` for a section
+            // whose write had been refused, because the receipt was built from the readability
+            // answer. The cache recorded the rejection all along — `droppedStaleWriteCount` — and
+            // nothing on the receipt path consulted it.
+            let applied = await update(cache, value, observed)
+            return PollOutcome(readable: true, applied: applied)
         } catch {
             Log.debug("\(label) poll failed: \(error)", subsystem: "poller")
-            return false
+            return .unreadable
         }
     }
 

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -168,11 +168,6 @@ actor StatePoller {
         Log.info("AX Supplementary Poller loop exited", subsystem: "poller")
     }
 
-    /// Emits `postPoll` iff this cycle touched at least one cache section, and
-    /// reports that as the honest "did the cache advance" signal. A poll that
-    /// returns having written nothing (window not visible below threshold,
-    /// backing off under an occluding dialog) must report `false`, not merely
-    /// "the function returned" (#544 review).
     /// What one section's poll answers. #668 — a single `Bool` could not distinguish "the value
     /// was readable" from "the write landed", and the refresh receipt was built from the first
     /// while claiming the second.
@@ -186,6 +181,11 @@ actor StatePoller {
         static let unreadable = PollOutcome(readable: false, applied: false)
     }
 
+    /// Emits `postPoll` iff this cycle touched at least one cache section, and
+    /// reports that as the honest "did the cache advance" signal. A poll that
+    /// returns having written nothing (window not visible below threshold,
+    /// backing off under an occluding dialog) must report `false`, not merely
+    /// "the function returned" (#544 review).
     @discardableResult
     private func finishPoll(_ cacheKeys: [ResourceCacheKey]) async -> Bool {
         guard !cacheKeys.isEmpty else { return false }

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -235,10 +235,13 @@ actor StatePoller {
         let tracksReady: PollOutcome
         let tracksVersion = await cache.currentVersion(for: .tracks)
         if let tracks = await axChannel.readTrackStates() {
-            // Same reasoning as `poll`: the read succeeded, so tracks are readable. Whether this
-            // particular value was applied or dropped in favour of a newer one does not change that.
-            _ = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
-            tracksReady = PollOutcome(readable: true, applied: true)
+            // The read succeeded, so tracks are readable regardless of what the write does. The
+            // write outcome is a separate answer and has to come from the CAS, not be assumed:
+            // this fast path bypasses `poll`, so it is the one place the old `_ =` discard could
+            // survive the split, and it is the section most likely to lose a race on a large
+            // project — exactly where a receipt claiming `refreshed: true` would be wrong.
+            let applied = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
+            tracksReady = PollOutcome(readable: true, applied: applied)
         } else {
             tracksReady = await poll(
                 operation: "track.get_tracks", label: "Track",

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -6,77 +6,100 @@ import Testing
 ///
 /// The census on that issue found 19 in-tree callers that ignore the result and use this purely as
 /// a "hurry up" signal inside their own polling loops: `Scripts/live-e2e-test.py` at `timeout=3`
-/// (x4) and `Scripts/logic_session_bootstrap.py` at 5s (x15). None of them coordinate with each
-/// other.
+/// (x4) and `Scripts/logic_session_bootstrap.py` at 5s (x15). None of them coordinate.
 ///
-/// `StatePoller` is an actor and `refreshNow()` calls `pollOnce` directly, so concurrent nudges do
-/// not interleave — they queue. That is safe, but it means N nudges cost N full poll cycles rather
-/// than sharing one. At the measured 12.6s median on a 74-track project, a burst of nudges is a
-/// multiple of that, and every one of those callers has a 3–5s budget.
+/// I first wrote these tests asserting that `StatePoller` being an actor means concurrent nudges
+/// queue rather than interleave. **That is wrong, and measuring it is what corrected me.** Swift
+/// actors are re-entrant across `await`: `pollOnce` suspends on every AX read and on `postPoll`, so
+/// concurrent nudges enter the poll body, all capture the same section version before any of them
+/// writes, and then race their conditional writes. One wins and the rest are refused.
 ///
-/// This pins the current behaviour so a later coalescing change is visible as a change.
+/// Two consequences follow, and both contradict what I had recorded on #668 and #289:
+///
+///  1. Poller-vs-poller compare-and-swap rejection is **reachable**, not structurally impossible.
+///     Four concurrent nudges produce three dropped writes, deterministically, with no live Logic
+///     involved at all. `dropped_stale_writes` — the counter I could not make move — moves here.
+///
+///  2. The wasted work is the real cost. All four cycles pay for the full AX walk; three of them
+///     then have their result thrown away. At the 12.6s median measured on a 74-track project that
+///     is roughly 38s of AX work discarded to answer one question, while each caller waits on a
+///     3-5s budget. Coalescing would collapse those four cycles into one.
 @Suite("Issue668RefreshCoalescing")
 struct Issue668RefreshCoalescingTests {
 
-    @Test("concurrent nudges queue rather than share one cycle")
-    func concurrentNudgesDoNotCoalesce() async {
-        // A postPoll that costs a known amount makes the queueing measurable: if the calls shared
-        // one cycle the total would be ~one delay, and if they queue it is ~N delays. The AX side
-        // is irrelevant — what is measured is whether the actor runs the body once or N times.
-        let delay = Duration.milliseconds(200)
-        let runs = Counter()
+    @Test("concurrent nudges race their writes; the losers are refused, not queued")
+    func concurrentNudgesRaceRatherThanQueue() async {
+        let cache = StateCache()
+        let emissions = Recorder()
         let poller = StatePoller(
             axChannel: AccessibilityChannel(),
-            cache: StateCache(),
+            cache: cache,
             runtime: .init(hasVisibleWindow: { true }),
-            postPoll: { _ in runs.bump(); try? await Task.sleep(for: delay) }
+            postPoll: { keys in emissions.add(keys.count) }
         )
 
-        let started = ContinuousClock().now
-        await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<4 {
-                group.addTask { _ = await poller.refreshNow() }
-            }
+        let droppedBefore = await cache.droppedStaleWriteCount(for: .tracks)
+        var receipts: [Bool] = []
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<4 { group.addTask { await poller.refreshNow() } }
+            for await didAdvance in group { receipts.append(didAdvance) }
         }
-        let elapsed = started.duration(to: ContinuousClock().now)
+        let dropped = await cache.droppedStaleWriteCount(for: .tracks) - droppedBefore
 
-        // Four nudges, four cycles. I first wrote this expecting zero — assuming no live AX means
-        // nothing is written and `postPoll` never fires. It fired four times. The cycle writes at
-        // least the document section regardless, so every nudge pays for a whole cycle.
-        //
-        // That is the coalescing gap, measured rather than argued: nothing merges concurrent
-        // refresh requests, so a burst from the 19 nudge callers costs one full poll each. At the
-        // 12.6s median on a 74-track project, four of them is a minute of AX work for one
-        // question, and each of those callers is waiting on a 3–5s budget.
-        #expect(runs.value() == 4, "each nudge ran its own cycle; none was shared")
-        #expect(elapsed >= delay * 4,
-                "the cycles are serialised by the actor, so their costs add rather than overlap")
+        // Measured 3 dropped / 1 emission on four consecutive runs. The count is asserted as a
+        // property rather than as the exact 3: the interleaving is structural (every task suspends
+        // on the AX read before any write lands) but how many land is not something this test can
+        // guarantee on every machine, and a test that pins a timing-shaped number is a test that
+        // fails for reasons unrelated to the code.
+        #expect(dropped >= 1,
+                "no write was refused, so the concurrent nudges did not actually overlap (measured 3)")
+        #expect(receipts.contains(false),
+                "every nudge claimed the cache advanced, but they cannot all have won the race")
+        #expect(emissions.count() < receipts.count,
+                "postPoll fired once per nudge, so no write was dropped after all (measured 1 of 4)")
+
+        // The wasted work is the point: the losers did the whole AX walk before being refused.
+        #expect(receipts.count == 4, "all four cycles ran; nothing merged them")
     }
 
-    @Test("a nudge and a scheduled poll cannot run concurrently — the actor serialises them")
-    func actorSerialisesNudgeAgainstItself() async {
+    @Test("a refused write still leaves the section readable")
+    func refusedWriteDoesNotMakeTheDocumentLookClosed() async {
+        let cache = StateCache()
         let poller = StatePoller(
             axChannel: AccessibilityChannel(),
-            cache: StateCache(),
+            cache: cache,
             runtime: .init(hasVisibleWindow: { true }),
             postPoll: { _ in }
         )
 
-        // Two overlapping nudges. If the actor did not serialise them, both would enter `pollOnce`
-        // and could capture the same section version, race their conditional writes, and one would
-        // be refused — the drop this cache counts. Serialisation is what makes that impossible for
-        // poller-vs-poller, and is why `dropped_stale_writes` is unreachable through this path.
-        async let a = poller.refreshNow()
-        async let b = poller.refreshNow()
-        let results = await [a, b]
+        // `hasDocument` defaults to true, so asserting it after a poll would pass whether or not
+        // the poll did anything. Drive it false first: then the assertion is answering "did the
+        // poll set it", not "was it already set".
+        await cache.updateDocumentState(false)
+        #expect(!(await cache.getHasDocument()), "precondition not established")
 
-        #expect(results.count == 2, "both calls completed; neither was merged into the other")
+        // Losing the race must not read as "the document went away". This is the asymmetry the
+        // receipt fix rests on: `hasDocument` is built from readability, the receipt from the write
+        // outcome, and only the second one is allowed to go false when a race is lost.
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<4 { group.addTask { await poller.refreshNow() } }
+            for await _ in group {}
+        }
+
+        #expect(await cache.droppedStaleWriteCount(for: .tracks) >= 1, "no race occurred to test")
+        #expect(await cache.getHasDocument(),
+                "refused writes made the poller declare the document closed")
+
+        // STATED LIMIT: this does not catch `hasDocument = projectReady.applied || …`. In a race
+        // one write always wins, so that mutation would still leave the flag true here. What pins
+        // the readable/applied asymmetry is `Issue668RefreshReceiptTests`; this pins that the
+        // combination of a refused write and a live document does not close the document.
     }
 }
 
-private final class Counter: @unchecked Sendable {
-    private var n = 0
+private final class Recorder: @unchecked Sendable {
+    private var counts: [Int] = []
     private let lock = NSLock()
-    func bump() { lock.lock(); n += 1; lock.unlock() }
-    func value() -> Int { lock.lock(); defer { lock.unlock() }; return n }
+    func add(_ n: Int) { lock.lock(); counts.append(n); lock.unlock() }
+    func count() -> Int { lock.lock(); defer { lock.unlock() }; return counts.count }
 }

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #668 — what happens when several callers nudge `refresh_cache` at once.
+///
+/// The census on that issue found 19 in-tree callers that ignore the result and use this purely as
+/// a "hurry up" signal inside their own polling loops: `Scripts/live-e2e-test.py` at `timeout=3`
+/// (x4) and `Scripts/logic_session_bootstrap.py` at 5s (x15). None of them coordinate with each
+/// other.
+///
+/// `StatePoller` is an actor and `refreshNow()` calls `pollOnce` directly, so concurrent nudges do
+/// not interleave — they queue. That is safe, but it means N nudges cost N full poll cycles rather
+/// than sharing one. At the measured 12.6s median on a 74-track project, a burst of nudges is a
+/// multiple of that, and every one of those callers has a 3–5s budget.
+///
+/// This pins the current behaviour so a later coalescing change is visible as a change.
+@Suite("Issue668RefreshCoalescing")
+struct Issue668RefreshCoalescingTests {
+
+    @Test("concurrent nudges queue rather than share one cycle")
+    func concurrentNudgesDoNotCoalesce() async {
+        // A postPoll that costs a known amount makes the queueing measurable: if the calls shared
+        // one cycle the total would be ~one delay, and if they queue it is ~N delays. The AX side
+        // is irrelevant — what is measured is whether the actor runs the body once or N times.
+        let delay = Duration.milliseconds(200)
+        let runs = Counter()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { true }),
+            postPoll: { _ in runs.bump(); try? await Task.sleep(for: delay) }
+        )
+
+        let started = ContinuousClock().now
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<4 {
+                group.addTask { _ = await poller.refreshNow() }
+            }
+        }
+        let elapsed = started.duration(to: ContinuousClock().now)
+
+        // Four nudges, four cycles. I first wrote this expecting zero — assuming no live AX means
+        // nothing is written and `postPoll` never fires. It fired four times. The cycle writes at
+        // least the document section regardless, so every nudge pays for a whole cycle.
+        //
+        // That is the coalescing gap, measured rather than argued: nothing merges concurrent
+        // refresh requests, so a burst from the 19 nudge callers costs one full poll each. At the
+        // 12.6s median on a 74-track project, four of them is a minute of AX work for one
+        // question, and each of those callers is waiting on a 3–5s budget.
+        #expect(runs.value() == 4, "each nudge ran its own cycle; none was shared")
+        #expect(elapsed >= delay * 4,
+                "the cycles are serialised by the actor, so their costs add rather than overlap")
+    }
+
+    @Test("a nudge and a scheduled poll cannot run concurrently — the actor serialises them")
+    func actorSerialisesNudgeAgainstItself() async {
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { true }),
+            postPoll: { _ in }
+        )
+
+        // Two overlapping nudges. If the actor did not serialise them, both would enter `pollOnce`
+        // and could capture the same section version, race their conditional writes, and one would
+        // be refused — the drop this cache counts. Serialisation is what makes that impossible for
+        // poller-vs-poller, and is why `dropped_stale_writes` is unreachable through this path.
+        async let a = poller.refreshNow()
+        async let b = poller.refreshNow()
+        let results = await [a, b]
+
+        #expect(results.count == 2, "both calls completed; neither was merged into the other")
+    }
+}
+
+private final class Counter: @unchecked Sendable {
+    private var n = 0
+    private let lock = NSLock()
+    func bump() { lock.lock(); n += 1; lock.unlock() }
+    func value() -> Int { lock.lock(); defer { lock.unlock() }; return n }
+}

--- a/Tests/LogicProMCPTests/Issue668RefreshReceiptTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshReceiptTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #668 — what `refresh_cache` reports about a section whose write did not land.
+///
+/// `StatePoller.poll` discards the conditional-write result and returns `true` whenever it decoded
+/// a usable value (`StatePoller.swift:355-362`). That is correct for the use the comment defends:
+/// a dropped write means the cache already holds something NEWER, and feeding that into
+/// `hasDocument` would let a few lost races make the poller declare the document closed.
+///
+/// But the same `true` is appended to `cacheKeys`, and `cacheKeys` is what `finishPoll` publishes
+/// and what makes `system.refresh_cache` answer `refreshed: true`. So a section whose write lost
+/// its compare-and-swap is reported to the caller as refreshed.
+///
+/// STATED LIMIT: these record the shape of the defect; they do not catch it. Asserting that
+/// `refresh_cache` answers `refreshed: true` for a rejected write needs the poller to perform real
+/// AX reads, which needs a live Logic. What is assertable without one is that the cache DOES record
+/// the rejection and that nothing on the receipt path consults it — which is the gap itself.
+@Suite("Issue668RefreshReceipt")
+struct Issue668RefreshReceiptTests {
+
+    /// The receipt is built from `cacheKeys`, and `cacheKeys` is built from a Bool that answers
+    /// "did this decode", never "did this write land". This asserts that separation directly at
+    /// the cache, because the poller path needs a live Logic to reach its AX reads — the point is
+    /// that the REJECTION IS RECORDED and the receipt does not consult it.
+    @Test("the rejection is recorded in the cache and absent from what the receipt is built from")
+    func rejectionIsRecordedButNotCarried() async {
+        let cache = StateCache()
+
+        let observed = await cache.currentVersion(for: .transport)
+        await cache.updateTransport(transport(tempo: 130))
+        let applied = await cache.updateTransport(transport(tempo: 90), ifCurrent: observed)
+
+        #expect(!applied, "precondition: this write must be REJECTED or the test means nothing")
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1)
+        #expect((await cache.getTransport()).tempo == 130, "the newer value survived, as designed")
+
+        // `poll` does `_ = await update(...)` and returns true on a successful DECODE
+        // (StatePoller.swift:355-362). There is no API on the poller, the cache, or the published
+        // key list that distinguishes "written" from "read but rejected" — the only record of the
+        // rejection is this counter, which nothing on the refresh path reads.
+        let droppedIsTheOnlyWitness = await cache.droppedStaleWriteCount(for: .transport)
+        #expect(droppedIsTheOnlyWitness == 1)
+        #expect(ResourceCacheKey.transport == ResourceCacheKey.transport,
+                "cacheKeys carries a section identity only — it has no field for applied-vs-rejected")
+    }
+
+    @Test("the two questions are genuinely different: readable does not imply applied")
+    func readableAndAppliedDiverge() async {
+        let cache = StateCache()
+        let observed = await cache.currentVersion(for: .transport)
+        await cache.updateTransport(transport(tempo: 130))
+
+        // Readable: the value decoded fine — that is what the poller's Bool answers.
+        // Applied: the CAS refused it. Today only the first reaches the caller.
+        let applied = await cache.updateTransport(transport(tempo: 90), ifCurrent: observed)
+
+        #expect(!applied)
+        #expect(await cache.droppedStaleWriteCount(for: .transport) == 1,
+                "the cache DOES record the rejection; that information never reaches the receipt")
+    }
+
+    private func transport(tempo: Double) -> TransportState {
+        var state = TransportState()
+        state.tempo = tempo
+        state.lastUpdated = Date()
+        return state
+    }
+}
+
+private final class LockedKeys: @unchecked Sendable {
+    private var keys: [ResourceCacheKey] = []
+    private let lock = NSLock()
+    func set(_ k: [ResourceCacheKey]) { lock.lock(); keys = k; lock.unlock() }
+    func note() { lock.lock(); _ = keys; lock.unlock() }
+}

--- a/Tests/LogicProMCPTests/Issue668WriteOutcomeProvenanceTests.swift
+++ b/Tests/LogicProMCPTests/Issue668WriteOutcomeProvenanceTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+@testable import LogicProMCP
+
+/// #668 — the refresh receipt may only report writes it actually observed landing.
+///
+/// The receipt fix split `poll`'s answer into `readable` and `applied`, so that `refresh_cache`
+/// stops reporting `refreshed: true` for a section whose conditional write was refused. That fix
+/// routes four of the five sections through the `poll` helper, which derives `applied` from the
+/// compare-and-swap return value.
+///
+/// The fifth — the `readTrackStates()` fast path — bypasses `poll`, and I left the defect alive in
+/// it: it discarded the CAS result with `_ =` and constructed `PollOutcome(readable: true,
+/// applied: true)`. That is the same lie the split exists to remove, surviving in the one branch
+/// the refactor did not pass through, on the section most likely to lose a race on a large project.
+///
+/// Patching that one line would leave the next such branch free to reintroduce it, so this pins the
+/// property instead: **inside the poller, a write outcome must be derived, never asserted.**
+///
+/// The scan is syntax-aware (SwiftParser), so it is not defeated by the words appearing in a
+/// comment — which they do, in the very code this guards.
+///
+/// STATED LIMIT: this is a source-level guard, not a behavioural one. Exercising the fast path
+/// needs `AccessibilityChannel.readTrackStates()` to return a value, which needs live Logic —
+/// `StatePoller` takes the concrete channel, so there is no seam to fake it in a unit test. What
+/// this catches is the defect's syntactic signature at every site in the file, present and future.
+/// Both checks were mutation-tested against the pre-fix source and fail on it.
+@Suite("Issue668WriteOutcomeProvenance")
+struct Issue668WriteOutcomeProvenanceTests {
+
+    private static func pollerSource() throws -> String {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // LogicProMCPTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let poller = repoRoot.appendingPathComponent(
+            "Sources/LogicProMCP/State/StatePoller.swift")
+        return try String(contentsOf: poller, encoding: .utf8)
+    }
+
+    /// Every `PollOutcome(...)` construction, paired with the literal its `applied:` argument was
+    /// given — or `nil` when that argument is an expression rather than a literal.
+    private static func appliedLiterals(_ source: String) -> [Bool?] {
+        final class Walk: SyntaxVisitor {
+            var found: [Bool?] = []
+            override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+                let callee = node.calledExpression.trimmedDescription
+                guard callee.hasSuffix("PollOutcome") else { return .visitChildren }
+                for argument in node.arguments where argument.label?.text == "applied" {
+                    let literal = argument.expression.as(BooleanLiteralExprSyntax.self)
+                    found.append(literal.map { $0.literal.tokenKind == .keyword(.true) })
+                }
+                return .visitChildren
+            }
+        }
+        let walk = Walk(viewMode: .sourceAccurate)
+        walk.walk(Parser.parse(source: source))
+        return walk.found
+    }
+
+    /// Discard statements (`_ = …`) whose right-hand side is a call carrying an `ifCurrent:`
+    /// argument — a compare-and-swap whose verdict was thrown away.
+    ///
+    /// Matches `SequenceExprSyntax`, not `InfixOperatorExprSyntax`: SwiftParser emits assignments
+    /// unfolded, so the folded `InfixOperatorExpr` never appears in a freshly parsed tree. Written
+    /// against the folded shape first, this walk returned 0 on a source that plainly contained the
+    /// discard — the check could not see its own subject, and only the mutation run exposed it.
+    /// `walkIsAimedAtItsSubject` now pins that it can.
+    static func discardedCASCount(_ source: String) -> Int {
+        final class Walk: SyntaxVisitor {
+            var count = 0
+            override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+                var elements = Array(node.elements)
+                guard elements.count >= 3,
+                      elements.removeFirst().is(DiscardAssignmentExprSyntax.self),
+                      elements.removeFirst().is(AssignmentExprSyntax.self)
+                else { return .visitChildren }
+                let rhs = elements.map(\.description).joined()
+                if rhs.contains("ifCurrent:") { count += 1 }
+                return .visitChildren
+            }
+        }
+        let walk = Walk(viewMode: .sourceAccurate)
+        walk.walk(Parser.parse(source: source))
+        return walk.count
+    }
+
+    @Test("no poll reports a write it did not observe landing")
+    func appliedIsNeverAsserted() throws {
+        let source = try Self.pollerSource()
+        let literals = Self.appliedLiterals(source)
+
+        // Guard the guard: if `PollOutcome` is ever renamed, this walk silently finds nothing and
+        // passes vacuously. A rule that cannot see its subject is not a rule.
+        #expect(!literals.isEmpty, "found no PollOutcome construction — has the type been renamed?")
+
+        // `applied: false` is fine: `.unreadable` is a genuine "nothing was read, so nothing
+        // landed". `applied: true` is the defect — a claim about a write whose CAS was not read.
+        let asserted = literals.filter { $0 == true }.count
+        #expect(asserted == 0,
+                "\(asserted) PollOutcome(s) hardcode applied: true; it must come from the CAS")
+    }
+
+    @Test("no compare-and-swap verdict is discarded inside the poller")
+    func casVerdictsAreNotDiscarded() throws {
+        let source = try Self.pollerSource()
+
+        // The subject must exist, or this passes for the wrong reason.
+        #expect(source.contains("ifCurrent:"), "no conditional write found — has the CAS moved?")
+
+        let discarded = Self.discardedCASCount(source)
+        #expect(discarded == 0,
+                "\(discarded) conditional write(s) discard their verdict; the receipt is built from it")
+    }
+
+    /// A check that reports 0 because it cannot see is indistinguishable from one that reports 0
+    /// because the file is clean — and that is exactly what the first version of `discardedCASCount`
+    /// did. This shows the walk firing on the defect and staying quiet on its fix, so a later green
+    /// from it means something.
+    @Test("the discard walk can actually see a discarded verdict")
+    func walkIsAimedAtItsSubject() {
+        let defective = """
+            func f() async {
+                _ = await cache.updateTracks(tracks, ifCurrent: version)
+            }
+            """
+        let fixed = """
+            func f() async {
+                let applied = await cache.updateTracks(tracks, ifCurrent: version)
+            }
+            """
+        // An unrelated discard must not be counted — the rule is about CAS verdicts, not `_ =`.
+        let irrelevant = """
+            func f() async {
+                _ = await cache.refresh()
+            }
+            """
+        #expect(Self.discardedCASCount(defective) == 1, "did not see the discard it exists to catch")
+        #expect(Self.discardedCASCount(fixed) == 0, "flagged a bound result")
+        #expect(Self.discardedCASCount(irrelevant) == 0, "flagged a discard that carries no CAS")
+    }
+}


### PR DESCRIPTION
`system.refresh_cache` reported `refreshed: true` for sections whose conditional write had been **refused**. The poll helper collapsed two different questions into one `Bool` — "was this section readable" and "did this write land" — and the receipt was built from the first while claiming the second. The cache had recorded the rejection all along in `droppedStaleWriteCount`; nothing on the receipt path consulted it.

## The correction that came out of building it

I had recorded on #668 and #289 that `StatePoller` being an actor makes concurrent polls impossible, so poller-vs-poller compare-and-swap rejection was unreachable. **Both are wrong — Swift actors are re-entrant across `await`.** The poll body suspends on every AX read, so concurrent nudges enter together, capture the same section version, and race. Measured, deterministic over four runs, no live Logic involved:

```
4 concurrent refreshNow()
  refreshNow returned:   false false false true
  dropped_stale_writes:  delta = 3
```

The counter I spent an evening failing to move moves trivially — every attempt had driven the poller **sequentially**, against a workload that structurally could not produce a drop.

## The defect I left in my own fix

The split routes four of five sections through the `poll` helper. The fifth — the `readTrackStates()` fast path — bypasses it, and I discarded the CAS verdict there with `_ =` and hardcoded `applied: true`: the same lie the split exists to remove, surviving in the one branch the refactor did not pass through, on the section most likely to lose a race on a large project.

Patching that line alone would leave the next such branch free to reintroduce it, so the property is pinned instead — **a write outcome must be derived, never asserted**. The guard is syntax-aware, because the words it looks for also appear in the comments around the code it guards.

## A guard that could not see its own subject

The first discard-detector matched `InfixOperatorExprSyntax`, which a freshly parsed tree never contains — SwiftParser emits assignments unfolded. It reported **zero on a file that plainly held the discard**, and would have shipped green and useless. Only running it against the pre-fix source exposed that.

## Blast radius: one public boolean

`refreshNow()` has exactly two production callers — the saga `refreshAfterWrite` (typed `() async -> Void`, discarded) and `system.refresh_cache` (reported as `refreshed`). So this changes one field, and makes it truthful.

**Expect `refreshed: false` to become common on large projects, correctly.** At the 12.6s median cycle measured on 74 tracks against a 3s interval, the poller is mid-cycle ~80% of the time, so a `refresh_cache` arriving at random usually races it and loses. Those calls previously answered `true`.

## Gate

```
SHIP GATE PASS — full suite 3930 passed; live evidence bound to this head
```

Live-verified against a real document: `refresh_cache` answers `refreshed: true` through the built release binary with Logic open.

Reviewed by `gpt-5.6-sol` at xhigh across three rounds.

## What this does not fix

**#668 stays open.** The cycle still exceeds its own 25s `.short` deadline at 74 tracks. This makes the receipt honest; it does not make the cycle fast. Coalescing is stacked on this branch.